### PR TITLE
feat(slack): compare agent gym candidates

### DIFF
--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -24,6 +24,7 @@ export * from "./evaluation-run-result.js";
 export * from "./evaluation-slices.js";
 export * from "./evaluation-readiness.js";
 export * from "./paired-evaluation.js";
+export * from "./paired-case-deltas.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -23,6 +23,7 @@ export * from "./evaluation-run-plan.js";
 export * from "./evaluation-run-result.js";
 export * from "./evaluation-slices.js";
 export * from "./evaluation-readiness.js";
+export * from "./paired-evaluation.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -27,6 +27,7 @@ export * from "./paired-evaluation.js";
 export * from "./paired-case-deltas.js";
 export * from "./paired-uncertainty.js";
 export * from "./paired-slices.js";
+export * from "./promotion-input.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -26,6 +26,7 @@ export * from "./evaluation-readiness.js";
 export * from "./paired-evaluation.js";
 export * from "./paired-case-deltas.js";
 export * from "./paired-uncertainty.js";
+export * from "./paired-slices.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -25,6 +25,7 @@ export * from "./evaluation-slices.js";
 export * from "./evaluation-readiness.js";
 export * from "./paired-evaluation.js";
 export * from "./paired-case-deltas.js";
+export * from "./paired-uncertainty.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/paired-case-deltas.ts
+++ b/apps/slack-companion/src/agent-gym/paired-case-deltas.ts
@@ -1,0 +1,144 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymEvaluationRunResult,
+  type AgentGymEvaluationRunResultV1,
+} from "./evaluation-run-result.js";
+import {
+  validateAgentGymPairedEvaluation,
+  type AgentGymPairedEvaluationV1,
+} from "./paired-evaluation.js";
+
+export interface AgentGymPairedCaseDeltaV1 {
+  readonly baseline_evaluation_digest: string;
+  readonly baseline_score: number;
+  readonly candidate_evaluation_digest: string;
+  readonly candidate_score: number;
+  readonly case_digest: string;
+  readonly case_ref: string;
+  readonly delta: number;
+  readonly disposition: "improved" | "regressed" | "tied";
+}
+
+export interface AgentGymPairedCaseDeltaReportV1 {
+  readonly case_count: number;
+  readonly cases: readonly AgentGymPairedCaseDeltaV1[];
+  readonly improvement_count: number;
+  readonly mean_delta: number;
+  readonly pair_digest: string;
+  readonly regression_count: number;
+  readonly report_digest: string;
+  readonly schema_version: "agent-gym-paired-case-delta-report/v1";
+  readonly tie_count: number;
+}
+
+/** Computes exact per-case score movement without dropping tied or regressed cases. */
+export function calculateAgentGymPairedCaseDeltas(
+  pairInput: AgentGymPairedEvaluationV1,
+  baselineInput: AgentGymEvaluationRunResultV1,
+  candidateInput: AgentGymEvaluationRunResultV1,
+): AgentGymPairedCaseDeltaReportV1 {
+  const pair = validateAgentGymPairedEvaluation(pairInput);
+  const baseline = validateAgentGymEvaluationRunResult(baselineInput);
+  const candidate = validateAgentGymEvaluationRunResult(candidateInput);
+  if (baseline.result_digest !== pair.baseline_result_digest
+    || candidate.result_digest !== pair.candidate_result_digest
+    || baseline.candidate_ref !== pair.baseline_candidate_ref
+    || candidate.candidate_ref !== pair.candidate_ref
+    || baseline.case_count !== pair.case_count || candidate.case_count !== pair.case_count) invalid();
+  const candidateByCase = new Map(candidate.cases.map((entry) => [entry.case_ref, entry]));
+  const cases = baseline.cases.map((baselineCase) => {
+    const candidateCase = candidateByCase.get(baselineCase.case_ref);
+    if (candidateCase === undefined || candidateCase.case_digest !== baselineCase.case_digest
+      || baselineCase.weighted_score === null || candidateCase.weighted_score === null) invalid();
+    const delta = candidateCase.weighted_score - baselineCase.weighted_score;
+    return Object.freeze({
+      baseline_evaluation_digest: baselineCase.evaluation_digest,
+      baseline_score: baselineCase.weighted_score,
+      candidate_evaluation_digest: candidateCase.evaluation_digest,
+      candidate_score: candidateCase.weighted_score,
+      case_digest: baselineCase.case_digest,
+      case_ref: baselineCase.case_ref,
+      delta,
+      disposition: delta > 0 ? "improved" as const : delta < 0 ? "regressed" as const : "tied" as const,
+    });
+  });
+  const body = {
+    case_count: cases.length,
+    cases: cases.map((entry) => ({ ...entry })),
+    improvement_count: cases.filter((entry) => entry.disposition === "improved").length,
+    mean_delta: cases.reduce((total, entry) => total + entry.delta, 0) / cases.length,
+    pair_digest: pair.pair_digest,
+    regression_count: cases.filter((entry) => entry.disposition === "regressed").length,
+    schema_version: "agent-gym-paired-case-delta-report/v1" as const,
+    tie_count: cases.filter((entry) => entry.disposition === "tied").length,
+  };
+  return Object.freeze({
+    ...body,
+    cases: Object.freeze(cases),
+    report_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymPairedCaseDeltaReport(
+  value: AgentGymPairedCaseDeltaReportV1,
+): AgentGymPairedCaseDeltaReportV1 {
+  if (value.schema_version !== "agent-gym-paired-case-delta-report/v1") invalid();
+  for (const digest of [value.pair_digest, value.report_digest]) digestValue(digest);
+  integer(value.case_count, 100_000, false);
+  integer(value.improvement_count, value.case_count, true);
+  integer(value.regression_count, value.case_count, true);
+  integer(value.tie_count, value.case_count, true);
+  finite(value.mean_delta, -1, 1);
+  if (!Array.isArray(value.cases) || value.cases.length !== value.case_count
+    || value.improvement_count + value.regression_count + value.tie_count !== value.case_count) invalid();
+  const caseRefs = new Set<string>();
+  const cases = value.cases.map((entry) => {
+    reference(entry.case_ref);
+    for (const digest of [entry.case_digest, entry.baseline_evaluation_digest,
+      entry.candidate_evaluation_digest]) digestValue(digest);
+    unit(entry.baseline_score);
+    unit(entry.candidate_score);
+    finite(entry.delta, -1, 1);
+    const expectedDelta = entry.candidate_score - entry.baseline_score;
+    const expectedDisposition = expectedDelta > 0 ? "improved" : expectedDelta < 0 ? "regressed" : "tied";
+    if (caseRefs.has(entry.case_ref) || Math.abs(entry.delta - expectedDelta) > 1e-12
+      || entry.disposition !== expectedDisposition) invalid();
+    caseRefs.add(entry.case_ref);
+    return Object.freeze({ ...entry });
+  });
+  const mean = cases.reduce((total, entry) => total + entry.delta, 0) / cases.length;
+  if (Math.abs(mean - value.mean_delta) > 1e-12
+    || cases.filter((entry) => entry.disposition === "improved").length !== value.improvement_count
+    || cases.filter((entry) => entry.disposition === "regressed").length !== value.regression_count
+    || cases.filter((entry) => entry.disposition === "tied").length !== value.tie_count) invalid();
+  const body = {
+    case_count: value.case_count,
+    cases: cases.map((entry) => ({ ...entry })),
+    improvement_count: value.improvement_count,
+    mean_delta: value.mean_delta,
+    pair_digest: value.pair_digest,
+    regression_count: value.regression_count,
+    schema_version: value.schema_version,
+    tie_count: value.tie_count,
+  };
+  if (digestAgentGymJson(body) !== value.report_digest) invalid();
+  return Object.freeze({ ...value, cases: Object.freeze(cases) });
+}
+
+function digestValue(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function integer(value: number, maximum: number, allowZero: boolean): void {
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1) || value > maximum) invalid();
+}
+function finite(value: number, minimum: number, maximum: number): void {
+  if (!Number.isFinite(value) || value < minimum || value > maximum) invalid();
+}
+function unit(value: number): void { finite(value, 0, 1); }
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym paired case delta report is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/paired-evaluation.ts
+++ b/apps/slack-companion/src/agent-gym/paired-evaluation.ts
@@ -1,0 +1,139 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymEvaluationReadinessDecision,
+  type AgentGymEvaluationReadinessDecisionV1,
+} from "./evaluation-readiness.js";
+import {
+  validateAgentGymEvaluationRunResult,
+  type AgentGymEvaluationRunResultV1,
+} from "./evaluation-run-result.js";
+import type { AgentGymEvaluationSuiteV1 } from "./evaluation-suite.js";
+
+export interface AgentGymPairedEvaluationV1 {
+  readonly baseline_candidate_ref: string;
+  readonly baseline_readiness_digest: string;
+  readonly baseline_result_digest: string;
+  readonly candidate_ref: string;
+  readonly candidate_readiness_digest: string;
+  readonly candidate_result_digest: string;
+  readonly case_count: number;
+  readonly case_set_digest: string;
+  readonly pair_digest: string;
+  readonly pair_ref: string;
+  readonly paired_at: string;
+  readonly schema_version: "agent-gym-paired-evaluation/v1";
+  readonly suite_digest: string;
+}
+
+/** Binds ready baseline and challenger runs over one identical sealed case set. */
+export function pairAgentGymEvaluationRuns(
+  suite: AgentGymEvaluationSuiteV1,
+  baselineResultInput: AgentGymEvaluationRunResultV1,
+  baselineReadinessInput: AgentGymEvaluationReadinessDecisionV1,
+  candidateResultInput: AgentGymEvaluationRunResultV1,
+  candidateReadinessInput: AgentGymEvaluationReadinessDecisionV1,
+  input: { readonly pair_ref: string; readonly paired_at: string },
+): AgentGymPairedEvaluationV1 {
+  validateSuite(suite);
+  const baselineResult = validateAgentGymEvaluationRunResult(baselineResultInput);
+  const candidateResult = validateAgentGymEvaluationRunResult(candidateResultInput);
+  const baselineReadiness = validateAgentGymEvaluationReadinessDecision(baselineReadinessInput);
+  const candidateReadiness = validateAgentGymEvaluationReadinessDecision(candidateReadinessInput);
+  reference(input.pair_ref);
+  timestamp(input.paired_at);
+  if (!baselineReadiness.ready || !candidateReadiness.ready
+    || baselineResult.suite_digest !== suite.suite_digest
+    || candidateResult.suite_digest !== suite.suite_digest
+    || baselineReadiness.suite_digest !== suite.suite_digest
+    || candidateReadiness.suite_digest !== suite.suite_digest
+    || baselineReadiness.run_result_digest !== baselineResult.result_digest
+    || candidateReadiness.run_result_digest !== candidateResult.result_digest
+    || baselineResult.candidate_ref === candidateResult.candidate_ref
+    || Date.parse(input.paired_at) < Date.parse(baselineReadiness.decided_at)
+    || Date.parse(input.paired_at) < Date.parse(candidateReadiness.decided_at)) invalid();
+  const expectedCases = suite.cases.map((entry) => `${entry.case_ref}\0${entry.case_digest}`);
+  const baselineCases = baselineResult.cases.map((entry) => `${entry.case_ref}\0${entry.case_digest}`);
+  const candidateCases = candidateResult.cases.map((entry) => `${entry.case_ref}\0${entry.case_digest}`);
+  if (digestAgentGymJson(expectedCases) !== digestAgentGymJson(baselineCases)
+    || digestAgentGymJson(expectedCases) !== digestAgentGymJson(candidateCases)) invalid();
+  const body = {
+    baseline_candidate_ref: baselineResult.candidate_ref,
+    baseline_readiness_digest: baselineReadiness.decision_digest,
+    baseline_result_digest: baselineResult.result_digest,
+    candidate_ref: candidateResult.candidate_ref,
+    candidate_readiness_digest: candidateReadiness.decision_digest,
+    candidate_result_digest: candidateResult.result_digest,
+    case_count: suite.case_count,
+    case_set_digest: suite.case_set_digest,
+    pair_ref: input.pair_ref,
+    paired_at: input.paired_at,
+    schema_version: "agent-gym-paired-evaluation/v1" as const,
+    suite_digest: suite.suite_digest,
+  };
+  return Object.freeze({ ...body, pair_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymPairedEvaluation(
+  value: AgentGymPairedEvaluationV1,
+): AgentGymPairedEvaluationV1 {
+  if (value.schema_version !== "agent-gym-paired-evaluation/v1") invalid();
+  for (const ref of [value.baseline_candidate_ref, value.candidate_ref, value.pair_ref]) reference(ref);
+  if (value.baseline_candidate_ref === value.candidate_ref) invalid();
+  timestamp(value.paired_at);
+  for (const digest of [value.baseline_readiness_digest, value.baseline_result_digest,
+    value.candidate_readiness_digest, value.candidate_result_digest, value.case_set_digest,
+    value.pair_digest, value.suite_digest]) digestValue(digest);
+  if (!Number.isSafeInteger(value.case_count) || value.case_count < 1 || value.case_count > 100_000) invalid();
+  const body = {
+    baseline_candidate_ref: value.baseline_candidate_ref,
+    baseline_readiness_digest: value.baseline_readiness_digest,
+    baseline_result_digest: value.baseline_result_digest,
+    candidate_ref: value.candidate_ref,
+    candidate_readiness_digest: value.candidate_readiness_digest,
+    candidate_result_digest: value.candidate_result_digest,
+    case_count: value.case_count,
+    case_set_digest: value.case_set_digest,
+    pair_ref: value.pair_ref,
+    paired_at: value.paired_at,
+    schema_version: value.schema_version,
+    suite_digest: value.suite_digest,
+  };
+  if (digestAgentGymJson(body) !== value.pair_digest) invalid();
+  return Object.freeze({ ...value });
+}
+
+function validateSuite(value: AgentGymEvaluationSuiteV1): void {
+  if (value.schema_version !== "agent-gym-evaluation-suite/v1") invalid();
+  const body = {
+    case_count: value.case_count,
+    case_set_digest: value.case_set_digest,
+    cases: value.cases.map((entry) => ({
+      case_digest: entry.case_digest,
+      case_ref: entry.case_ref,
+      labels: [...entry.labels],
+      partition: entry.partition,
+    })),
+    corpus_digest: value.corpus_digest,
+    corpus_quality_receipt_digest: value.corpus_quality_receipt_digest,
+    evaluator_admission_decision_digest: value.evaluator_admission_decision_digest,
+    evaluator_digests: [...value.evaluator_digests],
+    partitions: [...value.partitions],
+    rubric_digest: value.rubric_digest,
+    schema_version: value.schema_version,
+    suite_ref: value.suite_ref,
+  };
+  if (digestAgentGymJson(body) !== value.suite_digest) invalid();
+}
+function digestValue(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym paired evaluation is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/paired-slices.ts
+++ b/apps/slack-companion/src/agent-gym/paired-slices.ts
@@ -1,0 +1,154 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import type { AgentGymEvaluationSuiteV1 } from "./evaluation-suite.js";
+import {
+  validateAgentGymPairedCaseDeltaReport,
+  type AgentGymPairedCaseDeltaReportV1,
+} from "./paired-case-deltas.js";
+
+export interface AgentGymPairedSliceV1 {
+  readonly baseline_score: number;
+  readonly candidate_score: number;
+  readonly case_count: number;
+  readonly delta: number;
+  readonly improvement_count: number;
+  readonly regression_count: number;
+  readonly slice_id: string;
+  readonly tie_count: number;
+}
+
+export interface AgentGymPairedSliceReportV1 {
+  readonly delta_report_digest: string;
+  readonly report_digest: string;
+  readonly schema_version: "agent-gym-paired-slice-report/v1";
+  readonly slices: readonly AgentGymPairedSliceV1[];
+  readonly suite_digest: string;
+}
+
+/** Preserves paired movement across overall, partition, and label slices. */
+export function summarizeAgentGymPairedSlices(
+  suite: AgentGymEvaluationSuiteV1,
+  deltaInput: AgentGymPairedCaseDeltaReportV1,
+): AgentGymPairedSliceReportV1 {
+  validateSuite(suite);
+  const deltaReport = validateAgentGymPairedCaseDeltaReport(deltaInput);
+  const deltaByCase = new Map(deltaReport.cases.map((entry) => [entry.case_ref, entry]));
+  if (suite.cases.some((entry) => deltaByCase.get(entry.case_ref)?.case_digest !== entry.case_digest)
+    || deltaReport.case_count !== suite.case_count) invalid();
+  const definitions: { readonly slice_id: string; readonly case_refs: readonly string[] }[] = [{
+    case_refs: suite.cases.map((entry) => entry.case_ref),
+    slice_id: "overall:all",
+  }];
+  for (const partition of suite.partitions) definitions.push({
+    case_refs: suite.cases.filter((entry) => entry.partition === partition).map((entry) => entry.case_ref),
+    slice_id: `partition:${partition}`,
+  });
+  for (const label of [...new Set(suite.cases.flatMap((entry) => entry.labels))].sort()) definitions.push({
+    case_refs: suite.cases.filter((entry) => entry.labels.includes(label)).map((entry) => entry.case_ref),
+    slice_id: `label:${label}`,
+  });
+  const slices = definitions.map((definition) => {
+    const cases = definition.case_refs.map((caseRef) => deltaByCase.get(caseRef) ?? invalid());
+    const baselineScore = mean(cases.map((entry) => entry.baseline_score));
+    const candidateScore = mean(cases.map((entry) => entry.candidate_score));
+    return Object.freeze({
+      baseline_score: baselineScore,
+      candidate_score: candidateScore,
+      case_count: cases.length,
+      delta: candidateScore - baselineScore,
+      improvement_count: cases.filter((entry) => entry.disposition === "improved").length,
+      regression_count: cases.filter((entry) => entry.disposition === "regressed").length,
+      slice_id: definition.slice_id,
+      tie_count: cases.filter((entry) => entry.disposition === "tied").length,
+    });
+  }).sort((left, right) => left.slice_id.localeCompare(right.slice_id));
+  const body = {
+    delta_report_digest: deltaReport.report_digest,
+    schema_version: "agent-gym-paired-slice-report/v1" as const,
+    slices: slices.map((entry) => ({ ...entry })),
+    suite_digest: suite.suite_digest,
+  };
+  return Object.freeze({
+    ...body,
+    slices: Object.freeze(slices),
+    report_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymPairedSliceReport(
+  value: AgentGymPairedSliceReportV1,
+): AgentGymPairedSliceReportV1 {
+  if (value.schema_version !== "agent-gym-paired-slice-report/v1") invalid();
+  for (const digest of [value.delta_report_digest, value.report_digest, value.suite_digest]) digestValue(digest);
+  if (!Array.isArray(value.slices) || value.slices.length === 0 || value.slices.length > 1_000) invalid();
+  const sliceIds = new Set<string>();
+  const slices = value.slices.map((entry) => {
+    text(entry.slice_id);
+    unit(entry.baseline_score);
+    unit(entry.candidate_score);
+    finite(entry.delta, -1, 1);
+    integer(entry.case_count, 100_000, false);
+    integer(entry.improvement_count, entry.case_count, true);
+    integer(entry.regression_count, entry.case_count, true);
+    integer(entry.tie_count, entry.case_count, true);
+    if (sliceIds.has(entry.slice_id)
+      || entry.improvement_count + entry.regression_count + entry.tie_count !== entry.case_count
+      || Math.abs(entry.candidate_score - entry.baseline_score - entry.delta) > 1e-12) invalid();
+    sliceIds.add(entry.slice_id);
+    return Object.freeze({ ...entry });
+  });
+  if (!sliceIds.has("overall:all")
+    || slices.some((entry, index) => index > 0 && slices[index - 1]!.slice_id >= entry.slice_id)) invalid();
+  const body = {
+    delta_report_digest: value.delta_report_digest,
+    schema_version: value.schema_version,
+    slices: slices.map((entry) => ({ ...entry })),
+    suite_digest: value.suite_digest,
+  };
+  if (digestAgentGymJson(body) !== value.report_digest) invalid();
+  return Object.freeze({ ...value, slices: Object.freeze(slices) });
+}
+
+function validateSuite(value: AgentGymEvaluationSuiteV1): void {
+  if (value.schema_version !== "agent-gym-evaluation-suite/v1") invalid();
+  const body = {
+    case_count: value.case_count,
+    case_set_digest: value.case_set_digest,
+    cases: value.cases.map((entry) => ({
+      case_digest: entry.case_digest,
+      case_ref: entry.case_ref,
+      labels: [...entry.labels],
+      partition: entry.partition,
+    })),
+    corpus_digest: value.corpus_digest,
+    corpus_quality_receipt_digest: value.corpus_quality_receipt_digest,
+    evaluator_admission_decision_digest: value.evaluator_admission_decision_digest,
+    evaluator_digests: [...value.evaluator_digests],
+    partitions: [...value.partitions],
+    rubric_digest: value.rubric_digest,
+    schema_version: value.schema_version,
+    suite_ref: value.suite_ref,
+  };
+  if (digestAgentGymJson(body) !== value.suite_digest) invalid();
+}
+function mean(values: readonly number[]): number {
+  if (values.length === 0) invalid();
+  return values.reduce((total, value) => total + value, 0) / values.length;
+}
+function digestValue(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function text(value: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > 160
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function integer(value: number, maximum: number, allowZero: boolean): void {
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1) || value > maximum) invalid();
+}
+function finite(value: number, minimum: number, maximum: number): void {
+  if (!Number.isFinite(value) || value < minimum || value > maximum) invalid();
+}
+function unit(value: number): void { finite(value, 0, 1); }
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym paired slice report is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/paired-uncertainty.ts
+++ b/apps/slack-companion/src/agent-gym/paired-uncertainty.ts
@@ -1,0 +1,132 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymPairedCaseDeltaReport,
+  type AgentGymPairedCaseDeltaReportV1,
+} from "./paired-case-deltas.js";
+
+export interface AgentGymPairedBootstrapPolicyV1 {
+  readonly confidence_level: number;
+  readonly policy_ref: string;
+  readonly resample_count: number;
+  readonly schema_version: "agent-gym-paired-bootstrap-policy/v1";
+  readonly seed_digest: string;
+}
+
+export interface AgentGymPairedUncertaintyV1 {
+  readonly confidence_level: number;
+  readonly delta_report_digest: string;
+  readonly lower_bound: number;
+  readonly method: "paired_bootstrap";
+  readonly observed_mean_delta: number;
+  readonly policy_ref: string;
+  readonly probability_positive: number;
+  readonly resample_count: number;
+  readonly schema_version: "agent-gym-paired-uncertainty/v1";
+  readonly seed_digest: string;
+  readonly uncertainty_digest: string;
+  readonly upper_bound: number;
+}
+
+/** Computes a reproducible paired bootstrap without model or wall-clock variance. */
+export function estimateAgentGymPairedUncertainty(
+  deltaInput: AgentGymPairedCaseDeltaReportV1,
+  policy: AgentGymPairedBootstrapPolicyV1,
+): AgentGymPairedUncertaintyV1 {
+  const deltaReport = validateAgentGymPairedCaseDeltaReport(deltaInput);
+  validatePolicy(policy);
+  const random = xorshift32(Number.parseInt(policy.seed_digest.slice(7, 15), 16));
+  const means: number[] = [];
+  for (let sample = 0; sample < policy.resample_count; sample += 1) {
+    let total = 0;
+    for (let index = 0; index < deltaReport.case_count; index += 1) {
+      total += deltaReport.cases[Math.floor(random() * deltaReport.case_count)]!.delta;
+    }
+    means.push(total / deltaReport.case_count);
+  }
+  means.sort((left, right) => left - right);
+  const alpha = (1 - policy.confidence_level) / 2;
+  const lowerIndex = Math.floor(alpha * (means.length - 1));
+  const upperIndex = Math.ceil((1 - alpha) * (means.length - 1));
+  const body = {
+    confidence_level: policy.confidence_level,
+    delta_report_digest: deltaReport.report_digest,
+    lower_bound: means[lowerIndex]!,
+    method: "paired_bootstrap" as const,
+    observed_mean_delta: deltaReport.mean_delta,
+    policy_ref: policy.policy_ref,
+    probability_positive: means.filter((value) => value > 0).length / means.length,
+    resample_count: policy.resample_count,
+    schema_version: "agent-gym-paired-uncertainty/v1" as const,
+    seed_digest: policy.seed_digest,
+    upper_bound: means[upperIndex]!,
+  };
+  return Object.freeze({ ...body, uncertainty_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymPairedUncertainty(
+  value: AgentGymPairedUncertaintyV1,
+): AgentGymPairedUncertaintyV1 {
+  if (value.schema_version !== "agent-gym-paired-uncertainty/v1"
+    || value.method !== "paired_bootstrap") invalid();
+  reference(value.policy_ref);
+  for (const digest of [value.delta_report_digest, value.seed_digest, value.uncertainty_digest]) digestValue(digest);
+  confidence(value.confidence_level);
+  unit(value.probability_positive);
+  finite(value.lower_bound, -1, 1);
+  finite(value.upper_bound, -1, 1);
+  finite(value.observed_mean_delta, -1, 1);
+  if (value.lower_bound > value.upper_bound
+    || !Number.isSafeInteger(value.resample_count)
+    || value.resample_count < 100 || value.resample_count > 100_000) invalid();
+  const body = {
+    confidence_level: value.confidence_level,
+    delta_report_digest: value.delta_report_digest,
+    lower_bound: value.lower_bound,
+    method: value.method,
+    observed_mean_delta: value.observed_mean_delta,
+    policy_ref: value.policy_ref,
+    probability_positive: value.probability_positive,
+    resample_count: value.resample_count,
+    schema_version: value.schema_version,
+    seed_digest: value.seed_digest,
+    upper_bound: value.upper_bound,
+  };
+  if (digestAgentGymJson(body) !== value.uncertainty_digest) invalid();
+  return Object.freeze({ ...value });
+}
+
+function validatePolicy(value: AgentGymPairedBootstrapPolicyV1): void {
+  if (value.schema_version !== "agent-gym-paired-bootstrap-policy/v1") invalid();
+  reference(value.policy_ref);
+  digestValue(value.seed_digest);
+  confidence(value.confidence_level);
+  if (!Number.isSafeInteger(value.resample_count)
+    || value.resample_count < 100 || value.resample_count > 100_000) invalid();
+}
+
+function xorshift32(seed: number): () => number {
+  let state = seed === 0 ? 0x9e3779b9 : seed >>> 0;
+  return () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    return (state >>> 0) / 0x1_0000_0000;
+  };
+}
+function digestValue(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function confidence(value: number): void {
+  if (!Number.isFinite(value) || value < 0.8 || value >= 1) invalid();
+}
+function finite(value: number, minimum: number, maximum: number): void {
+  if (!Number.isFinite(value) || value < minimum || value > maximum) invalid();
+}
+function unit(value: number): void { finite(value, 0, 1); }
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym paired uncertainty is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/promotion-input.ts
+++ b/apps/slack-companion/src/agent-gym/promotion-input.ts
@@ -1,0 +1,182 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymPairedCaseDeltaReport,
+  type AgentGymPairedCaseDeltaReportV1,
+} from "./paired-case-deltas.js";
+import {
+  validateAgentGymPairedEvaluation,
+  type AgentGymPairedEvaluationV1,
+} from "./paired-evaluation.js";
+import {
+  validateAgentGymPairedSliceReport,
+  type AgentGymPairedSliceReportV1,
+} from "./paired-slices.js";
+import {
+  validateAgentGymPairedUncertainty,
+  type AgentGymPairedUncertaintyV1,
+} from "./paired-uncertainty.js";
+
+export type AgentGymPromotionInputBlockerCode =
+  | "comparison.case_regression"
+  | "comparison.confidence_below_minimum"
+  | "comparison.interval_not_positive"
+  | "comparison.mean_below_threshold"
+  | "comparison.required_slice_missing"
+  | "comparison.slice_regression";
+
+export interface AgentGymPromotionInputPolicyV1 {
+  readonly maximum_case_regressions: number;
+  readonly minimum_mean_delta: number;
+  readonly minimum_probability_positive: number;
+  readonly policy_ref: string;
+  readonly required_slice_ids: readonly string[];
+  readonly schema_version: "agent-gym-promotion-input-policy/v1";
+}
+
+export interface AgentGymPromotionInputReceiptV1 {
+  readonly baseline_candidate_ref: string;
+  readonly blocker_codes: readonly AgentGymPromotionInputBlockerCode[];
+  readonly candidate_ref: string;
+  readonly case_delta_report_digest: string;
+  readonly eligible: boolean;
+  readonly evaluated_at: string;
+  readonly pair_digest: string;
+  readonly policy_digest: string;
+  readonly policy_ref: string;
+  readonly receipt_digest: string;
+  readonly schema_version: "agent-gym-promotion-input-receipt/v1";
+  readonly slice_report_digest: string;
+  readonly uncertainty_digest: string;
+}
+
+/** Converts paired evidence into one policy-bound, fail-closed promotion input. */
+export function issueAgentGymPromotionInput(
+  pairInput: AgentGymPairedEvaluationV1,
+  deltasInput: AgentGymPairedCaseDeltaReportV1,
+  uncertaintyInput: AgentGymPairedUncertaintyV1,
+  slicesInput: AgentGymPairedSliceReportV1,
+  policy: AgentGymPromotionInputPolicyV1,
+  evaluatedAt: string,
+): AgentGymPromotionInputReceiptV1 {
+  const pair = validateAgentGymPairedEvaluation(pairInput);
+  const deltas = validateAgentGymPairedCaseDeltaReport(deltasInput);
+  const uncertainty = validateAgentGymPairedUncertainty(uncertaintyInput);
+  const slices = validateAgentGymPairedSliceReport(slicesInput);
+  validatePolicy(policy);
+  timestamp(evaluatedAt);
+  if (deltas.pair_digest !== pair.pair_digest
+    || uncertainty.delta_report_digest !== deltas.report_digest
+    || slices.delta_report_digest !== deltas.report_digest
+    || slices.suite_digest !== pair.suite_digest
+    || Date.parse(evaluatedAt) < Date.parse(pair.paired_at)) invalid();
+  const blockers = new Set<AgentGymPromotionInputBlockerCode>();
+  if (deltas.mean_delta < policy.minimum_mean_delta) blockers.add("comparison.mean_below_threshold");
+  if (deltas.regression_count > policy.maximum_case_regressions) blockers.add("comparison.case_regression");
+  if (uncertainty.lower_bound <= 0) blockers.add("comparison.interval_not_positive");
+  if (uncertainty.probability_positive < policy.minimum_probability_positive) {
+    blockers.add("comparison.confidence_below_minimum");
+  }
+  const sliceById = new Map(slices.slices.map((slice) => [slice.slice_id, slice]));
+  for (const sliceId of policy.required_slice_ids) {
+    const slice = sliceById.get(sliceId);
+    if (slice === undefined) blockers.add("comparison.required_slice_missing");
+    else if (slice.delta < 0 || slice.regression_count > 0) blockers.add("comparison.slice_regression");
+  }
+  const blockerCodes = [...blockers].sort();
+  const policyBody = {
+    maximum_case_regressions: policy.maximum_case_regressions,
+    minimum_mean_delta: policy.minimum_mean_delta,
+    minimum_probability_positive: policy.minimum_probability_positive,
+    policy_ref: policy.policy_ref,
+    required_slice_ids: [...policy.required_slice_ids],
+    schema_version: policy.schema_version,
+  };
+  const body = {
+    baseline_candidate_ref: pair.baseline_candidate_ref,
+    blocker_codes: blockerCodes,
+    candidate_ref: pair.candidate_ref,
+    case_delta_report_digest: deltas.report_digest,
+    eligible: blockerCodes.length === 0,
+    evaluated_at: evaluatedAt,
+    pair_digest: pair.pair_digest,
+    policy_digest: digestAgentGymJson(policyBody),
+    policy_ref: policy.policy_ref,
+    schema_version: "agent-gym-promotion-input-receipt/v1" as const,
+    slice_report_digest: slices.report_digest,
+    uncertainty_digest: uncertainty.uncertainty_digest,
+  };
+  return Object.freeze({
+    ...body,
+    blocker_codes: Object.freeze(blockerCodes),
+    receipt_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymPromotionInput(
+  value: AgentGymPromotionInputReceiptV1,
+): AgentGymPromotionInputReceiptV1 {
+  if (value.schema_version !== "agent-gym-promotion-input-receipt/v1") invalid();
+  for (const ref of [value.baseline_candidate_ref, value.candidate_ref, value.policy_ref]) reference(ref);
+  if (value.baseline_candidate_ref === value.candidate_ref) invalid();
+  timestamp(value.evaluated_at);
+  for (const digest of [value.case_delta_report_digest, value.pair_digest, value.policy_digest,
+    value.receipt_digest, value.slice_report_digest, value.uncertainty_digest]) digestValue(digest);
+  const allowed: readonly AgentGymPromotionInputBlockerCode[] = [
+    "comparison.case_regression", "comparison.confidence_below_minimum",
+    "comparison.interval_not_positive", "comparison.mean_below_threshold",
+    "comparison.required_slice_missing", "comparison.slice_regression",
+  ];
+  if (!Array.isArray(value.blocker_codes) || value.blocker_codes.length > allowed.length
+    || new Set(value.blocker_codes).size !== value.blocker_codes.length
+    || value.blocker_codes.some((code) => !allowed.includes(code))
+    || value.blocker_codes.some((code, index) => index > 0 && value.blocker_codes[index - 1]! >= code)
+    || value.eligible !== (value.blocker_codes.length === 0)) invalid();
+  const body = {
+    baseline_candidate_ref: value.baseline_candidate_ref,
+    blocker_codes: value.blocker_codes,
+    candidate_ref: value.candidate_ref,
+    case_delta_report_digest: value.case_delta_report_digest,
+    eligible: value.eligible,
+    evaluated_at: value.evaluated_at,
+    pair_digest: value.pair_digest,
+    policy_digest: value.policy_digest,
+    policy_ref: value.policy_ref,
+    schema_version: value.schema_version,
+    slice_report_digest: value.slice_report_digest,
+    uncertainty_digest: value.uncertainty_digest,
+  };
+  if (digestAgentGymJson(body) !== value.receipt_digest) invalid();
+  return Object.freeze({ ...value, blocker_codes: Object.freeze([...value.blocker_codes]) });
+}
+
+function validatePolicy(value: AgentGymPromotionInputPolicyV1): void {
+  if (value.schema_version !== "agent-gym-promotion-input-policy/v1") invalid();
+  reference(value.policy_ref);
+  finite(value.minimum_mean_delta, 0, 1);
+  finite(value.minimum_probability_positive, 0.5, 1);
+  if (!Number.isSafeInteger(value.maximum_case_regressions)
+    || value.maximum_case_regressions < 0 || value.maximum_case_regressions > 100_000
+    || !Array.isArray(value.required_slice_ids) || value.required_slice_ids.length > 1_000
+    || new Set(value.required_slice_ids).size !== value.required_slice_ids.length) invalid();
+  for (const sliceId of value.required_slice_ids) text(sliceId);
+}
+function digestValue(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function text(value: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > 160
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function finite(value: number, minimum: number, maximum: number): void {
+  if (!Number.isFinite(value) || value < minimum || value > maximum) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym promotion input is invalid.");
+}

--- a/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
+++ b/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
@@ -13,6 +13,7 @@ import {
   defineAgentGymEvaluatorManifest,
   defineAgentGymEvaluatorRubric,
   estimateAgentGymPairedUncertainty,
+  issueAgentGymPromotionInput,
   planAgentGymEvaluationRun,
   pairAgentGymEvaluationRuns,
   recordAgentGymCaseEvaluation,
@@ -27,6 +28,7 @@ import {
   validateAgentGymPairedCaseDeltaReport,
   validateAgentGymPairedUncertainty,
   validateAgentGymPairedSliceReport,
+  validateAgentGymPromotionInput,
 } from "../src/index.js";
 
 test("evaluation suites seal admitted non-training cases", () => {
@@ -234,6 +236,35 @@ test("paired slices expose regressions by partition and label", () => {
   assert.deepEqual(validateAgentGymPairedSliceReport(report), report);
 });
 
+test("promotion inputs bind complete paired evidence and policy", () => {
+  const evidence = pairedEvidence();
+  const receipt = issueAgentGymPromotionInput(
+    evidence.comparison.pair,
+    evidence.deltas,
+    evidence.uncertainty,
+    evidence.slices,
+    promotionInputPolicy(),
+    "2026-08-12T11:09:00.000Z",
+  );
+  assert.equal(receipt.eligible, true);
+  assert.deepEqual(receipt.blocker_codes, []);
+  assert.deepEqual(validateAgentGymPromotionInput(receipt), receipt);
+});
+
+test("promotion inputs block a practical improvement below policy", () => {
+  const evidence = pairedEvidence();
+  const receipt = issueAgentGymPromotionInput(
+    evidence.comparison.pair,
+    evidence.deltas,
+    evidence.uncertainty,
+    evidence.slices,
+    { ...promotionInputPolicy(), minimum_mean_delta: 0.2 },
+    "2026-08-12T11:09:00.000Z",
+  );
+  assert.equal(receipt.eligible, false);
+  assert.deepEqual(receipt.blocker_codes, ["comparison.mean_below_threshold"]);
+});
+
 function evaluationSetup() {
   const fixtures = [
     fixture("train", "train", "Train request."),
@@ -413,6 +444,39 @@ function pairedComparisonSetup() {
     { pair_ref: "agent-gym-pair://nightly/one", paired_at: "2026-08-12T11:08:00.000Z" },
   );
   return { baseline, candidate, pair, setup, suite };
+}
+
+function pairedEvidence() {
+  const comparison = pairedComparisonSetup();
+  const deltas = calculateAgentGymPairedCaseDeltas(
+    comparison.pair,
+    comparison.baseline.result,
+    comparison.candidate.result,
+  );
+  const uncertainty = estimateAgentGymPairedUncertainty(deltas, {
+    confidence_level: 0.95,
+    policy_ref: "agent-gym-bootstrap-policy://nightly/default",
+    resample_count: 1_000,
+    schema_version: "agent-gym-paired-bootstrap-policy/v1",
+    seed_digest: comparison.pair.pair_digest,
+  });
+  return {
+    comparison,
+    deltas,
+    slices: summarizeAgentGymPairedSlices(comparison.suite, deltas),
+    uncertainty,
+  };
+}
+
+function promotionInputPolicy() {
+  return {
+    maximum_case_regressions: 0,
+    minimum_mean_delta: 0.05,
+    minimum_probability_positive: 0.95,
+    policy_ref: "agent-gym-promotion-input-policy://default/v1",
+    required_slice_ids: ["partition:held_out", "partition:shadow"],
+    schema_version: "agent-gym-promotion-input-policy/v1" as const,
+  };
 }
 
 function runPlanInput() {

--- a/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
+++ b/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
@@ -18,6 +18,7 @@ import {
   recordAgentGymCaseEvaluation,
   recordAgentGymCorpusQuality,
   summarizeAgentGymEvaluationSlices,
+  summarizeAgentGymPairedSlices,
   validateAgentGymEvaluationRunPlan,
   validateAgentGymEvaluationRunResult,
   validateAgentGymEvaluationReadinessDecision,
@@ -25,6 +26,7 @@ import {
   validateAgentGymPairedEvaluation,
   validateAgentGymPairedCaseDeltaReport,
   validateAgentGymPairedUncertainty,
+  validateAgentGymPairedSliceReport,
 } from "../src/index.js";
 
 test("evaluation suites seal admitted non-training cases", () => {
@@ -216,6 +218,20 @@ test("paired uncertainty is reproducible from a sealed seed", () => {
   assert.deepEqual(first, second);
   assert.equal(first.probability_positive, 1);
   assert.deepEqual(validateAgentGymPairedUncertainty(first), first);
+});
+
+test("paired slices expose regressions by partition and label", () => {
+  const comparison = pairedComparisonSetup();
+  const deltas = calculateAgentGymPairedCaseDeltas(
+    comparison.pair,
+    comparison.baseline.result,
+    comparison.candidate.result,
+  );
+  const report = summarizeAgentGymPairedSlices(comparison.suite, deltas);
+  assert.equal(report.slices.find((entry) => entry.slice_id === "overall:all")?.case_count, 2);
+  assert.equal(report.slices.find((entry) => entry.slice_id === "label:safety")?.improvement_count, 1);
+  assert.equal(report.slices.find((entry) => entry.slice_id === "partition:shadow")?.regression_count, 0);
+  assert.deepEqual(validateAgentGymPairedSliceReport(report), report);
 });
 
 function evaluationSetup() {

--- a/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
+++ b/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
@@ -12,6 +12,7 @@ import {
   defineAgentGymEvaluatorManifest,
   defineAgentGymEvaluatorRubric,
   planAgentGymEvaluationRun,
+  pairAgentGymEvaluationRuns,
   recordAgentGymCaseEvaluation,
   recordAgentGymCorpusQuality,
   summarizeAgentGymEvaluationSlices,
@@ -19,6 +20,7 @@ import {
   validateAgentGymEvaluationRunResult,
   validateAgentGymEvaluationReadinessDecision,
   validateAgentGymEvaluationSliceReport,
+  validateAgentGymPairedEvaluation,
 } from "../src/index.js";
 
 test("evaluation suites seal admitted non-training cases", () => {
@@ -159,6 +161,24 @@ test("evaluation readiness preserves invalid judge output as a blocker", () => {
   ]);
 });
 
+test("paired evaluations require ready runs over the same case set", () => {
+  const setup = evaluationSetup();
+  const suite = suiteFrom(setup);
+  const baseline = completedRunFor(setup, suite, "baseline", 0.8);
+  const candidate = completedRunFor(setup, suite, "challenger", 0.9);
+  const paired = pairAgentGymEvaluationRuns(
+    suite,
+    baseline.result,
+    baseline.readiness,
+    candidate.result,
+    candidate.readiness,
+    { pair_ref: "agent-gym-pair://nightly/one", paired_at: "2026-08-12T11:08:00.000Z" },
+  );
+  assert.equal(paired.case_count, 2);
+  assert.notEqual(paired.baseline_candidate_ref, paired.candidate_ref);
+  assert.deepEqual(validateAgentGymPairedEvaluation(paired), paired);
+});
+
 function evaluationSetup() {
   const fixtures = [
     fixture("train", "train", "Train request."),
@@ -275,6 +295,53 @@ function readinessPolicy() {
     ],
     schema_version: "agent-gym-evaluation-readiness-policy/v1" as const,
   };
+}
+
+function completedRunFor(
+  setup: ReturnType<typeof evaluationSetup>,
+  suite: ReturnType<typeof defineAgentGymEvaluationSuite>,
+  candidate: string,
+  score: number,
+) {
+  const runInput = {
+    ...runPlanInput(),
+    candidate_ref: `agent-gym-candidate://slack/${candidate}`,
+    run_ref: `agent-gym-evaluation-run://nightly/${candidate}`,
+  };
+  const plan = planAgentGymEvaluationRun(suite, runInput);
+  const evaluations = suite.cases.map((entry, index) => recordAgentGymCaseEvaluation(
+    setup.rubric,
+    [setup.modelJudge, setup.deterministic],
+    {
+      candidate_ref: runInput.candidate_ref,
+      case_ref: entry.case_ref,
+      evaluated_at: "2026-08-12T11:05:30.000Z",
+      evaluation_ref: `agent-gym-evaluation://nightly/${candidate}/case-${index}`,
+      invalid_reason_codes: [],
+      metrics: [
+        { evaluator_digest: setup.modelJudge.evaluator_digest, metric_id: "answer.grounded", reason_codes: [], score },
+        { evaluator_digest: setup.deterministic.evaluator_digest, metric_id: "effect.authorized", reason_codes: [], score: 1 },
+      ],
+      replay_ref: `agent-gym-replay://nightly/${candidate}/case-${index}`,
+      schema_version: "agent-gym-case-evaluation/v1",
+      valid: true,
+    },
+  ));
+  const result = completeAgentGymEvaluationRun(
+    suite,
+    plan,
+    evaluations,
+    { completed_at: "2026-08-12T11:06:00.000Z", started_at: "2026-08-12T11:05:00.000Z" },
+  );
+  const report = summarizeAgentGymEvaluationSlices(suite, result);
+  const readiness = decideAgentGymEvaluationReadiness(
+    suite,
+    result,
+    report,
+    readinessPolicy(),
+    "2026-08-12T11:07:00.000Z",
+  );
+  return { readiness, report, result };
 }
 
 function runPlanInput() {

--- a/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
+++ b/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
@@ -12,6 +12,7 @@ import {
   defineAgentGymEvaluationSuite,
   defineAgentGymEvaluatorManifest,
   defineAgentGymEvaluatorRubric,
+  estimateAgentGymPairedUncertainty,
   planAgentGymEvaluationRun,
   pairAgentGymEvaluationRuns,
   recordAgentGymCaseEvaluation,
@@ -23,6 +24,7 @@ import {
   validateAgentGymEvaluationSliceReport,
   validateAgentGymPairedEvaluation,
   validateAgentGymPairedCaseDeltaReport,
+  validateAgentGymPairedUncertainty,
 } from "../src/index.js";
 
 test("evaluation suites seal admitted non-training cases", () => {
@@ -193,6 +195,27 @@ test("paired case deltas retain every improvement and regression", () => {
   assert.equal(report.regression_count, 0);
   assert.ok(report.mean_delta > 0);
   assert.deepEqual(validateAgentGymPairedCaseDeltaReport(report), report);
+});
+
+test("paired uncertainty is reproducible from a sealed seed", () => {
+  const comparison = pairedComparisonSetup();
+  const deltas = calculateAgentGymPairedCaseDeltas(
+    comparison.pair,
+    comparison.baseline.result,
+    comparison.candidate.result,
+  );
+  const policy = {
+    confidence_level: 0.95,
+    policy_ref: "agent-gym-bootstrap-policy://nightly/default",
+    resample_count: 1_000,
+    schema_version: "agent-gym-paired-bootstrap-policy/v1" as const,
+    seed_digest: comparison.pair.pair_digest,
+  };
+  const first = estimateAgentGymPairedUncertainty(deltas, policy);
+  const second = estimateAgentGymPairedUncertainty(deltas, policy);
+  assert.deepEqual(first, second);
+  assert.equal(first.probability_positive, 1);
+  assert.deepEqual(validateAgentGymPairedUncertainty(first), first);
 });
 
 function evaluationSetup() {

--- a/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
+++ b/apps/slack-companion/test/agent-gym-evaluation-suite.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   buildAgentGymCorpus,
   calibrateAgentGymEvaluator,
+  calculateAgentGymPairedCaseDeltas,
   completeAgentGymEvaluationRun,
   decideAgentGymCorpusAdmission,
   decideAgentGymEvaluatorAdmission,
@@ -21,6 +22,7 @@ import {
   validateAgentGymEvaluationReadinessDecision,
   validateAgentGymEvaluationSliceReport,
   validateAgentGymPairedEvaluation,
+  validateAgentGymPairedCaseDeltaReport,
 } from "../src/index.js";
 
 test("evaluation suites seal admitted non-training cases", () => {
@@ -177,6 +179,20 @@ test("paired evaluations require ready runs over the same case set", () => {
   assert.equal(paired.case_count, 2);
   assert.notEqual(paired.baseline_candidate_ref, paired.candidate_ref);
   assert.deepEqual(validateAgentGymPairedEvaluation(paired), paired);
+});
+
+test("paired case deltas retain every improvement and regression", () => {
+  const comparison = pairedComparisonSetup();
+  const report = calculateAgentGymPairedCaseDeltas(
+    comparison.pair,
+    comparison.baseline.result,
+    comparison.candidate.result,
+  );
+  assert.equal(report.case_count, 2);
+  assert.equal(report.improvement_count, 2);
+  assert.equal(report.regression_count, 0);
+  assert.ok(report.mean_delta > 0);
+  assert.deepEqual(validateAgentGymPairedCaseDeltaReport(report), report);
 });
 
 function evaluationSetup() {
@@ -342,6 +358,22 @@ function completedRunFor(
     "2026-08-12T11:07:00.000Z",
   );
   return { readiness, report, result };
+}
+
+function pairedComparisonSetup() {
+  const setup = evaluationSetup();
+  const suite = suiteFrom(setup);
+  const baseline = completedRunFor(setup, suite, "baseline", 0.8);
+  const candidate = completedRunFor(setup, suite, "challenger", 0.9);
+  const pair = pairAgentGymEvaluationRuns(
+    suite,
+    baseline.result,
+    baseline.readiness,
+    candidate.result,
+    candidate.readiness,
+    { pair_ref: "agent-gym-pair://nightly/one", paired_at: "2026-08-12T11:08:00.000Z" },
+  );
+  return { baseline, candidate, pair, setup, suite };
 }
 
 function runPlanInput() {


### PR DESCRIPTION
## Summary
- bind baseline and challenger runs to the same sealed evaluation suite
- retain per-case and protected-slice movement instead of aggregate-only scores
- compute reproducible paired uncertainty and receipt policy-bound promotion inputs

## Validation
- `npm run typecheck` in `apps/slack-companion`
- `npm test` in `apps/slack-companion` (657 tests)

## Delivery
- Portable Agent Gym contracts and deterministic evaluation logic only
- No environment configuration, credentials, infrastructure, or deployment changes
- Practice Registry connector unavailable; repository checks remain authoritative for this PR
