### PR TITLE
Allow bounded graph readiness warm-up

### DIFF
--- a/crates/organizational-store/src/neo4j.rs
+++ b/crates/organizational-store/src/neo4j.rs
@@ -138,7 +138,10 @@ WHERE state.ready = true
 SET state.graph_revision = $graph_revision
 "#;
 
-const HEALTH_TIMEOUT: Duration = Duration::from_secs(2);
+// A fresh ECS task can spend several seconds establishing the first routed Bolt
+// connection. Keep readiness bounded, but do not kill an otherwise healthy
+// authority during that one-time connection warm-up.
+const HEALTH_TIMEOUT: Duration = Duration::from_secs(10);
 const PROJECTION_BATCH_SIZE: usize = 1_000;
 
 const LIFECYCLE_FILTER: &str = r#"
@@ -1250,7 +1253,7 @@ impl AgentGraph for Neo4jProjector {
             .await
             .map_err(|_| {
                 ContextError::BackendUnavailable(
-                    "Neo4j readiness query exceeded 2 seconds".to_owned(),
+                    "Neo4j readiness query exceeded 10 seconds".to_owned(),
                 )
             })?
             .map_err(context_backend)
@@ -2030,6 +2033,11 @@ mod tests {
     use cerebro_agent_context::{FactQuery, QueryAbsentEdge, QueryDirection, QueryEdge, QueryNode};
 
     use super::*;
+
+    #[test]
+    fn readiness_allows_one_bounded_connection_warmup() {
+        assert_eq!(HEALTH_TIMEOUT, Duration::from_secs(10));
+    }
 
     #[test]
     fn projection_is_tenant_scoped_batched_and_uses_generic_relation_edges() {


### PR DESCRIPTION
## Summary

- allow the first routed Neo4j readiness query up to 10 seconds
- keep the readiness check bounded and preserve fail-closed startup
- add a regression test for the warm-up budget

## Validation

- `cargo fmt --check`
- `cargo test -p cerebro-organizational-store readiness_allows_one_bounded_connection_warmup`
- `cargo clippy -p cerebro-organizational-store --all-targets -- -D warnings`