### PR TITLE
feat(slack): establish agent gym contracts

### DIFF
--- a/apps/slack-companion/src/agent-gym/candidate-manifest.ts
+++ b/apps/slack-companion/src/agent-gym/candidate-manifest.ts
@@ -1,0 +1,53 @@
+import { AgentGymContractError } from "./index.js";
+
+export interface AgentGymCandidateManifestV1 {
+  readonly candidate_ref: string;
+  readonly max_output_tokens: number;
+  readonly model_id: string;
+  readonly policy_digest: `sha256:${string}`;
+  readonly prompt_digest: `sha256:${string}`;
+  readonly provider: "aws_bedrock" | "recorded";
+  readonly region?: string;
+  readonly schema_version: "agent-gym-candidate-manifest/v1";
+  readonly source_revision: string;
+  readonly tool_catalog_digest: `sha256:${string}`;
+  readonly tool_ids: readonly string[];
+}
+
+/** Binds an evaluated candidate to exact source, prompt, policy, tools, and model. */
+export function validateAgentGymCandidateManifest(
+  manifest: AgentGymCandidateManifestV1,
+): AgentGymCandidateManifestV1 {
+  if (manifest.schema_version !== "agent-gym-candidate-manifest/v1") invalid();
+  reference(manifest.candidate_ref);
+  bounded(manifest.model_id, 240);
+  digest(manifest.policy_digest);
+  digest(manifest.prompt_digest);
+  digest(manifest.tool_catalog_digest);
+  if (!/^[0-9a-f]{40}$/u.test(manifest.source_revision)) invalid();
+  if (!Number.isSafeInteger(manifest.max_output_tokens)
+    || manifest.max_output_tokens < 1 || manifest.max_output_tokens > 32_768) invalid();
+  if (!["aws_bedrock", "recorded"].includes(manifest.provider)) invalid();
+  if (manifest.provider === "aws_bedrock") {
+    if (manifest.region === undefined || !/^[a-z]{2}(?:-gov)?-[a-z]+-\d$/u.test(manifest.region)) invalid();
+  } else if (manifest.region !== undefined) invalid();
+  if (!Array.isArray(manifest.tool_ids) || manifest.tool_ids.length > 128
+    || new Set(manifest.tool_ids).size !== manifest.tool_ids.length) invalid();
+  for (const toolId of manifest.tool_ids) bounded(toolId, 160);
+  return Object.freeze({ ...manifest, tool_ids: Object.freeze([...manifest.tool_ids]) });
+}
+
+function bounded(value: string, maximum: number): void {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function digest(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  bounded(value, 240);
+  if (!value.includes("://")) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym candidate manifest is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/fixture-case.ts
+++ b/apps/slack-companion/src/agent-gym/fixture-case.ts
@@ -1,0 +1,122 @@
+import { AgentGymContractError } from "./index.js";
+
+export type AgentGymJson =
+  | boolean | number | string | null
+  | readonly AgentGymJson[]
+  | { readonly [key: string]: AgentGymJson };
+
+export type AgentGymSlackEventKind =
+  | "app_home_opened"
+  | "button_action"
+  | "direct_message"
+  | "mention"
+  | "message_changed"
+  | "message_deleted"
+  | "reaction_added"
+  | "thread_reply";
+
+export interface AgentGymSlackEventV1 {
+  readonly event_ref: string;
+  readonly kind: AgentGymSlackEventKind;
+  readonly occurred_at: string;
+  readonly payload: { readonly [key: string]: AgentGymJson };
+}
+
+export interface AgentGymToolFixtureV1 {
+  readonly call_ref: string;
+  readonly error_code?: string;
+  readonly input: { readonly [key: string]: AgentGymJson };
+  readonly outcome: "error" | "success" | "timeout";
+  readonly output?: { readonly [key: string]: AgentGymJson };
+  readonly tool_id: string;
+}
+
+export interface AgentGymFixtureCaseV1 {
+  readonly case_ref: string;
+  readonly expected_invariants: readonly string[];
+  readonly labels: readonly string[];
+  readonly partition: "held_out" | "shadow" | "train";
+  readonly schema_version: "agent-gym-fixture-case/v1";
+  readonly slack_events: readonly AgentGymSlackEventV1[];
+  readonly tool_fixtures: readonly AgentGymToolFixtureV1[];
+}
+
+const EVENT_KINDS: readonly AgentGymSlackEventKind[] = [
+  "app_home_opened", "button_action", "direct_message", "mention",
+  "message_changed", "message_deleted", "reaction_added", "thread_reply",
+];
+
+/** Validates and freezes one portable Slack-agent scenario. */
+export function validateAgentGymFixtureCase(
+  fixture: AgentGymFixtureCaseV1,
+): AgentGymFixtureCaseV1 {
+  if (fixture.schema_version !== "agent-gym-fixture-case/v1") invalid();
+  reference(fixture.case_ref, "case reference");
+  if (!["held_out", "shadow", "train"].includes(fixture.partition)) invalid();
+  strings(fixture.labels, 32, "labels");
+  strings(fixture.expected_invariants, 64, "expected invariants");
+  if (fixture.slack_events.length === 0 || fixture.slack_events.length > 100) invalid();
+  const eventRefs = new Set<string>();
+  const events = fixture.slack_events.map((event) => {
+    reference(event.event_ref, "event reference");
+    if (eventRefs.has(event.event_ref) || !EVENT_KINDS.includes(event.kind)) invalid();
+    eventRefs.add(event.event_ref);
+    timestamp(event.occurred_at);
+    jsonObject(event.payload, "event payload");
+    return Object.freeze({ ...event, payload: deepFreeze(event.payload) });
+  });
+  const callRefs = new Set<string>();
+  const tools = fixture.tool_fixtures.map((tool) => {
+    reference(tool.call_ref, "tool call reference");
+    text(tool.tool_id, 160, "tool id");
+    if (callRefs.has(tool.call_ref) || !["error", "success", "timeout"].includes(tool.outcome)) invalid();
+    callRefs.add(tool.call_ref);
+    jsonObject(tool.input, "tool input");
+    if (tool.outcome === "success" && tool.output === undefined) invalid();
+    if (tool.output !== undefined) jsonObject(tool.output, "tool output");
+    if (tool.error_code !== undefined) text(tool.error_code, 120, "tool error code");
+    return Object.freeze({
+      ...tool,
+      input: deepFreeze(tool.input),
+      ...(tool.output === undefined ? {} : { output: deepFreeze(tool.output) }),
+    });
+  });
+  return Object.freeze({
+    ...fixture,
+    expected_invariants: Object.freeze([...fixture.expected_invariants]),
+    labels: Object.freeze([...fixture.labels]),
+    slack_events: Object.freeze(events),
+    tool_fixtures: Object.freeze(tools),
+  });
+}
+
+function deepFreeze<T extends AgentGymJson>(value: T): T {
+  if (value !== null && typeof value === "object") {
+    for (const nested of Object.values(value)) deepFreeze(nested);
+    Object.freeze(value);
+  }
+  return value;
+}
+function invalid(): never { throw new AgentGymContractError("Agent gym fixture is invalid."); }
+function jsonObject(value: object, field: string): void {
+  try {
+    const encoded = JSON.stringify(value);
+    if (encoded === undefined || Buffer.byteLength(encoded, "utf8") > 256_000) throw new Error();
+  } catch { throw new AgentGymContractError(`Agent gym ${field} is invalid.`); }
+}
+function reference(value: string, field: string): void {
+  text(value, 240, field);
+  if (!value.includes("://")) throw new AgentGymContractError(`Agent gym ${field} is invalid.`);
+}
+function strings(values: readonly string[], limit: number, field: string): void {
+  if (!Array.isArray(values) || values.length > limit || new Set(values).size !== values.length) invalid();
+  for (const value of values) text(value, 160, field);
+}
+function text(value: string, maximum: number, field: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum || /[\u0000-\u001f\u007f]/u.test(value)) {
+    throw new AgentGymContractError(`Agent gym ${field} is invalid.`);
+  }
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -12,3 +12,4 @@ export class AgentGymContractError extends Error {
 }
 
 export * from "./fixture-case.js";
+export * from "./candidate-manifest.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -10,3 +10,5 @@ export class AgentGymContractError extends Error {
     this.name = "AgentGymContractError";
   }
 }
