### PR TITLE
fix: bound source runtime backfills

### DIFF
--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -40,7 +40,7 @@ A Deep source is exempt from the flat LOC ceiling but is instead held to the **D
 | `grc` | 1195 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
 | `okta` | 2254 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 763 | Separate request plumbing from emitted record construction. |
-| `sentinelone` | 2108 | Extract API paging, agent/application readers, and shared response normalization. |
+| `sentinelone` | 2097 | Extract API paging, agent/application readers, and shared response normalization. |
 | `vulnview` | 1002 | Split feed/client access from vulnerability record normalization. |
 
 ## Cross-Source Duplication Guardrail

--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -40,7 +40,7 @@ A Deep source is exempt from the flat LOC ceiling but is instead held to the **D
 | `grc` | 1195 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
 | `okta` | 2254 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 763 | Separate request plumbing from emitted record construction. |
-| `sentinelone` | 2097 | Extract API paging, agent/application readers, and shared response normalization. |
+| `sentinelone` | 2096 | Extract API paging, agent/application readers, and shared response normalization. |
 | `vulnview` | 1002 | Split feed/client access from vulnerability record normalization. |
 
 ## Cross-Source Duplication Guardrail

--- a/internal/sourcecdk/fanout_page.go
+++ b/internal/sourcecdk/fanout_page.go
@@ -1,0 +1,110 @@
+package sourcecdk
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type fanoutPageCursor struct {
+	ParentID         string `json:"parent_id"`
+	NextParentCursor string `json:"next_parent_cursor,omitempty"`
+	AfterRecordID    string `json:"after_record_id,omitempty"`
+}
+
+// PageFanoutRecords bounds a child collection while preserving the provider's
+// parent cursor. It is intended for APIs that list parents first and expose all
+// children for one parent without child pagination.
+func PageFanoutRecords[T any](
+	rawCursor string,
+	cursorPrefix string,
+	limit int,
+	configuredParentID string,
+	resolveParent func(string) (string, string, error),
+	readRecords func(string) ([]T, error),
+	recordID func(T) string,
+) ([]T, string, error) {
+	if limit <= 0 {
+		return nil, "", fmt.Errorf("fanout page limit must be positive")
+	}
+	state, providerCursor, encoded, err := decodeFanoutPageCursor(rawCursor, cursorPrefix)
+	if err != nil {
+		return nil, "", err
+	}
+	configuredParentID = strings.TrimSpace(configuredParentID)
+	if configuredParentID != "" {
+		if !encoded && strings.TrimSpace(rawCursor) != "" {
+			return nil, "", nil
+		}
+		if state.ParentID != "" && state.ParentID != configuredParentID {
+			return nil, "", fmt.Errorf("fanout cursor parent does not match configured parent")
+		}
+		state.ParentID, state.NextParentCursor = configuredParentID, ""
+	} else if state.ParentID == "" {
+		state.ParentID, state.NextParentCursor, err = resolveParent(providerCursor)
+		if err != nil {
+			return nil, "", err
+		}
+	}
+	if state.ParentID == "" {
+		return nil, state.NextParentCursor, nil
+	}
+	records, err := readRecords(state.ParentID)
+	if err != nil {
+		return nil, "", err
+	}
+	sort.Slice(records, func(i, j int) bool { return recordID(records[i]) < recordID(records[j]) })
+	for index, record := range records {
+		id := strings.TrimSpace(recordID(record))
+		if id == "" || (index > 0 && id == strings.TrimSpace(recordID(records[index-1]))) {
+			return nil, "", fmt.Errorf("fanout record identity must be non-empty and unique")
+		}
+	}
+	start := sort.Search(len(records), func(index int) bool { return recordID(records[index]) > state.AfterRecordID })
+	end := start + limit
+	if end > len(records) {
+		end = len(records)
+	}
+	page := records[start:end]
+	if end == len(records) {
+		return page, state.NextParentCursor, nil
+	}
+	state.AfterRecordID = recordID(records[end-1])
+	next, err := encodeFanoutPageCursor(state, cursorPrefix)
+	if err != nil {
+		return nil, "", err
+	}
+	return page, next, nil
+}
+
+func decodeFanoutPageCursor(raw string, prefix string) (fanoutPageCursor, string, bool, error) {
+	trimmed := strings.TrimSpace(raw)
+	if !strings.HasPrefix(trimmed, prefix) {
+		return fanoutPageCursor{}, trimmed, false, nil
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(trimmed, prefix))
+	if err != nil {
+		return fanoutPageCursor{}, "", true, fmt.Errorf("decode fanout cursor: %w", err)
+	}
+	var state fanoutPageCursor
+	if err := json.Unmarshal(payload, &state); err != nil {
+		return fanoutPageCursor{}, "", true, fmt.Errorf("decode fanout cursor payload: %w", err)
+	}
+	state.ParentID = strings.TrimSpace(state.ParentID)
+	state.NextParentCursor = strings.TrimSpace(state.NextParentCursor)
+	state.AfterRecordID = strings.TrimSpace(state.AfterRecordID)
+	if state.ParentID == "" {
+		return fanoutPageCursor{}, "", true, fmt.Errorf("fanout cursor parent is required")
+	}
+	return state, "", true, nil
+}
+
+func encodeFanoutPageCursor(state fanoutPageCursor, prefix string) (string, error) {
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return "", fmt.Errorf("encode fanout cursor: %w", err)
+	}
+	return prefix + base64.RawURLEncoding.EncodeToString(payload), nil
+}

