### PR TITLE
feat(slack): gate agent gym canary traffic

### DIFF
--- a/apps/slack-companion/src/agent-gym/canary-action-plan.ts
+++ b/apps/slack-companion/src/agent-gym/canary-action-plan.ts
@@ -1,0 +1,183 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymCanaryGateDecision,
+  type AgentGymCanaryGateDecisionV1,
+} from "./canary-gate.js";
+import {
+  validateAgentGymChampionTransition,
+  type AgentGymChampionTransitionV1,
+} from "./champion-transition.js";
+
+export type AgentGymCanaryAction =
+  | "complete_rollout"
+  | "hold_traffic"
+  | "increase_traffic"
+  | "rollback_candidate";
+
+export interface AgentGymCanaryActionPolicyV1 {
+  readonly maximum_traffic_step_percent: number;
+  readonly policy_ref: string;
+  readonly schema_version: "agent-gym-canary-action-policy/v1";
+}
+
+export interface AgentGymCanaryActionPlanV1 {
+  readonly action: AgentGymCanaryAction;
+  readonly action_ref: string;
+  readonly candidate_ref: string;
+  readonly expires_at: string;
+  readonly from_traffic_percent: number;
+  readonly gate_decision_digest: string;
+  readonly idempotency_key: string;
+  readonly plan_digest: string;
+  readonly planned_at: string;
+  readonly policy_digest: string;
+  readonly policy_ref: string;
+  readonly rollback_candidate_ref: string | null;
+  readonly schema_version: "agent-gym-canary-action-plan/v1";
+  readonly target_ref: string;
+  readonly to_traffic_percent: number;
+  readonly transition_digest: string;
+}
+
+/** Plans one bounded traffic action from an exact canary gate decision. */
+export function planAgentGymCanaryAction(
+  transitionValue: AgentGymChampionTransitionV1,
+  decisionValue: AgentGymCanaryGateDecisionV1,
+  policy: AgentGymCanaryActionPolicyV1,
+  input: {
+    readonly action_ref: string;
+    readonly expires_at: string;
+    readonly planned_at: string;
+    readonly requested_traffic_percent: number;
+  },
+): AgentGymCanaryActionPlanV1 {
+  const transition = validateAgentGymChampionTransition(transitionValue);
+  const decision = validateAgentGymCanaryGateDecision(decisionValue);
+  validatePolicy(policy);
+  reference(input.action_ref);
+  timestamp(input.planned_at);
+  timestamp(input.expires_at);
+  percent(input.requested_traffic_percent);
+  if (transition.active_candidate_ref !== decision.candidate_ref
+    || transition.target_ref !== decision.target_ref
+    || Date.parse(input.planned_at) < Date.parse(decision.evaluated_at)
+    || Date.parse(input.expires_at) <= Date.parse(input.planned_at)) invalid();
+  let action: AgentGymCanaryAction;
+  let rollbackCandidateRef: string | null = null;
+  if (decision.disposition === "rollback") {
+    if (input.requested_traffic_percent !== 0) invalid();
+    action = "rollback_candidate";
+    rollbackCandidateRef = transition.from_candidate_ref;
+  } else if (decision.disposition === "hold") {
+    if (input.requested_traffic_percent !== transition.traffic_percent) invalid();
+    action = "hold_traffic";
+  } else if (transition.traffic_percent === 100) {
+    if (input.requested_traffic_percent !== 100) invalid();
+    action = "complete_rollout";
+  } else {
+    const step = input.requested_traffic_percent - transition.traffic_percent;
+    if (step < 1 || step > policy.maximum_traffic_step_percent) invalid();
+    action = "increase_traffic";
+  }
+  const policyBody = {
+    maximum_traffic_step_percent: policy.maximum_traffic_step_percent,
+    policy_ref: policy.policy_ref,
+    schema_version: policy.schema_version,
+  };
+  const identity = {
+    action_ref: input.action_ref,
+    gate_decision_digest: decision.decision_digest,
+    target_ref: transition.target_ref,
+    transition_digest: transition.transition_digest,
+  };
+  const body = {
+    action,
+    action_ref: input.action_ref,
+    candidate_ref: transition.active_candidate_ref,
+    expires_at: input.expires_at,
+    from_traffic_percent: transition.traffic_percent,
+    gate_decision_digest: decision.decision_digest,
+    idempotency_key: digestAgentGymJson(identity),
+    planned_at: input.planned_at,
+    policy_digest: digestAgentGymJson(policyBody),
+    policy_ref: policy.policy_ref,
+    rollback_candidate_ref: rollbackCandidateRef,
+    schema_version: "agent-gym-canary-action-plan/v1" as const,
+    target_ref: transition.target_ref,
+    to_traffic_percent: input.requested_traffic_percent,
+    transition_digest: transition.transition_digest,
+  };
+  return Object.freeze({ ...body, plan_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymCanaryActionPlan(
+  value: AgentGymCanaryActionPlanV1,
+): AgentGymCanaryActionPlanV1 {
+  if (value.schema_version !== "agent-gym-canary-action-plan/v1") invalid();
+  for (const ref of [value.action_ref, value.candidate_ref, value.policy_ref, value.target_ref]) reference(ref);
+  if (value.rollback_candidate_ref !== null) reference(value.rollback_candidate_ref);
+  timestamp(value.planned_at);
+  timestamp(value.expires_at);
+  if (Date.parse(value.expires_at) <= Date.parse(value.planned_at)) invalid();
+  percent(value.from_traffic_percent);
+  percent(value.to_traffic_percent);
+  for (const valueDigest of [value.gate_decision_digest, value.idempotency_key,
+    value.plan_digest, value.policy_digest, value.transition_digest]) digest(valueDigest);
+  if (value.action === "rollback_candidate") {
+    if (value.to_traffic_percent !== 0 || value.rollback_candidate_ref === null
+      || value.rollback_candidate_ref === value.candidate_ref) invalid();
+  } else if (value.action === "hold_traffic") {
+    if (value.to_traffic_percent !== value.from_traffic_percent || value.rollback_candidate_ref !== null) invalid();
+  } else if (value.action === "increase_traffic") {
+    if (value.to_traffic_percent <= value.from_traffic_percent || value.rollback_candidate_ref !== null) invalid();
+  } else if (value.action === "complete_rollout") {
+    if (value.from_traffic_percent !== 100 || value.to_traffic_percent !== 100
+      || value.rollback_candidate_ref !== null) invalid();
+  } else invalid();
+  const identity = {
+    action_ref: value.action_ref,
+    gate_decision_digest: value.gate_decision_digest,
+    target_ref: value.target_ref,
+    transition_digest: value.transition_digest,
+  };
+  if (digestAgentGymJson(identity) !== value.idempotency_key) invalid();
+  const body = {
+    action: value.action,
+    action_ref: value.action_ref,
+    candidate_ref: value.candidate_ref,
+    expires_at: value.expires_at,
+    from_traffic_percent: value.from_traffic_percent,
+    gate_decision_digest: value.gate_decision_digest,
+    idempotency_key: value.idempotency_key,
+    planned_at: value.planned_at,
+    policy_digest: value.policy_digest,
+    policy_ref: value.policy_ref,
+    rollback_candidate_ref: value.rollback_candidate_ref,
+    schema_version: value.schema_version,
+    target_ref: value.target_ref,
+    to_traffic_percent: value.to_traffic_percent,
+    transition_digest: value.transition_digest,
+  };
+  if (digestAgentGymJson(body) !== value.plan_digest) invalid();
+  return Object.freeze({ ...value });
+}
+
+function validatePolicy(value: AgentGymCanaryActionPolicyV1): void {
+  if (value.schema_version !== "agent-gym-canary-action-policy/v1") invalid();
+  reference(value.policy_ref);
+  if (!Number.isSafeInteger(value.maximum_traffic_step_percent)
+    || value.maximum_traffic_step_percent < 1 || value.maximum_traffic_step_percent > 100) invalid();
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function percent(value: number): void {
+  if (!Number.isSafeInteger(value) || value < 0 || value > 100) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never { throw new AgentGymContractError("Agent gym canary action plan is invalid."); }

--- a/apps/slack-companion/src/agent-gym/canary-action-receipt.ts
+++ b/apps/slack-companion/src/agent-gym/canary-action-receipt.ts
@@ -1,0 +1,162 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymCanaryActionPlan,
+  type AgentGymCanaryActionPlanV1,
+} from "./canary-action-plan.js";
+
+export type AgentGymCanaryActionStatus = "applied" | "indeterminate" | "rejected";
+
+export interface AgentGymCanaryActionReceiptV1 {
+  readonly action: AgentGymCanaryActionPlanV1["action"];
+  readonly action_ref: string;
+  readonly candidate_ref: string;
+  readonly completed_at: string;
+  readonly executor_ref: string;
+  readonly failure_codes: readonly string[];
+  readonly observed_active_candidate_ref: string | null;
+  readonly observed_candidate_traffic_percent: number | null;
+  readonly plan_digest: string;
+  readonly receipt_digest: string;
+  readonly receipt_ref: string;
+  readonly schema_version: "agent-gym-canary-action-receipt/v1";
+  readonly started_at: string;
+  readonly status: AgentGymCanaryActionStatus;
+  readonly target_ref: string;
+}
+
+/** Records an observed canary action result without claiming unknown state. */
+export function recordAgentGymCanaryAction(
+  planValue: AgentGymCanaryActionPlanV1,
+  input: Omit<AgentGymCanaryActionReceiptV1,
+    "action" | "action_ref" | "candidate_ref" | "plan_digest" | "receipt_digest"
+    | "schema_version" | "target_ref">,
+): AgentGymCanaryActionReceiptV1 {
+  const plan = validateAgentGymCanaryActionPlan(planValue);
+  validateInput(input);
+  if (Date.parse(input.started_at) < Date.parse(plan.planned_at)
+    || Date.parse(input.started_at) >= Date.parse(plan.expires_at)
+    || Date.parse(input.completed_at) < Date.parse(input.started_at)) invalid();
+  validateObservedOutcome(plan, input);
+  const body = {
+    action: plan.action,
+    action_ref: plan.action_ref,
+    candidate_ref: plan.candidate_ref,
+    completed_at: input.completed_at,
+    executor_ref: input.executor_ref,
+    failure_codes: [...input.failure_codes],
+    observed_active_candidate_ref: input.observed_active_candidate_ref,
+    observed_candidate_traffic_percent: input.observed_candidate_traffic_percent,
+    plan_digest: plan.plan_digest,
+    receipt_ref: input.receipt_ref,
+    schema_version: "agent-gym-canary-action-receipt/v1" as const,
+    started_at: input.started_at,
+    status: input.status,
+    target_ref: plan.target_ref,
+  };
+  return Object.freeze({
+    ...body,
+    failure_codes: Object.freeze(body.failure_codes),
+    receipt_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymCanaryActionReceipt(
+  value: AgentGymCanaryActionReceiptV1,
+): AgentGymCanaryActionReceiptV1 {
+  if (value.schema_version !== "agent-gym-canary-action-receipt/v1") invalid();
+  validateInput(value);
+  for (const ref of [value.action_ref, value.candidate_ref, value.target_ref]) reference(ref);
+  digest(value.plan_digest);
+  digest(value.receipt_digest);
+  if (Date.parse(value.completed_at) < Date.parse(value.started_at)) invalid();
+  if (value.status === "applied") {
+    if (value.failure_codes.length !== 0 || value.observed_active_candidate_ref === null
+      || value.observed_candidate_traffic_percent === null) invalid();
+    if (value.action !== "rollback_candidate"
+      && value.observed_active_candidate_ref !== value.candidate_ref) invalid();
+    if (value.action === "rollback_candidate"
+      && (value.observed_active_candidate_ref === value.candidate_ref
+        || value.observed_candidate_traffic_percent !== 0)) invalid();
+  } else if (value.status === "rejected") {
+    if (value.failure_codes.length === 0 || value.observed_active_candidate_ref !== value.candidate_ref
+      || value.observed_candidate_traffic_percent === null) invalid();
+  } else if (value.status === "indeterminate") {
+    if (value.failure_codes.length === 0 || value.observed_active_candidate_ref !== null
+      || value.observed_candidate_traffic_percent !== null) invalid();
+  } else invalid();
+  const body = {
+    action: value.action,
+    action_ref: value.action_ref,
+    candidate_ref: value.candidate_ref,
+    completed_at: value.completed_at,
+    executor_ref: value.executor_ref,
+    failure_codes: value.failure_codes,
+    observed_active_candidate_ref: value.observed_active_candidate_ref,
+    observed_candidate_traffic_percent: value.observed_candidate_traffic_percent,
+    plan_digest: value.plan_digest,
+    receipt_ref: value.receipt_ref,
+    schema_version: value.schema_version,
+    started_at: value.started_at,
+    status: value.status,
+    target_ref: value.target_ref,
+  };
+  if (digestAgentGymJson(body) !== value.receipt_digest) invalid();
+  return Object.freeze({ ...value, failure_codes: Object.freeze([...value.failure_codes]) });
+}
+
+function validateObservedOutcome(
+  plan: AgentGymCanaryActionPlanV1,
+  input: Pick<AgentGymCanaryActionReceiptV1,
+    "failure_codes" | "observed_active_candidate_ref" | "observed_candidate_traffic_percent" | "status">,
+): void {
+  if (input.status === "applied") {
+    const expectedActive = plan.action === "rollback_candidate"
+      ? plan.rollback_candidate_ref
+      : plan.candidate_ref;
+    if (input.failure_codes.length !== 0 || input.observed_active_candidate_ref !== expectedActive
+      || input.observed_candidate_traffic_percent !== plan.to_traffic_percent) invalid();
+  } else if (input.status === "rejected") {
+    if (input.failure_codes.length === 0 || input.observed_active_candidate_ref !== plan.candidate_ref
+      || input.observed_candidate_traffic_percent !== plan.from_traffic_percent) invalid();
+  } else if (input.status === "indeterminate") {
+    if (input.failure_codes.length === 0 || input.observed_active_candidate_ref !== null
+      || input.observed_candidate_traffic_percent !== null) invalid();
+  } else invalid();
+}
+function validateInput(value: {
+  readonly completed_at: string;
+  readonly executor_ref: string;
+  readonly failure_codes: readonly string[];
+  readonly observed_active_candidate_ref: string | null;
+  readonly observed_candidate_traffic_percent: number | null;
+  readonly receipt_ref: string;
+  readonly started_at: string;
+  readonly status: AgentGymCanaryActionStatus;
+}): void {
+  reference(value.executor_ref);
+  reference(value.receipt_ref);
+  if (value.observed_active_candidate_ref !== null) reference(value.observed_active_candidate_ref);
+  timestamp(value.started_at);
+  timestamp(value.completed_at);
+  if (value.observed_candidate_traffic_percent !== null) percent(value.observed_candidate_traffic_percent);
+  if (!Array.isArray(value.failure_codes) || value.failure_codes.length > 64
+    || new Set(value.failure_codes).size !== value.failure_codes.length) invalid();
+  for (const code of value.failure_codes) text(code);
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function percent(value: number): void {
+  if (!Number.isSafeInteger(value) || value < 0 || value > 100) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function text(value: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > 160
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never { throw new AgentGymContractError("Agent gym canary action receipt is invalid."); }

--- a/apps/slack-companion/src/agent-gym/canary-gate.ts
+++ b/apps/slack-companion/src/agent-gym/canary-gate.ts
@@ -1,0 +1,167 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymCanaryWindow,
+  type AgentGymCanaryWindowV1,
+} from "./canary-window.js";
+
+export type AgentGymCanaryGateDisposition = "advance" | "hold" | "rollback";
+export type AgentGymCanaryGateBlockerCode =
+  | "canary.critical_blocker"
+  | "canary.failure_rate_exceeded"
+  | "canary.insufficient_samples"
+  | "canary.latency_exceeded"
+  | "canary.quality_below_minimum";
+
+export interface AgentGymCanaryGatePolicyV1 {
+  readonly maximum_failure_rate: number;
+  readonly maximum_p95_latency_ms: number;
+  readonly minimum_mean_quality_score: number;
+  readonly minimum_observation_count: number;
+  readonly policy_ref: string;
+  readonly rollback_blocker_codes: readonly string[];
+  readonly schema_version: "agent-gym-canary-gate-policy/v1";
+}
+
+export interface AgentGymCanaryGateDecisionV1 {
+  readonly blocker_codes: readonly AgentGymCanaryGateBlockerCode[];
+  readonly candidate_ref: string;
+  readonly decision_digest: string;
+  readonly decision_ref: string;
+  readonly disposition: AgentGymCanaryGateDisposition;
+  readonly evaluated_at: string;
+  readonly observed_failure_rate: number;
+  readonly policy_digest: string;
+  readonly policy_ref: string;
+  readonly schema_version: "agent-gym-canary-gate-decision/v1";
+  readonly target_ref: string;
+  readonly window_digest: string;
+}
+
+/** Applies explicit canary thresholds without environment-specific mutation. */
+export function decideAgentGymCanaryGate(
+  windowValue: AgentGymCanaryWindowV1,
+  policy: AgentGymCanaryGatePolicyV1,
+  input: { readonly decision_ref: string; readonly evaluated_at: string },
+): AgentGymCanaryGateDecisionV1 {
+  const window = validateAgentGymCanaryWindow(windowValue);
+  validatePolicy(policy);
+  reference(input.decision_ref);
+  timestamp(input.evaluated_at);
+  if (Date.parse(input.evaluated_at) < Date.parse(window.ended_at)) invalid();
+  const failureRate = window.failed_count / window.observation_count;
+  const blockers = new Set<AgentGymCanaryGateBlockerCode>();
+  const insufficient = window.observation_count < policy.minimum_observation_count;
+  const critical = window.blocker_codes.some((code) => policy.rollback_blocker_codes.includes(code));
+  if (insufficient) blockers.add("canary.insufficient_samples");
+  if (critical) blockers.add("canary.critical_blocker");
+  if (failureRate > policy.maximum_failure_rate) blockers.add("canary.failure_rate_exceeded");
+  if (window.p95_latency_ms > policy.maximum_p95_latency_ms) blockers.add("canary.latency_exceeded");
+  if (window.mean_quality_score < policy.minimum_mean_quality_score) {
+    blockers.add("canary.quality_below_minimum");
+  }
+  const blockerCodes = [...blockers].sort();
+  const thresholdFailure = blockerCodes.some((code) => code !== "canary.insufficient_samples");
+  const disposition: AgentGymCanaryGateDisposition = critical || (!insufficient && thresholdFailure)
+    ? "rollback"
+    : insufficient ? "hold" : "advance";
+  const policyBody = {
+    maximum_failure_rate: policy.maximum_failure_rate,
+    maximum_p95_latency_ms: policy.maximum_p95_latency_ms,
+    minimum_mean_quality_score: policy.minimum_mean_quality_score,
+    minimum_observation_count: policy.minimum_observation_count,
+    policy_ref: policy.policy_ref,
+    rollback_blocker_codes: [...policy.rollback_blocker_codes],
+    schema_version: policy.schema_version,
+  };
+  const body = {
+    blocker_codes: blockerCodes,
+    candidate_ref: window.candidate_ref,
+    decision_ref: input.decision_ref,
+    disposition,
+    evaluated_at: input.evaluated_at,
+    observed_failure_rate: failureRate,
+    policy_digest: digestAgentGymJson(policyBody),
+    policy_ref: policy.policy_ref,
+    schema_version: "agent-gym-canary-gate-decision/v1" as const,
+    target_ref: window.target_ref,
+    window_digest: window.window_digest,
+  };
+  return Object.freeze({
+    ...body,
+    blocker_codes: Object.freeze(blockerCodes),
+    decision_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymCanaryGateDecision(
+  value: AgentGymCanaryGateDecisionV1,
+): AgentGymCanaryGateDecisionV1 {
+  if (value.schema_version !== "agent-gym-canary-gate-decision/v1") invalid();
+  for (const ref of [value.candidate_ref, value.decision_ref, value.policy_ref, value.target_ref]) reference(ref);
+  timestamp(value.evaluated_at);
+  for (const valueDigest of [value.decision_digest, value.policy_digest, value.window_digest]) digest(valueDigest);
+  finite(value.observed_failure_rate, 0, 1);
+  const allowed: readonly AgentGymCanaryGateBlockerCode[] = [
+    "canary.critical_blocker", "canary.failure_rate_exceeded", "canary.insufficient_samples",
+    "canary.latency_exceeded", "canary.quality_below_minimum",
+  ];
+  if (!Array.isArray(value.blocker_codes) || value.blocker_codes.length > allowed.length
+    || new Set(value.blocker_codes).size !== value.blocker_codes.length
+    || value.blocker_codes.some((code) => !allowed.includes(code))
+    || value.blocker_codes.some((code, index) => index > 0 && value.blocker_codes[index - 1]! >= code)) invalid();
+  if (value.disposition === "advance") {
+    if (value.blocker_codes.length !== 0) invalid();
+  } else if (value.disposition === "hold") {
+    if (!value.blocker_codes.includes("canary.insufficient_samples")
+      || value.blocker_codes.includes("canary.critical_blocker")) invalid();
+  } else if (value.disposition === "rollback") {
+    if (value.blocker_codes.length === 0) invalid();
+  } else invalid();
+  const body = {
+    blocker_codes: value.blocker_codes,
+    candidate_ref: value.candidate_ref,
+    decision_ref: value.decision_ref,
+    disposition: value.disposition,
+    evaluated_at: value.evaluated_at,
+    observed_failure_rate: value.observed_failure_rate,
+    policy_digest: value.policy_digest,
+    policy_ref: value.policy_ref,
+    schema_version: value.schema_version,
+    target_ref: value.target_ref,
+    window_digest: value.window_digest,
+  };
+  if (digestAgentGymJson(body) !== value.decision_digest) invalid();
+  return Object.freeze({ ...value, blocker_codes: Object.freeze([...value.blocker_codes]) });
+}
+
+function validatePolicy(value: AgentGymCanaryGatePolicyV1): void {
+  if (value.schema_version !== "agent-gym-canary-gate-policy/v1") invalid();
+  reference(value.policy_ref);
+  finite(value.maximum_failure_rate, 0, 1);
+  finite(value.minimum_mean_quality_score, 0, 1);
+  integer(value.maximum_p95_latency_ms, 3_600_000, false);
+  integer(value.minimum_observation_count, 1_000_000, false);
+  if (!Array.isArray(value.rollback_blocker_codes) || value.rollback_blocker_codes.length > 64
+    || new Set(value.rollback_blocker_codes).size !== value.rollback_blocker_codes.length) invalid();
+  for (const code of value.rollback_blocker_codes) text(code);
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function finite(value: number, minimum: number, maximum: number): void {
+  if (!Number.isFinite(value) || value < minimum || value > maximum) invalid();
+}
+function integer(value: number, maximum: number, allowZero = true): void {
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1) || value > maximum) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function text(value: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > 160
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never { throw new AgentGymContractError("Agent gym canary gate is invalid."); }

--- a/apps/slack-companion/src/agent-gym/canary-observation.ts
+++ b/apps/slack-companion/src/agent-gym/canary-observation.ts
@@ -1,0 +1,134 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymChampionTransition,
+  type AgentGymChampionTransitionV1,
+} from "./champion-transition.js";
+
+export type AgentGymCanaryObservationOutcome = "failed" | "passed";
+
+export interface AgentGymCanaryObservationV1 {
+  readonly blocker_codes: readonly string[];
+  readonly candidate_ref: string;
+  readonly evidence_refs: readonly string[];
+  readonly latency_ms: number;
+  readonly observation_digest: string;
+  readonly observation_ref: string;
+  readonly observed_at: string;
+  readonly outcome: AgentGymCanaryObservationOutcome;
+  readonly quality_score: number;
+  readonly sample_ref: string;
+  readonly schema_version: "agent-gym-canary-observation/v1";
+  readonly target_ref: string;
+  readonly transition_digest: string;
+}
+
+/** Records one provider-neutral sample against an exact champion transition. */
+export function recordAgentGymCanaryObservation(
+  transitionValue: AgentGymChampionTransitionV1,
+  input: Omit<AgentGymCanaryObservationV1,
+    "candidate_ref" | "observation_digest" | "schema_version" | "target_ref"
+    | "transition_digest">,
+): AgentGymCanaryObservationV1 {
+  const transition = validateAgentGymChampionTransition(transitionValue);
+  validateInput(input);
+  if (Date.parse(input.observed_at) < Date.parse(transition.effective_at)) invalid();
+  const body = {
+    blocker_codes: [...input.blocker_codes],
+    candidate_ref: transition.active_candidate_ref,
+    evidence_refs: [...input.evidence_refs],
+    latency_ms: input.latency_ms,
+    observation_ref: input.observation_ref,
+    observed_at: input.observed_at,
+    outcome: input.outcome,
+    quality_score: input.quality_score,
+    sample_ref: input.sample_ref,
+    schema_version: "agent-gym-canary-observation/v1" as const,
+    target_ref: transition.target_ref,
+    transition_digest: transition.transition_digest,
+  };
+  return Object.freeze({
+    ...body,
+    blocker_codes: Object.freeze(body.blocker_codes),
+    evidence_refs: Object.freeze(body.evidence_refs),
+    observation_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymCanaryObservation(
+  value: AgentGymCanaryObservationV1,
+): AgentGymCanaryObservationV1 {
+  if (value.schema_version !== "agent-gym-canary-observation/v1") invalid();
+  validateInput(value);
+  for (const ref of [value.candidate_ref, value.target_ref]) reference(ref);
+  digest(value.observation_digest);
+  digest(value.transition_digest);
+  const body = {
+    blocker_codes: value.blocker_codes,
+    candidate_ref: value.candidate_ref,
+    evidence_refs: value.evidence_refs,
+    latency_ms: value.latency_ms,
+    observation_ref: value.observation_ref,
+    observed_at: value.observed_at,
+    outcome: value.outcome,
+    quality_score: value.quality_score,
+    sample_ref: value.sample_ref,
+    schema_version: value.schema_version,
+    target_ref: value.target_ref,
+    transition_digest: value.transition_digest,
+  };
+  if (digestAgentGymJson(body) !== value.observation_digest) invalid();
+  return Object.freeze({
+    ...value,
+    blocker_codes: Object.freeze([...value.blocker_codes]),
+    evidence_refs: Object.freeze([...value.evidence_refs]),
+  });
+}
+
+function validateInput(value: {
+  readonly blocker_codes: readonly string[];
+  readonly evidence_refs: readonly string[];
+  readonly latency_ms: number;
+  readonly observation_ref: string;
+  readonly observed_at: string;
+  readonly outcome: AgentGymCanaryObservationOutcome;
+  readonly quality_score: number;
+  readonly sample_ref: string;
+}): void {
+  reference(value.observation_ref);
+  reference(value.sample_ref);
+  timestamp(value.observed_at);
+  finite(value.quality_score, 0, 1);
+  if (!Number.isSafeInteger(value.latency_ms) || value.latency_ms < 0 || value.latency_ms > 3_600_000
+    || !Array.isArray(value.blocker_codes) || value.blocker_codes.length > 64
+    || new Set(value.blocker_codes).size !== value.blocker_codes.length
+    || !Array.isArray(value.evidence_refs) || value.evidence_refs.length > 64
+    || new Set(value.evidence_refs).size !== value.evidence_refs.length) invalid();
+  for (const code of value.blocker_codes) text(code);
+  for (const ref of value.evidence_refs) reference(ref);
+  if (value.outcome === "passed") {
+    if (value.blocker_codes.length !== 0 || value.evidence_refs.length === 0) invalid();
+  } else if (value.outcome === "failed") {
+    if (value.blocker_codes.length === 0) invalid();
+  } else invalid();
+}
+function digest(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function finite(value: number, minimum: number, maximum: number): void {
+  if (!Number.isFinite(value) || value < minimum || value > maximum) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function text(value: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > 160
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym canary observation is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/canary-window.ts
+++ b/apps/slack-companion/src/agent-gym/canary-window.ts
@@ -1,0 +1,148 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymCanaryObservation,
+  type AgentGymCanaryObservationV1,
+} from "./canary-observation.js";
+
+export interface AgentGymCanaryWindowV1 {
+  readonly blocker_codes: readonly string[];
+  readonly candidate_ref: string;
+  readonly ended_at: string;
+  readonly failed_count: number;
+  readonly mean_quality_score: number;
+  readonly observation_count: number;
+  readonly observation_digests: readonly string[];
+  readonly p95_latency_ms: number;
+  readonly passed_count: number;
+  readonly schema_version: "agent-gym-canary-window/v1";
+  readonly started_at: string;
+  readonly target_ref: string;
+  readonly transition_digest: string;
+  readonly window_digest: string;
+  readonly window_ref: string;
+}
+
+/** Seals a chronological canary sample window for deterministic gating. */
+export function sealAgentGymCanaryWindow(
+  observationValues: readonly AgentGymCanaryObservationV1[],
+  input: { readonly ended_at: string; readonly started_at: string; readonly window_ref: string },
+): AgentGymCanaryWindowV1 {
+  timestamp(input.started_at);
+  timestamp(input.ended_at);
+  reference(input.window_ref);
+  if (Date.parse(input.ended_at) < Date.parse(input.started_at)
+    || !Array.isArray(observationValues) || observationValues.length === 0
+    || observationValues.length > 1_000_000) invalid();
+  const observations = observationValues.map(validateAgentGymCanaryObservation).sort((left, right) =>
+    left.observed_at.localeCompare(right.observed_at) || left.observation_ref.localeCompare(right.observation_ref));
+  const first = observations[0]!;
+  const refs = new Set<string>();
+  const samples = new Set<string>();
+  const digests = new Set<string>();
+  for (const observation of observations) {
+    if (observation.transition_digest !== first.transition_digest
+      || observation.candidate_ref !== first.candidate_ref || observation.target_ref !== first.target_ref
+      || Date.parse(observation.observed_at) < Date.parse(input.started_at)
+      || Date.parse(observation.observed_at) > Date.parse(input.ended_at)
+      || refs.has(observation.observation_ref) || samples.has(observation.sample_ref)
+      || digests.has(observation.observation_digest)) invalid();
+    refs.add(observation.observation_ref);
+    samples.add(observation.sample_ref);
+    digests.add(observation.observation_digest);
+  }
+  const passedCount = observations.filter((entry) => entry.outcome === "passed").length;
+  const failedCount = observations.length - passedCount;
+  const quality = observations.reduce((sum, entry) => sum + entry.quality_score, 0) / observations.length;
+  const latencies = observations.map((entry) => entry.latency_ms).sort((left, right) => left - right);
+  const p95 = latencies[Math.ceil(latencies.length * 0.95) - 1]!;
+  const blockers = [...new Set(observations.flatMap((entry) => entry.blocker_codes))].sort();
+  const body = {
+    blocker_codes: blockers,
+    candidate_ref: first.candidate_ref,
+    ended_at: input.ended_at,
+    failed_count: failedCount,
+    mean_quality_score: quality,
+    observation_count: observations.length,
+    observation_digests: observations.map((entry) => entry.observation_digest),
+    p95_latency_ms: p95,
+    passed_count: passedCount,
+    schema_version: "agent-gym-canary-window/v1" as const,
+    started_at: input.started_at,
+    target_ref: first.target_ref,
+    transition_digest: first.transition_digest,
+    window_ref: input.window_ref,
+  };
+  return Object.freeze({
+    ...body,
+    blocker_codes: Object.freeze(blockers),
+    observation_digests: Object.freeze(body.observation_digests),
+    window_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymCanaryWindow(value: AgentGymCanaryWindowV1): AgentGymCanaryWindowV1 {
+  if (value.schema_version !== "agent-gym-canary-window/v1") invalid();
+  for (const ref of [value.candidate_ref, value.target_ref, value.window_ref]) reference(ref);
+  timestamp(value.started_at);
+  timestamp(value.ended_at);
+  if (Date.parse(value.ended_at) < Date.parse(value.started_at)) invalid();
+  digest(value.transition_digest);
+  digest(value.window_digest);
+  integer(value.observation_count, 1_000_000, false);
+  integer(value.passed_count, value.observation_count);
+  integer(value.failed_count, value.observation_count);
+  integer(value.p95_latency_ms, 3_600_000);
+  finite(value.mean_quality_score, 0, 1);
+  if (value.passed_count + value.failed_count !== value.observation_count
+    || !Array.isArray(value.observation_digests)
+    || value.observation_digests.length !== value.observation_count
+    || new Set(value.observation_digests).size !== value.observation_digests.length
+    || !Array.isArray(value.blocker_codes) || value.blocker_codes.length > 64
+    || new Set(value.blocker_codes).size !== value.blocker_codes.length
+    || value.blocker_codes.some((code, index) => index > 0 && value.blocker_codes[index - 1]! >= code)) invalid();
+  for (const valueDigest of value.observation_digests) digest(valueDigest);
+  for (const code of value.blocker_codes) text(code);
+  const body = {
+    blocker_codes: value.blocker_codes,
+    candidate_ref: value.candidate_ref,
+    ended_at: value.ended_at,
+    failed_count: value.failed_count,
+    mean_quality_score: value.mean_quality_score,
+    observation_count: value.observation_count,
+    observation_digests: value.observation_digests,
+    p95_latency_ms: value.p95_latency_ms,
+    passed_count: value.passed_count,
+    schema_version: value.schema_version,
+    started_at: value.started_at,
+    target_ref: value.target_ref,
+    transition_digest: value.transition_digest,
+    window_ref: value.window_ref,
+  };
+  if (digestAgentGymJson(body) !== value.window_digest) invalid();
+  return Object.freeze({
+    ...value,
+    blocker_codes: Object.freeze([...value.blocker_codes]),
+    observation_digests: Object.freeze([...value.observation_digests]),
+  });
+}
+
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function finite(value: number, minimum: number, maximum: number): void {
+  if (!Number.isFinite(value) || value < minimum || value > maximum) invalid();
+}
+function integer(value: number, maximum: number, allowZero = true): void {
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1) || value > maximum) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function text(value: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > 160
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never { throw new AgentGymContractError("Agent gym canary window is invalid."); }

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -37,6 +37,7 @@ export * from "./canary-observation.js";
 export * from "./canary-window.js";
 export * from "./canary-gate.js";
 export * from "./canary-action-plan.js";
+export * from "./canary-action-receipt.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -36,6 +36,7 @@ export * from "./champion-transition.js";
 export * from "./canary-observation.js";
 export * from "./canary-window.js";
 export * from "./canary-gate.js";
+export * from "./canary-action-plan.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -35,6 +35,7 @@ export * from "./activation-receipt.js";
 export * from "./champion-transition.js";
 export * from "./canary-observation.js";
 export * from "./canary-window.js";
+export * from "./canary-gate.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -33,6 +33,7 @@ export * from "./promotion-authorization.js";
 export * from "./activation-plan.js";
 export * from "./activation-receipt.js";
 export * from "./champion-transition.js";
+export * from "./canary-observation.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -34,6 +34,7 @@ export * from "./activation-plan.js";
 export * from "./activation-receipt.js";
 export * from "./champion-transition.js";
 export * from "./canary-observation.js";
+export * from "./canary-window.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/test/agent-gym-canary-control.test.ts
+++ b/apps/slack-companion/test/agent-gym-canary-control.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  digestAgentGymJson,
+  recordAgentGymCanaryObservation,
+  validateAgentGymCanaryObservation,
+  type AgentGymChampionTransitionV1,
+} from "../src/index.js";
+
+test("canary observations bind evidence to one champion transition", () => {
+  const observation = recordAgentGymCanaryObservation(championTransition(), {
+    blocker_codes: [],
+    evidence_refs: ["agent-gym-evidence://canary/sample-one"],
+    latency_ms: 850,
+    observation_ref: "agent-gym-canary-observation://nightly/one",
+    observed_at: "2026-08-12T11:16:00.000Z",
+    outcome: "passed",
+    quality_score: 0.92,
+    sample_ref: "agent-gym-sample://nightly/one",
+  });
+  assert.equal(observation.candidate_ref, championTransition().active_candidate_ref);
+  assert.deepEqual(validateAgentGymCanaryObservation(observation), observation);
+});
+
+test("passed canary observations require evidence and no blockers", () => {
+  assert.throws(() => recordAgentGymCanaryObservation(championTransition(), {
+    blocker_codes: ["answer.missing_evidence"],
+    evidence_refs: [],
+    latency_ms: 850,
+    observation_ref: "agent-gym-canary-observation://nightly/invalid",
+    observed_at: "2026-08-12T11:16:00.000Z",
+    outcome: "passed",
+    quality_score: 0.92,
+    sample_ref: "agent-gym-sample://nightly/invalid",
+  }), /canary observation is invalid/u);
+});
+
+function championTransition(): AgentGymChampionTransitionV1 {
+  const body = {
+    activation_receipt_digest: digest("a"),
+    active_candidate_ref: "agent-gym-candidate://nightly/challenger",
+    effective_at: "2026-08-12T11:15:00.000Z",
+    from_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    mode: "promote" as const,
+    previous_transition_digest: null,
+    rollback_of_transition_digest: null,
+    schema_version: "agent-gym-champion-transition/v1" as const,
+    sequence: 1,
+    target_ref: "agent-gym-target://slack-companion/default",
+    traffic_percent: 10,
+    transition_ref: "agent-gym-champion-transition://nightly/one",
+  };
+  return { ...body, transition_digest: digestAgentGymJson(body) };
+}
+
+function digest(character: string): string {
+  return `sha256:${character.repeat(64)}`;
+}

--- a/apps/slack-companion/test/agent-gym-canary-control.test.ts
+++ b/apps/slack-companion/test/agent-gym-canary-control.test.ts
@@ -4,7 +4,9 @@ import test from "node:test";
 import {
   digestAgentGymJson,
   recordAgentGymCanaryObservation,
+  sealAgentGymCanaryWindow,
   validateAgentGymCanaryObservation,
+  validateAgentGymCanaryWindow,
   type AgentGymChampionTransitionV1,
 } from "../src/index.js";
 
@@ -35,6 +37,71 @@ test("passed canary observations require evidence and no blockers", () => {
     sample_ref: "agent-gym-sample://nightly/invalid",
   }), /canary observation is invalid/u);
 });
+
+test("canary windows seal ordered samples and aggregate failures", () => {
+  const window = sealAgentGymCanaryWindow([
+    canaryObservation("two", "2026-08-12T11:17:00.000Z", "failed", 1_100, 0.4),
+    canaryObservation("one", "2026-08-12T11:16:00.000Z", "passed", 800, 0.9),
+  ], {
+    ended_at: "2026-08-12T11:18:00.000Z",
+    started_at: "2026-08-12T11:15:00.000Z",
+    window_ref: "agent-gym-canary-window://nightly/one",
+  });
+  assert.equal(window.observation_count, 2);
+  assert.equal(window.failed_count, 1);
+  assert.equal(window.p95_latency_ms, 1_100);
+  assert.deepEqual(window.blocker_codes, ["answer.missing_evidence"]);
+  assert.deepEqual(validateAgentGymCanaryWindow(window), window);
+});
+
+test("canary windows reject samples from another transition", () => {
+  const changed = { ...championTransition(), transition_ref: "agent-gym-champion-transition://nightly/two" };
+  const { transition_digest: _ignored, ...changedBody } = changed;
+  const other = recordAgentGymCanaryObservation({
+    ...changedBody,
+    transition_digest: digestAgentGymJson(changedBody),
+  }, observationInput("other", "2026-08-12T11:17:00.000Z", "passed", 900, 0.9));
+  assert.throws(() => sealAgentGymCanaryWindow([
+    canaryObservation("one", "2026-08-12T11:16:00.000Z", "passed", 800, 0.9),
+    other,
+  ], {
+    ended_at: "2026-08-12T11:18:00.000Z",
+    started_at: "2026-08-12T11:15:00.000Z",
+    window_ref: "agent-gym-canary-window://nightly/mixed",
+  }), /canary window is invalid/u);
+});
+
+function canaryObservation(
+  id: string,
+  observedAt: string,
+  outcome: "failed" | "passed",
+  latencyMs: number,
+  qualityScore: number,
+) {
+  return recordAgentGymCanaryObservation(
+    championTransition(),
+    observationInput(id, observedAt, outcome, latencyMs, qualityScore),
+  );
+}
+
+function observationInput(
+  id: string,
+  observedAt: string,
+  outcome: "failed" | "passed",
+  latencyMs: number,
+  qualityScore: number,
+) {
+  return {
+    blocker_codes: outcome === "passed" ? [] : ["answer.missing_evidence"],
+    evidence_refs: outcome === "passed" ? [`agent-gym-evidence://canary/${id}`] : [],
+    latency_ms: latencyMs,
+    observation_ref: `agent-gym-canary-observation://nightly/${id}`,
+    observed_at: observedAt,
+    outcome,
+    quality_score: qualityScore,
+    sample_ref: `agent-gym-sample://nightly/${id}`,
+  };
+}
 
 function championTransition(): AgentGymChampionTransitionV1 {
   const body = {

--- a/apps/slack-companion/test/agent-gym-canary-control.test.ts
+++ b/apps/slack-companion/test/agent-gym-canary-control.test.ts
@@ -5,12 +5,14 @@ import {
   digestAgentGymJson,
   decideAgentGymCanaryGate,
   planAgentGymCanaryAction,
+  recordAgentGymCanaryAction,
   recordAgentGymCanaryObservation,
   sealAgentGymCanaryWindow,
   validateAgentGymCanaryObservation,
   validateAgentGymCanaryWindow,
   validateAgentGymCanaryGateDecision,
   validateAgentGymCanaryActionPlan,
+  validateAgentGymCanaryActionReceipt,
   type AgentGymChampionTransitionV1,
 } from "../src/index.js";
 
@@ -126,6 +128,46 @@ test("rollback decisions cannot increase candidate traffic", () => {
     },
   ), /canary action plan is invalid/u);
 });
+
+test("canary action receipts prove the rollback candidate is active", () => {
+  const receipt = recordAgentGymCanaryAction(rollbackActionPlan(), {
+    completed_at: "2026-08-12T11:22:00.000Z",
+    executor_ref: "agent-gym-executor://canary/default",
+    failure_codes: [],
+    observed_active_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    observed_candidate_traffic_percent: 0,
+    receipt_ref: "agent-gym-canary-action-receipt://nightly/rollback",
+    started_at: "2026-08-12T11:21:00.000Z",
+    status: "applied",
+  });
+  assert.equal(receipt.status, "applied");
+  assert.equal(receipt.observed_candidate_traffic_percent, 0);
+  assert.deepEqual(validateAgentGymCanaryActionReceipt(receipt), receipt);
+});
+
+test("canary action receipts preserve indeterminate state without guessing", () => {
+  const receipt = recordAgentGymCanaryAction(rollbackActionPlan(), {
+    completed_at: "2026-08-12T11:22:00.000Z",
+    executor_ref: "agent-gym-executor://canary/default",
+    failure_codes: ["action.observation_unavailable"],
+    observed_active_candidate_ref: null,
+    observed_candidate_traffic_percent: null,
+    receipt_ref: "agent-gym-canary-action-receipt://nightly/indeterminate",
+    started_at: "2026-08-12T11:21:00.000Z",
+    status: "indeterminate",
+  });
+  assert.equal(receipt.status, "indeterminate");
+  assert.equal(receipt.observed_active_candidate_ref, null);
+});
+
+function rollbackActionPlan() {
+  return planAgentGymCanaryAction(championTransition(), canaryGateDecision(), canaryActionPolicy(), {
+    action_ref: "agent-gym-canary-action://nightly/rollback",
+    expires_at: "2026-08-12T11:30:00.000Z",
+    planned_at: "2026-08-12T11:20:00.000Z",
+    requested_traffic_percent: 0,
+  });
+}
 
 function canaryGateDecision() {
   return decideAgentGymCanaryGate(canaryWindow(), canaryPolicy(), {

--- a/apps/slack-companion/test/agent-gym-canary-control.test.ts
+++ b/apps/slack-companion/test/agent-gym-canary-control.test.ts
@@ -3,10 +3,12 @@ import test from "node:test";
 
 import {
   digestAgentGymJson,
+  decideAgentGymCanaryGate,
   recordAgentGymCanaryObservation,
   sealAgentGymCanaryWindow,
   validateAgentGymCanaryObservation,
   validateAgentGymCanaryWindow,
+  validateAgentGymCanaryGateDecision,
   type AgentGymChampionTransitionV1,
 } from "../src/index.js";
 
@@ -70,6 +72,58 @@ test("canary windows reject samples from another transition", () => {
     window_ref: "agent-gym-canary-window://nightly/mixed",
   }), /canary window is invalid/u);
 });
+
+test("canary gates roll back complete windows above thresholds", () => {
+  const decision = decideAgentGymCanaryGate(canaryWindow(), canaryPolicy(), {
+    decision_ref: "agent-gym-canary-gate://nightly/one",
+    evaluated_at: "2026-08-12T11:19:00.000Z",
+  });
+  assert.equal(decision.disposition, "rollback");
+  assert.deepEqual(decision.blocker_codes, [
+    "canary.failure_rate_exceeded",
+    "canary.quality_below_minimum",
+  ]);
+  assert.deepEqual(validateAgentGymCanaryGateDecision(decision), decision);
+});
+
+test("canary gates hold incomplete windows without overriding evidence", () => {
+  const oneSample = sealAgentGymCanaryWindow([
+    canaryObservation("one", "2026-08-12T11:16:00.000Z", "passed", 800, 0.9),
+  ], {
+    ended_at: "2026-08-12T11:18:00.000Z",
+    started_at: "2026-08-12T11:15:00.000Z",
+    window_ref: "agent-gym-canary-window://nightly/incomplete",
+  });
+  const decision = decideAgentGymCanaryGate(oneSample, canaryPolicy(), {
+    decision_ref: "agent-gym-canary-gate://nightly/incomplete",
+    evaluated_at: "2026-08-12T11:19:00.000Z",
+  });
+  assert.equal(decision.disposition, "hold");
+  assert.deepEqual(decision.blocker_codes, ["canary.insufficient_samples"]);
+});
+
+function canaryWindow() {
+  return sealAgentGymCanaryWindow([
+    canaryObservation("two", "2026-08-12T11:17:00.000Z", "failed", 1_100, 0.4),
+    canaryObservation("one", "2026-08-12T11:16:00.000Z", "passed", 800, 0.9),
+  ], {
+    ended_at: "2026-08-12T11:18:00.000Z",
+    started_at: "2026-08-12T11:15:00.000Z",
+    window_ref: "agent-gym-canary-window://nightly/one",
+  });
+}
+
+function canaryPolicy() {
+  return {
+    maximum_failure_rate: 0.1,
+    maximum_p95_latency_ms: 1_500,
+    minimum_mean_quality_score: 0.8,
+    minimum_observation_count: 2,
+    policy_ref: "agent-gym-canary-policy://nightly/default",
+    rollback_blocker_codes: ["safety.blocker"],
+    schema_version: "agent-gym-canary-gate-policy/v1" as const,
+  };
+}
 
 function canaryObservation(
   id: string,

--- a/apps/slack-companion/test/agent-gym-canary-control.test.ts
+++ b/apps/slack-companion/test/agent-gym-canary-control.test.ts
@@ -4,11 +4,13 @@ import test from "node:test";
 import {
   digestAgentGymJson,
   decideAgentGymCanaryGate,
+  planAgentGymCanaryAction,
   recordAgentGymCanaryObservation,
   sealAgentGymCanaryWindow,
   validateAgentGymCanaryObservation,
   validateAgentGymCanaryWindow,
   validateAgentGymCanaryGateDecision,
+  validateAgentGymCanaryActionPlan,
   type AgentGymChampionTransitionV1,
 } from "../src/index.js";
 
@@ -101,6 +103,44 @@ test("canary gates hold incomplete windows without overriding evidence", () => {
   assert.equal(decision.disposition, "hold");
   assert.deepEqual(decision.blocker_codes, ["canary.insufficient_samples"]);
 });
+
+test("canary action plans turn rollback evidence into zero candidate traffic", () => {
+  const plan = planAgentGymCanaryAction(championTransition(), canaryGateDecision(), canaryActionPolicy(), {
+    action_ref: "agent-gym-canary-action://nightly/rollback",
+    expires_at: "2026-08-12T11:30:00.000Z",
+    planned_at: "2026-08-12T11:20:00.000Z",
+    requested_traffic_percent: 0,
+  });
+  assert.equal(plan.action, "rollback_candidate");
+  assert.equal(plan.rollback_candidate_ref, "agent-gym-candidate://nightly/baseline");
+  assert.deepEqual(validateAgentGymCanaryActionPlan(plan), plan);
+});
+
+test("rollback decisions cannot increase candidate traffic", () => {
+  assert.throws(() => planAgentGymCanaryAction(
+    championTransition(), canaryGateDecision(), canaryActionPolicy(), {
+      action_ref: "agent-gym-canary-action://nightly/invalid-increase",
+      expires_at: "2026-08-12T11:30:00.000Z",
+      planned_at: "2026-08-12T11:20:00.000Z",
+      requested_traffic_percent: 20,
+    },
+  ), /canary action plan is invalid/u);
+});
+
+function canaryGateDecision() {
+  return decideAgentGymCanaryGate(canaryWindow(), canaryPolicy(), {
+    decision_ref: "agent-gym-canary-gate://nightly/one",
+    evaluated_at: "2026-08-12T11:19:00.000Z",
+  });
+}
+
+function canaryActionPolicy() {
+  return {
+    maximum_traffic_step_percent: 25,
+    policy_ref: "agent-gym-canary-action-policy://nightly/default",
+    schema_version: "agent-gym-canary-action-policy/v1" as const,
+  };
+}
 
 function canaryWindow() {
   return sealAgentGymCanaryWindow([


### PR DESCRIPTION
## Summary
- bind provider-neutral canary observations to exact champion transitions
- seal chronological evidence windows and gate them with explicit failure, quality, and latency thresholds
- plan bounded traffic actions and receipt applied, rejected, or indeterminate outcomes without guessing state

## Validation
- `npm run typecheck` in `apps/slack-companion`
- `npm test` in `apps/slack-companion` (677 tests)

## Delivery
- Portable Agent Gym contracts and deterministic canary-control logic only
- No environment configuration, credentials, infrastructure, routes, or deployment changes
- Practice Registry connector unavailable; repository checks remain authoritative for this PR
