### PR TITLE
feat(slack): control agent gym promotion lifecycle

### DIFF
--- a/apps/slack-companion/src/agent-gym/activation-plan.ts
+++ b/apps/slack-companion/src/agent-gym/activation-plan.ts
@@ -1,0 +1,155 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymCandidateManifest,
+  type AgentGymCandidateManifestV1,
+} from "./candidate-manifest.js";
+import {
+  validateAgentGymPromotionAuthorization,
+  type AgentGymPromotionAuthorizationV1,
+} from "./promotion-authorization.js";
+
+export type AgentGymActivationMode = "canary" | "direct";
+
+export interface AgentGymActivationPlanV1 {
+  readonly activation_ref: string;
+  readonly authorization_digest: string;
+  readonly baseline_candidate_ref: string;
+  readonly candidate_manifest_digest: string;
+  readonly candidate_ref: string;
+  readonly expires_at: string;
+  readonly idempotency_key: string;
+  readonly initial_traffic_percent: number;
+  readonly mode: AgentGymActivationMode;
+  readonly plan_digest: string;
+  readonly planned_at: string;
+  readonly schema_version: "agent-gym-activation-plan/v1";
+  readonly target_ref: string;
+  readonly verdict_digest: string;
+}
+
+/** Plans an authorized candidate activation without owning environment routes. */
+export function planAgentGymCandidateActivation(
+  authorizationValue: AgentGymPromotionAuthorizationV1,
+  candidateValue: AgentGymCandidateManifestV1,
+  input: {
+    readonly activation_ref: string;
+    readonly baseline_candidate_ref: string;
+    readonly initial_traffic_percent: number;
+    readonly mode: AgentGymActivationMode;
+    readonly planned_at: string;
+    readonly target_ref: string;
+  },
+): AgentGymActivationPlanV1 {
+  const authorization = validateAgentGymPromotionAuthorization(authorizationValue);
+  const candidate = validateAgentGymCandidateManifest(candidateValue);
+  validateInput(input);
+  if (authorization.outcome !== "authorized" || authorization.candidate_ref !== candidate.candidate_ref
+    || input.baseline_candidate_ref === candidate.candidate_ref
+    || Date.parse(input.planned_at) < Date.parse(authorization.issued_at)
+    || Date.parse(input.planned_at) >= Date.parse(authorization.expires_at)) invalid();
+  const candidateBody = {
+    candidate_ref: candidate.candidate_ref,
+    max_output_tokens: candidate.max_output_tokens,
+    model_id: candidate.model_id,
+    policy_digest: candidate.policy_digest,
+    prompt_digest: candidate.prompt_digest,
+    provider: candidate.provider,
+    ...(candidate.region === undefined ? {} : { region: candidate.region }),
+    schema_version: candidate.schema_version,
+    source_revision: candidate.source_revision,
+    tool_catalog_digest: candidate.tool_catalog_digest,
+    tool_ids: candidate.tool_ids,
+  };
+  const identity = {
+    activation_ref: input.activation_ref,
+    authorization_digest: authorization.authorization_digest,
+    candidate_ref: candidate.candidate_ref,
+    target_ref: input.target_ref,
+  };
+  const body = {
+    activation_ref: input.activation_ref,
+    authorization_digest: authorization.authorization_digest,
+    baseline_candidate_ref: input.baseline_candidate_ref,
+    candidate_manifest_digest: digestAgentGymJson(candidateBody),
+    candidate_ref: candidate.candidate_ref,
+    expires_at: authorization.expires_at,
+    idempotency_key: digestAgentGymJson(identity),
+    initial_traffic_percent: input.initial_traffic_percent,
+    mode: input.mode,
+    planned_at: input.planned_at,
+    schema_version: "agent-gym-activation-plan/v1" as const,
+    target_ref: input.target_ref,
+    verdict_digest: authorization.verdict_digest,
+  };
+  return Object.freeze({ ...body, plan_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymActivationPlan(value: AgentGymActivationPlanV1): AgentGymActivationPlanV1 {
+  if (value.schema_version !== "agent-gym-activation-plan/v1") invalid();
+  for (const ref of [value.activation_ref, value.baseline_candidate_ref, value.candidate_ref,
+    value.target_ref]) reference(ref);
+  if (value.baseline_candidate_ref === value.candidate_ref) invalid();
+  for (const valueDigest of [value.authorization_digest, value.candidate_manifest_digest,
+    value.idempotency_key, value.plan_digest, value.verdict_digest]) digest(valueDigest);
+  timestamp(value.planned_at);
+  timestamp(value.expires_at);
+  if (Date.parse(value.planned_at) >= Date.parse(value.expires_at)) invalid();
+  modeAndTraffic(value.mode, value.initial_traffic_percent);
+  const identity = {
+    activation_ref: value.activation_ref,
+    authorization_digest: value.authorization_digest,
+    candidate_ref: value.candidate_ref,
+    target_ref: value.target_ref,
+  };
+  if (digestAgentGymJson(identity) !== value.idempotency_key) invalid();
+  const body = {
+    activation_ref: value.activation_ref,
+    authorization_digest: value.authorization_digest,
+    baseline_candidate_ref: value.baseline_candidate_ref,
+    candidate_manifest_digest: value.candidate_manifest_digest,
+    candidate_ref: value.candidate_ref,
+    expires_at: value.expires_at,
+    idempotency_key: value.idempotency_key,
+    initial_traffic_percent: value.initial_traffic_percent,
+    mode: value.mode,
+    planned_at: value.planned_at,
+    schema_version: value.schema_version,
+    target_ref: value.target_ref,
+    verdict_digest: value.verdict_digest,
+  };
+  if (digestAgentGymJson(body) !== value.plan_digest) invalid();
+  return Object.freeze({ ...value });
+}
+
+function validateInput(value: {
+  readonly activation_ref: string;
+  readonly baseline_candidate_ref: string;
+  readonly initial_traffic_percent: number;
+  readonly mode: AgentGymActivationMode;
+  readonly planned_at: string;
+  readonly target_ref: string;
+}): void {
+  for (const ref of [value.activation_ref, value.baseline_candidate_ref, value.target_ref]) reference(ref);
+  timestamp(value.planned_at);
+  modeAndTraffic(value.mode, value.initial_traffic_percent);
+}
+function modeAndTraffic(mode: AgentGymActivationMode, percent: number): void {
+  if (!Number.isSafeInteger(percent) || percent < 1 || percent > 100) invalid();
+  if (mode === "canary") { if (percent > 50) invalid(); }
+  else if (mode === "direct") { if (percent !== 100) invalid(); }
+  else invalid();
+}
+function digest(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym activation plan is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/activation-receipt.ts
+++ b/apps/slack-companion/src/agent-gym/activation-receipt.ts
@@ -1,0 +1,145 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymActivationPlan,
+  type AgentGymActivationPlanV1,
+} from "./activation-plan.js";
+
+export type AgentGymActivationStatus = "applied" | "rejected";
+
+export interface AgentGymActivationReceiptV1 {
+  readonly activation_ref: string;
+  readonly candidate_ref: string;
+  readonly completed_at: string;
+  readonly executor_ref: string;
+  readonly failure_codes: readonly string[];
+  readonly observed_active_candidate_ref: string;
+  readonly observed_traffic_percent: number;
+  readonly plan_digest: string;
+  readonly previous_candidate_ref: string;
+  readonly receipt_digest: string;
+  readonly receipt_ref: string;
+  readonly schema_version: "agent-gym-activation-receipt/v1";
+  readonly started_at: string;
+  readonly status: AgentGymActivationStatus;
+  readonly target_ref: string;
+}
+
+/** Records the observed result of executing one exact activation plan. */
+export function recordAgentGymActivation(
+  planValue: AgentGymActivationPlanV1,
+  input: Omit<AgentGymActivationReceiptV1,
+    "activation_ref" | "candidate_ref" | "plan_digest" | "receipt_digest"
+    | "schema_version" | "target_ref">,
+): AgentGymActivationReceiptV1 {
+  const plan = validateAgentGymActivationPlan(planValue);
+  validateInput(input);
+  if (input.previous_candidate_ref !== plan.baseline_candidate_ref
+    || Date.parse(input.started_at) < Date.parse(plan.planned_at)
+    || Date.parse(input.completed_at) < Date.parse(input.started_at)
+    || Date.parse(input.started_at) >= Date.parse(plan.expires_at)) invalid();
+  if (input.status === "applied") {
+    if (input.failure_codes.length !== 0
+      || input.observed_active_candidate_ref !== plan.candidate_ref
+      || input.observed_traffic_percent !== plan.initial_traffic_percent) invalid();
+  } else if (input.failure_codes.length === 0
+    || input.observed_active_candidate_ref !== plan.baseline_candidate_ref
+    || input.observed_traffic_percent !== 0) invalid();
+  const body = {
+    activation_ref: plan.activation_ref,
+    candidate_ref: plan.candidate_ref,
+    completed_at: input.completed_at,
+    executor_ref: input.executor_ref,
+    failure_codes: [...input.failure_codes],
+    observed_active_candidate_ref: input.observed_active_candidate_ref,
+    observed_traffic_percent: input.observed_traffic_percent,
+    plan_digest: plan.plan_digest,
+    previous_candidate_ref: input.previous_candidate_ref,
+    receipt_ref: input.receipt_ref,
+    schema_version: "agent-gym-activation-receipt/v1" as const,
+    started_at: input.started_at,
+    status: input.status,
+    target_ref: plan.target_ref,
+  };
+  return Object.freeze({
+    ...body,
+    failure_codes: Object.freeze(body.failure_codes),
+    receipt_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymActivationReceipt(
+  value: AgentGymActivationReceiptV1,
+): AgentGymActivationReceiptV1 {
+  if (value.schema_version !== "agent-gym-activation-receipt/v1") invalid();
+  validateInput(value);
+  for (const ref of [value.activation_ref, value.candidate_ref, value.target_ref]) reference(ref);
+  digest(value.plan_digest);
+  digest(value.receipt_digest);
+  if (Date.parse(value.completed_at) < Date.parse(value.started_at)) invalid();
+  if (value.status === "applied") {
+    if (value.failure_codes.length !== 0 || value.observed_active_candidate_ref !== value.candidate_ref
+      || value.observed_traffic_percent < 1) invalid();
+  } else if (value.status === "rejected") {
+    if (value.failure_codes.length === 0
+      || value.observed_active_candidate_ref !== value.previous_candidate_ref
+      || value.observed_traffic_percent !== 0) invalid();
+  } else invalid();
+  const body = {
+    activation_ref: value.activation_ref,
+    candidate_ref: value.candidate_ref,
+    completed_at: value.completed_at,
+    executor_ref: value.executor_ref,
+    failure_codes: value.failure_codes,
+    observed_active_candidate_ref: value.observed_active_candidate_ref,
+    observed_traffic_percent: value.observed_traffic_percent,
+    plan_digest: value.plan_digest,
+    previous_candidate_ref: value.previous_candidate_ref,
+    receipt_ref: value.receipt_ref,
+    schema_version: value.schema_version,
+    started_at: value.started_at,
+    status: value.status,
+    target_ref: value.target_ref,
+  };
+  if (digestAgentGymJson(body) !== value.receipt_digest) invalid();
+  return Object.freeze({ ...value, failure_codes: Object.freeze([...value.failure_codes]) });
+}
+
+function validateInput(value: {
+  readonly completed_at: string;
+  readonly executor_ref: string;
+  readonly failure_codes: readonly string[];
+  readonly observed_active_candidate_ref: string;
+  readonly observed_traffic_percent: number;
+  readonly previous_candidate_ref: string;
+  readonly receipt_ref: string;
+  readonly started_at: string;
+  readonly status: AgentGymActivationStatus;
+}): void {
+  for (const ref of [value.executor_ref, value.observed_active_candidate_ref,
+    value.previous_candidate_ref, value.receipt_ref]) reference(ref);
+  timestamp(value.started_at);
+  timestamp(value.completed_at);
+  if (!Number.isSafeInteger(value.observed_traffic_percent)
+    || value.observed_traffic_percent < 0 || value.observed_traffic_percent > 100
+    || !Array.isArray(value.failure_codes) || value.failure_codes.length > 64
+    || new Set(value.failure_codes).size !== value.failure_codes.length) invalid();
+  for (const code of value.failure_codes) text(code);
+}
+function digest(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function text(value: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > 160
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym activation receipt is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/champion-transition.ts
+++ b/apps/slack-companion/src/agent-gym/champion-transition.ts
@@ -1,0 +1,128 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymActivationReceipt,
+  type AgentGymActivationReceiptV1,
+} from "./activation-receipt.js";
+
+export type AgentGymChampionTransitionMode = "promote" | "rollback";
+
+export interface AgentGymChampionTransitionV1 {
+  readonly activation_receipt_digest: string;
+  readonly active_candidate_ref: string;
+  readonly effective_at: string;
+  readonly from_candidate_ref: string;
+  readonly mode: AgentGymChampionTransitionMode;
+  readonly previous_transition_digest: string | null;
+  readonly rollback_of_transition_digest: string | null;
+  readonly schema_version: "agent-gym-champion-transition/v1";
+  readonly sequence: number;
+  readonly target_ref: string;
+  readonly traffic_percent: number;
+  readonly transition_digest: string;
+  readonly transition_ref: string;
+}
+
+/** Advances an append-only champion lineage from an observed activation receipt. */
+export function recordAgentGymChampionTransition(
+  receiptValue: AgentGymActivationReceiptV1,
+  previousValue: AgentGymChampionTransitionV1 | undefined,
+  input: {
+    readonly effective_at: string;
+    readonly mode: AgentGymChampionTransitionMode;
+    readonly rollback_target?: AgentGymChampionTransitionV1;
+    readonly transition_ref: string;
+  },
+): AgentGymChampionTransitionV1 {
+  const receipt = validateAgentGymActivationReceipt(receiptValue);
+  const previous = previousValue === undefined
+    ? undefined
+    : validateAgentGymChampionTransition(previousValue);
+  const rollbackTarget = input.rollback_target === undefined
+    ? undefined
+    : validateAgentGymChampionTransition(input.rollback_target);
+  timestamp(input.effective_at);
+  reference(input.transition_ref);
+  if (receipt.status !== "applied"
+    || Date.parse(input.effective_at) < Date.parse(receipt.completed_at)) invalid();
+  if (previous === undefined) {
+    if (input.mode !== "promote" || rollbackTarget !== undefined) invalid();
+  } else if (previous.target_ref !== receipt.target_ref
+    || previous.active_candidate_ref !== receipt.previous_candidate_ref
+    || Date.parse(input.effective_at) < Date.parse(previous.effective_at)) invalid();
+  if (input.mode === "rollback") {
+    if (previous === undefined || rollbackTarget === undefined
+      || rollbackTarget.target_ref !== receipt.target_ref
+      || rollbackTarget.active_candidate_ref !== receipt.candidate_ref
+      || rollbackTarget.sequence >= previous.sequence) invalid();
+  } else if (input.mode !== "promote" || rollbackTarget !== undefined) invalid();
+  const body = {
+    activation_receipt_digest: receipt.receipt_digest,
+    active_candidate_ref: receipt.candidate_ref,
+    effective_at: input.effective_at,
+    from_candidate_ref: receipt.previous_candidate_ref,
+    mode: input.mode,
+    previous_transition_digest: previous?.transition_digest ?? null,
+    rollback_of_transition_digest: rollbackTarget?.transition_digest ?? null,
+    schema_version: "agent-gym-champion-transition/v1" as const,
+    sequence: (previous?.sequence ?? 0) + 1,
+    target_ref: receipt.target_ref,
+    traffic_percent: receipt.observed_traffic_percent,
+    transition_ref: input.transition_ref,
+  };
+  return Object.freeze({ ...body, transition_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymChampionTransition(
+  value: AgentGymChampionTransitionV1,
+): AgentGymChampionTransitionV1 {
+  if (value.schema_version !== "agent-gym-champion-transition/v1") invalid();
+  for (const ref of [value.active_candidate_ref, value.from_candidate_ref,
+    value.target_ref, value.transition_ref]) reference(ref);
+  if (value.active_candidate_ref === value.from_candidate_ref) invalid();
+  timestamp(value.effective_at);
+  digest(value.activation_receipt_digest);
+  digest(value.transition_digest);
+  if (value.previous_transition_digest !== null) digest(value.previous_transition_digest);
+  if (value.rollback_of_transition_digest !== null) digest(value.rollback_of_transition_digest);
+  if (!Number.isSafeInteger(value.sequence) || value.sequence < 1 || value.sequence > 1_000_000
+    || !Number.isSafeInteger(value.traffic_percent) || value.traffic_percent < 1
+    || value.traffic_percent > 100) invalid();
+  if (value.sequence === 1 && value.previous_transition_digest !== null) invalid();
+  if (value.sequence > 1 && value.previous_transition_digest === null) invalid();
+  if (value.mode === "rollback") {
+    if (value.rollback_of_transition_digest === null || value.sequence < 2) invalid();
+  } else if (value.mode === "promote") {
+    if (value.rollback_of_transition_digest !== null) invalid();
+  } else invalid();
+  const body = {
+    activation_receipt_digest: value.activation_receipt_digest,
+    active_candidate_ref: value.active_candidate_ref,
+    effective_at: value.effective_at,
+    from_candidate_ref: value.from_candidate_ref,
+    mode: value.mode,
+    previous_transition_digest: value.previous_transition_digest,
+    rollback_of_transition_digest: value.rollback_of_transition_digest,
+    schema_version: value.schema_version,
+    sequence: value.sequence,
+    target_ref: value.target_ref,
+    traffic_percent: value.traffic_percent,
+    transition_ref: value.transition_ref,
+  };
+  if (digestAgentGymJson(body) !== value.transition_digest) invalid();
+  return Object.freeze({ ...value });
+}
+
+function digest(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym champion transition is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -31,6 +31,7 @@ export * from "./promotion-input.js";
 export * from "./promotion-verdict.js";
 export * from "./promotion-authorization.js";
 export * from "./activation-plan.js";
+export * from "./activation-receipt.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -32,6 +32,7 @@ export * from "./promotion-verdict.js";
 export * from "./promotion-authorization.js";
 export * from "./activation-plan.js";
 export * from "./activation-receipt.js";
+export * from "./champion-transition.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -30,6 +30,7 @@ export * from "./paired-slices.js";
 export * from "./promotion-input.js";
 export * from "./promotion-verdict.js";
 export * from "./promotion-authorization.js";
+export * from "./activation-plan.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -28,6 +28,7 @@ export * from "./paired-case-deltas.js";
 export * from "./paired-uncertainty.js";
 export * from "./paired-slices.js";
 export * from "./promotion-input.js";
+export * from "./promotion-verdict.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -29,6 +29,7 @@ export * from "./paired-uncertainty.js";
 export * from "./paired-slices.js";
 export * from "./promotion-input.js";
 export * from "./promotion-verdict.js";
+export * from "./promotion-authorization.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/promotion-authorization.ts
+++ b/apps/slack-companion/src/agent-gym/promotion-authorization.ts
@@ -1,0 +1,124 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymPromotionVerdict,
+  type AgentGymPromotionVerdictDisposition,
+  type AgentGymPromotionVerdictV1,
+} from "./promotion-verdict.js";
+
+export type AgentGymPromotionAuthorizationOutcome = "authorized" | "denied";
+
+export interface AgentGymPromotionAuthorizationV1 {
+  readonly authorization_digest: string;
+  readonly authorization_ref: string;
+  readonly authority_ref: string;
+  readonly candidate_ref: string;
+  readonly expires_at: string;
+  readonly issued_at: string;
+  readonly issued_by_ref: string;
+  readonly outcome: AgentGymPromotionAuthorizationOutcome;
+  readonly permission: "activate_candidate";
+  readonly reason_codes: readonly string[];
+  readonly schema_version: "agent-gym-promotion-authorization/v1";
+  readonly verdict_digest: string;
+  readonly verdict_disposition: AgentGymPromotionVerdictDisposition;
+}
+
+/** Records activation authority separately from the evaluation verdict. */
+export function issueAgentGymPromotionAuthorization(
+  verdictValue: AgentGymPromotionVerdictV1,
+  input: Omit<AgentGymPromotionAuthorizationV1,
+    "authorization_digest" | "candidate_ref" | "permission" | "schema_version"
+    | "verdict_digest" | "verdict_disposition">,
+): AgentGymPromotionAuthorizationV1 {
+  const verdict = validateAgentGymPromotionVerdict(verdictValue);
+  validateInput(input);
+  if (Date.parse(input.issued_at) < Date.parse(verdict.decided_at)
+    || Date.parse(input.expires_at) <= Date.parse(input.issued_at)
+    || (input.outcome === "authorized" && verdict.disposition !== "promote")) invalid();
+  const body = {
+    authorization_ref: input.authorization_ref,
+    authority_ref: input.authority_ref,
+    candidate_ref: verdict.candidate_ref,
+    expires_at: input.expires_at,
+    issued_at: input.issued_at,
+    issued_by_ref: input.issued_by_ref,
+    outcome: input.outcome,
+    permission: "activate_candidate" as const,
+    reason_codes: [...input.reason_codes],
+    schema_version: "agent-gym-promotion-authorization/v1" as const,
+    verdict_digest: verdict.verdict_digest,
+    verdict_disposition: verdict.disposition,
+  };
+  return Object.freeze({
+    ...body,
+    authorization_digest: digestAgentGymJson(body),
+    reason_codes: Object.freeze(body.reason_codes),
+  });
+}
+
+export function validateAgentGymPromotionAuthorization(
+  value: AgentGymPromotionAuthorizationV1,
+): AgentGymPromotionAuthorizationV1 {
+  if (value.schema_version !== "agent-gym-promotion-authorization/v1"
+    || value.permission !== "activate_candidate") invalid();
+  validateInput(value);
+  digest(value.authorization_digest);
+  digest(value.verdict_digest);
+  if (!(["blocked", "promote"] as const).includes(value.verdict_disposition)) invalid();
+  if (Date.parse(value.expires_at) <= Date.parse(value.issued_at)
+    || (value.outcome === "authorized" && value.verdict_disposition !== "promote")) invalid();
+  const body = {
+    authorization_ref: value.authorization_ref,
+    authority_ref: value.authority_ref,
+    candidate_ref: value.candidate_ref,
+    expires_at: value.expires_at,
+    issued_at: value.issued_at,
+    issued_by_ref: value.issued_by_ref,
+    outcome: value.outcome,
+    permission: value.permission,
+    reason_codes: value.reason_codes,
+    schema_version: value.schema_version,
+    verdict_digest: value.verdict_digest,
+    verdict_disposition: value.verdict_disposition,
+  };
+  if (digestAgentGymJson(body) !== value.authorization_digest) invalid();
+  return Object.freeze({ ...value, reason_codes: Object.freeze([...value.reason_codes]) });
+}
+
+function validateInput(value: {
+  readonly authorization_ref: string;
+  readonly authority_ref: string;
+  readonly candidate_ref?: string;
+  readonly expires_at: string;
+  readonly issued_at: string;
+  readonly issued_by_ref: string;
+  readonly outcome: AgentGymPromotionAuthorizationOutcome;
+  readonly reason_codes: readonly string[];
+}): void {
+  for (const ref of [value.authorization_ref, value.authority_ref, value.issued_by_ref]) reference(ref);
+  if (value.candidate_ref !== undefined) reference(value.candidate_ref);
+  timestamp(value.issued_at);
+  timestamp(value.expires_at);
+  if (!(["authorized", "denied"] as const).includes(value.outcome)
+    || !Array.isArray(value.reason_codes) || value.reason_codes.length === 0
+    || value.reason_codes.length > 64 || new Set(value.reason_codes).size !== value.reason_codes.length) invalid();
+  for (const code of value.reason_codes) text(code);
+}
+function digest(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function text(value: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > 160
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym promotion authorization is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/promotion-verdict.ts
+++ b/apps/slack-companion/src/agent-gym/promotion-verdict.ts
@@ -1,0 +1,95 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymPromotionInput,
+  type AgentGymPromotionInputReceiptV1,
+} from "./promotion-input.js";
+
+export type AgentGymPromotionVerdictDisposition = "blocked" | "promote";
+
+export interface AgentGymPromotionVerdictV1 {
+  readonly baseline_candidate_ref: string;
+  readonly candidate_ref: string;
+  readonly decided_at: string;
+  readonly decision_ref: string;
+  readonly disposition: AgentGymPromotionVerdictDisposition;
+  readonly promotion_input_digest: string;
+  readonly reason_codes: readonly string[];
+  readonly schema_version: "agent-gym-promotion-verdict/v1";
+  readonly verdict_digest: string;
+}
+
+/** Converts a policy-bound comparison receipt into a deterministic verdict. */
+export function decideAgentGymPromotionVerdict(
+  inputValue: AgentGymPromotionInputReceiptV1,
+  decision: { readonly decided_at: string; readonly decision_ref: string },
+): AgentGymPromotionVerdictV1 {
+  const input = validateAgentGymPromotionInput(inputValue);
+  timestamp(decision.decided_at);
+  reference(decision.decision_ref);
+  if (Date.parse(decision.decided_at) < Date.parse(input.evaluated_at)) invalid();
+  const disposition: AgentGymPromotionVerdictDisposition = input.eligible ? "promote" : "blocked";
+  const reasonCodes = input.eligible
+    ? ["comparison.eligible"]
+    : [...input.blocker_codes];
+  const body = {
+    baseline_candidate_ref: input.baseline_candidate_ref,
+    candidate_ref: input.candidate_ref,
+    decided_at: decision.decided_at,
+    decision_ref: decision.decision_ref,
+    disposition,
+    promotion_input_digest: input.receipt_digest,
+    reason_codes: reasonCodes,
+    schema_version: "agent-gym-promotion-verdict/v1" as const,
+  };
+  return Object.freeze({
+    ...body,
+    reason_codes: Object.freeze(reasonCodes),
+    verdict_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymPromotionVerdict(
+  value: AgentGymPromotionVerdictV1,
+): AgentGymPromotionVerdictV1 {
+  if (value.schema_version !== "agent-gym-promotion-verdict/v1") invalid();
+  for (const ref of [value.baseline_candidate_ref, value.candidate_ref, value.decision_ref]) reference(ref);
+  if (value.baseline_candidate_ref === value.candidate_ref) invalid();
+  timestamp(value.decided_at);
+  digest(value.promotion_input_digest);
+  digest(value.verdict_digest);
+  if (!Array.isArray(value.reason_codes) || value.reason_codes.length === 0
+    || value.reason_codes.length > 64 || new Set(value.reason_codes).size !== value.reason_codes.length
+    || value.reason_codes.some((code) => !code || code.length > 160)) invalid();
+  if (value.disposition === "promote") {
+    if (value.reason_codes.length !== 1 || value.reason_codes[0] !== "comparison.eligible") invalid();
+  } else if (value.disposition === "blocked") {
+    if (value.reason_codes.includes("comparison.eligible")) invalid();
+  } else invalid();
+  const body = {
+    baseline_candidate_ref: value.baseline_candidate_ref,
+    candidate_ref: value.candidate_ref,
+    decided_at: value.decided_at,
+    decision_ref: value.decision_ref,
+    disposition: value.disposition,
+    promotion_input_digest: value.promotion_input_digest,
+    reason_codes: value.reason_codes,
+    schema_version: value.schema_version,
+  };
+  if (digestAgentGymJson(body) !== value.verdict_digest) invalid();
+  return Object.freeze({ ...value, reason_codes: Object.freeze([...value.reason_codes]) });
+}
+
+function digest(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym promotion verdict is invalid.");
+}

--- a/apps/slack-companion/test/agent-gym-promotion-lifecycle.test.ts
+++ b/apps/slack-companion/test/agent-gym-promotion-lifecycle.test.ts
@@ -7,8 +7,10 @@ import {
   issueAgentGymPromotionAuthorization,
   planAgentGymCandidateActivation,
   recordAgentGymActivation,
+  recordAgentGymChampionTransition,
   validateAgentGymActivationPlan,
   validateAgentGymActivationReceipt,
+  validateAgentGymChampionTransition,
   validateAgentGymPromotionAuthorization,
   validateAgentGymPromotionVerdict,
   type AgentGymPromotionInputReceiptV1,
@@ -130,6 +132,51 @@ test("activation receipts reject unobserved success", () => {
     status: "applied",
   }), /activation receipt is invalid/u);
 });
+
+test("champion transitions append observed activation state", () => {
+  const transition = recordAgentGymChampionTransition(activationReceipt(), undefined, {
+    effective_at: "2026-08-12T11:15:00.000Z",
+    mode: "promote",
+    transition_ref: "agent-gym-champion-transition://nightly/one",
+  });
+  assert.equal(transition.sequence, 1);
+  assert.equal(transition.active_candidate_ref, "agent-gym-candidate://nightly/challenger");
+  assert.equal(transition.previous_transition_digest, null);
+  assert.deepEqual(validateAgentGymChampionTransition(transition), transition);
+});
+
+test("champion transitions require an applied activation receipt", () => {
+  const rejected = recordAgentGymActivation(activationPlan(), {
+    completed_at: "2026-08-12T11:14:00.000Z",
+    executor_ref: "agent-gym-executor://release/default",
+    failure_codes: ["activation.health_check_failed"],
+    observed_active_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    observed_traffic_percent: 0,
+    previous_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    receipt_ref: "agent-gym-activation-receipt://nightly/rejected",
+    started_at: "2026-08-12T11:13:00.000Z",
+    status: "rejected",
+  });
+  assert.throws(() => recordAgentGymChampionTransition(rejected, undefined, {
+    effective_at: "2026-08-12T11:15:00.000Z",
+    mode: "promote",
+    transition_ref: "agent-gym-champion-transition://nightly/rejected",
+  }), /champion transition is invalid/u);
+});
+
+function activationReceipt() {
+  return recordAgentGymActivation(activationPlan(), {
+    completed_at: "2026-08-12T11:14:00.000Z",
+    executor_ref: "agent-gym-executor://release/default",
+    failure_codes: [],
+    observed_active_candidate_ref: "agent-gym-candidate://nightly/challenger",
+    observed_traffic_percent: 10,
+    previous_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    receipt_ref: "agent-gym-activation-receipt://nightly/one",
+    started_at: "2026-08-12T11:13:00.000Z",
+    status: "applied",
+  });
+}
 
 function activationPlan() {
   return planAgentGymCandidateActivation(promotionAuthorization(), candidateManifest(), {

--- a/apps/slack-companion/test/agent-gym-promotion-lifecycle.test.ts
+++ b/apps/slack-companion/test/agent-gym-promotion-lifecycle.test.ts
@@ -6,7 +6,9 @@ import {
   digestAgentGymJson,
   issueAgentGymPromotionAuthorization,
   planAgentGymCandidateActivation,
+  recordAgentGymActivation,
   validateAgentGymActivationPlan,
+  validateAgentGymActivationReceipt,
   validateAgentGymPromotionAuthorization,
   validateAgentGymPromotionVerdict,
   type AgentGymPromotionInputReceiptV1,
@@ -97,6 +99,48 @@ test("expired authority cannot produce an activation plan", () => {
     target_ref: "agent-gym-target://slack-companion/default",
   }), /activation plan is invalid/u);
 });
+
+test("activation receipts retain exact observed candidate state", () => {
+  const receipt = recordAgentGymActivation(activationPlan(), {
+    completed_at: "2026-08-12T11:14:00.000Z",
+    executor_ref: "agent-gym-executor://release/default",
+    failure_codes: [],
+    observed_active_candidate_ref: "agent-gym-candidate://nightly/challenger",
+    observed_traffic_percent: 10,
+    previous_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    receipt_ref: "agent-gym-activation-receipt://nightly/one",
+    started_at: "2026-08-12T11:13:00.000Z",
+    status: "applied",
+  });
+  assert.equal(receipt.status, "applied");
+  assert.equal(receipt.observed_active_candidate_ref, receipt.candidate_ref);
+  assert.deepEqual(validateAgentGymActivationReceipt(receipt), receipt);
+});
+
+test("activation receipts reject unobserved success", () => {
+  assert.throws(() => recordAgentGymActivation(activationPlan(), {
+    completed_at: "2026-08-12T11:14:00.000Z",
+    executor_ref: "agent-gym-executor://release/default",
+    failure_codes: [],
+    observed_active_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    observed_traffic_percent: 10,
+    previous_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    receipt_ref: "agent-gym-activation-receipt://nightly/unobserved",
+    started_at: "2026-08-12T11:13:00.000Z",
+    status: "applied",
+  }), /activation receipt is invalid/u);
+});
+
+function activationPlan() {
+  return planAgentGymCandidateActivation(promotionAuthorization(), candidateManifest(), {
+    activation_ref: "agent-gym-activation://nightly/one",
+    baseline_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    initial_traffic_percent: 10,
+    mode: "canary",
+    planned_at: "2026-08-12T11:12:00.000Z",
+    target_ref: "agent-gym-target://slack-companion/default",
+  });
+}
 
 function promotionAuthorization() {
   return issueAgentGymPromotionAuthorization(promotionVerdict(), {

--- a/apps/slack-companion/test/agent-gym-promotion-lifecycle.test.ts
+++ b/apps/slack-companion/test/agent-gym-promotion-lifecycle.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  decideAgentGymPromotionVerdict,
+  digestAgentGymJson,
+  validateAgentGymPromotionVerdict,
+  type AgentGymPromotionInputReceiptV1,
+} from "../src/index.js";
+
+test("promotion verdicts deterministically preserve eligible evidence", () => {
+  const verdict = decideAgentGymPromotionVerdict(promotionInput(), {
+    decided_at: "2026-08-12T11:10:00.000Z",
+    decision_ref: "agent-gym-promotion-verdict://nightly/one",
+  });
+  assert.equal(verdict.disposition, "promote");
+  assert.deepEqual(verdict.reason_codes, ["comparison.eligible"]);
+  assert.deepEqual(validateAgentGymPromotionVerdict(verdict), verdict);
+});
+
+test("promotion verdicts cannot rewrite policy blockers", () => {
+  const input = promotionInput({
+    blocker_codes: ["comparison.slice_regression"],
+    eligible: false,
+  });
+  const verdict = decideAgentGymPromotionVerdict(input, {
+    decided_at: "2026-08-12T11:10:00.000Z",
+    decision_ref: "agent-gym-promotion-verdict://nightly/blocked",
+  });
+  assert.equal(verdict.disposition, "blocked");
+  assert.deepEqual(verdict.reason_codes, ["comparison.slice_regression"]);
+  assert.throws(() => validateAgentGymPromotionVerdict({
+    ...verdict,
+    disposition: "promote",
+  }), /promotion verdict is invalid/u);
+});
+
+function promotionInput(
+  overrides: Partial<AgentGymPromotionInputReceiptV1> = {},
+): AgentGymPromotionInputReceiptV1 {
+  const body = {
+    baseline_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    blocker_codes: [],
+    candidate_ref: "agent-gym-candidate://nightly/challenger",
+    case_delta_report_digest: digest("a"),
+    eligible: true,
+    evaluated_at: "2026-08-12T11:09:00.000Z",
+    pair_digest: digest("b"),
+    policy_digest: digest("c"),
+    policy_ref: "agent-gym-promotion-input-policy://nightly/default",
+    schema_version: "agent-gym-promotion-input-receipt/v1" as const,
+    slice_report_digest: digest("e"),
+    uncertainty_digest: digest("f"),
+    ...overrides,
+  };
+  return { ...body, receipt_digest: digestAgentGymJson(body) };
+}
+
+function digest(character: string): string {
+  return `sha256:${character.repeat(64)}`;
+}

--- a/apps/slack-companion/test/agent-gym-promotion-lifecycle.test.ts
+++ b/apps/slack-companion/test/agent-gym-promotion-lifecycle.test.ts
@@ -4,6 +4,8 @@ import test from "node:test";
 import {
   decideAgentGymPromotionVerdict,
   digestAgentGymJson,
+  issueAgentGymPromotionAuthorization,
+  validateAgentGymPromotionAuthorization,
   validateAgentGymPromotionVerdict,
   type AgentGymPromotionInputReceiptV1,
 } from "../src/index.js";
@@ -34,6 +36,47 @@ test("promotion verdicts cannot rewrite policy blockers", () => {
     disposition: "promote",
   }), /promotion verdict is invalid/u);
 });
+
+test("promotion authorization is separate, scoped, and expiring", () => {
+  const authorization = issueAgentGymPromotionAuthorization(promotionVerdict(), {
+    authorization_ref: "agent-gym-promotion-authorization://nightly/one",
+    authority_ref: "agent-gym-authority://release/default",
+    expires_at: "2026-08-12T12:11:00.000Z",
+    issued_at: "2026-08-12T11:11:00.000Z",
+    issued_by_ref: "agent-gym-actor://release/controller",
+    outcome: "authorized",
+    reason_codes: ["release.policy_satisfied"],
+  });
+  assert.equal(authorization.permission, "activate_candidate");
+  assert.equal(authorization.outcome, "authorized");
+  assert.deepEqual(validateAgentGymPromotionAuthorization(authorization), authorization);
+});
+
+test("blocked verdicts cannot receive activation authority", () => {
+  const blocked = decideAgentGymPromotionVerdict(promotionInput({
+    blocker_codes: ["comparison.slice_regression"],
+    eligible: false,
+  }), {
+    decided_at: "2026-08-12T11:10:00.000Z",
+    decision_ref: "agent-gym-promotion-verdict://nightly/blocked-authorization",
+  });
+  assert.throws(() => issueAgentGymPromotionAuthorization(blocked, {
+    authorization_ref: "agent-gym-promotion-authorization://nightly/blocked",
+    authority_ref: "agent-gym-authority://release/default",
+    expires_at: "2026-08-12T12:11:00.000Z",
+    issued_at: "2026-08-12T11:11:00.000Z",
+    issued_by_ref: "agent-gym-actor://release/controller",
+    outcome: "authorized",
+    reason_codes: ["release.policy_satisfied"],
+  }), /promotion authorization is invalid/u);
+});
+
+function promotionVerdict() {
+  return decideAgentGymPromotionVerdict(promotionInput(), {
+    decided_at: "2026-08-12T11:10:00.000Z",
+    decision_ref: "agent-gym-promotion-verdict://nightly/one",
+  });
+}
 
 function promotionInput(
   overrides: Partial<AgentGymPromotionInputReceiptV1> = {},

--- a/apps/slack-companion/test/agent-gym-promotion-lifecycle.test.ts
+++ b/apps/slack-companion/test/agent-gym-promotion-lifecycle.test.ts
@@ -5,6 +5,8 @@ import {
   decideAgentGymPromotionVerdict,
   digestAgentGymJson,
   issueAgentGymPromotionAuthorization,
+  planAgentGymCandidateActivation,
+  validateAgentGymActivationPlan,
   validateAgentGymPromotionAuthorization,
   validateAgentGymPromotionVerdict,
   type AgentGymPromotionInputReceiptV1,
@@ -70,6 +72,59 @@ test("blocked verdicts cannot receive activation authority", () => {
     reason_codes: ["release.policy_satisfied"],
   }), /promotion authorization is invalid/u);
 });
+
+test("activation plans bind exact candidates, authority, and canary scope", () => {
+  const plan = planAgentGymCandidateActivation(promotionAuthorization(), candidateManifest(), {
+    activation_ref: "agent-gym-activation://nightly/one",
+    baseline_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    initial_traffic_percent: 10,
+    mode: "canary",
+    planned_at: "2026-08-12T11:12:00.000Z",
+    target_ref: "agent-gym-target://slack-companion/default",
+  });
+  assert.equal(plan.initial_traffic_percent, 10);
+  assert.match(plan.idempotency_key, /^sha256:[0-9a-f]{64}$/u);
+  assert.deepEqual(validateAgentGymActivationPlan(plan), plan);
+});
+
+test("expired authority cannot produce an activation plan", () => {
+  assert.throws(() => planAgentGymCandidateActivation(promotionAuthorization(), candidateManifest(), {
+    activation_ref: "agent-gym-activation://nightly/expired",
+    baseline_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    initial_traffic_percent: 100,
+    mode: "direct",
+    planned_at: "2026-08-12T12:11:00.000Z",
+    target_ref: "agent-gym-target://slack-companion/default",
+  }), /activation plan is invalid/u);
+});
+
+function promotionAuthorization() {
+  return issueAgentGymPromotionAuthorization(promotionVerdict(), {
+    authorization_ref: "agent-gym-promotion-authorization://nightly/one",
+    authority_ref: "agent-gym-authority://release/default",
+    expires_at: "2026-08-12T12:11:00.000Z",
+    issued_at: "2026-08-12T11:11:00.000Z",
+    issued_by_ref: "agent-gym-actor://release/controller",
+    outcome: "authorized",
+    reason_codes: ["release.policy_satisfied"],
+  });
+}
+
+function candidateManifest() {
+  return {
+    candidate_ref: "agent-gym-candidate://nightly/challenger",
+    max_output_tokens: 1_024,
+    model_id: "us.anthropic.claude-sonnet-4-20250514-v1:0",
+    policy_digest: digest("1") as `sha256:${string}`,
+    prompt_digest: digest("2") as `sha256:${string}`,
+    provider: "aws_bedrock" as const,
+    region: "us-east-1",
+    schema_version: "agent-gym-candidate-manifest/v1" as const,
+    source_revision: "3".repeat(40),
+    tool_catalog_digest: digest("4") as `sha256:${string}`,
+    tool_ids: ["cerebro.search"],
+  };
+}
 
 function promotionVerdict() {
   return decideAgentGymPromotionVerdict(promotionInput(), {


### PR DESCRIPTION
## Summary
- convert policy-bound comparison evidence into deterministic promotion verdicts
- separate expiring activation authority from evaluation decisions
- bind canary plans, observed activation receipts, and append-only champion lineage

## Validation
- `npm run typecheck` in `apps/slack-companion`
- `npm test` in `apps/slack-companion` (667 tests)

## Delivery
- Portable Agent Gym contracts and deterministic lifecycle logic only
- No environment configuration, credentials, infrastructure, routes, or deployment changes
- Practice Registry connector unavailable; repository checks remain authoritative for this PR