--- a/internal/sourcecdk/fanout_page_test.go
+++ b/internal/sourcecdk/fanout_page_test.go
@@ -1,0 +1,57 @@
+package sourcecdk
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPageFanoutRecordsBoundsChildrenAndPreservesParentCursor(t *testing.T) {
+	parents := map[string]struct {
+		id   string
+		next string
+	}{
+		"":              {id: "parent-1", next: "provider-next"},
+		"provider-next": {id: "parent-2"},
+	}
+	records := map[string][]string{
+		"parent-1": {"record-3", "record-1", "record-2"},
+		"parent-2": {"record-4"},
+	}
+	resolve := func(cursor string) (string, string, error) {
+		parent := parents[cursor]
+		return parent.id, parent.next, nil
+	}
+	read := func(parentID string) ([]string, error) { return records[parentID], nil }
+	identity := func(record string) string { return record }
+
+	first, cursor, err := PageFanoutRecords("", "test:", 2, "", resolve, read, identity)
+	if err != nil {
+		t.Fatalf("PageFanoutRecords(first) error = %v", err)
+	}
+	if !reflect.DeepEqual(first, []string{"record-1", "record-2"}) || cursor == "" {
+		t.Fatalf("first = %v, cursor = %q", first, cursor)
+	}
+	second, cursor, err := PageFanoutRecords(cursor, "test:", 2, "", resolve, read, identity)
+	if err != nil {
+		t.Fatalf("PageFanoutRecords(second) error = %v", err)
+	}
+	if !reflect.DeepEqual(second, []string{"record-3"}) || cursor != "provider-next" {
+		t.Fatalf("second = %v, cursor = %q", second, cursor)
+	}
+	third, cursor, err := PageFanoutRecords(cursor, "test:", 2, "", resolve, read, identity)
+	if err != nil {
+		t.Fatalf("PageFanoutRecords(third) error = %v", err)
+	}
+	if !reflect.DeepEqual(third, []string{"record-4"}) || cursor != "" {
+		t.Fatalf("third = %v, cursor = %q", third, cursor)
+	}
+}
+
+func TestPageFanoutRecordsRejectsDuplicateIdentity(t *testing.T) {
+	_, _, err := PageFanoutRecords("", "test:", 2, "parent", nil,
+		func(string) ([]string, error) { return []string{"duplicate", "duplicate"}, nil },
+		func(record string) string { return record })
+	if err == nil {
+		t.Fatal("PageFanoutRecords() error = nil, want duplicate identity rejection")
+	}
+}

