### PR TITLE
feat(slack): gate agent gym corpus quality

### DIFF
--- a/apps/slack-companion/src/agent-gym/corpus-admission.ts
+++ b/apps/slack-companion/src/agent-gym/corpus-admission.ts
@@ -1,0 +1,51 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import {
+  evaluateAgentGymCorpusCoverage,
+  type AgentGymCorpusCoveragePolicyV1,
+} from "./corpus-coverage.js";
+import { auditAgentGymCorpusLeakage } from "./corpus-leakage.js";
+import type { AgentGymFixtureCaseV1 } from "./fixture-case.js";
+
+export type AgentGymCorpusAdmissionBlockerCode =
+  | "corpus.duplicate_scenario"
+  | "corpus.partition_leakage"
+  | "corpus.partition_underfilled"
+  | "corpus.slice_underfilled";
+
+export interface AgentGymCorpusAdmissionDecisionV1 {
+  readonly admitted: boolean;
+  readonly blocker_codes: readonly AgentGymCorpusAdmissionBlockerCode[];
+  readonly corpus_digest: string;
+  readonly coverage_gap_count: number;
+  readonly coverage_policy_ref: string;
+  readonly decision_digest: string;
+  readonly leakage_finding_count: number;
+  readonly schema_version: "agent-gym-corpus-admission-decision/v1";
+}
+
+/** Fails corpus admission closed on coverage gaps or repeated scenarios. */
+export function decideAgentGymCorpusAdmission(
+  fixtures: readonly AgentGymFixtureCaseV1[],
+  policy: AgentGymCorpusCoveragePolicyV1,
+): AgentGymCorpusAdmissionDecisionV1 {
+  const coverage = evaluateAgentGymCorpusCoverage(fixtures, policy);
+  const leakage = auditAgentGymCorpusLeakage(fixtures);
+  const blockerCodes = [...new Set<AgentGymCorpusAdmissionBlockerCode>([
+    ...coverage.gaps.map((gap) => gap.gap_code),
+    ...leakage.findings.map((finding) => finding.finding_code),
+  ])].sort();
+  const body = {
+    admitted: blockerCodes.length === 0,
+    blocker_codes: blockerCodes,
+    corpus_digest: coverage.corpus_digest,
+    coverage_gap_count: coverage.gaps.length,
+    coverage_policy_ref: coverage.policy_ref,
+    leakage_finding_count: leakage.findings.length,
+    schema_version: "agent-gym-corpus-admission-decision/v1" as const,
+  };
+  return Object.freeze({
+    ...body,
+    blocker_codes: Object.freeze(blockerCodes),
+    decision_digest: digestAgentGymJson(body),
+  });
+}

