### PR TITLE
fix: keep Okta projection scopes distinct

### DIFF
--- a/internal/connectorcatalog/catalog/identity-access-secrets/okta.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets/okta.yaml
@@ -177,11 +177,11 @@ entries:
               families:
                 - group_membership
               high_value: true
-              id: group_memberships
+              id: group_membership_projection
               notes:
                 - The hand-written Okta runtime supplies the group identifier while reading each group's members.
               support: supported
-              title: Group memberships
+              title: Group membership event projection
               type: relationship
           default_enabled: false
           event:
@@ -337,11 +337,11 @@ entries:
               families:
                 - application
               high_value: true
-              id: applications
+              id: application_projection
               notes:
                 - The hand-written Okta runtime emits one okta.application event per application; this exact family keeps durable events projectable during replay and forwarding.
               support: supported
-              title: Applications
+              title: Application event projection
               type: entity_family
           default_enabled: false
           event:

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -253,7 +253,7 @@ func TestBuiltinOktaCatalogDeclaresComplianceIdentityEvidenceDepth(t *testing.T)
 		{id: "user_lifecycle", dimensionType: "lifecycle_state", support: "partial", evidenceType: "identity_configuration", controlDomain: "identity_access", requiredFamily: "dormant_user"},
 		{id: "mfa_posture", dimensionType: "app_entitlement", support: "partial", evidenceType: "identity_configuration", controlDomain: "identity_access", requiredFamily: "mfa"},
 		{id: "external_accounts", dimensionType: "entity_family", support: "partial", evidenceType: "access_review", controlDomain: "identity_access", requiredFamily: "external_user"},
-		{id: "group_memberships", dimensionType: "relationship", support: "supported", evidenceType: "access_review", controlDomain: "identity_access", requiredFamily: "group_membership"},
+		{id: "group_membership_projection", dimensionType: "relationship", support: "supported", evidenceType: "access_review", controlDomain: "identity_access", requiredFamily: "group_membership"},
 		{id: "admin_membership", dimensionType: "relationship", support: "partial", evidenceType: "identity_configuration", controlDomain: "identity_access", requiredFamily: "privileged_role"},
 		{id: "app_access", dimensionType: "app_entitlement", support: "partial", evidenceType: "identity_configuration", controlDomain: "identity_access", requiredFamily: "app_assignment"},
 		{id: "identity_audit_events", dimensionType: "audit_event", support: "partial", evidenceType: "logging_configuration", controlDomain: "logging_monitoring", requiredFamily: "session"},
@@ -275,7 +275,7 @@ func TestBuiltinOktaCatalogDeclaresComplianceIdentityEvidenceDepth(t *testing.T)
 			t.Fatalf("dimension %s families = %#v, want %q", want.id, dimension.Families, want.requiredFamily)
 		}
 	}
-	groupMemberships := dimensions["group_memberships"]
+	groupMemberships := dimensions["group_membership_projection"]
 	if !hasString(groupMemberships.Notes, "The hand-written Okta runtime supplies the group identifier while reading each group's members.") {
 		t.Fatalf("group_memberships notes = %#v, want source projection support note", groupMemberships.Notes)
 	}
@@ -298,6 +298,15 @@ func TestBuiltinOktaCatalogDeclaresComplianceIdentityEvidenceDepth(t *testing.T)
 	}
 	if application.Projection == nil || application.Projection.Template != "identity_application" {
 		t.Fatalf("okta application projection = %#v, want native application entity", application.Projection)
+	}
+	seenDimensionIDs := map[string]string{}
+	for _, family := range okta.Definition.ResourceFamilies {
+		for _, dimension := range family.Coverage {
+			if owner, exists := seenDimensionIDs[dimension.ID]; exists {
+				t.Fatalf("okta coverage dimension %q is shared by families %q and %q", dimension.ID, owner, family.ID)
+			}
+			seenDimensionIDs[dimension.ID] = family.ID
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- give the hand-written group-membership and application projection lanes distinct coverage-option IDs and labels
- preserve the existing user-selectable `group_memberships` and `applications` option identities
- reject duplicate Okta coverage-option IDs in the catalog contract test

## Validation

- `go test -race ./internal/connectorcatalog ./internal/connectorpreview`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/writer/cerebro/pull/2237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->