### PR TITLE
feat(slack): add offline event simulation

### DIFF
--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -20,3 +20,4 @@ export * from "./promotion-decision.js";
 export * from "./replay-run.js";
 export * from "./run-summary.js";
 export * from "./scorecard.js";
+export * from "./slack-simulator.js";

--- a/apps/slack-companion/src/agent-gym/slack-simulator.ts
+++ b/apps/slack-companion/src/agent-gym/slack-simulator.ts
@@ -1,0 +1,102 @@
+import { createHash } from "node:crypto";
+import type { AgentGymJson, AgentGymSlackEventV1 } from "./fixture-case.js";
+import { AgentGymContractError } from "./index.js";
+
+export type AgentGymSlackInvocationRoute =
+  | "assistant_turn"
+  | "interaction"
+  | "publish_home";
+
+export interface AgentGymSlackInvocationV1 {
+  readonly action?: {
+    readonly action_id: string;
+    readonly value: string;
+  };
+  readonly actor_ref: string;
+  readonly conversation_ref: string;
+  readonly event_ref: string;
+  readonly invocation_ref: string;
+  readonly occurred_at: string;
+  readonly route: AgentGymSlackInvocationRoute;
+  readonly schema_version: "agent-gym-slack-invocation/v1";
+  readonly text?: string;
+}
+
+/** Simulates normalization of one Slack app mention without Slack network access. */
+export function simulateSlackMention(
+  event: AgentGymSlackEventV1,
+): AgentGymSlackInvocationV1 {
+  if (event.kind !== "mention") invalid("mention event");
+  const payload = object(event.payload);
+  const teamId = field(payload, "team_id");
+  const channelId = field(payload, "channel_id");
+  const userId = field(payload, "user_id");
+  const messageTs = timestampField(payload, "ts");
+  const threadTs = optionalTimestampField(payload, "thread_ts") ?? messageTs;
+  const botUserId = field(payload, "bot_user_id");
+  const rawText = field(payload, "text", 12_000);
+  const mention = `<@${botUserId}>`;
+  const text = rawText.replace(mention, "").trim();
+  if (!rawText.includes(mention) || !text) invalid("mention text");
+  return invocation(event, {
+    actor_ref: ref("slack-user", teamId, userId),
+    conversation_ref: ref("slack-thread", teamId, channelId, threadTs),
+    route: "assistant_turn",
+    text,
+  });
+}
+
+function invocation(
+  event: AgentGymSlackEventV1,
+  input: Omit<AgentGymSlackInvocationV1,
+    "event_ref" | "invocation_ref" | "occurred_at" | "schema_version">,
+): AgentGymSlackInvocationV1 {
+  return Object.freeze({
+    ...input,
+    event_ref: event.event_ref,
+    invocation_ref: `slack-invocation://sha256/${digest(JSON.stringify({
+      event_ref: event.event_ref,
+      ...input,
+    }))}`,
+    occurred_at: event.occurred_at,
+    schema_version: "agent-gym-slack-invocation/v1",
+  });
+}
+
+function digest(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+function field(
+  payload: Readonly<Record<string, AgentGymJson>>,
+  name: string,
+  maximum = 240,
+): string {
+  const value = payload[name];
+  if (typeof value !== "string" || !value.trim() || value.length > maximum
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid(name);
+  return value;
+}
+function object(value: AgentGymJson): Readonly<Record<string, AgentGymJson>> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) invalid("payload");
+  return value;
+}
+function optionalTimestampField(
+  payload: Readonly<Record<string, AgentGymJson>>,
+  name: string,
+): string | undefined {
+  return payload[name] === undefined ? undefined : timestampField(payload, name);
+}
+function ref(kind: string, ...parts: readonly string[]): string {
+  return `${kind}://sha256/${digest(parts.join(":"))}`;
+}
+function timestampField(
+  payload: Readonly<Record<string, AgentGymJson>>,
+  name: string,
+): string {
+  const value = field(payload, name, 40);
+  if (!/^\d{10,16}\.\d{6}$/u.test(value)) invalid(name);
+  return value;
+}
+function invalid(fieldName: string): never {
+  throw new AgentGymContractError(`Agent gym Slack ${fieldName} is invalid.`);
+}

--- a/apps/slack-companion/src/agent-gym/slack-simulator.ts
+++ b/apps/slack-companion/src/agent-gym/slack-simulator.ts
@@ -66,6 +66,28 @@ export function simulateSlackMention(
   });
 }
 
