### PR TITLE
feat(slack): gate agent gym evaluators

### DIFF
--- a/apps/slack-companion/src/agent-gym/case-evaluation.ts
+++ b/apps/slack-companion/src/agent-gym/case-evaluation.ts
@@ -1,0 +1,170 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  defineAgentGymEvaluatorManifest,
+  type AgentGymEvaluatorManifestV1,
+} from "./evaluator-manifest.js";
+import {
+  defineAgentGymEvaluatorRubric,
+  type AgentGymEvaluatorRubricV1,
+} from "./evaluator-rubric.js";
+
+export interface AgentGymMetricEvaluationV1 {
+  readonly evaluator_digest: string;
+  readonly metric_id: string;
+  readonly reason_codes: readonly string[];
+  readonly score: number;
+}
+
+export interface AgentGymCaseEvaluationV1 {
+  readonly blocker_codes: readonly string[];
+  readonly candidate_ref: string;
+  readonly case_ref: string;
+  readonly evaluated_at: string;
+  readonly evaluation_digest: string;
+  readonly evaluation_ref: string;
+  readonly evaluator_digests: readonly string[];
+  readonly invalid_reason_codes: readonly string[];
+  readonly metrics: readonly AgentGymMetricEvaluationV1[];
+  readonly replay_ref: string;
+  readonly rubric_digest: string;
+  readonly schema_version: "agent-gym-case-evaluation/v1";
+  readonly valid: boolean;
+  readonly weighted_score: number | null;
+}
+
+export interface AgentGymCaseEvaluationInputV1 {
+  readonly candidate_ref: string;
+  readonly case_ref: string;
+  readonly evaluated_at: string;
+  readonly evaluation_ref: string;
+  readonly invalid_reason_codes: readonly string[];
+  readonly metrics: readonly AgentGymMetricEvaluationV1[];
+  readonly replay_ref: string;
+  readonly schema_version: "agent-gym-case-evaluation/v1";
+  readonly valid: boolean;
+}
+
+/** Records valid scores or an explicit invalid evaluator result, never both. */
+export function recordAgentGymCaseEvaluation(
+  rubric: AgentGymEvaluatorRubricV1,
+  evaluators: readonly AgentGymEvaluatorManifestV1[],
+  input: AgentGymCaseEvaluationInputV1,
+): AgentGymCaseEvaluationV1 {
+  validateRubric(rubric);
+  const evaluatorByKind = validateEvaluators(evaluators, rubric.rubric_digest);
+  if (input.schema_version !== "agent-gym-case-evaluation/v1") invalid();
+  for (const value of [input.candidate_ref, input.case_ref, input.evaluation_ref, input.replay_ref]) reference(value);
+  timestamp(input.evaluated_at);
+  strings(input.invalid_reason_codes, 32, input.valid ? "empty" : "nonempty");
+  if (!input.valid && input.metrics.length !== 0) invalid();
+  const metrics = input.valid
+    ? validateMetrics(input.metrics, rubric, evaluatorByKind)
+    : Object.freeze([] as AgentGymMetricEvaluationV1[]);
+  const blockerCodes = input.valid ? rubric.metrics
+    .filter((metric, index) => metric.blocking && metrics[index]!.score < metric.minimum_score)
+    .map((metric) => `metric.${metric.metric_id}.below_minimum`) : [];
+  const totalWeight = rubric.metrics.reduce((total, metric) => total + metric.weight, 0);
+  const weightedScore = input.valid
+    ? metrics.reduce((total, metric, index) => total + metric.score * rubric.metrics[index]!.weight, 0) / totalWeight
+    : null;
+  const evaluatorDigests = [...evaluators.map((value) => value.evaluator_digest)].sort();
+  const body = {
+    blocker_codes: blockerCodes,
+    candidate_ref: input.candidate_ref,
+    case_ref: input.case_ref,
+    evaluated_at: input.evaluated_at,
+    evaluation_ref: input.evaluation_ref,
+    evaluator_digests: evaluatorDigests,
+    invalid_reason_codes: [...input.invalid_reason_codes],
+    metrics: metrics.map((metric) => ({ ...metric, reason_codes: [...metric.reason_codes] })),
+    replay_ref: input.replay_ref,
+    rubric_digest: rubric.rubric_digest,
+    schema_version: input.schema_version,
+    valid: input.valid,
+    weighted_score: weightedScore,
+  };
+  return Object.freeze({
+    ...body,
+    blocker_codes: Object.freeze(blockerCodes),
+    evaluator_digests: Object.freeze(evaluatorDigests),
+    invalid_reason_codes: Object.freeze([...input.invalid_reason_codes]),
+    metrics,
+    evaluation_digest: digestAgentGymJson(body),
+  });
+}
+
+function validateRubric(value: AgentGymEvaluatorRubricV1): void {
+  const expected = defineAgentGymEvaluatorRubric({
+    metrics: value.metrics,
+    rubric_ref: value.rubric_ref,
+    schema_version: value.schema_version,
+  });
+  if (expected.rubric_digest !== value.rubric_digest) invalid();
+}
+
+function validateEvaluators(
+  values: readonly AgentGymEvaluatorManifestV1[],
+  rubricDigest: string,
+): ReadonlyMap<AgentGymEvaluatorManifestV1["evaluator_kind"], AgentGymEvaluatorManifestV1> {
+  if (!Array.isArray(values) || values.length === 0 || values.length > 2) invalid();
+  const byKind = new Map<AgentGymEvaluatorManifestV1["evaluator_kind"], AgentGymEvaluatorManifestV1>();
+  for (const value of values) {
+    const expected = defineAgentGymEvaluatorManifest({
+      evaluator_kind: value.evaluator_kind,
+      evaluator_ref: value.evaluator_ref,
+      implementation_digest: value.implementation_digest,
+      ...(value.model === undefined ? {} : { model: value.model }),
+      output_schema_digest: value.output_schema_digest,
+      rubric_digest: value.rubric_digest,
+      schema_version: value.schema_version,
+    });
+    if (expected.evaluator_digest !== value.evaluator_digest
+      || value.rubric_digest !== rubricDigest || byKind.has(value.evaluator_kind)) invalid();
+    byKind.set(value.evaluator_kind, value);
+  }
+  return byKind;
+}
+
+function validateMetrics(
+  values: readonly AgentGymMetricEvaluationV1[],
+  rubric: AgentGymEvaluatorRubricV1,
+  evaluators: ReadonlyMap<AgentGymEvaluatorManifestV1["evaluator_kind"], AgentGymEvaluatorManifestV1>,
+): readonly AgentGymMetricEvaluationV1[] {
+  if (!Array.isArray(values) || values.length !== rubric.metrics.length) invalid();
+  return Object.freeze(values.map((value, index) => {
+    const metric = rubric.metrics[index]!;
+    const evaluator = evaluators.get(metric.evaluator_kind);
+    if (value.metric_id !== metric.metric_id || value.evaluator_digest !== evaluator?.evaluator_digest) invalid();
+    unit(value.score);
+    strings(value.reason_codes, 32, "any");
+    return Object.freeze({ ...value, reason_codes: Object.freeze([...value.reason_codes]) });
+  }));
+}
+
+function strings(
+  values: readonly string[],
+  maximum: number,
+  emptiness: "any" | "empty" | "nonempty",
+): void {
+  if (!Array.isArray(values) || values.length > maximum || new Set(values).size !== values.length
+    || (emptiness === "empty" && values.length !== 0)
+    || (emptiness === "nonempty" && values.length === 0)) invalid();
+  for (const value of values) bounded(value, 160);
+}
+function bounded(value: string, maximum: number): void {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function unit(value: number): void {
+  if (!Number.isFinite(value) || value < 0 || value > 1) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym case evaluation is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/evaluator-admission.ts
+++ b/apps/slack-companion/src/agent-gym/evaluator-admission.ts
@@ -1,0 +1,181 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import type { AgentGymEvaluatorCalibrationV1 } from "./evaluator-calibration.js";
+import {
+  defineAgentGymEvaluatorManifest,
+  type AgentGymEvaluatorManifestV1,
+} from "./evaluator-manifest.js";
+import {
+  defineAgentGymEvaluatorRubric,
+  type AgentGymEvaluatorRubricV1,
+} from "./evaluator-rubric.js";
+
+export type AgentGymEvaluatorAdmissionBlockerCode =
+  | "evaluator.calibration_failed"
+  | "evaluator.calibration_future"
+  | "evaluator.calibration_missing"
+  | "evaluator.calibration_policy_mismatch"
+  | "evaluator.calibration_stale"
+  | "evaluator.calibration_dataset_mismatch"
+  | "evaluator.kind_missing"
+  | "evaluator.rubric_mismatch";
+
+export interface AgentGymEvaluatorAdmissionPolicyV1 {
+  readonly maximum_calibration_age_ms: number;
+  readonly policy_ref: string;
+  readonly required_calibration_dataset_digest: string;
+  readonly required_calibration_policy_digest: string;
+  readonly schema_version: "agent-gym-evaluator-admission-policy/v1";
+}
+
+export interface AgentGymEvaluatorAdmissionDecisionV1 {
+  readonly admitted: boolean;
+  readonly blocker_codes: readonly AgentGymEvaluatorAdmissionBlockerCode[];
+  readonly calibration_digests: readonly string[];
+  readonly decided_at: string;
+  readonly decision_digest: string;
+  readonly evaluator_digests: readonly string[];
+  readonly policy_ref: string;
+  readonly rubric_digest: string;
+  readonly schema_version: "agent-gym-evaluator-admission-decision/v1";
+}
+
+/** Fails evaluator admission closed when identity or calibration evidence is incomplete. */
+export function decideAgentGymEvaluatorAdmission(
+  rubric: AgentGymEvaluatorRubricV1,
+  evaluators: readonly AgentGymEvaluatorManifestV1[],
+  calibrations: readonly AgentGymEvaluatorCalibrationV1[],
+  policy: AgentGymEvaluatorAdmissionPolicyV1,
+  decidedAt: string,
+): AgentGymEvaluatorAdmissionDecisionV1 {
+  validateRubric(rubric);
+  validatePolicy(policy);
+  timestamp(decidedAt);
+  if (!Array.isArray(evaluators) || evaluators.length === 0 || evaluators.length > 2
+    || !Array.isArray(calibrations) || calibrations.length > 2) invalid();
+  const blockerCodes = new Set<AgentGymEvaluatorAdmissionBlockerCode>();
+  const evaluatorByKind = new Map<AgentGymEvaluatorManifestV1["evaluator_kind"], AgentGymEvaluatorManifestV1>();
+  for (const evaluator of evaluators) {
+    validateEvaluator(evaluator);
+    if (evaluatorByKind.has(evaluator.evaluator_kind)) invalid();
+    evaluatorByKind.set(evaluator.evaluator_kind, evaluator);
+    if (evaluator.rubric_digest !== rubric.rubric_digest) blockerCodes.add("evaluator.rubric_mismatch");
+  }
+  const requiredKinds = new Set(rubric.metrics.map((metric) => metric.evaluator_kind));
+  for (const kind of requiredKinds) if (!evaluatorByKind.has(kind)) blockerCodes.add("evaluator.kind_missing");
+  const calibrationByEvaluator = new Map<string, AgentGymEvaluatorCalibrationV1>();
+  const modelJudgeDigests = new Set(evaluators
+    .filter((value) => value.evaluator_kind === "model_judge")
+    .map((value) => value.evaluator_digest));
+  for (const calibration of calibrations) {
+    validateCalibration(calibration);
+    if (!modelJudgeDigests.has(calibration.evaluator_digest)
+      || calibrationByEvaluator.has(calibration.evaluator_digest)) invalid();
+    calibrationByEvaluator.set(calibration.evaluator_digest, calibration);
+  }
+  const decidedTime = Date.parse(decidedAt);
+  for (const evaluator of evaluators) {
+    if (evaluator.evaluator_kind !== "model_judge") continue;
+    const calibration = calibrationByEvaluator.get(evaluator.evaluator_digest);
+    if (calibration === undefined) {
+      blockerCodes.add("evaluator.calibration_missing");
+      continue;
+    }
+    if (!calibration.passed) blockerCodes.add("evaluator.calibration_failed");
+    if (calibration.calibration_dataset_digest !== policy.required_calibration_dataset_digest) {
+      blockerCodes.add("evaluator.calibration_dataset_mismatch");
+    }
+    if (calibration.policy_digest !== policy.required_calibration_policy_digest) {
+      blockerCodes.add("evaluator.calibration_policy_mismatch");
+    }
+    const calibratedTime = Date.parse(calibration.calibrated_at);
+    if (calibratedTime > decidedTime) blockerCodes.add("evaluator.calibration_future");
+    if (decidedTime - calibratedTime > policy.maximum_calibration_age_ms) {
+      blockerCodes.add("evaluator.calibration_stale");
+    }
+  }
+  const blockers = [...blockerCodes].sort();
+  const body = {
+    admitted: blockers.length === 0,
+    blocker_codes: blockers,
+    calibration_digests: [...calibrations.map((value) => value.calibration_digest)].sort(),
+    decided_at: decidedAt,
+    evaluator_digests: [...evaluators.map((value) => value.evaluator_digest)].sort(),
+    policy_ref: policy.policy_ref,
+    rubric_digest: rubric.rubric_digest,
+    schema_version: "agent-gym-evaluator-admission-decision/v1" as const,
+  };
+  return Object.freeze({
+    ...body,
+    blocker_codes: Object.freeze(blockers),
+    calibration_digests: Object.freeze(body.calibration_digests),
+    evaluator_digests: Object.freeze(body.evaluator_digests),
+    decision_digest: digestAgentGymJson(body),
+  });
+}
+
+function validateRubric(value: AgentGymEvaluatorRubricV1): void {
+  if (defineAgentGymEvaluatorRubric({
+    metrics: value.metrics,
+    rubric_ref: value.rubric_ref,
+    schema_version: value.schema_version,
+  }).rubric_digest !== value.rubric_digest) invalid();
+}
+function validateEvaluator(value: AgentGymEvaluatorManifestV1): void {
+  if (defineAgentGymEvaluatorManifest({
+    evaluator_kind: value.evaluator_kind,
+    evaluator_ref: value.evaluator_ref,
+    implementation_digest: value.implementation_digest,
+    ...(value.model === undefined ? {} : { model: value.model }),
+    output_schema_digest: value.output_schema_digest,
+    rubric_digest: value.rubric_digest,
+    schema_version: value.schema_version,
+  }).evaluator_digest !== value.evaluator_digest) invalid();
+}
+function validateCalibration(value: AgentGymEvaluatorCalibrationV1): void {
+  if (value.schema_version !== "agent-gym-evaluator-calibration/v1") invalid();
+  timestamp(value.calibrated_at);
+  for (const digest of [value.calibration_dataset_digest, value.evaluator_digest,
+    value.calibration_digest, value.policy_digest]) digestValue(digest);
+  reference(value.policy_ref);
+  unit(value.maximum_absolute_error);
+  unit(value.mean_absolute_error);
+  if (value.mean_absolute_error > value.maximum_absolute_error
+    || !Number.isSafeInteger(value.sample_count) || value.sample_count < 0 || value.sample_count > 10_000) invalid();
+  const body = {
+    calibration_dataset_digest: value.calibration_dataset_digest,
+    calibrated_at: value.calibrated_at,
+    evaluator_digest: value.evaluator_digest,
+    maximum_absolute_error: value.maximum_absolute_error,
+    mean_absolute_error: value.mean_absolute_error,
+    passed: value.passed,
+    policy_digest: value.policy_digest,
+    policy_ref: value.policy_ref,
+    sample_count: value.sample_count,
+    schema_version: value.schema_version,
+  };
+  if (digestAgentGymJson(body) !== value.calibration_digest) invalid();
+}
+function validatePolicy(value: AgentGymEvaluatorAdmissionPolicyV1): void {
+  if (value.schema_version !== "agent-gym-evaluator-admission-policy/v1") invalid();
+  reference(value.policy_ref);
+  digestValue(value.required_calibration_dataset_digest);
+  digestValue(value.required_calibration_policy_digest);
+  if (!Number.isSafeInteger(value.maximum_calibration_age_ms)
+    || value.maximum_calibration_age_ms < 1 || value.maximum_calibration_age_ms > 366 * 24 * 60 * 60 * 1_000) invalid();
+}
+function digestValue(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function unit(value: number): void {
+  if (!Number.isFinite(value) || value < 0 || value > 1) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym evaluator admission is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/evaluator-calibration.ts
+++ b/apps/slack-companion/src/agent-gym/evaluator-calibration.ts
@@ -27,6 +27,7 @@ export interface AgentGymEvaluatorCalibrationV1 {
   readonly maximum_absolute_error: number;
   readonly mean_absolute_error: number;
   readonly passed: boolean;
+  readonly policy_digest: string;
   readonly policy_ref: string;
   readonly sample_count: number;
   readonly schema_version: "agent-gym-evaluator-calibration/v1";
@@ -45,6 +46,13 @@ export function calibrateAgentGymEvaluator(
   validateEvaluator(evaluator);
   if (evaluator.evaluator_kind !== "model_judge") invalid();
   validatePolicy(policy);
+  const policyDigest = digestAgentGymJson({
+    maximum_mean_absolute_error: policy.maximum_mean_absolute_error,
+    maximum_sample_absolute_error: policy.maximum_sample_absolute_error,
+    minimum_sample_count: policy.minimum_sample_count,
+    policy_ref: policy.policy_ref,
+    schema_version: policy.schema_version,
+  });
   timestamp(input.calibrated_at);
   digest(input.calibration_dataset_digest);
   if (!Array.isArray(input.samples) || input.samples.length > 10_000) invalid();
@@ -70,6 +78,7 @@ export function calibrateAgentGymEvaluator(
     passed: errors.length >= policy.minimum_sample_count
       && meanAbsoluteError <= policy.maximum_mean_absolute_error
       && maximumAbsoluteError <= policy.maximum_sample_absolute_error,
+    policy_digest: policyDigest,
     policy_ref: policy.policy_ref,
     sample_count: errors.length,
     schema_version: "agent-gym-evaluator-calibration/v1" as const,

--- a/apps/slack-companion/src/agent-gym/evaluator-calibration.ts
+++ b/apps/slack-companion/src/agent-gym/evaluator-calibration.ts
@@ -1,0 +1,115 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  defineAgentGymEvaluatorManifest,
+  type AgentGymEvaluatorManifestV1,
+} from "./evaluator-manifest.js";
+
+export interface AgentGymCalibrationPolicyV1 {
+  readonly maximum_mean_absolute_error: number;
+  readonly maximum_sample_absolute_error: number;
+  readonly minimum_sample_count: number;
+  readonly policy_ref: string;
+  readonly schema_version: "agent-gym-calibration-policy/v1";
+}
+
+export interface AgentGymCalibrationSampleV1 {
+  readonly expected_score: number;
+  readonly observed_score: number;
+  readonly sample_ref: string;
+}
+
+export interface AgentGymEvaluatorCalibrationV1 {
+  readonly calibration_dataset_digest: string;
+  readonly calibration_digest: string;
+  readonly calibrated_at: string;
+  readonly evaluator_digest: string;
+  readonly maximum_absolute_error: number;
+  readonly mean_absolute_error: number;
+  readonly passed: boolean;
+  readonly policy_ref: string;
+  readonly sample_count: number;
+  readonly schema_version: "agent-gym-evaluator-calibration/v1";
+}
+
+/** Measures one model judge against a sealed human-labeled calibration set. */
+export function calibrateAgentGymEvaluator(
+  evaluator: AgentGymEvaluatorManifestV1,
+  policy: AgentGymCalibrationPolicyV1,
+  input: {
+    readonly calibrated_at: string;
+    readonly calibration_dataset_digest: string;
+    readonly samples: readonly AgentGymCalibrationSampleV1[];
+  },
+): AgentGymEvaluatorCalibrationV1 {
+  validateEvaluator(evaluator);
+  if (evaluator.evaluator_kind !== "model_judge") invalid();
+  validatePolicy(policy);
+  timestamp(input.calibrated_at);
+  digest(input.calibration_dataset_digest);
+  if (!Array.isArray(input.samples) || input.samples.length > 10_000) invalid();
+  const sampleRefs = new Set<string>();
+  const errors = input.samples.map((sample) => {
+    reference(sample.sample_ref);
+    if (sampleRefs.has(sample.sample_ref)) invalid();
+    sampleRefs.add(sample.sample_ref);
+    unit(sample.expected_score);
+    unit(sample.observed_score);
+    return Math.abs(sample.expected_score - sample.observed_score);
+  });
+  const meanAbsoluteError = errors.length === 0
+    ? 1
+    : errors.reduce((total, value) => total + value, 0) / errors.length;
+  const maximumAbsoluteError = errors.length === 0 ? 1 : Math.max(...errors);
+  const body = {
+    calibration_dataset_digest: input.calibration_dataset_digest,
+    calibrated_at: input.calibrated_at,
+    evaluator_digest: evaluator.evaluator_digest,
+    maximum_absolute_error: maximumAbsoluteError,
+    mean_absolute_error: meanAbsoluteError,
+    passed: errors.length >= policy.minimum_sample_count
+      && meanAbsoluteError <= policy.maximum_mean_absolute_error
+      && maximumAbsoluteError <= policy.maximum_sample_absolute_error,
+    policy_ref: policy.policy_ref,
+    sample_count: errors.length,
+    schema_version: "agent-gym-evaluator-calibration/v1" as const,
+  };
+  return Object.freeze({ ...body, calibration_digest: digestAgentGymJson(body) });
+}
+
+function validateEvaluator(value: AgentGymEvaluatorManifestV1): void {
+  const expected = defineAgentGymEvaluatorManifest({
+    evaluator_kind: value.evaluator_kind,
+    evaluator_ref: value.evaluator_ref,
+    implementation_digest: value.implementation_digest,
+    ...(value.model === undefined ? {} : { model: value.model }),
+    output_schema_digest: value.output_schema_digest,
+    rubric_digest: value.rubric_digest,
+    schema_version: value.schema_version,
+  });
+  if (expected.evaluator_digest !== value.evaluator_digest) invalid();
+}
+function validatePolicy(value: AgentGymCalibrationPolicyV1): void {
+  if (value.schema_version !== "agent-gym-calibration-policy/v1") invalid();
+  reference(value.policy_ref);
+  unit(value.maximum_mean_absolute_error);
+  unit(value.maximum_sample_absolute_error);
+  if (value.maximum_mean_absolute_error > value.maximum_sample_absolute_error
+    || !Number.isSafeInteger(value.minimum_sample_count)
+    || value.minimum_sample_count < 1 || value.minimum_sample_count > 10_000) invalid();
+}
+function digest(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function unit(value: number): void {
+  if (!Number.isFinite(value) || value < 0 || value > 1) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym evaluator calibration is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/evaluator-manifest.ts
+++ b/apps/slack-companion/src/agent-gym/evaluator-manifest.ts
@@ -1,0 +1,66 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+
+export interface AgentGymEvaluatorModelBindingV1 {
+  readonly inference_config_digest: string;
+  readonly model_ref: string;
+}
+
+export interface AgentGymEvaluatorManifestV1 {
+  readonly evaluator_digest: string;
+  readonly evaluator_kind: "deterministic" | "model_judge";
+  readonly evaluator_ref: string;
+  readonly implementation_digest: string;
+  readonly model?: AgentGymEvaluatorModelBindingV1;
+  readonly output_schema_digest: string;
+  readonly rubric_digest: string;
+  readonly schema_version: "agent-gym-evaluator-manifest/v1";
+}
+
+export type AgentGymEvaluatorManifestInputV1 = Omit<AgentGymEvaluatorManifestV1, "evaluator_digest">;
+
+/** Seals evaluator code, output schema, rubric, and optional model configuration. */
+export function defineAgentGymEvaluatorManifest(
+  input: AgentGymEvaluatorManifestInputV1,
+): AgentGymEvaluatorManifestV1 {
+  if (input.schema_version !== "agent-gym-evaluator-manifest/v1"
+    || !["deterministic", "model_judge"].includes(input.evaluator_kind)) invalid();
+  reference(input.evaluator_ref);
+  for (const value of [input.implementation_digest, input.output_schema_digest, input.rubric_digest]) digest(value);
+  if ((input.evaluator_kind === "model_judge") !== (input.model !== undefined)) invalid();
+  const model = input.model === undefined ? undefined : validateModel(input.model);
+  const modelBody = model === undefined ? undefined : {
+    inference_config_digest: model.inference_config_digest,
+    model_ref: model.model_ref,
+  };
+  const body = {
+    evaluator_kind: input.evaluator_kind,
+    evaluator_ref: input.evaluator_ref,
+    implementation_digest: input.implementation_digest,
+    ...(modelBody === undefined ? {} : { model: modelBody }),
+    output_schema_digest: input.output_schema_digest,
+    rubric_digest: input.rubric_digest,
+    schema_version: input.schema_version,
+  };
+  return Object.freeze({
+    ...body,
+    ...(modelBody === undefined ? {} : { model: Object.freeze(modelBody) }),
+    evaluator_digest: digestAgentGymJson(body),
+  });
+}
+
+function validateModel(value: AgentGymEvaluatorModelBindingV1): AgentGymEvaluatorModelBindingV1 {
+  reference(value.model_ref);
+  digest(value.inference_config_digest);
+  return { ...value };
+}
+
+function digest(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym evaluator manifest is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/evaluator-rubric.ts
+++ b/apps/slack-companion/src/agent-gym/evaluator-rubric.ts
@@ -1,0 +1,62 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+
+export interface AgentGymRubricMetricV1 {
+  readonly blocking: boolean;
+  readonly evaluator_kind: "deterministic" | "model_judge";
+  readonly metric_id: string;
+  readonly minimum_score: number;
+  readonly weight: number;
+}
+
+export interface AgentGymEvaluatorRubricV1 {
+  readonly metrics: readonly AgentGymRubricMetricV1[];
+  readonly rubric_digest: string;
+  readonly rubric_ref: string;
+  readonly schema_version: "agent-gym-evaluator-rubric/v1";
+}
+
+export type AgentGymEvaluatorRubricInputV1 = Omit<AgentGymEvaluatorRubricV1, "rubric_digest">;
+
+/** Seals the metric contract used to judge every candidate in a comparison. */
+export function defineAgentGymEvaluatorRubric(
+  input: AgentGymEvaluatorRubricInputV1,
+): AgentGymEvaluatorRubricV1 {
+  if (input.schema_version !== "agent-gym-evaluator-rubric/v1") invalid();
+  reference(input.rubric_ref);
+  if (!Array.isArray(input.metrics) || input.metrics.length === 0 || input.metrics.length > 128) invalid();
+  const metricIds = new Set<string>();
+  const metrics = input.metrics.map((metric) => {
+    bounded(metric.metric_id, 160);
+    if (metricIds.has(metric.metric_id)
+      || !["deterministic", "model_judge"].includes(metric.evaluator_kind)) invalid();
+    metricIds.add(metric.metric_id);
+    unit(metric.minimum_score);
+    if (!Number.isFinite(metric.weight) || metric.weight <= 0 || metric.weight > 100) invalid();
+    return Object.freeze({ ...metric });
+  });
+  const body = {
+    metrics: metrics.map((metric) => ({ ...metric })),
+    rubric_ref: input.rubric_ref,
+    schema_version: input.schema_version,
+  };
+  return Object.freeze({
+    ...body,
+    metrics: Object.freeze(metrics),
+    rubric_digest: digestAgentGymJson(body),
+  });
+}
+
+function bounded(value: string, maximum: number): void {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function unit(value: number): void {
+  if (!Number.isFinite(value) || value < 0 || value > 1) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym evaluator rubric is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -16,6 +16,7 @@ export * from "./corpus-quality.js";
 export * from "./evaluator-rubric.js";
 export * from "./evaluator-manifest.js";
 export * from "./case-evaluation.js";
+export * from "./evaluator-calibration.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -17,6 +17,7 @@ export * from "./evaluator-rubric.js";
 export * from "./evaluator-manifest.js";
 export * from "./case-evaluation.js";
 export * from "./evaluator-calibration.js";
+export * from "./evaluator-admission.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -13,6 +13,7 @@ export * from "./corpus-leakage.js";
 export * from "./corpus-coverage.js";
 export * from "./corpus-admission.js";
 export * from "./corpus-quality.js";
+export * from "./evaluator-rubric.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -14,6 +14,7 @@ export * from "./corpus-coverage.js";
 export * from "./corpus-admission.js";
 export * from "./corpus-quality.js";
 export * from "./evaluator-rubric.js";
+export * from "./evaluator-manifest.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -15,6 +15,7 @@ export * from "./corpus-admission.js";
 export * from "./corpus-quality.js";
 export * from "./evaluator-rubric.js";
 export * from "./evaluator-manifest.js";
+export * from "./case-evaluation.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/test/agent-gym-evaluator-control.test.ts
+++ b/apps/slack-companion/test/agent-gym-evaluator-control.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  calibrateAgentGymEvaluator,
   defineAgentGymEvaluatorManifest,
   defineAgentGymEvaluatorRubric,
   recordAgentGymCaseEvaluation,
@@ -64,6 +65,34 @@ test("invalid evaluator output cannot carry candidate scores", () => {
   }), /case evaluation is invalid/u);
 });
 
+test("model judge calibration measures a sealed labeled dataset", () => {
+  const evaluator = defineAgentGymEvaluatorManifest(modelJudgeManifestInput());
+  const calibration = calibrateAgentGymEvaluator(evaluator, calibrationPolicy(), {
+    calibrated_at: "2026-08-12T10:47:00.000Z",
+    calibration_dataset_digest: digest("f"),
+    samples: [
+      { expected_score: 0.9, observed_score: 0.85, sample_ref: "agent-gym-calibration-sample://one" },
+      { expected_score: 0.5, observed_score: 0.55, sample_ref: "agent-gym-calibration-sample://two" },
+    ],
+  });
+  assert.equal(calibration.passed, true);
+  assert.ok(calibration.mean_absolute_error < 0.1);
+  assert.match(calibration.calibration_digest, /^sha256:[0-9a-f]{64}$/u);
+});
+
+test("model judge calibration fails closed on too few labeled samples", () => {
+  const calibration = calibrateAgentGymEvaluator(
+    defineAgentGymEvaluatorManifest(modelJudgeManifestInput()),
+    calibrationPolicy(),
+    {
+      calibrated_at: "2026-08-12T10:47:00.000Z",
+      calibration_dataset_digest: digest("f"),
+      samples: [{ expected_score: 1, observed_score: 1, sample_ref: "agent-gym-calibration-sample://one" }],
+    },
+  );
+  assert.equal(calibration.passed, false);
+});
+
 function rubricInput() {
   return {
     metrics: [
@@ -124,6 +153,16 @@ function caseEvaluationInput() {
     replay_ref: "agent-gym-replay://nightly/held-out-one",
     schema_version: "agent-gym-case-evaluation/v1" as const,
     valid: true,
+  };
+}
+
+function calibrationPolicy() {
+  return {
+    maximum_mean_absolute_error: 0.1,
+    maximum_sample_absolute_error: 0.2,
+    minimum_sample_count: 2,
+    policy_ref: "agent-gym-calibration-policy://model-judge/default-v1",
+    schema_version: "agent-gym-calibration-policy/v1" as const,
   };
 }
 

--- a/apps/slack-companion/test/agent-gym-evaluator-control.test.ts
+++ b/apps/slack-companion/test/agent-gym-evaluator-control.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   defineAgentGymEvaluatorManifest,
   defineAgentGymEvaluatorRubric,
+  recordAgentGymCaseEvaluation,
 } from "../src/index.js";
 
 test("evaluator rubrics seal ordered metric policy", () => {
@@ -32,6 +33,35 @@ test("deterministic evaluator manifests reject model configuration", () => {
     ...modelJudgeManifestInput(),
     evaluator_kind: "deterministic",
   }), /evaluator manifest is invalid/u);
+});
+
+test("case evaluations bind ordered metrics to exact evaluator versions", () => {
+  const rubric = defineAgentGymEvaluatorRubric(rubricInput());
+  const modelJudge = defineAgentGymEvaluatorManifest(modelJudgeManifestInput());
+  const deterministic = defineAgentGymEvaluatorManifest(deterministicManifestInput());
+  const evaluation = recordAgentGymCaseEvaluation(rubric, [modelJudge, deterministic], {
+    ...caseEvaluationInput(),
+    metrics: [
+      { evaluator_digest: modelJudge.evaluator_digest, metric_id: "answer.grounded", reason_codes: [], score: 0.9 },
+      { evaluator_digest: deterministic.evaluator_digest, metric_id: "effect.authorized", reason_codes: [], score: 1 },
+    ],
+  });
+  assert.equal(evaluation.valid, true);
+  assert.equal(evaluation.weighted_score, 2.8 / 3);
+  assert.deepEqual(evaluation.blocker_codes, []);
+});
+
+test("invalid evaluator output cannot carry candidate scores", () => {
+  const rubric = defineAgentGymEvaluatorRubric(rubricInput());
+  assert.throws(() => recordAgentGymCaseEvaluation(rubric, [
+    defineAgentGymEvaluatorManifest(modelJudgeManifestInput()),
+    defineAgentGymEvaluatorManifest(deterministicManifestInput()),
+  ], {
+    ...caseEvaluationInput(),
+    invalid_reason_codes: ["judge.output_schema_mismatch"],
+    metrics: [{ evaluator_digest: digest("d"), metric_id: "answer.grounded", reason_codes: [], score: 1 }],
+    valid: false,
+  }), /case evaluation is invalid/u);
 });
 
 function rubricInput() {
@@ -69,6 +99,31 @@ function modelJudgeManifestInput() {
     output_schema_digest: digest("c"),
     rubric_digest: defineAgentGymEvaluatorRubric(rubricInput()).rubric_digest,
     schema_version: "agent-gym-evaluator-manifest/v1" as const,
+  };
+}
+
+function deterministicManifestInput() {
+  return {
+    evaluator_kind: "deterministic" as const,
+    evaluator_ref: "agent-gym-evaluator://effect-authority/v1",
+    implementation_digest: digest("d"),
+    output_schema_digest: digest("e"),
+    rubric_digest: defineAgentGymEvaluatorRubric(rubricInput()).rubric_digest,
+    schema_version: "agent-gym-evaluator-manifest/v1" as const,
+  };
+}
+
+function caseEvaluationInput() {
+  return {
+    candidate_ref: "agent-gym-candidate://slack/challenger",
+    case_ref: "agent-gym-case://slack/held-out-one",
+    evaluated_at: "2026-08-12T10:45:00.000Z",
+    evaluation_ref: "agent-gym-evaluation://nightly/held-out-one",
+    invalid_reason_codes: [],
+    metrics: [],
+    replay_ref: "agent-gym-replay://nightly/held-out-one",
+    schema_version: "agent-gym-case-evaluation/v1" as const,
+    valid: true,
   };
 }
 

--- a/apps/slack-companion/test/agent-gym-evaluator-control.test.ts
+++ b/apps/slack-companion/test/agent-gym-evaluator-control.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   calibrateAgentGymEvaluator,
+  decideAgentGymEvaluatorAdmission,
   defineAgentGymEvaluatorManifest,
   defineAgentGymEvaluatorRubric,
   recordAgentGymCaseEvaluation,
@@ -93,6 +94,62 @@ test("model judge calibration fails closed on too few labeled samples", () => {
   assert.equal(calibration.passed, false);
 });
 
+test("evaluator admission requires current passing calibration", () => {
+  const rubric = defineAgentGymEvaluatorRubric(rubricInput());
+  const modelJudge = defineAgentGymEvaluatorManifest(modelJudgeManifestInput());
+  const deterministic = defineAgentGymEvaluatorManifest(deterministicManifestInput());
+  const decision = decideAgentGymEvaluatorAdmission(
+    rubric,
+    [modelJudge, deterministic],
+    [passingCalibration(modelJudge)],
+    admissionPolicy(),
+    "2026-08-12T10:50:00.000Z",
+  );
+  assert.equal(decision.admitted, true);
+  assert.deepEqual(decision.blocker_codes, []);
+  assert.match(decision.decision_digest, /^sha256:[0-9a-f]{64}$/u);
+});
+
+test("evaluator admission blocks stale calibration", () => {
+  const rubric = defineAgentGymEvaluatorRubric(rubricInput());
+  const modelJudge = defineAgentGymEvaluatorManifest(modelJudgeManifestInput());
+  const decision = decideAgentGymEvaluatorAdmission(
+    rubric,
+    [modelJudge, defineAgentGymEvaluatorManifest(deterministicManifestInput())],
+    [passingCalibration(modelJudge, "2026-08-10T10:50:00.000Z")],
+    admissionPolicy(),
+    "2026-08-12T10:50:00.000Z",
+  );
+  assert.equal(decision.admitted, false);
+  assert.deepEqual(decision.blocker_codes, ["evaluator.calibration_stale"]);
+});
+
+test("evaluator admission rejects calibration performed under another policy", () => {
+  const rubric = defineAgentGymEvaluatorRubric(rubricInput());
+  const modelJudge = defineAgentGymEvaluatorManifest(modelJudgeManifestInput());
+  const laxPolicy = {
+    ...calibrationPolicy(),
+    maximum_mean_absolute_error: 1,
+    maximum_sample_absolute_error: 1,
+    minimum_sample_count: 1,
+    policy_ref: "agent-gym-calibration-policy://model-judge/lax",
+  };
+  const calibration = calibrateAgentGymEvaluator(modelJudge, laxPolicy, {
+    calibrated_at: "2026-08-12T10:48:00.000Z",
+    calibration_dataset_digest: digest("f"),
+    samples: [{ expected_score: 1, observed_score: 0, sample_ref: "agent-gym-calibration-sample://lax" }],
+  });
+  const decision = decideAgentGymEvaluatorAdmission(
+    rubric,
+    [modelJudge, defineAgentGymEvaluatorManifest(deterministicManifestInput())],
+    [calibration],
+    admissionPolicy(),
+    "2026-08-12T10:50:00.000Z",
+  );
+  assert.equal(decision.admitted, false);
+  assert.deepEqual(decision.blocker_codes, ["evaluator.calibration_policy_mismatch"]);
+});
+
 function rubricInput() {
   return {
     metrics: [
@@ -164,6 +221,43 @@ function calibrationPolicy() {
     policy_ref: "agent-gym-calibration-policy://model-judge/default-v1",
     schema_version: "agent-gym-calibration-policy/v1" as const,
   };
+}
+
+function admissionPolicy() {
+  const calibration = calibrationPolicy();
+  return {
+    maximum_calibration_age_ms: 24 * 60 * 60 * 1_000,
+    policy_ref: "agent-gym-evaluator-admission-policy://default/v1",
+    required_calibration_dataset_digest: digest("f"),
+    required_calibration_policy_digest: passingCalibrationPolicyDigest(calibration),
+    schema_version: "agent-gym-evaluator-admission-policy/v1" as const,
+  };
+}
+
+function passingCalibrationPolicyDigest(policy: ReturnType<typeof calibrationPolicy>): string {
+  const evaluator = defineAgentGymEvaluatorManifest(modelJudgeManifestInput());
+  return calibrateAgentGymEvaluator(evaluator, policy, {
+    calibrated_at: "2026-08-12T10:48:00.000Z",
+    calibration_dataset_digest: digest("f"),
+    samples: [
+      { expected_score: 0.9, observed_score: 0.85, sample_ref: "agent-gym-calibration-sample://one" },
+      { expected_score: 0.5, observed_score: 0.55, sample_ref: "agent-gym-calibration-sample://two" },
+    ],
+  }).policy_digest;
+}
+
+function passingCalibration(
+  evaluator: ReturnType<typeof defineAgentGymEvaluatorManifest>,
+  calibratedAt = "2026-08-12T10:48:00.000Z",
+) {
+  return calibrateAgentGymEvaluator(evaluator, calibrationPolicy(), {
+    calibrated_at: calibratedAt,
+    calibration_dataset_digest: digest("f"),
+    samples: [
+      { expected_score: 0.9, observed_score: 0.85, sample_ref: "agent-gym-calibration-sample://one" },
+      { expected_score: 0.5, observed_score: 0.55, sample_ref: "agent-gym-calibration-sample://two" },
+    ],
+  });
 }
 
 function digest(character: string): string {

--- a/apps/slack-companion/test/agent-gym-evaluator-control.test.ts
+++ b/apps/slack-companion/test/agent-gym-evaluator-control.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { defineAgentGymEvaluatorRubric } from "../src/index.js";
+
+test("evaluator rubrics seal ordered metric policy", () => {
+  const rubric = defineAgentGymEvaluatorRubric(rubricInput());
+  assert.match(rubric.rubric_digest, /^sha256:[0-9a-f]{64}$/u);
+  assert.equal(Object.isFrozen(rubric.metrics), true);
+  assert.equal(rubric.metrics[1]?.blocking, true);
+});
+
+test("evaluator rubrics reject duplicate metric identities", () => {
+  const input = rubricInput();
+  assert.throws(() => defineAgentGymEvaluatorRubric({
+    ...input,
+    metrics: [input.metrics[0]!, input.metrics[0]!],
+  }), /evaluator rubric is invalid/u);
+});
+
+function rubricInput() {
+  return {
+    metrics: [
+      {
+        blocking: false,
+        evaluator_kind: "model_judge" as const,
+        metric_id: "answer.grounded",
+        minimum_score: 0.8,
+        weight: 2,
+      },
+      {
+        blocking: true,
+        evaluator_kind: "deterministic" as const,
+        metric_id: "effect.authorized",
+        minimum_score: 1,
+        weight: 1,
+      },
+    ],
+    rubric_ref: "agent-gym-rubric://slack/default-v1",
+    schema_version: "agent-gym-evaluator-rubric/v1" as const,
+  };
+}

--- a/apps/slack-companion/test/agent-gym-evaluator-control.test.ts
+++ b/apps/slack-companion/test/agent-gym-evaluator-control.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { defineAgentGymEvaluatorRubric } from "../src/index.js";
+import {
+  defineAgentGymEvaluatorManifest,
+  defineAgentGymEvaluatorRubric,
+} from "../src/index.js";
 
 test("evaluator rubrics seal ordered metric policy", () => {
   const rubric = defineAgentGymEvaluatorRubric(rubricInput());
@@ -16,6 +19,19 @@ test("evaluator rubrics reject duplicate metric identities", () => {
     ...input,
     metrics: [input.metrics[0]!, input.metrics[0]!],
   }), /evaluator rubric is invalid/u);
+});
+
+test("model judge manifests bind exact model inference configuration", () => {
+  const manifest = defineAgentGymEvaluatorManifest(modelJudgeManifestInput());
+  assert.match(manifest.evaluator_digest, /^sha256:[0-9a-f]{64}$/u);
+  assert.equal(manifest.model?.model_ref, "model://judge/primary");
+});
+
+test("deterministic evaluator manifests reject model configuration", () => {
+  assert.throws(() => defineAgentGymEvaluatorManifest({
+    ...modelJudgeManifestInput(),
+    evaluator_kind: "deterministic",
+  }), /evaluator manifest is invalid/u);
 });
 
 function rubricInput() {
@@ -39,4 +55,23 @@ function rubricInput() {
     rubric_ref: "agent-gym-rubric://slack/default-v1",
     schema_version: "agent-gym-evaluator-rubric/v1" as const,
   };
+}
+
+function modelJudgeManifestInput() {
+  return {
+    evaluator_kind: "model_judge" as const,
+    evaluator_ref: "agent-gym-evaluator://grounding/v1",
+    implementation_digest: digest("a"),
+    model: {
+      inference_config_digest: digest("b"),
+      model_ref: "model://judge/primary",
+    },
+    output_schema_digest: digest("c"),
+    rubric_digest: defineAgentGymEvaluatorRubric(rubricInput()).rubric_digest,
+    schema_version: "agent-gym-evaluator-manifest/v1" as const,
+  };
+}
+
+function digest(character: string): string {
+  return `sha256:${character.repeat(64)}`;
 }


### PR DESCRIPTION
## Summary
- seal evaluator rubrics and exact evaluator implementations
- record invalid-safe, content-bound per-case evaluation evidence
- calibrate model judges and fail admission closed on stale, mismatched, or insufficient evidence

## Verification
- DDESK TypeScript typecheck
- DDESK evaluator-control tests: 11 passed
- DDESK full Slack companion suite: 642 passed

Part of the Agent Gym delivery sequence (commits 61–65 of 200).