--- a/apps/slack-companion/src/agent-gym/corpus-coverage.ts
+++ b/apps/slack-companion/src/agent-gym/corpus-coverage.ts
@@ -1,0 +1,100 @@
+import { AgentGymContractError } from "./contract-error.js";
+import { createAgentGymCorpusManifest } from "./corpus-manifest.js";
+import { validateAgentGymFixtureCase, type AgentGymFixtureCaseV1 } from "./fixture-case.js";
+
+type Partition = AgentGymFixtureCaseV1["partition"];
+
+export interface AgentGymCorpusCoveragePolicyV1 {
+  readonly minimum_partition_cases: Readonly<Record<Partition, number>>;
+  readonly policy_ref: string;
+  readonly required_slices: readonly {
+    readonly label: string;
+    readonly minimum_case_count: number;
+    readonly partition: Partition;
+  }[];
+  readonly schema_version: "agent-gym-corpus-coverage-policy/v1";
+}
+
+export interface AgentGymCorpusCoverageGapV1 {
+  readonly actual_case_count: number;
+  readonly gap_code: "corpus.partition_underfilled" | "corpus.slice_underfilled";
+  readonly label?: string;
+  readonly minimum_case_count: number;
+  readonly partition: Partition;
+}
+
+export interface AgentGymCorpusCoverageReportV1 {
+  readonly corpus_digest: string;
+  readonly gaps: readonly AgentGymCorpusCoverageGapV1[];
+  readonly passed: boolean;
+  readonly policy_ref: string;
+  readonly schema_version: "agent-gym-corpus-coverage-report/v1";
+}
+
+/** Evaluates explicit partition and label-slice coverage requirements. */
+export function evaluateAgentGymCorpusCoverage(
+  fixtures: readonly AgentGymFixtureCaseV1[],
+  policy: AgentGymCorpusCoveragePolicyV1,
+): AgentGymCorpusCoverageReportV1 {
+  validatePolicy(policy);
+  const manifest = createAgentGymCorpusManifest(fixtures);
+  const values = fixtures.map(validateAgentGymFixtureCase);
+  const gaps: AgentGymCorpusCoverageGapV1[] = [];
+  for (const partition of ["held_out", "shadow", "train"] as const) {
+    const actual = values.filter((fixture) => fixture.partition === partition).length;
+    const minimum = policy.minimum_partition_cases[partition];
+    if (actual < minimum) gaps.push({
+      actual_case_count: actual,
+      gap_code: "corpus.partition_underfilled",
+      minimum_case_count: minimum,
+      partition,
+    });
+  }
+  for (const slice of policy.required_slices) {
+    const actual = values.filter((fixture) =>
+      fixture.partition === slice.partition && fixture.labels.includes(slice.label)
+    ).length;
+    if (actual < slice.minimum_case_count) gaps.push({
+      actual_case_count: actual,
+      gap_code: "corpus.slice_underfilled",
+      label: slice.label,
+      minimum_case_count: slice.minimum_case_count,
+      partition: slice.partition,
+    });
+  }
+  return Object.freeze({
+    corpus_digest: manifest.corpus_digest,
+    gaps: Object.freeze(gaps.map((gap) => Object.freeze(gap))),
+    passed: gaps.length === 0,
+    policy_ref: policy.policy_ref,
+    schema_version: "agent-gym-corpus-coverage-report/v1",
+  });
+}
+
+function validatePolicy(policy: AgentGymCorpusCoveragePolicyV1): void {
+  if (policy.schema_version !== "agent-gym-corpus-coverage-policy/v1"
+    || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(policy.policy_ref)
+    || policy.policy_ref.length > 240
+    || policy.required_slices.length > 256) invalid();
+  for (const partition of ["held_out", "shadow", "train"] as const) {
+    count(policy.minimum_partition_cases[partition], true);
+  }
+  const identities = new Set<string>();
+  for (const slice of policy.required_slices) {
+    if (!["held_out", "shadow", "train"].includes(slice.partition)
+      || !slice.label.trim() || slice.label.length > 160
+      || /[\u0000-\u001f\u007f]/u.test(slice.label)) invalid();
+    count(slice.minimum_case_count, false);
+    const identity = `${slice.partition}\0${slice.label}`;
+    if (identities.has(identity)) invalid();
+    identities.add(identity);
+  }
+}
+
+function count(value: number, allowZero: boolean): void {
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1) || value > 100_000) invalid();
+}
+
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym corpus coverage policy is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/corpus-leakage.ts
+++ b/apps/slack-companion/src/agent-gym/corpus-leakage.ts
@@ -1,0 +1,55 @@
+import { createAgentGymCorpusManifest } from "./corpus-manifest.js";
+import {
+  agentGymFixtureScenarioDigest,
+  validateAgentGymFixtureCase,
+  type AgentGymFixtureCaseV1,
+} from "./fixture-case.js";
+
+export interface AgentGymCorpusLeakageFindingV1 {
+  readonly case_refs: readonly string[];
+  readonly finding_code: "corpus.duplicate_scenario" | "corpus.partition_leakage";
+  readonly partitions: readonly AgentGymFixtureCaseV1["partition"][];
+  readonly scenario_digest: string;
+}
+
+export interface AgentGymCorpusLeakageReportV1 {
+  readonly corpus_digest: string;
+  readonly findings: readonly AgentGymCorpusLeakageFindingV1[];
+  readonly passed: boolean;
+  readonly schema_version: "agent-gym-corpus-leakage-report/v1";
+}
+
+/** Finds repeated scenarios, including train-to-evaluation partition leakage. */
+export function auditAgentGymCorpusLeakage(
+  fixtures: readonly AgentGymFixtureCaseV1[],
+): AgentGymCorpusLeakageReportV1 {
+  const manifest = createAgentGymCorpusManifest(fixtures);
+  const scenarios = new Map<string, { case_ref: string; partition: AgentGymFixtureCaseV1["partition"] }[]>();
+  for (const fixture of fixtures) {
+    const value = validateAgentGymFixtureCase(fixture);
+    const digest = agentGymFixtureScenarioDigest(value);
+    const entries = scenarios.get(digest) ?? [];
+    entries.push({ case_ref: value.case_ref, partition: value.partition });
+    scenarios.set(digest, entries);
+  }
+  const findings = [...scenarios.entries()]
+    .filter(([, entries]) => entries.length > 1)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([scenario_digest, entries]) => {
+      const partitions = [...new Set(entries.map((entry) => entry.partition))].sort();
+      return Object.freeze({
+        case_refs: Object.freeze(entries.map((entry) => entry.case_ref).sort()),
+        finding_code: partitions.length > 1
+          ? "corpus.partition_leakage" as const
+          : "corpus.duplicate_scenario" as const,
+        partitions: Object.freeze(partitions),
+        scenario_digest,
+      });
+    });
+  return Object.freeze({
+    corpus_digest: manifest.corpus_digest,
+    findings: Object.freeze(findings),
+    passed: findings.length === 0,
+    schema_version: "agent-gym-corpus-leakage-report/v1",
+  });
+}

