### PR TITLE
feat(slack): expand offline tool fixtures

### DIFF
--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -22,6 +22,7 @@ export * from "./run-summary.js";
 export * from "./scorecard.js";
 export * from "./slack-simulator.js";
 export * from "./tool-fixtures.js";
+export * from "./tool-fixture-runtime.js";
 export * from "./slack-delivery.js";
 export * from "./slack-failure.js";
 export * from "./slack-effects.js";

--- a/apps/slack-companion/src/agent-gym/tool-fixture-runtime.ts
+++ b/apps/slack-companion/src/agent-gym/tool-fixture-runtime.ts
@@ -1,0 +1,59 @@
+import type { AgentGymJson } from "./fixture-case.js";
+import { AgentGymContractError } from "./index.js";
+
+export interface AgentGymToolPageFixtureV1 {
+  readonly call_ref: string;
+  readonly items: readonly AgentGymJson[];
+  readonly next_cursor: string | null;
+  readonly page_index: number;
+  readonly schema_version: "agent-gym-tool-page-fixture/v1";
+  readonly tool_id: string;
+}
+
+export interface CreateAgentGymToolPageFixture {
+  readonly call_ref: string;
+  readonly items: readonly AgentGymJson[];
+  readonly next_cursor: string | null;
+  readonly page_index: number;
+  readonly tool_id: string;
+}
+
+/** Creates one deterministic page without contacting or advancing a live source. */
+export function createAgentGymToolPageFixture(
+  input: CreateAgentGymToolPageFixture,
+): AgentGymToolPageFixtureV1 {
+  reference(input.call_ref);
+  identifier(input.tool_id, 160);
+  if (!Array.isArray(input.items) || input.items.length > 1_000
+    || !Number.isSafeInteger(input.page_index) || input.page_index < 0
+    || input.page_index > 10_000) invalidPage();
+  if (input.next_cursor !== null) identifier(input.next_cursor, 1_000);
+  const items = structuredClone(input.items);
+  deepFreeze(items);
+  return Object.freeze({
+    ...input,
+    items,
+    schema_version: "agent-gym-tool-page-fixture/v1",
+  });
+}
+
+function deepFreeze(value: AgentGymJson): void {
+  if (value !== null && typeof value === "object") {
+    for (const nested of Object.values(value)) deepFreeze(nested);
+    Object.freeze(value);
+  }
+}
+
+function identifier(value: string, maximum: number): void {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalidPage();
+}
+
+function reference(value: string): void {
+  identifier(value, 240);
+  if (!value.includes("://")) invalidPage();
+}
+
+function invalidPage(): never {
+  throw new AgentGymContractError("Agent gym tool page fixture is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/tool-fixture-runtime.ts
+++ b/apps/slack-companion/src/agent-gym/tool-fixture-runtime.ts
@@ -1,5 +1,6 @@
 import type { AgentGymJson } from "./fixture-case.js";
 import { AgentGymContractError } from "./index.js";
+import type { AgentGymToolRegistrySnapshotV1 } from "./tool-fixtures.js";
 
 export interface AgentGymToolPageFixtureV1 {
   readonly call_ref: string;
@@ -50,6 +51,44 @@ export type CreateAgentGymAuthorizationFixture = Omit<
   AgentGymAuthorizationFixtureV1,
   "schema_version"
 >;
+
+export interface AgentGymToolCallV1 {
+  readonly call_ref: string;
+  readonly input: Readonly<Record<string, AgentGymJson>>;
+  readonly tool_id: string;
+}
+
+export interface AgentGymToolCallValidationV1 {
+  readonly call_ref: string;
+  readonly issues: readonly string[];
+  readonly schema_version: "agent-gym-tool-call-validation/v1";
+  readonly tool_id: string;
+  readonly valid: boolean;
+}
+
+/** Validates a replayed call against the frozen registry's JSON Schema subset. */
+export function validateAgentGymToolCall(
+  registry: AgentGymToolRegistrySnapshotV1,
+  call: AgentGymToolCallV1,
+): AgentGymToolCallValidationV1 {
+  reference(call.call_ref, invalidToolCall);
+  toolIdentifier(call.tool_id, invalidToolCall);
+  const definition = registry.tools.find((tool) => tool.tool_id === call.tool_id);
+  const issues: string[] = [];
+  if (definition === undefined) {
+    issues.push("tool.not_registered");
+  } else {
+    validateSchema(definition.input_schema, call.input, "$", issues, 0);
+  }
+  const stableIssues = Object.freeze([...new Set(issues)].sort());
+  return Object.freeze({
+    call_ref: call.call_ref,
+    issues: stableIssues,
+    schema_version: "agent-gym-tool-call-validation/v1",
+    tool_id: call.tool_id,
+    valid: stableIssues.length === 0,
+  });
+}
 
 /** Records a replay-only authorization decision with its policy evidence. */
 export function createAgentGymAuthorizationFixture(
@@ -142,6 +181,91 @@ function code(value: string, maximum: number): void {
     || !/^[a-z0-9][a-z0-9._:-]*$/u.test(value)) invalidAuthorization();
 }
 
+function validateSchema(
+  schema: AgentGymJson,
+  value: AgentGymJson,
+  path: string,
+  issues: string[],
+  depth: number,
+): void {
+  if (issues.length >= 128) return;
+  if (depth > 32 || !jsonRecord(schema) || typeof schema.type !== "string") {
+    issues.push(`${path}:schema.unsupported`);
+    return;
+  }
+  if (!matchesType(schema.type, value)) {
+    issues.push(`${path}:input.type_mismatch`);
+    return;
+  }
+  if (Array.isArray(schema.enum)
+    && !schema.enum.some((candidate) => JSON.stringify(candidate) === JSON.stringify(value))) {
+    issues.push(`${path}:input.enum_mismatch`);
+  }
+  if (schema.type === "object" && jsonRecord(value)) {
+    const properties = schema.properties;
+    if (properties !== undefined && !jsonRecord(properties)) {
+      issues.push(`${path}:schema.unsupported`);
+      return;
+    }
+    const required = schema.required;
+    if (required !== undefined) {
+      if (!Array.isArray(required)) {
+        issues.push(`${path}:schema.unsupported`);
+        return;
+      }
+      for (const name of required) {
+        if (typeof name !== "string") {
+          issues.push(`${path}:schema.unsupported`);
+          return;
+        }
+        if (!(name in value)) issues.push(`${path}.${name}:input.required_missing`);
+      }
+    }
+    if (schema.additionalProperties === false && jsonRecord(properties)) {
+      for (const name of Object.keys(value)) {
+        if (!(name in properties)) issues.push(`${path}.${name}:input.unknown_property`);
+      }
+    }
+    if (jsonRecord(properties)) {
+      for (const [name, propertyValue] of Object.entries(value)) {
+        const propertySchema = properties[name];
+        if (propertySchema !== undefined) {
+          validateSchema(propertySchema, propertyValue, `${path}.${name}`, issues, depth + 1);
+        }
+      }
+    }
+  }
+  const itemSchema = schema.items;
+  if (schema.type === "array" && Array.isArray(value) && itemSchema !== undefined) {
+    for (const [index, item] of value.entries()) {
+      validateSchema(itemSchema, item, `${path}[${index}]`, issues, depth + 1);
+    }
+  }
+}
+
+function matchesType(type: string, value: AgentGymJson): boolean {
+  switch (type) {
+    case "array": return Array.isArray(value);
+    case "boolean": return typeof value === "boolean";
+    case "integer": return typeof value === "number" && Number.isSafeInteger(value);
+    case "null": return value === null;
+    case "number": return typeof value === "number" && Number.isFinite(value);
+    case "object": return jsonRecord(value);
+    case "string": return typeof value === "string";
+    default: return false;
+  }
+}
+
+function jsonRecord(value: AgentGymJson | undefined): value is Readonly<Record<string, AgentGymJson>> {
+  return value !== null && value !== undefined && typeof value === "object"
+    && !Array.isArray(value);
+}
+
+function toolIdentifier(value: string, invalid: () => never): void {
+  if (typeof value !== "string" || !value.trim() || value.length > 160
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+
 function invalidPage(): never {
   throw new AgentGymContractError("Agent gym tool page fixture is invalid.");
 }
@@ -152,4 +276,8 @@ function invalidStaleEvidence(): never {
 
 function invalidAuthorization(): never {
   throw new AgentGymContractError("Agent gym authorization fixture is invalid.");
+}
+
+function invalidToolCall(): never {
+  throw new AgentGymContractError("Agent gym tool call is invalid.");
 }

--- a/apps/slack-companion/src/agent-gym/tool-fixture-runtime.ts
+++ b/apps/slack-companion/src/agent-gym/tool-fixture-runtime.ts
@@ -35,11 +35,46 @@ export interface CreateAgentGymStaleEvidenceFixture {
   readonly observed_at: string;
 }
 
+export interface AgentGymAuthorizationFixtureV1 {
+  readonly action: string;
+  readonly decision: "allow" | "deny";
+  readonly policy_ref: string;
+  readonly principal_ref: string;
+  readonly reason_code: string;
+  readonly request_ref: string;
+  readonly resource_ref: string;
+  readonly schema_version: "agent-gym-authorization-fixture/v1";
+}
+
+export type CreateAgentGymAuthorizationFixture = Omit<
+  AgentGymAuthorizationFixtureV1,
+  "schema_version"
+>;
+
+/** Records a replay-only authorization decision with its policy evidence. */
+export function createAgentGymAuthorizationFixture(
+  input: CreateAgentGymAuthorizationFixture,
+): AgentGymAuthorizationFixtureV1 {
+  reference(input.request_ref, invalidAuthorization);
+  reference(input.policy_ref, invalidAuthorization);
+  reference(input.principal_ref, invalidAuthorization);
+  reference(input.resource_ref, invalidAuthorization);
+  code(input.action, 160);
+  code(input.reason_code, 160);
+  if (input.decision !== "allow" && input.decision !== "deny") {
+    invalidAuthorization();
+  }
+  return Object.freeze({
+    ...input,
+    schema_version: "agent-gym-authorization-fixture/v1",
+  });
+}
+
 /** Evaluates evidence age against an explicit replay clock. */
 export function createAgentGymStaleEvidenceFixture(
   input: CreateAgentGymStaleEvidenceFixture,
 ): AgentGymStaleEvidenceFixtureV1 {
-  reference(input.evidence_ref);
+  reference(input.evidence_ref, invalidStaleEvidence);
   const observedAt = canonicalTime(input.observed_at);
   const evaluatedAt = canonicalTime(input.evaluated_at);
   if (!Number.isSafeInteger(input.max_age_ms) || input.max_age_ms < 1
@@ -88,9 +123,9 @@ function identifier(value: string, maximum: number): void {
     || /[\u0000-\u001f\u007f]/u.test(value)) invalidPage();
 }
 
-function reference(value: string): void {
-  identifier(value, 240);
-  if (!value.includes("://")) invalidPage();
+function reference(value: string, invalid: () => never = invalidPage): void {
+  if (typeof value !== "string" || !value.trim() || value.length > 240
+    || /[\u0000-\u001f\u007f]/u.test(value) || !value.includes("://")) invalid();
 }
 
 function canonicalTime(value: string): number {
@@ -102,10 +137,19 @@ function canonicalTime(value: string): number {
   return parsed;
 }
 
+function code(value: string, maximum: number): void {
+  if (typeof value !== "string" || value.length > maximum
+    || !/^[a-z0-9][a-z0-9._:-]*$/u.test(value)) invalidAuthorization();
+}
+
 function invalidPage(): never {
   throw new AgentGymContractError("Agent gym tool page fixture is invalid.");
 }
 
 function invalidStaleEvidence(): never {
   throw new AgentGymContractError("Agent gym stale evidence fixture is invalid.");
+}
+
+function invalidAuthorization(): never {
+  throw new AgentGymContractError("Agent gym authorization fixture is invalid.");
 }

--- a/apps/slack-companion/src/agent-gym/tool-fixture-runtime.ts
+++ b/apps/slack-companion/src/agent-gym/tool-fixture-runtime.ts
@@ -18,6 +18,45 @@ export interface CreateAgentGymToolPageFixture {
   readonly tool_id: string;
 }
 
+export interface AgentGymStaleEvidenceFixtureV1 {
+  readonly age_ms: number;
+  readonly evaluated_at: string;
+  readonly evidence_ref: string;
+  readonly max_age_ms: number;
+  readonly observed_at: string;
+  readonly schema_version: "agent-gym-stale-evidence-fixture/v1";
+  readonly stale: boolean;
+}
+
+export interface CreateAgentGymStaleEvidenceFixture {
+  readonly evaluated_at: string;
+  readonly evidence_ref: string;
+  readonly max_age_ms: number;
+  readonly observed_at: string;
+}
+
+/** Evaluates evidence age against an explicit replay clock. */
+export function createAgentGymStaleEvidenceFixture(
+  input: CreateAgentGymStaleEvidenceFixture,
+): AgentGymStaleEvidenceFixtureV1 {
+  reference(input.evidence_ref);
+  const observedAt = canonicalTime(input.observed_at);
+  const evaluatedAt = canonicalTime(input.evaluated_at);
+  if (!Number.isSafeInteger(input.max_age_ms) || input.max_age_ms < 1
+    || input.max_age_ms > 365 * 24 * 60 * 60_000
+    || evaluatedAt < observedAt) invalidStaleEvidence();
+  const ageMs = evaluatedAt - observedAt;
+  return Object.freeze({
+    age_ms: ageMs,
+    evaluated_at: input.evaluated_at,
+    evidence_ref: input.evidence_ref,
+    max_age_ms: input.max_age_ms,
+    observed_at: input.observed_at,
+    schema_version: "agent-gym-stale-evidence-fixture/v1",
+    stale: ageMs > input.max_age_ms,
+  });
+}
+
 /** Creates one deterministic page without contacting or advancing a live source. */
 export function createAgentGymToolPageFixture(
   input: CreateAgentGymToolPageFixture,
@@ -54,6 +93,19 @@ function reference(value: string): void {
   if (!value.includes("://")) invalidPage();
 }
 
+function canonicalTime(value: string): number {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)) {
+    invalidStaleEvidence();
+  }
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) invalidStaleEvidence();
+  return parsed;
+}
+
 function invalidPage(): never {
   throw new AgentGymContractError("Agent gym tool page fixture is invalid.");
+}
+
+function invalidStaleEvidence(): never {
+  throw new AgentGymContractError("Agent gym stale evidence fixture is invalid.");
 }

--- a/apps/slack-companion/src/agent-gym/tool-fixture-runtime.ts
+++ b/apps/slack-companion/src/agent-gym/tool-fixture-runtime.ts
@@ -66,6 +66,45 @@ export interface AgentGymToolCallValidationV1 {
   readonly valid: boolean;
 }
 
+export interface AgentGymToolUsageAnalysisV1 {
+  readonly call_count: number;
+  readonly schema_version: "agent-gym-tool-usage-analysis/v1";
+  readonly unregistered_tool_ids: readonly string[];
+  readonly unused_tool_ids: readonly string[];
+  readonly used_tool_ids: readonly string[];
+}
+
+/** Reports excess registry surface and calls outside the declared tool boundary. */
+export function analyzeAgentGymToolUsage(
+  registry: AgentGymToolRegistrySnapshotV1,
+  calls: readonly AgentGymToolCallV1[],
+): AgentGymToolUsageAnalysisV1 {
+  if (!Array.isArray(calls) || calls.length > 10_000) invalidToolUsage();
+  const callRefs = new Set<string>();
+  const calledToolIds = new Set<string>();
+  for (const call of calls) {
+    reference(call.call_ref, invalidToolUsage);
+    toolIdentifier(call.tool_id, invalidToolUsage);
+    if (callRefs.has(call.call_ref)) invalidToolUsage();
+    callRefs.add(call.call_ref);
+    calledToolIds.add(call.tool_id);
+  }
+  const registeredToolIds = new Set(registry.tools.map((tool) => tool.tool_id));
+  const usedToolIds = [...calledToolIds]
+    .filter((toolId) => registeredToolIds.has(toolId)).sort();
+  const unusedToolIds = [...registeredToolIds]
+    .filter((toolId) => !calledToolIds.has(toolId)).sort();
+  const unregisteredToolIds = [...calledToolIds]
+    .filter((toolId) => !registeredToolIds.has(toolId)).sort();
+  return Object.freeze({
+    call_count: calls.length,
+    schema_version: "agent-gym-tool-usage-analysis/v1",
+    unregistered_tool_ids: Object.freeze(unregisteredToolIds),
+    unused_tool_ids: Object.freeze(unusedToolIds),
+    used_tool_ids: Object.freeze(usedToolIds),
+  });
+}
+
 /** Validates a replayed call against the frozen registry's JSON Schema subset. */
 export function validateAgentGymToolCall(
   registry: AgentGymToolRegistrySnapshotV1,
@@ -280,4 +319,8 @@ function invalidAuthorization(): never {
 
 function invalidToolCall(): never {
   throw new AgentGymContractError("Agent gym tool call is invalid.");
+}
+
+function invalidToolUsage(): never {
+  throw new AgentGymContractError("Agent gym tool usage is invalid.");
 }

--- a/apps/slack-companion/test/agent-gym-tool-fixture-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-tool-fixture-runtime.test.ts
@@ -1,7 +1,30 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { createAgentGymToolPageFixture } from "../src/index.js";
+import {
+  createAgentGymStaleEvidenceFixture,
+  createAgentGymToolPageFixture,
+} from "../src/index.js";
+
+test("stale evidence fixtures use the replay clock", () => {
+  const fixture = createAgentGymStaleEvidenceFixture({
+    evaluated_at: "2026-08-12T09:05:00.000Z",
+    evidence_ref: "evidence://one",
+    max_age_ms: 60_000,
+    observed_at: "2026-08-12T09:00:00.000Z",
+  });
+  assert.equal(fixture.age_ms, 300_000);
+  assert.equal(fixture.stale, true);
+});
+
+test("stale evidence fixtures reject future observations", () => {
+  assert.throws(() => createAgentGymStaleEvidenceFixture({
+    evaluated_at: "2026-08-12T09:00:00.000Z",
+    evidence_ref: "evidence://one",
+    max_age_ms: 60_000,
+    observed_at: "2026-08-12T09:05:00.000Z",
+  }), /stale evidence fixture is invalid/u);
+});
 
 test("pagination fixtures retain a deterministic continuation boundary", () => {
   const fixture = createAgentGymToolPageFixture({

--- a/apps/slack-companion/test/agent-gym-tool-fixture-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-tool-fixture-runtime.test.ts
@@ -2,12 +2,37 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  analyzeAgentGymToolUsage,
   createAgentGymAuthorizationFixture,
   createAgentGymStaleEvidenceFixture,
   createAgentGymToolPageFixture,
   createAgentGymToolRegistry,
   validateAgentGymToolCall,
 } from "../src/index.js";
+
+test("tool usage analysis identifies unused and unregistered tools", () => {
+  const registry = createAgentGymToolRegistry([
+    { description: "Read evidence.", input_schema: { type: "object" }, tool_id: "evidence.read" },
+    { description: "Read work.", input_schema: { type: "object" }, tool_id: "work.read" },
+  ]);
+  const analysis = analyzeAgentGymToolUsage(registry, [
+    { call_ref: "tool-call://one", input: {}, tool_id: "evidence.read" },
+    { call_ref: "tool-call://two", input: {}, tool_id: "unknown.read" },
+  ]);
+  assert.deepEqual(analysis.used_tool_ids, ["evidence.read"]);
+  assert.deepEqual(analysis.unused_tool_ids, ["work.read"]);
+  assert.deepEqual(analysis.unregistered_tool_ids, ["unknown.read"]);
+});
+
+test("tool usage analysis rejects duplicate call references", () => {
+  const registry = createAgentGymToolRegistry([
+    { description: "Read evidence.", input_schema: { type: "object" }, tool_id: "evidence.read" },
+  ]);
+  assert.throws(() => analyzeAgentGymToolUsage(registry, [
+    { call_ref: "tool-call://one", input: {}, tool_id: "evidence.read" },
+    { call_ref: "tool-call://one", input: {}, tool_id: "evidence.read" },
+  ]), /tool usage is invalid/u);
+});
 
 test("tool-call validation reports missing required input", () => {
   const registry = createAgentGymToolRegistry([{

--- a/apps/slack-companion/test/agent-gym-tool-fixture-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-tool-fixture-runtime.test.ts
@@ -5,7 +5,49 @@ import {
   createAgentGymAuthorizationFixture,
   createAgentGymStaleEvidenceFixture,
   createAgentGymToolPageFixture,
+  createAgentGymToolRegistry,
+  validateAgentGymToolCall,
 } from "../src/index.js";
+
+test("tool-call validation reports missing required input", () => {
+  const registry = createAgentGymToolRegistry([{
+    description: "Read current evidence.",
+    input_schema: {
+      additionalProperties: false,
+      properties: { query: { type: "string" } },
+      required: ["query"],
+      type: "object",
+    },
+    tool_id: "cerebro.search",
+  }]);
+  const validation = validateAgentGymToolCall(registry, {
+    call_ref: "tool-call://search/one",
+    input: {},
+    tool_id: "cerebro.search",
+  });
+  assert.equal(validation.valid, false);
+  assert.deepEqual(validation.issues, ["$.query:input.required_missing"]);
+});
+
+test("tool-call validation accepts schema-conforming input", () => {
+  const registry = createAgentGymToolRegistry([{
+    description: "Read current evidence.",
+    input_schema: {
+      additionalProperties: false,
+      properties: { query: { type: "string" } },
+      required: ["query"],
+      type: "object",
+    },
+    tool_id: "cerebro.search",
+  }]);
+  const validation = validateAgentGymToolCall(registry, {
+    call_ref: "tool-call://search/one",
+    input: { query: "current evidence" },
+    tool_id: "cerebro.search",
+  });
+  assert.equal(validation.valid, true);
+  assert.deepEqual(validation.issues, []);
+});
 
 test("authorization fixtures retain the policy evidence for a denial", () => {
   const fixture = createAgentGymAuthorizationFixture({

--- a/apps/slack-companion/test/agent-gym-tool-fixture-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-tool-fixture-runtime.test.ts
@@ -2,9 +2,36 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  createAgentGymAuthorizationFixture,
   createAgentGymStaleEvidenceFixture,
   createAgentGymToolPageFixture,
 } from "../src/index.js";
+
+test("authorization fixtures retain the policy evidence for a denial", () => {
+  const fixture = createAgentGymAuthorizationFixture({
+    action: "evidence.read",
+    decision: "deny",
+    policy_ref: "policy://evidence-reader/v3",
+    principal_ref: "principal://user/U123",
+    reason_code: "principal.not_entitled",
+    request_ref: "authorization-request://one",
+    resource_ref: "evidence://one",
+  });
+  assert.equal(fixture.decision, "deny");
+  assert.equal(fixture.policy_ref, "policy://evidence-reader/v3");
+});
+
+test("authorization fixtures fail closed on unknown decisions", () => {
+  assert.throws(() => createAgentGymAuthorizationFixture({
+    action: "evidence.read",
+    decision: "unknown" as "allow",
+    policy_ref: "policy://evidence-reader/v3",
+    principal_ref: "principal://user/U123",
+    reason_code: "decision.unavailable",
+    request_ref: "authorization-request://one",
+    resource_ref: "evidence://one",
+  }), /authorization fixture is invalid/u);
+});
 
 test("stale evidence fixtures use the replay clock", () => {
   const fixture = createAgentGymStaleEvidenceFixture({

--- a/apps/slack-companion/test/agent-gym-tool-fixture-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-tool-fixture-runtime.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createAgentGymToolPageFixture } from "../src/index.js";
+
+test("pagination fixtures retain a deterministic continuation boundary", () => {
+  const fixture = createAgentGymToolPageFixture({
+    call_ref: "tool-call://search/one",
+    items: [{ evidence_ref: "evidence://one" }],
+    next_cursor: "cursor-two",
+    page_index: 0,
+    tool_id: "cerebro.search",
+  });
+  assert.equal(fixture.next_cursor, "cursor-two");
+  assert.equal(fixture.schema_version, "agent-gym-tool-page-fixture/v1");
+  assert.equal(Object.isFrozen(fixture.items), true);
+});
+
+test("pagination fixtures reject invalid page indexes", () => {
+  assert.throws(() => createAgentGymToolPageFixture({
+    call_ref: "tool-call://search/one",
+    items: [],
+    next_cursor: null,
+    page_index: -1,
+    tool_id: "cerebro.search",
+  }), /page fixture is invalid/u);
+});


### PR DESCRIPTION
## Summary

- add deterministic pagination, evidence-age, and authorization fixtures
- validate replayed tool calls against the frozen registry schema
- report unused registry surface and unregistered tool calls

## Test plan

- `npm run typecheck --workspace @writer/cerebro-slack-companion`
- focused Agent Gym harness: 70/70 tests
- full Slack companion suite: 591/591 tests

## Invariants

- fixtures do not contact live tools or wait on wall-clock time
- authorization decisions retain explicit policy evidence and fail closed on unknown states
- registry and usage results are stable across declaration order