### PR TITLE
feat(slack): add resilient offline model replay

### DIFF
--- a/apps/slack-companion/src/agent-gym/artifact.ts
+++ b/apps/slack-companion/src/agent-gym/artifact.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 
 export interface AgentGymArtifactIdentityV1 {
   readonly byte_length: number;

--- a/apps/slack-companion/src/agent-gym/candidate-manifest.ts
+++ b/apps/slack-companion/src/agent-gym/candidate-manifest.ts
@@ -1,4 +1,4 @@
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 
 export interface AgentGymCandidateManifestV1 {
   readonly candidate_ref: string;

--- a/apps/slack-companion/src/agent-gym/cli.ts
+++ b/apps/slack-companion/src/agent-gym/cli.ts
@@ -1,4 +1,5 @@
-import { AgentGymContractError, CEREBRO_AGENT_GYM } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { CEREBRO_AGENT_GYM } from "./index.js";
 
 export interface AgentGymCliCommandV1 {
   readonly command: "compare" | "replay" | "validate" | "version";

--- a/apps/slack-companion/src/agent-gym/comparison.ts
+++ b/apps/slack-companion/src/agent-gym/comparison.ts
@@ -1,4 +1,4 @@
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 
 export interface AgentGymSliceDeltaV1 {
   readonly baseline_score: number;

--- a/apps/slack-companion/src/agent-gym/contract-error.ts
+++ b/apps/slack-companion/src/agent-gym/contract-error.ts
@@ -1,0 +1,6 @@
+export class AgentGymContractError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AgentGymContractError";
+  }
+}

--- a/apps/slack-companion/src/agent-gym/fixture-case.ts
+++ b/apps/slack-companion/src/agent-gym/fixture-case.ts
@@ -1,4 +1,4 @@
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 
 export type AgentGymJson =
   | boolean | number | string | null

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -4,16 +4,11 @@ export const CEREBRO_AGENT_GYM = Object.freeze({
   schema_version: "cerebro-agent-gym/v1",
 });
 
-export class AgentGymContractError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "AgentGymContractError";
-  }
-}
-
+export * from "./contract-error.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";
+export * from "./model-batch.js";
 export * from "./model-failure.js";
 export * from "./model-retry.js";
 export * from "./model-invocation.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -15,6 +15,7 @@ export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";
 export * from "./model-failure.js";
+export * from "./model-retry.js";
 export * from "./model-invocation.js";
 export * from "./recorded-model.js";
 export * from "./artifact.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -14,6 +14,7 @@ export class AgentGymContractError extends Error {
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";
+export * from "./model-failure.js";
 export * from "./model-invocation.js";
 export * from "./recorded-model.js";
 export * from "./artifact.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -17,6 +17,7 @@ export * from "./model-budget.js";
 export * from "./model-failure.js";
 export * from "./model-retry.js";
 export * from "./model-invocation.js";
+export * from "./model-ledger.js";
 export * from "./recorded-model.js";
 export * from "./artifact.js";
 export * from "./candidate-manifest.js";

