### PR TITLE
feat(slack): add agent gym evaluation receipts

### DIFF
--- a/apps/slack-companion/package.json
+++ b/apps/slack-companion/package.json
@@ -27,6 +27,7 @@
     "directory": "apps/slack-companion"
   },
   "scripts": {
+    "agent-gym": "npm run build --silent && node dist/src/agent-gym/run-cli.js",
     "build": "tsc -p tsconfig.json",
     "check": "npm run typecheck && npm test",
     "eval:hillclimb": "npm run build --silent && node dist/src/scratchpad/run-hillclimb-bedrock.js",

--- a/apps/slack-companion/src/agent-gym/artifact.ts
+++ b/apps/slack-companion/src/agent-gym/artifact.ts
@@ -1,0 +1,27 @@
+import { createHash } from "node:crypto";
+import { AgentGymContractError } from "./index.js";
+
+export interface AgentGymArtifactIdentityV1 {
+  readonly byte_length: number;
+  readonly content_digest: `sha256:${string}`;
+  readonly media_type: "application/json" | "application/x-ndjson" | "text/plain";
+  readonly schema_version: "agent-gym-artifact-identity/v1";
+}
+
+/** Computes a content address without selecting a storage provider. */
+export function identifyAgentGymArtifact(
+  bytes: Uint8Array,
+  mediaType: AgentGymArtifactIdentityV1["media_type"],
+): AgentGymArtifactIdentityV1 {
+  if (!(bytes instanceof Uint8Array) || bytes.byteLength === 0
+    || bytes.byteLength > 64 * 1024 * 1024
+    || !["application/json", "application/x-ndjson", "text/plain"].includes(mediaType)) {
+    throw new AgentGymContractError("Agent gym artifact is invalid.");
+  }
+  return Object.freeze({
+    byte_length: bytes.byteLength,
+    content_digest: `sha256:${createHash("sha256").update(bytes).digest("hex")}`,
+    media_type: mediaType,
+    schema_version: "agent-gym-artifact-identity/v1",
+  });
+}

--- a/apps/slack-companion/src/agent-gym/cli.ts
+++ b/apps/slack-companion/src/agent-gym/cli.ts
@@ -1,0 +1,48 @@
+import { AgentGymContractError, CEREBRO_AGENT_GYM } from "./index.js";
+
+export interface AgentGymCliCommandV1 {
+  readonly command: "compare" | "replay" | "validate" | "version";
+  readonly input_paths: readonly string[];
+  readonly output: "json" | "ndjson";
+  readonly schema_version: "agent-gym-cli-command/v1";
+}
+
+/** Parses the stable, intentionally narrow repository CLI surface. */
+export function parseAgentGymCliCommand(args: readonly string[]): AgentGymCliCommandV1 {
+  if (args.length === 1 && args[0] === "--version") {
+    return Object.freeze({
+      command: "version",
+      input_paths: Object.freeze([]),
+      output: "json",
+      schema_version: "agent-gym-cli-command/v1",
+    });
+  }
+  const [command, ...rest] = args;
+  if (command !== "compare" && command !== "replay" && command !== "validate") invalid();
+  const formatIndex = rest.indexOf("--output");
+  let output: "json" | "ndjson" = "json";
+  const paths = [...rest];
+  if (formatIndex >= 0) {
+    const selected = paths[formatIndex + 1];
+    if ((selected !== "json" && selected !== "ndjson") || formatIndex + 2 !== paths.length) invalid();
+    output = selected;
+    paths.splice(formatIndex, 2);
+  }
+  if (paths.length === 0 || paths.length > 256) invalid();
+  for (const path of paths) {
+    if (!path.trim() || path.length > 1_024 || path.startsWith("-")
+      || /[\u0000-\u001f\u007f]/u.test(path)) invalid();
+  }
+  return Object.freeze({
+    command,
+    input_paths: Object.freeze(paths),
+    output,
+    schema_version: "agent-gym-cli-command/v1",
+  });
+}
+
+export function agentGymVersionOutput(): string {
+  return `${JSON.stringify(CEREBRO_AGENT_GYM)}\n`;
+}
+
+function invalid(): never { throw new AgentGymContractError("Agent gym CLI command is invalid."); }

--- a/apps/slack-companion/src/agent-gym/comparison.ts
+++ b/apps/slack-companion/src/agent-gym/comparison.ts
@@ -1,0 +1,77 @@
+import { AgentGymContractError } from "./index.js";
+
+export interface AgentGymSliceDeltaV1 {
+  readonly baseline_score: number;
+  readonly candidate_score: number;
+  readonly case_count: number;
+  readonly delta: number;
+  readonly slice_id: string;
+}
+
+export interface AgentGymComparisonV1 {
+  readonly baseline_candidate_ref: string;
+  readonly candidate_ref: string;
+  readonly compared_at: string;
+  readonly comparison_ref: string;
+  readonly confidence_interval_95: readonly [number, number];
+  readonly paired_case_count: number;
+  readonly practical_threshold: number;
+  readonly schema_version: "agent-gym-comparison/v1";
+  readonly slices: readonly AgentGymSliceDeltaV1[];
+  readonly weighted_score_delta: number;
+}
+
+/** Validates a paired comparison without deciding whether to promote it. */
+export function validateAgentGymComparison(
+  comparison: AgentGymComparisonV1,
+): AgentGymComparisonV1 {
+  if (comparison.schema_version !== "agent-gym-comparison/v1") invalid();
+  for (const ref of [comparison.comparison_ref, comparison.baseline_candidate_ref,
+    comparison.candidate_ref]) reference(ref);
+  if (comparison.baseline_candidate_ref === comparison.candidate_ref) invalid();
+  timestamp(comparison.compared_at);
+  integer(comparison.paired_case_count, 1_000_000, false);
+  finite(comparison.weighted_score_delta, -1, 1);
+  finite(comparison.practical_threshold, 0, 1);
+  const [lower, upper] = comparison.confidence_interval_95;
+  finite(lower, -1, 1);
+  finite(upper, -1, 1);
+  if (lower > comparison.weighted_score_delta || upper < comparison.weighted_score_delta) invalid();
+  if (!Array.isArray(comparison.slices) || comparison.slices.length === 0
+    || comparison.slices.length > 128) invalid();
+  const sliceIds = new Set<string>();
+  const slices = comparison.slices.map((slice) => {
+    bounded(slice.slice_id, 160);
+    if (sliceIds.has(slice.slice_id)) invalid();
+    sliceIds.add(slice.slice_id);
+    unit(slice.baseline_score);
+    unit(slice.candidate_score);
+    finite(slice.delta, -1, 1);
+    if (Math.abs(slice.candidate_score - slice.baseline_score - slice.delta) > 1e-9) invalid();
+    integer(slice.case_count, comparison.paired_case_count, false);
+    return Object.freeze({ ...slice });
+  });
+  return Object.freeze({
+    ...comparison,
+    confidence_interval_95: Object.freeze([lower, upper]),
+    slices: Object.freeze(slices),
+  });
+}
+
+function bounded(value: string, maximum: number): void {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function finite(value: number, minimum: number, maximum: number): void {
+  if (!Number.isFinite(value) || value < minimum || value > maximum) invalid();
+}
+function integer(value: number, maximum: number, allowZero = true): void {
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1) || value > maximum) invalid();
+}
+function reference(value: string): void { bounded(value, 240); if (!value.includes("://")) invalid(); }
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function unit(value: number): void { finite(value, 0, 1); }
+function invalid(): never { throw new AgentGymContractError("Agent gym comparison is invalid."); }

