### PR TITLE
Align candidate readiness probe deadline

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -477,7 +477,7 @@ jobs:
             http://127.0.0.1:18080/readyz)" = 200
           docker stop cerebro-rust-neo4j
           readiness_body="${RUNNER_TEMP}/rust-readiness-outage.json"
-          readiness_code="$(curl --max-time 15 -sS -o "${readiness_body}" -w '%{http_code}' \
+          readiness_code="$(curl --max-time 90 -sS -o "${readiness_body}" -w '%{http_code}' \
             http://127.0.0.1:18080/readyz)"
           test "${readiness_code}" = 503
           jq -e '.code == "graph_unavailable"' "${readiness_body}" >/dev/null

--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -261,7 +261,7 @@ jobs:
           test "$(curl --max-time 5 -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:18080/readyz)" = 200
           docker stop cerebro-rust-only-neo4j
           body="${RUNNER_TEMP}/rust-only-readiness.json"
-          test "$(curl --max-time 15 -sS -o "${body}" -w '%{http_code}' http://127.0.0.1:18080/readyz)" = 503
+          test "$(curl --max-time 90 -sS -o "${body}" -w '%{http_code}' http://127.0.0.1:18080/readyz)" = 503
           jq -e '.code == "graph_unavailable"' "${body}" >/dev/null
           test "$(curl --max-time 5 -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:18080/healthz)" = 200
       - name: Attach the Rust-only receipt

--- a/tools/archtests/packaging_contract_guardrails_test.go
+++ b/tools/archtests/packaging_contract_guardrails_test.go
@@ -205,7 +205,7 @@ func TestReleaseWorkflowsKeepCandidateAndStableBoundaries(t *testing.T) {
 		"rust-organizational-e2e:",
 		"cerebro.rust-organizational-e2e/v1",
 		"Prove process liveness and backend readiness split",
-		`readiness_code="$(curl --max-time 15`,
+		`readiness_code="$(curl --max-time 90`,
 		`.code == "graph_unavailable"`,
 		"Attach the Rust E2E receipt to the candidate digest",
 		"rust_e2e_receipt_sha256",
@@ -303,6 +303,17 @@ func TestReleaseWorkflowsKeepCandidateAndStableBoundaries(t *testing.T) {
 	}
 	if !strings.Contains(makefileText, `go build -trimpath -ldflags="-s -w" -o .dist/cerebro`) {
 		t.Fatal("docker-smoke must strip the runtime binary before loading the image")
+	}
+}
+
+func TestRustOnlyCandidateAllowsReadinessDeadlineToExpire(t *testing.T) {
+	root := repoRoot(t)
+	workflow, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "rust-only-candidate.yml"))
+	if err != nil {
+		t.Fatalf("read Rust-only candidate workflow: %v", err)
+	}
+	if !strings.Contains(string(workflow), `curl --max-time 90`) {
+		t.Fatal("Rust-only candidate readiness client must outlive the 75-second backend deadline")
 	}
 }
 


### PR DESCRIPTION
## What changed
- let Rust-only candidate and release readiness clients outlive the 75-second fail-closed backend deadline
- add an architecture regression for the Rust-only candidate probe budget

## Exact failure
Candidate run `31476485450` built both native images and the signed manifest, then timed out its 15-second curl while the service correctly waited on the 75-second backend deadline.

## Validation
- `go test ./tools/archtests -run 'Test(CandidateReleasePackagingContract|RustOnlyCandidateAllowsReadinessDeadlineToExpire)$' -count=1`\n- workflow YAML parse\n- `git diff --check`