+/** Simulates a reply bound to the exact existing Slack thread identity. */
+export function simulateSlackThreadReply(
+  event: AgentGymSlackEventV1,
+): AgentGymSlackInvocationV1 {
+  if (event.kind !== "thread_reply") invalid("thread-reply event");
+  const payload = object(event.payload);
+  const teamId = field(payload, "team_id");
+  const channelId = field(payload, "channel_id");
+  if (!/^[CG][A-Z0-9]+$/u.test(channelId)) invalid("thread-reply channel");
+  const userId = field(payload, "user_id");
+  const messageTs = timestampField(payload, "ts");
+  const threadTs = timestampField(payload, "thread_ts");
+  if (threadTs === messageTs) invalid("thread-reply timestamp");
+  const text = field(payload, "text", 12_000).trim();
+  return invocation(event, {
+    actor_ref: ref("slack-user", teamId, userId),
+    conversation_ref: ref("slack-thread", teamId, channelId, threadTs),
+    route: "assistant_turn",
+    text,
+  });
+}
+
 function invocation(
   event: AgentGymSlackEventV1,
   input: Omit<AgentGymSlackInvocationV1,

--- a/apps/slack-companion/src/agent-gym/slack-simulator.ts
+++ b/apps/slack-companion/src/agent-gym/slack-simulator.ts
@@ -22,6 +22,22 @@ export interface AgentGymSlackInvocationV1 {
   readonly text?: string;
 }
 
+/** Simulates an App Home open as a request to publish current operator state. */
+export function simulateSlackAppHomeOpened(
+  event: AgentGymSlackEventV1,
+): AgentGymSlackInvocationV1 {
+  if (event.kind !== "app_home_opened") invalid("App Home event");
+  const payload = object(event.payload);
+  const teamId = field(payload, "team_id");
+  const userId = field(payload, "user_id");
+  if (field(payload, "tab", 20) !== "home") invalid("App Home tab");
+  return invocation(event, {
+    actor_ref: ref("slack-user", teamId, userId),
+    conversation_ref: ref("slack-home", teamId, userId),
+    route: "publish_home",
+  });
+}
+
 /** Simulates normalization of one direct message without contacting Slack. */
 export function simulateSlackDirectMessage(
   event: AgentGymSlackEventV1,

--- a/apps/slack-companion/src/agent-gym/slack-simulator.ts
+++ b/apps/slack-companion/src/agent-gym/slack-simulator.ts
@@ -38,6 +38,29 @@ export function simulateSlackAppHomeOpened(
   });
 }
 
