### PR TITLE
fix: restore bounded graph rollback reads

### DIFF
--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -1929,6 +1929,146 @@ func endpointOwnerIDCleanupPrefixes(tenantID string, sources []string) ([]string
 	return stalePrefixes, replacementPrefixes
 }
 
+// GetEntityNeighborhood retains the bounded compatibility read used by
+// explicit legacy rollback and shadow verification. Rust remains the default
+// product-read authority; callers reach this method only through a configured
+// compatibility mode.
+func (s *Store) GetEntityNeighborhood(ctx context.Context, rootURN string, limit int) (*ports.EntityNeighborhood, error) {
+	normalizedRootURN := strings.TrimSpace(rootURN)
+	if normalizedRootURN == "" {
+		return nil, errors.New("root urn is required")
+	}
+	if err := s.requireConfigured(); err != nil {
+		return nil, err
+	}
+	neighborhood := &ports.EntityNeighborhood{
+		Neighbors: []*ports.NeighborhoodNode{},
+		Relations: []*ports.NeighborhoodRelation{},
+	}
+	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
+		neighborhood = &ports.EntityNeighborhood{
+			Neighbors: []*ports.NeighborhoodNode{},
+			Relations: []*ports.NeighborhoodRelation{},
+		}
+		root, err := lookupNeighborhoodNode(ctx, tx, normalizedRootURN)
+		if err != nil {
+			return nil, err
+		}
+		neighborhood.Root = root
+		if limit <= 0 {
+			return nil, nil
+		}
+		neighbors := make(map[string]*ports.NeighborhoodNode)
+		relations := make(map[string]*ports.NeighborhoodRelation)
+		remaining, err := collectNeighborhoodRows(ctx, tx, `MATCH (root:Entity {urn: $root_urn})-[r:RELATION]->(neighbor:Entity)
+RETURN neighbor.urn AS neighbor_urn, neighbor.entity_type AS neighbor_type, neighbor.label AS neighbor_label,
+       root.urn AS from_urn, r.relation AS relation_type, neighbor.urn AS to_urn, coalesce(r.attributes_json, '{}') AS attributes_json
+ORDER BY neighbor.urn, r.relation LIMIT $limit`, map[string]any{"root_urn": normalizedRootURN, "limit": limit}, limit, neighbors, relations)
+		if err != nil {
+			return nil, err
+		}
+		if remaining > 0 {
+			if _, err := collectNeighborhoodRows(ctx, tx, `MATCH (neighbor:Entity)-[r:RELATION]->(root:Entity {urn: $root_urn})
+RETURN neighbor.urn AS neighbor_urn, neighbor.entity_type AS neighbor_type, neighbor.label AS neighbor_label,
+       neighbor.urn AS from_urn, r.relation AS relation_type, root.urn AS to_urn, coalesce(r.attributes_json, '{}') AS attributes_json
+ORDER BY neighbor.urn, r.relation LIMIT $limit`, map[string]any{"root_urn": normalizedRootURN, "limit": remaining}, remaining, neighbors, relations); err != nil {
+				return nil, err
+			}
+		}
+		neighborhood.Neighbors = neighborhoodNodes(neighbors)
+		neighborhood.Relations = neighborhoodRelations(relations)
+		return nil, nil
+	}); err != nil {
+		return nil, err
+	}
+	return neighborhood, nil
+}
+
+// GetEntityNeighborhoods retains the batched compatibility read used by
+// explicit legacy rollback and shadow verification. It preserves the same
+// per-root edge ordering as GetEntityNeighborhood while collapsing frontier
+// expansion into three read queries instead of three queries per root.
+func (s *Store) GetEntityNeighborhoods(ctx context.Context, rootURNs []string, limit int) (map[string]*ports.EntityNeighborhood, error) {
+	roots := normalizeNeighborhoodRootURNs(rootURNs)
+	if len(roots) == 0 {
+		return map[string]*ports.EntityNeighborhood{}, nil
+	}
+	if err := s.requireConfigured(); err != nil {
+		return nil, err
+	}
+	neighborhoods := make(map[string]*ports.EntityNeighborhood, len(roots))
+	if _, err := s.read(ctx, func(ctx context.Context, tx neo4jdriver.ManagedTransaction) (any, error) {
+		accumulators := make(map[string]*neighborhoodAccumulator, len(roots))
+		result, err := tx.Run(ctx, `MATCH (e:Entity)
+WHERE e.urn IN $root_urns
+RETURN e.urn, e.entity_type, e.label`, map[string]any{"root_urns": roots})
+		if err != nil {
+			return nil, fmt.Errorf("query graph roots: %w", err)
+		}
+		for result.Next(ctx) {
+			record := result.Record()
+			root := &ports.NeighborhoodNode{
+				URN:        stringValue(record.Values[0]),
+				EntityType: stringValue(record.Values[1]),
+				Label:      stringValue(record.Values[2]),
+			}
+			accumulators[root.URN] = &neighborhoodAccumulator{
+				neighborhood: &ports.EntityNeighborhood{
+					Root:      root,
+					Neighbors: []*ports.NeighborhoodNode{},
+					Relations: []*ports.NeighborhoodRelation{},
+				},
+				neighbors: make(map[string]*ports.NeighborhoodNode),
+				relations: make(map[string]*ports.NeighborhoodRelation),
+				remaining: limit,
+			}
+		}
+		if err := result.Err(); err != nil {
+			return nil, fmt.Errorf("query graph roots: %w", err)
+		}
+		presentRoots := make([]string, 0, len(roots))
+		for _, rootURN := range roots {
+			if accumulators[rootURN] != nil {
+				presentRoots = append(presentRoots, rootURN)
+			}
+		}
+		if limit > 0 && len(presentRoots) > 0 {
+			params := map[string]any{"root_urns": presentRoots, "limit": limit}
+			if err := collectBatchedNeighborhoodRows(ctx, tx, outgoingNeighborhoodBatchQuery, params, accumulators); err != nil {
+				return nil, err
+			}
+			incomingRootsByLimit := make(map[int][]string)
+			for _, rootURN := range presentRoots {
+				remaining := accumulators[rootURN].remaining
+				if remaining > 0 {
+					incomingRootsByLimit[remaining] = append(incomingRootsByLimit[remaining], rootURN)
+				}
+			}
+			incomingLimits := make([]int, 0, len(incomingRootsByLimit))
+			for remaining := range incomingRootsByLimit {
+				incomingLimits = append(incomingLimits, remaining)
+			}
+			slices.Sort(incomingLimits)
+			for _, remaining := range incomingLimits {
+				params := map[string]any{"root_urns": incomingRootsByLimit[remaining], "limit": remaining}
+				if err := collectBatchedNeighborhoodRows(ctx, tx, incomingNeighborhoodBatchQuery, params, accumulators); err != nil {
+					return nil, err
+				}
+			}
+		}
+		for _, rootURN := range presentRoots {
+			accumulator := accumulators[rootURN]
+			accumulator.neighborhood.Neighbors = neighborhoodNodes(accumulator.neighbors)
+			accumulator.neighborhood.Relations = neighborhoodRelations(accumulator.relations)
+			neighborhoods[rootURN] = accumulator.neighborhood
+		}
+		return nil, nil
+	}); err != nil {
+		return nil, err
+	}
+	return neighborhoods, nil
+}
+
 // ExecuteReadCypher runs one bounded read-only Cypher query and returns its rows.
 //
 // The store enforces a row cap to keep graph rules from accidentally pulling unbounded result
