### PR TITLE
Align Neo4j readiness with driver retries

### DIFF
--- a/crates/organizational-store/src/neo4j.rs
+++ b/crates/organizational-store/src/neo4j.rs
@@ -138,10 +138,11 @@ WHERE state.ready = true
 SET state.graph_revision = $graph_revision
 "#;
 
-// A fresh ECS task can spend several seconds establishing the first routed Bolt
-// connection. Keep readiness bounded, but do not kill an otherwise healthy
-// authority during that one-time connection warm-up.
-const HEALTH_TIMEOUT: Duration = Duration::from_secs(10);
+// A fresh ECS task can encounter transient failures while establishing its
+// first routed Bolt connection. neo4rs retries those failures for up to 60
+// seconds, so keep the outer bound above that horizon while still failing
+// closed on a stalled backend.
+const HEALTH_TIMEOUT: Duration = Duration::from_secs(75);
 const PROJECTION_BATCH_SIZE: usize = 1_000;
 
 const LIFECYCLE_FILTER: &str = r#"
@@ -1253,7 +1254,7 @@ impl AgentGraph for Neo4jProjector {
             .await
             .map_err(|_| {
                 ContextError::BackendUnavailable(
-                    "Neo4j readiness query exceeded 10 seconds".to_owned(),
+                    "Neo4j readiness query exceeded 75 seconds".to_owned(),
                 )
             })?
             .map_err(context_backend)
@@ -2036,7 +2037,7 @@ mod tests {
 
     #[test]
     fn readiness_allows_one_bounded_connection_warmup() {
-        assert_eq!(HEALTH_TIMEOUT, Duration::from_secs(10));
+        assert_eq!(HEALTH_TIMEOUT, Duration::from_secs(75));
     }
 
     #[test]


### PR DESCRIPTION
## What changed
- allow the Neo4j driver to finish its bounded transient-failure retry cycle during Rust Slack authority startup
- retain a 75-second fail-closed outer deadline
- update the readiness regression assertion

## Why
The live sec-dev Rust authority can reach the governed graph over TCP, but its 10-second outer deadline cancels `neo4rs` before the driver can finish its documented retry horizon. The process exhausts startup attempts and never becomes ready.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p cerebro-organizational-store --lib readiness_allows_one_bounded_connection_warmup`
- `cargo clippy -p cerebro-organizational-store --all-targets -- -D warnings`
- `git diff --check`