--- a/sources/archetype/source.go
+++ b/sources/archetype/source.go
@@ -112,10 +112,10 @@ func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, c
 		return sourcecdk.NotModifiedPull(checkpoint), nil
 	}
 	repos := archetypeclient.Repositories(ctx, clientSettings)
-	vulnerabilities := make([][]vulnerabilityRecord, len(newScans))
+	vulnerabilities, vulnerabilitiesUnavailable := make([][]vulnerabilityRecord, len(newScans)), make([]bool, len(newScans))
 	if st.family != "scan" {
 		var err error
-		vulnerabilities, err = archetypeclient.VulnerabilitiesForScans(ctx, clientSettings, newScans)
+		vulnerabilities, vulnerabilitiesUnavailable, err = archetypeclient.VulnerabilitiesForScans(ctx, clientSettings, newScans)
 		if err != nil {
 			return sourcecdk.Pull{}, err
 		}
@@ -123,7 +123,7 @@ func (s *Source) ReadWithCheckpoint(ctx context.Context, cfg sourcecdk.Config, c
 	knowledgeRepos := map[int]bool{}
 	events := []*primitives.Event{}
 	for i, scan := range newScans {
-		events = append(events, scanEvent(st, scan, repos[scan.RepositoryID]))
+		events = append(events, scanEvent(st, scan, repos[scan.RepositoryID], archetypeclient.VulnerabilityCollectionState(st.family != "scan", vulnerabilitiesUnavailable[i])))
 		if st.family == "scan" {
 			continue
 		}
@@ -221,8 +221,8 @@ func parseFanoutConcurrency(raw string) (int, error) {
 	}
 	return value, nil
 }
-func scanEvent(st settings, scan scanRecord, repo repositoryRecord) *primitives.Event {
-	attrs := map[string]string{"scan_id": strconv.Itoa(scan.ID), "repository_id": strconv.Itoa(scan.RepositoryID), "status": scan.Status, "owner": repo.Owner, "repo": repo.Name, "source_product": sourceID}
+func scanEvent(st settings, scan scanRecord, repo repositoryRecord, vulnerabilityCollectionState string) *primitives.Event {
+	attrs := map[string]string{"scan_id": strconv.Itoa(scan.ID), "repository_id": strconv.Itoa(scan.RepositoryID), "status": scan.Status, "owner": repo.Owner, "repo": repo.Name, "source_product": sourceID, "vulnerability_collection_state": vulnerabilityCollectionState}
 	return event(st, "archetype.scan", "archetype-scan-"+strconv.Itoa(scan.ID), "archetype/scan/v1", archetypeclient.ScanTime(scan, time.Now().UTC()), attrs, scan)
 }
 func vulnerabilityEvent(st settings, scan scanRecord, vuln vulnerabilityRecord, repo repositoryRecord) *primitives.Event {

--- a/sources/archetype/source_test.go
+++ b/sources/archetype/source_test.go
@@ -75,8 +75,48 @@ func TestSourceReadEmitsScanAndVulnerabilityEvents(t *testing.T) {
 	if got := pull.Events[1].GetAttributes()["repo"]; got != "Archetype" {
 		t.Fatalf("vulnerability repo attr = %q, want Archetype", got)
 	}
+	if got := pull.Events[0].GetAttributes()["vulnerability_collection_state"]; got != "complete" {
+		t.Fatalf("scan vulnerability_collection_state = %q, want complete", got)
+	}
 	if got := pull.Checkpoint.GetCursorOpaque(); got != "1" {
 		t.Fatalf("checkpoint cursor = %q, want 1", got)
+	}
+}
+
+func TestSourceReadMarksUnavailableVulnerabilityCollection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/scans":
+			writeJSON(t, w, []map[string]any{{"id": 6142, "repository_id": 7, "status": "completed"}})
+		case "/api/v1/repositories":
+			writeJSON(t, w, []map[string]any{{"id": 7, "owner": "WriterInternal", "name": "Archetype"}})
+		case "/api/v1/scans/6142/vulnerabilities":
+			http.Error(w, "scan result expired", http.StatusBadRequest)
+		case "/api/v1/repositories/7/knowledge":
+			writeJSON(t, w, map[string]any{"entries": []map[string]any{}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"base_url":  server.URL,
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 || pull.Events[0].GetKind() != "archetype.scan" {
+		t.Fatalf("events = %#v, want one preserved scan event", pull.Events)
+	}
+	if got := pull.Events[0].GetAttributes()["vulnerability_collection_state"]; got != "unavailable" {
+		t.Fatalf("vulnerability_collection_state = %q, want unavailable", got)
 	}
 }
 

--- a/sources/gcp/source_test.go
+++ b/sources/gcp/source_test.go
@@ -1057,7 +1057,7 @@ func TestReadLiveGCPAuditLogsWithCheckpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadWithCheckpoint(%s) error = %v", familyAudit, err)
 	}
-	if len(pull.Events) != 1 || pull.Events[0].GetId() != "gcp-audit-new-audit" {
+	if len(pull.Events) != 1 || !strings.HasPrefix(pull.Events[0].GetId(), "gcp-audit-") {
 		t.Fatalf("events = %#v, want only new audit", pull.Events)
 	}
 	if pull.ShortCircuitReason != sourcecdk.PullShortCircuitReasonWatermarkReached {

--- a/sources/internal/archetypeclient/client.go
+++ b/sources/internal/archetypeclient/client.go
@@ -146,8 +146,9 @@ func RepositoryKnowledge(ctx context.Context, st Settings, repositoryID int) ([]
 	return response.Entries, true
 }
 
-func VulnerabilitiesForScans(ctx context.Context, st Settings, scans []Scan) ([][]Vulnerability, error) {
+func VulnerabilitiesForScans(ctx context.Context, st Settings, scans []Scan) ([][]Vulnerability, []bool, error) {
 	out := make([][]Vulnerability, len(scans))
+	unavailable := make([]bool, len(scans))
 	group, groupCtx := errgroup.WithContext(ctx)
 	fanout := st.FanoutConcurrency
 	if fanout <= 0 {
@@ -159,11 +160,29 @@ func VulnerabilitiesForScans(ctx context.Context, st Settings, scans []Scan) ([]
 		group.Go(func() error {
 			var vulns []Vulnerability
 			if err := Get(groupCtx, st, fmt.Sprintf("/scans/%d/vulnerabilities", scan.ID), &vulns); err != nil {
+				// Archetype returns 400 when a retained scan no longer has a
+				// queryable vulnerability result. Preserve the scan as evidence,
+				// but mark its vulnerability collection unavailable instead of
+				// aborting every other scan in the page.
+				if sourcecdk.IsHTTPStatus(err, http.StatusBadRequest) {
+					unavailable[i] = true
+					return nil
+				}
 				return err
 			}
 			out[i] = vulns
 			return nil
 		})
 	}
-	return out, group.Wait()
+	return out, unavailable, group.Wait()
+}
+
+func VulnerabilityCollectionState(requested bool, unavailable bool) string {
+	if !requested {
+		return "not_requested"
+	}
+	if unavailable {
+		return "unavailable"
+	}
+	return "complete"
 }

--- a/sources/internal/archetypeclient/client_test.go
+++ b/sources/internal/archetypeclient/client_test.go
@@ -25,7 +25,7 @@ func TestVulnerabilitiesForScansDefaultsZeroFanoutConcurrency(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	got, err := VulnerabilitiesForScans(ctx, Settings{
+	got, unavailable, err := VulnerabilitiesForScans(ctx, Settings{
 		SourceID:      "archetype",
 		BaseURL:       server.URL,
 		AllowLoopback: true,
@@ -35,5 +35,37 @@ func TestVulnerabilitiesForScansDefaultsZeroFanoutConcurrency(t *testing.T) {
 	}
 	if len(got) != 2 || len(got[0]) != 1 || got[0][0].ID != 10 || len(got[1]) != 1 || got[1][0].ID != 20 {
 		t.Fatalf("VulnerabilitiesForScans() = %#v, want ordered vulnerability batches", got)
+	}
+	if unavailable[0] || unavailable[1] {
+		t.Fatalf("unavailable = %v, want all false", unavailable)
+	}
+}
+
+func TestVulnerabilitiesForScansPreservesUnavailableScan(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/scans/1/vulnerabilities":
+			http.Error(w, "scan result expired", http.StatusBadRequest)
+		case "/scans/2/vulnerabilities":
+			_, _ = w.Write([]byte(`[{"id":20,"scan_id":2,"severity":"critical"}]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	got, unavailable, err := VulnerabilitiesForScans(context.Background(), Settings{
+		SourceID:      "archetype",
+		BaseURL:       server.URL,
+		AllowLoopback: true,
+	}, []Scan{{ID: 1}, {ID: 2}})
+	if err != nil {
+		t.Fatalf("VulnerabilitiesForScans() error = %v", err)
+	}
+	if len(got) != 2 || len(got[0]) != 0 || len(got[1]) != 1 || got[1][0].ID != 20 {
+		t.Fatalf("VulnerabilitiesForScans() = %#v, want unavailable then complete batch", got)
+	}
+	if !unavailable[0] || unavailable[1] {
+		t.Fatalf("unavailable = %v, want [true false]", unavailable)
 	}
 }

--- a/sources/internal/gcpcloud/events.go
+++ b/sources/internal/gcpcloud/events.go
@@ -2,7 +2,9 @@ package gcpcloud
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"regexp"
 	"sort"
@@ -102,6 +104,7 @@ func computeAggregatedScopeField(scope string, fallback string) string {
 
 type AuditRecord struct {
 	InsertID     string        `json:"insertId"`
+	LogName      string        `json:"logName"`
 	Timestamp    string        `json:"timestamp"`
 	ProtoPayload AuditProto    `json:"protoPayload"`
 	Resource     AuditResource `json:"resource"`
@@ -135,6 +138,8 @@ func AuditEvent(settings Settings, record AuditRecord) (*primitives.Event, error
 		"event_name":         record.ProtoPayload.MethodName,
 		"event_type":         record.ProtoPayload.MethodName,
 		"family":             "audit",
+		"log_insert_id":      record.InsertID,
+		"log_name":           record.LogName,
 		"resource_id":        resourceID,
 		"resource_name":      resourceID,
 		"resource_type":      firstNonEmpty(record.Resource.Type, record.ProtoPayload.ServiceName, "resource"),
@@ -149,7 +154,19 @@ func AuditEvent(settings Settings, record AuditRecord) (*primitives.Event, error
 			occurredAt = parsed.UTC()
 		}
 	}
-	return sourceEventAt(settings, "gcp-audit-"+firstNonEmpty(record.InsertID, record.ProtoPayload.MethodName), "gcp.audit", "gcp/audit/v1", payload, attributes, occurredAt)
+	return sourceEventAt(settings, auditEventID(settings, record, resourceID), "gcp.audit", "gcp/audit/v1", payload, attributes, occurredAt)
+}
+
+func auditEventID(settings Settings, record AuditRecord, resourceID string) string {
+	identity := strings.Join([]string{
+		settings.ProjectID,
+		record.LogName,
+		firstNonEmpty(record.InsertID, record.ProtoPayload.MethodName),
+		record.Timestamp,
+		resourceID,
+	}, "\x00")
+	digest := sha256.Sum256([]byte(identity))
+	return "gcp-audit-" + fmt.Sprintf("%x", digest[:16])
 }
 
 func publicPrincipal(value string) bool {

--- a/sources/internal/gcpcloud/events_test.go
+++ b/sources/internal/gcpcloud/events_test.go
@@ -2,6 +2,44 @@ package gcpcloud
 
 import "testing"
 
+func TestAuditEventIdentityDisambiguatesProviderInsertID(t *testing.T) {
+	settings := Settings{ProjectID: "writer-prod", TenantID: "writer"}
+	first := AuditRecord{
+		InsertID:  "shared-insert-id",
+		LogName:   "projects/writer-prod/logs/cloudaudit.googleapis.com%2Factivity",
+		Timestamp: "2026-08-11T00:00:00Z",
+		ProtoPayload: AuditProto{
+			MethodName:   "storage.buckets.update",
+			ResourceName: "projects/_/buckets/one",
+		},
+	}
+	second := first
+	second.Timestamp = "2026-08-11T00:00:01Z"
+	second.ProtoPayload.ResourceName = "projects/_/buckets/two"
+
+	firstEvent, err := AuditEvent(settings, first)
+	if err != nil {
+		t.Fatalf("AuditEvent(first) error = %v", err)
+	}
+	repeated, err := AuditEvent(settings, first)
+	if err != nil {
+		t.Fatalf("AuditEvent(repeated) error = %v", err)
+	}
+	secondEvent, err := AuditEvent(settings, second)
+	if err != nil {
+		t.Fatalf("AuditEvent(second) error = %v", err)
+	}
+	if firstEvent.GetId() != repeated.GetId() {
+		t.Fatalf("repeated id = %q, want %q", repeated.GetId(), firstEvent.GetId())
+	}
+	if firstEvent.GetId() == secondEvent.GetId() {
+		t.Fatalf("distinct audit events share id %q", firstEvent.GetId())
+	}
+	if firstEvent.GetAttributes()["log_insert_id"] != first.InsertID || firstEvent.GetAttributes()["log_name"] != first.LogName {
+		t.Fatalf("audit identity attributes = %#v", firstEvent.GetAttributes())
+	}
+}
+
 func TestGCSObjectEventDoesNotDowngradeMetadataClassification(t *testing.T) {
 	event, err := GCSObjectEvent(Settings{ProjectID: "writer-prod"}, GCSObjectRecord{
 		ID:       "data/training.csv/1",

--- a/sources/sentinelone/list.go
+++ b/sources/sentinelone/list.go
@@ -10,6 +10,8 @@ import (
 	"github.com/writer/cerebro/internal/sourcecdk"
 )
 
+const applicationCursorPrefix = "cerebro-sentinelone-application-v1:"
+
 func (s *Source) listThreats(ctx context.Context, settings settings, cursor string, limit int) ([]threatRecord, string, error) {
 	query := buildPagedQuery(cursor, limit)
 	sourcecdk.AddQueryParam(query, "createdAt__gte", settings.since)
@@ -53,49 +55,36 @@ func (s *Source) listActivities(ctx context.Context, settings settings, cursor s
 }
 
 func (s *Source) listApplications(ctx context.Context, settings settings, cursor string, limit int) ([]applicationRecord, string, error) {
-	if strings.TrimSpace(settings.agentID) == "" {
-		agents, next, err := s.listAgents(ctx, settings, cursor, limit)
-		if err != nil {
-			return nil, "", err
-		}
-		records := make([]applicationRecord, 0)
-		for _, agent := range agents {
-			agentID := strings.TrimSpace(agent.ID)
-			if agentID == "" {
-				continue
+	return sourcecdk.PageFanoutRecords(cursor, applicationCursorPrefix, limit, settings.agentID,
+		func(parentCursor string) (string, string, error) {
+			agents, next, err := s.listAgents(ctx, settings, parentCursor, 1)
+			if err != nil || len(agents) == 0 {
+				return "", next, err
 			}
-			applications, _, err := s.listApplicationsForAgent(ctx, settings, agentID)
-			if err != nil {
-				return nil, "", err
-			}
-			records = append(records, applications...)
-		}
-		return records, next, nil
-	}
-	if cursor != "" {
-		return nil, "", nil
-	}
-	return s.listApplicationsForAgent(ctx, settings, settings.agentID)
+			return strings.TrimSpace(agents[0].ID), next, nil
+		}, func(agentID string) ([]applicationRecord, error) {
+			return s.listApplicationsForAgent(ctx, settings, agentID)
+		}, func(record applicationRecord) string { return applicationID(settings, record) })
 }
 
-func (s *Source) listApplicationsForAgent(ctx context.Context, settings settings, agentID string) ([]applicationRecord, string, error) {
+func (s *Source) listApplicationsForAgent(ctx context.Context, settings settings, agentID string) ([]applicationRecord, error) {
 	query := url.Values{}
 	sourcecdk.AddQueryParam(query, "ids", agentID)
 	var resp struct {
 		Data []json.RawMessage `json:"data"`
 	}
 	if err := s.getJSON(ctx, settings, "/web/api/v2.1/agents/applications", query, &resp); err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	records := make([]applicationRecord, 0, len(resp.Data))
 	for _, item := range resp.Data {
 		var record applicationRecord
 		if err := json.Unmarshal(item, &record); err != nil {
-			return nil, "", fmt.Errorf("decode sentinelone application record: %w", err)
+			return nil, fmt.Errorf("decode sentinelone application record: %w", err)
 		}
 		record.AgentID = agentID
 		record.setRaw(cloneRaw(item))
 		records = append(records, record)
 	}
-	return records, "", nil
+	return records, nil
 }

--- a/sources/sentinelone/source_test.go
+++ b/sources/sentinelone/source_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -218,6 +219,71 @@ func TestApplicationFamilyKeepsAgentCursorWhenPageHasNoApplications(t *testing.T
 	}
 	if got := second.Events[0].Attributes["agent_id"]; got != "A-2" {
 		t.Fatalf("second agent_id = %q, want A-2", got)
+	}
+}
+
+func TestApplicationFamilyBoundsExpandedAgentInventory(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/web/api/v2.1/agents":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data":       []map[string]any{{"id": "A-1", "computerName": "host-A-1"}},
+				"pagination": map[string]any{},
+			})
+		case "/web/api/v2.1/agents/applications":
+			applications := make([]map[string]any, 0, 5)
+			for index := 5; index >= 1; index-- {
+				applications = append(applications, map[string]any{
+					"name":      fmt.Sprintf("Application %d", index),
+					"publisher": "Example Inc",
+					"version":   "1.0.0",
+				})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": applications})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackBaseURL = true
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": server.URL,
+		"family":   "application",
+		"per_page": "2",
+		"token":    fixtureToken,
+	})
+
+	var cursor *cerebrov1.SourceCursor
+	ids := make([]string, 0, 5)
+	for page := 0; page < 3; page++ {
+		pull, err := source.Read(context.Background(), cfg, cursor)
+		if err != nil {
+			t.Fatalf("Read(page %d) error = %v", page+1, err)
+		}
+		if len(pull.Events) > 2 {
+			t.Fatalf("len(page %d Events) = %d, want at most 2", page+1, len(pull.Events))
+		}
+		for _, event := range pull.Events {
+			ids = append(ids, event.GetId())
+		}
+		cursor = pull.NextCursor
+	}
+	if len(ids) != 5 {
+		t.Fatalf("event ids = %q, want five applications", ids)
+	}
+	if cursor != nil {
+		t.Fatalf("final cursor = %#v, want nil", cursor)
+	}
+	for index := 1; index < len(ids); index++ {
+		if ids[index-1] >= ids[index] {
+			t.Fatalf("event ids = %q, want stable ascending pages", ids)
+		}
 	}
 }
 

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -38,7 +38,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"grc":             1195,
 	"okta":            2254,
 	"panopticon":      763,
-	"sentinelone":     2108,
+	"sentinelone":     2097,
 	"vulnview":        1002,
 }
 

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -38,7 +38,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"grc":             1195,
 	"okta":            2254,
 	"panopticon":      763,
-	"sentinelone":     2097,
+	"sentinelone":     2096,
 	"vulnview":        1002,
 }
 


### PR DESCRIPTION
## Summary

- preserve scan evidence when a vulnerability result is unavailable
- derive stable scoped audit event identities
- bound parent-child source fan-out with durable cursors
- ratchet the provider package size ceiling downward

## Validation

- focused Go source and Source CDK tests
- pinned golangci-lint v2.11.4
- architecture guardrails
