### PR TITLE
fix: keep Okta projection scopes distinct

### DIFF
--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -179,7 +179,7 @@ jobs:
           '
           summary="$(docker run --rm "${CANDIDATE_IMAGE}" catalog-summary)"
           test "$(jq -r .sources <<<"${summary}")" -eq 794
-          test "$(jq -r .families <<<"${summary}")" -eq 3892
+          test "$(jq -r .families <<<"${summary}")" -eq 3893
       - name: Start disposable PostgreSQL, Neo4j, and JetStream
         run: |
           set -euo pipefail
@@ -247,7 +247,7 @@ jobs:
             | .checks += [
                 {name:"rust_entrypoint",status:"passed",evidence:"image starts cerebro-platform directly"},
                 {name:"go_binary_absent",status:"passed",evidence:"/usr/local/bin/cerebro is absent"},
-                {name:"source_catalog",status:"passed",evidence:"794 sources and 3892 families loaded"}
+                {name:"source_catalog",status:"passed",evidence:"794 sources and 3893 families loaded"}
               ]
           ' .dist/rust-only-e2e/rust-only-e2e-receipt.json \
             > .dist/rust-only-e2e/receipt.tmp

--- a/crates/cerebro-platform/src/append_log_consumer.rs
+++ b/crates/cerebro-platform/src/append_log_consumer.rs
@@ -1373,6 +1373,15 @@ mod tests {
             ),
             None
         );