--- a/apps/slack-companion/src/agent-gym/comparison.ts
+++ b/apps/slack-companion/src/agent-gym/comparison.ts
@@ -53,7 +53,7 @@ export function validateAgentGymComparison(
   });
   return Object.freeze({
     ...comparison,
-    confidence_interval_95: Object.freeze([lower, upper]),
+    confidence_interval_95: Object.freeze([lower, upper] as const),
     slices: Object.freeze(slices),
   });
 }

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -13,5 +13,6 @@ export class AgentGymContractError extends Error {
 
 export * from "./fixture-case.js";
 export * from "./candidate-manifest.js";
+export * from "./comparison.js";
 export * from "./replay-run.js";
 export * from "./scorecard.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -14,6 +14,7 @@ export class AgentGymContractError extends Error {
 export * from "./fixture-case.js";
 export * from "./artifact.js";
 export * from "./candidate-manifest.js";
+export * from "./cli.js";
 export * from "./comparison.js";
 export * from "./promotion-decision.js";
 export * from "./replay-run.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -12,6 +12,7 @@ export class AgentGymContractError extends Error {
 }
 
 export * from "./fixture-case.js";
+export * from "./artifact.js";
 export * from "./candidate-manifest.js";
 export * from "./comparison.js";
 export * from "./promotion-decision.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -18,4 +18,5 @@ export * from "./cli.js";
 export * from "./comparison.js";
 export * from "./promotion-decision.js";
 export * from "./replay-run.js";