@@ -2889,6 +3029,138 @@ RETURN count(a)`, params)
 	return updated == 1, nil
 }
 
+func lookupNeighborhoodNode(ctx context.Context, tx neo4jdriver.ManagedTransaction, rootURN string) (*ports.NeighborhoodNode, error) {
+	result, err := tx.Run(ctx, "MATCH (e:Entity {urn: $urn}) RETURN e.urn, e.entity_type, e.label", map[string]any{"urn": rootURN})
+	if err != nil {
+		return nil, fmt.Errorf("query graph root %q: %w", rootURN, err)
+	}
+	if !result.Next(ctx) {
+		if err := result.Err(); err != nil {
+			return nil, fmt.Errorf("query graph root %q: %w", rootURN, err)
+		}
+		return nil, fmt.Errorf("%w: %s", ports.ErrGraphEntityNotFound, rootURN)
+	}
+	record := result.Record()
+	return &ports.NeighborhoodNode{
+		URN:        stringValue(record.Values[0]),
+		EntityType: stringValue(record.Values[1]),
+		Label:      stringValue(record.Values[2]),
+	}, result.Err()
+}
+
+type neighborhoodAccumulator struct {
+	neighborhood *ports.EntityNeighborhood
+	neighbors    map[string]*ports.NeighborhoodNode
+	relations    map[string]*ports.NeighborhoodRelation
+	remaining    int
+}
+
+const outgoingNeighborhoodBatchQuery = `UNWIND $root_urns AS root_urn
+MATCH (root:Entity {urn: root_urn})
+CALL {
+  WITH root
+  MATCH (root)-[r:RELATION]->(neighbor:Entity)
+  RETURN neighbor.urn AS neighbor_urn, neighbor.entity_type AS neighbor_type, neighbor.label AS neighbor_label,
+         root.urn AS from_urn, r.relation AS relation_type, neighbor.urn AS to_urn, coalesce(r.attributes_json, '{}') AS attributes_json
+  ORDER BY neighbor.urn, r.relation
+  LIMIT $limit
+}
+RETURN root_urn, neighbor_urn, neighbor_type, neighbor_label, from_urn, relation_type, to_urn, attributes_json
+ORDER BY root_urn, neighbor_urn, relation_type`
+
+const incomingNeighborhoodBatchQuery = `UNWIND $root_urns AS root_urn
+MATCH (root:Entity {urn: root_urn})
+CALL {
+  WITH root
+  MATCH (neighbor:Entity)-[r:RELATION]->(root)
+  RETURN neighbor.urn AS neighbor_urn, neighbor.entity_type AS neighbor_type, neighbor.label AS neighbor_label,
+         neighbor.urn AS from_urn, r.relation AS relation_type, root.urn AS to_urn, coalesce(r.attributes_json, '{}') AS attributes_json
+  ORDER BY neighbor.urn, r.relation
+  LIMIT $limit
+}
+RETURN root_urn, neighbor_urn, neighbor_type, neighbor_label, from_urn, relation_type, to_urn, attributes_json
+ORDER BY root_urn, neighbor_urn, relation_type`
+
+func normalizeNeighborhoodRootURNs(rootURNs []string) []string {
+	roots := make([]string, 0, len(rootURNs))
+	seen := make(map[string]bool, len(rootURNs))
+	for _, raw := range rootURNs {
+		rootURN := strings.TrimSpace(raw)
+		if rootURN == "" || seen[rootURN] {
+			continue
+		}
+		seen[rootURN] = true
+		roots = append(roots, rootURN)
+	}
+	return roots
+}
+
+func collectNeighborhoodRows(ctx context.Context, tx neo4jdriver.ManagedTransaction, query string, params map[string]any, remaining int, neighbors map[string]*ports.NeighborhoodNode, relations map[string]*ports.NeighborhoodRelation) (int, error) {
+	result, err := tx.Run(ctx, query, params)
+	if err != nil {
+		return remaining, fmt.Errorf("query graph neighborhood: %w", err)
+	}
+	for result.Next(ctx) {
+		record := result.Record()
+		neighbor := &ports.NeighborhoodNode{
+			URN:        stringValue(record.Values[0]),
+			EntityType: stringValue(record.Values[1]),
+			Label:      stringValue(record.Values[2]),
+		}
+		attributes, err := decodeGraphAttributes(stringValue(record.Values[6]))
+		if err != nil {
+			return remaining, fmt.Errorf("decode graph neighborhood relation attributes: %w", err)
+		}
+		relation := &ports.NeighborhoodRelation{
+			FromURN:    stringValue(record.Values[3]),
+			Relation:   stringValue(record.Values[4]),
+			ToURN:      stringValue(record.Values[5]),
+			Attributes: attributes,
+		}
+		neighbors[neighbor.URN] = neighbor
+		relations[relation.FromURN+"|"+relation.Relation+"|"+relation.ToURN] = relation
+		remaining--
+		if remaining == 0 {
+			break
+		}
+	}
+	return remaining, result.Err()
+}
+
+func collectBatchedNeighborhoodRows(ctx context.Context, tx neo4jdriver.ManagedTransaction, query string, params map[string]any, accumulators map[string]*neighborhoodAccumulator) error {
+	result, err := tx.Run(ctx, query, params)
+	if err != nil {
+		return fmt.Errorf("query graph neighborhoods: %w", err)
+	}
+	for result.Next(ctx) {
+		record := result.Record()
+		rootURN := stringValue(record.Values[0])
+		accumulator := accumulators[rootURN]
+		if accumulator == nil || accumulator.remaining <= 0 {
+			continue
+		}
+		neighbor := &ports.NeighborhoodNode{
+			URN:        stringValue(record.Values[1]),
+			EntityType: stringValue(record.Values[2]),
+			Label:      stringValue(record.Values[3]),
+		}
+		attributes, err := decodeGraphAttributes(stringValue(record.Values[7]))
+		if err != nil {
+			return fmt.Errorf("decode graph neighborhood relation attributes: %w", err)
+		}
+		relation := &ports.NeighborhoodRelation{
+			FromURN:    stringValue(record.Values[4]),
+			Relation:   stringValue(record.Values[5]),
+			ToURN:      stringValue(record.Values[6]),
+			Attributes: attributes,
+		}
+		accumulator.neighbors[neighbor.URN] = neighbor
+		accumulator.relations[relation.FromURN+"|"+relation.Relation+"|"+relation.ToURN] = relation
+		accumulator.remaining--
+	}
+	return result.Err()
+}
+
 func graphAttributesJSON(attributes map[string]string) (string, error) {
 	if len(attributes) == 0 {
 		return `{}`, nil
@@ -3005,6 +3277,49 @@ func mergeAttributeValue(key, existing, incoming string) string {
 		return existing
 	}
 	return incoming
+}
+
+func decodeGraphAttributes(payload string) (map[string]string, error) {
+	trimmed := strings.TrimSpace(payload)
+	if trimmed == "" || trimmed == "{}" {
+		return nil, nil
+	}
+	attributes := map[string]string{}
+	if err := json.Unmarshal([]byte(trimmed), &attributes); err != nil {
+		return nil, err
+	}
+	return attributes, nil
+}
+
+func neighborhoodNodes(values map[string]*ports.NeighborhoodNode) []*ports.NeighborhoodNode {
+	nodes := make([]*ports.NeighborhoodNode, 0, len(values))
+	for _, node := range values {
+		nodes = append(nodes, node)
+	}
+	slices.SortFunc(nodes, func(left *ports.NeighborhoodNode, right *ports.NeighborhoodNode) int {
+		switch {
+		case left.URN < right.URN:
+			return -1
+		case left.URN > right.URN:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return nodes
+}
+
+func neighborhoodRelations(values map[string]*ports.NeighborhoodRelation) []*ports.NeighborhoodRelation {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	relations := make([]*ports.NeighborhoodRelation, 0, len(keys))
+	for _, key := range keys {
+		relations = append(relations, values[key])
+	}
+	return relations
 }
 
 func ingestRunReturnQuery(prefix string) string {

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -39,6 +39,41 @@ func TestProjectedEntityMergePreservesExistingLabelsForFallbackLabels(t *testing
 	}
 }
 
+func TestNeighborhoodRelationsOrdersByStoredRelationKey(t *testing.T) {
+	relations := map[string]*ports.NeighborhoodRelation{
+		"urn:cerebro:writer:asset:b|depends_on|urn:cerebro:writer:asset:a": {
+			FromURN:  "urn:cerebro:writer:asset:b",
+			Relation: "depends_on",
+			ToURN:    "urn:cerebro:writer:asset:a",
+		},
+		"urn:cerebro:writer:asset:a|owns|urn:cerebro:writer:asset:c": {
+			FromURN:  "urn:cerebro:writer:asset:a",
+			Relation: "owns",
+			ToURN:    "urn:cerebro:writer:asset:c",
+		},
+		"urn:cerebro:writer:asset:a|depends_on|urn:cerebro:writer:asset:b": {
+			FromURN:  "urn:cerebro:writer:asset:a",
+			Relation: "depends_on",
+			ToURN:    "urn:cerebro:writer:asset:b",
+		},
+	}
+
+	result := neighborhoodRelations(relations)
+
+	if len(result) != 3 {
+		t.Fatalf("neighborhoodRelations() len = %d, want 3", len(result))
+	}
+	if result[0].FromURN != "urn:cerebro:writer:asset:a" || result[0].Relation != "depends_on" || result[0].ToURN != "urn:cerebro:writer:asset:b" {
+		t.Fatalf("neighborhoodRelations()[0] = %#v, want asset:a depends_on asset:b", result[0])
+	}
+	if result[1].FromURN != "urn:cerebro:writer:asset:a" || result[1].Relation != "owns" || result[1].ToURN != "urn:cerebro:writer:asset:c" {
+		t.Fatalf("neighborhoodRelations()[1] = %#v, want asset:a owns asset:c", result[1])
+	}
+	if result[2].FromURN != "urn:cerebro:writer:asset:b" || result[2].Relation != "depends_on" || result[2].ToURN != "urn:cerebro:writer:asset:a" {
+		t.Fatalf("neighborhoodRelations()[2] = %#v, want asset:b depends_on asset:a", result[2])
+	}
+}
+
 func TestScanIngestRunRecordIncludesCheckpointTerminalState(t *testing.T) {
 	record := &neo4jdriver.Record{Values: []any{
 		"run-1", "runtime-1", "github", "writer", "checkpoint-1", "page-2", false,
@@ -521,6 +556,13 @@ func TestNeo4jDockerProjectionAndQueries(t *testing.T) {
 	}
 	if relationCounts["maintains"] != 1 || relationCounts["tracks"] != 1 || relationCounts["missing"] != 0 {
 		t.Fatalf("RelationCounts() = %#v, want maintains=1 tracks=1 missing=0", relationCounts)
+	}
+	neighborhood, err := store.GetEntityNeighborhood(ctx, user.URN, 5)
+	if err != nil {
+		t.Fatalf("GetEntityNeighborhood() error = %v", err)
+	}
+	if neighborhood.Root == nil || neighborhood.Root.URN != user.URN || len(neighborhood.Neighbors) != 1 || len(neighborhood.Relations) != 1 {
+		t.Fatalf("GetEntityNeighborhood() = %#v", neighborhood)
 	}
 	target := &ports.ProjectedEntity{URN: "urn:cerebro:writer:grc_target:target-1", TenantID: "writer", SourceID: "grc", EntityType: "grc.target", Label: "target-1"}
 	source := &ports.ProjectedEntity{URN: "urn:cerebro:writer:source:grc", TenantID: "writer", SourceID: "grc", EntityType: "source", Label: "grc"}

--- a/tools/archtests/rust_organizational_platform_test.go
+++ b/tools/archtests/rust_organizational_platform_test.go
@@ -186,12 +186,12 @@ func TestRustOrganizationalPlatformBoundary(t *testing.T) {
 	}
 
 	goNeo4jStore := readText(t, filepath.Join(root, "internal/graphstore/neo4j/store.go"))
-	for _, forbidden := range []string{
+	for _, rollbackCompatibility := range []string{
 		"func (s *Store) GetEntityNeighborhood(",
 		"func (s *Store) GetEntityNeighborhoods(",
 	} {
-		if strings.Contains(goNeo4jStore, forbidden) {
-			t.Errorf("Go Neo4j store restored retired product-read authority %q", forbidden)
+		if !strings.Contains(goNeo4jStore, rollbackCompatibility) {
+			t.Errorf("Go Neo4j store removed required rollback compatibility %q", rollbackCompatibility)
 		}
 	}
 	for _, retained := range []string{


### PR DESCRIPTION
## Summary

- restore the bounded Neo4j neighborhood compatibility methods required by explicit legacy rollback and shadow verification
- keep Rust as the default product-read authority
- preserve the architecture guard so removing the rollback boundary fails deterministically

## Failure addressed

Releases after v2.1.756 could not start with `CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE=shadow` or `legacy` because the Neo4j store no longer implemented the typed compatibility port. That also made the protected legacy rollback drill impossible to execute before Rust authority promotion.

## Validation

- DDESK: `go test -count=1 ./internal/graphstore/neo4j`
- hosted: all Go test, race, and lint shards; structural checks; release smoke; Rust-authority browser integration
- `git diff --check`
- exact-image seeded graph and Docker smoke remain hosted merge gates

## Authority boundary

The restored methods are supplied only as the configured compatibility reader. Authority mode continues to use Rust for bounded product reads; raw Cypher compatibility remains unchanged.