### PR TITLE
fix: project Okta group replay events

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -1679,7 +1679,7 @@ mod tests {
         .unwrap();
         let summary = catalog.summary();
         assert_eq!(summary.sources, 794);
-        assert_eq!(summary.families, 3_893);
+        assert_eq!(summary.families, 3_894);
         assert_eq!(
             summary.projection_classes.values().sum::<usize>(),
             summary.families

--- a/crates/source-runtime-next/src/mapper.rs
+++ b/crates/source-runtime-next/src/mapper.rs
@@ -806,6 +806,55 @@ mod tests {
     }
 
     #[test]
+    fn okta_runtime_group_becomes_a_native_group_entity() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("okta").unwrap().clone();
+        let collection = CompleteCollection::new(
+            TenantId::parse("tenant-a").unwrap(),
+            SourceRuntimeId::parse("okta-prod").unwrap(),
+            CollectionId::parse("collection-okta-group-1").unwrap(),
+            "okta.group",
+            10,
+        )
+        .unwrap();
+        let batch = CollectedBatch {
+            scope: CollectedScope::Complete(collection),
+            records: vec![SourceRecord {
+                observation_id: ObservationId::parse("observation-okta-group-1").unwrap(),
+                family: "group".to_owned(),
+                provider_kind: "okta.group".to_owned(),
+                provider_id: "group-1".to_owned(),
+                fields: BTreeMap::from([
+                    ("group_id".to_owned(), "group-1".to_owned()),
+                    ("group_name".to_owned(), "Security".to_owned()),
+                ]),
+                payload: serde_json::json!({
+                    "id": "group-1",
+                    "profile": {"name": "Security"},
+                    "type": "OKTA_GROUP"
+                }),
+            }],
+            next_cursor: None,
+        };
+
+        let delta = CatalogGraphMapper::new(source, "v1")
+            .unwrap()
+            .map(&batch)
+            .unwrap();
+
+        assert_eq!(delta.entities().len(), 1);
+        assert!(delta.assertions().is_empty());
+        let group = &delta.entities()[0];
+        assert_eq!(group.kind(), &EntityKind::Group);
+        assert_eq!(group.label(), "Security");
+    }
+
+    #[test]
     fn okta_runtime_application_becomes_a_native_application_entity() {
         let root = repository_root();
         let catalog = SourceCatalog::load(

--- a/internal/connectorcatalog/catalog/identity-access-secrets/okta.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets/okta.yaml
@@ -170,6 +170,45 @@ entries:
           record_selector: $.data[*]
         - coverage:
             - control_domains:
+                - asset_inventory
+                - identity_access
+              evidence_types:
+                - access_review
+                - identity_configuration
+                - source_snapshot
+              families:
+                - group
+              high_value: true
+              id: group_projection
+              notes:
+                - The hand-written Okta runtime emits one okta.group event per group; this exact family keeps durable events projectable during replay and forwarding.
+              support: supported
+              title: Group event projection
+              type: entity_family
+          default_enabled: false
+          event:
+            kind: okta.group
+            required_payload_fields:
+              - id
+            schema_ref: okta/group/v1
+            urn_kind: okta_group
+          id: group
+          id_field: id
+          label: Group
+          method: GET
+          name_field: profile.name
+          pagination:
+            link_header: Link
+            type: link
+          path: /api/v1/groups
+          projection:
+            fields:
+              group_id: group_id|id
+              group_name: group_name|profile.name|name
+            template: identity_group
+          record_selector: $[*]
+        - coverage:
+            - control_domains:
                 - identity_access
               evidence_types:
                 - access_review

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -279,13 +279,28 @@ func TestBuiltinOktaCatalogDeclaresComplianceIdentityEvidenceDepth(t *testing.T)
 	if !hasString(groupMemberships.Notes, "The hand-written Okta runtime supplies the group identifier while reading each group's members.") {
 		t.Fatalf("group_memberships notes = %#v, want source projection support note", groupMemberships.Notes)
 	}
+	var group *connectordefinitions.ResourceFamily
 	var application *connectordefinitions.ResourceFamily
 	for index := range okta.Definition.ResourceFamilies {
 		family := &okta.Definition.ResourceFamilies[index]
+		if family.ID == "group" {
+			group = family
+		}
 		if family.ID == "application" {
 			application = family
-			break
 		}
+	}
+	if group == nil {
+		t.Fatal("okta group compatibility family not found")
+	}
+	if group.DefaultEnabled {
+		t.Fatal("okta group compatibility family must not start a second collector")
+	}
+	if group.Event.Kind != "okta.group" || group.Event.SchemaRef != "okta/group/v1" {
+		t.Fatalf("okta group event = %#v, want durable hand-written runtime contract", group.Event)
+	}
+	if group.Projection == nil || group.Projection.Template != "identity_group" {
+		t.Fatalf("okta group projection = %#v, want native group entity", group.Projection)
 	}
 	if application == nil {
 		t.Fatal("okta application compatibility family not found")


### PR DESCRIPTION
## Summary
- add the exact disabled `okta.group` compatibility family to the compiled catalog
- map hand-written runtime group events to native organizational group entities
- cover the catalog contract and Rust mapping path with regressions

## Cutover evidence
The sec-dev v4 Rust organizational replay failed closed in batch 7 because one `events.okta.group` record was not in the compiled catalog. The cumulative receipt stopped at 700,000 messages with 1 rejection; the forward-consumer handoff remains unmerged.

## Validation
- `cargo fmt --all -- --check` on DDESK: passed
- targeted DDESK tests: interrupted when the assigned desk instance terminated
- hosted checks are required before merge