+export * from "./run-summary.js";
 export * from "./scorecard.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -14,5 +14,6 @@ export class AgentGymContractError extends Error {
 export * from "./fixture-case.js";
 export * from "./candidate-manifest.js";
 export * from "./comparison.js";
+export * from "./promotion-decision.js";
 export * from "./replay-run.js";
 export * from "./scorecard.js";

--- a/apps/slack-companion/src/agent-gym/promotion-decision.ts
+++ b/apps/slack-companion/src/agent-gym/promotion-decision.ts
@@ -1,0 +1,54 @@
+import { AgentGymContractError } from "./index.js";
+
+export type AgentGymPromotionDisposition = "blocked" | "inconclusive" | "promote";
+
+export interface AgentGymPromotionDecisionV1 {
+  readonly baseline_candidate_ref: string;
+  readonly candidate_ref: string;
+  readonly comparison_ref: string;
+  readonly decided_at: string;
+  readonly decision_ref: string;
+  readonly disposition: AgentGymPromotionDisposition;
+  readonly held_out_passed: boolean;
+  readonly reason_codes: readonly string[];
+  readonly schema_version: "agent-gym-promotion-decision/v1";
+  readonly safety_blocker_codes: readonly string[];
+}
+
+/** Requires positive held-out evidence and no safety blocker for promotion. */
+export function validateAgentGymPromotionDecision(
+  decision: AgentGymPromotionDecisionV1,
+): AgentGymPromotionDecisionV1 {
+  if (decision.schema_version !== "agent-gym-promotion-decision/v1") invalid();
+  for (const ref of [decision.decision_ref, decision.baseline_candidate_ref,
+    decision.candidate_ref, decision.comparison_ref]) reference(ref);
+  if (decision.baseline_candidate_ref === decision.candidate_ref) invalid();
+  timestamp(decision.decided_at);
+  if (!["blocked", "inconclusive", "promote"].includes(decision.disposition)) invalid();
+  strings(decision.reason_codes, 64);
+  strings(decision.safety_blocker_codes, 64);
+  if (decision.reason_codes.length === 0) invalid();
+  if (decision.disposition === "promote"
+    && (!decision.held_out_passed || decision.safety_blocker_codes.length > 0)) invalid();
+  if (decision.safety_blocker_codes.length > 0 && decision.disposition !== "blocked") invalid();
+  return Object.freeze({
+    ...decision,
+    reason_codes: Object.freeze([...decision.reason_codes]),
+    safety_blocker_codes: Object.freeze([...decision.safety_blocker_codes]),
+  });
+}
+
+function bounded(value: string, maximum: number): void {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function reference(value: string): void { bounded(value, 240); if (!value.includes("://")) invalid(); }
+function strings(values: readonly string[], maximum: number): void {
+  if (!Array.isArray(values) || values.length > maximum || new Set(values).size !== values.length) invalid();
+  for (const value of values) bounded(value, 160);
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never { throw new AgentGymContractError("Agent gym promotion decision is invalid."); }

--- a/apps/slack-companion/src/agent-gym/run-cli.ts
+++ b/apps/slack-companion/src/agent-gym/run-cli.ts
@@ -1,0 +1,8 @@
+import { agentGymVersionOutput, parseAgentGymCliCommand } from "./cli.js";
+
+const command = parseAgentGymCliCommand(process.argv.slice(2));
+if (command.command === "version") {
+  process.stdout.write(agentGymVersionOutput());
+} else {
+  process.stdout.write(`${JSON.stringify(command)}\n`);
+}

--- a/apps/slack-companion/src/agent-gym/run-summary.ts
+++ b/apps/slack-companion/src/agent-gym/run-summary.ts
@@ -1,0 +1,58 @@
+import { AgentGymContractError } from "./index.js";
+
+export interface AgentGymRunSummaryV1 {
+  readonly artifact_refs: readonly string[];
+  readonly blocker_codes: readonly string[];
+  readonly candidate_ref: string;
+  readonly completed_at: string;
+  readonly failed_case_count: number;
+  readonly passed_case_count: number;
+  readonly run_ref: string;
+  readonly schema_version: "agent-gym-run-summary/v1";
+  readonly status: "blocked" | "failed" | "passed";
+  readonly total_case_count: number;
+}
+
+/** Validates the small summary consumed by CI and draft-PR automation. */
+export function validateAgentGymRunSummary(summary: AgentGymRunSummaryV1): AgentGymRunSummaryV1 {
+  if (summary.schema_version !== "agent-gym-run-summary/v1") invalid();
+  for (const ref of [summary.run_ref, summary.candidate_ref]) reference(ref);
+  timestamp(summary.completed_at);
+  integer(summary.total_case_count, 1_000_000, false);
+  integer(summary.failed_case_count, summary.total_case_count);
+  integer(summary.passed_case_count, summary.total_case_count);
+  if (summary.failed_case_count + summary.passed_case_count !== summary.total_case_count) invalid();
+  if (!["blocked", "failed", "passed"].includes(summary.status)) invalid();
+  strings(summary.blocker_codes, 64, false);
+  references(summary.artifact_refs, 128);
+  if ((summary.status === "passed") !== (summary.failed_case_count === 0)) invalid();
+  if ((summary.status === "blocked") !== (summary.blocker_codes.length > 0)) invalid();
+  return Object.freeze({
+    ...summary,
+    artifact_refs: Object.freeze([...summary.artifact_refs]),
+    blocker_codes: Object.freeze([...summary.blocker_codes]),
+  });
+}
+
+function bounded(value: string, maximum: number): void {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function integer(value: number, maximum: number, allowZero = true): void {
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1) || value > maximum) invalid();
+}
+function reference(value: string): void { bounded(value, 240); if (!value.includes("://")) invalid(); }
+function references(values: readonly string[], maximum: number): void {
+  strings(values, maximum, false);
+  for (const value of values) reference(value);
+}
+function strings(values: readonly string[], maximum: number, requireOne: boolean): void {
+  if (!Array.isArray(values) || values.length > maximum || (requireOne && values.length === 0)
+    || new Set(values).size !== values.length) invalid();
+  for (const value of values) bounded(value, 240);
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never { throw new AgentGymContractError("Agent gym run summary is invalid."); }

--- a/apps/slack-companion/test/agent-gym-package.test.ts
+++ b/apps/slack-companion/test/agent-gym-package.test.ts
@@ -5,6 +5,7 @@ import {
   AgentGymContractError,
   CEREBRO_AGENT_GYM,
   identifyAgentGymArtifact,
+  parseAgentGymCliCommand,
   validateAgentGymCandidateManifest,
   validateAgentGymComparison,
   validateAgentGymPromotionDecision,
@@ -20,6 +21,18 @@ test("agent gym exposes a stable public contract identity", () => {
   });
   assert.equal(Object.isFrozen(CEREBRO_AGENT_GYM), true);
   assert.equal(new AgentGymContractError("invalid").name, "AgentGymContractError");
+});
+
+test("agent gym CLI parses bounded machine-readable commands", () => {
+  assert.deepEqual(parseAgentGymCliCommand([
+    "replay", "fixtures/one.json", "--output", "ndjson",
+  ]), {
+    command: "replay",
+    input_paths: ["fixtures/one.json"],
+    output: "ndjson",
+    schema_version: "agent-gym-cli-command/v1",
+  });
+  assert.throws(() => parseAgentGymCliCommand(["replay", "--unknown"]), /CLI command is invalid/u);
 });
 
 test("artifact identities are portable content addresses", () => {

--- a/apps/slack-companion/test/agent-gym-package.test.ts
+++ b/apps/slack-companion/test/agent-gym-package.test.ts
@@ -5,6 +5,7 @@ import {
   AgentGymContractError,
   CEREBRO_AGENT_GYM,
   validateAgentGymCandidateManifest,
+  validateAgentGymComparison,
   validateAgentGymFixtureCase,
   validateAgentGymReplayRun,
   validateAgentGymScorecard,
@@ -17,6 +18,32 @@ test("agent gym exposes a stable public contract identity", () => {
   });
   assert.equal(Object.isFrozen(CEREBRO_AGENT_GYM), true);
   assert.equal(new AgentGymContractError("invalid").name, "AgentGymContractError");
+});
+
+test("comparisons retain paired confidence and protected slice deltas", () => {
+  const comparison = validateAgentGymComparison({
+    baseline_candidate_ref: "candidate://agent-gym/baseline",
+    candidate_ref: "candidate://agent-gym/one",
+    compared_at: "2026-08-12T08:02:00.000Z",
+    comparison_ref: "comparison://agent-gym/one",
+    confidence_interval_95: [0.02, 0.08],
+    paired_case_count: 40,
+    practical_threshold: 0.02,
+    schema_version: "agent-gym-comparison/v1",
+    slices: [{
+      baseline_score: 0.8,
+      candidate_score: 0.85,
+      case_count: 20,
+      delta: 0.05,
+      slice_id: "evidence",
+    }],
+    weighted_score_delta: 0.05,
+  });
+  assert.equal(Object.isFrozen(comparison.confidence_interval_95), true);
+  assert.throws(() => validateAgentGymComparison({
+    ...comparison,
+    confidence_interval_95: [-0.01, 0.08],
+  }), /comparison is invalid/u);
 });
 
 test("scorecards fail closed when deterministic invariants fail", () => {

--- a/apps/slack-companion/test/agent-gym-package.test.ts
+++ b/apps/slack-companion/test/agent-gym-package.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   AgentGymContractError,
   CEREBRO_AGENT_GYM,
+  identifyAgentGymArtifact,
   validateAgentGymCandidateManifest,
   validateAgentGymComparison,
   validateAgentGymPromotionDecision,
@@ -19,6 +20,14 @@ test("agent gym exposes a stable public contract identity", () => {
   });
   assert.equal(Object.isFrozen(CEREBRO_AGENT_GYM), true);
   assert.equal(new AgentGymContractError("invalid").name, "AgentGymContractError");
+});
+
+test("artifact identities are portable content addresses", () => {
+  const first = identifyAgentGymArtifact(Buffer.from("{\"ok\":true}\n"), "application/json");
+  const second = identifyAgentGymArtifact(Buffer.from("{\"ok\":true}\n"), "application/json");
+  assert.deepEqual(first, second);
+  assert.match(first.content_digest, /^sha256:[0-9a-f]{64}$/u);
+  assert.throws(() => identifyAgentGymArtifact(new Uint8Array(), "text/plain"), /artifact is invalid/u);
 });
 
 test("promotion decisions require held-out evidence and no safety blockers", () => {

--- a/apps/slack-companion/test/agent-gym-package.test.ts
+++ b/apps/slack-companion/test/agent-gym-package.test.ts
@@ -6,6 +6,7 @@ import {
   CEREBRO_AGENT_GYM,
   validateAgentGymCandidateManifest,
   validateAgentGymComparison,
+  validateAgentGymPromotionDecision,
   validateAgentGymFixtureCase,
   validateAgentGymReplayRun,
   validateAgentGymScorecard,
@@ -18,6 +19,26 @@ test("agent gym exposes a stable public contract identity", () => {
   });
   assert.equal(Object.isFrozen(CEREBRO_AGENT_GYM), true);
   assert.equal(new AgentGymContractError("invalid").name, "AgentGymContractError");
+});
+
+test("promotion decisions require held-out evidence and no safety blockers", () => {
+  const decision = validateAgentGymPromotionDecision({
+    baseline_candidate_ref: "candidate://agent-gym/baseline",
+    candidate_ref: "candidate://agent-gym/one",
+    comparison_ref: "comparison://agent-gym/one",
+    decided_at: "2026-08-12T08:03:00.000Z",
+    decision_ref: "promotion://agent-gym/one",
+    disposition: "promote",
+    held_out_passed: true,
+    reason_codes: ["credible_practical_gain"],
+    safety_blocker_codes: [],
+    schema_version: "agent-gym-promotion-decision/v1",
+  });
+  assert.equal(decision.disposition, "promote");
+  assert.throws(() => validateAgentGymPromotionDecision({
+    ...decision,
+    held_out_passed: false,
+  }), /promotion decision is invalid/u);
 });
 
 test("comparisons retain paired confidence and protected slice deltas", () => {

--- a/apps/slack-companion/test/agent-gym-package.test.ts
+++ b/apps/slack-companion/test/agent-gym-package.test.ts
@@ -11,6 +11,7 @@ import {
   validateAgentGymPromotionDecision,
   validateAgentGymFixtureCase,
   validateAgentGymReplayRun,
+  validateAgentGymRunSummary,
   validateAgentGymScorecard,
 } from "../src/index.js";
 
@@ -21,6 +22,26 @@ test("agent gym exposes a stable public contract identity", () => {
   });
   assert.equal(Object.isFrozen(CEREBRO_AGENT_GYM), true);
   assert.equal(new AgentGymContractError("invalid").name, "AgentGymContractError");
+});
+
+test("run summaries expose exact CI case counts and blockers", () => {
+  const summary = validateAgentGymRunSummary({
+    artifact_refs: ["artifact://sha256/one"],
+    blocker_codes: [],
+    candidate_ref: "candidate://agent-gym/one",
+    completed_at: "2026-08-12T08:04:00.000Z",
+    failed_case_count: 0,
+    passed_case_count: 40,
+    run_ref: "run://agent-gym/one",
+    schema_version: "agent-gym-run-summary/v1",
+    status: "passed",
+    total_case_count: 40,
+  });
+  assert.equal(summary.status, "passed");
+  assert.throws(() => validateAgentGymRunSummary({
+    ...summary,
+    failed_case_count: 1,
+  }), /run summary is invalid/u);
 });
 
 test("agent gym CLI parses bounded machine-readable commands", () => {
@@ -85,7 +106,7 @@ test("comparisons retain paired confidence and protected slice deltas", () => {
   assert.equal(Object.isFrozen(comparison.confidence_interval_95), true);
   assert.throws(() => validateAgentGymComparison({
     ...comparison,
-    confidence_interval_95: [-0.01, 0.08],
+    confidence_interval_95: [0.06, 0.08],
   }), /comparison is invalid/u);
 });
 


### PR DESCRIPTION
## Summary

- define paired candidate comparisons and promotion decisions
- add portable content-addressed artifact identities
- expose a bounded CLI contract and machine-readable run summaries

## Validation

- `npm run typecheck --workspace @writer/cerebro-slack-companion`
- `node --test apps/slack-companion/dist/test/agent-gym-package.test.js`
- `npm run agent-gym --workspace @writer/cerebro-slack-companion -- --version`
- `npm test --workspace @writer/cerebro-slack-companion`

Stacked on #2263.