### PR TITLE
feat(slack): close the answer feedback loop

### DIFF
--- a/apps/slack-companion-host/src/runtime/outcome-store.ts
+++ b/apps/slack-companion-host/src/runtime/outcome-store.ts
@@ -2,6 +2,13 @@ import { createHash, randomUUID } from "node:crypto";
 import { mkdir, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import {
+  evaluateAssistantTurn,
+  recordAnswerFeedback,
+  type AnswerFeedbackCategoryV1,
+  type AnswerFeedbackRecordV1,
+  type AssistantTurnEvaluationV1,
+} from "@writer/cerebro-slack-companion";
+import {
   ASSISTANT_EXECUTION_LANES,
   AssistantTurnHostAdapter,
   type AssistantExecutionLane,
@@ -14,12 +21,16 @@ import {
 } from "../assistant-turn.js";
 
 export const OUTCOME_OBSERVATION_WINDOW_MS = 24 * 60 * 60 * 1_000;
+export const OUTCOME_RETENTION_MS = 30 * 24 * 60 * 60 * 1_000;
 export const TELEMETRY_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
 const MAX_TELEMETRY_RECEIPTS = 100_000;
 
 export interface PendingAssistantOutcome {
+  assessed_at?: string;
   delivered_message_ts: string;
   execution_lane: AssistantExecutionLane;
+  feedback_categories?: AnswerFeedbackCategoryV1[];
+  feedback_record_refs?: string[];
   latency_budget_ms: number;
   negative_feedback_count: number;
   opened_at: string;
@@ -29,6 +40,23 @@ export interface PendingAssistantOutcome {
   user_correction_count: number;
   useful_answer_at?: string;
   verified: boolean;
+}
+
+export interface AssistantOutcomeStoreSummary {
+  assessment_count: number;
+  evaluation_count: number;
+  feedback_count: number;
+  pending_count: number;
+}
+
+export interface RecordAssistantFeedbackInput {
+  actor_ref: string;
+  answer_ref: string;
+  category: AnswerFeedbackCategoryV1;
+  delivered_message_ts: string;
+  observed_at: string;
+  tenant_ref: string;
+  thread_ref: string;
 }
 
 export interface OutcomeStoreOptions {
@@ -57,6 +85,8 @@ export class FileOutcomeStore
       mkdir(this.directory("pending"), { recursive: true }),
       mkdir(this.directory("assessments"), { recursive: true }),
       mkdir(this.directory("delivery"), { recursive: true }),
+      mkdir(this.directory("evaluations"), { recursive: true }),
+      mkdir(this.directory("feedback"), { recursive: true }),
       mkdir(this.directory("status"), { recursive: true }),
       mkdir(this.directory("telemetry"), { recursive: true }),
     ]);
@@ -77,6 +107,7 @@ export class FileOutcomeStore
         if (pending.delivered_message_ts !== deliveredMessageTs) continue;
         await this.atomicWrite(this.path("pending", pending.request_id), {
           ...pending,
+          assessed_at: undefined,
           negative_feedback_count: pending.negative_feedback_count + 1,
         });
         recorded = true;
@@ -86,6 +117,93 @@ export class FileOutcomeStore
     return recorded;
   }
 
+  async recordFeedback(
+    input: RecordAssistantFeedbackInput,
+  ): Promise<AnswerFeedbackRecordV1 | undefined> {
+    validateFeedbackInput(input);
+    let recorded: AnswerFeedbackRecordV1 | undefined;
+    await this.serialize(async () => {
+      for (const file of await this.pendingFiles()) {
+        const pending = await this.readPending(file);
+        if (pending.delivered_message_ts !== input.delivered_message_ts) continue;
+        let feedback = await this.findFeedback({
+          actor_ref: input.actor_ref,
+          answer_ref: input.answer_ref,
+          category: input.category,
+          feedback_key: pending.request_id,
+        });
+        if (feedback === undefined) {
+          feedback = recordAnswerFeedback({
+            actor_ref: input.actor_ref,
+            answer_ref: input.answer_ref,
+            category: input.category,
+            feedback_key: pending.request_id,
+            observed_at: input.observed_at,
+            request_ref: `assistant-request://sha256/${digest(pending.request_id)}`,
+            tenant_ref: input.tenant_ref,
+            thread_ref: input.thread_ref,
+          });
+          const feedbackPath = this.path("feedback", feedback.record_ref);
+          try {
+            const collision = JSON.parse(
+              await readFile(feedbackPath, "utf8"),
+            ) as AnswerFeedbackRecordV1;
+            if (JSON.stringify(collision) !== JSON.stringify(feedback)) {
+              throw new Error("Assistant feedback identity changed content.");
+            }
+            feedback = collision;
+          } catch (error) {
+            if (errorCode(error) !== "ENOENT") throw error;
+            await this.atomicWrite(feedbackPath, feedback);
+          }
+        }
+        recorded = feedback;
+        if ((pending.feedback_record_refs ?? []).includes(feedback.record_ref)) {
+          return;
+        }
+        const feedbackCategories = [
+          ...new Set([...(pending.feedback_categories ?? []), input.category]),
+        ];
+        await this.atomicWrite(this.path("pending", pending.request_id), {
+          ...pending,
+          assessed_at: undefined,
+          feedback_categories: feedbackCategories,
+          feedback_record_refs: [
+            ...(pending.feedback_record_refs ?? []),
+            feedback.record_ref,
+          ],
+          negative_feedback_count: pending.negative_feedback_count
+            + (input.category === "helpful" ? 0 : 1),
+        });
+        return;
+      }
+    });
+    return recorded;
+  }
+
+  async summary(): Promise<AssistantOutcomeStoreSummary> {
+    await this.initialize();
+    const count = async (name: string): Promise<number> =>
+      (await readdir(this.directory(name))).filter((file) => file.endsWith(".json")).length;
+    const [assessmentCount, evaluationCount, feedbackCount, pendingFiles] =
+      await Promise.all([
+        count("assessments"),
+        count("evaluations"),
+        count("feedback"),
+        this.pendingFiles(),
+      ]);
+    let pendingCount = 0;
+    for (const file of pendingFiles) {
+      if ((await this.readPending(file)).assessed_at === undefined) pendingCount += 1;
+    }
+    return {
+      assessment_count: assessmentCount,
+      evaluation_count: evaluationCount,
+      feedback_count: feedbackCount,
+      pending_count: pendingCount,
+    };
+  }
+
   async assessDue(host: AssistantTurnHostAdapter): Promise<number> {
     let assessed = 0;
     await this.initialize();
@@ -93,9 +211,15 @@ export class FileOutcomeStore
       await this.pruneTelemetryReceipts();
       for (const file of await this.pendingFiles()) {
         const pending = await this.readPending(file);
+        if (pending.assessed_at !== undefined) {
+          if (this.clock().getTime() - Date.parse(pending.assessed_at) >= OUTCOME_RETENTION_MS) {
+            await unlink(file);
+          }
+          continue;
+        }
         const openedAt = Date.parse(pending.opened_at);
         if (this.clock().getTime() - openedAt < OUTCOME_OBSERVATION_WINDOW_MS) continue;
-        await host.recordOutcome({
+        const assessment = await host.recordOutcome({
           assessment_at: this.clock().toISOString(),
           evaluation_blockers: pending.verified ? [] : ["outcome_unknown"],
           execution_lane: pending.execution_lane,
@@ -109,7 +233,15 @@ export class FileOutcomeStore
           useful_answer_at: pending.useful_answer_at,
           verified: pending.verified,
         });
-        await unlink(file);
+        const evaluation = productionEvaluation(pending, assessment.outcome_state);
+        await this.atomicWrite(
+          this.path("evaluations", `${pending.request_id}:production`),
+          evaluation,
+        );
+        await this.atomicWrite(this.path("pending", pending.request_id), {
+          ...pending,
+          assessed_at: this.clock().toISOString(),
+        });
         assessed += 1;
       }
     });
@@ -169,6 +301,27 @@ export class FileOutcomeStore
     return decoded;
   }
 
+  private async findFeedback(
+    identity: Pick<
+      AnswerFeedbackRecordV1,
+      "actor_ref" | "answer_ref" | "category" | "feedback_key"
+    >,
+  ): Promise<AnswerFeedbackRecordV1 | undefined> {
+    for (const file of (await readdir(this.directory("feedback"))).sort()) {
+      if (!file.endsWith(".json")) continue;
+      const decoded = JSON.parse(
+        await readFile(join(this.directory("feedback"), file), "utf8"),
+      ) as AnswerFeedbackRecordV1;
+      if (
+        decoded.actor_ref === identity.actor_ref
+        && decoded.answer_ref === identity.answer_ref
+        && decoded.category === identity.category
+        && decoded.feedback_key === identity.feedback_key
+      ) return decoded;
+    }
+    return undefined;
+  }
+
   private async atomicWrite(path: string, value: unknown): Promise<void> {
     await mkdir(dirname(path), { recursive: true });
     const temporary = `${path}.${randomUUID()}.tmp`;
@@ -221,6 +374,87 @@ export class FileOutcomeStore
   }
 }
 