+
+export * from "./fixture-case.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -13,3 +13,4 @@ export class AgentGymContractError extends Error {
 
 export * from "./fixture-case.js";
 export * from "./candidate-manifest.js";
+export * from "./replay-run.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -14,3 +14,4 @@ export class AgentGymContractError extends Error {
 export * from "./fixture-case.js";
 export * from "./candidate-manifest.js";
 export * from "./replay-run.js";
+export * from "./scorecard.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -1,0 +1,12 @@
+/** Stable identity for the repository-native, Slack-independent agent harness. */
+export const CEREBRO_AGENT_GYM = Object.freeze({
+  artifact_namespace: "cerebro-agent-gym",
+  schema_version: "cerebro-agent-gym/v1",
+});
+
+export class AgentGymContractError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AgentGymContractError";
+  }
+}

--- a/apps/slack-companion/src/agent-gym/replay-run.ts
+++ b/apps/slack-companion/src/agent-gym/replay-run.ts
@@ -1,0 +1,76 @@
+import { AgentGymContractError } from "./index.js";
+
+export interface AgentGymReplayTurnV1 {
+  readonly content_digest: `sha256:${string}`;
+  readonly kind: "effect" | "input" | "model" | "tool";
+  readonly latency_ms: number;
+  readonly provider_request_id?: string;
+  readonly recorded_at: string;
+  readonly token_usage?: {
+    readonly input_tokens: number;
+    readonly output_tokens: number;
+  };
+  readonly turn_index: number;
+}
+
+export interface AgentGymReplayRunV1 {
+  readonly artifact_digest: `sha256:${string}`;
+  readonly candidate_ref: string;
+  readonly completed_at: string;
+  readonly failure_code?: string;
+  readonly fixture_ref: string;
+  readonly run_ref: string;
+  readonly schema_version: "agent-gym-replay-run/v1";
+  readonly started_at: string;
+  readonly status: "failed" | "passed";
+  readonly turns: readonly AgentGymReplayTurnV1[];
+}
+
+/** Validates the immutable receipt for one complete fixture replay. */
+export function validateAgentGymReplayRun(run: AgentGymReplayRunV1): AgentGymReplayRunV1 {
+  if (run.schema_version !== "agent-gym-replay-run/v1") invalid();
+  for (const ref of [run.run_ref, run.candidate_ref, run.fixture_ref]) reference(ref);
+  timestamp(run.started_at);
+  timestamp(run.completed_at);
+  if (Date.parse(run.completed_at) < Date.parse(run.started_at)) invalid();
+  digest(run.artifact_digest);
+  if (!["failed", "passed"].includes(run.status)) invalid();
+  if ((run.status === "failed") !== (run.failure_code !== undefined)) invalid();
+  if (run.failure_code !== undefined) bounded(run.failure_code, 120);
+  if (!Array.isArray(run.turns) || run.turns.length === 0 || run.turns.length > 1_000) invalid();
+  let priorTime = Date.parse(run.started_at);
+  const turns = run.turns.map((turn, index) => {
+    if (turn.turn_index !== index || !["effect", "input", "model", "tool"].includes(turn.kind)) invalid();
+    timestamp(turn.recorded_at);
+    const time = Date.parse(turn.recorded_at);
+    if (time < priorTime || time > Date.parse(run.completed_at)) invalid();
+    priorTime = time;
+    digest(turn.content_digest);
+    integer(turn.latency_ms, 3_600_000);
+    if (turn.provider_request_id !== undefined) bounded(turn.provider_request_id, 240);
+    if (turn.token_usage !== undefined) {
+      integer(turn.token_usage.input_tokens, 100_000_000);
+      integer(turn.token_usage.output_tokens, 100_000_000);
+    }
+    return Object.freeze({
+      ...turn,
+      ...(turn.token_usage === undefined ? {} : { token_usage: Object.freeze({ ...turn.token_usage }) }),
+    });
+  });
+  return Object.freeze({ ...run, turns: Object.freeze(turns) });
+}
+
+function bounded(value: string, maximum: number): void {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function integer(value: number, maximum: number): void {
+  if (!Number.isSafeInteger(value) || value < 0 || value > maximum) invalid();
+}
+function reference(value: string): void { bounded(value, 240); if (!value.includes("://")) invalid(); }
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never { throw new AgentGymContractError("Agent gym replay run is invalid."); }

--- a/apps/slack-companion/src/agent-gym/scorecard.ts
+++ b/apps/slack-companion/src/agent-gym/scorecard.ts
@@ -1,0 +1,74 @@
+import { AgentGymContractError } from "./index.js";
+
+export interface AgentGymMetricScoreV1 {
+  readonly evaluator: "deterministic" | "model_judge";
+  readonly metric_id: string;
+  readonly passed: boolean;
+  readonly reason_codes: readonly string[];
+  readonly score: number;
+  readonly weight: number;
+}
+
+export interface AgentGymScorecardV1 {
+  readonly blocker_codes: readonly string[];
+  readonly candidate_ref: string;
+  readonly evaluated_at: string;
+  readonly fixture_ref: string;
+  readonly metrics: readonly AgentGymMetricScoreV1[];
+  readonly replay_ref: string;
+  readonly schema_version: "agent-gym-scorecard/v1";
+  readonly scorecard_ref: string;
+  readonly weighted_score: number;
+}
+
+/** Validates one fail-closed deterministic and judge scorecard. */
+export function validateAgentGymScorecard(scorecard: AgentGymScorecardV1): AgentGymScorecardV1 {
+  if (scorecard.schema_version !== "agent-gym-scorecard/v1") invalid();
+  for (const ref of [scorecard.scorecard_ref, scorecard.candidate_ref,
+    scorecard.fixture_ref, scorecard.replay_ref]) reference(ref);
+  timestamp(scorecard.evaluated_at);
+  strings(scorecard.blocker_codes, 64);
+  if (!Array.isArray(scorecard.metrics) || scorecard.metrics.length === 0
+    || scorecard.metrics.length > 128) invalid();
+  const metricIds = new Set<string>();
+  const metrics = scorecard.metrics.map((metric) => {
+    bounded(metric.metric_id, 160);
+    if (metricIds.has(metric.metric_id)
+      || !["deterministic", "model_judge"].includes(metric.evaluator)) invalid();
+    metricIds.add(metric.metric_id);
+    unit(metric.score);
+    if (!Number.isFinite(metric.weight) || metric.weight <= 0 || metric.weight > 100) invalid();
+    strings(metric.reason_codes, 32);
+    if (metric.evaluator === "deterministic" && metric.passed !== (metric.score === 1)) invalid();
+    return Object.freeze({ ...metric, reason_codes: Object.freeze([...metric.reason_codes]) });
+  });
+  const expected = metrics.reduce((total, metric) => total + metric.score * metric.weight, 0)
+    / metrics.reduce((total, metric) => total + metric.weight, 0);
+  unit(scorecard.weighted_score);
+  if (Math.abs(expected - scorecard.weighted_score) > 1e-9) invalid();
+  const failedDeterministic = metrics.filter((metric) =>
+    metric.evaluator === "deterministic" && !metric.passed
+  );
+  if (failedDeterministic.length > 0 && scorecard.blocker_codes.length === 0) invalid();
+  return Object.freeze({
+    ...scorecard,
+    blocker_codes: Object.freeze([...scorecard.blocker_codes]),
+    metrics: Object.freeze(metrics),
+  });
+}
+
+function bounded(value: string, maximum: number): void {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function reference(value: string): void { bounded(value, 240); if (!value.includes("://")) invalid(); }
+function strings(values: readonly string[], maximum: number): void {
+  if (!Array.isArray(values) || values.length > maximum || new Set(values).size !== values.length) invalid();
+  for (const value of values) bounded(value, 160);
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function unit(value: number): void { if (!Number.isFinite(value) || value < 0 || value > 1) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym scorecard is invalid."); }

--- a/apps/slack-companion/src/index.ts
+++ b/apps/slack-companion/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./admission.js";
+export * from "./agent-gym/index.js";
 export * from "./autonomy/contracts.js";
 export * from "./autonomy/ledger.js";
 export * from "./autonomy/ports.js";

--- a/apps/slack-companion/test/agent-gym-package.test.ts
+++ b/apps/slack-companion/test/agent-gym-package.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AgentGymContractError, CEREBRO_AGENT_GYM } from "../src/index.js";
+
+test("agent gym exposes a stable public contract identity", () => {
+  assert.deepEqual(CEREBRO_AGENT_GYM, {
+    artifact_namespace: "cerebro-agent-gym",
+    schema_version: "cerebro-agent-gym/v1",
+  });
+  assert.equal(Object.isFrozen(CEREBRO_AGENT_GYM), true);
+  assert.equal(new AgentGymContractError("invalid").name, "AgentGymContractError");
+});

--- a/apps/slack-companion/test/agent-gym-package.test.ts
+++ b/apps/slack-companion/test/agent-gym-package.test.ts
@@ -6,6 +6,7 @@ import {
   CEREBRO_AGENT_GYM,
   validateAgentGymCandidateManifest,
   validateAgentGymFixtureCase,
+  validateAgentGymReplayRun,
 } from "../src/index.js";
 
 test("agent gym exposes a stable public contract identity", () => {
@@ -15,6 +16,33 @@ test("agent gym exposes a stable public contract identity", () => {
   });
   assert.equal(Object.isFrozen(CEREBRO_AGENT_GYM), true);
   assert.equal(new AgentGymContractError("invalid").name, "AgentGymContractError");
+});
+
+test("replay runs preserve ordered model and effect receipts", () => {
+  const digest = `sha256:${"c".repeat(64)}` as const;
+  const run = validateAgentGymReplayRun({
+    artifact_digest: digest,
+    candidate_ref: "candidate://agent-gym/one",
+    completed_at: "2026-08-12T08:00:02.000Z",
+    fixture_ref: "case://agent-gym/mention-one",
+    run_ref: "replay://agent-gym/one",
+    schema_version: "agent-gym-replay-run/v1",
+    started_at: "2026-08-12T08:00:00.000Z",
+    status: "passed",
+    turns: [{
+      content_digest: digest,
+      kind: "model",
+      latency_ms: 800,
+      recorded_at: "2026-08-12T08:00:01.000Z",
+      token_usage: { input_tokens: 100, output_tokens: 25 },
+      turn_index: 0,
+    }],
+  });
+  assert.equal(Object.isFrozen(run.turns[0]?.token_usage), true);
+  assert.throws(() => validateAgentGymReplayRun({
+    ...run,
+    status: "failed",
+  }), /replay run is invalid/u);
 });
 
 test("candidate manifests bind every evaluation input to immutable digests", () => {

--- a/apps/slack-companion/test/agent-gym-package.test.ts
+++ b/apps/slack-companion/test/agent-gym-package.test.ts
@@ -7,6 +7,7 @@ import {
   validateAgentGymCandidateManifest,
   validateAgentGymFixtureCase,
   validateAgentGymReplayRun,
+  validateAgentGymScorecard,
 } from "../src/index.js";
 
 test("agent gym exposes a stable public contract identity", () => {
@@ -16,6 +17,40 @@ test("agent gym exposes a stable public contract identity", () => {
   });
   assert.equal(Object.isFrozen(CEREBRO_AGENT_GYM), true);
   assert.equal(new AgentGymContractError("invalid").name, "AgentGymContractError");
+});
+
+test("scorecards fail closed when deterministic invariants fail", () => {
+  const input = {
+    blocker_codes: ["missing_evidence"],
+    candidate_ref: "candidate://agent-gym/one",
+    evaluated_at: "2026-08-12T08:01:00.000Z",
+    fixture_ref: "case://agent-gym/mention-one",
+    metrics: [{
+      evaluator: "deterministic" as const,
+      metric_id: "answer_has_evidence",
+      passed: false,
+      reason_codes: ["no_evidence_ref"],
+      score: 0,
+      weight: 2,
+    }, {
+      evaluator: "model_judge" as const,
+      metric_id: "response_quality",
+      passed: true,
+      reason_codes: [],
+      score: 0.75,
+      weight: 1,
+    }],
+    replay_ref: "replay://agent-gym/one",
+    schema_version: "agent-gym-scorecard/v1" as const,
+    scorecard_ref: "scorecard://agent-gym/one",
+    weighted_score: 0.25,
+  };
+  const scorecard = validateAgentGymScorecard(input);
+  assert.equal(scorecard.weighted_score, 0.25);
+  assert.throws(() => validateAgentGymScorecard({
+    ...input,
+    blocker_codes: [],
+  }), /scorecard is invalid/u);
 });
 
 test("replay runs preserve ordered model and effect receipts", () => {

--- a/apps/slack-companion/test/agent-gym-package.test.ts
+++ b/apps/slack-companion/test/agent-gym-package.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   AgentGymContractError,
   CEREBRO_AGENT_GYM,
+  validateAgentGymCandidateManifest,
   validateAgentGymFixtureCase,
 } from "../src/index.js";
 
@@ -14,6 +15,28 @@ test("agent gym exposes a stable public contract identity", () => {
   });
   assert.equal(Object.isFrozen(CEREBRO_AGENT_GYM), true);
   assert.equal(new AgentGymContractError("invalid").name, "AgentGymContractError");
+});
+
+test("candidate manifests bind every evaluation input to immutable digests", () => {
+  const digest = `sha256:${"a".repeat(64)}` as const;
+  const candidate = validateAgentGymCandidateManifest({
+    candidate_ref: "candidate://agent-gym/one",
+    max_output_tokens: 800,
+    model_id: "inference-profile.example-model",
+    policy_digest: digest,
+    prompt_digest: digest,
+    provider: "aws_bedrock",
+    region: "us-east-1",
+    schema_version: "agent-gym-candidate-manifest/v1",
+    source_revision: "b".repeat(40),
+    tool_catalog_digest: digest,
+    tool_ids: ["cerebro.search"],
+  });
+  assert.equal(Object.isFrozen(candidate.tool_ids), true);
+  assert.throws(() => validateAgentGymCandidateManifest({
+    ...candidate,
+    provider: "recorded",
+  }), /candidate manifest is invalid/u);
 });
 
 test("fixture cases retain ordered Slack events and deterministic tool results", () => {

--- a/apps/slack-companion/test/agent-gym-package.test.ts
+++ b/apps/slack-companion/test/agent-gym-package.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { AgentGymContractError, CEREBRO_AGENT_GYM } from "../src/index.js";
+import {
+  AgentGymContractError,
+  CEREBRO_AGENT_GYM,
+  validateAgentGymFixtureCase,
+} from "../src/index.js";
 
 test("agent gym exposes a stable public contract identity", () => {
   assert.deepEqual(CEREBRO_AGENT_GYM, {
@@ -10,4 +14,33 @@ test("agent gym exposes a stable public contract identity", () => {
   });
   assert.equal(Object.isFrozen(CEREBRO_AGENT_GYM), true);
   assert.equal(new AgentGymContractError("invalid").name, "AgentGymContractError");
+});
+
+test("fixture cases retain ordered Slack events and deterministic tool results", () => {
+  const fixture = validateAgentGymFixtureCase({
+    case_ref: "case://agent-gym/mention-one",
+    expected_invariants: ["answer_has_evidence"],
+    labels: ["lookup"],
+    partition: "train",
+    schema_version: "agent-gym-fixture-case/v1",
+    slack_events: [{
+      event_ref: "slack-event://one",
+      kind: "mention",
+      occurred_at: "2026-08-12T08:00:00.000Z",
+      payload: { text: "What changed?" },
+    }],
+    tool_fixtures: [{
+      call_ref: "tool-call://one",
+      input: { query: "recent changes" },
+      outcome: "success",
+      output: { count: 2 },
+      tool_id: "cerebro.search",
+    }],
+  });
+  assert.equal(fixture.slack_events[0]?.kind, "mention");
+  assert.equal(Object.isFrozen(fixture.tool_fixtures[0]?.output), true);
+  assert.throws(() => validateAgentGymFixtureCase({
+    ...fixture,
+    slack_events: [fixture.slack_events[0]!, fixture.slack_events[0]!],
+  }), /fixture is invalid/u);
 });


### PR DESCRIPTION
## Summary

- establish the portable agent evaluation harness namespace
- define versioned fixture, candidate, replay, and scorecard contracts
- reject malformed or internally inconsistent evaluation records

## Validation

- `npm run typecheck --workspace @writer/cerebro-slack-companion`
- `node --test apps/slack-companion/dist/test/agent-gym-package.test.js`
- `npm test --workspace @writer/cerebro-slack-companion`