### PR TITLE
feat(slack): simulate event mutation and retries

### DIFF
--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -21,3 +21,4 @@ export * from "./replay-run.js";
 export * from "./run-summary.js";
 export * from "./scorecard.js";
 export * from "./slack-simulator.js";
+export * from "./slack-delivery.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -22,3 +22,4 @@ export * from "./run-summary.js";
 export * from "./scorecard.js";
 export * from "./slack-simulator.js";
 export * from "./slack-delivery.js";
+export * from "./slack-failure.js";

--- a/apps/slack-companion/src/agent-gym/slack-delivery.ts
+++ b/apps/slack-companion/src/agent-gym/slack-delivery.ts
@@ -1,0 +1,31 @@
+import { AgentGymContractError } from "./index.js";
+import type { AgentGymSlackInvocationV1 } from "./slack-simulator.js";
+
+export interface AgentGymSlackDeliveryResultV1 {
+  readonly disposition: "admitted" | "duplicate";
+  readonly event_ref: string;
+  readonly invocation_ref: string;
+  readonly schema_version: "agent-gym-slack-delivery-result/v1";
+}
+
+/** Models Slack at-least-once delivery while rejecting changed retries. */
+export class AgentGymSlackDeliveryLedger {
+  readonly #invocationByEvent = new Map<string, string>();
+
+  admit(invocation: AgentGymSlackInvocationV1): AgentGymSlackDeliveryResultV1 {
+    if (invocation.schema_version !== "agent-gym-slack-invocation/v1") {
+      throw new AgentGymContractError("Agent gym Slack invocation is invalid.");
+    }
+    const prior = this.#invocationByEvent.get(invocation.event_ref);
+    if (prior !== undefined && prior !== invocation.invocation_ref) {
+      throw new AgentGymContractError("Agent gym Slack event retry changed payload.");
+    }
+    this.#invocationByEvent.set(invocation.event_ref, invocation.invocation_ref);
+    return Object.freeze({
+      disposition: prior === undefined ? "admitted" : "duplicate",
+      event_ref: invocation.event_ref,
+      invocation_ref: invocation.invocation_ref,
+      schema_version: "agent-gym-slack-delivery-result/v1",
+    });
+  }
+}

--- a/apps/slack-companion/src/agent-gym/slack-failure.ts
+++ b/apps/slack-companion/src/agent-gym/slack-failure.ts
@@ -1,0 +1,79 @@
+import { AgentGymContractError } from "./index.js";
+
+export interface AgentGymSlackApiAttemptV1 {
+  readonly attempt_index: number;
+  readonly observed_at: string;
+  readonly outcome: "rate_limited" | "success" | "timeout";
+  readonly retry_after_ms?: number;
+}
+
+export interface AgentGymSlackRetryPolicyV1 {
+  readonly maximum_attempts: number;
+  readonly maximum_delay_ms: number;
+  readonly timeout_base_delay_ms: number;
+}
+
+export interface AgentGymSlackRetryPlanV1 {
+  readonly attempt_index: number;
+  readonly delay_ms?: number;
+  readonly disposition: "completed" | "exhausted" | "retry";
+  readonly next_attempt_at?: string;
+  readonly reason: "rate_limited" | "success" | "timeout";
+  readonly schema_version: "agent-gym-slack-retry-plan/v1";
+}
+
+/** Produces deterministic retry behavior for simulated Slack API outcomes. */
+export function planAgentGymSlackApiRetry(
+  attempt: AgentGymSlackApiAttemptV1,
+  policy: AgentGymSlackRetryPolicyV1,
+): AgentGymSlackRetryPlanV1 {
+  integer(attempt.attempt_index, 20);
+  timestamp(attempt.observed_at);
+  integer(policy.maximum_attempts, 20, false);
+  integer(policy.maximum_delay_ms, 15 * 60_000, false);
+  integer(policy.timeout_base_delay_ms, policy.maximum_delay_ms, false);
+  if (attempt.attempt_index >= policy.maximum_attempts) invalid();
+  if (!["rate_limited", "success", "timeout"].includes(attempt.outcome)) invalid();
+  if (attempt.outcome === "rate_limited") {
+    if (attempt.retry_after_ms === undefined) invalid();
+    integer(attempt.retry_after_ms, policy.maximum_delay_ms, false);
+  } else if (attempt.retry_after_ms !== undefined) invalid();
+  if (attempt.outcome === "success") {
+    return result(attempt, "completed");
+  }
+  if (attempt.attempt_index + 1 >= policy.maximum_attempts) {
+    return result(attempt, "exhausted");
+  }
+  const delay = attempt.outcome === "rate_limited"
+    ? attempt.retry_after_ms ?? invalid()
+    : Math.min(
+        policy.maximum_delay_ms,
+        policy.timeout_base_delay_ms * (2 ** attempt.attempt_index),
+      );
+  return result(attempt, "retry", delay);
+}
+
+function result(
+  attempt: AgentGymSlackApiAttemptV1,
+  disposition: AgentGymSlackRetryPlanV1["disposition"],
+  delay?: number,
+): AgentGymSlackRetryPlanV1 {
+  return Object.freeze({
+    attempt_index: attempt.attempt_index,
+    ...(delay === undefined ? {} : {
+      delay_ms: delay,
+      next_attempt_at: new Date(Date.parse(attempt.observed_at) + delay).toISOString(),
+    }),
+    disposition,
+    reason: attempt.outcome,
+    schema_version: "agent-gym-slack-retry-plan/v1",
+  });
+}
+function integer(value: number, maximum: number, allowZero = true): void {
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1) || value > maximum) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never { throw new AgentGymContractError("Agent gym Slack retry input is invalid."); }

