### PR TITLE
Honor configured graph ingest page limits

### DIFF
--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -822,7 +822,7 @@ func TestRunOrchestratorIterationSkipsGraphRulesUntilGraphIngestCatchesSyncCurso
 }
 
 func TestRunOrchestratorIterationAlignsGraphIngestWithSyncPageBudget(t *testing.T) {
-	registry, err := sourcecdk.NewRegistry(orchestratorPagedSource{pages: 3})
+	registry, err := sourcecdk.NewRegistry(orchestratorPagedSource{pages: 8})
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
@@ -850,7 +850,7 @@ func TestRunOrchestratorIterationAlignsGraphIngestWithSyncPageBudget(t *testing.
 		sourceruntime.New(registry, store, eventLog, nil),
 		findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry),
 		graphingest.New(registry, store, sourceprojection.New(nil, graphStore), graphStore),
-		orchestratorOptions{PageLimit: 3, GraphPageLimit: 1},
+		orchestratorOptions{PageLimit: 8, GraphPageLimit: 1},
 		1,
 	)
 	if err != nil {
@@ -860,8 +860,8 @@ func TestRunOrchestratorIterationAlignsGraphIngestWithSyncPageBudget(t *testing.
 		t.Fatalf("runtime result count = %d, want 1", got)
 	}
 	runtimeResult := result.Runtimes[0]
-	if runtimeResult.PagesRead != 3 || runtimeResult.EventsAppended != 3 {
-		t.Fatalf("sync pages/events = %d/%d, want 3/3", runtimeResult.PagesRead, runtimeResult.EventsAppended)
+	if runtimeResult.PagesRead != 8 || runtimeResult.EventsAppended != 8 {
+		t.Fatalf("sync pages/events = %d/%d, want 8/8", runtimeResult.PagesRead, runtimeResult.EventsAppended)
 	}
 	if runtimeResult.GraphIngest != "completed" {
 		t.Fatalf("graph ingest status = %q, want completed", runtimeResult.GraphIngest)
@@ -873,8 +873,8 @@ func TestRunOrchestratorIterationAlignsGraphIngestWithSyncPageBudget(t *testing.
 	if len(runs) != 1 {
 		t.Fatalf("completed ingest runs = %d, want 1", len(runs))
 	}
-	if runs[0].PagesRead != 3 {
-		t.Fatalf("graph ingest pages read = %d, want synced page budget 3 despite graph_page_limit=1", runs[0].PagesRead)
+	if runs[0].PagesRead != 8 {
+		t.Fatalf("graph ingest pages read = %d, want synced page budget 8 despite graph_page_limit=1", runs[0].PagesRead)
 	}
 }
 

--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -30,7 +30,6 @@ const (
 	MaxPageLimit                      = 100
 	DefaultStatusLimit                = 25
 	MaxStatusLimit                    = 500
-	defaultOrchestratorPageLimit      = 5
 	progressRunUpdateTimeout          = 15 * time.Second
 	terminalRunUpdateTimeout          = 15 * time.Second
 	defaultCleanupLimit               = 1000
@@ -274,7 +273,6 @@ func (s *Service) RunRuntime(ctx context.Context, request RuntimeRequest) (resul
 	if err != nil {
 		return nil, err
 	}
-	pageLimit = applyRuntimeBackpressureLimit(request, pageLimit)
 	spanAttributes = spanAttributes.WithField(telemetry.Field{Key: "effective_page_limit", Value: pageLimit})
 	startedAt := time.Now().UTC()
 	run := graphstore.IngestRun{
@@ -362,13 +360,6 @@ func (s *Service) acquireRuntimeLease(ctx context.Context, runtimeID string, alr
 		return ctx, noop, fmt.Errorf("%w: %s", sourceruntime.ErrSyncInProgress, runtimeID)
 	}
 	return leaseCtx, release, nil
-}
-
-func applyRuntimeBackpressureLimit(request RuntimeRequest, pageLimit uint32) uint32 {
-	if strings.TrimSpace(request.Trigger) == "orchestrator" && pageLimit > defaultOrchestratorPageLimit {
-		return defaultOrchestratorPageLimit
-	}
-	return pageLimit
 }
 
 func graphIngestTelemetryAttributes(attributes telemetry.Attributes, result *RunResult) telemetry.Attributes {

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -315,7 +315,7 @@ func TestRunRuntimeUsesCallerHeldRuntimeLease(t *testing.T) {
 	}
 }
 
-func TestRunRuntimeAppliesOrchestratorBackpressurePageLimit(t *testing.T) {
+func TestRunRuntimeHonorsOrchestratorPageLimit(t *testing.T) {
 	registry, err := sourcecdk.NewRegistry(&multiCursorPagedSource{
 		id:    "paged",
 		pages: graphIngestTestPages(8, "paged"),
@@ -356,11 +356,11 @@ func TestRunRuntimeAppliesOrchestratorBackpressurePageLimit(t *testing.T) {
 	if orchestratorResult.Ingest == nil {
 		t.Fatal("RunRuntime(orchestrator) ingest = nil")
 	}
-	if orchestratorResult.Ingest.PagesRead != defaultOrchestratorPageLimit || orchestratorResult.Ingest.EventsRead != defaultOrchestratorPageLimit {
-		t.Fatalf("orchestrator pages/events = %d/%d, want %d/%d", orchestratorResult.Ingest.PagesRead, orchestratorResult.Ingest.EventsRead, defaultOrchestratorPageLimit, defaultOrchestratorPageLimit)
+	if orchestratorResult.Ingest.PagesRead != 8 || orchestratorResult.Ingest.EventsRead != 8 {
+		t.Fatalf("orchestrator pages/events = %d/%d, want the configured 8/8", orchestratorResult.Ingest.PagesRead, orchestratorResult.Ingest.EventsRead)
 	}
-	if orchestratorResult.Ingest.NextCursor != "page-5" {
-		t.Fatalf("orchestrator next cursor = %q, want page-5", orchestratorResult.Ingest.NextCursor)
+	if orchestratorResult.Ingest.NextCursor != "" || !orchestratorResult.Ingest.CheckpointComplete {
+		t.Fatalf("orchestrator checkpoint = next:%q complete:%t, want complete", orchestratorResult.Ingest.NextCursor, orchestratorResult.Ingest.CheckpointComplete)
 	}
 
 	manualResult, err := service.RunRuntime(context.Background(), RuntimeRequest{


### PR DESCRIPTION
The scheduled orchestrator already computes a graph projection budget from the reviewed per-runtime limit and the number of source pages read while holding the runtime lease. Graph ingestion then silently capped that budget at five pages, leaving durable checkpoint debt for larger source runs.

This change removes the second implicit cap so the caller-provided, normalized limit remains authoritative. Existing maximum validation and private per-runtime contention limits remain unchanged.

Validation:
- `go test ./internal/graphingest ./cmd/cerebro`