### PR TITLE
feat(slack): add offline model replay runtime

### DIFF
--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -12,6 +12,7 @@ export class AgentGymContractError extends Error {
 }
 
 export * from "./fixture-case.js";
+export * from "./model-runtime.js";
 export * from "./artifact.js";
 export * from "./candidate-manifest.js";
 export * from "./cli.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -13,6 +13,7 @@ export class AgentGymContractError extends Error {
 
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
+export * from "./recorded-model.js";
 export * from "./artifact.js";
 export * from "./candidate-manifest.js";
 export * from "./cli.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -14,6 +14,7 @@ export class AgentGymContractError extends Error {
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";
+export * from "./model-invocation.js";
 export * from "./recorded-model.js";
 export * from "./artifact.js";
 export * from "./candidate-manifest.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -13,6 +13,7 @@ export class AgentGymContractError extends Error {
 
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
+export * from "./model-budget.js";
 export * from "./recorded-model.js";
 export * from "./artifact.js";
 export * from "./candidate-manifest.js";

--- a/apps/slack-companion/src/agent-gym/model-budget.ts
+++ b/apps/slack-companion/src/agent-gym/model-budget.ts
@@ -1,0 +1,84 @@
+import { AgentGymContractError } from "./index.js";
+import {
+  type AgentGymModelResponseV1,
+  validateAgentGymModelResponse,
+} from "./model-runtime.js";
+
+export interface AgentGymModelBudgetV1 {
+  readonly max_input_tokens: number;
+  readonly max_invocations: number;
+  readonly max_latency_ms: number;
+  readonly max_output_tokens: number;
+  readonly max_total_tokens: number;
+  readonly schema_version: "agent-gym-model-budget/v1";
+}
+
+export interface AgentGymModelBudgetEvaluationV1 {
+  readonly allowed: boolean;
+  readonly blockers: readonly string[];
+  readonly input_tokens: number;
+  readonly invocation_count: number;
+  readonly latency_ms: number;
+  readonly output_tokens: number;
+  readonly schema_version: "agent-gym-model-budget-evaluation/v1";
+  readonly total_tokens: number;
+}
+
+/** Evaluates aggregate replay use without hiding which limit was exceeded. */
+export function evaluateAgentGymModelBudget(
+  rawBudget: AgentGymModelBudgetV1,
+  rawResponses: readonly AgentGymModelResponseV1[],
+): AgentGymModelBudgetEvaluationV1 {
+  const budget = validateBudget(rawBudget);
+  if (!Array.isArray(rawResponses) || rawResponses.length > 10_000) invalidBudget();
+  const invocationRefs = new Set<string>();
+  const responses = rawResponses.map((rawResponse) => {
+    const response = validateAgentGymModelResponse(rawResponse);
+    if (invocationRefs.has(response.invocation_ref)) invalidBudget();
+    invocationRefs.add(response.invocation_ref);
+    return response;
+  });
+  const inputTokens = sum(responses.map((response) => response.token_usage.input_tokens));
+  const outputTokens = sum(responses.map((response) => response.token_usage.output_tokens));
+  const totalTokens = sum(responses.map((response) => response.token_usage.total_tokens));
+  const latencyMs = sum(responses.map((response) => response.latency_ms));
+  const blockers = [
+    responses.length > budget.max_invocations ? "model_invocations_exceeded" : undefined,
+    inputTokens > budget.max_input_tokens ? "model_input_tokens_exceeded" : undefined,
+    outputTokens > budget.max_output_tokens ? "model_output_tokens_exceeded" : undefined,
+    totalTokens > budget.max_total_tokens ? "model_total_tokens_exceeded" : undefined,
+    latencyMs > budget.max_latency_ms ? "model_latency_exceeded" : undefined,
+  ].filter((value): value is string => value !== undefined);
+  return Object.freeze({
+    allowed: blockers.length === 0,
+    blockers: Object.freeze(blockers),
+    input_tokens: inputTokens,
+    invocation_count: responses.length,
+    latency_ms: latencyMs,
+    output_tokens: outputTokens,
+    schema_version: "agent-gym-model-budget-evaluation/v1",
+    total_tokens: totalTokens,
+  });
+}
+
+function validateBudget(budget: AgentGymModelBudgetV1): AgentGymModelBudgetV1 {
+  if (budget.schema_version !== "agent-gym-model-budget/v1") invalidBudget();
+  integer(budget.max_invocations, 10_000);
+  integer(budget.max_input_tokens, 100_000_000);
+  integer(budget.max_output_tokens, 100_000_000);
+  integer(budget.max_total_tokens, 200_000_000);
+  integer(budget.max_latency_ms, 24 * 60 * 60_000);
+  return Object.freeze({ ...budget });
+}
+
+function integer(value: number, maximum: number): void {
+  if (!Number.isSafeInteger(value) || value < 1 || value > maximum) invalidBudget();
+}
+
+function sum(values: readonly number[]): number {
+  return values.reduce((total, value) => total + value, 0);
+}
+
+function invalidBudget(): never {
+  throw new AgentGymContractError("Agent gym model budget is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/model-invocation.ts
+++ b/apps/slack-companion/src/agent-gym/model-invocation.ts
@@ -1,0 +1,86 @@
+import { createHash } from "node:crypto";
+import { AgentGymContractError } from "./index.js";
+import {
+  evaluateAgentGymModelBudget,
+  type AgentGymModelBudgetEvaluationV1,
+  type AgentGymModelBudgetV1,
+} from "./model-budget.js";
+import {
+  agentGymModelRequestDigest,
+  type AgentGymModelInvocationRequestV1,
+  type AgentGymModelPort,
+  type AgentGymModelResponseV1,
+  validateAgentGymModelRequest,
+  validateAgentGymModelResponse,
+} from "./model-runtime.js";
+
+export interface AgentGymModelInvocationReceiptV1 {
+  readonly budget: AgentGymModelBudgetEvaluationV1;
+  readonly candidate_ref: string;
+  readonly evaluated_at: string;
+  readonly invocation_ref: string;
+  readonly latency_ms: number;
+  readonly model_id: string;
+  readonly provider_request_ref?: string;
+  readonly request_digest: `sha256:${string}`;
+  readonly response_digest: `sha256:${string}`;
+  readonly response_source: "live" | "recorded";
+  readonly schema_version: "agent-gym-model-invocation-receipt/v1";
+  readonly stop_reason: AgentGymModelResponseV1["stop_reason"];
+  readonly token_usage: AgentGymModelResponseV1["token_usage"];
+}
+
+export interface AgentGymModelInvocationResultV1 {
+  readonly receipt: AgentGymModelInvocationReceiptV1;
+  readonly response: AgentGymModelResponseV1;
+}
+
+/** Invokes one model port and emits a response-bound, replayable receipt. */
+export async function invokeAgentGymModel(
+  rawRequest: AgentGymModelInvocationRequestV1,
+  budget: AgentGymModelBudgetV1,
+  model: AgentGymModelPort,
+  evaluatedAt: string,
+): Promise<AgentGymModelInvocationResultV1> {
+  const request = validateAgentGymModelRequest(rawRequest);
+  timestamp(evaluatedAt);
+  const requestDigest = agentGymModelRequestDigest(request);
+  const response = validateAgentGymModelResponse(await model.invoke(request));
+  if (response.invocation_ref !== request.invocation_ref
+    || response.model_id !== request.model_id
+    || response.request_digest !== requestDigest) invalidBinding();
+  const budgetEvaluation = evaluateAgentGymModelBudget(budget, [response]);
+  const receipt = Object.freeze({
+    budget: budgetEvaluation,
+    candidate_ref: request.candidate_ref,
+    evaluated_at: evaluatedAt,
+    invocation_ref: request.invocation_ref,
+    latency_ms: response.latency_ms,
+    model_id: response.model_id,
+    ...(response.provider_request_ref === undefined
+      ? {}
+      : { provider_request_ref: response.provider_request_ref }),
+    request_digest: requestDigest,
+    response_digest: digest(response),
+    response_source: response.response_source,
+    schema_version: "agent-gym-model-invocation-receipt/v1" as const,
+    stop_reason: response.stop_reason,
+    token_usage: response.token_usage,
+  });
+  return Object.freeze({ receipt, response });
+}
+
+function digest(value: AgentGymModelResponseV1): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(JSON.stringify(value)).digest("hex")}`;
+}
+
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) {
+    throw new AgentGymContractError("Agent gym model invocation time is invalid.");
+  }
+}
+
+function invalidBinding(): never {
+  throw new AgentGymContractError("Agent gym model invocation binding is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/model-runtime.ts
+++ b/apps/slack-companion/src/agent-gym/model-runtime.ts
@@ -16,20 +16,32 @@ export interface AgentGymModelInvocationRequestV1 {
   readonly system_prompt: string;
 }
 
-export interface AgentGymRecordedModelResponseV1 {
+interface AgentGymModelResponseFields {
   readonly invocation_ref: string;
   readonly latency_ms: number;
   readonly model_id: string;
   readonly output_text: string;
   readonly provider_request_ref?: string;
   readonly request_digest: `sha256:${string}`;
-  readonly schema_version: "agent-gym-recorded-model-response/v1";
   readonly stop_reason: "content_filtered" | "end_turn" | "max_tokens";
   readonly token_usage: {
     readonly input_tokens: number;
     readonly output_tokens: number;
     readonly total_tokens: number;
   };
+}
+
+export interface AgentGymRecordedModelResponseV1 extends AgentGymModelResponseFields {
+  readonly schema_version: "agent-gym-recorded-model-response/v1";
+}
+
+export interface AgentGymModelResponseV1 extends AgentGymModelResponseFields {
+  readonly response_source: "live" | "recorded";
+  readonly schema_version: "agent-gym-model-response/v1";
+}
+
+export interface AgentGymModelPort {
+  invoke(request: AgentGymModelInvocationRequestV1): Promise<AgentGymModelResponseV1>;
 }
 
 /** Validates recorded provider output without trusting it as a live receipt. */
@@ -39,30 +51,9 @@ export function validateAgentGymRecordedModelResponse(
   if (response.schema_version !== "agent-gym-recorded-model-response/v1") {
     invalidResponse();
   }
-  referenceWith(response.invocation_ref, invalidResponse);
-  boundedWith(response.model_id, 240, invalidResponse);
-  digest(response.request_digest);
-  if (response.provider_request_ref !== undefined) {
-    referenceWith(response.provider_request_ref, invalidResponse);
-  }
-  if (!Number.isSafeInteger(response.latency_ms) || response.latency_ms < 0
-    || response.latency_ms > 60 * 60_000
-    || !["content_filtered", "end_turn", "max_tokens"].includes(response.stop_reason)) {
-    invalidResponse();
-  }
-  if (typeof response.output_text !== "string" || response.output_text.length > 256_000
-    || /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/u.test(response.output_text)
-    || (response.stop_reason !== "content_filtered" && !response.output_text.trim())) {
-    invalidResponse();
-  }
-  const { input_tokens: inputTokens, output_tokens: outputTokens, total_tokens: totalTokens } =
-    response.token_usage;
-  for (const tokens of [inputTokens, outputTokens, totalTokens]) {
-    if (!Number.isSafeInteger(tokens) || tokens < 0 || tokens > 10_000_000) {
-      invalidResponse();
-    }
-  }
-  if (totalTokens !== inputTokens + outputTokens) invalidResponse();
+  validateResponseFields(response, invalidResponse);
+  const { input_tokens: inputTokens, output_tokens: outputTokens,
+    total_tokens: totalTokens } = response.token_usage;
   return Object.freeze({
     invocation_ref: response.invocation_ref,
     latency_ms: response.latency_ms,
@@ -79,6 +70,31 @@ export function validateAgentGymRecordedModelResponse(
       output_tokens: outputTokens,
       total_tokens: totalTokens,
     }),
+  });
+}
+
+/** Validates the common response returned by recorded and live model ports. */
+export function validateAgentGymModelResponse(
+  response: AgentGymModelResponseV1,
+): AgentGymModelResponseV1 {
+  if (response.schema_version !== "agent-gym-model-response/v1"
+    || (response.response_source !== "live" && response.response_source !== "recorded")) {
+    invalidModelResponse();
+  }
+  validateResponseFields(response, invalidModelResponse);
+  return Object.freeze({
+    invocation_ref: response.invocation_ref,
+    latency_ms: response.latency_ms,
+    model_id: response.model_id,
+    output_text: response.output_text,
+    ...(response.provider_request_ref === undefined
+      ? {}
+      : { provider_request_ref: response.provider_request_ref }),
+    request_digest: response.request_digest,
+    response_source: response.response_source,
+    schema_version: "agent-gym-model-response/v1",
+    stop_reason: response.stop_reason,
+    token_usage: Object.freeze({ ...response.token_usage }),
   });
 }
 
@@ -144,6 +160,34 @@ function digest(value: string): void {
   if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalidResponse();
 }
 
+function validateResponseFields(
+  response: AgentGymModelResponseFields,
+  invalid: () => never,
+): void {
+  referenceWith(response.invocation_ref, invalid);
+  boundedWith(response.model_id, 240, invalid);
+  if (!/^sha256:[0-9a-f]{64}$/u.test(response.request_digest)) invalid();
+  if (response.provider_request_ref !== undefined) {
+    referenceWith(response.provider_request_ref, invalid);
+  }
+  if (!Number.isSafeInteger(response.latency_ms) || response.latency_ms < 0
+    || response.latency_ms > 60 * 60_000
+    || !["content_filtered", "end_turn", "max_tokens"].includes(response.stop_reason)) {
+    invalid();
+  }
+  if (typeof response.output_text !== "string" || response.output_text.length > 256_000
+    || /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/u.test(response.output_text)
+    || (response.stop_reason !== "content_filtered" && !response.output_text.trim())) {
+    invalid();
+  }
+  const { input_tokens: inputTokens, output_tokens: outputTokens,
+    total_tokens: totalTokens } = response.token_usage;
+  for (const tokens of [inputTokens, outputTokens, totalTokens]) {
+    if (!Number.isSafeInteger(tokens) || tokens < 0 || tokens > 10_000_000) invalid();
+  }
+  if (totalTokens !== inputTokens + outputTokens) invalid();
+}
+
 function text(value: string, maximum: number): void {
   if (typeof value !== "string" || !value.trim() || value.length > maximum
     || /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/u.test(value)) {
@@ -157,4 +201,8 @@ function invalidRequest(): never {
 
 function invalidResponse(): never {
   throw new AgentGymContractError("Agent gym recorded model response is invalid.");
+}
+
+function invalidModelResponse(): never {
+  throw new AgentGymContractError("Agent gym model response is invalid.");
 }

--- a/apps/slack-companion/src/agent-gym/model-runtime.ts
+++ b/apps/slack-companion/src/agent-gym/model-runtime.ts
@@ -16,6 +16,72 @@ export interface AgentGymModelInvocationRequestV1 {
   readonly system_prompt: string;
 }
 
+export interface AgentGymRecordedModelResponseV1 {
+  readonly invocation_ref: string;
+  readonly latency_ms: number;
+  readonly model_id: string;
+  readonly output_text: string;
+  readonly provider_request_ref?: string;
+  readonly request_digest: `sha256:${string}`;
+  readonly schema_version: "agent-gym-recorded-model-response/v1";
+  readonly stop_reason: "content_filtered" | "end_turn" | "max_tokens";
+  readonly token_usage: {
+    readonly input_tokens: number;
+    readonly output_tokens: number;
+    readonly total_tokens: number;
+  };
+}
+
+/** Validates recorded provider output without trusting it as a live receipt. */
+export function validateAgentGymRecordedModelResponse(
+  response: AgentGymRecordedModelResponseV1,
+): AgentGymRecordedModelResponseV1 {
+  if (response.schema_version !== "agent-gym-recorded-model-response/v1") {
+    invalidResponse();
+  }
+  referenceWith(response.invocation_ref, invalidResponse);
+  boundedWith(response.model_id, 240, invalidResponse);
+  digest(response.request_digest);
+  if (response.provider_request_ref !== undefined) {
+    referenceWith(response.provider_request_ref, invalidResponse);
+  }
+  if (!Number.isSafeInteger(response.latency_ms) || response.latency_ms < 0
+    || response.latency_ms > 60 * 60_000
+    || !["content_filtered", "end_turn", "max_tokens"].includes(response.stop_reason)) {
+    invalidResponse();
+  }
+  if (typeof response.output_text !== "string" || response.output_text.length > 256_000
+    || /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/u.test(response.output_text)
+    || (response.stop_reason !== "content_filtered" && !response.output_text.trim())) {
+    invalidResponse();
+  }
+  const { input_tokens: inputTokens, output_tokens: outputTokens, total_tokens: totalTokens } =
+    response.token_usage;
+  for (const tokens of [inputTokens, outputTokens, totalTokens]) {
+    if (!Number.isSafeInteger(tokens) || tokens < 0 || tokens > 10_000_000) {
+      invalidResponse();
+    }
+  }
+  if (totalTokens !== inputTokens + outputTokens) invalidResponse();
+  return Object.freeze({
+    invocation_ref: response.invocation_ref,
+    latency_ms: response.latency_ms,
+    model_id: response.model_id,
+    output_text: response.output_text,
+    ...(response.provider_request_ref === undefined
+      ? {}
+      : { provider_request_ref: response.provider_request_ref }),
+    request_digest: response.request_digest,
+    schema_version: "agent-gym-recorded-model-response/v1",
+    stop_reason: response.stop_reason,
+    token_usage: Object.freeze({
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      total_tokens: totalTokens,
+    }),
+  });
+}
+
 /** Validates and freezes one provider-neutral text-model invocation. */
 export function validateAgentGymModelRequest(
   request: AgentGymModelInvocationRequestV1,
@@ -64,6 +130,20 @@ function reference(value: string): void {
   if (!value.includes("://")) invalidRequest();
 }
 
+function referenceWith(value: string, invalid: () => never): void {
+  boundedWith(value, 240, invalid);
+  if (!value.includes("://")) invalid();
+}
+
+function boundedWith(value: string, maximum: number, invalid: () => never): void {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+
+function digest(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalidResponse();
+}
+
 function text(value: string, maximum: number): void {
   if (typeof value !== "string" || !value.trim() || value.length > maximum
     || /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/u.test(value)) {
@@ -73,4 +153,8 @@ function text(value: string, maximum: number): void {
 
 function invalidRequest(): never {
   throw new AgentGymContractError("Agent gym model request is invalid.");
+}
+
+function invalidResponse(): never {
+  throw new AgentGymContractError("Agent gym recorded model response is invalid.");
 }

--- a/apps/slack-companion/src/agent-gym/model-runtime.ts
+++ b/apps/slack-companion/src/agent-gym/model-runtime.ts
@@ -1,0 +1,76 @@
+import { createHash } from "node:crypto";
+import { AgentGymContractError } from "./index.js";
+
+export interface AgentGymModelTextMessageV1 {
+  readonly role: "assistant" | "user";
+  readonly text: string;
+}
+
+export interface AgentGymModelInvocationRequestV1 {
+  readonly candidate_ref: string;
+  readonly invocation_ref: string;
+  readonly max_output_tokens: number;
+  readonly messages: readonly AgentGymModelTextMessageV1[];
+  readonly model_id: string;
+  readonly schema_version: "agent-gym-model-request/v1";
+  readonly system_prompt: string;
+}
+
+/** Validates and freezes one provider-neutral text-model invocation. */
+export function validateAgentGymModelRequest(
+  request: AgentGymModelInvocationRequestV1,
+): AgentGymModelInvocationRequestV1 {
+  if (request.schema_version !== "agent-gym-model-request/v1") invalidRequest();
+  reference(request.candidate_ref);
+  reference(request.invocation_ref);
+  text(request.model_id, 240);
+  text(request.system_prompt, 64_000);
+  if (!Number.isSafeInteger(request.max_output_tokens)
+    || request.max_output_tokens < 1 || request.max_output_tokens > 32_768
+    || !Array.isArray(request.messages) || request.messages.length < 1
+    || request.messages.length > 64) invalidRequest();
+  const messages = request.messages.map((message, index) => {
+    if (message.role !== "assistant" && message.role !== "user") invalidRequest();
+    text(message.text, 64_000);
+    if (index > 0 && request.messages[index - 1]?.role === message.role) invalidRequest();
+    return Object.freeze({ role: message.role, text: message.text });
+  });
+  if (messages[0]?.role !== "user" || messages.at(-1)?.role !== "user") {
+    invalidRequest();
+  }
+  const validated = Object.freeze({
+    candidate_ref: request.candidate_ref,
+    invocation_ref: request.invocation_ref,
+    max_output_tokens: request.max_output_tokens,
+    messages: Object.freeze(messages),
+    model_id: request.model_id,
+    schema_version: "agent-gym-model-request/v1" as const,
+    system_prompt: request.system_prompt,
+  });
+  if (Buffer.byteLength(JSON.stringify(validated), "utf8") > 256_000) invalidRequest();
+  return validated;
+}
+
+/** Binds a fixture response to the validated request bytes. */
+export function agentGymModelRequestDigest(
+  request: AgentGymModelInvocationRequestV1,
+): `sha256:${string}` {
+  const validated = validateAgentGymModelRequest(request);
+  return `sha256:${createHash("sha256").update(JSON.stringify(validated)).digest("hex")}`;
+}
+
+function reference(value: string): void {
+  text(value, 240);
+  if (!value.includes("://")) invalidRequest();
+}
+
+function text(value: string, maximum: number): void {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum
+    || /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/u.test(value)) {
+    invalidRequest();
+  }
+}
+
+function invalidRequest(): never {
+  throw new AgentGymContractError("Agent gym model request is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/recorded-model.ts
+++ b/apps/slack-companion/src/agent-gym/recorded-model.ts
@@ -1,0 +1,57 @@
+import { AgentGymContractError } from "./index.js";
+import {
+  agentGymModelRequestDigest,
+  type AgentGymModelInvocationRequestV1,
+  type AgentGymModelPort,
+  type AgentGymModelResponseV1,
+  type AgentGymRecordedModelResponseV1,
+  validateAgentGymModelRequest,
+  validateAgentGymModelResponse,
+  validateAgentGymRecordedModelResponse,
+} from "./model-runtime.js";
+
+/** Serves exact recorded outputs through the same provider-neutral model port. */
+export class RecordedAgentGymModel implements AgentGymModelPort {
+  readonly #responses: ReadonlyMap<string, AgentGymRecordedModelResponseV1>;
+
+  constructor(responses: readonly AgentGymRecordedModelResponseV1[]) {
+    if (!Array.isArray(responses) || responses.length < 1 || responses.length > 10_000) {
+      invalidFixtures();
+    }
+    const byDigest = new Map<string, AgentGymRecordedModelResponseV1>();
+    for (const rawResponse of responses) {
+      const response = validateAgentGymRecordedModelResponse(rawResponse);
+      if (byDigest.has(response.request_digest)) invalidFixtures();
+      byDigest.set(response.request_digest, response);
+    }
+    this.#responses = byDigest;
+  }
+
+  async invoke(
+    rawRequest: AgentGymModelInvocationRequestV1,
+  ): Promise<AgentGymModelResponseV1> {
+    const request = validateAgentGymModelRequest(rawRequest);
+    const requestDigest = agentGymModelRequestDigest(request);
+    const recorded = this.#responses.get(requestDigest);
+    if (recorded === undefined) missingFixture();
+    if (recorded.invocation_ref !== request.invocation_ref
+      || recorded.model_id !== request.model_id) invalidBinding();
+    return validateAgentGymModelResponse({
+      ...recorded,
+      response_source: "recorded",
+      schema_version: "agent-gym-model-response/v1",
+    });
+  }
+}
+
+function invalidFixtures(): never {
+  throw new AgentGymContractError("Agent gym recorded model fixtures are invalid.");
+}
+
+function missingFixture(): never {
+  throw new AgentGymContractError("Agent gym recorded model fixture is missing.");
+}
+
+function invalidBinding(): never {
+  throw new AgentGymContractError("Agent gym recorded model binding is invalid.");
+}

--- a/apps/slack-companion/test/agent-gym-model-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-model-runtime.test.ts
@@ -3,8 +3,40 @@ import test from "node:test";
 
 import {
   agentGymModelRequestDigest,
+  validateAgentGymRecordedModelResponse,
   validateAgentGymModelRequest,
 } from "../src/index.js";
+
+test("recorded model responses retain usage and request identity", () => {
+  const modelRequest = request();
+  const response = validateAgentGymRecordedModelResponse({
+    invocation_ref: modelRequest.invocation_ref,
+    latency_ms: 42,
+    model_id: modelRequest.model_id,
+    output_text: "The current evidence is incomplete.",
+    provider_request_ref: "provider-request://recorded/one",
+    request_digest: agentGymModelRequestDigest(modelRequest),
+    schema_version: "agent-gym-recorded-model-response/v1",
+    stop_reason: "end_turn",
+    token_usage: { input_tokens: 18, output_tokens: 7, total_tokens: 25 },
+  });
+  assert.equal(Object.isFrozen(response.token_usage), true);
+  assert.equal(response.token_usage.total_tokens, 25);
+});
+
+test("recorded model responses reject inconsistent token totals", () => {
+  const modelRequest = request();
+  assert.throws(() => validateAgentGymRecordedModelResponse({
+    invocation_ref: modelRequest.invocation_ref,
+    latency_ms: 42,
+    model_id: modelRequest.model_id,
+    output_text: "The current evidence is incomplete.",
+    request_digest: agentGymModelRequestDigest(modelRequest),
+    schema_version: "agent-gym-recorded-model-response/v1",
+    stop_reason: "end_turn",
+    token_usage: { input_tokens: 18, output_tokens: 7, total_tokens: 24 },
+  }), /recorded model response is invalid/u);
+});
 
 function request() {
   return {

--- a/apps/slack-companion/test/agent-gym-model-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-model-runtime.test.ts
@@ -3,9 +3,39 @@ import test from "node:test";
 
 import {
   agentGymModelRequestDigest,
+  RecordedAgentGymModel,
   validateAgentGymRecordedModelResponse,
   validateAgentGymModelRequest,
 } from "../src/index.js";
+
+function recordedResponse(modelRequest = request()) {
+  return {
+    invocation_ref: modelRequest.invocation_ref,
+    latency_ms: 42,
+    model_id: modelRequest.model_id,
+    output_text: "The current evidence is incomplete.",
+    request_digest: agentGymModelRequestDigest(modelRequest),
+    schema_version: "agent-gym-recorded-model-response/v1" as const,
+    stop_reason: "end_turn" as const,
+    token_usage: { input_tokens: 18, output_tokens: 7, total_tokens: 25 },
+  };
+}
+
+test("recorded model ports replay the exact bound response", async () => {
+  const modelRequest = request();
+  const model = new RecordedAgentGymModel([recordedResponse(modelRequest)]);
+  const response = await model.invoke(modelRequest);
+  assert.equal(response.response_source, "recorded");
+  assert.equal(response.output_text, "The current evidence is incomplete.");
+});
+
+test("recorded model ports reject unrecorded requests", async () => {
+  const model = new RecordedAgentGymModel([recordedResponse()]);
+  await assert.rejects(model.invoke({
+    ...request(),
+    messages: [{ role: "user", text: "Summarize different evidence." }],
+  }), /recorded model fixture is missing/u);
+});
 
 test("recorded model responses retain usage and request identity", () => {
   const modelRequest = request();

--- a/apps/slack-companion/test/agent-gym-model-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-model-runtime.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  agentGymModelRequestDigest,
+  validateAgentGymModelRequest,
+} from "../src/index.js";
+
+function request() {
+  return {
+    candidate_ref: "candidate://baseline",
+    invocation_ref: "model-invocation://case-one/one",
+    max_output_tokens: 512,
+    messages: [{ role: "user" as const, text: "Summarize the current evidence." }],
+    model_id: "recorded.model-v1",
+    schema_version: "agent-gym-model-request/v1" as const,
+    system_prompt: "Use only supplied evidence.",
+  };
+}
+
+test("model requests freeze a provider-neutral conversation", () => {
+  const validated = validateAgentGymModelRequest(request());
+  assert.equal(Object.isFrozen(validated), true);
+  assert.equal(Object.isFrozen(validated.messages), true);
+  assert.match(agentGymModelRequestDigest(validated), /^sha256:[0-9a-f]{64}$/u);
+});
+
+test("model requests must end with a user turn", () => {
+  assert.throws(() => validateAgentGymModelRequest({
+    ...request(),
+    messages: [
+      { role: "user", text: "Summarize the current evidence." },
+      { role: "assistant", text: "The evidence is incomplete." },
+    ],
+  }), /model request is invalid/u);
+});

--- a/apps/slack-companion/test/agent-gym-model-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-model-runtime.test.ts
@@ -4,10 +4,43 @@ import test from "node:test";
 import {
   agentGymModelRequestDigest,
   evaluateAgentGymModelBudget,
+  invokeAgentGymModel,
   RecordedAgentGymModel,
   validateAgentGymRecordedModelResponse,
   validateAgentGymModelRequest,
 } from "../src/index.js";
+
+test("model invocation receipts bind request, response, and budget", async () => {
+  const modelRequest = request();
+  const model = new RecordedAgentGymModel([recordedResponse(modelRequest)]);
+  const result = await invokeAgentGymModel(
+    modelRequest,
+    modelBudget(),
+    model,
+    "2026-08-12T09:30:00.000Z",
+  );
+  assert.equal(result.receipt.budget.allowed, true);
+  assert.equal(result.receipt.request_digest, agentGymModelRequestDigest(modelRequest));
+  assert.match(result.receipt.response_digest, /^sha256:[0-9a-f]{64}$/u);
+  assert.equal(result.receipt.response_source, "recorded");
+});
+
+test("model invocation receipts reject a response for another request", async () => {
+  const modelRequest = request();
+  await assert.rejects(invokeAgentGymModel(
+    modelRequest,
+    modelBudget(),
+    {
+      async invoke() {
+        return {
+          ...modelResponse(),
+          invocation_ref: "model-invocation://other",
+        };
+      },
+    },
+    "2026-08-12T09:30:00.000Z",
+  ), /model invocation binding is invalid/u);
+});
 
 function modelResponse() {
   return {

--- a/apps/slack-companion/test/agent-gym-model-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-model-runtime.test.ts
@@ -3,10 +3,62 @@ import test from "node:test";
 
 import {
   agentGymModelRequestDigest,
+  evaluateAgentGymModelBudget,
   RecordedAgentGymModel,
   validateAgentGymRecordedModelResponse,
   validateAgentGymModelRequest,
 } from "../src/index.js";
+
+function modelResponse() {
+  return {
+    ...recordedResponse(),
+    response_source: "recorded" as const,
+    schema_version: "agent-gym-model-response/v1" as const,
+  };
+}
+
+function modelBudget() {
+  return {
+    max_input_tokens: 20,
+    max_invocations: 1,
+    max_latency_ms: 100,
+    max_output_tokens: 10,
+    max_total_tokens: 30,
+    schema_version: "agent-gym-model-budget/v1" as const,
+  };
+}
+
+test("model budget evaluation accounts for the complete response", () => {
+  const evaluation = evaluateAgentGymModelBudget(modelBudget(), [modelResponse()]);
+  assert.equal(evaluation.allowed, true);
+  assert.deepEqual(evaluation, {
+    allowed: true,
+    blockers: [],
+    input_tokens: 18,
+    invocation_count: 1,
+    latency_ms: 42,
+    output_tokens: 7,
+    schema_version: "agent-gym-model-budget-evaluation/v1",
+    total_tokens: 25,
+  });
+});
+
+test("model budget evaluation names every exceeded limit", () => {
+  const evaluation = evaluateAgentGymModelBudget({
+    ...modelBudget(),
+    max_input_tokens: 17,
+    max_latency_ms: 41,
+    max_output_tokens: 6,
+    max_total_tokens: 24,
+  }, [modelResponse()]);
+  assert.equal(evaluation.allowed, false);
+  assert.deepEqual(evaluation.blockers, [
+    "model_input_tokens_exceeded",
+    "model_output_tokens_exceeded",
+    "model_total_tokens_exceeded",
+    "model_latency_exceeded",
+  ]);
+});
 
 function recordedResponse(modelRequest = request()) {
   return {


### PR DESCRIPTION
## Summary

- define provider-neutral model requests and response fixtures
- replay exact recorded responses through a common model port
- enforce token, invocation, latency, and aggregate budgets
- emit content-addressed invocation receipts for later comparisons

## Test plan

- `npm run typecheck --workspace @writer/cerebro-slack-companion`
- focused Agent Gym harness: 80/80 tests
- full Slack companion suite: 601/601 tests

## Invariants

- offline replay never contacts a hosted model
- every recorded response is bound to the exact request digest, model, and invocation
- budget violations remain explicit blockers in the invocation receipt
- public contracts contain no credentials, routes, or deployment topology