+function productionEvaluation(
+  pending: PendingAssistantOutcome,
+  outcomeState: PendingAssistantOutcome["outcome_state"],
+): AssistantTurnEvaluationV1 {
+  const evaluatedOutcomeState = pending.verified ? outcomeState : "unknown";
+  const feedbackCategory = preferredFeedbackCategory(
+    pending.feedback_categories ?? [],
+  );
+  const observation = {
+    delivered_message_ts: pending.delivered_message_ts,
+    feedback_categories: pending.feedback_categories ?? [],
+    outcome_state: evaluatedOutcomeState,
+    request_id: pending.request_id,
+    verified: pending.verified,
+  };
+  const latency = pending.useful_answer_at === undefined
+    ? pending.latency_budget_ms + 1
+    : Math.max(0, Date.parse(pending.useful_answer_at) - Date.parse(pending.opened_at));
+  return evaluateAssistantTurn({
+    // This host observes delivery, latency, outcome, verification, and feedback.
+    // It does not infer claim, source, capability, or tool counts from the lane.
+    case_digest: `sha256:${digest(pending.request_id)}`,
+    case_ref: `assistant-case://sha256/${digest(pending.request_id)}`,
+    claim_count: 0,
+    coverage_boundary_disclosed: false,
+    coverage_boundary_required: false,
+    delivery: {
+      complete: true,
+      disposition: "respond",
+      planned_part_count: 1,
+      posted_part_count: 1,
+    },
+    delivered_action_count: 0,
+    disclosed_source_failure_count: 0,
+    evaluator_ref: "evaluator://assistant-turn/production-outcome-feedback-v1",
+    execution_lane: pending.execution_lane,
+    ...(feedbackCategory === undefined
+      ? pending.negative_feedback_count > 0
+        ? { explicit_feedback: "negative" as const }
+        : {}
+      : {
+          explicit_feedback: feedbackCategory === "helpful" ? "positive" as const : "negative" as const,
+          explicit_feedback_category: feedbackCategory,
+        }),
+    grounded_claim_count: 0,
+    internal_machinery_exposure_count: 0,
+    latency_ms: latency,
+    observation_digest: `sha256:${digest(JSON.stringify(observation))}`,
+    observation_ref: `assistant-observation://sha256/${digest(JSON.stringify(observation))}`,
+    outcome_state: evaluatedOutcomeState,
+    partition: "train",
+    policy_ref: "policy://slack-companion/deployed-outcome-feedback",
+    redundant_tool_call_count: 0,
+    relevant_evidence_source_count: 0,
+    required_action_count: 0,
+    requires_evidence: false,
+    response_expected: true,
+    selected_capability_count: 0,
+    source_failure_count: 0,
+    subject_bound_claim_count: 0,
+    tool_call_count: 0,
+    unnecessary_clarification_count: 0,
+    used_evidence_source_count: 0,
+    user_correction: pending.user_correction_count > 0,
+  });
+}
+
+function preferredFeedbackCategory(
+  categories: readonly AnswerFeedbackCategoryV1[],
+): AnswerFeedbackCategoryV1 | undefined {
+  for (const category of [
+    "missed_source",
+    "wrong_owner",
+    "needs_followup",
+    "helpful",
+  ] as const) {
+    if (categories.includes(category)) return category;
+  }
+  return undefined;
+}
+
 function validatePending(value: unknown): asserts value is PendingAssistantOutcome {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
     throw new Error("Pending assistant outcome is invalid.");
@@ -228,6 +462,9 @@ function validatePending(value: unknown): asserts value is PendingAssistantOutco
   const pending = value as Partial<PendingAssistantOutcome>;
   if (
     pending.schema_version !== "assistant-turn-pending-outcome/v1"
+    || (pending.assessed_at !== undefined
+      && (typeof pending.assessed_at !== "string"
+        || !Number.isFinite(Date.parse(pending.assessed_at))))
     || typeof pending.request_id !== "string"
     || pending.request_id.length === 0
     || typeof pending.delivered_message_ts !== "string"
@@ -238,8 +475,39 @@ function validatePending(value: unknown): asserts value is PendingAssistantOutco
     || typeof pending.opened_at !== "string"
     || !Number.isFinite(Date.parse(pending.opened_at))
     || typeof pending.verified !== "boolean"
+    || (pending.feedback_categories !== undefined
+      && (!Array.isArray(pending.feedback_categories)
+        || new Set(pending.feedback_categories).size !== pending.feedback_categories.length
+        || pending.feedback_categories.some((category) =>
+          !["helpful", "missed_source", "wrong_owner", "needs_followup"].includes(category))))
+    || (pending.feedback_record_refs !== undefined
+      && (!Array.isArray(pending.feedback_record_refs)
+        || new Set(pending.feedback_record_refs).size !== pending.feedback_record_refs.length
+        || pending.feedback_record_refs.some((reference) =>
+          typeof reference !== "string"
+          || !/^feedback:\/\/answer\/[a-f0-9]{64}$/u.test(reference))))
   ) {
     throw new Error("Pending assistant outcome is invalid.");
+  }
+}
+
+function validateFeedbackInput(input: RecordAssistantFeedbackInput): void {
+  if (
+    !["helpful", "missed_source", "wrong_owner", "needs_followup"].includes(input.category)
+    || !input.delivered_message_ts.trim()
+    || !Number.isFinite(Date.parse(input.observed_at))
+  ) {
+    throw new Error("Assistant feedback input is invalid.");
+  }
+  for (const value of [
+    input.actor_ref,
+    input.answer_ref,
+    input.tenant_ref,
+    input.thread_ref,
+  ]) {
+    if (!/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) {
+      throw new Error("Assistant feedback references are invalid.");
+    }
   }
 }
 