--- a/apps/slack-companion/src/agent-gym/model-batch.ts
+++ b/apps/slack-companion/src/agent-gym/model-batch.ts
@@ -1,0 +1,58 @@
+import { AgentGymContractError } from "./contract-error.js";
+import type { AgentGymModelBudgetV1 } from "./model-budget.js";
+import {
+  invokeAgentGymModel,
+  type AgentGymModelInvocationResultV1,
+} from "./model-invocation.js";
+import {
+  createAgentGymModelInvocationLedger,
+  type AgentGymModelInvocationLedgerV1,
+} from "./model-ledger.js";
+import type {
+  AgentGymModelInvocationRequestV1,
+  AgentGymModelPort,
+} from "./model-runtime.js";
+
+export interface AgentGymModelBatchResultV1 {
+  readonly batch_ref: string;
+  readonly ledger: AgentGymModelInvocationLedgerV1;
+  readonly results: readonly AgentGymModelInvocationResultV1[];
+  readonly schema_version: "agent-gym-model-batch-result/v1";
+}
+
+/** Replays a stable request sequence without Slack, provider concurrency, or wall time. */
+export async function runAgentGymModelBatch(
+  batchRef: string,
+  requests: readonly AgentGymModelInvocationRequestV1[],
+  budget: AgentGymModelBudgetV1,
+  model: AgentGymModelPort,
+  evaluatedAt: string,
+): Promise<AgentGymModelBatchResultV1> {
+  reference(batchRef);
+  if (!Array.isArray(requests) || requests.length < 1 || requests.length > 10_000
+    || new Set(requests.map((request) => request.invocation_ref)).size !== requests.length) {
+    invalid();
+  }
+  const results: AgentGymModelInvocationResultV1[] = [];
+  for (const request of requests) {
+    results.push(await invokeAgentGymModel(request, budget, model, evaluatedAt));
+  }
+  const frozenResults = Object.freeze(results);
+  return Object.freeze({
+    batch_ref: batchRef,
+    ledger: createAgentGymModelInvocationLedger(
+      frozenResults.map((result) => result.receipt),
+    ),
+    results: frozenResults,
+    schema_version: "agent-gym-model-batch-result/v1",
+  });
+}
+
+function reference(value: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > 240
+    || /[\u0000-\u001f\u007f]/u.test(value) || !value.includes("://")) invalid();
+}
+
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym model batch is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/model-budget.ts
+++ b/apps/slack-companion/src/agent-gym/model-budget.ts
@@ -1,4 +1,4 @@
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 import {
   type AgentGymModelResponseV1,
   validateAgentGymModelResponse,

--- a/apps/slack-companion/src/agent-gym/model-failure.ts
+++ b/apps/slack-companion/src/agent-gym/model-failure.ts
@@ -1,0 +1,54 @@
+import { AgentGymContractError } from "./index.js";
+
+export interface AgentGymModelFailureV1 {
+  readonly error_code: string;
+  readonly invocation_ref: string;
+  readonly message: string;
+  readonly model_id: string;
+  readonly provider_request_ref?: string;
+  readonly retry_after_ms?: number;
+  readonly retryable: boolean;
+  readonly schema_version: "agent-gym-model-failure/v1";
+}
+
+/** A typed model failure that can be replayed without leaking provider errors. */
+export class AgentGymModelInvocationError extends AgentGymContractError {
+  readonly failure: AgentGymModelFailureV1;
+
+  constructor(rawFailure: AgentGymModelFailureV1) {
+    const failure = validateAgentGymModelFailure(rawFailure);
+    super(failure.message);
+    this.name = "AgentGymModelInvocationError";
+    this.failure = failure;
+  }
+}
+
+export function validateAgentGymModelFailure(
+  failure: AgentGymModelFailureV1,
+): AgentGymModelFailureV1 {
+  if (failure.schema_version !== "agent-gym-model-failure/v1") invalid();
+  reference(failure.invocation_ref);
+  bounded(failure.model_id, 240);
+  bounded(failure.error_code, 160);
+  bounded(failure.message, 2_000);
+  if (!/^[a-z0-9][a-z0-9._-]*$/u.test(failure.error_code)) invalid();
+  if (failure.provider_request_ref !== undefined) reference(failure.provider_request_ref);
+  if (failure.retry_after_ms !== undefined
+    && (!Number.isSafeInteger(failure.retry_after_ms) || failure.retry_after_ms < 1
+      || failure.retry_after_ms > 60 * 60_000 || !failure.retryable)) invalid();
+  return Object.freeze({ ...failure });
+}
+
+function bounded(value: string, maximum: number): void {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+
+function reference(value: string): void {
+  bounded(value, 240);
+  if (!value.includes("://")) invalid();
+}
+
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym model failure is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/model-failure.ts
+++ b/apps/slack-companion/src/agent-gym/model-failure.ts
@@ -1,4 +1,4 @@
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 
 export interface AgentGymModelFailureV1 {
   readonly error_code: string;

--- a/apps/slack-companion/src/agent-gym/model-invocation.ts
+++ b/apps/slack-companion/src/agent-gym/model-invocation.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 import {
   evaluateAgentGymModelBudget,
   type AgentGymModelBudgetEvaluationV1,

--- a/apps/slack-companion/src/agent-gym/model-ledger.ts
+++ b/apps/slack-companion/src/agent-gym/model-ledger.ts
@@ -1,4 +1,4 @@
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 import type { AgentGymModelInvocationReceiptV1 } from "./model-invocation.js";
 
 export interface AgentGymModelInvocationLedgerV1 {

--- a/apps/slack-companion/src/agent-gym/model-ledger.ts
+++ b/apps/slack-companion/src/agent-gym/model-ledger.ts
@@ -1,0 +1,46 @@
+import { AgentGymContractError } from "./index.js";
+import type { AgentGymModelInvocationReceiptV1 } from "./model-invocation.js";
+
+export interface AgentGymModelInvocationLedgerV1 {
+  readonly blocked_invocation_count: number;
+  readonly input_tokens: number;
+  readonly invocation_count: number;
+  readonly invocation_refs: readonly string[];
+  readonly latency_ms: number;
+  readonly output_tokens: number;
+  readonly recorded_invocation_count: number;
+  readonly schema_version: "agent-gym-model-invocation-ledger/v1";
+  readonly total_tokens: number;
+}
+
+/** Aggregates invocation receipts while retaining their immutable identities. */
+export function createAgentGymModelInvocationLedger(
+  receipts: readonly AgentGymModelInvocationReceiptV1[],
+): AgentGymModelInvocationLedgerV1 {
+  if (!Array.isArray(receipts) || receipts.length > 10_000) invalid();
+  const invocationRefs = receipts.map((receipt) => receipt.invocation_ref);
+  if (new Set(invocationRefs).size !== invocationRefs.length) invalid();
+  return Object.freeze({
+    blocked_invocation_count: receipts.filter((receipt) => !receipt.budget.allowed).length,
+    input_tokens: sum(receipts.map((receipt) => receipt.token_usage.input_tokens)),
+    invocation_count: receipts.length,
+    invocation_refs: Object.freeze([...invocationRefs].sort()),
+    latency_ms: sum(receipts.map((receipt) => receipt.latency_ms)),
+    output_tokens: sum(receipts.map((receipt) => receipt.token_usage.output_tokens)),
+    recorded_invocation_count: receipts.filter(
+      (receipt) => receipt.response_source === "recorded",
+    ).length,
+    schema_version: "agent-gym-model-invocation-ledger/v1",
+    total_tokens: sum(receipts.map((receipt) => receipt.token_usage.total_tokens)),
+  });
+}
+
+function sum(values: readonly number[]): number {
+  const total = values.reduce((current, value) => current + value, 0);
+  if (!Number.isSafeInteger(total) || total < 0) invalid();
+  return total;
+}
+
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym model invocation ledger is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/model-retry.ts
+++ b/apps/slack-companion/src/agent-gym/model-retry.ts
@@ -1,5 +1,11 @@
 import { AgentGymContractError } from "./index.js";
 import type { AgentGymModelFailureV1 } from "./model-failure.js";
+import { AgentGymModelInvocationError } from "./model-failure.js";
+import type {
+  AgentGymModelInvocationRequestV1,
+  AgentGymModelPort,
+  AgentGymModelResponseV1,
+} from "./model-runtime.js";
 
 export interface AgentGymModelRetryPolicyV1 {
   readonly backoff_ms: readonly number[];
@@ -15,6 +21,54 @@ export interface AgentGymModelRetryDecisionV1 {
   readonly reason_code: string;
   readonly retry: boolean;
   readonly schema_version: "agent-gym-model-retry-decision/v1";
+}
+
+export interface AgentGymModelRetryAttemptV1 {
+  readonly attempt: number;
+  readonly delay_ms: number;
+  readonly error_code?: string;
+  readonly outcome: "failure" | "success";
+}
+
+export interface AgentGymModelRetryResultV1 {
+  readonly attempts: readonly AgentGymModelRetryAttemptV1[];
+  readonly response: AgentGymModelResponseV1;
+  readonly schema_version: "agent-gym-model-retry-result/v1";
+  readonly virtual_elapsed_ms: number;
+}
+
+/** Executes retries using virtual delay accounting; it never sleeps. */
+export async function invokeAgentGymModelWithRetry(
+  request: AgentGymModelInvocationRequestV1,
+  policy: AgentGymModelRetryPolicyV1,
+  model: AgentGymModelPort,
+): Promise<AgentGymModelRetryResultV1> {
+  const attempts: AgentGymModelRetryAttemptV1[] = [];
+  let elapsedMs = 0;
+  for (let attempt = 1; attempt <= policy.max_attempts; attempt += 1) {
+    try {
+      const response = await model.invoke(request);
+      attempts.push(Object.freeze({ attempt, delay_ms: 0, outcome: "success" }));
+      return Object.freeze({
+        attempts: Object.freeze(attempts),
+        response,
+        schema_version: "agent-gym-model-retry-result/v1",
+        virtual_elapsed_ms: elapsedMs,
+      });
+    } catch (error: unknown) {
+      if (!(error instanceof AgentGymModelInvocationError)) throw error;
+      const decision = decideAgentGymModelRetry(policy, error.failure, attempt, elapsedMs);
+      attempts.push(Object.freeze({
+        attempt,
+        delay_ms: decision.delay_ms ?? 0,
+        error_code: error.failure.error_code,
+        outcome: "failure",
+      }));
+      if (!decision.retry) throw error;
+      elapsedMs += decision.delay_ms ?? 0;
+    }
+  }
+  throw new AgentGymContractError("Agent gym model retry execution is invalid.");
 }
 
 /** Makes a deterministic retry decision without sleeping or reading wall time. */

--- a/apps/slack-companion/src/agent-gym/model-retry.ts
+++ b/apps/slack-companion/src/agent-gym/model-retry.ts
@@ -1,0 +1,80 @@
+import { AgentGymContractError } from "./index.js";
+import type { AgentGymModelFailureV1 } from "./model-failure.js";
+
+export interface AgentGymModelRetryPolicyV1 {
+  readonly backoff_ms: readonly number[];
+  readonly max_attempts: number;
+  readonly max_elapsed_ms: number;
+  readonly retryable_error_codes: readonly string[];
+  readonly schema_version: "agent-gym-model-retry-policy/v1";
+}
+
+export interface AgentGymModelRetryDecisionV1 {
+  readonly attempt: number;
+  readonly delay_ms: number | null;
+  readonly reason_code: string;
+  readonly retry: boolean;
+  readonly schema_version: "agent-gym-model-retry-decision/v1";
+}
+
+/** Makes a deterministic retry decision without sleeping or reading wall time. */
+export function decideAgentGymModelRetry(
+  rawPolicy: AgentGymModelRetryPolicyV1,
+  failure: AgentGymModelFailureV1,
+  attempt: number,
+  elapsedMs: number,
+): AgentGymModelRetryDecisionV1 {
+  const policy = validatePolicy(rawPolicy);
+  integer(attempt, policy.max_attempts);
+  if (!Number.isSafeInteger(elapsedMs) || elapsedMs < 0
+    || elapsedMs > policy.max_elapsed_ms) invalid();
+  const delay = failure.retry_after_ms ?? policy.backoff_ms[attempt - 1] ?? 0;
+  const reasonCode = !failure.retryable
+    ? "failure.not_retryable"
+    : !policy.retryable_error_codes.includes(failure.error_code)
+      ? "failure.code_not_allowed"
+      : attempt >= policy.max_attempts
+        ? "retry.attempts_exhausted"
+        : elapsedMs + delay > policy.max_elapsed_ms
+          ? "retry.elapsed_budget_exhausted"
+          : "retry.scheduled";
+  const retry = reasonCode === "retry.scheduled";
+  return Object.freeze({
+    attempt,
+    delay_ms: retry ? delay : null,
+    reason_code: reasonCode,
+    retry,
+    schema_version: "agent-gym-model-retry-decision/v1",
+  });
+}
+
+function validatePolicy(policy: AgentGymModelRetryPolicyV1): AgentGymModelRetryPolicyV1 {
+  if (policy.schema_version !== "agent-gym-model-retry-policy/v1") invalid();
+  integer(policy.max_attempts, 10);
+  integer(policy.max_elapsed_ms, 60 * 60_000);
+  if (!Array.isArray(policy.backoff_ms) || policy.backoff_ms.length > 9
+    || policy.backoff_ms.length < policy.max_attempts - 1
+    || !Array.isArray(policy.retryable_error_codes)
+    || policy.retryable_error_codes.length < 1
+    || policy.retryable_error_codes.length > 64
+    || new Set(policy.retryable_error_codes).size !== policy.retryable_error_codes.length) invalid();
+  for (const delay of policy.backoff_ms) integer(delay, policy.max_elapsed_ms, true);
+  for (const code of policy.retryable_error_codes) {
+    if (!/^[a-z0-9][a-z0-9._-]*$/u.test(code)) invalid();
+  }
+  return Object.freeze({
+    ...policy,
+    backoff_ms: Object.freeze([...policy.backoff_ms]),
+    retryable_error_codes: Object.freeze([...policy.retryable_error_codes]),
+  });
+}
+
+function integer(value: number, maximum: number, allowZero = false): void {
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1) || value > maximum) {
+    invalid();
+  }
+}
+
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym model retry policy is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/model-retry.ts
+++ b/apps/slack-companion/src/agent-gym/model-retry.ts
@@ -1,4 +1,4 @@
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 import type { AgentGymModelFailureV1 } from "./model-failure.js";
 import { AgentGymModelInvocationError } from "./model-failure.js";
 import type {

--- a/apps/slack-companion/src/agent-gym/model-runtime.ts
+++ b/apps/slack-companion/src/agent-gym/model-runtime.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 
 export interface AgentGymModelTextMessageV1 {
   readonly role: "assistant" | "user";

--- a/apps/slack-companion/src/agent-gym/promotion-decision.ts
+++ b/apps/slack-companion/src/agent-gym/promotion-decision.ts
@@ -1,4 +1,4 @@
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 
 export type AgentGymPromotionDisposition = "blocked" | "inconclusive" | "promote";
 

--- a/apps/slack-companion/src/agent-gym/recorded-model.ts
+++ b/apps/slack-companion/src/agent-gym/recorded-model.ts
@@ -1,4 +1,4 @@
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 import {
   agentGymModelRequestDigest,
   type AgentGymModelInvocationRequestV1,

--- a/apps/slack-companion/src/agent-gym/replay-run.ts
+++ b/apps/slack-companion/src/agent-gym/replay-run.ts
@@ -1,4 +1,4 @@
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 
 export interface AgentGymReplayTurnV1 {
   readonly content_digest: `sha256:${string}`;

--- a/apps/slack-companion/src/agent-gym/run-summary.ts
+++ b/apps/slack-companion/src/agent-gym/run-summary.ts
@@ -1,4 +1,4 @@
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 
 export interface AgentGymRunSummaryV1 {
   readonly artifact_refs: readonly string[];

--- a/apps/slack-companion/src/agent-gym/scorecard.ts
+++ b/apps/slack-companion/src/agent-gym/scorecard.ts
@@ -1,4 +1,4 @@
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 
 export interface AgentGymMetricScoreV1 {
   readonly evaluator: "deterministic" | "model_judge";

--- a/apps/slack-companion/src/agent-gym/slack-delivery.ts
+++ b/apps/slack-companion/src/agent-gym/slack-delivery.ts
@@ -1,4 +1,4 @@
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 import type { AgentGymSlackInvocationV1 } from "./slack-simulator.js";
 
 export interface AgentGymSlackDeliveryResultV1 {

--- a/apps/slack-companion/src/agent-gym/slack-effect-runtime.ts
+++ b/apps/slack-companion/src/agent-gym/slack-effect-runtime.ts
@@ -1,4 +1,4 @@
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 import type { AgentGymSlackEffectV1 } from "./slack-effects.js";
 
 export interface AgentGymSlackEffectAdmissionV1 {

--- a/apps/slack-companion/src/agent-gym/slack-effect-snapshot.ts
+++ b/apps/slack-companion/src/agent-gym/slack-effect-snapshot.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 import type { AgentGymSlackEffectV1 } from "./slack-effects.js";
 
 export interface AgentGymSlackEffectSnapshotV1 {

--- a/apps/slack-companion/src/agent-gym/slack-effects.ts
+++ b/apps/slack-companion/src/agent-gym/slack-effects.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import type { AgentGymJson } from "./fixture-case.js";
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 
 export type AgentGymSlackEffectOperation =
   | "open_modal"

--- a/apps/slack-companion/src/agent-gym/slack-failure.ts
+++ b/apps/slack-companion/src/agent-gym/slack-failure.ts
@@ -1,4 +1,4 @@
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 
 export interface AgentGymSlackApiAttemptV1 {
   readonly attempt_index: number;

--- a/apps/slack-companion/src/agent-gym/slack-simulator.ts
+++ b/apps/slack-companion/src/agent-gym/slack-simulator.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import type { AgentGymJson, AgentGymSlackEventV1 } from "./fixture-case.js";
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 
 export type AgentGymSlackInvocationRoute =
   | "assistant_turn"

--- a/apps/slack-companion/src/agent-gym/tool-fixture-runtime.ts
+++ b/apps/slack-companion/src/agent-gym/tool-fixture-runtime.ts
@@ -1,5 +1,5 @@
 import type { AgentGymJson } from "./fixture-case.js";
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 import type { AgentGymToolRegistrySnapshotV1 } from "./tool-fixtures.js";
 
 export interface AgentGymToolPageFixtureV1 {

--- a/apps/slack-companion/src/agent-gym/tool-fixtures.ts
+++ b/apps/slack-companion/src/agent-gym/tool-fixtures.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import type { AgentGymJson } from "./fixture-case.js";
-import { AgentGymContractError } from "./index.js";
+import { AgentGymContractError } from "./contract-error.js";
 
 export interface AgentGymToolDefinitionV1 {
   readonly description: string;

--- a/apps/slack-companion/test/agent-gym-model-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-model-runtime.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   agentGymModelRequestDigest,
   AgentGymModelInvocationError,
+  createAgentGymModelInvocationLedger,
   decideAgentGymModelRetry,
   invokeAgentGymModelWithRetry,
   evaluateAgentGymModelBudget,
@@ -13,6 +14,34 @@ import {
   validateAgentGymModelFailure,
   validateAgentGymModelRequest,
 } from "../src/index.js";
+
+test("model invocation ledgers aggregate replay cost and blockers", async () => {
+  const modelRequest = request();
+  const result = await invokeAgentGymModel(
+    modelRequest,
+    modelBudget(),
+    new RecordedAgentGymModel([recordedResponse(modelRequest)]),
+    "2026-08-12T09:45:00.000Z",
+  );
+  const ledger = createAgentGymModelInvocationLedger([result.receipt]);
+  assert.equal(ledger.invocation_count, 1);
+  assert.equal(ledger.recorded_invocation_count, 1);
+  assert.equal(ledger.blocked_invocation_count, 0);
+  assert.equal(ledger.total_tokens, 25);
+});
+
+test("model invocation ledgers reject duplicate invocation identities", async () => {
+  const modelRequest = request();
+  const result = await invokeAgentGymModel(
+    modelRequest,
+    modelBudget(),
+    new RecordedAgentGymModel([recordedResponse(modelRequest)]),
+    "2026-08-12T09:45:00.000Z",
+  );
+  assert.throws(() => createAgentGymModelInvocationLedger([
+    result.receipt, result.receipt,
+  ]), /invocation ledger is invalid/u);
+});
 
 test("model retry execution advances virtual time without sleeping", async () => {
   let invocationCount = 0;

--- a/apps/slack-companion/test/agent-gym-model-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-model-runtime.test.ts
@@ -3,12 +3,42 @@ import test from "node:test";
 
 import {
   agentGymModelRequestDigest,
+  AgentGymModelInvocationError,
   evaluateAgentGymModelBudget,
   invokeAgentGymModel,
   RecordedAgentGymModel,
   validateAgentGymRecordedModelResponse,
+  validateAgentGymModelFailure,
   validateAgentGymModelRequest,
 } from "../src/index.js";
+
+test("model failures retain retry and provider correlation", () => {
+  const failure = validateAgentGymModelFailure({
+    error_code: "provider.throttled",
+    invocation_ref: "model-invocation://one",
+    message: "The model provider throttled the request.",
+    model_id: "recorded.model-v1",
+    provider_request_ref: "provider-request://one",
+    retry_after_ms: 250,
+    retryable: true,
+    schema_version: "agent-gym-model-failure/v1",
+  });
+  const error = new AgentGymModelInvocationError(failure);
+  assert.equal(error.failure.retry_after_ms, 250);
+  assert.equal(error.name, "AgentGymModelInvocationError");
+});
+
+test("model failures reject retry delay on terminal errors", () => {
+  assert.throws(() => validateAgentGymModelFailure({
+    error_code: "request.invalid",
+    invocation_ref: "model-invocation://one",
+    message: "The request is invalid.",
+    model_id: "recorded.model-v1",
+    retry_after_ms: 250,
+    retryable: false,
+    schema_version: "agent-gym-model-failure/v1",
+  }), /model failure is invalid/u);
+});
 
 test("model invocation receipts bind request, response, and budget", async () => {
   const modelRequest = request();

--- a/apps/slack-companion/test/agent-gym-model-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-model-runtime.test.ts
@@ -5,6 +5,7 @@ import {
   agentGymModelRequestDigest,
   AgentGymModelInvocationError,
   decideAgentGymModelRetry,
+  invokeAgentGymModelWithRetry,
   evaluateAgentGymModelBudget,
   invokeAgentGymModel,
   RecordedAgentGymModel,
@@ -12,6 +13,29 @@ import {
   validateAgentGymModelFailure,
   validateAgentGymModelRequest,
 } from "../src/index.js";
+
+test("model retry execution advances virtual time without sleeping", async () => {
+  let invocationCount = 0;
+  const result = await invokeAgentGymModelWithRetry(request(), retryPolicy(), {
+    async invoke() {
+      invocationCount += 1;
+      if (invocationCount < 3) throw new AgentGymModelInvocationError(retryableFailure());
+      return modelResponse();
+    },
+  });
+  assert.equal(result.virtual_elapsed_ms, 350);
+  assert.deepEqual(result.attempts.map((attempt) => attempt.outcome), [
+    "failure", "failure", "success",
+  ]);
+});
+
+test("model retry execution propagates terminal failures", async () => {
+  const failure = { ...retryableFailure(), retryable: false };
+  await assert.rejects(invokeAgentGymModelWithRetry(request(), retryPolicy(), {
+    async invoke() { throw new AgentGymModelInvocationError(failure); },
+  }), (error: unknown) => error instanceof AgentGymModelInvocationError
+    && error.failure.error_code === "provider.throttled");
+});
 
 function retryPolicy() {
   return {

--- a/apps/slack-companion/test/agent-gym-model-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-model-runtime.test.ts
@@ -10,10 +10,46 @@ import {
   evaluateAgentGymModelBudget,
   invokeAgentGymModel,
   RecordedAgentGymModel,
+  runAgentGymModelBatch,
   validateAgentGymRecordedModelResponse,
   validateAgentGymModelFailure,
   validateAgentGymModelRequest,
 } from "../src/index.js";
+
+test("model batches replay requests in declared order", async () => {
+  const first = request();
+  const second = {
+    ...request(),
+    invocation_ref: "model-invocation://case-two/one",
+    messages: [{ role: "user" as const, text: "Summarize the second case." }],
+  };
+  const model = new RecordedAgentGymModel([
+    recordedResponse(first),
+    recordedResponse(second),
+  ]);
+  const batch = await runAgentGymModelBatch(
+    "model-batch://one",
+    [first, second],
+    modelBudget(),
+    model,
+    "2026-08-12T09:45:00.000Z",
+  );
+  assert.deepEqual(batch.results.map((result) => result.receipt.invocation_ref), [
+    first.invocation_ref,
+    second.invocation_ref,
+  ]);
+  assert.equal(batch.ledger.invocation_count, 2);
+});
+
+test("model batches reject duplicate invocation identities", async () => {
+  await assert.rejects(runAgentGymModelBatch(
+    "model-batch://one",
+    [request(), request()],
+    modelBudget(),
+    new RecordedAgentGymModel([recordedResponse()]),
+    "2026-08-12T09:45:00.000Z",
+  ), /model batch is invalid/u);
+});
 
 test("model invocation ledgers aggregate replay cost and blockers", async () => {
   const modelRequest = request();

--- a/apps/slack-companion/test/agent-gym-model-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-model-runtime.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   agentGymModelRequestDigest,
   AgentGymModelInvocationError,
+  decideAgentGymModelRetry,
   evaluateAgentGymModelBudget,
   invokeAgentGymModel,
   RecordedAgentGymModel,
@@ -11,6 +12,43 @@ import {
   validateAgentGymModelFailure,
   validateAgentGymModelRequest,
 } from "../src/index.js";
+
+function retryPolicy() {
+  return {
+    backoff_ms: [100, 250],
+    max_attempts: 3,
+    max_elapsed_ms: 1_000,
+    retryable_error_codes: ["provider.throttled"],
+    schema_version: "agent-gym-model-retry-policy/v1" as const,
+  };
+}
+
+function retryableFailure() {
+  return {
+    error_code: "provider.throttled",
+    invocation_ref: "model-invocation://one",
+    message: "The model provider throttled the request.",
+    model_id: "recorded.model-v1",
+    retryable: true,
+    schema_version: "agent-gym-model-failure/v1" as const,
+  };
+}
+
+test("model retry decisions use deterministic backoff", () => {
+  assert.deepEqual(decideAgentGymModelRetry(retryPolicy(), retryableFailure(), 1, 20), {
+    attempt: 1,
+    delay_ms: 100,
+    reason_code: "retry.scheduled",
+    retry: true,
+    schema_version: "agent-gym-model-retry-decision/v1",
+  });
+});
+
+test("model retry decisions stop at the attempt boundary", () => {
+  const decision = decideAgentGymModelRetry(retryPolicy(), retryableFailure(), 3, 500);
+  assert.equal(decision.retry, false);
+  assert.equal(decision.reason_code, "retry.attempts_exhausted");
+});
 
 test("model failures retain retry and provider correlation", () => {
   const failure = validateAgentGymModelFailure({


### PR DESCRIPTION
## Summary

- type replayable model-provider failures without leaking raw provider errors
- define deterministic retry policy and virtual-time retry execution
- aggregate model invocation receipts into stable usage ledgers
- run ordered offline model batches without Slack or hosted-model calls
- move the shared contract error into a leaf module to prevent ESM cycles

## Test plan

- `npm run typecheck --workspace @writer/cerebro-slack-companion`
- focused Agent Gym harness: 90/90 tests
- full Slack companion suite: 611/611 tests

## Invariants

- retries never sleep or read wall-clock time
- terminal failures remain terminal and retain structured reason codes
- offline batches preserve declared request order and reject duplicate invocation identities
- public contracts contain no credentials, routes, or deployment topology