### PR TITLE
Retry transient GCP source requests

### DIFF
--- a/sources/gcp/source.go
+++ b/sources/gcp/source.go
@@ -820,7 +820,7 @@ func getBytes(ctx context.Context, source *Source, settings settings, defaultBas
 	if source != nil && source.client != nil {
 		client = source.client
 	}
-	resp, err := sourcehttp.DoWithRetry(ctx, client, req, sourcehttp.RetryOptions{MaxAttempts: 1, MaxBodyBytes: maxBytes})
+	resp, err := sourcehttp.DoWithRetry(ctx, client, req, sourcehttp.RetryOptions{MaxBodyBytes: maxBytes})
 	if err != nil {
 		return nil, false, fmt.Errorf("request %s: %w", requestPath, err)
 	}

--- a/sources/gcp/source_test.go
+++ b/sources/gcp/source_test.go
@@ -236,6 +236,48 @@ func TestGCPProviderUnavailableReturnsError(t *testing.T) {
 	}
 }
 
+func TestGCPRetriesRateLimitedPOSTRequest(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if r.URL.Path != "/v2/entries:list" {
+			http.NotFound(w, r)
+			return
+		}
+		if attempts == 1 {
+			http.Error(w, `{"error":"quota exhausted"}`, http.StatusTooManyRequests)
+			return
+		}
+		writeJSON(t, w, map[string]any{"entries": []map[string]any{{
+			"insertId":     "audit-1",
+			"timestamp":    "2026-04-23T00:00:00Z",
+			"protoPayload": map[string]any{"methodName": "SetIamPolicy"},
+		}}})
+	}))
+	defer server.Close()
+	source, err := newLiveTestSource()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url":   server.URL,
+		"family":     familyAudit,
+		"project_id": "writer-prod",
+		"token":      "test-token",
+	})
+
+	pull, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read(audit) error = %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(pull.Events))
+	}
+}
+
 func TestReadLiveGCPServiceAccountPreview(t *testing.T) {
 	server := httptest.NewServer(newGCPAPIHandler(t))
 	defer server.Close()


### PR DESCRIPTION
## What changed
- use the shared bounded HTTP retry policy for GCP requests
- preserve replayable POST bodies across a retry
- cover a Cloud Logging-style 429 followed by success

## Why
A single transient 429 or 5xx currently fails the entire GCP source runtime because the adapter explicitly limits requests to one attempt. That leaves the latest collection and downstream graph projection failed even when the provider recovers immediately.

## Verification
- DDESK: `go test ./internal/sourcehttp ./sources/gcp`
- DDESK: `go test -race ./sources/gcp`