--- a/apps/slack-companion-host/src/runtime/slack-runtime.ts
+++ b/apps/slack-companion-host/src/runtime/slack-runtime.ts
@@ -12,10 +12,16 @@ import {
   assistantTurnBudget,
   buildAssistantTurnEvidenceFallback,
   createToolCatalog,
+  decodeSlackActionEnvelope,
+  decideSlackAction,
   formatSlackThreadScratchpadContext,
   parseSlackRememberCommand,
   parseSlackThreadScratchpadCommand,
   preflightAssistantTurnInvocation,
+  projectSlackAnswerFeedbackActions,
+  projectSlackBlocks,
+  projectSlackOperatorHome,
+  SLACK_OPERATOR_ACTION_REGISTRY,
   projectAssistantTurnProgress,
   projectSlackMultipartDelivery,
   slackChannelContextScopeRef,
@@ -26,6 +32,7 @@ import {
   type SlackThreadScratchpadPort,
   type SlackThreadWorkingStateV1,
   type SlackThreadWorkingOutcome,
+  type AnswerFeedbackCategoryV1,
 } from "@writer/cerebro-slack-companion";
 import {
   AssistantTurnHostAdapter,
@@ -135,7 +142,12 @@ export interface SlackMentionClient extends SlackThreadRepliesClient {
       text: string;
       thread_ts: string;
     }): Promise<{ ts?: string }>;
-    update(input: { channel: string; text: string; ts: string }): Promise<unknown>;
+    update(input: {
+      blocks?: HomeView["blocks"];
+      channel: string;
+      text: string;
+      ts: string;
+    }): Promise<unknown>;
   };
 }
 
