### PR TITLE
feat(slack): bind agent gym corpus identity

### DIFF
--- a/apps/slack-companion/src/agent-gym/canonical-json.ts
+++ b/apps/slack-companion/src/agent-gym/canonical-json.ts
@@ -1,0 +1,45 @@
+import { createHash } from "node:crypto";
+
+import { AgentGymContractError } from "./contract-error.js";
+import type { AgentGymJson } from "./fixture-case.js";
+
+const MAXIMUM_DEPTH = 100;
+
+/** Encodes portable agent-gym data with stable object-key ordering. */
+export function canonicalAgentGymJson(value: AgentGymJson): string {
+  return encode(value, 0);
+}
+
+/** Returns a content identity for portable agent-gym data. */
+export function digestAgentGymJson(value: AgentGymJson): string {
+  return `sha256:${createHash("sha256").update(canonicalAgentGymJson(value), "utf8").digest("hex")}`;
+}
+
+function encode(value: AgentGymJson, depth: number): string {
+  if (depth > MAXIMUM_DEPTH) invalid();
+  if (value === null || typeof value === "boolean" || typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) invalid();
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    if (Object.keys(value).length !== value.length) invalid();
+    return `[${value.map((item) => encode(item, depth + 1)).join(",")}]`;
+  }
+  if (typeof value !== "object") invalid();
+  const prototype = Object.getPrototypeOf(value) as object | null;
+  if (prototype !== Object.prototype && prototype !== null) invalid();
+  const keys = Object.keys(value).sort();
+  if (Reflect.ownKeys(value).length !== keys.length) invalid();
+  return `{${keys.map((key) => {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)) invalid();
+    return `${JSON.stringify(key)}:${encode(descriptor.value as AgentGymJson, depth + 1)}`;
+  }).join(",")}}`;
+}
+
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym canonical JSON is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/corpus-build.ts
+++ b/apps/slack-companion/src/agent-gym/corpus-build.ts
@@ -1,0 +1,66 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { createAgentGymCorpusInventory } from "./corpus-inventory.js";
+import { createAgentGymCorpusManifest } from "./corpus-manifest.js";
+import type { AgentGymFixtureCaseV1 } from "./fixture-case.js";
+
+export interface AgentGymCorpusBuildInputV1 {
+  readonly build_ref: string;
+  readonly built_at: string;
+  readonly source_revision: string;
+}
+
+export interface AgentGymCorpusBuildReceiptV1 {
+  readonly build_ref: string;
+  readonly built_at: string;
+  readonly case_count: number;
+  readonly corpus_digest: string;
+  readonly inventory_digest: string;
+  readonly receipt_digest: string;
+  readonly schema_version: "agent-gym-corpus-build-receipt/v1";
+  readonly source_revision: string;
+}
+
+/** Produces a durable receipt for the exact corpus assembled from source. */
+export function buildAgentGymCorpus(
+  fixtures: readonly AgentGymFixtureCaseV1[],
+  input: AgentGymCorpusBuildInputV1,
+): AgentGymCorpusBuildReceiptV1 {
+  reference(input.build_ref, "build reference");
+  reference(input.source_revision, "source revision");
+  timestamp(input.built_at);
+  const manifest = createAgentGymCorpusManifest(fixtures);
+  const inventory = createAgentGymCorpusInventory(fixtures);
+  const inventoryDigest = digestAgentGymJson({
+    case_count: inventory.case_count,
+    corpus_digest: inventory.corpus_digest,
+    labels: inventory.labels.map((entry) => ({
+      case_count: entry.case_count,
+      label: entry.label,
+    })),
+    partitions: inventory.partitions,
+    schema_version: inventory.schema_version,
+  });
+  const body = {
+    build_ref: input.build_ref,
+    built_at: input.built_at,
+    case_count: manifest.case_count,
+    corpus_digest: manifest.corpus_digest,
+    inventory_digest: inventoryDigest,
+    schema_version: "agent-gym-corpus-build-receipt/v1" as const,
+    source_revision: input.source_revision,
+  };
+  return Object.freeze({ ...body, receipt_digest: digestAgentGymJson(body) });
+}
+
+function reference(value: string, field: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) {
+    throw new AgentGymContractError(`Agent gym corpus ${field} is invalid.`);
+  }
+}
+
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) {
+    throw new AgentGymContractError("Agent gym corpus build timestamp is invalid.");
+  }
+}