--- a/apps/slack-companion/src/agent-gym/slack-simulator.ts
+++ b/apps/slack-companion/src/agent-gym/slack-simulator.ts
@@ -105,6 +105,27 @@ export function simulateSlackMention(
   });
 }
 
+/** Simulates a reaction as explicit interaction evidence on one message. */
+export function simulateSlackReactionAdded(
+  event: AgentGymSlackEventV1,
+): AgentGymSlackInvocationV1 {
+  if (event.kind !== "reaction_added") invalid("reaction event");
+  const payload = object(event.payload);
+  const teamId = field(payload, "team_id");
+  const channelId = field(payload, "channel_id");
+  if (!/^[CDG][A-Z0-9]+$/u.test(channelId)) invalid("reaction channel");
+  const userId = field(payload, "user_id");
+  const itemTs = timestampField(payload, "item_ts");
+  const reaction = field(payload, "reaction", 100);
+  if (!/^[a-z0-9][a-z0-9_+-]*$/u.test(reaction)) invalid("reaction name");
+  return invocation(event, {
+    action: Object.freeze({ action_id: "reaction.added", value: reaction }),
+    actor_ref: ref("slack-user", teamId, userId),
+    conversation_ref: ref("slack-message", teamId, channelId, itemTs),
+    route: "interaction",
+  });
+}
+
 /** Simulates a reply bound to the exact existing Slack thread identity. */
 export function simulateSlackThreadReply(
   event: AgentGymSlackEventV1,

--- a/apps/slack-companion/src/agent-gym/slack-simulator.ts
+++ b/apps/slack-companion/src/agent-gym/slack-simulator.ts
@@ -126,6 +126,33 @@ export function simulateSlackReactionAdded(
   });
 }
 
