### PR TITLE
Stream model-authored Slack progress updates

### DIFF
--- a/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
+++ b/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
@@ -25,6 +25,13 @@ export interface RustWakeExecutionReceipt {
   state: "awaiting_delivery";
 }
 
+export interface RustAgentProgressUpdate {
+  occurredAt: string;
+  phase: "refining" | "scoping" | "working";
+  sequence: number;
+  status: string;
+}
+
 export interface RustWakeDeliveryLease {
   commitment_ref: string;
   delivery_attempt_ref: string;
@@ -110,6 +117,7 @@ export class CerebroAskClient {
     requestId: string;
     signal: AbortSignal;
     threadRef: string;
+    onProgress?: (update: RustAgentProgressUpdate) => Promise<void>;
     workingState?: {
       active_lane?: CerebroAskResult["executionLane"];
       current_request: string;
@@ -129,7 +137,13 @@ export class CerebroAskClient {
       || message.messageRef !== undefined
       || message.receivedAt !== undefined
     );
-    const response = await this.fetchImpl(`${this.options.agentRuntimeUrl}/v1/turns/run`, {
+    let turnComplete = false;
+    const progressTask = input.onProgress
+      ? this.followAgentTurnProgress(input, () => turnComplete)
+      : undefined;
+    let response: Response;
+    try {
+      response = await this.fetchImpl(`${this.options.agentRuntimeUrl}/v1/turns/run`, {
       method: "POST",
       headers: {
         Accept: "application/json",
@@ -174,12 +188,16 @@ export class CerebroAskClient {
         working_state: input.workingState ?? null,
       }),
       signal: input.signal,
-    }).catch((error: unknown) => {
-      if (input.signal.aborted) {
-        throw new CerebroAskError("timed_out", "The Rust agent did not finish before the turn deadline.");
-      }
-      throw new CerebroAskError("unavailable", errorMessage(error));
-    });
+      }).catch((error: unknown) => {
+        if (input.signal.aborted) {
+          throw new CerebroAskError("timed_out", "The Rust agent did not finish before the turn deadline.");
+        }
+        throw new CerebroAskError("unavailable", errorMessage(error));
+      });
+    } finally {
+      turnComplete = true;
+      await progressTask;
+    }
     if (!response.ok) {
       throw new CerebroAskError(
         sourceState(response.status),
@@ -254,6 +272,59 @@ export class CerebroAskClient {
       safeRefusal: true,
       traceId: input.requestId,
     };
+  }
+
+  private async followAgentTurnProgress(
+    input: {
+      onProgress?: (update: RustAgentProgressUpdate) => Promise<void>;
+      requestId: string;
+      signal: AbortSignal;
+      threadRef: string;
+    },
+    turnComplete: () => boolean,
+  ): Promise<void> {
+    if (!this.options.agentRuntimeUrl || !input.onProgress) return;
+    let afterSequence = 0;
+    let lastStatus = "";
+    const poll = async (): Promise<void> => {
+      const query = new URLSearchParams({
+        after_sequence: String(afterSequence),
+        request_id: input.requestId,
+        thread_ref: input.threadRef,
+      });
+      const response = await this.fetchImpl(
+        `${this.options.agentRuntimeUrl}/v1/turns/progress?${query}`,
+        { headers: { Accept: "application/json" }, signal: input.signal },
+      );
+      if (!response.ok) return;
+      const progress = parseAgentTurnProgress(await response.json());
+      afterSequence = progress.latestSequence;
+      for (const update of progress.updates) {
+        if (update.status === lastStatus) continue;
+        try {
+          await input.onProgress?.(update);
+          lastStatus = update.status;
+        } catch {
+          // A failed progress edit must not discard the terminal answer.
+        }
+      }
+    };
+    while (!turnComplete() && !input.signal.aborted) {
+      await delay(750);
+      if (turnComplete() || input.signal.aborted) break;
+      try {
+        await poll();
+      } catch {
+        // Progress polling is best-effort; the exact turn remains authoritative.
+      }
+    }
+    if (!input.signal.aborted) {
+      try {
+        await poll();
+      } catch {
+        // The final response can still be delivered when progress is unavailable.
+      }
+    }
   }
 
   async recordAgentTurnDelivery(input: {
@@ -552,6 +623,52 @@ type RustAgentTurnOutcome =
   | {
       outcome: "ignored";
     };
+
+function parseAgentTurnProgress(value: unknown): {
+  latestSequence: number;
+  updates: RustAgentProgressUpdate[];
+} {
+  const progress = objectWithKeys(value, [
+    "latest_sequence",
+    "schema_version",
+    "updates",
+  ], "agent turn progress");
+  if (
+    progress.schema_version !== "agent-turn-progress/v1"
+    || !Number.isSafeInteger(progress.latest_sequence)
+    || Number(progress.latest_sequence) < 0
+    || !Array.isArray(progress.updates)
+  ) {
+    throw new CerebroAskError("unavailable", "The Rust agent progress response is invalid.");
+  }
+  const updates = progress.updates.map((value) => {
+    const update = objectWithKeys(value, [
+      "occurred_at",
+      "phase",
+      "sequence",
+      "status",
+    ], "agent turn progress update");
+    if (
+      !canonicalTimestamp(update.occurred_at)
+      || !["refining", "scoping", "working"].includes(String(update.phase))
+      || !positiveInteger(update.sequence)
+      || !text(update.status)
+    ) {
+      throw new CerebroAskError("unavailable", "A Rust agent progress update is invalid.");
+    }
+    return {
+      occurredAt: String(update.occurred_at),
+      phase: update.phase as RustAgentProgressUpdate["phase"],
+      sequence: Number(update.sequence),
+      status: String(update.status),
+    };
+  });
+  return { latestSequence: Number(progress.latest_sequence), updates };
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
 
 function parseWakeRunResponse(value: unknown): RustWakeExecutionReceipt | undefined {
   const response = objectWithKeys(value, ["wake"], "wake execution response");

--- a/apps/slack-companion-host/src/runtime/slack-runtime.ts
+++ b/apps/slack-companion-host/src/runtime/slack-runtime.ts
@@ -40,6 +40,7 @@ import {
   approvalCommandCode,
   type CerebroAskHistoryMessage,
   type CerebroAskResult,
+  type RustAgentProgressUpdate,
 } from "./cerebro-ask-client.js";
 import type { FileAgentApprovalStore } from "./agent-approval-store.js";
 import {
@@ -171,6 +172,7 @@ export interface AssistantQuestionInput {
   threadContext?: string | readonly CerebroAskHistoryMessage[];
   text: string;
   threadRef: string;
+  onProgress?: (update: RustAgentProgressUpdate) => Promise<void>;
   workingState?: SlackThreadWorkingStateV1;
 }
 
@@ -315,6 +317,7 @@ export class AssistantQuestionService {
           requestId: turnRequestId,
           signal: this.timeoutSignal(budget.latency_budget_ms),
           threadRef: input.threadRef,
+          ...(input.onProgress === undefined ? {} : { onProgress: input.onProgress }),
           ...(input.workingState === undefined
             ? {}
             : {
@@ -1493,6 +1496,18 @@ export async function handleSlackMention(input: {
       threadContext,
       text: input.event.text,
       threadRef: scratchpadRef,
+      ...(input.priorDeliveryAttempt
+        ? {}
+        : {
+            onProgress: async (update: RustAgentProgressUpdate) => {
+              await input.leaseGuard?.();
+              await input.client.chat.update({
+                channel: input.event.channel,
+                text: formatEnvironmentMessage(input.config, update.status),
+                ts: deliveredMessageTs,
+              });
+            },
+          }),
       ...(scratchpad?.working_state === undefined
         ? {}
         : { workingState: scratchpad.working_state }),

--- a/apps/slack-companion-host/test/off-slack-transport.test.ts
+++ b/apps/slack-companion-host/test/off-slack-transport.test.ts
@@ -119,12 +119,23 @@ test("transport replay reuses the metadata-bound Slack message", async () => {
   const root = await mkdtemp(join(tmpdir(), "cerebro-off-slack-replay-"));
   try {
     let candidateCalls = 0;
+    let progressCalls = 0;
     const askClient = new CerebroAskClient({
       agentRuntimeUrl: "http://127.0.0.1:8091",
       answerAuthority: rejectingLegacyAuthority(),
       apiKey: "unused",
       baseUrl: "https://legacy.example.com",
-      fetchImpl: async () => {
+      fetchImpl: async (url, init) => {
+        if (String(url).includes("/v1/turns/progress")) {
+          progressCalls += 1;
+          return Response.json({
+            latest_sequence: 0,
+            request_id: "slack-request-progress",
+            schema_version: "agent-turn-progress/v1",
+            updates: [],
+          });
+        }
+        assert.equal(init?.method, "POST");
         candidateCalls += 1;
         return Response.json({
           evidence_refs: [],
@@ -172,6 +183,7 @@ test("transport replay reuses the metadata-bound Slack message", async () => {
     ]);
     assert.deepEqual(replay.operations.map((operation) => operation.method), ["chat.update"]);
     assert.equal(candidateCalls, 2);
+    assert.equal(progressCalls, 1);
   } finally {
     await rm(root, { force: true, recursive: true });
   }

--- a/apps/slack-companion-host/test/runtime-host.test.ts
+++ b/apps/slack-companion-host/test/runtime-host.test.ts
@@ -596,6 +596,72 @@ test("Slack uses the Rust agent turn endpoint without calling the legacy ask rou
   assert.equal(result.citationValidationPassed, true);
 });
 
+test("Slack delivers model-authored Rust progress while the turn is running", async () => {
+  const requests: Request[] = [];
+  const updates: string[] = [];
+  const client = new CerebroAskClient({
+    agentRuntimeUrl: "http://127.0.0.1:8091",
+    answerAuthority: testAnswerAuthority,
+    apiKey: "unused",
+    baseUrl: "https://legacy.example.com",
+    fetchImpl: async (input, init) => {
+      const request = new Request(input, init);
+      requests.push(request);
+      if (new URL(request.url).pathname === "/v1/turns/progress") {
+        return Response.json({
+          latest_sequence: 7,
+          schema_version: "agent-turn-progress/v1",
+          updates: [{
+            occurred_at: "2026-08-11T07:00:01Z",
+            phase: "scoping",
+            sequence: 5,
+            status: "I’m narrowing to production identity risk because it best answers the operator’s decision.",
+          }, {
+            occurred_at: "2026-08-11T07:00:02Z",
+            phase: "working",
+            sequence: 7,
+            status: "I’m checking whether current access evidence supports that focus before expanding it.",
+          }],
+        });
+      }
+      return Response.json({
+        evidence_refs: ["evidence://graph/current"],
+        final_state: "answered",
+        lane: "investigate",
+        markdown: "The current identity risk is verified.",
+        outcome: "delivered",
+        schema_version: "agent-turn-result/v1",
+        tool_call_count: 2,
+      });
+    },
+    tenantId: "writer",
+  });
+
+  await client.runAgentTurn({
+    actorRef: "slack-user:U-ONE",
+    assessmentAt: "2026-08-11T07:00:00Z",
+    onProgress: async (update) => {
+      updates.push(update.status);
+    },
+    question: "What is scariest in production?",
+    requestId: "request-progress",
+    signal: new AbortController().signal,
+    threadRef: "slack-thread:T-ONE:C-ONE:thread-one",
+  });
+
+  assert.deepEqual(updates, [
+    "I’m narrowing to production identity risk because it best answers the operator’s decision.",
+    "I’m checking whether current access evidence supports that focus before expanding it.",
+  ]);
+  const progressRequest = requests.find((request) =>
+    new URL(request.url).pathname === "/v1/turns/progress"
+  );
+  assert.equal(
+    new URL(progressRequest?.url ?? "").searchParams.get("request_id"),
+    "request-progress",
+  );
+});
+
 test("Slack acknowledges a pending Rust response only after transport delivery", async () => {
   const requests: Request[] = [];
   const client = new CerebroAskClient({

--- a/crates/agent-runtime/src/session.rs
+++ b/crates/agent-runtime/src/session.rs
@@ -2280,6 +2280,11 @@ pub async fn run_session_turn_recorded(
         .collect::<BTreeMap<_, _>>();
     let prior_commitment_checkpoint = prior_commitment_checkpoint(&session, &trigger);
     let (resumed, mut plan, turn_observations) = resume_turn_state(&session, &input.request_id);
+    let mut plan_progress_index = if resumed {
+        resumed_plan_progress_count(&session, &input.request_id)
+    } else {
+        0
+    };
     if matches!(trigger, SessionTurnTrigger::Operator)
         && plan
             .as_ref()
@@ -2474,6 +2479,24 @@ pub async fn run_session_turn_recorded(
                     journal,
                 )
                 .await?;
+                plan_progress_index = 0;
+                if matches!(trigger, SessionTurnTrigger::Operator) {
+                    let progress_phase = if plan.is_some() {
+                        "refining"
+                    } else {
+                        "scoping"
+                    };
+                    emit_next_plan_progress(
+                        &session,
+                        &input.assessment_at,
+                        &mut events,
+                        &proposed,
+                        &mut plan_progress_index,
+                        progress_phase,
+                        journal,
+                    )
+                    .await?;
+                }
                 plan = Some(proposed);
                 repairs = 0;
                 repair_feedback.clear();
@@ -2612,6 +2635,18 @@ pub async fn run_session_turn_recorded(
                         )
                         .await?;
                     }
+                }
+                if matches!(trigger, SessionTurnTrigger::Operator) {
+                    emit_next_plan_progress(
+                        &session,
+                        &input.assessment_at,
+                        &mut events,
+                        &established,
+                        &mut plan_progress_index,
+                        "working",
+                        journal,
+                    )
+                    .await?;
                 }
                 let results = join_all(
                     calls
@@ -4897,6 +4932,28 @@ fn resume_turn_state(
     (true, plan, observations)
 }
 
+fn resumed_plan_progress_count(session: &AgentSession, request_id: &str) -> usize {
+    let Some(started_index) = session.events.iter().rposition(|event| {
+        matches!(
+            &event.event,
+            SessionEvent::TurnStarted {
+                request_id: started,
+            } if started == request_id
+        )
+    }) else {
+        return 0;
+    };
+    let plan_index = session.events[started_index..]
+        .iter()
+        .rposition(|event| matches!(event.event, SessionEvent::PlanEstablished { .. }))
+        .map_or(started_index, |index| started_index + index);
+    session.events[plan_index + 1..]
+        .iter()
+        .take_while(|event| !matches!(event.event, SessionEvent::PlanEstablished { .. }))
+        .filter(|event| matches!(event.event, SessionEvent::Progressed { .. }))
+        .count()
+}
+
 fn prior_read_observations(
     session: &AgentSession,
     assessment_at: OffsetDateTime,
@@ -5102,6 +5159,33 @@ async fn emit_event(
     journal
         .record(events.last().expect("an emitted event was appended"))
         .await
+}
+
+async fn emit_next_plan_progress(
+    session: &AgentSession,
+    occurred_at: &str,
+    events: &mut Vec<SessionEventRecord>,
+    plan: &ResearchPlan,
+    next_index: &mut usize,
+    phase: &str,
+    journal: &dyn SessionJournal,
+) -> Result<(), AgentRuntimeError> {
+    let Some(status) = plan.user_visible_work.get(*next_index) else {
+        return Ok(());
+    };
+    emit_event(
+        session,
+        occurred_at,
+        events,
+        SessionEvent::Progressed {
+            phase: phase.into(),
+            status: status.trim().into(),
+        },
+        journal,
+    )
+    .await?;
+    *next_index += 1;
+    Ok(())
 }
 
 async fn emit_final_events(
@@ -5834,6 +5918,18 @@ pub fn validate_plan(
     {
         return Err(AgentRuntimeError::InvalidFinal(
             "research plan selected an unavailable tool".into(),
+        ));
+    }
+    if plan.user_visible_work.len() > 4
+        || plan
+            .user_visible_work
+            .iter()
+            .any(|status| status.trim().is_empty() || !bounded(status, MAX_TEXT_BYTES))
+        || plan.user_visible_work.iter().collect::<BTreeSet<_>>().len()
+            != plan.user_visible_work.len()
+    {
+        return Err(AgentRuntimeError::InvalidFinal(
+            "user-visible plan updates must contain at most four unique bounded messages".into(),
         ));
     }
     if let Some(follow_through) = &plan.follow_through {
@@ -12544,10 +12640,22 @@ mod tests {
     async fn one_loop_plans_reads_reviews_and_prepares_delivery() {
         let mut candidate = draft();
         candidate.message = format!("Unreviewed prefix. {}", candidate.message);
+        let mut progress_plan = plan();
+        progress_plan.user_visible_work = vec![
+            "I’m narrowing to connector alpha because it is the decision-relevant source.".into(),
+            "I’m checking its current state before drawing a conclusion.".into(),
+        ];
+        let mut revised_plan = progress_plan.clone();
+        revised_plan.decision =
+            "The current observation confirms connector alpha is the relevant focus.".into();
+        revised_plan.user_visible_work = vec![
+            "The current observation confirms this focus; I’m reconciling it with the requested outcome."
+                .into(),
+        ];
         let model = ScriptedSessionModel {
             decisions: Mutex::new(VecDeque::from([
                 SessionModelDecision::EstablishPlanAndInvoke {
-                    plan: plan(),
+                    plan: progress_plan,
                     calls: vec![ToolCall {
                         call_id: "call:1".into(),
                         tool_id: "connector.read".into(),
@@ -12555,6 +12663,7 @@ mod tests {
                         input: json!({"connector_ref": "connector:alpha"}),
                     }],
                 },
+                SessionModelDecision::EstablishPlan { plan: revised_plan },
                 SessionModelDecision::Finish { draft: candidate },
             ])),
         };
@@ -12593,6 +12702,38 @@ mod tests {
             events
                 .iter()
                 .any(|event| matches!(event.event, SessionEvent::PlanEstablished { .. }))
+        );
+        assert!(events.iter().any(|event| matches!(
+            &event.event,
+            SessionEvent::Progressed { phase, status }
+                if phase == "scoping"
+                    && status == "I’m narrowing to connector alpha because it is the decision-relevant source."
+        )));
+        let progress = events
+            .iter()
+            .filter_map(|event| match &event.event {
+                SessionEvent::Progressed { phase, status } => {
+                    Some((phase.as_str(), status.as_str()))
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            progress,
+            vec![
+                (
+                    "scoping",
+                    "I’m narrowing to connector alpha because it is the decision-relevant source."
+                ),
+                (
+                    "working",
+                    "I’m checking its current state before drawing a conclusion."
+                ),
+                (
+                    "refining",
+                    "The current observation confirms this focus; I’m reconciling it with the requested outcome."
+                ),
+            ]
         );
         assert!(
             !events

--- a/crates/cerebro-platform/src/slack_agent.rs
+++ b/crates/cerebro-platform/src/slack_agent.rs
@@ -94,6 +94,21 @@ pub(super) struct SlackAgentModelAttestation {
 }
 
 #[derive(Clone, Debug, serde::Serialize)]
+pub struct AgentTurnProgress {
+    pub schema_version: &'static str,
+    pub latest_sequence: u64,
+    pub updates: Vec<AgentTurnProgressUpdate>,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct AgentTurnProgressUpdate {
+    pub sequence: u64,
+    pub occurred_at: String,
+    pub phase: String,
+    pub status: String,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct AgentWakeTurn {
     pub commitment_ref: String,
     pub request_id: String,
@@ -129,6 +144,34 @@ impl SlackAgentService {
 
     pub(super) fn model_attestation(&self) -> SlackAgentModelAttestation {
         self.model.attestation()
+    }
+
+    pub async fn turn_progress(
+        &self,
+        thread_ref: &str,
+        request_id: &str,
+        after_sequence: u64,
+    ) -> Result<AgentTurnProgress, AgentRuntimeError> {
+        if thread_ref.trim().is_empty()
+            || request_id.trim().is_empty()
+            || thread_ref.len() > 8 * 1024
+            || request_id.len() > 8 * 1024
+        {
+            return Err(AgentRuntimeError::InvalidRequest(
+                "turn progress identity is invalid".into(),
+            ));
+        }
+        let store = self.sessions.as_ref().ok_or_else(|| {
+            AgentRuntimeError::ModelUnavailable("durable session store is not configured".into())
+        })?;
+        let Some(session) = store.load_by_thread(&self.tenant_id, thread_ref).await? else {
+            return Ok(AgentTurnProgress {
+                schema_version: "agent-turn-progress/v1",
+                latest_sequence: after_sequence,
+                updates: Vec::new(),
+            });
+        };
+        Ok(project_turn_progress(&session, request_id, after_sequence))
     }
 
     async fn initialize(tenant_id: String) -> Result<Self, Box<dyn Error>> {
@@ -847,6 +890,52 @@ fn validate_delivery_receipt(
         ));
     }
     Ok(())
+}
+
+fn project_turn_progress(
+    session: &AgentSession,
+    request_id: &str,
+    after_sequence: u64,
+) -> AgentTurnProgress {
+    let Some(started_index) = session.events.iter().rposition(|record| {
+        matches!(
+            &record.event,
+            SessionEvent::TurnStarted { request_id: started } if started == request_id
+        )
+    }) else {
+        return AgentTurnProgress {
+            schema_version: "agent-turn-progress/v1",
+            latest_sequence: after_sequence,
+            updates: Vec::new(),
+        };
+    };
+    let updates = session.events[started_index..]
+        .iter()
+        .take_while(|record| {
+            !matches!(
+                &record.event,
+                SessionEvent::TurnStarted { request_id: started } if started != request_id
+            )
+        })
+        .filter(|record| record.sequence > after_sequence)
+        .filter_map(|record| match &record.event {
+            SessionEvent::Progressed { phase, status } => Some(AgentTurnProgressUpdate {
+                sequence: record.sequence,
+                occurred_at: record.occurred_at.clone(),
+                phase: phase.clone(),
+                status: status.clone(),
+            }),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let latest_sequence = updates
+        .last()
+        .map_or(after_sequence, |update| update.sequence);
+    AgentTurnProgress {
+        schema_version: "agent-turn-progress/v1",
+        latest_sequence,
+        updates,
+    }
 }
 
 fn is_sha256_digest(value: &str) -> bool {
@@ -2957,7 +3046,7 @@ Return one flat JSON object with decision, plan, calls, and draft every time. pl
 - In converse, current-system facts explicitly supplied by the operator may be used as attributed premises for a confidence boundary, implication, or verification plan. Say what follows from the premise without saying Cerebro independently observed it. A green dashboard supplied by the operator can support “given that premise, the service appears up”; it cannot support “I am confident the service is healthy” or “I verified the user path.” One successful run supports only that exact run; it does not establish general route reliability, untouched code, unchanged architecture, or any other change-scope fact the operator did not supply. Do not substitute a coverage-gap refusal when the operator asked only for reasoning from supplied premises.
 - When the operator asks generally what security questions Cerebro is good at, answer with reasoning strengths rather than an operational inventory: separating fact from inference, connecting evidence to risk and decisions, finding the exact missing proof, and defining a bounded owner, trigger, and closure condition. Keep it natural and concise. Do not claim named tools, provider access, live data, scheduling, or execution without a current capability observation. This is a real answer, not a coverage-gap fallback.
 - When the requested lane is converse and the operator is appraising this exchange, answer the human question directly and candidly from the conversation. Do not replace it with a security-graph boundary, a capability inventory, a current-state lookup, or a generic invitation. Describe no release, deployment, integration, tool binding, verified improvement, or completed work without current evidence.
-- Before any evidence tool, establish_plan once. The plan must name the decision, lane, resolved entities, required claims, selected tools, stop conditions, short user-visible work, and follow_through. user_visible_work is authored by you, not by the Rust host. For a broad or ambiguous request, make its first item a concise natural-language scope note that says what slice you chose, why that slice best answers the operator's question, and which material dimension is outside this pass. Do not put tool names, query syntax, row limits, schemas, or internal lifecycle terms in that note. Select at least one available read tool, and give every required claim at least one source_candidate drawn from selected_tools. An Answered operating plan always requires successful, complete, fresh same-turn evidence for every required claim; when that proof is unavailable, use Partial or Blocked. When the accepted semantic route records delegated future observation, follow_through must define the complete executor contract before any tool runs: a stable commitment_ref, exact required read tools, acceptance criteria, next action, typed attention policy, bounded check delay, and verification. acceptance_all contains the desired completion values. alert_any contains only explicit boolean authority signals for a gap, regression, conflict, staleness, or mismatch. notify_on_change contains exact scalar or string values whose transition materially changes the operator's next safe action and which the operator asked to hear about; it is not routine progress reporting. Otherwise set follow_through to null. Rust materializes this plan into the durable scheduled commitment; final prose does not author or rewrite scheduling authority. Select only tools in available_tools.
+- Before any evidence tool, establish_plan once. The plan must name the decision, lane, resolved entities, required claims, selected tools, stop conditions, short user-visible work, and follow_through. user_visible_work is authored by you, not by the Rust host. Write two to four concise, chronological Slack updates that communicate the work rather than model or tool mechanics: what you are narrowing to, why that slice is decision-relevant, what evidence dimension you are checking next and why, and what material dimension remains outside the current pass. For a broad or ambiguous request, make the first item a natural-language scope note that states the chosen slice, why it best answers the operator's question, and the excluded material dimension. After the first evidence batch on a broad or ambiguous request, establish one materially revised plan whose first user_visible_work item says whether the evidence confirmed or changed the focus, why, and what you will examine next. Do not put tool names, query syntax, row limits, schemas, internal lifecycle terms, or unsupported findings in any progress update. Select at least one available read tool, and give every required claim at least one source_candidate drawn from selected_tools. An Answered operating plan always requires successful, complete, fresh same-turn evidence for every required claim; when that proof is unavailable, use Partial or Blocked. When the accepted semantic route records delegated future observation, follow_through must define the complete executor contract before any tool runs: a stable commitment_ref, exact required read tools, acceptance criteria, next action, typed attention policy, bounded check delay, and verification. acceptance_all contains the desired completion values. alert_any contains only explicit boolean authority signals for a gap, regression, conflict, staleness, or mismatch. notify_on_change contains exact scalar or string values whose transition materially changes the operator's next safe action and which the operator asked to hear about; it is not routine progress reporting. Otherwise set follow_through to null. Rust materializes this plan into the durable scheduled commitment; final prose does not author or rewrite scheduling authority. Select only tools in available_tools.
 - “Set up,” “schedule,” or “arrange” a re-inspection, recheck, or follow-up check is explicit future delegation even when the same sentence also says “keep going” or “take it as far as you can.” Perform the useful baseline read now and persist the bounded follow_through; an immediate read alone does not answer that request.
 - When the request concerns Slack history, a linked message, a prior conversation, GitHub, code, deployments, the web, company knowledge, or another provider and the exact provider tool is not already obvious, select capability.search first with the user's intent. Search defaults to observe/read capabilities; request another authority or effect class only when the operator's request requires it. Use capability.describe only when the matching descriptor does not make its input contract clear. For a read or proposal MCP match, revise the plan to the returned execution_tool_id and call it with the exact returned selection_ref plus provider input matching the selected descriptor. A host-admitted external effect remains visible as its exact MCP tool id and may run only in an Act plan through the ordinary exact-input approval boundary. Never substitute graph.search for a missing or undiscovered provider capability.
 - capability.search, capability.describe, and capability.overview describe the bound catalog and its authority policy. Catalog metadata never establishes a fact about Slack, GitHub, a deployment, a web page, or any other external system. Invoke the discovered provider tool before making a current claim. If no matching tool is bound, state that exact capability gap instead of querying an unrelated source.
@@ -5517,10 +5606,12 @@ mod tests {
         assert!(instructions.contains("do not ask the operator to narrow the question"));
         assert!(instructions.contains("user_visible_work is authored by you"));
         assert!(
-            instructions.contains(
-                "what slice you chose, why that slice best answers the operator's question"
-            )
+            instructions.contains("what you are narrowing to, why that slice is decision-relevant")
         );
+        assert!(instructions.contains("Write two to four concise, chronological Slack updates"));
+        assert!(instructions.contains(
+            "whether the evidence confirmed or changed the focus, why, and what you will examine next"
+        ));
         assert!(instructions.contains("how the evidence changed or confirmed that focus"));
         assert!(instructions.contains("This is useful reasoning transparency"));
         assert!(
@@ -5530,6 +5621,73 @@ mod tests {
             !built_in_capability_catalog()
                 .iter()
                 .any(|tool| tool.tool_id.contains("graph.reason"))
+        );
+    }
+
+    #[test]
+    fn turn_progress_projects_only_new_model_authored_updates_for_the_request() {
+        let request = replay_request();
+        let mut session = new_session(&request).unwrap();
+        session.events = vec![
+            SessionEventRecord {
+                schema_version: AGENT_SESSION_EVENT_V2.into(),
+                session_ref: session.session_ref.clone(),
+                sequence: 1,
+                occurred_at: "2026-08-11T07:00:00Z".into(),
+                event: SessionEvent::TurnStarted {
+                    request_id: request.request_id.clone(),
+                },
+            },
+            SessionEventRecord {
+                schema_version: AGENT_SESSION_EVENT_V2.into(),
+                session_ref: session.session_ref.clone(),
+                sequence: 2,
+                occurred_at: "2026-08-11T07:00:01Z".into(),
+                event: SessionEvent::Progressed {
+                    phase: "scoping".into(),
+                    status: "I’m narrowing to the current identity-risk slice because it is decision-relevant."
+                        .into(),
+                },
+            },
+            SessionEventRecord {
+                schema_version: AGENT_SESSION_EVENT_V2.into(),
+                session_ref: session.session_ref.clone(),
+                sequence: 3,
+                occurred_at: "2026-08-11T07:00:02Z".into(),
+                event: SessionEvent::Progressed {
+                    phase: "working".into(),
+                    status: "I’m checking current access evidence before expanding the scope."
+                        .into(),
+                },
+            },
+            SessionEventRecord {
+                schema_version: AGENT_SESSION_EVENT_V2.into(),
+                session_ref: session.session_ref.clone(),
+                sequence: 4,
+                occurred_at: "2026-08-11T07:01:00Z".into(),
+                event: SessionEvent::TurnStarted {
+                    request_id: "request:later".into(),
+                },
+            },
+            SessionEventRecord {
+                schema_version: AGENT_SESSION_EVENT_V2.into(),
+                session_ref: session.session_ref.clone(),
+                sequence: 5,
+                occurred_at: "2026-08-11T07:01:01Z".into(),
+                event: SessionEvent::Progressed {
+                    phase: "scoping".into(),
+                    status: "This belongs to another request.".into(),
+                },
+            },
+        ];
+
+        let progress = project_turn_progress(&session, &request.request_id, 2);
+
+        assert_eq!(progress.latest_sequence, 3);
+        assert_eq!(progress.updates.len(), 1);
+        assert_eq!(
+            progress.updates[0].status,
+            "I’m checking current access evidence before expanding the scope."
         );
     }
 

--- a/crates/cerebro-platform/src/slack_authority.rs
+++ b/crates/cerebro-platform/src/slack_authority.rs
@@ -11,7 +11,7 @@ use std::{
 
 use axum::{
     Json, Router,
-    extract::{DefaultBodyLimit, State},
+    extract::{DefaultBodyLimit, Query, State},
     http::StatusCode,
     routing::{get, post},
 };
@@ -28,7 +28,8 @@ use sha2::{Digest, Sha256};
 
 use crate::{
     slack_agent::{
-        AgentWakeDeliveryReceipt, AgentWakeTurn, SlackAgentModelAttestation, SlackAgentService,
+        AgentTurnProgress, AgentWakeDeliveryReceipt, AgentWakeTurn, SlackAgentModelAttestation,
+        SlackAgentService,
     },
     slack_agent_session::AgentPendingWakeDelivery,
 };
@@ -56,6 +57,15 @@ struct WakeRunResponse {
 #[derive(Serialize)]
 struct WakeDeliveryClaimResponse {
     delivery: Option<AgentPendingWakeDelivery>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TurnProgressQuery {
+    thread_ref: String,
+    request_id: String,
+    #[serde(default)]
+    after_sequence: u64,
 }
 
 struct AuthorityRuntime {
@@ -226,6 +236,7 @@ fn router(question_policy: QuestionPolicy, agent: Option<SlackAgentService>) -> 
         .route("/v1/questions/authorize", post(authorize_question_route))
         .route("/v1/answers/validate", post(validate_answer_route))
         .route("/v1/turns/run", post(run_turn_route))
+        .route("/v1/turns/progress", get(turn_progress_route))
         .route("/v1/turns/deliveries", post(record_delivery_route))
         .route("/v1/wakes/run", post(run_due_wake_route))
         .route(
@@ -235,6 +246,26 @@ fn router(question_policy: QuestionPolicy, agent: Option<SlackAgentService>) -> 
         .route("/v1/wakes/deliveries", post(record_wake_delivery_route))
         .layer(DefaultBodyLimit::max(MAX_REQUEST_BYTES))
         .with_state(Arc::new(AuthorityRuntime::new(question_policy, agent)))
+}
+
+async fn turn_progress_route(
+    State(runtime): State<Arc<AuthorityRuntime>>,
+    Query(query): Query<TurnProgressQuery>,
+) -> Result<Json<AgentTurnProgress>, (StatusCode, Json<ErrorResponse>)> {
+    let agent = runtime.agent.as_ref().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse {
+                code: "agent_not_configured",
+                message: "The Rust Slack agent runtime is not configured.".into(),
+            }),
+        )
+    })?;
+    agent
+        .turn_progress(&query.thread_ref, &query.request_id, query.after_sequence)
+        .await
+        .map(Json)
+        .map_err(agent_error)
 }
 
 async fn claim_pending_wake_delivery_route(


### PR DESCRIPTION
## What changed

- make the Rust agent author 2-4 concrete progress updates as part of its plan
- publish durable `scoping`, `working`, and `refining` updates from the Rust session journal
- let the Slack companion poll those updates while the turn runs and edit the existing placeholder message
- suppress progress replay during delivery recovery while preserving final-message reconciliation

## Behavior

For broad requests, the model now tells the user what scope it chose and why, what evidence it is checking next and why, and—after the first evidence—whether that evidence confirmed or changed the focus. The TypeScript companion transports those Rust-authored updates; it does not generate or narrow the investigation itself.

## Validation

- `cargo fmt --check`
- `cargo clippy -p cerebro-agent-runtime -p cerebro-platform --all-targets -- -D warnings`
- `cargo test -p cerebro-agent-runtime` (162 passed)
- `cargo test -p cerebro-platform` (228 passed, 7 environment-gated ignored)
- `cargo test -p cerebro-platform --test rust_only_runtime_contract` (6 passed)
- `npm run check --workspace @writer/cerebro-slack-companion-host` on DDESK (138 passed)
- `go run ./tools/reviewcheck`
