### PR TITLE
Agent/agent gym tool fixtures 01

### DIFF
--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -23,3 +23,4 @@ export * from "./scorecard.js";
 export * from "./slack-simulator.js";
 export * from "./slack-delivery.js";
 export * from "./slack-failure.js";
+export * from "./slack-effects.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -24,3 +24,4 @@ export * from "./slack-simulator.js";
 export * from "./slack-delivery.js";
 export * from "./slack-failure.js";
 export * from "./slack-effects.js";
+export * from "./slack-effect-runtime.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -25,3 +25,4 @@ export * from "./slack-delivery.js";
 export * from "./slack-failure.js";
 export * from "./slack-effects.js";
 export * from "./slack-effect-runtime.js";
+export * from "./slack-effect-snapshot.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -21,6 +21,7 @@ export * from "./replay-run.js";
 export * from "./run-summary.js";
 export * from "./scorecard.js";
 export * from "./slack-simulator.js";
+export * from "./tool-fixtures.js";
 export * from "./slack-delivery.js";
 export * from "./slack-failure.js";
 export * from "./slack-effects.js";

--- a/apps/slack-companion/src/agent-gym/slack-effect-runtime.ts
+++ b/apps/slack-companion/src/agent-gym/slack-effect-runtime.ts
@@ -13,6 +13,40 @@ export interface AgentGymSlackEffectPlanEntryV1 {
   readonly effect: AgentGymSlackEffectV1;
 }
 