@@ -866,12 +878,16 @@ export class SlackCompanionRuntime {
       if (!context.teamId || !this.config.allowedTeamIds.has(context.teamId)) return;
       if (this.archetype) {
         try {
-          const view = await this.archetype.home({
+          const archetypeView = await this.archetype.home({
             slack: client,
             teamId: context.teamId,
             userId: event.user,
           });
-          await client.views.publish({ user_id: event.user, view });
+          const operatorView = await this.operatorHomeView(context.teamId, event.user);
+          await client.views.publish({
+            user_id: event.user,
+            view: mergeHomeViews(operatorView, archetypeView),
+          });
         } catch (error) {
           logArchetypeFailure("home", error);
           await client.views.publish({
@@ -883,8 +899,79 @@ export class SlackCompanionRuntime {
       }
       await client.views.publish({
         user_id: event.user,
-        view: environmentHomeView(this.config),
+        view: await this.operatorHomeView(context.teamId, event.user),
       });
+    });
+
+    this.app.action(/^cerebro\.action\.[a-f0-9]{32}$/u, async ({
+      ack,
+      action,
+      body,
+    }) => {
+      if (action.type !== "button" || !action.value) {
+        await ack();
+        return;
+      }
+      const teamId = body.team?.id;
+      const channelId = "channel" in body ? body.channel?.id : undefined;
+      const message = "message" in body ? body.message : undefined;
+      const messageTs = message?.ts;
+      const threadTs = "thread_ts" in (message ?? {})
+        && typeof message?.thread_ts === "string"
+        ? message.thread_ts
+        : messageTs;
+      if (
+        !teamId
+        || !channelId
+        || !messageTs
+        || !threadTs
+        || !this.config.allowedTeamIds.has(teamId)
+      ) {
+        await ack();
+        return;
+      }
+      let envelope: ReturnType<typeof decodeSlackActionEnvelope>;
+      try {
+        envelope = decodeSlackActionEnvelope(action.value);
+      } catch {
+        await ack();
+        return;
+      }
+      const decision = decideSlackAction(SLACK_OPERATOR_ACTION_REGISTRY, {
+        action: envelope,
+        available_capabilities: [{
+          capability_id: "assistant.feedback",
+          level: "required",
+          version: "v1",
+        }],
+      });
+      if (
+        decision.disposition !== "admit"
+        || envelope.command !== "answer_feedback"
+      ) {
+        await ack();
+        return;
+      }
+      const category = feedbackCategory(envelope.action);
+      if (category === undefined) {
+        await ack();
+        return;
+      }
+      const answerRef = slackAnswerRef(teamId, channelId, messageTs);
+      if (envelope.subject_ref !== answerRef) {
+        await ack();
+        return;
+      }
+      await this.outcomes.recordFeedback({
+        actor_ref: slackScratchpadAuthorRef(teamId, body.user.id),
+        answer_ref: answerRef,
+        category,
+        delivered_message_ts: messageTs,
+        observed_at: new Date().toISOString(),
+        tenant_ref: `slack-team://sha256/${digest(teamId)}`,
+        thread_ref: slackThreadScratchpadRef(teamId, channelId, threadTs),
+      });
+      await ack();
     });
 
     this.app.action(/^archetype_start_work_[0-9a-f]+$/u, async ({
@@ -999,6 +1086,28 @@ export class SlackCompanionRuntime {
         state: "failed",
       })}\n`);
     }
+  }
+
+  private async operatorHomeView(teamId: string, userId: string): Promise<HomeView> {
+    const summary = await this.outcomes.summary();
+    const projection = projectSlackOperatorHome({
+      enabled_capabilities: [
+        "Evidence-backed answers",
+        ...(this.config.rustAgentEnabled ? ["Durable work"] : []),
+        ...(this.archetype ? ["Assigned security work"] : []),
+      ],
+      notification_mode: this.config.notificationPreferences.enabled_classes.length === 0
+        ? "muted"
+        : this.config.notificationPreferences.enabled_classes.includes("digest")
+          ? "digest"
+          : "immediate",
+      pending_outcome_count: summary.pending_count,
+      projection_key: `operator-home-${digest(`${teamId}:${userId}`)}`,
+      source_states: [{ label: "Slack runtime", state: "available" }],
+      statuses: [],
+      view_selector: `operator-${digest(`${teamId}:${userId}`)}`,
+    });
+    return projection.view as HomeView;
   }
 
   private flushSlackIngress(): Promise<void> {
@@ -1549,6 +1658,16 @@ export async function handleSlackMention(input: {
     }
     await input.leaseGuard?.();
     await input.client.chat.update({
+      blocks: answerFeedbackBlocks({
+        answerRef: slackAnswerRef(
+          input.event.teamId,
+          input.event.channel,
+          deliveredMessageTs,
+        ),
+        deliveredAt,
+        deliveredText,
+        feedbackKey: requestKey,
+      }),
       channel: input.event.channel,
       text: deliveredText,
       ts: deliveredMessageTs,
@@ -1859,6 +1978,71 @@ export function environmentHomeView(
         }],
       },
     ],
+  };
+}
+
+function answerFeedbackBlocks(input: {
+  answerRef: string;
+  deliveredAt: string;
+  deliveredText: string;
+  feedbackKey: string;
+}): HomeView["blocks"] {
+  const actions = projectSlackAnswerFeedbackActions({
+    feedback_key: input.feedbackKey,
+    issued_at: input.deliveredAt,
+    subject_ref: input.answerRef,
+  });
+  const controls = projectSlackBlocks({
+    actions,
+    projection_key: `answer-feedback-${digest(input.answerRef)}`,
+    sections: ["Answer feedback"],
+  });
+  const actionBlock = controls.blocks.find((block) => block.type === "actions");
+  if (actionBlock === undefined) throw new Error("Answer feedback controls are incomplete.");
+  const answerBlocks = splitSlackSections(input.deliveredText).map((text) => ({
+    type: "section" as const,
+    text: { type: "mrkdwn" as const, text },
+  }));
+  return [
+    ...answerBlocks,
+    {
+      type: "context" as const,
+      elements: [{
+        type: "mrkdwn" as const,
+        text: "Was this answer useful?",
+      }],
+    },
+    actionBlock,
+  ] as HomeView["blocks"];
+}
+
+function splitSlackSections(value: string): string[] {
+  const characters = Array.from(value);
+  const sections: string[] = [];
+  for (let index = 0; index < characters.length; index += 2_800) {
+    sections.push(characters.slice(index, index + 2_800).join(""));
+  }
+  return sections.length === 0 ? ["No answer was delivered."] : sections;
+}
+
+function slackAnswerRef(teamId: string, channelId: string, messageTs: string): string {
+  return `slack-answer://sha256/${digest(`${teamId}:${channelId}:${messageTs}`)}`;
+}
+
+function feedbackCategory(actionId: string): AnswerFeedbackCategoryV1 | undefined {
+  switch (actionId) {
+    case "answer.feedback.helpful": return "helpful";
+    case "answer.feedback.missed_source": return "missed_source";
+    case "answer.feedback.wrong_owner": return "wrong_owner";
+    case "answer.feedback.needs_followup": return "needs_followup";
+    default: return undefined;
+  }
+}
+
+function mergeHomeViews(primary: HomeView, secondary: HomeView): HomeView {
+  return {
+    type: "home",
+    blocks: [...(primary.blocks ?? []), ...(secondary.blocks ?? [])].slice(0, 100),
   };
 }
 

--- a/apps/slack-companion-host/test/runtime-host.test.ts
+++ b/apps/slack-companion-host/test/runtime-host.test.ts
@@ -3376,13 +3376,15 @@ test("a restart reuses the durable Slack message binding without searching or po
       .digest("hex")
       .slice(0, 8)}-`;
     let updatedTs = "";
+    let updatedBlocks: unknown;
     const client = {
       chat: {
         postMessage: async () => {
           throw new Error("a durable binding must suppress a duplicate post");
         },
-        update: async (input: { ts: string }) => {
+        update: async (input: { blocks?: unknown; ts: string }) => {
           updatedTs = input.ts;
+          updatedBlocks = input.blocks;
         },
       },
       conversations: {
@@ -3424,6 +3426,12 @@ test("a restart reuses the durable Slack message binding without searching or po
       true,
     );
     assert.equal(updatedTs, "1710000000.000002");
+    const renderedBlocks = JSON.stringify(updatedBlocks);
+    assert.match(renderedBlocks, /Was this answer useful\?/u);
+    assert.match(renderedBlocks, /cerebro\.action\.[a-f0-9]{32}/u);
+    assert.match(renderedBlocks, /Missed source/u);
+    assert.match(renderedBlocks, /Wrong owner/u);
+    assert.match(renderedBlocks, /Needs follow-up/u);
   } finally {
     await rm(root, { force: true, recursive: true });
   }
@@ -3621,6 +3629,83 @@ test("outcome store applies negative feedback before the durable 24-hour assessm
     const assessment = JSON.parse(await readFile(join(root, "assessments", assessmentFiles[0]!), "utf8"));
     assert.equal(assessment.negative_feedback_count, 1);
     assert.equal(assessment.verified_outcome_within_slo, false);
+    const evaluationFiles = await readdir(join(root, "evaluations"));
+    assert.equal(evaluationFiles.length, 1);
+    const evaluation = JSON.parse(
+      await readFile(join(root, "evaluations", evaluationFiles[0]!), "utf8"),
+    );
+    assert.equal(evaluation.partition, "train");
+    assert.equal(evaluation.blockers.includes("negative_feedback"), true);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("structured answer feedback is durable, idempotent, and reopens an assessed outcome", async () => {
+  const root = await mkdtemp(join(tmpdir(), "cerebro-slack-feedback-"));
+  let now = new Date("2026-07-19T10:00:01.000Z");
+  try {
+    const store = new FileOutcomeStore(root, {
+      clock: () => now,
+      log: () => undefined,
+    });
+    await store.recordPending({
+      delivered_message_ts: "1710000000.000001",
+      execution_lane: "lookup",
+      latency_budget_ms: 30_000,
+      negative_feedback_count: 0,
+      opened_at: "2026-07-18T10:00:00.000Z",
+      outcome_state: "completed",
+      request_id: "request-feedback",
+      schema_version: "assistant-turn-pending-outcome/v1",
+      user_correction_count: 0,
+      useful_answer_at: "2026-07-18T10:00:10.000Z",
+      verified: true,
+    });
+    assert.equal(await store.assessDue(createAssistantTurnHost(store)), 1);
+
+    const input = {
+      actor_ref: "slack-actor://sha256/actor",
+      answer_ref: "slack-answer://sha256/answer",
+      category: "missed_source" as const,
+      delivered_message_ts: "1710000000.000001",
+      observed_at: now.toISOString(),
+      tenant_ref: "slack-team://sha256/team",
+      thread_ref: "slack-thread://sha256/thread",
+    };
+    const first = await store.recordFeedback(input);
+    assert.ok(first);
+    const replay = await store.recordFeedback(input);
+    assert.deepEqual(replay, first);
+    const pendingFile = (await readdir(join(root, "pending")))[0]!;
+    const pendingPath = join(root, "pending", pendingFile);
+    const pendingAfterFeedback = JSON.parse(await readFile(pendingPath, "utf8"));
+    await writeFile(pendingPath, `${JSON.stringify({
+      ...pendingAfterFeedback,
+      assessed_at: now.toISOString(),
+      feedback_categories: undefined,
+      feedback_record_refs: undefined,
+      negative_feedback_count: 0,
+    })}\n`);
+    const delayedReplay = await store.recordFeedback({
+      ...input,
+      observed_at: "2026-07-19T10:00:01.500Z",
+    });
+    assert.deepEqual(delayedReplay, first);
+    assert.equal((await readdir(join(root, "feedback"))).length, 1);
+    assert.equal((await store.summary()).pending_count, 1);
+    const reconciledPending = JSON.parse(await readFile(pendingPath, "utf8"));
+    assert.deepEqual(reconciledPending.feedback_record_refs, [first.record_ref]);
+    assert.equal(reconciledPending.negative_feedback_count, 1);
+
+    now = new Date("2026-07-19T10:00:02.000Z");
+    assert.equal(await store.assessDue(createAssistantTurnHost(store)), 1);
+    const evaluationFile = (await readdir(join(root, "evaluations")))[0]!;
+    const evaluation = JSON.parse(
+      await readFile(join(root, "evaluations", evaluationFile), "utf8"),
+    );
+    assert.equal(evaluation.blockers.includes("missed_source_feedback"), true);
+    assert.equal((await store.summary()).pending_count, 0);
   } finally {
     await rm(root, { force: true, recursive: true });
   }

--- a/apps/slack-companion/src/operator/home.ts
+++ b/apps/slack-companion/src/operator/home.ts
@@ -7,10 +7,10 @@ export interface SlackOperatorSourceStateV1 {
 }
 
 export interface SlackOperatorHomeInputV1 {
-  readonly active_commitment_count: number;
   readonly enabled_capabilities: readonly string[];
-  readonly memory_note_count: number;
+  readonly memory_note_count?: number;
   readonly notification_mode: "immediate" | "digest" | "muted";
+  readonly pending_outcome_count: number;
   readonly projection_key: string;
   readonly source_states: readonly SlackOperatorSourceStateV1[];
   readonly statuses: readonly SlackStatusProjectionV1[];
@@ -23,8 +23,10 @@ export class SlackOperatorHomeError extends Error {}
 export function projectSlackOperatorHome(
   input: SlackOperatorHomeInputV1,
 ): SlackHomeProjectionV1 {
-  integer(input.active_commitment_count, "active commitment count");
-  integer(input.memory_note_count, "memory note count");
+  integer(input.pending_outcome_count, "pending outcome count");
+  if (input.memory_note_count !== undefined) {
+    integer(input.memory_note_count, "memory note count");
+  }
   if (!Array.isArray(input.enabled_capabilities) || input.enabled_capabilities.length > 20
     || new Set(input.enabled_capabilities).size !== input.enabled_capabilities.length) {
     throw new SlackOperatorHomeError("Enabled capabilities are invalid.");
@@ -46,8 +48,8 @@ export function projectSlackOperatorHome(
     summary: [
       `Scope: ${capabilities.length === 0 ? "No capabilities enabled" : capabilities.join(", ")}`,
       `Sources: ${sources.length === 0 ? "No source health reported" : sources.join("; ")}`,
-      `Memory: ${input.memory_note_count} retained notes`,
-      `Follow-through: ${input.active_commitment_count} active commitments; notifications ${input.notification_mode}`,
+      `Memory: ${input.memory_note_count === undefined ? "unavailable" : `${input.memory_note_count} retained notes`}`,
+      `Outcome checks: ${input.pending_outcome_count} pending; notifications ${input.notification_mode}`,
     ].join("\n"),
     title: "Cerebro operator state",
     view_selector: input.view_selector,

--- a/apps/slack-companion/test/operator-loop-improvements.test.ts
+++ b/apps/slack-companion/test/operator-loop-improvements.test.ts
@@ -78,10 +78,10 @@ test("memory retrieval evaluation is separate, bounded, and explicit when unavai
 
 test("operator Home reports scope, source health, memory, and follow-through", () => {
   const projection = projectSlackOperatorHome({
-    active_commitment_count: 2,
     enabled_capabilities: ["security findings", "source health"],
     memory_note_count: 7,
     notification_mode: "digest",
+    pending_outcome_count: 2,
     projection_key: "operator-home:U123",
     source_states: [
       { label: "Graph", state: "available" },
@@ -94,7 +94,18 @@ test("operator Home reports scope, source health, memory, and follow-through", (
   assert.match(rendered, /Scope: security findings, source health/u);
   assert.match(rendered, /Audit logs: degraded; Graph: available/u);
   assert.match(rendered, /Memory: 7 retained notes/u);
-  assert.match(rendered, /2 active commitments; notifications digest/u);
+  assert.match(rendered, /Outcome checks: 2 pending; notifications digest/u);
+
+  const unavailable = projectSlackOperatorHome({
+    enabled_capabilities: [],
+    notification_mode: "muted",
+    pending_outcome_count: 0,
+    projection_key: "operator-home:unknown-memory",
+    source_states: [],
+    statuses: [],
+    view_selector: "tenant-user:unknown-memory",
+  });
+  assert.match(JSON.stringify(unavailable.view.blocks), /Memory: unavailable/u);
 });
 
 test("effect approvals expose exact-input controls without authorizing the click", () => {


### PR DESCRIPTION
## Summary

- add structured feedback controls to delivered Slack answers and bind every click to the exact answer
- persist immutable, retry-safe feedback before acknowledging Slack and reopen assessed outcomes when new feedback arrives
- generate retained production outcome/feedback evaluation receipts after the observation window
- publish observed operator state in App Home without inventing memory, source-health, or commitment counts

## Test Plan

- `npm run check --workspace @writer/cerebro-slack-companion-host` (140 tests)
- `node --test --test-concurrency=1 apps/slack-companion/dist/test/*.test.js` (521 tests)
- `node --test apps/slack-companion/dist/test/operator-loop-improvements.test.js` (6 tests)

## Known Invariants

- Feedback is persisted before Slack acknowledgement; failed persistence remains retryable.
- Exact feedback retries do not create another record or increment the outcome twice.
- Unverified outcomes remain unknown in production evaluation receipts.
- Production receipts use the train partition and do not infer unobserved claim, source, capability, or tool counts.
- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Deterministic Review

- Fast local invariant check: `make review-invariants`.
- Focus review on changed behavior and the invariants above.
- The required `deterministic-review` check runs the exact PR range through invariant, contract, structural, architecture, scanner, vulnerability, leak, and workflow-permission gates.
- Use a manual `@droid` task only when explicitly requested for broad auth, graph, source HTTP, or state-machine investigation; it is not an automatic merge gate.
- Land with `make land-pr PR=<number>` so the deterministic review check and required checks pass before branch deletion.