+        assert_eq!(
+            replay_legacy_projection_skip(
+                ConsumerMode::Replay,
+                "okta",
+                "application",
+                &missing_catalog,
+            ),
+            None
+        );
     }
 
     #[test]

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -1679,7 +1679,7 @@ mod tests {
         .unwrap();
         let summary = catalog.summary();
         assert_eq!(summary.sources, 794);
-        assert_eq!(summary.families, 3_892);
+        assert_eq!(summary.families, 3_893);
         assert_eq!(
             summary.projection_classes.values().sum::<usize>(),
             summary.families
@@ -1762,6 +1762,29 @@ mod tests {
                 .get("member_id")
                 .map(String::as_str),
             Some("member_id|member_user_id|user_id|id")
+        );
+        // The checked-in catalog also describes events produced by hand-written
+        // connectors. Those exact, singular family IDs are durable protocol
+        // names: replay must not guess that `application` means the separate
+        // declarative `applications` endpoint.
+        let okta_application = catalog
+            .get("okta")
+            .unwrap()
+            .families()
+            .iter()
+            .find(|family| family.id() == "application")
+            .unwrap();
+        assert_eq!(
+            okta_application.projection().template(),
+            "identity_application"
+        );
+        assert_eq!(
+            okta_application
+                .projection()
+                .fields()
+                .get("app_id")
+                .map(String::as_str),
+            Some("app_id|id")
         );
         assert_eq!(
             catalog.get("airbrake").unwrap().auth_query_parameters(),

--- a/crates/source-runtime-next/src/mapper.rs
+++ b/crates/source-runtime-next/src/mapper.rs
@@ -649,6 +649,10 @@ fn label_for(
     let keys: &[&str] = match template {
         "identity_user" => &["display_name", "email", "user_id"],
         "identity_group" => &["group_name", "group_email", "group_id"],
+        // Application events commonly expose both a provider-internal name and
+        // a human-facing label. Prefer the normalized application name so graph
+        // readers see the same label that the source runtime selected.
+        "identity_application" => &["app_name", "app_label", "name", "app_id"],
         "repository" => &["repository_name", "resource_name", "name"],
         "deployment" => &["deployment_name", "resource_name", "name"],
         "policy" => &["policy_name", "resource_name", "name"],
@@ -799,6 +803,69 @@ mod tests {
             panic!("expected relationship")
         };
         assert_eq!(assertion.relation(), RelationKind::MemberOf);
+    }
+
+    #[test]
+    fn okta_runtime_application_becomes_a_native_application_entity() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("okta").unwrap().clone();
+        let collection = CompleteCollection::new(
+            TenantId::parse("tenant-a").unwrap(),
+            SourceRuntimeId::parse("okta-prod").unwrap(),
+            CollectionId::parse("collection-okta-application-1").unwrap(),
+            "okta.application",
+            10,
+        )
+        .unwrap();
+        let batch = CollectedBatch {
+            scope: CollectedScope::Complete(collection),
+            records: vec![SourceRecord {
+                observation_id: ObservationId::parse("observation-okta-application-1").unwrap(),
+                family: "application".to_owned(),
+                provider_kind: "okta.application".to_owned(),
+                provider_id: "app-1".to_owned(),
+                fields: BTreeMap::from([
+                    ("app_id".to_owned(), "app-1".to_owned()),
+                    ("app_name".to_owned(), "Payroll".to_owned()),
+                    ("oauth_public_client".to_owned(), "false".to_owned()),
+                    ("status".to_owned(), "ACTIVE".to_owned()),
+                ]),
+                payload: serde_json::json!({
+                    "id": "app-1",
+                    "label": "Payroll",
+                    "name": "payroll_oidc",
+                    "status": "ACTIVE"
+                }),
+            }],
+            next_cursor: None,
+        };
+
+        let delta = CatalogGraphMapper::new(source, "v1")
+            .unwrap()
+            .map(&batch)
+            .unwrap();
+
+        assert_eq!(delta.entities().len(), 1);
+        assert!(delta.assertions().is_empty());
+        let application = &delta.entities()[0];
+        assert_eq!(application.kind(), &EntityKind::Application);
+        assert_eq!(application.label(), "Payroll");
+        assert_eq!(
+            application.properties().get("status").map(String::as_str),
+            Some("ACTIVE")
+        );
+        assert_eq!(
+            application
+                .properties()
+                .get("oauth_public_client")
+                .map(String::as_str),
+            Some("false")
+        );
     }
 
     #[test]

--- a/docs/operations/organizational-projection-replay.md
+++ b/docs/operations/organizational-projection-replay.md
@@ -78,12 +78,39 @@ skips: the legacy `asset.data_sensitivity` kind, invalid historical observation
 IDs for `gcp.iam_role_assignment`, `gcp.effective_permission`, and
 `aws.public_endpoint`, the catalog-owned `cerebro.health.jetstream_canary`
 without a source envelope, and permanent projection failures for the retired
-`okta.threat_insight` family. The active `okta.group_membership` family is not a
-compatibility skip: its hand-written collector events project through the
-compiled native relationship template. Replay compatibility applies only in
-replay mode. The forward consumer continues to reject every legacy shape.
+`okta.threat_insight` family. The active `okta.group_membership` and
+`okta.application` families are not compatibility skips: their hand-written
+collector events project through exact compiled native relationship and
+application templates. Replay compatibility applies only in replay mode. The
+forward consumer continues to reject every legacy shape.
 Inspect the completed run and review the per-source-family skipped counters as
 the durable evidence for these records.
+
+## Repair an active-family rejection
+
+An active source-family rejection is a contract failure, not historical noise.
+Do not add the family to the replay skip list and do not reset the run. Preserve
+the failed consumer, its run row, its end-sequence fence, and its per-family
+rejection counters.
+
+If the error says a family is absent from the compiled catalog:
+
+1. Compare the committed event's exact `source_id`, family, kind, schema, and
+   required fields with the hand-written source contract.
+2. Add the exact durable family ID to the connector catalog. Keep the family
+   disabled for collection when the hand-written collector remains its owner;
+   the entry exists to make committed events projectable, not to start a second
+   collector.
+3. Map the family to a native graph template and test the entity or relationship
+   shape in every runtime that claims the template is executable.
+4. Build a new candidate and verify its compiled catalog summary and exact
+   source-family projection locally and in the Rust-only candidate workflow.
+5. Start a new replay consumer and run ID at the failed run's original
+   `first_sequence`, using the same immutable `end_sequence` fence.
+
+The replacement replay must independently reach `completed` with zero rejected
+messages. A successful new run does not erase or supersede the failed receipt;
+operators retain both records to show the failure, repair, and fresh proof.
 
 ## Start the forward durable after replay
 

--- a/internal/connectorcatalog/catalog/identity-access-secrets/okta.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets/okta.yaml
@@ -328,6 +328,63 @@ entries:
           record_selector: $.data[*]
         - coverage:
             - control_domains:
+                - asset_inventory
+                - identity_access
+              evidence_types:
+                - access_review
+                - identity_configuration
+                - source_snapshot
+              families:
+                - application
+              high_value: true
+              id: applications
+              notes:
+                - The hand-written Okta runtime emits one okta.application event per application; this exact family keeps durable events projectable during replay and forwarding.
+              support: supported
+              title: Applications
+              type: entity_family
+          default_enabled: false
+          event:
+            kind: okta.application
+            required_payload_fields:
+              - id
+            schema_ref: okta/application/v1
+            urn_kind: okta_application
+          id: application
+          id_field: id
+          label: Application
+          method: GET
+          name_field: label
+          pagination:
+            link_header: Link
+            type: link
+          path: /api/v1/apps
+          projection:
+            fields:
+              app_id: app_id|id
+              app_label: app_label|label
+              app_name: app_name|label|name
+              application_type: application_type
+              client_id: client_id
+              grant_types: grant_types
+              name: name
+              oauth2: oauth2
+              oauth_client_type: oauth_client_type
+              oauth_public_client: oauth_public_client
+              post_logout_redirect_uri_count: post_logout_redirect_uri_count
+              post_logout_redirect_uri_hosts: post_logout_redirect_uri_hosts
+              redirect_uri_count: redirect_uri_count
+              redirect_uri_hosts: redirect_uri_hosts
+              response_types: response_types
+              saml: saml
+              sign_on_mode: sign_on_mode
+              status: status
+              token_endpoint_auth_method: token_endpoint_auth_method
+              wildcard_redirect: wildcard_redirect
+            template: identity_application
+          record_selector: $[*]
+        - coverage:
+            - control_domains:
                 - logging_monitoring
               evidence_types:
                 - logging_configuration

--- a/internal/connectorcatalog/catalog/identity-access-secrets/okta.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets/okta.yaml
@@ -177,11 +177,11 @@ entries:
               families:
                 - group_membership
               high_value: true
-              id: group_memberships
+              id: group_membership_projection
               notes:
                 - The hand-written Okta runtime supplies the group identifier while reading each group's members.
               support: supported
-              title: Group memberships
+              title: Group membership event projection
               type: relationship
           default_enabled: false
           event:
@@ -337,11 +337,11 @@ entries:
               families:
                 - application
               high_value: true
-              id: applications
+              id: application_projection
               notes:
                 - The hand-written Okta runtime emits one okta.application event per application; this exact family keeps durable events projectable during replay and forwarding.
               support: supported
-              title: Applications
+              title: Application event projection
               type: entity_family
           default_enabled: false
           event:

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -279,6 +279,26 @@ func TestBuiltinOktaCatalogDeclaresComplianceIdentityEvidenceDepth(t *testing.T)
 	if !hasString(groupMemberships.Notes, "The hand-written Okta runtime supplies the group identifier while reading each group's members.") {
 		t.Fatalf("group_memberships notes = %#v, want source projection support note", groupMemberships.Notes)
 	}
+	var application *connectordefinitions.ResourceFamily
+	for index := range okta.Definition.ResourceFamilies {
+		family := &okta.Definition.ResourceFamilies[index]
+		if family.ID == "application" {
+			application = family
+			break
+		}
+	}
+	if application == nil {
+		t.Fatal("okta application compatibility family not found")
+	}
+	if application.DefaultEnabled {
+		t.Fatal("okta application compatibility family must not start a second collector")
+	}
+	if application.Event.Kind != "okta.application" || application.Event.SchemaRef != "okta/application/v1" {
+		t.Fatalf("okta application event = %#v, want durable hand-written runtime contract", application.Event)
+	}
+	if application.Projection == nil || application.Projection.Template != "identity_application" {
+		t.Fatalf("okta application projection = %#v, want native application entity", application.Projection)
+	}
 }
 
 func TestBuiltinOneLoginCatalogUsesVerifiedProviderAPI(t *testing.T) {

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -253,7 +253,7 @@ func TestBuiltinOktaCatalogDeclaresComplianceIdentityEvidenceDepth(t *testing.T)
 		{id: "user_lifecycle", dimensionType: "lifecycle_state", support: "partial", evidenceType: "identity_configuration", controlDomain: "identity_access", requiredFamily: "dormant_user"},
 		{id: "mfa_posture", dimensionType: "app_entitlement", support: "partial", evidenceType: "identity_configuration", controlDomain: "identity_access", requiredFamily: "mfa"},
 		{id: "external_accounts", dimensionType: "entity_family", support: "partial", evidenceType: "access_review", controlDomain: "identity_access", requiredFamily: "external_user"},
-		{id: "group_memberships", dimensionType: "relationship", support: "supported", evidenceType: "access_review", controlDomain: "identity_access", requiredFamily: "group_membership"},
+		{id: "group_membership_projection", dimensionType: "relationship", support: "supported", evidenceType: "access_review", controlDomain: "identity_access", requiredFamily: "group_membership"},
 		{id: "admin_membership", dimensionType: "relationship", support: "partial", evidenceType: "identity_configuration", controlDomain: "identity_access", requiredFamily: "privileged_role"},
 		{id: "app_access", dimensionType: "app_entitlement", support: "partial", evidenceType: "identity_configuration", controlDomain: "identity_access", requiredFamily: "app_assignment"},
 		{id: "identity_audit_events", dimensionType: "audit_event", support: "partial", evidenceType: "logging_configuration", controlDomain: "logging_monitoring", requiredFamily: "session"},
@@ -275,7 +275,7 @@ func TestBuiltinOktaCatalogDeclaresComplianceIdentityEvidenceDepth(t *testing.T)
 			t.Fatalf("dimension %s families = %#v, want %q", want.id, dimension.Families, want.requiredFamily)
 		}
 	}
-	groupMemberships := dimensions["group_memberships"]
+	groupMemberships := dimensions["group_membership_projection"]
 	if !hasString(groupMemberships.Notes, "The hand-written Okta runtime supplies the group identifier while reading each group's members.") {
 		t.Fatalf("group_memberships notes = %#v, want source projection support note", groupMemberships.Notes)
 	}
@@ -298,6 +298,15 @@ func TestBuiltinOktaCatalogDeclaresComplianceIdentityEvidenceDepth(t *testing.T)
 	}
 	if application.Projection == nil || application.Projection.Template != "identity_application" {
 		t.Fatalf("okta application projection = %#v, want native application entity", application.Projection)
+	}
+	seenDimensionIDs := map[string]string{}
+	for _, family := range okta.Definition.ResourceFamilies {
+		for _, dimension := range family.Coverage {
+			if owner, exists := seenDimensionIDs[dimension.ID]; exists {
+				t.Fatalf("okta coverage dimension %q is shared by families %q and %q", dimension.ID, owner, family.ID)
+			}
+			seenDimensionIDs[dimension.ID] = family.ID
+		}
 	}
 }
 