--- a/apps/slack-companion/src/agent-gym/corpus-inventory.ts
+++ b/apps/slack-companion/src/agent-gym/corpus-inventory.ts
@@ -1,0 +1,40 @@
+import {
+  createAgentGymCorpusManifest,
+  type AgentGymCorpusManifestV1,
+} from "./corpus-manifest.js";
+import type { AgentGymFixtureCaseV1 } from "./fixture-case.js";
+
+export interface AgentGymCorpusInventoryV1 {
+  readonly case_count: number;
+  readonly corpus_digest: string;
+  readonly labels: readonly {
+    readonly case_count: number;
+    readonly label: string;
+  }[];
+  readonly partitions: Readonly<Record<AgentGymFixtureCaseV1["partition"], number>>;
+  readonly schema_version: "agent-gym-corpus-inventory/v1";
+}
+
+/** Counts the exact partitions and labels represented by a corpus. */
+export function createAgentGymCorpusInventory(
+  fixtures: readonly AgentGymFixtureCaseV1[],
+): AgentGymCorpusInventoryV1 {
+  return inventory(createAgentGymCorpusManifest(fixtures));
+}
+
+function inventory(manifest: AgentGymCorpusManifestV1): AgentGymCorpusInventoryV1 {
+  const partitions = { held_out: 0, shadow: 0, train: 0 };
+  const labels = new Map<string, number>();
+  for (const entry of manifest.cases) {
+    partitions[entry.partition] += 1;
+    for (const label of entry.labels) labels.set(label, (labels.get(label) ?? 0) + 1);
+  }
+  return Object.freeze({
+    case_count: manifest.case_count,
+    corpus_digest: manifest.corpus_digest,
+    labels: Object.freeze([...labels].sort(([left], [right]) => left.localeCompare(right))
+      .map(([label, case_count]) => Object.freeze({ case_count, label }))),
+    partitions: Object.freeze(partitions),
+    schema_version: "agent-gym-corpus-inventory/v1",
+  });
+}

--- a/apps/slack-companion/src/agent-gym/corpus-manifest.ts
+++ b/apps/slack-companion/src/agent-gym/corpus-manifest.ts
@@ -1,0 +1,52 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  agentGymFixtureCaseDigest,
+  validateAgentGymFixtureCase,
+  type AgentGymFixtureCaseV1,
+} from "./fixture-case.js";
+
+export interface AgentGymCorpusManifestCaseV1 {
+  readonly case_digest: string;
+  readonly case_ref: string;
+  readonly labels: readonly string[];
+  readonly partition: AgentGymFixtureCaseV1["partition"];
+}
+
+export interface AgentGymCorpusManifestV1 {
+  readonly case_count: number;
+  readonly cases: readonly AgentGymCorpusManifestCaseV1[];
+  readonly corpus_digest: string;
+  readonly schema_version: "agent-gym-corpus-manifest/v1";
+}
+
+/** Builds an order-independent manifest for one validated evaluation corpus. */
+export function createAgentGymCorpusManifest(
+  fixtures: readonly AgentGymFixtureCaseV1[],
+): AgentGymCorpusManifestV1 {
+  if (fixtures.length === 0 || fixtures.length > 100_000) invalid();
+  const cases = fixtures.map((fixture) => {
+    const value = validateAgentGymFixtureCase(fixture);
+    return Object.freeze({
+      case_digest: agentGymFixtureCaseDigest(value),
+      case_ref: value.case_ref,
+      labels: Object.freeze([...value.labels].sort()),
+      partition: value.partition,
+    });
+  }).sort((left, right) => left.case_ref.localeCompare(right.case_ref));
+  if (new Set(cases.map((entry) => entry.case_ref)).size !== cases.length) invalid();
+  const body = {
+    case_count: cases.length,
+    cases,
+    schema_version: "agent-gym-corpus-manifest/v1" as const,
+  };
+  return Object.freeze({
+    ...body,
+    cases: Object.freeze(cases),
+    corpus_digest: digestAgentGymJson(body),
+  });
+}
+
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym corpus manifest is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/fixture-case.ts
+++ b/apps/slack-companion/src/agent-gym/fixture-case.ts
@@ -1,4 +1,5 @@
 import { AgentGymContractError } from "./contract-error.js";