--- a/apps/slack-companion/src/agent-gym/corpus-quality.ts
+++ b/apps/slack-companion/src/agent-gym/corpus-quality.ts
@@ -1,0 +1,82 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import type { AgentGymCorpusAdmissionDecisionV1 } from "./corpus-admission.js";
+import type { AgentGymCorpusBuildReceiptV1 } from "./corpus-build.js";
+import { AgentGymContractError } from "./contract-error.js";
+
+export interface AgentGymCorpusQualityReceiptV1 {
+  readonly admitted: boolean;
+  readonly admission_decision_digest: string;
+  readonly blocker_codes: AgentGymCorpusAdmissionDecisionV1["blocker_codes"];
+  readonly build_receipt_digest: string;
+  readonly corpus_digest: string;
+  readonly evaluated_at: string;
+  readonly evaluation_ref: string;
+  readonly receipt_digest: string;
+  readonly schema_version: "agent-gym-corpus-quality-receipt/v1";
+}
+
+/** Binds a source build to the exact deterministic corpus admission result. */
+export function recordAgentGymCorpusQuality(
+  build: AgentGymCorpusBuildReceiptV1,
+  decision: AgentGymCorpusAdmissionDecisionV1,
+  input: { readonly evaluated_at: string; readonly evaluation_ref: string },
+): AgentGymCorpusQualityReceiptV1 {
+  reference(input.evaluation_ref);
+  timestamp(input.evaluated_at);
+  if (build.schema_version !== "agent-gym-corpus-build-receipt/v1"
+    || decision.schema_version !== "agent-gym-corpus-admission-decision/v1"
+    || build.corpus_digest !== decision.corpus_digest
+    || build.receipt_digest !== digestAgentGymJson(buildBody(build))
+    || decision.decision_digest !== digestAgentGymJson(decisionBody(decision))) invalid();
+  const body = {
+    admitted: decision.admitted,
+    admission_decision_digest: decision.decision_digest,
+    blocker_codes: decision.blocker_codes,
+    build_receipt_digest: build.receipt_digest,
+    corpus_digest: build.corpus_digest,
+    evaluated_at: input.evaluated_at,
+    evaluation_ref: input.evaluation_ref,
+    schema_version: "agent-gym-corpus-quality-receipt/v1" as const,
+  };
+  return Object.freeze({
+    ...body,
+    blocker_codes: Object.freeze([...decision.blocker_codes]),
+    receipt_digest: digestAgentGymJson(body),
+  });
+}
+
+function buildBody(value: AgentGymCorpusBuildReceiptV1) {
+  return {
+    build_ref: value.build_ref,
+    built_at: value.built_at,
+    case_count: value.case_count,
+    corpus_digest: value.corpus_digest,
+    inventory_digest: value.inventory_digest,
+    schema_version: value.schema_version,
+    source_revision: value.source_revision,
+  };
+}
+
+function decisionBody(value: AgentGymCorpusAdmissionDecisionV1) {
+  return {
+    admitted: value.admitted,
+    blocker_codes: value.blocker_codes,
+    corpus_digest: value.corpus_digest,
+    coverage_gap_count: value.coverage_gap_count,
+    coverage_policy_ref: value.coverage_policy_ref,
+    leakage_finding_count: value.leakage_finding_count,
+    schema_version: value.schema_version,
+  };
+}
+
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym corpus quality receipt is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/fixture-case.ts
+++ b/apps/slack-companion/src/agent-gym/fixture-case.ts
@@ -68,6 +68,25 @@ export function agentGymFixtureCaseDigest(fixture: AgentGymFixtureCaseV1): strin
   });
 }
 
