### PR TITLE
Align candidate probes with readiness deadline

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -477,7 +477,7 @@ jobs:
             http://127.0.0.1:18080/readyz)" = 200
           docker stop cerebro-rust-neo4j
           readiness_body="${RUNNER_TEMP}/rust-readiness-outage.json"
-          readiness_code="$(curl --max-time 15 -sS -o "${readiness_body}" -w '%{http_code}' \
+          readiness_code="$(curl --max-time 90 -sS -o "${readiness_body}" -w '%{http_code}' \
             http://127.0.0.1:18080/readyz)"
           test "${readiness_code}" = 503
           jq -e '.code == "graph_unavailable"' "${readiness_body}" >/dev/null

--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -261,7 +261,7 @@ jobs:
           test "$(curl --max-time 5 -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:18080/readyz)" = 200
           docker stop cerebro-rust-only-neo4j
           body="${RUNNER_TEMP}/rust-only-readiness.json"
-          test "$(curl --max-time 15 -sS -o "${body}" -w '%{http_code}' http://127.0.0.1:18080/readyz)" = 503
+          test "$(curl --max-time 90 -sS -o "${body}" -w '%{http_code}' http://127.0.0.1:18080/readyz)" = 503
           jq -e '.code == "graph_unavailable"' "${body}" >/dev/null
           test "$(curl --max-time 5 -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:18080/healthz)" = 200
       - name: Attach the Rust-only receipt

--- a/tools/archtests/packaging_contract_guardrails_test.go
+++ b/tools/archtests/packaging_contract_guardrails_test.go
@@ -205,7 +205,7 @@ func TestReleaseWorkflowsKeepCandidateAndStableBoundaries(t *testing.T) {
 		"rust-organizational-e2e:",
 		"cerebro.rust-organizational-e2e/v1",
 		"Prove process liveness and backend readiness split",
-		`readiness_code="$(curl --max-time 15`,
+		`readiness_code="$(curl --max-time 90`,
 		`.code == "graph_unavailable"`,
 		"Attach the Rust E2E receipt to the candidate digest",
 		"rust_e2e_receipt_sha256",


### PR DESCRIPTION
## What changed

- give both candidate workflows a 90-second observation budget for the Rust `/readyz` outage probe
- keep the runtime's 75-second fail-closed readiness deadline authoritative
- update the release architecture guardrail to require the outer budget

## Failure receipt

Candidate Build run `31476485415` used the merged 75-second Rust readiness deadline from #2251, but its 15-second `curl` deadline expired before the runtime could return the expected `503 graph_unavailable` response.

## Validation

- workflow YAML parse for both candidate workflows
- `go test ./tools/archtests`
- `go run ./tools/reviewcheck`
- `git diff --check`