+/** Simulates a changed message as a fresh turn with prior content identity. */
+export function simulateSlackMessageChanged(
+  event: AgentGymSlackEventV1,
+): AgentGymSlackInvocationV1 {
+  if (event.kind !== "message_changed") invalid("message-change event");
+  const payload = object(event.payload);
+  const teamId = field(payload, "team_id");
+  const channelId = field(payload, "channel_id");
+  if (!/^[CDG][A-Z0-9]+$/u.test(channelId)) invalid("message-change channel");
+  const userId = field(payload, "user_id");
+  const messageTs = timestampField(payload, "ts");
+  const threadTs = optionalTimestampField(payload, "thread_ts") ?? messageTs;
+  const priorText = field(payload, "previous_text", 12_000).trim();
+  const text = field(payload, "text", 12_000).trim();
+  if (priorText === text) invalid("message-change text");
+  return invocation(event, {
+    action: Object.freeze({
+      action_id: "message.changed",
+      value: `sha256:${digest(priorText)}`,
+    }),
+    actor_ref: ref("slack-user", teamId, userId),
+    conversation_ref: ref("slack-thread", teamId, channelId, threadTs),
+    route: "assistant_turn",
+    text,
+  });
+}
+
 /** Simulates a reply bound to the exact existing Slack thread identity. */
 export function simulateSlackThreadReply(
   event: AgentGymSlackEventV1,

--- a/apps/slack-companion/src/agent-gym/slack-simulator.ts
+++ b/apps/slack-companion/src/agent-gym/slack-simulator.ts
@@ -153,6 +153,26 @@ export function simulateSlackMessageChanged(
   });
 }
 