+/** Identifies scenario content independently of case metadata and partition. */
+export function agentGymFixtureScenarioDigest(fixture: AgentGymFixtureCaseV1): string {
+  const value = validateAgentGymFixtureCase(fixture);
+  return digestAgentGymJson({
+    expected_invariants: value.expected_invariants,
+    slack_events: value.slack_events.map((event) => ({
+      kind: event.kind,
+      payload: event.payload,
+    })),
+    tool_fixtures: value.tool_fixtures.map((tool) => ({
+      ...(tool.error_code === undefined ? {} : { error_code: tool.error_code }),
+      input: tool.input,
+      outcome: tool.outcome,
+      ...(tool.output === undefined ? {} : { output: tool.output }),
+      tool_id: tool.tool_id,
+    })),
+  });
+}
+
 const EVENT_KINDS: readonly AgentGymSlackEventKind[] = [
   "app_home_opened", "button_action", "direct_message", "mention",
   "message_changed", "message_deleted", "reaction_added", "thread_reply",

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -9,6 +9,7 @@ export * from "./canonical-json.js";
 export * from "./corpus-manifest.js";
 export * from "./corpus-inventory.js";
 export * from "./corpus-build.js";
+export * from "./corpus-leakage.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -11,6 +11,7 @@ export * from "./corpus-inventory.js";
 export * from "./corpus-build.js";
 export * from "./corpus-leakage.js";
 export * from "./corpus-coverage.js";
+export * from "./corpus-admission.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -12,6 +12,7 @@ export * from "./corpus-build.js";
 export * from "./corpus-leakage.js";
 export * from "./corpus-coverage.js";
 export * from "./corpus-admission.js";
+export * from "./corpus-quality.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -10,6 +10,7 @@ export * from "./corpus-manifest.js";
 export * from "./corpus-inventory.js";
 export * from "./corpus-build.js";
 export * from "./corpus-leakage.js";
+export * from "./corpus-coverage.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/test/agent-gym-corpus-quality.test.ts
+++ b/apps/slack-companion/test/agent-gym-corpus-quality.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   agentGymFixtureScenarioDigest,
   auditAgentGymCorpusLeakage,
+  evaluateAgentGymCorpusCoverage,
 } from "../src/index.js";
 
 test("scenario digests ignore case metadata and partition", () => {
@@ -56,6 +57,44 @@ test("corpus leakage passes distinct replay scenarios", () => {
   assert.equal(report.passed, true);
   assert.deepEqual(report.findings, []);
 });
+
+test("corpus coverage names missing partitions and protected slices", () => {
+  const report = evaluateAgentGymCorpusCoverage([fixtureCase("train")], coveragePolicy());
+  assert.equal(report.passed, false);
+  assert.deepEqual(report.gaps, [
+    {
+      actual_case_count: 0,
+      gap_code: "corpus.partition_underfilled",
+      minimum_case_count: 1,
+      partition: "held_out",
+    },
+    {
+      actual_case_count: 0,
+      gap_code: "corpus.slice_underfilled",
+      label: "safety",
+      minimum_case_count: 1,
+      partition: "held_out",
+    },
+  ]);
+});
+
+test("corpus coverage passes explicit partition and slice minimums", () => {
+  const report = evaluateAgentGymCorpusCoverage([
+    fixtureCase("train"),
+    fixtureCase("held-out", "held_out", ["safety"]),
+  ], coveragePolicy());
+  assert.equal(report.passed, true);
+  assert.deepEqual(report.gaps, []);
+});
+
+function coveragePolicy() {
+  return {
+    minimum_partition_cases: { held_out: 1, shadow: 0, train: 1 },
+    policy_ref: "agent-gym-corpus-policy://default/v1",
+    required_slices: [{ label: "safety", minimum_case_count: 1, partition: "held_out" as const }],
+    schema_version: "agent-gym-corpus-coverage-policy/v1" as const,
+  };
+}
 
 function fixtureCase(
   suffix: string,

--- a/apps/slack-companion/test/agent-gym-corpus-quality.test.ts
+++ b/apps/slack-companion/test/agent-gym-corpus-quality.test.ts
@@ -4,8 +4,10 @@ import test from "node:test";
 import {
   agentGymFixtureScenarioDigest,
   auditAgentGymCorpusLeakage,
+  buildAgentGymCorpus,
   decideAgentGymCorpusAdmission,
   evaluateAgentGymCorpusCoverage,
+  recordAgentGymCorpusQuality,
 } from "../src/index.js";
 
 test("scenario digests ignore case metadata and partition", () => {
@@ -107,6 +109,42 @@ test("corpus admission accepts covered and isolated scenarios", () => {
   assert.equal(decision.admitted, true);
   assert.deepEqual(decision.blocker_codes, []);
 });
+
+test("corpus quality receipts bind source build and admission evidence", () => {
+  const fixtures = isolatedCorpus();
+  const receipt = recordAgentGymCorpusQuality(
+    buildAgentGymCorpus(fixtures, buildInput()),
+    decideAgentGymCorpusAdmission(fixtures, coveragePolicy()),
+    { evaluated_at: "2026-08-12T10:30:00.000Z", evaluation_ref: "agent-gym-quality://nightly/one" },
+  );
+  assert.equal(receipt.admitted, true);
+  assert.match(receipt.receipt_digest, /^sha256:[0-9a-f]{64}$/u);
+});
+
+test("corpus quality receipts reject a decision for another corpus", () => {
+  const fixtures = isolatedCorpus();
+  assert.throws(() => recordAgentGymCorpusQuality(
+    buildAgentGymCorpus([fixtureCase("train")], buildInput()),
+    decideAgentGymCorpusAdmission(fixtures, coveragePolicy()),
+    { evaluated_at: "2026-08-12T10:30:00.000Z", evaluation_ref: "agent-gym-quality://nightly/one" },
+  ), /quality receipt is invalid/u);
+});
+
+function isolatedCorpus() {
+  const heldOut = fixtureCase("held-out", "held_out", ["safety"]);
+  return [
+    fixtureCase("train"),
+    { ...heldOut, slack_events: [{ ...heldOut.slack_events[0]!, payload: { text: "Held-out alert." } }] },
+  ];
+}
+
+function buildInput() {
+  return {
+    build_ref: "agent-gym-corpus-build://nightly/quality",
+    built_at: "2026-08-12T10:25:00.000Z",
+    source_revision: "source-revision://cerebro/quality",
+  };
+}
 
 function coveragePolicy() {
   return {

--- a/apps/slack-companion/test/agent-gym-corpus-quality.test.ts
+++ b/apps/slack-companion/test/agent-gym-corpus-quality.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   agentGymFixtureScenarioDigest,
   auditAgentGymCorpusLeakage,
+  decideAgentGymCorpusAdmission,
   evaluateAgentGymCorpusCoverage,
 } from "../src/index.js";
 
@@ -85,6 +86,26 @@ test("corpus coverage passes explicit partition and slice minimums", () => {
   ], coveragePolicy());
   assert.equal(report.passed, true);
   assert.deepEqual(report.gaps, []);
+});
+
+test("corpus admission fails closed with stable blocker codes", () => {
+  const decision = decideAgentGymCorpusAdmission([
+    fixtureCase("train"),
+    fixtureCase("held-out", "held_out", ["safety"]),
+  ], coveragePolicy());
+  assert.equal(decision.admitted, false);
+  assert.deepEqual(decision.blocker_codes, ["corpus.partition_leakage"]);
+  assert.match(decision.decision_digest, /^sha256:[0-9a-f]{64}$/u);
+});
+
+test("corpus admission accepts covered and isolated scenarios", () => {
+  const heldOut = fixtureCase("held-out", "held_out", ["safety"]);
+  const decision = decideAgentGymCorpusAdmission([
+    fixtureCase("train"),
+    { ...heldOut, slack_events: [{ ...heldOut.slack_events[0]!, payload: { text: "Held-out alert." } }] },
+  ], coveragePolicy());
+  assert.equal(decision.admitted, true);
+  assert.deepEqual(decision.blocker_codes, []);
 });
 
 function coveragePolicy() {

--- a/apps/slack-companion/test/agent-gym-corpus-quality.test.ts
+++ b/apps/slack-companion/test/agent-gym-corpus-quality.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { agentGymFixtureScenarioDigest } from "../src/index.js";
+import {
+  agentGymFixtureScenarioDigest,
+  auditAgentGymCorpusLeakage,
+} from "../src/index.js";
 
 test("scenario digests ignore case metadata and partition", () => {
   const renamed = fixtureCase("two", "held_out", ["regression"]);
@@ -32,6 +35,26 @@ test("scenario digests change when replay content changes", () => {
     agentGymFixtureScenarioDigest(first),
     agentGymFixtureScenarioDigest(second),
   );
+});
+
+test("corpus leakage reports scenarios copied into held-out evaluation", () => {
+  const report = auditAgentGymCorpusLeakage([
+    fixtureCase("train", "train"),
+    fixtureCase("evaluation", "held_out"),
+  ]);
+  assert.equal(report.passed, false);
+  assert.equal(report.findings[0]?.finding_code, "corpus.partition_leakage");
+  assert.deepEqual(report.findings[0]?.partitions, ["held_out", "train"]);
+});
+
+test("corpus leakage passes distinct replay scenarios", () => {
+  const second = fixtureCase("held-out", "held_out");
+  const report = auditAgentGymCorpusLeakage([
+    fixtureCase("train"),
+    { ...second, slack_events: [{ ...second.slack_events[0]!, payload: { text: "Another alert." } }] },
+  ]);
+  assert.equal(report.passed, true);
+  assert.deepEqual(report.findings, []);
 });
 
 function fixtureCase(

--- a/apps/slack-companion/test/agent-gym-corpus-quality.test.ts
+++ b/apps/slack-companion/test/agent-gym-corpus-quality.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { agentGymFixtureScenarioDigest } from "../src/index.js";
+
+test("scenario digests ignore case metadata and partition", () => {
+  const renamed = fixtureCase("two", "held_out", ["regression"]);
+  assert.equal(
+    agentGymFixtureScenarioDigest(fixtureCase("one", "train", ["support"])),
+    agentGymFixtureScenarioDigest({
+      ...renamed,
+      slack_events: [{
+        ...renamed.slack_events[0]!,
+        event_ref: "slack-event://quality/renamed",
+        occurred_at: "2026-08-13T08:00:00.000Z",
+      }],
+      tool_fixtures: [{
+        ...renamed.tool_fixtures[0]!,
+        call_ref: "tool-call://quality/renamed",
+      }],
+    }),
+  );
+});
+
+test("scenario digests change when replay content changes", () => {
+  const first = fixtureCase("one");
+  const second = {
+    ...fixtureCase("two"),
+    slack_events: [{ ...fixtureCase("two").slack_events[0]!, payload: { text: "Different request." } }],
+  };
+  assert.notEqual(
+    agentGymFixtureScenarioDigest(first),
+    agentGymFixtureScenarioDigest(second),
+  );
+});
+
+function fixtureCase(
+  suffix: string,
+  partition: "held_out" | "shadow" | "train" = "train",
+  labels: readonly string[] = ["support"],
+) {
+  return {
+    case_ref: `agent-gym-case://quality/${suffix}`,
+    expected_invariants: ["answer-grounded"],
+    labels,
+    partition,
+    schema_version: "agent-gym-fixture-case/v1" as const,
+    slack_events: [{
+      event_ref: "slack-event://quality/one",
+      kind: "mention" as const,
+      occurred_at: "2026-08-12T10:20:00.000Z",
+      payload: { text: "Help with this alert." },
+    }],
+    tool_fixtures: [{
+      call_ref: "tool-call://quality/one",
+      input: { alert_ref: "alert://quality/one" },
+      outcome: "success" as const,
+      output: { severity: "high" },
+      tool_id: "alerts.read",
+    }],
+  };
+}


### PR DESCRIPTION
## Summary
- identify replay scenarios independently from mutable corpus metadata
- detect cross-partition scenario leakage and enforce explicit coverage policy
- fail corpus admission closed and emit content-bound quality receipts

## Verification
- DDESK TypeScript typecheck
- DDESK focused Agent Gym corpus tests: 10 passed
- DDESK full Slack companion suite before rebase: 631 passed

Part of the Agent Gym delivery sequence (commits 56–60 of 200).