+import { digestAgentGymJson } from "./canonical-json.js";
 
 export type AgentGymJson =
   | boolean | number | string | null
@@ -39,6 +40,32 @@ export interface AgentGymFixtureCaseV1 {
   readonly schema_version: "agent-gym-fixture-case/v1";
   readonly slack_events: readonly AgentGymSlackEventV1[];
   readonly tool_fixtures: readonly AgentGymToolFixtureV1[];
+}
+
+/** Returns the stable content identity of a validated fixture case. */
+export function agentGymFixtureCaseDigest(fixture: AgentGymFixtureCaseV1): string {
+  const value = validateAgentGymFixtureCase(fixture);
+  return digestAgentGymJson({
+    case_ref: value.case_ref,
+    expected_invariants: value.expected_invariants,
+    labels: value.labels,
+    partition: value.partition,
+    schema_version: value.schema_version,
+    slack_events: value.slack_events.map((event) => ({
+      event_ref: event.event_ref,
+      kind: event.kind,
+      occurred_at: event.occurred_at,
+      payload: event.payload,
+    })),
+    tool_fixtures: value.tool_fixtures.map((tool) => ({
+      call_ref: tool.call_ref,
+      ...(tool.error_code === undefined ? {} : { error_code: tool.error_code }),
+      input: tool.input,
+      outcome: tool.outcome,
+      ...(tool.output === undefined ? {} : { output: tool.output }),
+      tool_id: tool.tool_id,
+    })),
+  });
 }
 
 const EVENT_KINDS: readonly AgentGymSlackEventKind[] = [

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -6,6 +6,7 @@ export const CEREBRO_AGENT_GYM = Object.freeze({
 
 export * from "./contract-error.js";
 export * from "./canonical-json.js";
+export * from "./corpus-manifest.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -8,6 +8,7 @@ export * from "./contract-error.js";
 export * from "./canonical-json.js";
 export * from "./corpus-manifest.js";
 export * from "./corpus-inventory.js";
+export * from "./corpus-build.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -7,6 +7,7 @@ export const CEREBRO_AGENT_GYM = Object.freeze({
 export * from "./contract-error.js";
 export * from "./canonical-json.js";
 export * from "./corpus-manifest.js";
+export * from "./corpus-inventory.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -5,6 +5,7 @@ export const CEREBRO_AGENT_GYM = Object.freeze({
 });
 
 export * from "./contract-error.js";
+export * from "./canonical-json.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/test/agent-gym-corpus-identity.test.ts
+++ b/apps/slack-companion/test/agent-gym-corpus-identity.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  agentGymFixtureCaseDigest,
   canonicalAgentGymJson,
   digestAgentGymJson,
 } from "../src/index.js";
@@ -20,3 +21,46 @@ test("canonical agent-gym JSON rejects non-data properties", () => {
     /canonical JSON is invalid/u,
   );
 });