+/** Simulates deletion as a tombstone interaction without retaining message text. */
+export function simulateSlackMessageDeleted(
+  event: AgentGymSlackEventV1,
+): AgentGymSlackInvocationV1 {
+  if (event.kind !== "message_deleted") invalid("message-delete event");
+  const payload = object(event.payload);
+  const teamId = field(payload, "team_id");
+  const channelId = field(payload, "channel_id");
+  if (!/^[CDG][A-Z0-9]+$/u.test(channelId)) invalid("message-delete channel");
+  const userId = field(payload, "user_id");
+  const deletedTs = timestampField(payload, "deleted_ts");
+  const threadTs = optionalTimestampField(payload, "thread_ts") ?? deletedTs;
+  return invocation(event, {
+    action: Object.freeze({ action_id: "message.deleted", value: deletedTs }),
+    actor_ref: ref("slack-user", teamId, userId),
+    conversation_ref: ref("slack-thread", teamId, channelId, threadTs),
+    route: "interaction",
+  });
+}
+
 /** Simulates a reply bound to the exact existing Slack thread identity. */
 export function simulateSlackThreadReply(
   event: AgentGymSlackEventV1,

--- a/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
@@ -6,8 +6,44 @@ import {
   simulateSlackButtonAction,
   simulateSlackDirectMessage,
   simulateSlackMention,
+  simulateSlackReactionAdded,
   simulateSlackThreadReply,
 } from "../src/index.js";
+
+test("reaction simulation records exact message feedback without Slack", () => {
+  const invocation = simulateSlackReactionAdded({
+    event_ref: "slack-event://reaction/one",
+    kind: "reaction_added",
+    occurred_at: "2026-08-12T08:35:00.000Z",
+    payload: {
+      channel_id: "C12345",
+      item_ts: "1786523640.000001",
+      reaction: "thumbsup",
+      team_id: "T_ONE",
+      user_id: "U_ONE",
+    },
+  });
+  assert.deepEqual(invocation.action, {
+    action_id: "reaction.added",
+    value: "thumbsup",
+  });
+  assert.match(invocation.conversation_ref, /^slack-message:\/\/sha256\/[0-9a-f]{64}$/u);
+});
+
+test("reaction simulation rejects display emoji instead of stable names", () => {
+  assert.throws(() => simulateSlackReactionAdded({
+    event_ref: "slack-event://reaction/emoji",
+    kind: "reaction_added",
+    occurred_at: "2026-08-12T08:35:00.000Z",
+    payload: {
+      channel_id: "C12345",
+      item_ts: "1786523640.000001",
+      reaction: "👍",
+      team_id: "T_ONE",
+      user_id: "U_ONE",
+    },
+  }), /reaction name is invalid/u);
+});
 
 test("button simulation binds the exact action to its actor and thread", () => {
   const invocation = simulateSlackButtonAction({

--- a/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   AgentGymSlackDeliveryLedger,
+  planAgentGymSlackApiRetry,
   simulateSlackAppHomeOpened,
   simulateSlackButtonAction,
   simulateSlackDirectMessage,
@@ -12,6 +13,51 @@ import {
   simulateSlackReactionAdded,
   simulateSlackThreadReply,
 } from "../src/index.js";
+
+test("Slack API simulation honors retry-after and bounded timeout backoff", () => {
+  const policy = {
+    maximum_attempts: 4,
+    maximum_delay_ms: 60_000,
+    timeout_base_delay_ms: 1_000,
+  };
+  assert.deepEqual(planAgentGymSlackApiRetry({
+    attempt_index: 0,
+    observed_at: "2026-08-12T08:39:00.000Z",
+    outcome: "rate_limited",
+    retry_after_ms: 30_000,
+  }, policy), {
+    attempt_index: 0,
+    delay_ms: 30_000,
+    disposition: "retry",
+    next_attempt_at: "2026-08-12T08:39:30.000Z",
+    reason: "rate_limited",
+    schema_version: "agent-gym-slack-retry-plan/v1",
+  });
+  assert.equal(planAgentGymSlackApiRetry({
+    attempt_index: 2,
+    observed_at: "2026-08-12T08:39:00.000Z",
+    outcome: "timeout",
+  }, policy).delay_ms, 4_000);
+});
+
+test("Slack API simulation exhausts retries and rejects ambiguous outcomes", () => {
+  const policy = {
+    maximum_attempts: 2,
+    maximum_delay_ms: 60_000,
+    timeout_base_delay_ms: 1_000,
+  };
+  assert.equal(planAgentGymSlackApiRetry({
+    attempt_index: 1,
+    observed_at: "2026-08-12T08:39:00.000Z",
+    outcome: "timeout",
+  }, policy).disposition, "exhausted");
+  assert.throws(() => planAgentGymSlackApiRetry({
+    attempt_index: 0,
+    observed_at: "2026-08-12T08:39:00.000Z",
+    outcome: "success",
+    retry_after_ms: 1_000,
+  }, policy), /retry input is invalid/u);
+});
 
 test("delivery simulation admits once and suppresses exact Slack retries", () => {
   const event = {

--- a/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
@@ -7,9 +7,43 @@ import {
   simulateSlackDirectMessage,
   simulateSlackMention,
   simulateSlackMessageChanged,
+  simulateSlackMessageDeleted,
   simulateSlackReactionAdded,
   simulateSlackThreadReply,
 } from "../src/index.js";
+
+test("message-delete simulation emits a text-free tombstone", () => {
+  const invocation = simulateSlackMessageDeleted({
+    event_ref: "slack-event://deleted/one",
+    kind: "message_deleted",
+    occurred_at: "2026-08-12T08:37:00.000Z",
+    payload: {
+      channel_id: "C12345",
+      deleted_ts: "1786523640.000001",
+      team_id: "T_ONE",
+      thread_ts: "1786523400.000001",
+      user_id: "U_ONE",
+    },
+  });
+  assert.deepEqual(invocation.action, {
+    action_id: "message.deleted",
+    value: "1786523640.000001",
+  });
+  assert.equal(invocation.text, undefined);
+});
+
+test("message-delete simulation rejects a deletion without stable identity", () => {
+  assert.throws(() => simulateSlackMessageDeleted({
+    event_ref: "slack-event://deleted/missing",
+    kind: "message_deleted",
+    occurred_at: "2026-08-12T08:37:00.000Z",
+    payload: {
+      channel_id: "C12345",
+      team_id: "T_ONE",
+      user_id: "U_ONE",
+    },
+  }), /deleted_ts is invalid/u);
+});
 
 test("message-change simulation emits the correction and prior-content digest", () => {
   const invocation = simulateSlackMessageChanged({

--- a/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
@@ -6,9 +6,47 @@ import {
   simulateSlackButtonAction,
   simulateSlackDirectMessage,
   simulateSlackMention,
+  simulateSlackMessageChanged,
   simulateSlackReactionAdded,
   simulateSlackThreadReply,
 } from "../src/index.js";
+
+test("message-change simulation emits the correction and prior-content digest", () => {
+  const invocation = simulateSlackMessageChanged({
+    event_ref: "slack-event://changed/one",
+    kind: "message_changed",
+    occurred_at: "2026-08-12T08:36:00.000Z",
+    payload: {
+      channel_id: "C12345",
+      previous_text: "Use the first option.",
+      team_id: "T_ONE",
+      text: "Use the second option.",
+      thread_ts: "1786523400.000001",
+      ts: "1786523640.000001",
+      user_id: "U_ONE",
+    },
+  });
+  assert.equal(invocation.route, "assistant_turn");
+  assert.equal(invocation.text, "Use the second option.");
+  assert.equal(invocation.action?.action_id, "message.changed");
+  assert.match(invocation.action?.value ?? "", /^sha256:[0-9a-f]{64}$/u);
+});
+
+test("message-change simulation rejects a no-op edit", () => {
+  assert.throws(() => simulateSlackMessageChanged({
+    event_ref: "slack-event://changed/noop",
+    kind: "message_changed",
+    occurred_at: "2026-08-12T08:36:00.000Z",
+    payload: {
+      channel_id: "C12345",
+      previous_text: "No change.",
+      team_id: "T_ONE",
+      text: "No change.",
+      ts: "1786523640.000001",
+      user_id: "U_ONE",
+    },
+  }), /message-change text is invalid/u);
+});
 
 test("reaction simulation records exact message feedback without Slack", () => {
   const invocation = simulateSlackReactionAdded({

--- a/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-simulator.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  AgentGymSlackDeliveryLedger,
   simulateSlackAppHomeOpened,
   simulateSlackButtonAction,
   simulateSlackDirectMessage,
@@ -11,6 +12,46 @@ import {
   simulateSlackReactionAdded,
   simulateSlackThreadReply,
 } from "../src/index.js";
+
+test("delivery simulation admits once and suppresses exact Slack retries", () => {
+  const event = {
+    event_ref: "slack-event://retry/one",
+    kind: "direct_message" as const,
+    occurred_at: "2026-08-12T08:38:00.000Z",
+    payload: {
+      channel_id: "D12345",
+      team_id: "T_ONE",
+      text: "Continue.",
+      ts: "1786523880.000001",
+      user_id: "U_ONE",
+    },
+  };
+  const ledger = new AgentGymSlackDeliveryLedger();
+  const invocation = simulateSlackDirectMessage(event);
+  assert.equal(ledger.admit(invocation).disposition, "admitted");
+  assert.equal(ledger.admit(simulateSlackDirectMessage(event)).disposition, "duplicate");
+});
+
+test("delivery simulation rejects changed payload under one event identity", () => {
+  const ledger = new AgentGymSlackDeliveryLedger();
+  const event = {
+    event_ref: "slack-event://retry/changed",
+    kind: "direct_message" as const,
+    occurred_at: "2026-08-12T08:38:00.000Z",
+    payload: {
+      channel_id: "D12345",
+      team_id: "T_ONE",
+      text: "Continue.",
+      ts: "1786523880.000001",
+      user_id: "U_ONE",
+    },
+  };
+  ledger.admit(simulateSlackDirectMessage(event));
+  assert.throws(() => ledger.admit(simulateSlackDirectMessage({
+    ...event,
+    payload: { ...event.payload, text: "Do something else." },
+  })), /event retry changed payload/u);
+});
 
 test("message-delete simulation emits a text-free tombstone", () => {
   const invocation = simulateSlackMessageDeleted({


### PR DESCRIPTION
## Summary

- simulate reaction feedback, message edits, and deletion tombstones
- reject changed payloads under one Slack retry identity
- model rate limits, timeout backoff, and retry exhaustion deterministically

## Validation

- `npm run typecheck --workspace @writer/cerebro-slack-companion`
- `node --test apps/slack-companion/dist/test/agent-gym-package.test.js apps/slack-companion/dist/test/agent-gym-slack-simulator.test.js`
- `npm test --workspace @writer/cerebro-slack-companion`