+export interface AgentGymSlackEffectCheckpointV1 {
+  readonly accepted_effect_refs: readonly string[];
+  readonly checkpoint_ref: string;
+  readonly completed_effect_refs: readonly string[];
+  readonly schema_version: "agent-gym-slack-effect-checkpoint/v1";
+}
+
+/** Selects only accepted effects not durably completed before a restart. */
+export function resumeAgentGymSlackEffects(
+  checkpoint: AgentGymSlackEffectCheckpointV1,
+  effects: readonly AgentGymSlackEffectV1[],
+): readonly AgentGymSlackEffectV1[] {
+  if (checkpoint.schema_version !== "agent-gym-slack-effect-checkpoint/v1"
+    || !checkpoint.checkpoint_ref.includes("://")
+    || !Array.isArray(effects)
+    || effects.length > 1_000) invalidCheckpoint();
+  references(checkpoint.accepted_effect_refs, 1_000);
+  references(checkpoint.completed_effect_refs, 1_000);
+  const accepted = new Set(checkpoint.accepted_effect_refs);
+  const completed = new Set(checkpoint.completed_effect_refs);
+  if ([...completed].some((reference) => !accepted.has(reference))) invalidCheckpoint();
+  const effectByRef = new Map(effects.map((effect) => [effect.effect_ref, effect]));
+  if (effectByRef.size !== effects.length
+    || [...accepted].some((reference) => !effectByRef.has(reference))) invalidCheckpoint();
+  return Object.freeze([...accepted]
+    .filter((reference) => !completed.has(reference))
+    .sort()
+    .map((reference) => {
+      const effect = effectByRef.get(reference);
+      if (effect === undefined) return invalidCheckpoint();
+      return effect;
+    }));
+}
+
 /** Returns a deterministic dependency-respecting outbound effect order. */
 export function orderAgentGymSlackEffects(
   entries: readonly AgentGymSlackEffectPlanEntryV1[],
@@ -131,4 +165,15 @@ function invalidEffect(): never {
 }
 function invalidEffectPlan(): never {
   throw new AgentGymContractError("Agent gym Slack effect plan is invalid.");
+}
+function references(values: readonly string[], maximum: number): void {
+  if (!Array.isArray(values) || values.length > maximum
+    || new Set(values).size !== values.length
+    || values.some((value) => typeof value !== "string"
+      || !/^slack-effect:\/\/sha256\/[0-9a-f]{64}$/u.test(value))) {
+    invalidCheckpoint();
+  }
+}
+function invalidCheckpoint(): never {
+  throw new AgentGymContractError("Agent gym Slack effect checkpoint is invalid.");
 }

--- a/apps/slack-companion/src/agent-gym/slack-effect-runtime.ts
+++ b/apps/slack-companion/src/agent-gym/slack-effect-runtime.ts
@@ -67,7 +67,7 @@ export function orderAgentGymSlackEffects(
     entryByRef.set(entry.effect.effect_ref, entry);
   }
   for (const entry of entries) {
-    if (entry.after_effect_refs.some((reference) => !entryByRef.has(reference))) {
+    if (entry.after_effect_refs.some((reference: string) => !entryByRef.has(reference))) {
       invalidEffectPlan();
     }
   }
@@ -76,7 +76,7 @@ export function orderAgentGymSlackEffects(
   while (ordered.length < entries.length) {
     const ready = entries.filter((entry) =>
       !emitted.has(entry.effect.effect_ref)
-      && entry.after_effect_refs.every((reference) => emitted.has(reference))
+      && entry.after_effect_refs.every((reference: string) => emitted.has(reference))
     ).sort((left, right) => left.effect.effect_ref.localeCompare(right.effect.effect_ref));
     if (ready.length === 0) invalidEffectPlan();
     for (const entry of ready) {

--- a/apps/slack-companion/src/agent-gym/slack-effect-runtime.ts
+++ b/apps/slack-companion/src/agent-gym/slack-effect-runtime.ts
@@ -8,6 +8,51 @@ export interface AgentGymSlackEffectAdmissionV1 {
   readonly schema_version: "agent-gym-slack-effect-admission/v1";
 }
 
+export interface AgentGymSlackEffectPlanEntryV1 {
+  readonly after_effect_refs: readonly string[];
+  readonly effect: AgentGymSlackEffectV1;
+}
+
+/** Returns a deterministic dependency-respecting outbound effect order. */
+export function orderAgentGymSlackEffects(
+  entries: readonly AgentGymSlackEffectPlanEntryV1[],
+): readonly AgentGymSlackEffectV1[] {
+  if (!Array.isArray(entries) || entries.length === 0 || entries.length > 1_000) {
+    invalidEffectPlan();
+  }
+  const entryByRef = new Map<string, AgentGymSlackEffectPlanEntryV1>();
+  for (const entry of entries) {
+    if (entry.effect.schema_version !== "agent-gym-slack-effect/v1"
+      || entryByRef.has(entry.effect.effect_ref)
+      || !Array.isArray(entry.after_effect_refs)
+      || entry.after_effect_refs.length > 100
+      || new Set(entry.after_effect_refs).size !== entry.after_effect_refs.length
+      || entry.after_effect_refs.includes(entry.effect.effect_ref)) {
+      invalidEffectPlan();
+    }
+    entryByRef.set(entry.effect.effect_ref, entry);
+  }
+  for (const entry of entries) {
+    if (entry.after_effect_refs.some((reference) => !entryByRef.has(reference))) {
+      invalidEffectPlan();
+    }
+  }
+  const emitted = new Set<string>();
+  const ordered: AgentGymSlackEffectV1[] = [];
+  while (ordered.length < entries.length) {
+    const ready = entries.filter((entry) =>
+      !emitted.has(entry.effect.effect_ref)
+      && entry.after_effect_refs.every((reference) => emitted.has(reference))
+    ).sort((left, right) => left.effect.effect_ref.localeCompare(right.effect.effect_ref));
+    if (ready.length === 0) invalidEffectPlan();
+    for (const entry of ready) {
+      emitted.add(entry.effect.effect_ref);
+      ordered.push(entry.effect);
+    }
+  }
+  return Object.freeze(ordered);
+}
+
 /** Enforces exact-effect reuse under one outbound idempotency key. */
 export class AgentGymSlackEffectIdempotencyLedger {
   readonly #effectByKey = new Map<string, string>();
@@ -83,4 +128,7 @@ function invalid(): never {
 }
 function invalidEffect(): never {
   throw new AgentGymContractError("Agent gym Slack effect is invalid.");
+}
+function invalidEffectPlan(): never {
+  throw new AgentGymContractError("Agent gym Slack effect plan is invalid.");
 }

--- a/apps/slack-companion/src/agent-gym/slack-effect-runtime.ts
+++ b/apps/slack-companion/src/agent-gym/slack-effect-runtime.ts
@@ -1,4 +1,34 @@
 import { AgentGymContractError } from "./index.js";
+import type { AgentGymSlackEffectV1 } from "./slack-effects.js";
+
+export interface AgentGymSlackEffectAdmissionV1 {
+  readonly disposition: "accepted" | "duplicate";
+  readonly effect_ref: string;
+  readonly idempotency_key: string;
+  readonly schema_version: "agent-gym-slack-effect-admission/v1";
+}
+
+/** Enforces exact-effect reuse under one outbound idempotency key. */
+export class AgentGymSlackEffectIdempotencyLedger {
+  readonly #effectByKey = new Map<string, string>();
+
+  admit(effect: AgentGymSlackEffectV1): AgentGymSlackEffectAdmissionV1 {
+    if (effect.schema_version !== "agent-gym-slack-effect/v1") invalidEffect();
+    const prior = this.#effectByKey.get(effect.idempotency_key);
+    if (prior !== undefined && prior !== effect.effect_ref) {
+      throw new AgentGymContractError(
+        "Agent gym Slack idempotency key changed effect.",
+      );
+    }
+    this.#effectByKey.set(effect.idempotency_key, effect.effect_ref);
+    return Object.freeze({
+      disposition: prior === undefined ? "accepted" : "duplicate",
+      effect_ref: effect.effect_ref,
+      idempotency_key: effect.idempotency_key,
+      schema_version: "agent-gym-slack-effect-admission/v1",
+    });
+  }
+}
 
 export interface AgentGymSlackAcknowledgementInputV1 {
   readonly admitted_at?: string;
@@ -50,4 +80,7 @@ function timestamp(value: string): void {
 }
 function invalid(): never {
   throw new AgentGymContractError("Agent gym Slack acknowledgement input is invalid.");
+}
+function invalidEffect(): never {
+  throw new AgentGymContractError("Agent gym Slack effect is invalid.");
 }

--- a/apps/slack-companion/src/agent-gym/slack-effect-runtime.ts
+++ b/apps/slack-companion/src/agent-gym/slack-effect-runtime.ts
@@ -1,0 +1,53 @@
+import { AgentGymContractError } from "./index.js";
+
+export interface AgentGymSlackAcknowledgementInputV1 {
+  readonly admitted_at?: string;
+  readonly durable_admission: boolean;
+  readonly event_received_at: string;
+  readonly maximum_ack_latency_ms: number;
+}
+
+export interface AgentGymSlackAcknowledgementV1 {
+  readonly ack_latency_ms?: number;
+  readonly disposition: "acknowledge" | "deadline_missed" | "withhold";
+  readonly planned_ack_at?: string;
+  readonly schema_version: "agent-gym-slack-acknowledgement/v1";
+}
+
+/** Models Slack acknowledgement eligibility after durable event admission. */
+export function planAgentGymSlackAcknowledgement(
+  input: AgentGymSlackAcknowledgementInputV1,
+): AgentGymSlackAcknowledgementV1 {
+  timestamp(input.event_received_at);
+  integer(input.maximum_ack_latency_ms, 10_000, false);
+  if (!input.durable_admission) {
+    if (input.admitted_at !== undefined) invalid();
+    return Object.freeze({
+      disposition: "withhold",
+      schema_version: "agent-gym-slack-acknowledgement/v1",
+    });
+  }
+  if (input.admitted_at === undefined) invalid();
+  timestamp(input.admitted_at);
+  const latency = Date.parse(input.admitted_at) - Date.parse(input.event_received_at);
+  if (!Number.isSafeInteger(latency) || latency < 0 || latency > 5 * 60_000) invalid();
+  return Object.freeze({
+    ack_latency_ms: latency,
+    disposition: latency <= input.maximum_ack_latency_ms
+      ? "acknowledge"
+      : "deadline_missed",
+    planned_ack_at: input.admitted_at,
+    schema_version: "agent-gym-slack-acknowledgement/v1",
+  });
+}
+
+function integer(value: number, maximum: number, allowZero = true): void {
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1) || value > maximum) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym Slack acknowledgement input is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/slack-effect-snapshot.ts
+++ b/apps/slack-companion/src/agent-gym/slack-effect-snapshot.ts
@@ -1,0 +1,45 @@
+import { createHash } from "node:crypto";
+import { AgentGymContractError } from "./index.js";
+import type { AgentGymSlackEffectV1 } from "./slack-effects.js";
+
+export interface AgentGymSlackEffectSnapshotV1 {
+  readonly effect_count: number;
+  readonly effect_refs: readonly string[];
+  readonly operations: Readonly<Record<string, number>>;
+  readonly schema_version: "agent-gym-slack-effect-snapshot/v1";
+  readonly snapshot_digest: `sha256:${string}`;
+}
+
+/** Renders a stable, content-addressed summary for test and PR receipts. */
+export function snapshotAgentGymSlackEffects(
+  effects: readonly AgentGymSlackEffectV1[],
+): AgentGymSlackEffectSnapshotV1 {
+  if (!Array.isArray(effects) || effects.length > 10_000) invalid();
+  const byRef = [...effects].sort((left, right) =>
+    left.effect_ref.localeCompare(right.effect_ref)
+  );
+  if (new Set(byRef.map((effect) => effect.effect_ref)).size !== byRef.length
+    || byRef.some((effect) => effect.schema_version !== "agent-gym-slack-effect/v1")) invalid();
+  const operations: Record<string, number> = {};
+  for (const effect of byRef) {
+    operations[effect.operation] = (operations[effect.operation] ?? 0) + 1;
+  }
+  const effectRefs = Object.freeze(byRef.map((effect) => effect.effect_ref));
+  const frozenOperations = Object.freeze(Object.fromEntries(
+    Object.entries(operations).sort(([left], [right]) => left.localeCompare(right)),
+  ));
+  return Object.freeze({
+    effect_count: byRef.length,
+    effect_refs: effectRefs,
+    operations: frozenOperations,
+    schema_version: "agent-gym-slack-effect-snapshot/v1",
+    snapshot_digest: `sha256:${createHash("sha256").update(JSON.stringify({
+      effect_refs: effectRefs,
+      operations: frozenOperations,
+    })).digest("hex")}`,
+  });
+}
+
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym Slack effect snapshot is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/slack-effects.ts
+++ b/apps/slack-companion/src/agent-gym/slack-effects.ts
@@ -1,0 +1,86 @@
+import { createHash } from "node:crypto";
+import type { AgentGymJson } from "./fixture-case.js";
+import { AgentGymContractError } from "./index.js";
+
+export type AgentGymSlackEffectOperation =
+  | "open_modal"
+  | "post_ephemeral"
+  | "post_message"
+  | "publish_home"
+  | "update_message";
+
+export interface AgentGymSlackEffectV1 {
+  readonly effect_ref: string;
+  readonly idempotency_key: string;
+  readonly operation: AgentGymSlackEffectOperation;
+  readonly payload: Readonly<Record<string, AgentGymJson>>;
+  readonly schema_version: "agent-gym-slack-effect/v1";
+  readonly target_refs: readonly string[];
+}
+
+export interface CaptureAgentGymSlackPostMessage {
+  readonly channel_ref: string;
+  readonly idempotency_key: string;
+  readonly text: string;
+  readonly thread_ref?: string;
+}
+
+/** Captures a message post as data instead of invoking Slack. */
+export function captureAgentGymSlackPostMessage(
+  input: CaptureAgentGymSlackPostMessage,
+): AgentGymSlackEffectV1 {
+  reference(input.channel_ref, "channel reference");
+  if (input.thread_ref !== undefined) reference(input.thread_ref, "thread reference");
+  safeText(input.text, 40_000, "message text");
+  return effect("post_message", input.idempotency_key, [
+    input.channel_ref,
+    ...(input.thread_ref === undefined ? [] : [input.thread_ref]),
+  ], {
+    text: input.text,
+    ...(input.thread_ref === undefined ? {} : { thread_ref: input.thread_ref }),
+  });
+}
+
+function effect(
+  operation: AgentGymSlackEffectOperation,
+  idempotencyKey: string,
+  targetRefs: readonly string[],
+  payload: Readonly<Record<string, AgentGymJson>>,
+): AgentGymSlackEffectV1 {
+  bounded(idempotencyKey, 240, "idempotency key");
+  if (targetRefs.length === 0 || targetRefs.length > 8
+    || new Set(targetRefs).size !== targetRefs.length) invalid("targets");
+  const frozenPayload = Object.freeze({ ...payload });
+  return Object.freeze({
+    effect_ref: `slack-effect://sha256/${digest(JSON.stringify({
+      idempotency_key: idempotencyKey,
+      operation,
+      payload: frozenPayload,
+      target_refs: targetRefs,
+    }))}`,
+    idempotency_key: idempotencyKey,
+    operation,
+    payload: frozenPayload,
+    schema_version: "agent-gym-slack-effect/v1",
+    target_refs: Object.freeze([...targetRefs]),
+  });
+}
+
+function bounded(value: string, maximum: number, label: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid(label);
+}
+function digest(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+function reference(value: string, label: string): void {
+  bounded(value, 240, label);
+  if (!value.includes("://")) invalid(label);
+}
+function safeText(value: string, maximum: number, label: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum
+    || /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/u.test(value)) invalid(label);
+}
+function invalid(label: string): never {
+  throw new AgentGymContractError(`Agent gym Slack effect ${label} is invalid.`);
+}

--- a/apps/slack-companion/src/agent-gym/slack-effects.ts
+++ b/apps/slack-companion/src/agent-gym/slack-effects.ts
@@ -37,6 +37,27 @@ export interface CaptureAgentGymSlackPublishHome {
   readonly view: Readonly<Record<string, AgentGymJson>>;
 }
 
+export interface CaptureAgentGymSlackOpenModal {
+  readonly idempotency_key: string;
+  readonly trigger_ref: string;
+  readonly user_ref: string;
+  readonly view: Readonly<Record<string, AgentGymJson>>;
+}
+
+/** Captures a modal open request bound to its one-use trigger and actor. */
+export function captureAgentGymSlackOpenModal(
+  input: CaptureAgentGymSlackOpenModal,
+): AgentGymSlackEffectV1 {
+  reference(input.trigger_ref, "trigger reference");
+  reference(input.user_ref, "user reference");
+  jsonObject(input.view, "modal view");
+  if (input.view.type !== "modal") invalid("modal view type");
+  return effect("open_modal", input.idempotency_key, [
+    input.trigger_ref,
+    input.user_ref,
+  ], { view: input.view });
+}
+
 /** Captures an App Home publication with a fully inspectable view payload. */
 export function captureAgentGymSlackPublishHome(
   input: CaptureAgentGymSlackPublishHome,

--- a/apps/slack-companion/src/agent-gym/slack-effects.ts
+++ b/apps/slack-companion/src/agent-gym/slack-effects.ts
@@ -44,6 +44,33 @@ export interface CaptureAgentGymSlackOpenModal {
   readonly view: Readonly<Record<string, AgentGymJson>>;
 }
 
+export interface CaptureAgentGymSlackPostEphemeral {
+  readonly channel_ref: string;
+  readonly idempotency_key: string;
+  readonly text: string;
+  readonly thread_ref?: string;
+  readonly user_ref: string;
+}
+
+/** Captures a user-scoped ephemeral response with its channel boundary. */
+export function captureAgentGymSlackPostEphemeral(
+  input: CaptureAgentGymSlackPostEphemeral,
+): AgentGymSlackEffectV1 {
+  reference(input.channel_ref, "channel reference");
+  reference(input.user_ref, "user reference");
+  if (input.thread_ref !== undefined) reference(input.thread_ref, "thread reference");
+  safeText(input.text, 40_000, "ephemeral text");
+  return effect("post_ephemeral", input.idempotency_key, [
+    input.channel_ref,
+    input.user_ref,
+    ...(input.thread_ref === undefined ? [] : [input.thread_ref]),
+  ], {
+    text: input.text,
+    user_ref: input.user_ref,
+    ...(input.thread_ref === undefined ? {} : { thread_ref: input.thread_ref }),
+  });
+}
+
 /** Captures a modal open request bound to its one-use trigger and actor. */
 export function captureAgentGymSlackOpenModal(
   input: CaptureAgentGymSlackOpenModal,

--- a/apps/slack-companion/src/agent-gym/slack-effects.ts
+++ b/apps/slack-companion/src/agent-gym/slack-effects.ts
@@ -25,6 +25,23 @@ export interface CaptureAgentGymSlackPostMessage {
   readonly thread_ref?: string;
 }
 
+export interface CaptureAgentGymSlackUpdateMessage {
+  readonly idempotency_key: string;
+  readonly message_ref: string;
+  readonly text: string;
+}
+
+/** Captures replacement content bound to one existing message. */
+export function captureAgentGymSlackUpdateMessage(
+  input: CaptureAgentGymSlackUpdateMessage,
+): AgentGymSlackEffectV1 {
+  reference(input.message_ref, "message reference");
+  safeText(input.text, 40_000, "message text");
+  return effect("update_message", input.idempotency_key, [input.message_ref], {
+    text: input.text,
+  });
+}
+
 /** Captures a message post as data instead of invoking Slack. */
 export function captureAgentGymSlackPostMessage(
   input: CaptureAgentGymSlackPostMessage,

--- a/apps/slack-companion/src/agent-gym/slack-effects.ts
+++ b/apps/slack-companion/src/agent-gym/slack-effects.ts
@@ -31,6 +31,24 @@ export interface CaptureAgentGymSlackUpdateMessage {
   readonly text: string;
 }
 
+export interface CaptureAgentGymSlackPublishHome {
+  readonly idempotency_key: string;
+  readonly user_ref: string;
+  readonly view: Readonly<Record<string, AgentGymJson>>;
+}
+
+/** Captures an App Home publication with a fully inspectable view payload. */
+export function captureAgentGymSlackPublishHome(
+  input: CaptureAgentGymSlackPublishHome,
+): AgentGymSlackEffectV1 {
+  reference(input.user_ref, "user reference");
+  jsonObject(input.view, "Home view");
+  if (input.view.type !== "home") invalid("Home view type");
+  return effect("publish_home", input.idempotency_key, [input.user_ref], {
+    view: input.view,
+  });
+}
+
 /** Captures replacement content bound to one existing message. */
 export function captureAgentGymSlackUpdateMessage(
   input: CaptureAgentGymSlackUpdateMessage,
@@ -67,7 +85,7 @@ function effect(
   bounded(idempotencyKey, 240, "idempotency key");
   if (targetRefs.length === 0 || targetRefs.length > 8
     || new Set(targetRefs).size !== targetRefs.length) invalid("targets");
-  const frozenPayload = Object.freeze({ ...payload });
+  const frozenPayload = deepFreeze({ ...payload });
   return Object.freeze({
     effect_ref: `slack-effect://sha256/${digest(JSON.stringify({
       idempotency_key: idempotencyKey,
@@ -83,6 +101,14 @@ function effect(
   });
 }
 
+function deepFreeze<T extends AgentGymJson>(value: T): T {
+  if (value !== null && typeof value === "object") {
+    for (const nested of Object.values(value)) deepFreeze(nested);
+    Object.freeze(value);
+  }
+  return value;
+}
+
 function bounded(value: string, maximum: number, label: string): void {
   if (typeof value !== "string" || !value.trim() || value.length > maximum
     || /[\u0000-\u001f\u007f]/u.test(value)) invalid(label);
@@ -93,6 +119,14 @@ function digest(value: string): string {
 function reference(value: string, label: string): void {
   bounded(value, 240, label);
   if (!value.includes("://")) invalid(label);
+}
+function jsonObject(value: object, label: string): void {
+  try {
+    const encoded = JSON.stringify(value);
+    if (encoded === undefined || Buffer.byteLength(encoded, "utf8") > 256_000) invalid(label);
+  } catch {
+    invalid(label);
+  }
 }
 function safeText(value: string, maximum: number, label: string): void {
   if (typeof value !== "string" || !value.trim() || value.length > maximum

--- a/apps/slack-companion/src/agent-gym/tool-fixtures.ts
+++ b/apps/slack-companion/src/agent-gym/tool-fixtures.ts
@@ -32,6 +32,29 @@ export interface AgentGymToolErrorFixtureV1 {
   readonly tool_id: string;
 }
 
+export interface AgentGymToolTimeoutFixtureV1 {
+  readonly call_ref: string;
+  readonly elapsed_ms: number;
+  readonly timeout_ms: number;
+  readonly schema_version: "agent-gym-tool-timeout-fixture/v1";
+  readonly tool_id: string;
+}
+
+/** Records a deterministic timeout boundary without waiting in real time. */
+export function injectAgentGymToolTimeout(
+  input: Omit<AgentGymToolTimeoutFixtureV1, "schema_version">,
+): AgentGymToolTimeoutFixtureV1 {
+  reference(input.call_ref);
+  bounded(input.tool_id, 160);
+  integer(input.timeout_ms, 15 * 60_000, false);
+  integer(input.elapsed_ms, 60 * 60_000, false);
+  if (input.elapsed_ms < input.timeout_ms) invalidTimeout();
+  return Object.freeze({
+    ...input,
+    schema_version: "agent-gym-tool-timeout-fixture/v1",
+  });
+}
+
 /** Creates a bounded provider-error fixture without a thrown live error. */
 export function injectAgentGymToolError(
   input: Omit<AgentGymToolErrorFixtureV1, "schema_version">,
@@ -109,6 +132,10 @@ function reference(value: string): void {
   bounded(value, 240);
   if (!value.includes("://")) invalidResult();
 }
+function integer(value: number, maximum: number, allowZero = true): void {
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1)
+    || value > maximum) invalidTimeout();
+}
 function timestamp(value: string): void {
   if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
     || !Number.isFinite(Date.parse(value))) invalidResult();
@@ -121,4 +148,7 @@ function invalidResult(): never {
 }
 function invalidError(): never {
   throw new AgentGymContractError("Agent gym tool error fixture is invalid.");
+}
+function invalidTimeout(): never {
+  throw new AgentGymContractError("Agent gym tool timeout fixture is invalid.");
 }

--- a/apps/slack-companion/src/agent-gym/tool-fixtures.ts
+++ b/apps/slack-companion/src/agent-gym/tool-fixtures.ts
@@ -14,6 +14,41 @@ export interface AgentGymToolRegistrySnapshotV1 {
   readonly tools: readonly AgentGymToolDefinitionV1[];
 }
 
+export interface AgentGymRecordedToolResultV1 {
+  readonly call_ref: string;
+  readonly input_digest: `sha256:${string}`;
+  readonly output: Readonly<Record<string, AgentGymJson>>;
+  readonly recorded_at: string;
+  readonly schema_version: "agent-gym-recorded-tool-result/v1";
+  readonly tool_id: string;
+}
+
+export interface RecordAgentGymToolResult {
+  readonly call_ref: string;
+  readonly input: Readonly<Record<string, AgentGymJson>>;
+  readonly output: Readonly<Record<string, AgentGymJson>>;
+  readonly recorded_at: string;
+  readonly tool_id: string;
+}
+
+/** Records one successful tool response for deterministic replay. */
+export function recordAgentGymToolResult(
+  input: RecordAgentGymToolResult,
+): AgentGymRecordedToolResultV1 {
+  reference(input.call_ref);
+  bounded(input.tool_id, 160);
+  timestamp(input.recorded_at);
+  const output = deepFreeze({ ...input.output });
+  return Object.freeze({
+    call_ref: input.call_ref,
+    input_digest: `sha256:${createHash("sha256").update(JSON.stringify(input.input)).digest("hex")}`,
+    output,
+    recorded_at: input.recorded_at,
+    schema_version: "agent-gym-recorded-tool-result/v1",
+    tool_id: input.tool_id,
+  });
+}
+
 /** Builds a stable tool registry for one offline candidate replay. */
 export function createAgentGymToolRegistry(
   definitions: readonly AgentGymToolDefinitionV1[],
@@ -46,6 +81,17 @@ function deepFreeze<T extends AgentGymJson>(value: T): T {
   }
   return value;
 }
+function reference(value: string): void {
+  bounded(value, 240);
+  if (!value.includes("://")) invalidResult();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalidResult();
+}
 function invalid(): never {
   throw new AgentGymContractError("Agent gym tool registry is invalid.");
+}
+function invalidResult(): never {
+  throw new AgentGymContractError("Agent gym recorded tool result is invalid.");
 }

--- a/apps/slack-companion/src/agent-gym/tool-fixtures.ts
+++ b/apps/slack-companion/src/agent-gym/tool-fixtures.ts
@@ -40,6 +40,41 @@ export interface AgentGymToolTimeoutFixtureV1 {
   readonly tool_id: string;
 }
 
+export interface AgentGymPartialToolResultV1 {
+  readonly call_ref: string;
+  readonly missing_fields: readonly string[];
+  readonly output: Readonly<Record<string, AgentGymJson>>;
+  readonly reason_code: string;
+  readonly schema_version: "agent-gym-partial-tool-result/v1";
+  readonly tool_id: string;
+}
+
+/** Records useful but explicitly incomplete tool output. */
+export function injectAgentGymPartialToolResult(
+  input: Omit<AgentGymPartialToolResultV1, "schema_version">,
+): AgentGymPartialToolResultV1 {
+  reference(input.call_ref);
+  bounded(input.tool_id, 160);
+  bounded(input.reason_code, 120);
+  if (!/^[a-z0-9][a-z0-9._-]*$/u.test(input.reason_code)
+    || !Array.isArray(input.missing_fields)
+    || input.missing_fields.length === 0
+    || input.missing_fields.length > 64
+    || new Set(input.missing_fields).size !== input.missing_fields.length) {
+    invalidPartial();
+  }
+  for (const field of input.missing_fields) {
+    bounded(field, 160);
+    if (!/^[a-z][a-z0-9_.-]*$/u.test(field)) invalidPartial();
+  }
+  return Object.freeze({
+    ...input,
+    missing_fields: Object.freeze([...input.missing_fields].sort()),
+    output: deepFreeze({ ...input.output }),
+    schema_version: "agent-gym-partial-tool-result/v1",
+  });
+}
+
 /** Records a deterministic timeout boundary without waiting in real time. */
 export function injectAgentGymToolTimeout(
   input: Omit<AgentGymToolTimeoutFixtureV1, "schema_version">,
@@ -151,4 +186,7 @@ function invalidError(): never {
 }
 function invalidTimeout(): never {
   throw new AgentGymContractError("Agent gym tool timeout fixture is invalid.");
+}
+function invalidPartial(): never {
+  throw new AgentGymContractError("Agent gym partial tool result is invalid.");
 }

--- a/apps/slack-companion/src/agent-gym/tool-fixtures.ts
+++ b/apps/slack-companion/src/agent-gym/tool-fixtures.ts
@@ -1,0 +1,51 @@
+import { createHash } from "node:crypto";
+import type { AgentGymJson } from "./fixture-case.js";
+import { AgentGymContractError } from "./index.js";
+
+export interface AgentGymToolDefinitionV1 {
+  readonly description: string;
+  readonly input_schema: Readonly<Record<string, AgentGymJson>>;
+  readonly tool_id: string;
+}
+
+export interface AgentGymToolRegistrySnapshotV1 {
+  readonly registry_digest: `sha256:${string}`;
+  readonly schema_version: "agent-gym-tool-registry/v1";
+  readonly tools: readonly AgentGymToolDefinitionV1[];
+}
+
+/** Builds a stable tool registry for one offline candidate replay. */
+export function createAgentGymToolRegistry(
+  definitions: readonly AgentGymToolDefinitionV1[],
+): AgentGymToolRegistrySnapshotV1 {
+  if (!Array.isArray(definitions) || definitions.length === 0
+    || definitions.length > 256) invalid();
+  const tools = [...definitions].map((definition) => {
+    bounded(definition.tool_id, 160);
+    bounded(definition.description, 2_000);
+    if (definition.input_schema.type !== "object") invalid();
+    const schema = deepFreeze({ ...definition.input_schema });
+    return Object.freeze({ ...definition, input_schema: schema });
+  }).sort((left, right) => left.tool_id.localeCompare(right.tool_id));
+  if (new Set(tools.map((tool) => tool.tool_id)).size !== tools.length) invalid();
+  return Object.freeze({
+    registry_digest: `sha256:${createHash("sha256").update(JSON.stringify(tools)).digest("hex")}`,
+    schema_version: "agent-gym-tool-registry/v1",
+    tools: Object.freeze(tools),
+  });
+}
+
+function bounded(value: string, maximum: number): void {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function deepFreeze<T extends AgentGymJson>(value: T): T {
+  if (value !== null && typeof value === "object") {
+    for (const nested of Object.values(value)) deepFreeze(nested);
+    Object.freeze(value);
+  }
+  return value;
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym tool registry is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/tool-fixtures.ts
+++ b/apps/slack-companion/src/agent-gym/tool-fixtures.ts
@@ -23,6 +23,30 @@ export interface AgentGymRecordedToolResultV1 {
   readonly tool_id: string;
 }
 
+export interface AgentGymToolErrorFixtureV1 {
+  readonly call_ref: string;
+  readonly error_code: string;
+  readonly message: string;
+  readonly retryable: boolean;
+  readonly schema_version: "agent-gym-tool-error-fixture/v1";
+  readonly tool_id: string;
+}
+
+/** Creates a bounded provider-error fixture without a thrown live error. */
+export function injectAgentGymToolError(
+  input: Omit<AgentGymToolErrorFixtureV1, "schema_version">,
+): AgentGymToolErrorFixtureV1 {
+  reference(input.call_ref);
+  bounded(input.tool_id, 160);
+  bounded(input.error_code, 120);
+  bounded(input.message, 1_000);
+  if (!/^[a-z0-9][a-z0-9._-]*$/u.test(input.error_code)) invalidError();
+  return Object.freeze({
+    ...input,
+    schema_version: "agent-gym-tool-error-fixture/v1",
+  });
+}
+
 export interface RecordAgentGymToolResult {
   readonly call_ref: string;
   readonly input: Readonly<Record<string, AgentGymJson>>;
@@ -94,4 +118,7 @@ function invalid(): never {
 }
 function invalidResult(): never {
   throw new AgentGymContractError("Agent gym recorded tool result is invalid.");
+}
+function invalidError(): never {
+  throw new AgentGymContractError("Agent gym tool error fixture is invalid.");
 }

--- a/apps/slack-companion/test/agent-gym-slack-effect-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-effect-runtime.test.ts
@@ -7,8 +7,36 @@ import {
   captureAgentGymSlackUpdateMessage,
   orderAgentGymSlackEffects,
   resumeAgentGymSlackEffects,
+  snapshotAgentGymSlackEffects,
   planAgentGymSlackAcknowledgement,
 } from "../src/index.js";
+
+test("effect snapshots are stable across input order", () => {
+  const first = captureAgentGymSlackPostMessage({
+    channel_ref: "slack-channel://one",
+    idempotency_key: "answer:one",
+    text: "First.",
+  });
+  const second = captureAgentGymSlackUpdateMessage({
+    idempotency_key: "answer:one:complete",
+    message_ref: "slack-message://one",
+    text: "Complete.",
+  });
+  const snapshot = snapshotAgentGymSlackEffects([second, first]);
+  assert.deepEqual(snapshot, snapshotAgentGymSlackEffects([first, second]));
+  assert.deepEqual(snapshot.operations, { post_message: 1, update_message: 1 });
+  assert.match(snapshot.snapshot_digest, /^sha256:[0-9a-f]{64}$/u);
+  assert.equal(Object.isFrozen(snapshot.operations), true);
+});
+
+test("effect snapshots reject duplicate effect identities", () => {
+  const effect = captureAgentGymSlackPostMessage({
+    channel_ref: "slack-channel://one",
+    idempotency_key: "answer:one",
+    text: "First.",
+  });
+  assert.throws(() => snapshotAgentGymSlackEffects([effect, effect]), /snapshot is invalid/u);
+});
 
 test("effect resume returns accepted work not completed before a crash", () => {
   const first = captureAgentGymSlackPostMessage({

--- a/apps/slack-companion/test/agent-gym-slack-effect-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-effect-runtime.test.ts
@@ -4,8 +4,44 @@ import test from "node:test";
 import {
   AgentGymSlackEffectIdempotencyLedger,
   captureAgentGymSlackPostMessage,
+  captureAgentGymSlackUpdateMessage,
+  orderAgentGymSlackEffects,
   planAgentGymSlackAcknowledgement,
 } from "../src/index.js";
+
+test("effect ordering honors dependencies independent of input order", () => {
+  const posted = captureAgentGymSlackPostMessage({
+    channel_ref: "slack-channel://one",
+    idempotency_key: "answer:one",
+    text: "Working.",
+  });
+  const updated = captureAgentGymSlackUpdateMessage({
+    idempotency_key: "answer:one:complete",
+    message_ref: "slack-message://one",
+    text: "Complete.",
+  });
+  assert.deepEqual(orderAgentGymSlackEffects([
+    { after_effect_refs: [posted.effect_ref], effect: updated },
+    { after_effect_refs: [], effect: posted },
+  ]).map((effect) => effect.effect_ref), [posted.effect_ref, updated.effect_ref]);
+});
+
+test("effect ordering rejects dependency cycles", () => {
+  const first = captureAgentGymSlackPostMessage({
+    channel_ref: "slack-channel://one",
+    idempotency_key: "answer:one",
+    text: "First.",
+  });
+  const second = captureAgentGymSlackPostMessage({
+    channel_ref: "slack-channel://one",
+    idempotency_key: "answer:two",
+    text: "Second.",
+  });
+  assert.throws(() => orderAgentGymSlackEffects([
+    { after_effect_refs: [second.effect_ref], effect: first },
+    { after_effect_refs: [first.effect_ref], effect: second },
+  ]), /effect plan is invalid/u);
+});
 
 test("effect idempotency admits once and recognizes exact retries", () => {
   const ledger = new AgentGymSlackEffectIdempotencyLedger();

--- a/apps/slack-companion/test/agent-gym-slack-effect-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-effect-runtime.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { planAgentGymSlackAcknowledgement } from "../src/index.js";
+
+test("acknowledgement simulation waits for durable admission", () => {
+  assert.deepEqual(planAgentGymSlackAcknowledgement({
+    durable_admission: false,
+    event_received_at: "2026-08-12T08:52:00.000Z",
+    maximum_ack_latency_ms: 3_000,
+  }), {
+    disposition: "withhold",
+    schema_version: "agent-gym-slack-acknowledgement/v1",
+  });
+  assert.equal(planAgentGymSlackAcknowledgement({
+    admitted_at: "2026-08-12T08:52:02.500Z",
+    durable_admission: true,
+    event_received_at: "2026-08-12T08:52:00.000Z",
+    maximum_ack_latency_ms: 3_000,
+  }).disposition, "acknowledge");
+});
+
+test("acknowledgement simulation reports a missed deadline", () => {
+  const receipt = planAgentGymSlackAcknowledgement({
+    admitted_at: "2026-08-12T08:52:03.001Z",
+    durable_admission: true,
+    event_received_at: "2026-08-12T08:52:00.000Z",
+    maximum_ack_latency_ms: 3_000,
+  });
+  assert.equal(receipt.disposition, "deadline_missed");
+  assert.equal(receipt.ack_latency_ms, 3_001);
+});

--- a/apps/slack-companion/test/agent-gym-slack-effect-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-effect-runtime.test.ts
@@ -1,7 +1,36 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { planAgentGymSlackAcknowledgement } from "../src/index.js";
+import {
+  AgentGymSlackEffectIdempotencyLedger,
+  captureAgentGymSlackPostMessage,
+  planAgentGymSlackAcknowledgement,
+} from "../src/index.js";
+
+test("effect idempotency admits once and recognizes exact retries", () => {
+  const ledger = new AgentGymSlackEffectIdempotencyLedger();
+  const effect = captureAgentGymSlackPostMessage({
+    channel_ref: "slack-channel://one",
+    idempotency_key: "answer:one",
+    text: "Verified answer.",
+  });
+  assert.equal(ledger.admit(effect).disposition, "accepted");
+  assert.equal(ledger.admit(effect).disposition, "duplicate");
+});
+
+test("effect idempotency rejects changed output under one key", () => {
+  const ledger = new AgentGymSlackEffectIdempotencyLedger();
+  const input = {
+    channel_ref: "slack-channel://one",
+    idempotency_key: "answer:one",
+    text: "Verified answer.",
+  };
+  ledger.admit(captureAgentGymSlackPostMessage(input));
+  assert.throws(() => ledger.admit(captureAgentGymSlackPostMessage({
+    ...input,
+    text: "Different answer.",
+  })), /idempotency key changed effect/u);
+});
 
 test("acknowledgement simulation waits for durable admission", () => {
   assert.deepEqual(planAgentGymSlackAcknowledgement({

--- a/apps/slack-companion/test/agent-gym-slack-effect-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-effect-runtime.test.ts
@@ -6,8 +6,42 @@ import {
   captureAgentGymSlackPostMessage,
   captureAgentGymSlackUpdateMessage,
   orderAgentGymSlackEffects,
+  resumeAgentGymSlackEffects,
   planAgentGymSlackAcknowledgement,
 } from "../src/index.js";
+
+test("effect resume returns accepted work not completed before a crash", () => {
+  const first = captureAgentGymSlackPostMessage({
+    channel_ref: "slack-channel://one",
+    idempotency_key: "answer:one",
+    text: "First.",
+  });
+  const second = captureAgentGymSlackPostMessage({
+    channel_ref: "slack-channel://one",
+    idempotency_key: "answer:two",
+    text: "Second.",
+  });
+  assert.deepEqual(resumeAgentGymSlackEffects({
+    accepted_effect_refs: [first.effect_ref, second.effect_ref],
+    checkpoint_ref: "checkpoint://effects/one",
+    completed_effect_refs: [first.effect_ref],
+    schema_version: "agent-gym-slack-effect-checkpoint/v1",
+  }, [second, first]), [second]);
+});
+
+test("effect resume rejects completion without prior acceptance", () => {
+  const effect = captureAgentGymSlackPostMessage({
+    channel_ref: "slack-channel://one",
+    idempotency_key: "answer:one",
+    text: "First.",
+  });
+  assert.throws(() => resumeAgentGymSlackEffects({
+    accepted_effect_refs: [],
+    checkpoint_ref: "checkpoint://effects/one",
+    completed_effect_refs: [effect.effect_ref],
+    schema_version: "agent-gym-slack-effect-checkpoint/v1",
+  }, [effect]), /checkpoint is invalid/u);
+});
 
 test("effect ordering honors dependencies independent of input order", () => {
   const posted = captureAgentGymSlackPostMessage({

--- a/apps/slack-companion/test/agent-gym-slack-effects.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-effects.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { captureAgentGymSlackPostMessage } from "../src/index.js";
+
+test("message capture records a deterministic Slack-free effect", () => {
+  const input = {
+    channel_ref: "slack-channel://one",
+    idempotency_key: "answer:one",
+    text: "Current evidence:\n- one verified record",
+    thread_ref: "slack-thread://one",
+  };
+  const first = captureAgentGymSlackPostMessage(input);
+  assert.deepEqual(captureAgentGymSlackPostMessage(input), first);
+  assert.equal(first.operation, "post_message");
+  assert.match(first.effect_ref, /^slack-effect:\/\/sha256\/[0-9a-f]{64}$/u);
+  assert.equal(Object.isFrozen(first.payload), true);
+  assert.equal(Object.isFrozen(first.target_refs), true);
+});
+
+test("message capture rejects empty text and non-reference targets", () => {
+  assert.throws(() => captureAgentGymSlackPostMessage({
+    channel_ref: "channel-one",
+    idempotency_key: "answer:one",
+    text: "Answer",
+  }), /channel reference is invalid/u);
+});

--- a/apps/slack-companion/test/agent-gym-slack-effects.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-effects.test.ts
@@ -3,10 +3,37 @@ import test from "node:test";
 
 import {
   captureAgentGymSlackOpenModal,
+  captureAgentGymSlackPostEphemeral,
   captureAgentGymSlackPostMessage,
   captureAgentGymSlackPublishHome,
   captureAgentGymSlackUpdateMessage,
 } from "../src/index.js";
+
+test("ephemeral capture binds private text to one user and channel", () => {
+  const effect = captureAgentGymSlackPostEphemeral({
+    channel_ref: "slack-channel://one",
+    idempotency_key: "clarification:one",
+    text: "Choose the target account before execution.",
+    thread_ref: "slack-thread://one",
+    user_ref: "slack-user://one",
+  });
+  assert.equal(effect.operation, "post_ephemeral");
+  assert.deepEqual(effect.target_refs, [
+    "slack-channel://one",
+    "slack-user://one",
+    "slack-thread://one",
+  ]);
+  assert.equal(effect.payload.user_ref, "slack-user://one");
+});
+
+test("ephemeral capture rejects an absent actor boundary", () => {
+  assert.throws(() => captureAgentGymSlackPostEphemeral({
+    channel_ref: "slack-channel://one",
+    idempotency_key: "clarification:one",
+    text: "Choose the target account before execution.",
+    user_ref: "",
+  }), /user reference is invalid/u);
+});
 
 test("modal capture binds a valid modal to the actor and trigger", () => {
   const effect = captureAgentGymSlackOpenModal({

--- a/apps/slack-companion/test/agent-gym-slack-effects.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-effects.test.ts
@@ -1,7 +1,29 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { captureAgentGymSlackPostMessage } from "../src/index.js";
+import {
+  captureAgentGymSlackPostMessage,
+  captureAgentGymSlackUpdateMessage,
+} from "../src/index.js";
+
+test("message update capture binds replacement content to one message", () => {
+  const effect = captureAgentGymSlackUpdateMessage({
+    idempotency_key: "status:one:complete",
+    message_ref: "slack-message://one",
+    text: "Verification complete.",
+  });
+  assert.equal(effect.operation, "update_message");
+  assert.deepEqual(effect.target_refs, ["slack-message://one"]);
+  assert.deepEqual(effect.payload, { text: "Verification complete." });
+});
+
+test("message update capture rejects control characters", () => {
+  assert.throws(() => captureAgentGymSlackUpdateMessage({
+    idempotency_key: "status:one:complete",
+    message_ref: "slack-message://one",
+    text: "bad\u0000text",
+  }), /message text is invalid/u);
+});
 
 test("message capture records a deterministic Slack-free effect", () => {
   const input = {

--- a/apps/slack-companion/test/agent-gym-slack-effects.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-effects.test.ts
@@ -2,10 +2,38 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  captureAgentGymSlackOpenModal,
   captureAgentGymSlackPostMessage,
   captureAgentGymSlackPublishHome,
   captureAgentGymSlackUpdateMessage,
 } from "../src/index.js";
+
+test("modal capture binds a valid modal to the actor and trigger", () => {
+  const effect = captureAgentGymSlackOpenModal({
+    idempotency_key: "modal:approval:one",
+    trigger_ref: "slack-trigger://one",
+    user_ref: "slack-user://one",
+    view: {
+      callback_id: "approval.confirm",
+      title: { text: "Confirm action", type: "plain_text" },
+      type: "modal",
+    },
+  });
+  assert.equal(effect.operation, "open_modal");
+  assert.deepEqual(effect.target_refs, [
+    "slack-trigger://one",
+    "slack-user://one",
+  ]);
+});
+
+test("modal capture rejects a Home-shaped view", () => {
+  assert.throws(() => captureAgentGymSlackOpenModal({
+    idempotency_key: "modal:approval:one",
+    trigger_ref: "slack-trigger://one",
+    user_ref: "slack-user://one",
+    view: { type: "home" },
+  }), /modal view type is invalid/u);
+});
 
 test("Home publication capture retains a deeply frozen view", () => {
   const blocks = [{ text: "2 outcome checks pending", type: "section" }];

--- a/apps/slack-companion/test/agent-gym-slack-effects.test.ts
+++ b/apps/slack-companion/test/agent-gym-slack-effects.test.ts
@@ -3,8 +3,31 @@ import test from "node:test";
 
 import {
   captureAgentGymSlackPostMessage,
+  captureAgentGymSlackPublishHome,
   captureAgentGymSlackUpdateMessage,
 } from "../src/index.js";
+
+test("Home publication capture retains a deeply frozen view", () => {
+  const blocks = [{ text: "2 outcome checks pending", type: "section" }];
+  const view = { blocks, type: "home" };
+  const effect = captureAgentGymSlackPublishHome({
+    idempotency_key: "home:user-one:revision-one",
+    user_ref: "slack-user://one",
+    view,
+  });
+  assert.equal(effect.operation, "publish_home");
+  assert.equal(Object.isFrozen(view), true);
+  assert.equal(Object.isFrozen(blocks), true);
+  assert.equal(Object.isFrozen(blocks[0]), true);
+});
+
+test("Home publication capture rejects a modal-shaped view", () => {
+  assert.throws(() => captureAgentGymSlackPublishHome({
+    idempotency_key: "home:user-one:revision-one",
+    user_ref: "slack-user://one",
+    view: { type: "modal" },
+  }), /Home view type is invalid/u);
+});
 
 test("message update capture binds replacement content to one message", () => {
   const effect = captureAgentGymSlackUpdateMessage({

--- a/apps/slack-companion/test/agent-gym-tool-fixtures.test.ts
+++ b/apps/slack-companion/test/agent-gym-tool-fixtures.test.ts
@@ -4,8 +4,29 @@ import test from "node:test";
 import {
   createAgentGymToolRegistry,
   injectAgentGymToolError,
+  injectAgentGymToolTimeout,
   recordAgentGymToolResult,
 } from "../src/index.js";
+
+test("tool timeout injection advances virtual time without sleeping", () => {
+  const fixture = injectAgentGymToolTimeout({
+    call_ref: "tool-call://one",
+    elapsed_ms: 5_001,
+    timeout_ms: 5_000,
+    tool_id: "cerebro.search",
+  });
+  assert.equal(fixture.elapsed_ms, 5_001);
+  assert.equal(fixture.schema_version, "agent-gym-tool-timeout-fixture/v1");
+});
+
+test("tool timeout injection rejects a result before its deadline", () => {
+  assert.throws(() => injectAgentGymToolTimeout({
+    call_ref: "tool-call://one",
+    elapsed_ms: 4_999,
+    timeout_ms: 5_000,
+    tool_id: "cerebro.search",
+  }), /timeout fixture is invalid/u);
+});
 
 test("tool error injection preserves retryability as fixture data", () => {
   assert.deepEqual(injectAgentGymToolError({

--- a/apps/slack-companion/test/agent-gym-tool-fixtures.test.ts
+++ b/apps/slack-companion/test/agent-gym-tool-fixtures.test.ts
@@ -1,7 +1,30 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { createAgentGymToolRegistry } from "../src/index.js";
+import { createAgentGymToolRegistry, recordAgentGymToolResult } from "../src/index.js";
+
+test("recorded tool results bind output to exact input", () => {
+  const result = recordAgentGymToolResult({
+    call_ref: "tool-call://one",
+    input: { query: "current evidence" },
+    output: { records: [{ ref: "evidence://one" }] },
+    recorded_at: "2026-08-12T08:58:00.000Z",
+    tool_id: "cerebro.search",
+  });
+  assert.match(result.input_digest, /^sha256:[0-9a-f]{64}$/u);
+  assert.equal(Object.isFrozen(result.output), true);
+  assert.equal(Object.isFrozen(result.output.records), true);
+});
+
+test("recorded tool results require canonical time", () => {
+  assert.throws(() => recordAgentGymToolResult({
+    call_ref: "tool-call://one",
+    input: {},
+    output: {},
+    recorded_at: "2026-08-12T08:58:00Z",
+    tool_id: "cerebro.search",
+  }), /recorded tool result is invalid/u);
+});
 
 test("tool registry is stable across declaration order", () => {
   const first = {

--- a/apps/slack-companion/test/agent-gym-tool-fixtures.test.ts
+++ b/apps/slack-companion/test/agent-gym-tool-fixtures.test.ts
@@ -1,7 +1,38 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { createAgentGymToolRegistry, recordAgentGymToolResult } from "../src/index.js";
+import {
+  createAgentGymToolRegistry,
+  injectAgentGymToolError,
+  recordAgentGymToolResult,
+} from "../src/index.js";
+
+test("tool error injection preserves retryability as fixture data", () => {
+  assert.deepEqual(injectAgentGymToolError({
+    call_ref: "tool-call://one",
+    error_code: "source.unavailable",
+    message: "The evidence source is unavailable.",
+    retryable: true,
+    tool_id: "cerebro.search",
+  }), {
+    call_ref: "tool-call://one",
+    error_code: "source.unavailable",
+    message: "The evidence source is unavailable.",
+    retryable: true,
+    schema_version: "agent-gym-tool-error-fixture/v1",
+    tool_id: "cerebro.search",
+  });
+});
+
+test("tool error injection rejects display text as an error code", () => {
+  assert.throws(() => injectAgentGymToolError({
+    call_ref: "tool-call://one",
+    error_code: "Source Unavailable",
+    message: "The evidence source is unavailable.",
+    retryable: true,
+    tool_id: "cerebro.search",
+  }), /error fixture is invalid/u);
+});
 
 test("recorded tool results bind output to exact input", () => {
   const result = recordAgentGymToolResult({

--- a/apps/slack-companion/test/agent-gym-tool-fixtures.test.ts
+++ b/apps/slack-companion/test/agent-gym-tool-fixtures.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createAgentGymToolRegistry } from "../src/index.js";
+
+test("tool registry is stable across declaration order", () => {
+  const first = {
+    description: "Read current evidence.",
+    input_schema: { properties: { query: { type: "string" } }, type: "object" },
+    tool_id: "cerebro.search",
+  };
+  const second = {
+    description: "Read one work item.",
+    input_schema: { properties: { ref: { type: "string" } }, type: "object" },
+    tool_id: "work.get",
+  };
+  const registry = createAgentGymToolRegistry([second, first]);
+  assert.deepEqual(registry, createAgentGymToolRegistry([first, second]));
+  assert.deepEqual(registry.tools.map((tool) => tool.tool_id), [
+    "cerebro.search",
+    "work.get",
+  ]);
+  assert.match(registry.registry_digest, /^sha256:[0-9a-f]{64}$/u);
+});
+
+test("tool registry rejects duplicate identities", () => {
+  const tool = {
+    description: "Read current evidence.",
+    input_schema: { type: "object" },
+    tool_id: "cerebro.search",
+  };
+  assert.throws(() => createAgentGymToolRegistry([tool, tool]), /registry is invalid/u);
+});

--- a/apps/slack-companion/test/agent-gym-tool-fixtures.test.ts
+++ b/apps/slack-companion/test/agent-gym-tool-fixtures.test.ts
@@ -5,8 +5,32 @@ import {
   createAgentGymToolRegistry,
   injectAgentGymToolError,
   injectAgentGymToolTimeout,
+  injectAgentGymPartialToolResult,
   recordAgentGymToolResult,
 } from "../src/index.js";
+
+test("partial tool results preserve useful output and named gaps", () => {
+  const result = injectAgentGymPartialToolResult({
+    call_ref: "tool-call://one",
+    missing_fields: ["owner", "freshness.observed_at"],
+    output: { evidence_ref: "evidence://one" },
+    reason_code: "source.partial",
+    tool_id: "cerebro.search",
+  });
+  assert.deepEqual(result.missing_fields, ["freshness.observed_at", "owner"]);
+  assert.equal(result.output.evidence_ref, "evidence://one");
+  assert.equal(Object.isFrozen(result.output), true);
+});
+
+test("partial tool results require at least one named gap", () => {
+  assert.throws(() => injectAgentGymPartialToolResult({
+    call_ref: "tool-call://one",
+    missing_fields: [],
+    output: { evidence_ref: "evidence://one" },
+    reason_code: "source.partial",
+    tool_id: "cerebro.search",
+  }), /partial tool result is invalid/u);
+});
 
 test("tool timeout injection advances virtual time without sleeping", () => {
   const fixture = injectAgentGymToolTimeout({


### PR DESCRIPTION
## Summary


## Test Plan


## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Deterministic Review

- Fast local invariant check: `make review-invariants`.
- Focus review on changed behavior and the invariants above.
- The required `deterministic-review` check runs the exact PR range through invariant, contract, structural, architecture, scanner, vulnerability, leak, and workflow-permission gates.
- Use a manual `@droid` task only when explicitly requested for broad auth, graph, source HTTP, or state-machine investigation; it is not an automatic merge gate.
- Land with `make land-pr PR=<number>` so the deterministic review check and required checks pass before branch deletion.