+
+test("fixture case digests bind the complete portable scenario", () => {
+  const first = fixtureCase();
+  const second = { ...fixtureCase(), labels: ["safety", "support"] };
+  assert.notEqual(agentGymFixtureCaseDigest(first), agentGymFixtureCaseDigest(second));
+});
+
+test("fixture case digests are stable across object insertion order", () => {
+  const fixture = fixtureCase();
+  const reordered = {
+    tool_fixtures: fixture.tool_fixtures,
+    slack_events: fixture.slack_events,
+    schema_version: fixture.schema_version,
+    partition: fixture.partition,
+    labels: fixture.labels,
+    expected_invariants: fixture.expected_invariants,
+    case_ref: fixture.case_ref,
+  };
+  assert.equal(agentGymFixtureCaseDigest(fixture), agentGymFixtureCaseDigest(reordered));
+});
+
+function fixtureCase() {
+  return {
+    case_ref: "agent-gym-case://support/one",
+    expected_invariants: ["answer-grounded"],
+    labels: ["support"],
+    partition: "train" as const,
+    schema_version: "agent-gym-fixture-case/v1" as const,
+    slack_events: [{
+      event_ref: "slack-event://one",
+      kind: "mention" as const,
+      occurred_at: "2026-08-12T10:00:00.000Z",
+      payload: { text: "Help with this alert." },
+    }],
+    tool_fixtures: [{
+      call_ref: "tool-call://one",
+      input: { alert_ref: "alert://one" },
+      outcome: "success" as const,
+      output: { severity: "high" },
+      tool_id: "alerts.read",
+    }],
+  };
+}

--- a/apps/slack-companion/test/agent-gym-corpus-identity.test.ts
+++ b/apps/slack-companion/test/agent-gym-corpus-identity.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  canonicalAgentGymJson,
+  digestAgentGymJson,
+} from "../src/index.js";
+
+test("canonical agent-gym JSON ignores object insertion order", () => {
+  const first = { beta: [true, null], alpha: { two: 2, one: 1 } };
+  const second = { alpha: { one: 1, two: 2 }, beta: [true, null] };
+  assert.equal(canonicalAgentGymJson(first), canonicalAgentGymJson(second));
+  assert.equal(digestAgentGymJson(first), digestAgentGymJson(second));
+});
+
+test("canonical agent-gym JSON rejects non-data properties", () => {
+  const value = Object.defineProperty({ visible: true }, "hidden", { value: 1 });
+  assert.throws(
+    () => canonicalAgentGymJson(value),
+    /canonical JSON is invalid/u,
+  );
+});

--- a/apps/slack-companion/test/agent-gym-corpus-identity.test.ts
+++ b/apps/slack-companion/test/agent-gym-corpus-identity.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   agentGymFixtureCaseDigest,
+  buildAgentGymCorpus,
   canonicalAgentGymJson,
   createAgentGymCorpusInventory,
   createAgentGymCorpusManifest,
@@ -78,6 +79,25 @@ test("corpus inventories bind the manifest digest", () => {
     createAgentGymCorpusInventory(fixtures).corpus_digest,
     createAgentGymCorpusManifest(fixtures).corpus_digest,
   );
+});
+
+test("corpus build receipts bind source, membership, and inventory", () => {
+  const receipt = buildAgentGymCorpus([fixtureCase()], {
+    build_ref: "agent-gym-corpus-build://nightly/one",
+    built_at: "2026-08-12T10:15:00.000Z",
+    source_revision: "source-revision://cerebro/one",
+  });
+  assert.match(receipt.corpus_digest, /^sha256:[0-9a-f]{64}$/u);
+  assert.match(receipt.inventory_digest, /^sha256:[0-9a-f]{64}$/u);
+  assert.match(receipt.receipt_digest, /^sha256:[0-9a-f]{64}$/u);
+});
+
+test("corpus builds reject ambiguous source revisions", () => {
+  assert.throws(() => buildAgentGymCorpus([fixtureCase()], {
+    build_ref: "agent-gym-corpus-build://nightly/one",
+    built_at: "2026-08-12T10:15:00.000Z",
+    source_revision: "moving-main",
+  }), /source revision is invalid/u);
 });
 
 function fixtureCase(

--- a/apps/slack-companion/test/agent-gym-corpus-identity.test.ts
+++ b/apps/slack-companion/test/agent-gym-corpus-identity.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   agentGymFixtureCaseDigest,
   canonicalAgentGymJson,
+  createAgentGymCorpusManifest,
   digestAgentGymJson,
 } from "../src/index.js";
 
