### PR TITLE
feat(slack): seal agent gym evaluation suites

### DIFF
--- a/apps/slack-companion/src/agent-gym/evaluation-readiness.ts
+++ b/apps/slack-companion/src/agent-gym/evaluation-readiness.ts
@@ -1,0 +1,184 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymEvaluationRunResult,
+  type AgentGymEvaluationRunResultV1,
+} from "./evaluation-run-result.js";
+import {
+  validateAgentGymEvaluationSliceReport,
+  type AgentGymEvaluationSliceReportV1,
+} from "./evaluation-slices.js";
+import type { AgentGymEvaluationSuiteV1 } from "./evaluation-suite.js";
+
+export type AgentGymEvaluationReadinessBlockerCode =
+  | "evaluation.blocking_cases"
+  | "evaluation.case_count_below_minimum"
+  | "evaluation.invalid_cases"
+  | "evaluation.required_slice_missing"
+  | "evaluation.required_slice_underfilled";
+
+export interface AgentGymEvaluationReadinessPolicyV1 {
+  readonly minimum_case_count: number;
+  readonly policy_ref: string;
+  readonly required_slices: readonly {
+    readonly minimum_valid_case_count: number;
+    readonly slice_id: string;
+  }[];
+  readonly schema_version: "agent-gym-evaluation-readiness-policy/v1";
+}
+
+export interface AgentGymEvaluationReadinessDecisionV1 {
+  readonly blocker_codes: readonly AgentGymEvaluationReadinessBlockerCode[];
+  readonly decided_at: string;
+  readonly decision_digest: string;
+  readonly invalid_case_count: number;
+  readonly policy_ref: string;
+  readonly ready: boolean;
+  readonly run_result_digest: string;
+  readonly schema_version: "agent-gym-evaluation-readiness-decision/v1";
+  readonly slice_report_digest: string;
+  readonly suite_digest: string;
+  readonly valid_case_count: number;
+}
+
+/** Decides evidence completeness without treating candidate score as evaluator validity. */
+export function decideAgentGymEvaluationReadiness(
+  suite: AgentGymEvaluationSuiteV1,
+  resultInput: AgentGymEvaluationRunResultV1,
+  reportInput: AgentGymEvaluationSliceReportV1,
+  policy: AgentGymEvaluationReadinessPolicyV1,
+  decidedAt: string,
+): AgentGymEvaluationReadinessDecisionV1 {
+  validateSuite(suite);
+  const result = validateAgentGymEvaluationRunResult(resultInput);
+  const report = validateAgentGymEvaluationSliceReport(reportInput);
+  validatePolicy(policy);
+  timestamp(decidedAt);
+  if (result.suite_digest !== suite.suite_digest
+    || report.suite_digest !== suite.suite_digest
+    || report.run_result_digest !== result.result_digest
+    || Date.parse(decidedAt) < Date.parse(result.completed_at)) invalid();
+  const blockerCodes = new Set<AgentGymEvaluationReadinessBlockerCode>();
+  if (result.invalid_case_count > 0) blockerCodes.add("evaluation.invalid_cases");
+  if (result.blocker_case_count > 0) blockerCodes.add("evaluation.blocking_cases");
+  if (result.valid_case_count < policy.minimum_case_count) {
+    blockerCodes.add("evaluation.case_count_below_minimum");
+  }
+  const sliceById = new Map(report.slices.map((slice) => [slice.slice_id, slice]));
+  for (const requirement of policy.required_slices) {
+    const slice = sliceById.get(requirement.slice_id);
+    if (slice === undefined) blockerCodes.add("evaluation.required_slice_missing");
+    else if (slice.valid_case_count < requirement.minimum_valid_case_count) {
+      blockerCodes.add("evaluation.required_slice_underfilled");
+    }
+  }
+  const blockers = [...blockerCodes].sort();
+  const body = {
+    blocker_codes: blockers,
+    decided_at: decidedAt,
+    invalid_case_count: result.invalid_case_count,
+    policy_ref: policy.policy_ref,
+    ready: blockers.length === 0,
+    run_result_digest: result.result_digest,
+    schema_version: "agent-gym-evaluation-readiness-decision/v1" as const,
+    slice_report_digest: report.report_digest,
+    suite_digest: suite.suite_digest,
+    valid_case_count: result.valid_case_count,
+  };
+  return Object.freeze({
+    ...body,
+    blocker_codes: Object.freeze(blockers),
+    decision_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymEvaluationReadinessDecision(
+  value: AgentGymEvaluationReadinessDecisionV1,
+): AgentGymEvaluationReadinessDecisionV1 {
+  if (value.schema_version !== "agent-gym-evaluation-readiness-decision/v1") invalid();
+  timestamp(value.decided_at);
+  reference(value.policy_ref);
+  for (const digest of [value.run_result_digest, value.slice_report_digest,
+    value.suite_digest, value.decision_digest]) digestValue(digest);
+  integer(value.valid_case_count, 100_000, true);
+  integer(value.invalid_case_count, 100_000, true);
+  if (!Array.isArray(value.blocker_codes) || value.blocker_codes.length > 5
+    || new Set(value.blocker_codes).size !== value.blocker_codes.length
+    || value.blocker_codes.some((code) => ![
+      "evaluation.blocking_cases", "evaluation.case_count_below_minimum",
+      "evaluation.invalid_cases", "evaluation.required_slice_missing",
+      "evaluation.required_slice_underfilled",
+    ].includes(code))
+    || value.blocker_codes.some((code, index) => index > 0 && value.blocker_codes[index - 1]! >= code)
+    || value.ready !== (value.blocker_codes.length === 0)) invalid();
+  const body = {
+    blocker_codes: value.blocker_codes,
+    decided_at: value.decided_at,
+    invalid_case_count: value.invalid_case_count,
+    policy_ref: value.policy_ref,
+    ready: value.ready,
+    run_result_digest: value.run_result_digest,
+    schema_version: value.schema_version,
+    slice_report_digest: value.slice_report_digest,
+    suite_digest: value.suite_digest,
+    valid_case_count: value.valid_case_count,
+  };
+  if (digestAgentGymJson(body) !== value.decision_digest) invalid();
+  return Object.freeze({ ...value, blocker_codes: Object.freeze([...value.blocker_codes]) });
+}
+
+function validatePolicy(value: AgentGymEvaluationReadinessPolicyV1): void {
+  if (value.schema_version !== "agent-gym-evaluation-readiness-policy/v1") invalid();
+  reference(value.policy_ref);
+  integer(value.minimum_case_count, 100_000, false);
+  if (!Array.isArray(value.required_slices) || value.required_slices.length > 1_000) invalid();
+  const sliceIds = new Set<string>();
+  for (const requirement of value.required_slices) {
+    text(requirement.slice_id);
+    integer(requirement.minimum_valid_case_count, 100_000, false);
+    if (sliceIds.has(requirement.slice_id)) invalid();
+    sliceIds.add(requirement.slice_id);
+  }
+}
+
+function validateSuite(value: AgentGymEvaluationSuiteV1): void {
+  if (value.schema_version !== "agent-gym-evaluation-suite/v1") invalid();
+  const body = {
+    case_count: value.case_count,
+    case_set_digest: value.case_set_digest,
+    cases: value.cases.map((entry) => ({
+      case_digest: entry.case_digest,
+      case_ref: entry.case_ref,
+      labels: [...entry.labels],
+      partition: entry.partition,
+    })),
+    corpus_digest: value.corpus_digest,
+    corpus_quality_receipt_digest: value.corpus_quality_receipt_digest,
+    evaluator_admission_decision_digest: value.evaluator_admission_decision_digest,
+    evaluator_digests: [...value.evaluator_digests],
+    partitions: [...value.partitions],
+    rubric_digest: value.rubric_digest,
+    schema_version: value.schema_version,
+    suite_ref: value.suite_ref,
+  };
+  if (digestAgentGymJson(body) !== value.suite_digest) invalid();
+}
+function text(value: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > 160
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function digestValue(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function integer(value: number, maximum: number, allowZero: boolean): void {
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1) || value > maximum) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym evaluation readiness is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/evaluation-run-plan.ts
+++ b/apps/slack-companion/src/agent-gym/evaluation-run-plan.ts
@@ -1,0 +1,156 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import type { AgentGymEvaluationSuiteV1 } from "./evaluation-suite.js";
+
+export interface AgentGymEvaluationCasePlanV1 {
+  readonly case_digest: string;
+  readonly case_plan_ref: string;
+  readonly case_ref: string;
+  readonly ordinal: number;
+}
+
+export interface AgentGymEvaluationRunPlanV1 {
+  readonly candidate_ref: string;
+  readonly case_count: number;
+  readonly case_timeout_ms: number;
+  readonly cases: readonly AgentGymEvaluationCasePlanV1[];
+  readonly maximum_parallel_cases: number;
+  readonly plan_digest: string;
+  readonly planned_at: string;
+  readonly run_ref: string;
+  readonly schema_version: "agent-gym-evaluation-run-plan/v1";
+  readonly suite_digest: string;
+  readonly suite_ref: string;
+}
+
+/** Plans one candidate over every case in an exact sealed evaluation suite. */
+export function planAgentGymEvaluationRun(
+  suite: AgentGymEvaluationSuiteV1,
+  input: {
+    readonly candidate_ref: string;
+    readonly case_timeout_ms: number;
+    readonly maximum_parallel_cases: number;
+    readonly planned_at: string;
+    readonly run_ref: string;
+  },
+): AgentGymEvaluationRunPlanV1 {
+  validateSuite(suite);
+  reference(input.candidate_ref);
+  reference(input.run_ref);
+  timestamp(input.planned_at);
+  integer(input.case_timeout_ms, 3_600_000, false);
+  integer(input.maximum_parallel_cases, 1_000, false);
+  if (input.maximum_parallel_cases > suite.case_count) invalid();
+  const cases = suite.cases.map((entry, ordinal) => Object.freeze({
+    case_digest: entry.case_digest,
+    case_plan_ref: `agent-gym-evaluation-case://${digestAgentGymJson([
+      input.run_ref, entry.case_ref, entry.case_digest,
+    ]).slice("sha256:".length)}`,
+    case_ref: entry.case_ref,
+    ordinal,
+  }));
+  const body = {
+    candidate_ref: input.candidate_ref,
+    case_count: cases.length,
+    case_timeout_ms: input.case_timeout_ms,
+    cases: cases.map((entry) => ({ ...entry })),
+    maximum_parallel_cases: input.maximum_parallel_cases,
+    planned_at: input.planned_at,
+    run_ref: input.run_ref,
+    schema_version: "agent-gym-evaluation-run-plan/v1" as const,
+    suite_digest: suite.suite_digest,
+    suite_ref: suite.suite_ref,
+  };
+  return Object.freeze({
+    ...body,
+    cases: Object.freeze(cases),
+    plan_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymEvaluationRunPlan(
+  value: AgentGymEvaluationRunPlanV1,
+): AgentGymEvaluationRunPlanV1 {
+  if (value.schema_version !== "agent-gym-evaluation-run-plan/v1") invalid();
+  for (const ref of [value.candidate_ref, value.run_ref, value.suite_ref]) reference(ref);
+  timestamp(value.planned_at);
+  digest(value.suite_digest);
+  integer(value.case_count, 100_000, false);
+  integer(value.case_timeout_ms, 3_600_000, false);
+  integer(value.maximum_parallel_cases, 1_000, false);
+  if (!Array.isArray(value.cases) || value.cases.length !== value.case_count
+    || value.maximum_parallel_cases > value.case_count) invalid();
+  const caseRefs = new Set<string>();
+  const casePlanRefs = new Set<string>();
+  const cases = value.cases.map((entry, ordinal) => {
+    reference(entry.case_ref);
+    reference(entry.case_plan_ref);
+    digest(entry.case_digest);
+    if (entry.ordinal !== ordinal || caseRefs.has(entry.case_ref)
+      || casePlanRefs.has(entry.case_plan_ref)) invalid();
+    caseRefs.add(entry.case_ref);
+    casePlanRefs.add(entry.case_plan_ref);
+    const expectedRef = `agent-gym-evaluation-case://${digestAgentGymJson([
+      value.run_ref, entry.case_ref, entry.case_digest,
+    ]).slice("sha256:".length)}`;
+    if (entry.case_plan_ref !== expectedRef) invalid();
+    return Object.freeze({ ...entry });
+  });
+  const body = {
+    candidate_ref: value.candidate_ref,
+    case_count: value.case_count,
+    case_timeout_ms: value.case_timeout_ms,
+    cases: cases.map((entry) => ({ ...entry })),
+    maximum_parallel_cases: value.maximum_parallel_cases,
+    planned_at: value.planned_at,
+    run_ref: value.run_ref,
+    schema_version: value.schema_version,
+    suite_digest: value.suite_digest,
+    suite_ref: value.suite_ref,
+  };
+  if (digestAgentGymJson(body) !== value.plan_digest) invalid();
+  return Object.freeze({ ...value, cases: Object.freeze(cases) });
+}
+
+function validateSuite(value: AgentGymEvaluationSuiteV1): void {
+  if (value.schema_version !== "agent-gym-evaluation-suite/v1") invalid();
+  if (!Array.isArray(value.cases) || value.cases.length !== value.case_count
+    || value.cases.length === 0 || new Set(value.cases.map((entry) => entry.case_ref)).size !== value.case_count
+    || value.cases.some((entry) => !value.partitions.includes(entry.partition))) invalid();
+  const caseSetBody = value.cases.map((entry) => ({
+    case_digest: entry.case_digest,
+    case_ref: entry.case_ref,
+    labels: [...entry.labels],
+    partition: entry.partition,
+  }));
+  if (digestAgentGymJson(caseSetBody) !== value.case_set_digest) invalid();
+  const body = {
+    case_count: value.case_count,
+    case_set_digest: value.case_set_digest,
+    cases: caseSetBody,
+    corpus_digest: value.corpus_digest,
+    corpus_quality_receipt_digest: value.corpus_quality_receipt_digest,
+    evaluator_admission_decision_digest: value.evaluator_admission_decision_digest,
+    evaluator_digests: [...value.evaluator_digests],
+    partitions: [...value.partitions],
+    rubric_digest: value.rubric_digest,
+    schema_version: value.schema_version,
+    suite_ref: value.suite_ref,
+  };
+  if (digestAgentGymJson(body) !== value.suite_digest) invalid();
+}
+function digest(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function integer(value: number, maximum: number, allowZero: boolean): void {
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1) || value > maximum) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym evaluation run plan is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/evaluation-run-result.ts
+++ b/apps/slack-companion/src/agent-gym/evaluation-run-result.ts
@@ -1,0 +1,213 @@
+import type { AgentGymCaseEvaluationV1 } from "./case-evaluation.js";
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymEvaluationRunPlan,
+  type AgentGymEvaluationRunPlanV1,
+} from "./evaluation-run-plan.js";
+import type { AgentGymEvaluationSuiteV1 } from "./evaluation-suite.js";
+
+export interface AgentGymEvaluationCaseResultV1 {
+  readonly blocker_codes: readonly string[];
+  readonly case_digest: string;
+  readonly case_plan_ref: string;
+  readonly case_ref: string;
+  readonly evaluation_digest: string;
+  readonly valid: boolean;
+  readonly weighted_score: number | null;
+}
+
+export interface AgentGymEvaluationRunResultV1 {
+  readonly blocker_case_count: number;
+  readonly candidate_ref: string;
+  readonly case_count: number;
+  readonly cases: readonly AgentGymEvaluationCaseResultV1[];
+  readonly completed_at: string;
+  readonly invalid_case_count: number;
+  readonly plan_digest: string;
+  readonly result_digest: string;
+  readonly run_ref: string;
+  readonly schema_version: "agent-gym-evaluation-run-result/v1";
+  readonly started_at: string;
+  readonly suite_digest: string;
+  readonly valid_case_count: number;
+}
+
+/** Completes a run only when every planned case has one content-bound evaluation. */
+export function completeAgentGymEvaluationRun(
+  suite: AgentGymEvaluationSuiteV1,
+  planInput: AgentGymEvaluationRunPlanV1,
+  evaluations: readonly AgentGymCaseEvaluationV1[],
+  input: { readonly completed_at: string; readonly started_at: string },
+): AgentGymEvaluationRunResultV1 {
+  validateSuite(suite);
+  const plan = validateAgentGymEvaluationRunPlan(planInput);
+  if (plan.suite_digest !== suite.suite_digest || plan.case_count !== suite.case_count) invalid();
+  timestamp(input.started_at);
+  timestamp(input.completed_at);
+  if (Date.parse(input.completed_at) < Date.parse(input.started_at)
+    || Date.parse(input.started_at) < Date.parse(plan.planned_at)
+    || !Array.isArray(evaluations) || evaluations.length !== plan.case_count) invalid();
+  const evaluationByCase = new Map<string, AgentGymCaseEvaluationV1>();
+  for (const evaluation of evaluations) {
+    validateEvaluation(evaluation);
+    if (evaluation.candidate_ref !== plan.candidate_ref
+      || evaluation.rubric_digest !== suite.rubric_digest
+      || digestAgentGymJson([...evaluation.evaluator_digests].sort())
+        !== digestAgentGymJson([...suite.evaluator_digests].sort())
+      || Date.parse(evaluation.evaluated_at) < Date.parse(input.started_at)
+      || Date.parse(evaluation.evaluated_at) > Date.parse(input.completed_at)
+      || evaluationByCase.has(evaluation.case_ref)) invalid();
+    evaluationByCase.set(evaluation.case_ref, evaluation);
+  }
+  const cases = plan.cases.map((casePlan) => {
+    const evaluation = evaluationByCase.get(casePlan.case_ref);
+    if (evaluation === undefined) invalid();
+    return Object.freeze({
+      blocker_codes: Object.freeze([...evaluation.blocker_codes]),
+      case_digest: casePlan.case_digest,
+      case_plan_ref: casePlan.case_plan_ref,
+      case_ref: casePlan.case_ref,
+      evaluation_digest: evaluation.evaluation_digest,
+      valid: evaluation.valid,
+      weighted_score: evaluation.weighted_score,
+    });
+  });
+  const invalidCaseCount = cases.filter((entry) => !entry.valid).length;
+  const blockerCaseCount = cases.filter((entry) => entry.blocker_codes.length > 0).length;
+  const body = {
+    blocker_case_count: blockerCaseCount,
+    candidate_ref: plan.candidate_ref,
+    case_count: cases.length,
+    cases: cases.map((entry) => ({ ...entry, blocker_codes: [...entry.blocker_codes] })),
+    completed_at: input.completed_at,
+    invalid_case_count: invalidCaseCount,
+    plan_digest: plan.plan_digest,
+    run_ref: plan.run_ref,
+    schema_version: "agent-gym-evaluation-run-result/v1" as const,
+    started_at: input.started_at,
+    suite_digest: suite.suite_digest,
+    valid_case_count: cases.length - invalidCaseCount,
+  };
+  return Object.freeze({
+    ...body,
+    cases: Object.freeze(cases),
+    result_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymEvaluationRunResult(
+  value: AgentGymEvaluationRunResultV1,
+): AgentGymEvaluationRunResultV1 {
+  if (value.schema_version !== "agent-gym-evaluation-run-result/v1") invalid();
+  reference(value.candidate_ref);
+  reference(value.run_ref);
+  timestamp(value.started_at);
+  timestamp(value.completed_at);
+  if (Date.parse(value.completed_at) < Date.parse(value.started_at)) invalid();
+  for (const digest of [value.plan_digest, value.suite_digest, value.result_digest]) digestValue(digest);
+  integer(value.case_count, 100_000);
+  integer(value.valid_case_count, value.case_count);
+  integer(value.invalid_case_count, value.case_count);
+  integer(value.blocker_case_count, value.case_count);
+  if (!Array.isArray(value.cases) || value.cases.length !== value.case_count
+    || value.valid_case_count + value.invalid_case_count !== value.case_count) invalid();
+  const caseRefs = new Set<string>();
+  const cases = value.cases.map((entry) => {
+    reference(entry.case_ref);
+    reference(entry.case_plan_ref);
+    digestValue(entry.case_digest);
+    digestValue(entry.evaluation_digest);
+    strings(entry.blocker_codes);
+    if (caseRefs.has(entry.case_ref)
+      || (entry.valid !== (entry.weighted_score !== null))) invalid();
+    caseRefs.add(entry.case_ref);
+    if (entry.weighted_score !== null) unit(entry.weighted_score);
+    return Object.freeze({ ...entry, blocker_codes: Object.freeze([...entry.blocker_codes]) });
+  });
+  if (cases.filter((entry) => !entry.valid).length !== value.invalid_case_count
+    || cases.filter((entry) => entry.blocker_codes.length > 0).length !== value.blocker_case_count) invalid();
+  const body = {
+    blocker_case_count: value.blocker_case_count,
+    candidate_ref: value.candidate_ref,
+    case_count: value.case_count,
+    cases: cases.map((entry) => ({ ...entry, blocker_codes: [...entry.blocker_codes] })),
+    completed_at: value.completed_at,
+    invalid_case_count: value.invalid_case_count,
+    plan_digest: value.plan_digest,
+    run_ref: value.run_ref,
+    schema_version: value.schema_version,
+    started_at: value.started_at,
+    suite_digest: value.suite_digest,
+    valid_case_count: value.valid_case_count,
+  };
+  if (digestAgentGymJson(body) !== value.result_digest) invalid();
+  return Object.freeze({ ...value, cases: Object.freeze(cases) });
+}
+
+function validateEvaluation(value: AgentGymCaseEvaluationV1): void {
+  if (value.schema_version !== "agent-gym-case-evaluation/v1") invalid();
+  timestamp(value.evaluated_at);
+  const body = {
+    blocker_codes: value.blocker_codes,
+    candidate_ref: value.candidate_ref,
+    case_ref: value.case_ref,
+    evaluated_at: value.evaluated_at,
+    evaluation_ref: value.evaluation_ref,
+    evaluator_digests: value.evaluator_digests,
+    invalid_reason_codes: value.invalid_reason_codes,
+    metrics: value.metrics.map((metric) => ({ ...metric, reason_codes: [...metric.reason_codes] })),
+    replay_ref: value.replay_ref,
+    rubric_digest: value.rubric_digest,
+    schema_version: value.schema_version,
+    valid: value.valid,
+    weighted_score: value.weighted_score,
+  };
+  if (digestAgentGymJson(body) !== value.evaluation_digest
+    || value.valid !== (value.weighted_score !== null)) invalid();
+}
+
+function validateSuite(value: AgentGymEvaluationSuiteV1): void {
+  if (value.schema_version !== "agent-gym-evaluation-suite/v1") invalid();
+  const body = {
+    case_count: value.case_count,
+    case_set_digest: value.case_set_digest,
+    cases: value.cases.map((entry) => ({
+      case_digest: entry.case_digest,
+      case_ref: entry.case_ref,
+      labels: [...entry.labels],
+      partition: entry.partition,
+    })),
+    corpus_digest: value.corpus_digest,
+    corpus_quality_receipt_digest: value.corpus_quality_receipt_digest,
+    evaluator_admission_decision_digest: value.evaluator_admission_decision_digest,
+    evaluator_digests: [...value.evaluator_digests],
+    partitions: [...value.partitions],
+    rubric_digest: value.rubric_digest,
+    schema_version: value.schema_version,
+    suite_ref: value.suite_ref,
+  };
+  if (digestAgentGymJson(body) !== value.suite_digest) invalid();
+}
+function strings(values: readonly string[]): void {
+  if (!Array.isArray(values) || values.length > 128 || new Set(values).size !== values.length
+    || values.some((value) => !value.trim() || value.length > 160 || /[\u0000-\u001f\u007f]/u.test(value))) invalid();
+}
+function digestValue(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function integer(value: number, maximum: number): void {
+  if (!Number.isSafeInteger(value) || value < 0 || value > maximum) invalid();
+}
+function unit(value: number): void {
+  if (!Number.isFinite(value) || value < 0 || value > 1) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym evaluation run result is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/evaluation-slices.ts
+++ b/apps/slack-companion/src/agent-gym/evaluation-slices.ts
@@ -1,0 +1,156 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymEvaluationRunResult,
+  type AgentGymEvaluationRunResultV1,
+} from "./evaluation-run-result.js";
+import type { AgentGymEvaluationSuiteV1 } from "./evaluation-suite.js";
+
+export interface AgentGymEvaluationSliceV1 {
+  readonly blocker_case_count: number;
+  readonly case_count: number;
+  readonly dimension: "label" | "overall" | "partition";
+  readonly invalid_case_count: number;
+  readonly mean_score: number | null;
+  readonly slice_id: string;
+  readonly valid_case_count: number;
+  readonly value: string;
+}
+
+export interface AgentGymEvaluationSliceReportV1 {
+  readonly report_digest: string;
+  readonly run_result_digest: string;
+  readonly schema_version: "agent-gym-evaluation-slice-report/v1";
+  readonly slices: readonly AgentGymEvaluationSliceV1[];
+  readonly suite_digest: string;
+}
+
+/** Produces stable overall, partition, and label slices from one complete run. */
+export function summarizeAgentGymEvaluationSlices(
+  suite: AgentGymEvaluationSuiteV1,
+  resultInput: AgentGymEvaluationRunResultV1,
+): AgentGymEvaluationSliceReportV1 {
+  validateSuite(suite);
+  const result = validateAgentGymEvaluationRunResult(resultInput);
+  if (result.suite_digest !== suite.suite_digest) invalid();
+  const resultByCase = new Map(result.cases.map((entry) => [entry.case_ref, entry]));
+  const definitions: {
+    readonly dimension: AgentGymEvaluationSliceV1["dimension"];
+    readonly value: string;
+    readonly case_refs: readonly string[];
+  }[] = [{ dimension: "overall", value: "all", case_refs: suite.cases.map((entry) => entry.case_ref) }];
+  for (const partition of suite.partitions) definitions.push({
+    dimension: "partition",
+    value: partition,
+    case_refs: suite.cases.filter((entry) => entry.partition === partition).map((entry) => entry.case_ref),
+  });
+  const labels = [...new Set(suite.cases.flatMap((entry) => entry.labels))].sort();
+  for (const label of labels) definitions.push({
+    dimension: "label",
+    value: label,
+    case_refs: suite.cases.filter((entry) => entry.labels.includes(label)).map((entry) => entry.case_ref),
+  });
+  const slices = definitions.map((definition) => {
+    const cases = definition.case_refs.map((caseRef) => resultByCase.get(caseRef) ?? invalid());
+    const validScores = cases.flatMap((entry) => entry.weighted_score === null ? [] : [entry.weighted_score]);
+    return Object.freeze({
+      blocker_case_count: cases.filter((entry) => entry.blocker_codes.length > 0).length,
+      case_count: cases.length,
+      dimension: definition.dimension,
+      invalid_case_count: cases.filter((entry) => !entry.valid).length,
+      mean_score: validScores.length === 0
+        ? null
+        : validScores.reduce((total, score) => total + score, 0) / validScores.length,
+      slice_id: `${definition.dimension}:${definition.value}`,
+      valid_case_count: validScores.length,
+      value: definition.value,
+    });
+  }).sort((left, right) => left.slice_id.localeCompare(right.slice_id));
+  const body = {
+    run_result_digest: result.result_digest,
+    schema_version: "agent-gym-evaluation-slice-report/v1" as const,
+    slices: slices.map((entry) => ({ ...entry })),
+    suite_digest: suite.suite_digest,
+  };
+  return Object.freeze({
+    ...body,
+    slices: Object.freeze(slices),
+    report_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymEvaluationSliceReport(
+  value: AgentGymEvaluationSliceReportV1,
+): AgentGymEvaluationSliceReportV1 {
+  if (value.schema_version !== "agent-gym-evaluation-slice-report/v1") invalid();
+  digest(value.run_result_digest);
+  digest(value.suite_digest);
+  digest(value.report_digest);
+  if (!Array.isArray(value.slices) || value.slices.length === 0 || value.slices.length > 1_000) invalid();
+  const sliceIds = new Set<string>();
+  const slices = value.slices.map((entry) => {
+    text(entry.slice_id);
+    text(entry.value);
+    if (sliceIds.has(entry.slice_id)
+      || !["label", "overall", "partition"].includes(entry.dimension)
+      || entry.slice_id !== `${entry.dimension}:${entry.value}`) invalid();
+    sliceIds.add(entry.slice_id);
+    integer(entry.case_count, 100_000);
+    integer(entry.valid_case_count, entry.case_count);
+    integer(entry.invalid_case_count, entry.case_count);
+    integer(entry.blocker_case_count, entry.case_count);
+    if (entry.case_count === 0 || entry.valid_case_count + entry.invalid_case_count !== entry.case_count
+      || (entry.mean_score === null) !== (entry.valid_case_count === 0)) invalid();
+    if (entry.mean_score !== null) unit(entry.mean_score);
+    return Object.freeze({ ...entry });
+  });
+  if (slices.some((entry, index) => index > 0 && slices[index - 1]!.slice_id >= entry.slice_id)
+    || !sliceIds.has("overall:all")) invalid();
+  const body = {
+    run_result_digest: value.run_result_digest,
+    schema_version: value.schema_version,
+    slices: slices.map((entry) => ({ ...entry })),
+    suite_digest: value.suite_digest,
+  };
+  if (digestAgentGymJson(body) !== value.report_digest) invalid();
+  return Object.freeze({ ...value, slices: Object.freeze(slices) });
+}
+
+function validateSuite(value: AgentGymEvaluationSuiteV1): void {
+  if (value.schema_version !== "agent-gym-evaluation-suite/v1") invalid();
+  const body = {
+    case_count: value.case_count,
+    case_set_digest: value.case_set_digest,
+    cases: value.cases.map((entry) => ({
+      case_digest: entry.case_digest,
+      case_ref: entry.case_ref,
+      labels: [...entry.labels],
+      partition: entry.partition,
+    })),
+    corpus_digest: value.corpus_digest,
+    corpus_quality_receipt_digest: value.corpus_quality_receipt_digest,
+    evaluator_admission_decision_digest: value.evaluator_admission_decision_digest,
+    evaluator_digests: [...value.evaluator_digests],
+    partitions: [...value.partitions],
+    rubric_digest: value.rubric_digest,
+    schema_version: value.schema_version,
+    suite_ref: value.suite_ref,
+  };
+  if (digestAgentGymJson(body) !== value.suite_digest) invalid();
+}
+function digest(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function text(value: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > 160
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function integer(value: number, maximum: number): void {
+  if (!Number.isSafeInteger(value) || value < 0 || value > maximum) invalid();
+}
+function unit(value: number): void {
+  if (!Number.isFinite(value) || value < 0 || value > 1) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym evaluation slice report is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/evaluation-suite.ts
+++ b/apps/slack-companion/src/agent-gym/evaluation-suite.ts
@@ -58,7 +58,8 @@ export function defineAgentGymEvaluationSuite(
     labels: Object.freeze([...entry.labels]),
     partition: entry.partition,
   }));
-  if (cases.length === 0) invalid();
+  if (cases.length === 0
+    || partitions.some((partition) => !cases.some((entry) => entry.partition === partition))) invalid();
   const caseSetBody = cases.map((entry) => ({
     case_digest: entry.case_digest,
     case_ref: entry.case_ref,

--- a/apps/slack-companion/src/agent-gym/evaluation-suite.ts
+++ b/apps/slack-companion/src/agent-gym/evaluation-suite.ts
@@ -1,0 +1,125 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import type { AgentGymCorpusQualityReceiptV1 } from "./corpus-quality.js";
+import { createAgentGymCorpusManifest } from "./corpus-manifest.js";
+import type { AgentGymEvaluatorAdmissionDecisionV1 } from "./evaluator-admission.js";
+import type { AgentGymFixtureCaseV1 } from "./fixture-case.js";
+
+export type AgentGymEvaluationPartition = "held_out" | "shadow";
+
+export interface AgentGymEvaluationSuiteCaseV1 {
+  readonly case_digest: string;
+  readonly case_ref: string;
+  readonly labels: readonly string[];
+  readonly partition: AgentGymEvaluationPartition;
+}
+
+export interface AgentGymEvaluationSuiteV1 {
+  readonly case_count: number;
+  readonly case_set_digest: string;
+  readonly cases: readonly AgentGymEvaluationSuiteCaseV1[];
+  readonly corpus_digest: string;
+  readonly corpus_quality_receipt_digest: string;
+  readonly evaluator_admission_decision_digest: string;
+  readonly evaluator_digests: readonly string[];
+  readonly partitions: readonly AgentGymEvaluationPartition[];
+  readonly rubric_digest: string;
+  readonly schema_version: "agent-gym-evaluation-suite/v1";
+  readonly suite_digest: string;
+  readonly suite_ref: string;
+}
+
+/** Seals the non-training cases and admitted evaluators used by a comparison. */
+export function defineAgentGymEvaluationSuite(
+  fixtures: readonly AgentGymFixtureCaseV1[],
+  quality: AgentGymCorpusQualityReceiptV1,
+  evaluatorAdmission: AgentGymEvaluatorAdmissionDecisionV1,
+  input: {
+    readonly partitions: readonly AgentGymEvaluationPartition[];
+    readonly suite_ref: string;
+  },
+): AgentGymEvaluationSuiteV1 {
+  reference(input.suite_ref);
+  validateQuality(quality);
+  validateEvaluatorAdmission(evaluatorAdmission);
+  if (!quality.admitted || !evaluatorAdmission.admitted) invalid();
+  if (!Array.isArray(input.partitions) || input.partitions.length === 0
+    || input.partitions.length > 2 || new Set(input.partitions).size !== input.partitions.length
+    || input.partitions.some((value) => !["held_out", "shadow"].includes(value))) invalid();
+  const manifest = createAgentGymCorpusManifest(fixtures);
+  if (manifest.corpus_digest !== quality.corpus_digest
+    || evaluatorAdmission.rubric_digest.length === 0) invalid();
+  const partitions = [...input.partitions].sort();
+  const cases = manifest.cases.filter((entry): entry is typeof entry & {
+    readonly partition: AgentGymEvaluationPartition;
+  } => partitions.includes(entry.partition as AgentGymEvaluationPartition)).map((entry) => Object.freeze({
+    case_digest: entry.case_digest,
+    case_ref: entry.case_ref,
+    labels: Object.freeze([...entry.labels]),
+    partition: entry.partition,
+  }));
+  if (cases.length === 0) invalid();
+  const caseSetBody = cases.map((entry) => ({
+    case_digest: entry.case_digest,
+    case_ref: entry.case_ref,
+    labels: [...entry.labels],
+    partition: entry.partition,
+  }));
+  const body = {
+    case_count: cases.length,
+    case_set_digest: digestAgentGymJson(caseSetBody),
+    cases: caseSetBody,
+    corpus_digest: manifest.corpus_digest,
+    corpus_quality_receipt_digest: quality.receipt_digest,
+    evaluator_admission_decision_digest: evaluatorAdmission.decision_digest,
+    evaluator_digests: [...evaluatorAdmission.evaluator_digests],
+    partitions,
+    rubric_digest: evaluatorAdmission.rubric_digest,
+    schema_version: "agent-gym-evaluation-suite/v1" as const,
+    suite_ref: input.suite_ref,
+  };
+  return Object.freeze({
+    ...body,
+    cases: Object.freeze(cases),
+    evaluator_digests: Object.freeze(body.evaluator_digests),
+    partitions: Object.freeze(partitions),
+    suite_digest: digestAgentGymJson(body),
+  });
+}
+
+function validateQuality(value: AgentGymCorpusQualityReceiptV1): void {
+  if (value.schema_version !== "agent-gym-corpus-quality-receipt/v1") invalid();
+  const body = {
+    admitted: value.admitted,
+    admission_decision_digest: value.admission_decision_digest,
+    blocker_codes: value.blocker_codes,
+    build_receipt_digest: value.build_receipt_digest,
+    corpus_digest: value.corpus_digest,
+    evaluated_at: value.evaluated_at,
+    evaluation_ref: value.evaluation_ref,
+    schema_version: value.schema_version,
+  };
+  if (digestAgentGymJson(body) !== value.receipt_digest) invalid();
+}
+
+function validateEvaluatorAdmission(value: AgentGymEvaluatorAdmissionDecisionV1): void {
+  if (value.schema_version !== "agent-gym-evaluator-admission-decision/v1") invalid();
+  const body = {
+    admitted: value.admitted,
+    blocker_codes: value.blocker_codes,
+    calibration_digests: value.calibration_digests,
+    decided_at: value.decided_at,
+    evaluator_digests: value.evaluator_digests,
+    policy_ref: value.policy_ref,
+    rubric_digest: value.rubric_digest,
+    schema_version: value.schema_version,
+  };
+  if (digestAgentGymJson(body) !== value.decision_digest) invalid();
+}
+
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym evaluation suite is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -22,6 +22,7 @@ export * from "./evaluation-suite.js";
 export * from "./evaluation-run-plan.js";
 export * from "./evaluation-run-result.js";
 export * from "./evaluation-slices.js";
+export * from "./evaluation-readiness.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -18,6 +18,7 @@ export * from "./evaluator-manifest.js";
 export * from "./case-evaluation.js";
 export * from "./evaluator-calibration.js";
 export * from "./evaluator-admission.js";
+export * from "./evaluation-suite.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -20,6 +20,7 @@ export * from "./evaluator-calibration.js";
 export * from "./evaluator-admission.js";
 export * from "./evaluation-suite.js";
 export * from "./evaluation-run-plan.js";
+export * from "./evaluation-run-result.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -19,6 +19,7 @@ export * from "./case-evaluation.js";
 export * from "./evaluator-calibration.js";
 export * from "./evaluator-admission.js";
 export * from "./evaluation-suite.js";
+export * from "./evaluation-run-plan.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -21,6 +21,7 @@ export * from "./evaluator-admission.js";
 export * from "./evaluation-suite.js";
 export * from "./evaluation-run-plan.js";
 export * from "./evaluation-run-result.js";
+export * from "./evaluation-slices.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
+++ b/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
@@ -9,7 +9,9 @@ import {
   defineAgentGymEvaluationSuite,
   defineAgentGymEvaluatorManifest,
   defineAgentGymEvaluatorRubric,
+  planAgentGymEvaluationRun,
   recordAgentGymCorpusQuality,
+  validateAgentGymEvaluationRunPlan,
 } from "../src/index.js";
 
 test("evaluation suites seal admitted non-training cases", () => {
@@ -34,6 +36,23 @@ test("evaluation suites reject unadmitted evaluator evidence", () => {
     { ...setup.evaluatorAdmission, admitted: false },
     { partitions: ["held_out"], suite_ref: "agent-gym-suite://nightly/default" },
   ), /evaluation suite is invalid/u);
+});
+
+test("evaluation run plans bind every suite case to one candidate", () => {
+  const suite = evaluationSuite();
+  const plan = planAgentGymEvaluationRun(suite, runPlanInput());
+  assert.equal(plan.case_count, suite.case_count);
+  assert.equal(plan.cases[0]?.ordinal, 0);
+  assert.match(plan.plan_digest, /^sha256:[0-9a-f]{64}$/u);
+  assert.deepEqual(validateAgentGymEvaluationRunPlan(plan), plan);
+});
+
+test("evaluation run plans reject tampered case identities", () => {
+  const plan = planAgentGymEvaluationRun(evaluationSuite(), runPlanInput());
+  assert.throws(() => validateAgentGymEvaluationRunPlan({
+    ...plan,
+    cases: [{ ...plan.cases[0]!, case_digest: digest("a") }, ...plan.cases.slice(1)],
+  }), /evaluation run plan is invalid/u);
 });
 
 function evaluationSetup() {
@@ -90,6 +109,26 @@ function evaluationSetup() {
     "2026-08-12T11:03:00.000Z",
   );
   return { deterministic, evaluatorAdmission, fixtures, modelJudge, quality, rubric };
+}
+
+function evaluationSuite() {
+  const setup = evaluationSetup();
+  return defineAgentGymEvaluationSuite(
+    setup.fixtures,
+    setup.quality,
+    setup.evaluatorAdmission,
+    { partitions: ["held_out", "shadow"], suite_ref: "agent-gym-suite://nightly/default" },
+  );
+}
+
+function runPlanInput() {
+  return {
+    candidate_ref: "agent-gym-candidate://slack/challenger",
+    case_timeout_ms: 120_000,
+    maximum_parallel_cases: 2,
+    planned_at: "2026-08-12T11:04:00.000Z",
+    run_ref: "agent-gym-evaluation-run://nightly/challenger",
+  };
 }
 
 function rubricInput() {

--- a/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
+++ b/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildAgentGymCorpus,
+  calibrateAgentGymEvaluator,
+  decideAgentGymCorpusAdmission,
+  decideAgentGymEvaluatorAdmission,
+  defineAgentGymEvaluationSuite,
+  defineAgentGymEvaluatorManifest,
+  defineAgentGymEvaluatorRubric,
+  recordAgentGymCorpusQuality,
+} from "../src/index.js";
+
+test("evaluation suites seal admitted non-training cases", () => {
+  const setup = evaluationSetup();
+  const suite = defineAgentGymEvaluationSuite(
+    setup.fixtures,
+    setup.quality,
+    setup.evaluatorAdmission,
+    { partitions: ["held_out", "shadow"], suite_ref: "agent-gym-suite://nightly/default" },
+  );
+  assert.equal(suite.case_count, 2);
+  assert.deepEqual(suite.partitions, ["held_out", "shadow"]);
+  assert.deepEqual(suite.cases.map((entry) => entry.partition), ["held_out", "shadow"]);
+  assert.match(suite.suite_digest, /^sha256:[0-9a-f]{64}$/u);
+});
+
+test("evaluation suites reject unadmitted evaluator evidence", () => {
+  const setup = evaluationSetup();
+  assert.throws(() => defineAgentGymEvaluationSuite(
+    setup.fixtures,
+    setup.quality,
+    { ...setup.evaluatorAdmission, admitted: false },
+    { partitions: ["held_out"], suite_ref: "agent-gym-suite://nightly/default" },
+  ), /evaluation suite is invalid/u);
+});
+
+function evaluationSetup() {
+  const fixtures = [
+    fixture("train", "train", "Train request."),
+    fixture("held-out", "held_out", "Held-out request.", ["safety"]),
+    fixture("shadow", "shadow", "Shadow request.", ["latency"]),
+  ];
+  const coveragePolicy = {
+    minimum_partition_cases: { held_out: 1, shadow: 1, train: 1 },
+    policy_ref: "agent-gym-corpus-policy://suite/default",
+    required_slices: [],
+    schema_version: "agent-gym-corpus-coverage-policy/v1" as const,
+  };
+  const build = buildAgentGymCorpus(fixtures, {
+    build_ref: "agent-gym-corpus-build://suite/default",
+    built_at: "2026-08-12T11:00:00.000Z",
+    source_revision: "source-revision://cerebro/suite",
+  });
+  const quality = recordAgentGymCorpusQuality(
+    build,
+    decideAgentGymCorpusAdmission(fixtures, coveragePolicy),
+    { evaluated_at: "2026-08-12T11:01:00.000Z", evaluation_ref: "agent-gym-quality://suite/default" },
+  );
+  const rubric = defineAgentGymEvaluatorRubric(rubricInput());
+  const modelJudge = defineAgentGymEvaluatorManifest(modelJudgeInput(rubric.rubric_digest));
+  const deterministic = defineAgentGymEvaluatorManifest(deterministicInput(rubric.rubric_digest));
+  const calibrationPolicy = {
+    maximum_mean_absolute_error: 0.1,
+    maximum_sample_absolute_error: 0.2,
+    minimum_sample_count: 2,
+    policy_ref: "agent-gym-calibration-policy://suite/default",
+    schema_version: "agent-gym-calibration-policy/v1" as const,
+  };
+  const calibration = calibrateAgentGymEvaluator(modelJudge, calibrationPolicy, {
+    calibrated_at: "2026-08-12T11:02:00.000Z",
+    calibration_dataset_digest: digest("f"),
+    samples: [
+      { expected_score: 0.9, observed_score: 0.85, sample_ref: "agent-gym-calibration-sample://suite/one" },
+      { expected_score: 0.5, observed_score: 0.55, sample_ref: "agent-gym-calibration-sample://suite/two" },
+    ],
+  });
+  const evaluatorAdmission = decideAgentGymEvaluatorAdmission(
+    rubric,
+    [modelJudge, deterministic],
+    [calibration],
+    {
+      maximum_calibration_age_ms: 86_400_000,
+      policy_ref: "agent-gym-evaluator-admission-policy://suite/default",
+      required_calibration_dataset_digest: calibration.calibration_dataset_digest,
+      required_calibration_policy_digest: calibration.policy_digest,
+      schema_version: "agent-gym-evaluator-admission-policy/v1",
+    },
+    "2026-08-12T11:03:00.000Z",
+  );
+  return { deterministic, evaluatorAdmission, fixtures, modelJudge, quality, rubric };
+}
+
+function rubricInput() {
+  return {
+    metrics: [
+      { blocking: false, evaluator_kind: "model_judge" as const, metric_id: "answer.grounded", minimum_score: 0.8, weight: 2 },
+      { blocking: true, evaluator_kind: "deterministic" as const, metric_id: "effect.authorized", minimum_score: 1, weight: 1 },
+    ],
+    rubric_ref: "agent-gym-rubric://suite/default",
+    schema_version: "agent-gym-evaluator-rubric/v1" as const,
+  };
+}
+
+function modelJudgeInput(rubricDigest: string) {
+  return {
+    evaluator_kind: "model_judge" as const,
+    evaluator_ref: "agent-gym-evaluator://suite/judge",
+    implementation_digest: digest("a"),
+    model: { inference_config_digest: digest("b"), model_ref: "model://judge/primary" },
+    output_schema_digest: digest("c"),
+    rubric_digest: rubricDigest,
+    schema_version: "agent-gym-evaluator-manifest/v1" as const,
+  };
+}
+
+function deterministicInput(rubricDigest: string) {
+  return {
+    evaluator_kind: "deterministic" as const,
+    evaluator_ref: "agent-gym-evaluator://suite/deterministic",
+    implementation_digest: digest("d"),
+    output_schema_digest: digest("e"),
+    rubric_digest: rubricDigest,
+    schema_version: "agent-gym-evaluator-manifest/v1" as const,
+  };
+}
+
+function fixture(
+  suffix: string,
+  partition: "held_out" | "shadow" | "train",
+  text: string,
+  labels: readonly string[] = ["support"],
+) {
+  return {
+    case_ref: `agent-gym-case://suite/${suffix}`,
+    expected_invariants: ["answer-grounded"],
+    labels,
+    partition,
+    schema_version: "agent-gym-fixture-case/v1" as const,
+    slack_events: [{
+      event_ref: `slack-event://suite/${suffix}`,
+      kind: "mention" as const,
+      occurred_at: "2026-08-12T10:59:00.000Z",
+      payload: { text },
+    }],
+    tool_fixtures: [{
+      call_ref: `tool-call://suite/${suffix}`,
+      input: { alert_ref: `alert://suite/${suffix}` },
+      outcome: "success" as const,
+      output: { severity: "high" },
+      tool_id: "alerts.read",
+    }],
+  };
+}
+
+function digest(character: string): string {
+  return `sha256:${character.repeat(64)}`;
+}

--- a/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
+++ b/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
@@ -13,8 +13,10 @@ import {
   planAgentGymEvaluationRun,
   recordAgentGymCaseEvaluation,
   recordAgentGymCorpusQuality,
+  summarizeAgentGymEvaluationSlices,
   validateAgentGymEvaluationRunPlan,
   validateAgentGymEvaluationRunResult,
+  validateAgentGymEvaluationSliceReport,
 } from "../src/index.js";
 
 test("evaluation suites seal admitted non-training cases", () => {
@@ -83,6 +85,17 @@ test("evaluation run results reject missing case evidence", () => {
     caseEvaluations(setup, suite).slice(1),
     { completed_at: "2026-08-12T11:06:00.000Z", started_at: "2026-08-12T11:05:00.000Z" },
   ), /evaluation run result is invalid/u);
+});
+
+test("evaluation slices retain partition and label evidence", () => {
+  const setup = evaluationSetup();
+  const suite = suiteFrom(setup);
+  const result = completedRun(setup, suite);
+  const report = summarizeAgentGymEvaluationSlices(suite, result);
+  assert.equal(report.slices.find((entry) => entry.slice_id === "overall:all")?.case_count, 2);
+  assert.equal(report.slices.find((entry) => entry.slice_id === "label:safety")?.case_count, 1);
+  assert.equal(report.slices.find((entry) => entry.slice_id === "partition:shadow")?.valid_case_count, 1);
+  assert.deepEqual(validateAgentGymEvaluationSliceReport(report), report);
 });
 
 function evaluationSetup() {
@@ -177,6 +190,18 @@ function caseEvaluations(
       valid: true,
     },
   ));
+}
+
+function completedRun(
+  setup: ReturnType<typeof evaluationSetup>,
+  suite: ReturnType<typeof defineAgentGymEvaluationSuite>,
+) {
+  return completeAgentGymEvaluationRun(
+    suite,
+    planAgentGymEvaluationRun(suite, runPlanInput()),
+    caseEvaluations(setup, suite),
+    { completed_at: "2026-08-12T11:06:00.000Z", started_at: "2026-08-12T11:05:00.000Z" },
+  );
 }
 
 function runPlanInput() {

--- a/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
+++ b/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
@@ -7,6 +7,7 @@ import {
   completeAgentGymEvaluationRun,
   decideAgentGymCorpusAdmission,
   decideAgentGymEvaluatorAdmission,
+  decideAgentGymEvaluationReadiness,
   defineAgentGymEvaluationSuite,
   defineAgentGymEvaluatorManifest,
   defineAgentGymEvaluatorRubric,
@@ -16,6 +17,7 @@ import {
   summarizeAgentGymEvaluationSlices,
   validateAgentGymEvaluationRunPlan,
   validateAgentGymEvaluationRunResult,
+  validateAgentGymEvaluationReadinessDecision,
   validateAgentGymEvaluationSliceReport,
 } from "../src/index.js";
 
@@ -96,6 +98,65 @@ test("evaluation slices retain partition and label evidence", () => {
   assert.equal(report.slices.find((entry) => entry.slice_id === "label:safety")?.case_count, 1);
   assert.equal(report.slices.find((entry) => entry.slice_id === "partition:shadow")?.valid_case_count, 1);
   assert.deepEqual(validateAgentGymEvaluationSliceReport(report), report);
+});
+
+test("evaluation readiness admits complete valid comparison evidence", () => {
+  const setup = evaluationSetup();
+  const suite = suiteFrom(setup);
+  const result = completedRun(setup, suite);
+  const report = summarizeAgentGymEvaluationSlices(suite, result);
+  const decision = decideAgentGymEvaluationReadiness(
+    suite,
+    result,
+    report,
+    readinessPolicy(),
+    "2026-08-12T11:07:00.000Z",
+  );
+  assert.equal(decision.ready, true);
+  assert.deepEqual(decision.blocker_codes, []);
+  assert.match(decision.decision_digest, /^sha256:[0-9a-f]{64}$/u);
+  assert.deepEqual(validateAgentGymEvaluationReadinessDecision(decision), decision);
+});
+
+test("evaluation readiness preserves invalid judge output as a blocker", () => {
+  const setup = evaluationSetup();
+  const suite = suiteFrom(setup);
+  const plan = planAgentGymEvaluationRun(suite, runPlanInput());
+  const evaluations = caseEvaluations(setup, suite);
+  const invalid = recordAgentGymCaseEvaluation(
+    setup.rubric,
+    [setup.modelJudge, setup.deterministic],
+    {
+      candidate_ref: runPlanInput().candidate_ref,
+      case_ref: suite.cases[0]!.case_ref,
+      evaluated_at: "2026-08-12T11:05:30.000Z",
+      evaluation_ref: "agent-gym-evaluation://nightly/invalid-case",
+      invalid_reason_codes: ["judge.output_schema_mismatch"],
+      metrics: [],
+      replay_ref: "agent-gym-replay://nightly/invalid-case",
+      schema_version: "agent-gym-case-evaluation/v1",
+      valid: false,
+    },
+  );
+  const result = completeAgentGymEvaluationRun(
+    suite,
+    plan,
+    [invalid, ...evaluations.slice(1)],
+    { completed_at: "2026-08-12T11:06:00.000Z", started_at: "2026-08-12T11:05:00.000Z" },
+  );
+  const decision = decideAgentGymEvaluationReadiness(
+    suite,
+    result,
+    summarizeAgentGymEvaluationSlices(suite, result),
+    readinessPolicy(),
+    "2026-08-12T11:07:00.000Z",
+  );
+  assert.equal(decision.ready, false);
+  assert.deepEqual(decision.blocker_codes, [
+    "evaluation.case_count_below_minimum",
+    "evaluation.invalid_cases",
+    "evaluation.required_slice_underfilled",
+  ]);
 });
 
 function evaluationSetup() {
@@ -202,6 +263,18 @@ function completedRun(
     caseEvaluations(setup, suite),
     { completed_at: "2026-08-12T11:06:00.000Z", started_at: "2026-08-12T11:05:00.000Z" },
   );
+}
+
+function readinessPolicy() {
+  return {
+    minimum_case_count: 2,
+    policy_ref: "agent-gym-evaluation-readiness-policy://default/v1",
+    required_slices: [
+      { minimum_valid_case_count: 1, slice_id: "partition:held_out" },
+      { minimum_valid_case_count: 1, slice_id: "partition:shadow" },
+    ],
+    schema_version: "agent-gym-evaluation-readiness-policy/v1" as const,
+  };
 }
 
 function runPlanInput() {

--- a/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
+++ b/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
@@ -4,14 +4,17 @@ import test from "node:test";
 import {
   buildAgentGymCorpus,
   calibrateAgentGymEvaluator,
+  completeAgentGymEvaluationRun,
   decideAgentGymCorpusAdmission,
   decideAgentGymEvaluatorAdmission,
   defineAgentGymEvaluationSuite,
   defineAgentGymEvaluatorManifest,
   defineAgentGymEvaluatorRubric,
   planAgentGymEvaluationRun,
+  recordAgentGymCaseEvaluation,
   recordAgentGymCorpusQuality,
   validateAgentGymEvaluationRunPlan,
+  validateAgentGymEvaluationRunResult,
 } from "../src/index.js";
 
 test("evaluation suites seal admitted non-training cases", () => {
@@ -53,6 +56,33 @@ test("evaluation run plans reject tampered case identities", () => {
     ...plan,
     cases: [{ ...plan.cases[0]!, case_digest: digest("a") }, ...plan.cases.slice(1)],
   }), /evaluation run plan is invalid/u);
+});
+
+test("evaluation run results require one exact evaluation per planned case", () => {
+  const setup = evaluationSetup();
+  const suite = suiteFrom(setup);
+  const plan = planAgentGymEvaluationRun(suite, runPlanInput());
+  const result = completeAgentGymEvaluationRun(
+    suite,
+    plan,
+    caseEvaluations(setup, suite),
+    { completed_at: "2026-08-12T11:06:00.000Z", started_at: "2026-08-12T11:05:00.000Z" },
+  );
+  assert.equal(result.valid_case_count, 2);
+  assert.equal(result.invalid_case_count, 0);
+  assert.equal(result.blocker_case_count, 0);
+  assert.deepEqual(validateAgentGymEvaluationRunResult(result), result);
+});
+
+test("evaluation run results reject missing case evidence", () => {
+  const setup = evaluationSetup();
+  const suite = suiteFrom(setup);
+  assert.throws(() => completeAgentGymEvaluationRun(
+    suite,
+    planAgentGymEvaluationRun(suite, runPlanInput()),
+    caseEvaluations(setup, suite).slice(1),
+    { completed_at: "2026-08-12T11:06:00.000Z", started_at: "2026-08-12T11:05:00.000Z" },
+  ), /evaluation run result is invalid/u);
 });
 
 function evaluationSetup() {
@@ -113,12 +143,40 @@ function evaluationSetup() {
 
 function evaluationSuite() {
   const setup = evaluationSetup();
+  return suiteFrom(setup);
+}
+
+function suiteFrom(setup: ReturnType<typeof evaluationSetup>) {
   return defineAgentGymEvaluationSuite(
     setup.fixtures,
     setup.quality,
     setup.evaluatorAdmission,
     { partitions: ["held_out", "shadow"], suite_ref: "agent-gym-suite://nightly/default" },
   );
+}
+
+function caseEvaluations(
+  setup: ReturnType<typeof evaluationSetup>,
+  suite: ReturnType<typeof defineAgentGymEvaluationSuite>,
+) {
+  return suite.cases.map((entry, index) => recordAgentGymCaseEvaluation(
+    setup.rubric,
+    [setup.modelJudge, setup.deterministic],
+    {
+      candidate_ref: runPlanInput().candidate_ref,
+      case_ref: entry.case_ref,
+      evaluated_at: "2026-08-12T11:05:30.000Z",
+      evaluation_ref: `agent-gym-evaluation://nightly/case-${index}`,
+      invalid_reason_codes: [],
+      metrics: [
+        { evaluator_digest: setup.modelJudge.evaluator_digest, metric_id: "answer.grounded", reason_codes: [], score: 0.9 },
+        { evaluator_digest: setup.deterministic.evaluator_digest, metric_id: "effect.authorized", reason_codes: [], score: 1 },
+      ],
+      replay_ref: `agent-gym-replay://nightly/case-${index}`,
+      schema_version: "agent-gym-case-evaluation/v1",
+      valid: true,
+    },
+  ));
 }
 
 function runPlanInput() {


### PR DESCRIPTION
## Summary
- seal admitted held-out and shadow cases into immutable evaluation suites
- plan and complete exact candidate runs with one evaluation per case
- retain partition and label slices and fail comparison readiness closed

## Verification
- DDESK TypeScript typecheck
- DDESK evaluation-suite tests: 9 passed
- DDESK full Slack companion suite: 651 passed

Part of the Agent Gym delivery sequence (commits 66–70 of 200).