+/** Simulates a block-action click bound to its exact actor and conversation. */
+export function simulateSlackButtonAction(
+  event: AgentGymSlackEventV1,
+): AgentGymSlackInvocationV1 {
+  if (event.kind !== "button_action") invalid("button-action event");
+  const payload = object(event.payload);
+  const teamId = field(payload, "team_id");
+  const channelId = field(payload, "channel_id");
+  if (!/^[CDG][A-Z0-9]+$/u.test(channelId)) invalid("button-action channel");
+  const userId = field(payload, "user_id");
+  const messageTs = timestampField(payload, "message_ts");
+  const threadTs = optionalTimestampField(payload, "thread_ts") ?? messageTs;
+  const actionId = field(payload, "action_id", 255);
+  if (!/^[a-z0-9][a-z0-9._:-]*$/u.test(actionId)) invalid("button action id");
+  const value = field(payload, "value", 2_000);
+  return invocation(event, {
+    action: Object.freeze({ action_id: actionId, value }),
+    actor_ref: ref("slack-user", teamId, userId),
+    conversation_ref: ref("slack-thread", teamId, channelId, threadTs),
+    route: "interaction",
+  });
+}
+
 /** Simulates normalization of one direct message without contacting Slack. */
 export function simulateSlackDirectMessage(
   event: AgentGymSlackEventV1,
@@ -135,8 +158,13 @@ function field(
   return value;
 }
 function object(value: AgentGymJson): Readonly<Record<string, AgentGymJson>> {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) invalid("payload");
+  if (!isJsonObject(value)) invalid("payload");
   return value;
+}
+function isJsonObject(
+  value: AgentGymJson,
+): value is { readonly [key: string]: AgentGymJson } {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 function optionalTimestampField(
   payload: Readonly<Record<string, AgentGymJson>>,

--- a/apps/slack-companion/src/agent-gym/slack-simulator.ts
+++ b/apps/slack-companion/src/agent-gym/slack-simulator.ts
@@ -22,6 +22,26 @@ export interface AgentGymSlackInvocationV1 {
   readonly text?: string;
 }
 
+/** Simulates normalization of one direct message without contacting Slack. */
+export function simulateSlackDirectMessage(
+  event: AgentGymSlackEventV1,
+): AgentGymSlackInvocationV1 {
+  if (event.kind !== "direct_message") invalid("direct-message event");
+  const payload = object(event.payload);
+  const teamId = field(payload, "team_id");
+  const channelId = field(payload, "channel_id");
+  if (!/^D[A-Z0-9]+$/u.test(channelId)) invalid("direct-message channel");
+  const userId = field(payload, "user_id");
+  const messageTs = timestampField(payload, "ts");
+  const text = field(payload, "text", 12_000).trim();
+  return invocation(event, {
+    actor_ref: ref("slack-user", teamId, userId),
+    conversation_ref: ref("slack-dm", teamId, channelId, messageTs),
+    route: "assistant_turn",
+    text,
+  });
+}
+
 /** Simulates normalization of one Slack app mention without Slack network access. */
 export function simulateSlackMention(
   event: AgentGymSlackEventV1,

--- a/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
@@ -3,10 +3,50 @@ import test from "node:test";
 
 import {
   simulateSlackAppHomeOpened,
+  simulateSlackButtonAction,
   simulateSlackDirectMessage,
   simulateSlackMention,
   simulateSlackThreadReply,
 } from "../src/index.js";
+
+test("button simulation binds the exact action to its actor and thread", () => {
+  const invocation = simulateSlackButtonAction({
+    event_ref: "slack-event://button/one",
+    kind: "button_action",
+    occurred_at: "2026-08-12T08:34:00.000Z",
+    payload: {
+      action_id: "answer.feedback.correct",
+      channel_id: "C12345",
+      message_ts: "1786523640.000001",
+      team_id: "T_ONE",
+      thread_ts: "1786523400.000001",
+      user_id: "U_ONE",
+      value: "feedback://answer/one",
+    },
+  });
+  assert.equal(invocation.route, "interaction");
+  assert.deepEqual(invocation.action, {
+    action_id: "answer.feedback.correct",
+    value: "feedback://answer/one",
+  });
+  assert.equal(Object.isFrozen(invocation.action), true);
+});
+
+test("button simulation rejects an unbounded action identifier", () => {
+  assert.throws(() => simulateSlackButtonAction({
+    event_ref: "slack-event://button/bad",
+    kind: "button_action",
+    occurred_at: "2026-08-12T08:34:00.000Z",
+    payload: {
+      action_id: "Not a stable id",
+      channel_id: "C12345",
+      message_ts: "1786523640.000001",
+      team_id: "T_ONE",
+      user_id: "U_ONE",
+      value: "feedback://answer/one",
+    },
+  }), /button action id is invalid/u);
+});
 
 test("App Home simulation emits a publish request without message text", () => {
   const invocation = simulateSlackAppHomeOpened({

--- a/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
@@ -2,10 +2,33 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  simulateSlackAppHomeOpened,
   simulateSlackDirectMessage,
   simulateSlackMention,
   simulateSlackThreadReply,
 } from "../src/index.js";
+
+test("App Home simulation emits a publish request without message text", () => {
+  const invocation = simulateSlackAppHomeOpened({
+    event_ref: "slack-event://home/one",
+    kind: "app_home_opened",
+    occurred_at: "2026-08-12T08:33:00.000Z",
+    payload: { tab: "home", team_id: "T_ONE", user_id: "U_ONE" },
+  });
+  assert.equal(invocation.route, "publish_home");
+  assert.equal(invocation.text, undefined);
+  assert.equal(invocation.action, undefined);
+  assert.match(invocation.conversation_ref, /^slack-home:\/\/sha256\/[0-9a-f]{64}$/u);
+});
+
+test("App Home simulation rejects non-home tabs", () => {
+  assert.throws(() => simulateSlackAppHomeOpened({
+    event_ref: "slack-event://home/messages",
+    kind: "app_home_opened",
+    occurred_at: "2026-08-12T08:33:00.000Z",
+    payload: { tab: "messages", team_id: "T_ONE", user_id: "U_ONE" },
+  }), /App Home tab is invalid/u);
+});
 
 test("thread-reply simulation preserves the root conversation identity", () => {
   const base = {

--- a/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
@@ -1,7 +1,51 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { simulateSlackDirectMessage, simulateSlackMention } from "../src/index.js";
+import {
+  simulateSlackDirectMessage,
+  simulateSlackMention,
+  simulateSlackThreadReply,
+} from "../src/index.js";
+
+test("thread-reply simulation preserves the root conversation identity", () => {
+  const base = {
+    event_ref: "slack-event://reply/one",
+    kind: "thread_reply" as const,
+    occurred_at: "2026-08-12T08:32:00.000Z",
+    payload: {
+      channel_id: "C12345",
+      team_id: "T_ONE",
+      text: "Use the second option.",
+      thread_ts: "1786523400.000001",
+      ts: "1786523520.000001",
+      user_id: "U_ONE",
+    },
+  };
+  const invocation = simulateSlackThreadReply(base);
+  const anotherReply = simulateSlackThreadReply({
+    ...base,
+    event_ref: "slack-event://reply/two",
+    payload: { ...base.payload, ts: "1786523521.000001" },
+  });
+  assert.equal(invocation.conversation_ref, anotherReply.conversation_ref);
+  assert.equal(invocation.text, "Use the second option.");
+});
+
+test("thread-reply simulation rejects a root message posing as a reply", () => {
+  assert.throws(() => simulateSlackThreadReply({
+    event_ref: "slack-event://reply/root",
+    kind: "thread_reply",
+    occurred_at: "2026-08-12T08:32:00.000Z",
+    payload: {
+      channel_id: "C12345",
+      team_id: "T_ONE",
+      text: "Use the second option.",
+      thread_ts: "1786523520.000001",
+      ts: "1786523520.000001",
+      user_id: "U_ONE",
+    },
+  }), /thread-reply timestamp is invalid/u);
+});
 
 test("direct-message simulation routes one bounded private request", () => {
   const invocation = simulateSlackDirectMessage({

--- a/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
@@ -1,7 +1,40 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { simulateSlackMention } from "../src/index.js";
+import { simulateSlackDirectMessage, simulateSlackMention } from "../src/index.js";
+
+test("direct-message simulation routes one bounded private request", () => {
+  const invocation = simulateSlackDirectMessage({
+    event_ref: "slack-event://dm/one",
+    kind: "direct_message",
+    occurred_at: "2026-08-12T08:31:00.000Z",
+    payload: {
+      channel_id: "D12345",
+      team_id: "T_ONE",
+      text: "Summarize the current evidence.",
+      ts: "1786523460.000001",
+      user_id: "U_ONE",
+    },
+  });
+  assert.equal(invocation.route, "assistant_turn");
+  assert.equal(invocation.text, "Summarize the current evidence.");
+  assert.match(invocation.conversation_ref, /^slack-dm:\/\/sha256\/[0-9a-f]{64}$/u);
+});
+
+test("direct-message simulation rejects a public channel payload", () => {
+  assert.throws(() => simulateSlackDirectMessage({
+    event_ref: "slack-event://dm/public",
+    kind: "direct_message",
+    occurred_at: "2026-08-12T08:31:00.000Z",
+    payload: {
+      channel_id: "C12345",
+      team_id: "T_ONE",
+      text: "Summarize the current evidence.",
+      ts: "1786523460.000001",
+      user_id: "U_ONE",
+    },
+  }), /direct-message channel is invalid/u);
+});
 
 test("mention simulation produces a Slack-independent assistant invocation", () => {
   const invocation = simulateSlackMention({

--- a/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { simulateSlackMention } from "../src/index.js";
+
+test("mention simulation produces a Slack-independent assistant invocation", () => {
+  const invocation = simulateSlackMention({
+    event_ref: "slack-event://mention/one",
+    kind: "mention",
+    occurred_at: "2026-08-12T08:30:00.000Z",
+    payload: {
+      bot_user_id: "U_BOT",
+      channel_id: "C_ONE",
+      team_id: "T_ONE",
+      text: "<@U_BOT> What changed?",
+      thread_ts: "1786523400.000001",
+      ts: "1786523401.000001",
+      user_id: "U_ONE",
+    },
+  });
+  assert.equal(invocation.route, "assistant_turn");
+  assert.equal(invocation.text, "What changed?");
+  assert.match(invocation.actor_ref, /^slack-user:\/\/sha256\/[0-9a-f]{64}$/u);
+  assert.match(invocation.conversation_ref, /^slack-thread:\/\/sha256\/[0-9a-f]{64}$/u);
+  assert.match(invocation.invocation_ref, /^slack-invocation:\/\/sha256\/[0-9a-f]{64}$/u);
+  assert.equal(Object.isFrozen(invocation), true);
+});
+
+test("mention simulation rejects events without the addressed bot", () => {
+  assert.throws(() => simulateSlackMention({
+    event_ref: "slack-event://mention/missing",
+    kind: "mention",
+    occurred_at: "2026-08-12T08:30:00.000Z",
+    payload: {
+      bot_user_id: "U_BOT",
+      channel_id: "C_ONE",
+      team_id: "T_ONE",
+      text: "What changed?",
+      ts: "1786523401.000001",
+      user_id: "U_ONE",
+    },
+  }), /mention text is invalid/u);
+});


### PR DESCRIPTION
## Summary

- normalize mentions and direct messages without Slack network access
- preserve exact thread identity for simulated replies
- simulate App Home publication and bounded button interactions

This carries the five-commit simulator stack from #2265 onto the default branch.

## Validation

- `npm run typecheck --workspace @writer/cerebro-slack-companion`
- `node --test apps/slack-companion/dist/test/agent-gym-package.test.js apps/slack-companion/dist/test/agent-gym-slack-simulator.test.js`
- `npm test --workspace @writer/cerebro-slack-companion`