@@ -42,9 +43,25 @@ test("fixture case digests are stable across object insertion order", () => {
   assert.equal(agentGymFixtureCaseDigest(fixture), agentGymFixtureCaseDigest(reordered));
 });
 
-function fixtureCase() {
+test("corpus manifests are stable across fixture input order", () => {
+  const first = fixtureCase("agent-gym-case://support/one");
+  const second = fixtureCase("agent-gym-case://support/two");
+  assert.deepEqual(
+    createAgentGymCorpusManifest([first, second]),
+    createAgentGymCorpusManifest([second, first]),
+  );
+});
+
+test("corpus manifests reject duplicate case references", () => {
+  assert.throws(
+    () => createAgentGymCorpusManifest([fixtureCase(), fixtureCase()]),
+    /corpus manifest is invalid/u,
+  );
+});
+
+function fixtureCase(caseRef = "agent-gym-case://support/one") {
   return {
-    case_ref: "agent-gym-case://support/one",
+    case_ref: caseRef,
     expected_invariants: ["answer-grounded"],
     labels: ["support"],
     partition: "train" as const,

--- a/apps/slack-companion/test/agent-gym-corpus-identity.test.ts
+++ b/apps/slack-companion/test/agent-gym-corpus-identity.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   agentGymFixtureCaseDigest,
   canonicalAgentGymJson,
+  createAgentGymCorpusInventory,
   createAgentGymCorpusManifest,
   digestAgentGymJson,
 } from "../src/index.js";
@@ -59,12 +60,36 @@ test("corpus manifests reject duplicate case references", () => {
   );
 });
 
-function fixtureCase(caseRef = "agent-gym-case://support/one") {
+test("corpus inventories count every partition and label", () => {
+  const inventory = createAgentGymCorpusInventory([
+    fixtureCase("agent-gym-case://support/one", "train", ["support", "safety"]),
+    fixtureCase("agent-gym-case://support/two", "held_out", ["support"]),
+  ]);
+  assert.deepEqual(inventory.partitions, { held_out: 1, shadow: 0, train: 1 });
+  assert.deepEqual(inventory.labels, [
+    { case_count: 1, label: "safety" },
+    { case_count: 2, label: "support" },
+  ]);
+});
+
+test("corpus inventories bind the manifest digest", () => {
+  const fixtures = [fixtureCase()];
+  assert.equal(
+    createAgentGymCorpusInventory(fixtures).corpus_digest,
+    createAgentGymCorpusManifest(fixtures).corpus_digest,
+  );
+});
+
+function fixtureCase(
+  caseRef = "agent-gym-case://support/one",
+  partition: "held_out" | "shadow" | "train" = "train",
+  labels: readonly string[] = ["support"],
+) {
   return {
     case_ref: caseRef,
     expected_invariants: ["answer-grounded"],
-    labels: ["support"],
-    partition: "train" as const,
+    labels,
+    partition,
     schema_version: "agent-gym-fixture-case/v1" as const,
     slack_events: [{
       event_ref: "slack-event://one",


### PR DESCRIPTION
## Summary

- encode agent-gym JSON with deterministic object-key ordering and content digests
- bind fixture cases and complete corpora to portable SHA-256 identities
- publish corpus manifests, partition and label inventories, and source-bound build receipts

## Validation

- DDESK TypeScript typecheck
- focused corpus identity tests: 10 passed
- full Slack companion suite: 621 passed

No Slack API call or deployment change is included.