### PR TITLE
ci: update Rust candidate catalog receipt

### DIFF
--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -179,7 +179,7 @@ jobs:
           '
           summary="$(docker run --rm "${CANDIDATE_IMAGE}" catalog-summary)"
           test "$(jq -r .sources <<<"${summary}")" -eq 794
-          test "$(jq -r .families <<<"${summary}")" -eq 3893
+          test "$(jq -r .families <<<"${summary}")" -eq 3894
       - name: Start disposable PostgreSQL, Neo4j, and JetStream
         run: |
           set -euo pipefail
@@ -247,7 +247,7 @@ jobs:
             | .checks += [
                 {name:"rust_entrypoint",status:"passed",evidence:"image starts cerebro-platform directly"},
                 {name:"go_binary_absent",status:"passed",evidence:"/usr/local/bin/cerebro is absent"},
-                {name:"source_catalog",status:"passed",evidence:"794 sources and 3893 families loaded"}
+                {name:"source_catalog",status:"passed",evidence:"794 sources and 3894 families loaded"}
               ]
           ' .dist/rust-only-e2e/rust-only-e2e-receipt.json \
             > .dist/rust-only-e2e/receipt.tmp


### PR DESCRIPTION
## Summary
- update the Rust-only candidate image assertion to the current 3,894-family catalog
- bind the E2E receipt to the same current catalog count

## Validation
- `actionlint .github/workflows/rust-only-candidate.yml`
- Ruby YAML parse
- `git diff --check`

DDESK repository streaming returned an invalid-state error for this second workspace; hosted checks are the execution fallback for this two-line workflow-only correction.