### PR TITLE
Fix candidate readiness probe budget

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -477,7 +477,7 @@ jobs:
             http://127.0.0.1:18080/readyz)" = 200
           docker stop cerebro-rust-neo4j
           readiness_body="${RUNNER_TEMP}/rust-readiness-outage.json"
-          readiness_code="$(curl --max-time 5 -sS -o "${readiness_body}" -w '%{http_code}' \
+          readiness_code="$(curl --max-time 15 -sS -o "${readiness_body}" -w '%{http_code}' \
             http://127.0.0.1:18080/readyz)"
           test "${readiness_code}" = 503
           jq -e '.code == "graph_unavailable"' "${readiness_body}" >/dev/null

--- a/tools/archtests/packaging_contract_guardrails_test.go
+++ b/tools/archtests/packaging_contract_guardrails_test.go
@@ -205,7 +205,7 @@ func TestReleaseWorkflowsKeepCandidateAndStableBoundaries(t *testing.T) {
 		"rust-organizational-e2e:",
 		"cerebro.rust-organizational-e2e/v1",
 		"Prove process liveness and backend readiness split",
-		`readiness_code="$(curl --max-time 5`,
+		`readiness_code="$(curl --max-time 15`,
 		`.code == "graph_unavailable"`,
 		"Attach the Rust E2E receipt to the candidate digest",
 		"rust_e2e_receipt_sha256",


### PR DESCRIPTION
## What changed

- allow the Candidate Build fail-closed readiness probe to observe the bounded Neo4j timeout
- keep the workflow-side probe bounded at 15 seconds
- match the budget already used by the Rust-only candidate workflow

## Failure receipt

Candidate Build run `31472093378` reached the backend-outage assertion, but `curl --max-time 5` expired before `/readyz` returned the expected `503 graph_unavailable` response.

## Validation

- `git diff --check`
- workflow YAML parse
- `go run ./tools/reviewcheck`