--- a/internal/connectordefinitions/classifier.go
+++ b/internal/connectordefinitions/classifier.go
@@ -111,6 +111,7 @@ func DefaultGrammar() Grammar {
 			"evidence_cas_reference",
 			"finding",
 			"group_membership",
+			"identity_application",
 			"identity_group",
 			"identity_user",
 			"policy",

--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -1576,6 +1576,8 @@ func idKeysForFamily(family familyData) []string {
 		base = append(base, "user_id", "id", "email", "primary_email", "login")
 	case "identity_group":
 		base = append(base, "group_id", "id", "group_email", "email")
+	case "identity_application":
+		base = append(base, "app_id", "application_id", "client_id", "id")
 	case "group_membership":
 		base = append(base, "membership_id", "id", "group_id", "member_id", "user_id", "email")
 	case "audit_event":
@@ -1635,6 +1637,13 @@ func attributePathsForFamily(family familyData) map[string]string {
 		base["group_name"] = "group_name|name|display_name"
 		base["domain"] = "domain|tenant_domain|organization_domain"
 		base["description"] = "description|summary"
+	case "identity_application":
+		base["app_id"] = "app_id|application_id|client_id|id"
+		base["app_name"] = "app_name|app_label|label|name"
+		base["application_type"] = "application_type|app_type|type"
+		base["client_id"] = "client_id|credentials.oauthClient.client_id"
+		base["domain"] = "domain|tenant_domain|organization_domain"
+		base["status"] = "status|state|lifecycle_state"
 	case "group_membership":
 		base["group_id"] = "group_id|group.id|groupId"
 		base["group_email"] = "group_email|group.email"
@@ -2139,6 +2148,10 @@ func fixturePayload(request normalizedRequest, family familyData) map[string]any
 		payload["group_id"] = recordID
 		payload["group_email"] = fixtureEmail(request, "group")
 		payload["group_name"] = displayName
+	case "identity_application":
+		payload["app_id"] = recordID
+		payload["app_name"] = displayName
+		payload["status"] = "ACTIVE"
 	case "group_membership":
 		payload["group_id"] = fixtureRelatedRecordID(request, "groups")
 		payload["member_id"] = fixtureRelatedRecordID(request, "users")
@@ -2214,6 +2227,10 @@ func fixtureAttributes(request normalizedRequest, family familyData) map[string]
 		attributes["group_id"] = recordID
 		attributes["group_email"] = fixtureEmail(request, "group")
 		attributes["group_name"] = displayName
+	case "identity_application":
+		attributes["app_id"] = recordID
+		attributes["app_name"] = displayName
+		attributes["status"] = "ACTIVE"
 	case "group_membership":
 		attributes["group_id"] = fixtureRelatedRecordID(request, "groups")
 		attributes["member_id"] = fixtureRelatedRecordID(request, "users")
@@ -2587,6 +2604,14 @@ func renderProjectionGo(request normalizedRequest) string {
 				fmt.Fprintf(&b, "\treturn identityGroupProjections(event, identityProjectionProfile{Provider: %s})\n", strconv.Quote(request.SourceID))
 			}
 			fmt.Fprintf(&b, "}\n\n")
+		case "identity_application":
+			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n", family.ProjectorName)
+			if projectionFamilyNeedsAugmentation(family) {
+				fmt.Fprintf(&b, "\treturn projectCatalogRuntimeWithRelationships(%s, %sProjectionResource, func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n\t\treturn identityApplicationProjections(event, identityProjectionProfile{Provider: %s})\n\t}, event)\n", strconv.Quote(request.SourceID), family.ProjectorName, strconv.Quote(request.SourceID))
+			} else {
+				fmt.Fprintf(&b, "\treturn identityApplicationProjections(event, identityProjectionProfile{Provider: %s})\n", strconv.Quote(request.SourceID))
+			}
+			fmt.Fprintf(&b, "}\n\n")
 		case "group_membership":
 			fmt.Fprintf(&b, "func %s(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {\n", family.ProjectorName)
 			if projectionFamilyNeedsAugmentation(family) {
@@ -2762,6 +2787,8 @@ func projectionTestName(sourceID string, family familyData, classOrdinal int, us
 			suffix = "IdentityUser"
 		case "identity_group":
 			suffix = "IdentityGroup"
+		case "identity_application":
+			suffix = "IdentityApplication"
 		case "group_membership":
 			suffix = "GroupMembership"
 		case "audit_event":
@@ -2813,6 +2840,10 @@ func renderProjectionFamilyTest(b *strings.Builder, sourceID string, family fami
 		fmt.Fprintf(b, "func %s(t *testing.T) {\n", testName)
 		fmt.Fprintf(b, "\tevent := &cerebrov1.EventEnvelope{Id: \"event-1\", TenantId: \"tenant\", SourceId: %s, Kind: %s, Attributes: map[string]string{\"group_id\": \"group-1\", \"group_email\": \"group@example.test\", \"group_name\": \"Group One\"}}\n", strconv.Quote(sourceID), strconv.Quote(family.EventKind))
 		fmt.Fprintf(b, "\tentities, _, err := %s(event)\n\tif err != nil {\n\t\tt.Fatalf(\"projection error = %%v\", err)\n\t}\n\tif len(entities) == 0 {\n\t\tt.Fatal(\"expected projected identity group\")\n\t}\n}\n\n", family.ProjectorName)
+	case "identity_application":
+		fmt.Fprintf(b, "func %s(t *testing.T) {\n", testName)
+		fmt.Fprintf(b, "\tevent := &cerebrov1.EventEnvelope{Id: \"event-1\", TenantId: \"tenant\", SourceId: %s, Kind: %s, Attributes: map[string]string{\"app_id\": \"app-1\", \"app_name\": \"Payroll\", \"status\": \"ACTIVE\"}}\n", strconv.Quote(sourceID), strconv.Quote(family.EventKind))
+		fmt.Fprintf(b, "\tentities, _, err := %s(event)\n\tif err != nil {\n\t\tt.Fatalf(\"projection error = %%v\", err)\n\t}\n\tif len(entities) == 0 {\n\t\tt.Fatal(\"expected projected identity application\")\n\t}\n}\n\n", family.ProjectorName)
 	case "group_membership":
 		fmt.Fprintf(b, "func %s(t *testing.T) {\n", testName)
 		fmt.Fprintf(b, "\tevent := &cerebrov1.EventEnvelope{Id: \"event-1\", TenantId: \"tenant\", SourceId: %s, Kind: %s, Attributes: map[string]string{\"group_id\": \"group-1\", \"group_email\": \"group@example.test\", \"member_id\": \"user-1\", \"member_email\": \"user@example.test\"}}\n", strconv.Quote(sourceID), strconv.Quote(family.EventKind))

--- a/internal/sourcegen/projectionspec/spec_test.go
+++ b/internal/sourcegen/projectionspec/spec_test.go
@@ -57,6 +57,7 @@ func TestClassForReturnsExpectedMappings(t *testing.T) {
 		{"alert", "alert"},
 		{"identity_user", "identity_user"},
 		{"identity_group", "identity_group"},
+		{"identity_application", "identity_application"},
 		{"group_membership", "group_membership"},
 		{"audit_event", "audit_event"},
 		{"evidence_cas_reference", "evidence_cas_reference"},

--- a/internal/sourcegen/projectionspec/templates/identity_application.yaml
+++ b/internal/sourcegen/projectionspec/templates/identity_application.yaml
@@ -1,0 +1,10 @@
+id: identity_application
+class: identity_application
+graph_label: IdentityApplication
+urn_kind_prefix: "runtime_"
+event_kind_prefix: true
+description: Application identity from an identity or access provider.
+required_attributes:
+  - tenant_id
+  - source_event_id
+  - app_id

--- a/internal/sourceprojection/catalogruntime.go
+++ b/internal/sourceprojection/catalogruntime.go
@@ -102,6 +102,13 @@ func catalogRuntimeProjectorFor(sourceID string, resource connectordefinitions.R
 		base = func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 			return identityGroupProjections(event, identityProjectionProfile{Provider: sourceID})
 		}
+	case "identity_application":
+		// Application is an identity-owned graph entity, not a generic asset.
+		// Keeping this dispatch explicit makes the classifier's support claim and
+		// the generated Go projector describe the same graph semantics as Rust.
+		base = func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+			return identityApplicationProjections(event, identityProjectionProfile{Provider: sourceID})
+		}
 	case "group_membership":
 		base = func(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 			return identityGroupMembershipProjections(event, identityProjectionProfile{Provider: sourceID})

--- a/internal/sourceprojection/catalogruntime_test.go
+++ b/internal/sourceprojection/catalogruntime_test.go
@@ -142,6 +142,11 @@ func TestCatalogRuntimeProjectorsCoverGeneratedTemplates(t *testing.T) {
 					Projection: &connectordefinitions.ProjectionSpec{Template: "identity_user"},
 				},
 				{
+					ID:         "applications",
+					Event:      connectordefinitions.EventMappingSpec{Kind: "example_catalog.application"},
+					Projection: &connectordefinitions.ProjectionSpec{Template: "identity_application"},
+				},
+				{
 					ID:         "findings",
 					Event:      connectordefinitions.EventMappingSpec{Kind: "example_catalog.finding"},
 					Projection: &connectordefinitions.ProjectionSpec{Template: "finding"},
@@ -171,6 +176,12 @@ func TestCatalogRuntimeProjectorsCoverGeneratedTemplates(t *testing.T) {
 			kind:           "example_catalog.user",
 			attributes:     map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"},
 			wantEntityType: "example_catalog.user",
+		},
+		{
+			name:           "identity application",
+			kind:           "example_catalog.application",
+			attributes:     map[string]string{"app_id": "app-1", "app_name": "Payroll", "status": "ACTIVE"},
+			wantEntityType: "example_catalog.application",
 		},
 		{
 			name:           "finding",


### PR DESCRIPTION
## Summary

- give the hand-written group-membership and application projection lanes distinct coverage-option IDs and labels
- preserve the existing user-selectable `group_memberships` and `applications` option identities
- reject duplicate Okta coverage-option IDs in the catalog contract test

## Validation

- `go test -race ./internal/connectorcatalog ./internal/connectorpreview`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/2236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->