### PR TITLE
feat(slack): verify agent gym rollouts

### DIFF
--- a/apps/slack-companion/src/agent-gym/canary-action-verification.ts
+++ b/apps/slack-companion/src/agent-gym/canary-action-verification.ts
@@ -1,0 +1,140 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymCanaryActionPlan,
+  type AgentGymCanaryActionPlanV1,
+} from "./canary-action-plan.js";
+import {
+  validateAgentGymCanaryActionReceipt,
+  type AgentGymCanaryActionReceiptV1,
+} from "./canary-action-receipt.js";
+import {
+  validateAgentGymCanaryStateObservation,
+  type AgentGymCanaryStateObservationV1,
+} from "./canary-state-observation.js";
+
+export type AgentGymCanaryVerificationBlockerCode =
+  | "verification.action_not_applied"
+  | "verification.non_independent_observer"
+  | "verification.observation_unavailable"
+  | "verification.stale_observation"
+  | "verification.state_mismatch";
+
+export interface AgentGymCanaryActionVerificationV1 {
+  readonly action_receipt_digest: string;
+  readonly blocker_codes: readonly AgentGymCanaryVerificationBlockerCode[];
+  readonly candidate_ref: string;
+  readonly observation_digest: string;
+  readonly plan_digest: string;
+  readonly schema_version: "agent-gym-canary-action-verification/v1";
+  readonly target_ref: string;
+  readonly verification_digest: string;
+  readonly verification_ref: string;
+  readonly verified: boolean;
+  readonly verified_at: string;
+  readonly verifier_ref: string;
+}
+
+/** Verifies an action with a fresh observer that did not execute the action. */
+export function verifyAgentGymCanaryAction(
+  planValue: AgentGymCanaryActionPlanV1,
+  receiptValue: AgentGymCanaryActionReceiptV1,
+  observationValue: AgentGymCanaryStateObservationV1,
+  input: {
+    readonly verification_ref: string;
+    readonly verified_at: string;
+    readonly verifier_ref: string;
+  },
+): AgentGymCanaryActionVerificationV1 {
+  const plan = validateAgentGymCanaryActionPlan(planValue);
+  const receipt = validateAgentGymCanaryActionReceipt(receiptValue);
+  const observation = validateAgentGymCanaryStateObservation(observationValue);
+  reference(input.verification_ref);
+  reference(input.verifier_ref);
+  timestamp(input.verified_at);
+  if (receipt.plan_digest !== plan.plan_digest || observation.plan_digest !== plan.plan_digest
+    || receipt.candidate_ref !== plan.candidate_ref || observation.candidate_ref !== plan.candidate_ref
+    || receipt.target_ref !== plan.target_ref || observation.target_ref !== plan.target_ref
+    || input.verifier_ref !== observation.observer_ref
+    || Date.parse(input.verified_at) < Date.parse(observation.observed_at)) invalid();
+  const blockers = new Set<AgentGymCanaryVerificationBlockerCode>();
+  if (receipt.status !== "applied") blockers.add("verification.action_not_applied");
+  if (observation.status !== "observed") blockers.add("verification.observation_unavailable");
+  if (observation.observer_ref === receipt.executor_ref) blockers.add("verification.non_independent_observer");
+  if (Date.parse(observation.observed_at) < Date.parse(receipt.completed_at)) {
+    blockers.add("verification.stale_observation");
+  }
+  const expectedActive = plan.action === "rollback_candidate"
+    ? plan.rollback_candidate_ref
+    : plan.candidate_ref;
+  if (observation.status === "observed"
+    && (observation.active_candidate_ref !== expectedActive
+      || observation.candidate_traffic_percent !== plan.to_traffic_percent)) {
+    blockers.add("verification.state_mismatch");
+  }
+  const blockerCodes = [...blockers].sort();
+  const body = {
+    action_receipt_digest: receipt.receipt_digest,
+    blocker_codes: blockerCodes,
+    candidate_ref: plan.candidate_ref,
+    observation_digest: observation.observation_digest,
+    plan_digest: plan.plan_digest,
+    schema_version: "agent-gym-canary-action-verification/v1" as const,
+    target_ref: plan.target_ref,
+    verification_ref: input.verification_ref,
+    verified: blockerCodes.length === 0,
+    verified_at: input.verified_at,
+    verifier_ref: input.verifier_ref,
+  };
+  return Object.freeze({
+    ...body,
+    blocker_codes: Object.freeze(blockerCodes),
+    verification_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymCanaryActionVerification(
+  value: AgentGymCanaryActionVerificationV1,
+): AgentGymCanaryActionVerificationV1 {
+  if (value.schema_version !== "agent-gym-canary-action-verification/v1") invalid();
+  for (const ref of [value.candidate_ref, value.target_ref, value.verification_ref,
+    value.verifier_ref]) reference(ref);
+  timestamp(value.verified_at);
+  for (const valueDigest of [value.action_receipt_digest, value.observation_digest,
+    value.plan_digest, value.verification_digest]) digest(valueDigest);
+  const allowed: readonly AgentGymCanaryVerificationBlockerCode[] = [
+    "verification.action_not_applied", "verification.non_independent_observer",
+    "verification.observation_unavailable", "verification.stale_observation",
+    "verification.state_mismatch",
+  ];
+  if (!Array.isArray(value.blocker_codes) || value.blocker_codes.length > allowed.length
+    || new Set(value.blocker_codes).size !== value.blocker_codes.length
+    || value.blocker_codes.some((code) => !allowed.includes(code))
+    || value.blocker_codes.some((code, index) => index > 0 && value.blocker_codes[index - 1]! >= code)
+    || value.verified !== (value.blocker_codes.length === 0)) invalid();
+  const body = {
+    action_receipt_digest: value.action_receipt_digest,
+    blocker_codes: value.blocker_codes,
+    candidate_ref: value.candidate_ref,
+    observation_digest: value.observation_digest,
+    plan_digest: value.plan_digest,
+    schema_version: value.schema_version,
+    target_ref: value.target_ref,
+    verification_ref: value.verification_ref,
+    verified: value.verified,
+    verified_at: value.verified_at,
+    verifier_ref: value.verifier_ref,
+  };
+  if (digestAgentGymJson(body) !== value.verification_digest) invalid();
+  return Object.freeze({ ...value, blocker_codes: Object.freeze([...value.blocker_codes]) });
+}
+
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never { throw new AgentGymContractError("Agent gym canary action verification is invalid."); }

--- a/apps/slack-companion/src/agent-gym/canary-state-observation.ts
+++ b/apps/slack-companion/src/agent-gym/canary-state-observation.ts
@@ -1,0 +1,132 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymCanaryActionPlan,
+  type AgentGymCanaryActionPlanV1,
+} from "./canary-action-plan.js";
+
+export type AgentGymCanaryStateObservationStatus = "observed" | "unavailable";
+
+export interface AgentGymCanaryStateObservationV1 {
+  readonly active_candidate_ref: string | null;
+  readonly candidate_ref: string;
+  readonly candidate_traffic_percent: number | null;
+  readonly evidence_refs: readonly string[];
+  readonly observation_digest: string;
+  readonly observation_ref: string;
+  readonly observed_at: string;
+  readonly observer_ref: string;
+  readonly plan_digest: string;
+  readonly reason_codes: readonly string[];
+  readonly schema_version: "agent-gym-canary-state-observation/v1";
+  readonly status: AgentGymCanaryStateObservationStatus;
+  readonly target_ref: string;
+}
+
+/** Records a fresh provider-neutral observation after a planned traffic action. */
+export function recordAgentGymCanaryStateObservation(
+  planValue: AgentGymCanaryActionPlanV1,
+  input: Omit<AgentGymCanaryStateObservationV1,
+    "candidate_ref" | "observation_digest" | "plan_digest" | "schema_version" | "target_ref">,
+): AgentGymCanaryStateObservationV1 {
+  const plan = validateAgentGymCanaryActionPlan(planValue);
+  validateInput(input);
+  if (Date.parse(input.observed_at) < Date.parse(plan.planned_at)) invalid();
+  const body = {
+    active_candidate_ref: input.active_candidate_ref,
+    candidate_ref: plan.candidate_ref,
+    candidate_traffic_percent: input.candidate_traffic_percent,
+    evidence_refs: [...input.evidence_refs],
+    observation_ref: input.observation_ref,
+    observed_at: input.observed_at,
+    observer_ref: input.observer_ref,
+    plan_digest: plan.plan_digest,
+    reason_codes: [...input.reason_codes],
+    schema_version: "agent-gym-canary-state-observation/v1" as const,
+    status: input.status,
+    target_ref: plan.target_ref,
+  };
+  return Object.freeze({
+    ...body,
+    evidence_refs: Object.freeze(body.evidence_refs),
+    observation_digest: digestAgentGymJson(body),
+    reason_codes: Object.freeze(body.reason_codes),
+  });
+}
+
+export function validateAgentGymCanaryStateObservation(
+  value: AgentGymCanaryStateObservationV1,
+): AgentGymCanaryStateObservationV1 {
+  if (value.schema_version !== "agent-gym-canary-state-observation/v1") invalid();
+  validateInput(value);
+  reference(value.candidate_ref);
+  reference(value.target_ref);
+  digest(value.observation_digest);
+  digest(value.plan_digest);
+  const body = {
+    active_candidate_ref: value.active_candidate_ref,
+    candidate_ref: value.candidate_ref,
+    candidate_traffic_percent: value.candidate_traffic_percent,
+    evidence_refs: value.evidence_refs,
+    observation_ref: value.observation_ref,
+    observed_at: value.observed_at,
+    observer_ref: value.observer_ref,
+    plan_digest: value.plan_digest,
+    reason_codes: value.reason_codes,
+    schema_version: value.schema_version,
+    status: value.status,
+    target_ref: value.target_ref,
+  };
+  if (digestAgentGymJson(body) !== value.observation_digest) invalid();
+  return Object.freeze({
+    ...value,
+    evidence_refs: Object.freeze([...value.evidence_refs]),
+    reason_codes: Object.freeze([...value.reason_codes]),
+  });
+}
+
+function validateInput(value: {
+  readonly active_candidate_ref: string | null;
+  readonly candidate_traffic_percent: number | null;
+  readonly evidence_refs: readonly string[];
+  readonly observation_ref: string;
+  readonly observed_at: string;
+  readonly observer_ref: string;
+  readonly reason_codes: readonly string[];
+  readonly status: AgentGymCanaryStateObservationStatus;
+}): void {
+  reference(value.observation_ref);
+  reference(value.observer_ref);
+  timestamp(value.observed_at);
+  if (value.active_candidate_ref !== null) reference(value.active_candidate_ref);
+  if (value.candidate_traffic_percent !== null) percent(value.candidate_traffic_percent);
+  if (!Array.isArray(value.evidence_refs) || value.evidence_refs.length > 64
+    || new Set(value.evidence_refs).size !== value.evidence_refs.length
+    || !Array.isArray(value.reason_codes) || value.reason_codes.length > 64
+    || new Set(value.reason_codes).size !== value.reason_codes.length) invalid();
+  for (const ref of value.evidence_refs) reference(ref);
+  for (const code of value.reason_codes) text(code);
+  if (value.status === "observed") {
+    if (value.active_candidate_ref === null || value.candidate_traffic_percent === null
+      || value.evidence_refs.length === 0 || value.reason_codes.length !== 0) invalid();
+  } else if (value.status === "unavailable") {
+    if (value.active_candidate_ref !== null || value.candidate_traffic_percent !== null
+      || value.reason_codes.length === 0) invalid();
+  } else invalid();
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function percent(value: number): void {
+  if (!Number.isSafeInteger(value) || value < 0 || value > 100) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function text(value: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > 160
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never { throw new AgentGymContractError("Agent gym canary state observation is invalid."); }

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -39,6 +39,7 @@ export * from "./canary-gate.js";
 export * from "./canary-action-plan.js";
 export * from "./canary-action-receipt.js";
 export * from "./canary-state-observation.js";
+export * from "./canary-action-verification.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -41,6 +41,7 @@ export * from "./canary-action-receipt.js";
 export * from "./canary-state-observation.js";
 export * from "./canary-action-verification.js";
 export * from "./rollout-state.js";
+export * from "./rollout-completion.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -40,6 +40,7 @@ export * from "./canary-action-plan.js";
 export * from "./canary-action-receipt.js";
 export * from "./canary-state-observation.js";
 export * from "./canary-action-verification.js";
+export * from "./rollout-state.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -42,6 +42,7 @@ export * from "./canary-state-observation.js";
 export * from "./canary-action-verification.js";
 export * from "./rollout-state.js";
 export * from "./rollout-completion.js";
+export * from "./rollout-summary.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -38,6 +38,7 @@ export * from "./canary-window.js";
 export * from "./canary-gate.js";
 export * from "./canary-action-plan.js";
 export * from "./canary-action-receipt.js";
+export * from "./canary-state-observation.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/rollout-completion.ts
+++ b/apps/slack-companion/src/agent-gym/rollout-completion.ts
@@ -1,0 +1,106 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymRolloutState,
+  type AgentGymRolloutStateV1,
+} from "./rollout-state.js";
+
+export type AgentGymRolloutCompletionOutcome = "completed" | "incomplete" | "rolled_back";
+export type AgentGymRolloutCompletionBlockerCode = "rollout.canary_in_progress";
+
+export interface AgentGymRolloutCompletionV1 {
+  readonly active_candidate_ref: string;
+  readonly blocker_codes: readonly AgentGymRolloutCompletionBlockerCode[];
+  readonly candidate_ref: string;
+  readonly decided_at: string;
+  readonly decision_digest: string;
+  readonly decision_ref: string;
+  readonly outcome: AgentGymRolloutCompletionOutcome;
+  readonly schema_version: "agent-gym-rollout-completion/v1";
+  readonly state_digest: string;
+  readonly target_ref: string;
+  readonly terminal: boolean;
+}
+
+/** Closes a rollout only after verified full traffic or verified rollback. */
+export function decideAgentGymRolloutCompletion(
+  stateValue: AgentGymRolloutStateV1,
+  input: { readonly decided_at: string; readonly decision_ref: string },
+): AgentGymRolloutCompletionV1 {
+  const state = validateAgentGymRolloutState(stateValue);
+  timestamp(input.decided_at);
+  reference(input.decision_ref);
+  if (Date.parse(input.decided_at) < Date.parse(state.effective_at)) invalid();
+  const outcome: AgentGymRolloutCompletionOutcome = state.phase === "active"
+    ? "completed"
+    : state.phase === "rolled_back" ? "rolled_back" : "incomplete";
+  const blockerCodes: AgentGymRolloutCompletionBlockerCode[] = outcome === "incomplete"
+    ? ["rollout.canary_in_progress"]
+    : [];
+  const body = {
+    active_candidate_ref: state.active_candidate_ref,
+    blocker_codes: blockerCodes,
+    candidate_ref: state.candidate_ref,
+    decided_at: input.decided_at,
+    decision_ref: input.decision_ref,
+    outcome,
+    schema_version: "agent-gym-rollout-completion/v1" as const,
+    state_digest: state.state_digest,
+    target_ref: state.target_ref,
+    terminal: outcome !== "incomplete",
+  };
+  return Object.freeze({
+    ...body,
+    blocker_codes: Object.freeze(blockerCodes),
+    decision_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymRolloutCompletion(
+  value: AgentGymRolloutCompletionV1,
+): AgentGymRolloutCompletionV1 {
+  if (value.schema_version !== "agent-gym-rollout-completion/v1") invalid();
+  for (const ref of [value.active_candidate_ref, value.candidate_ref, value.decision_ref,
+    value.target_ref]) reference(ref);
+  timestamp(value.decided_at);
+  digest(value.decision_digest);
+  digest(value.state_digest);
+  if (!Array.isArray(value.blocker_codes) || value.blocker_codes.length > 1
+    || new Set(value.blocker_codes).size !== value.blocker_codes.length
+    || value.blocker_codes.some((code) => code !== "rollout.canary_in_progress")) invalid();
+  if (value.outcome === "completed") {
+    if (!value.terminal || value.blocker_codes.length !== 0
+      || value.active_candidate_ref !== value.candidate_ref) invalid();
+  } else if (value.outcome === "rolled_back") {
+    if (!value.terminal || value.blocker_codes.length !== 0
+      || value.active_candidate_ref === value.candidate_ref) invalid();
+  } else if (value.outcome === "incomplete") {
+    if (value.terminal || value.blocker_codes.length !== 1
+      || value.blocker_codes[0] !== "rollout.canary_in_progress"
+      || value.active_candidate_ref !== value.candidate_ref) invalid();
+  } else invalid();
+  const body = {
+    active_candidate_ref: value.active_candidate_ref,
+    blocker_codes: value.blocker_codes,
+    candidate_ref: value.candidate_ref,
+    decided_at: value.decided_at,
+    decision_ref: value.decision_ref,
+    outcome: value.outcome,
+    schema_version: value.schema_version,
+    state_digest: value.state_digest,
+    target_ref: value.target_ref,
+    terminal: value.terminal,
+  };
+  if (digestAgentGymJson(body) !== value.decision_digest) invalid();
+  return Object.freeze({ ...value, blocker_codes: Object.freeze([...value.blocker_codes]) });
+}
+
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never { throw new AgentGymContractError("Agent gym rollout completion is invalid."); }

--- a/apps/slack-companion/src/agent-gym/rollout-state.ts
+++ b/apps/slack-companion/src/agent-gym/rollout-state.ts
@@ -1,0 +1,132 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymCanaryActionPlan,
+  type AgentGymCanaryActionPlanV1,
+} from "./canary-action-plan.js";
+import {
+  validateAgentGymCanaryActionReceipt,
+  type AgentGymCanaryActionReceiptV1,
+} from "./canary-action-receipt.js";
+import {
+  validateAgentGymCanaryActionVerification,
+  type AgentGymCanaryActionVerificationV1,
+} from "./canary-action-verification.js";
+
+export type AgentGymRolloutPhase = "active" | "canary" | "rolled_back";
+
+export interface AgentGymRolloutStateV1 {
+  readonly action: AgentGymCanaryActionPlanV1["action"];
+  readonly action_receipt_digest: string;
+  readonly active_candidate_ref: string;
+  readonly candidate_ref: string;
+  readonly candidate_traffic_percent: number;
+  readonly effective_at: string;
+  readonly phase: AgentGymRolloutPhase;
+  readonly previous_state_digest: string | null;
+  readonly schema_version: "agent-gym-rollout-state/v1";
+  readonly sequence: number;
+  readonly state_digest: string;
+  readonly state_ref: string;
+  readonly target_ref: string;
+  readonly verification_digest: string;
+}
+
+/** Advances rollout state only from a successfully verified traffic action. */
+export function advanceAgentGymRolloutState(
+  planValue: AgentGymCanaryActionPlanV1,
+  receiptValue: AgentGymCanaryActionReceiptV1,
+  verificationValue: AgentGymCanaryActionVerificationV1,
+  previousValue: AgentGymRolloutStateV1 | undefined,
+  input: { readonly effective_at: string; readonly state_ref: string },
+): AgentGymRolloutStateV1 {
+  const plan = validateAgentGymCanaryActionPlan(planValue);
+  const receipt = validateAgentGymCanaryActionReceipt(receiptValue);
+  const verification = validateAgentGymCanaryActionVerification(verificationValue);
+  const previous = previousValue === undefined ? undefined : validateAgentGymRolloutState(previousValue);
+  timestamp(input.effective_at);
+  reference(input.state_ref);
+  if (!verification.verified || receipt.status !== "applied"
+    || receipt.plan_digest !== plan.plan_digest || verification.plan_digest !== plan.plan_digest
+    || verification.action_receipt_digest !== receipt.receipt_digest
+    || Date.parse(input.effective_at) < Date.parse(verification.verified_at)) invalid();
+  if (previous !== undefined && (previous.target_ref !== plan.target_ref
+    || previous.candidate_ref !== plan.candidate_ref
+    || previous.candidate_traffic_percent !== plan.from_traffic_percent)) invalid();
+  const activeCandidateRef = plan.action === "rollback_candidate"
+    ? plan.rollback_candidate_ref
+    : plan.candidate_ref;
+  if (activeCandidateRef === null) invalid();
+  let phase: AgentGymRolloutPhase;
+  if (plan.action === "rollback_candidate") phase = "rolled_back";
+  else if (plan.action === "complete_rollout") phase = "active";
+  else phase = "canary";
+  const body = {
+    action: plan.action,
+    action_receipt_digest: receipt.receipt_digest,
+    active_candidate_ref: activeCandidateRef,
+    candidate_ref: plan.candidate_ref,
+    candidate_traffic_percent: plan.to_traffic_percent,
+    effective_at: input.effective_at,
+    phase,
+    previous_state_digest: previous?.state_digest ?? null,
+    schema_version: "agent-gym-rollout-state/v1" as const,
+    sequence: (previous?.sequence ?? 0) + 1,
+    state_ref: input.state_ref,
+    target_ref: plan.target_ref,
+    verification_digest: verification.verification_digest,
+  };
+  return Object.freeze({ ...body, state_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRolloutState(value: AgentGymRolloutStateV1): AgentGymRolloutStateV1 {
+  if (value.schema_version !== "agent-gym-rollout-state/v1") invalid();
+  for (const ref of [value.active_candidate_ref, value.candidate_ref, value.state_ref,
+    value.target_ref]) reference(ref);
+  timestamp(value.effective_at);
+  for (const valueDigest of [value.action_receipt_digest, value.state_digest,
+    value.verification_digest]) digest(valueDigest);
+  if (value.previous_state_digest !== null) digest(value.previous_state_digest);
+  if (!Number.isSafeInteger(value.sequence) || value.sequence < 1 || value.sequence > 1_000_000
+    || !Number.isSafeInteger(value.candidate_traffic_percent)
+    || value.candidate_traffic_percent < 0 || value.candidate_traffic_percent > 100) invalid();
+  if ((value.sequence === 1) !== (value.previous_state_digest === null)) invalid();
+  if (value.phase === "active") {
+    if (value.action !== "complete_rollout" || value.candidate_traffic_percent !== 100
+      || value.active_candidate_ref !== value.candidate_ref) invalid();
+  } else if (value.phase === "rolled_back") {
+    if (value.action !== "rollback_candidate" || value.candidate_traffic_percent !== 0
+      || value.active_candidate_ref === value.candidate_ref) invalid();
+  } else if (value.phase === "canary") {
+    if (!(value.action === "increase_traffic" || value.action === "hold_traffic")
+      || value.candidate_traffic_percent < 1 || value.candidate_traffic_percent > 99
+      || value.active_candidate_ref !== value.candidate_ref) invalid();
+  } else invalid();
+  const body = {
+    action: value.action,
+    action_receipt_digest: value.action_receipt_digest,
+    active_candidate_ref: value.active_candidate_ref,
+    candidate_ref: value.candidate_ref,
+    candidate_traffic_percent: value.candidate_traffic_percent,
+    effective_at: value.effective_at,
+    phase: value.phase,
+    previous_state_digest: value.previous_state_digest,
+    schema_version: value.schema_version,
+    sequence: value.sequence,
+    state_ref: value.state_ref,
+    target_ref: value.target_ref,
+    verification_digest: value.verification_digest,
+  };
+  if (digestAgentGymJson(body) !== value.state_digest) invalid();
+  return Object.freeze({ ...value });
+}
+
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never { throw new AgentGymContractError("Agent gym rollout state is invalid."); }

--- a/apps/slack-companion/src/agent-gym/rollout-summary.ts
+++ b/apps/slack-companion/src/agent-gym/rollout-summary.ts
@@ -1,0 +1,124 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymRolloutCompletion,
+  type AgentGymRolloutCompletionOutcome,
+  type AgentGymRolloutCompletionV1,
+} from "./rollout-completion.js";
+import {
+  validateAgentGymRolloutState,
+  type AgentGymRolloutStateV1,
+} from "./rollout-state.js";
+
+export interface AgentGymRolloutSummaryV1 {
+  readonly active_candidate_ref: string;
+  readonly candidate_ref: string;
+  readonly completed_at: string;
+  readonly completion_decision_digest: string;
+  readonly outcome: AgentGymRolloutCompletionOutcome;
+  readonly schema_version: "agent-gym-rollout-summary/v1";
+  readonly started_at: string;
+  readonly state_count: number;
+  readonly state_digests: readonly string[];
+  readonly summary_digest: string;
+  readonly summary_ref: string;
+  readonly target_ref: string;
+  readonly terminal: boolean;
+}
+
+/** Seals the complete verified rollout state chain and its closure decision. */
+export function summarizeAgentGymRollout(
+  stateValues: readonly AgentGymRolloutStateV1[],
+  completionValue: AgentGymRolloutCompletionV1,
+  summaryRef: string,
+): AgentGymRolloutSummaryV1 {
+  reference(summaryRef);
+  if (!Array.isArray(stateValues) || stateValues.length === 0 || stateValues.length > 10_000) invalid();
+  const states = stateValues.map(validateAgentGymRolloutState);
+  const completion = validateAgentGymRolloutCompletion(completionValue);
+  const first = states[0]!;
+  for (let index = 0; index < states.length; index += 1) {
+    const state = states[index]!;
+    const previous = states[index - 1];
+    if (state.sequence !== index + 1 || state.target_ref !== first.target_ref
+      || state.candidate_ref !== first.candidate_ref
+      || (previous === undefined ? state.previous_state_digest !== null
+        : state.previous_state_digest !== previous.state_digest
+          || Date.parse(state.effective_at) < Date.parse(previous.effective_at))) invalid();
+  }
+  const finalState = states.at(-1)!;
+  if (completion.state_digest !== finalState.state_digest
+    || completion.candidate_ref !== finalState.candidate_ref
+    || completion.active_candidate_ref !== finalState.active_candidate_ref
+    || completion.target_ref !== finalState.target_ref
+    || Date.parse(completion.decided_at) < Date.parse(finalState.effective_at)) invalid();
+  const body = {
+    active_candidate_ref: completion.active_candidate_ref,
+    candidate_ref: completion.candidate_ref,
+    completed_at: completion.decided_at,
+    completion_decision_digest: completion.decision_digest,
+    outcome: completion.outcome,
+    schema_version: "agent-gym-rollout-summary/v1" as const,
+    started_at: first.effective_at,
+    state_count: states.length,
+    state_digests: states.map((state) => state.state_digest),
+    summary_ref: summaryRef,
+    target_ref: completion.target_ref,
+    terminal: completion.terminal,
+  };
+  return Object.freeze({
+    ...body,
+    state_digests: Object.freeze(body.state_digests),
+    summary_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymRolloutSummary(
+  value: AgentGymRolloutSummaryV1,
+): AgentGymRolloutSummaryV1 {
+  if (value.schema_version !== "agent-gym-rollout-summary/v1") invalid();
+  for (const ref of [value.active_candidate_ref, value.candidate_ref, value.summary_ref,
+    value.target_ref]) reference(ref);
+  timestamp(value.started_at);
+  timestamp(value.completed_at);
+  if (Date.parse(value.completed_at) < Date.parse(value.started_at)) invalid();
+  digest(value.completion_decision_digest);
+  digest(value.summary_digest);
+  if (!Number.isSafeInteger(value.state_count) || value.state_count < 1 || value.state_count > 10_000
+    || !Array.isArray(value.state_digests) || value.state_digests.length !== value.state_count
+    || new Set(value.state_digests).size !== value.state_digests.length) invalid();
+  for (const stateDigest of value.state_digests) digest(stateDigest);
+  if (value.outcome === "completed") {
+    if (!value.terminal || value.active_candidate_ref !== value.candidate_ref) invalid();
+  } else if (value.outcome === "rolled_back") {
+    if (!value.terminal || value.active_candidate_ref === value.candidate_ref) invalid();
+  } else if (value.outcome === "incomplete") {
+    if (value.terminal || value.active_candidate_ref !== value.candidate_ref) invalid();
+  } else invalid();
+  const body = {
+    active_candidate_ref: value.active_candidate_ref,
+    candidate_ref: value.candidate_ref,
+    completed_at: value.completed_at,
+    completion_decision_digest: value.completion_decision_digest,
+    outcome: value.outcome,
+    schema_version: value.schema_version,
+    started_at: value.started_at,
+    state_count: value.state_count,
+    state_digests: value.state_digests,
+    summary_ref: value.summary_ref,
+    target_ref: value.target_ref,
+    terminal: value.terminal,
+  };
+  if (digestAgentGymJson(body) !== value.summary_digest) invalid();
+  return Object.freeze({ ...value, state_digests: Object.freeze([...value.state_digests]) });
+}
+
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never { throw new AgentGymContractError("Agent gym rollout summary is invalid."); }

--- a/apps/slack-companion/test/agent-gym-release-verification.test.ts
+++ b/apps/slack-companion/test/agent-gym-release-verification.test.ts
@@ -3,7 +3,10 @@ import test from "node:test";
 
 import {
   digestAgentGymJson,
+  recordAgentGymCanaryAction,
   recordAgentGymCanaryStateObservation,
+  verifyAgentGymCanaryAction,
+  validateAgentGymCanaryActionVerification,
   validateAgentGymCanaryStateObservation,
   type AgentGymCanaryActionPlanV1,
 } from "../src/index.js";
@@ -35,6 +38,57 @@ test("unavailable state observations cannot guess active state", () => {
     status: "unavailable",
   }), /state observation is invalid/u);
 });
+
+test("canary action verification requires a fresh independent observer", () => {
+  const verification = verifyAgentGymCanaryAction(
+    actionPlan(), actionReceipt(), stateObservation("agent-gym-observer://verification/one"), {
+      verification_ref: "agent-gym-action-verification://nightly/one",
+      verified_at: "2026-08-12T11:24:00.000Z",
+      verifier_ref: "agent-gym-observer://verification/one",
+    },
+  );
+  assert.equal(verification.verified, true);
+  assert.deepEqual(verification.blocker_codes, []);
+  assert.deepEqual(validateAgentGymCanaryActionVerification(verification), verification);
+});
+
+test("an action executor cannot independently verify its own state", () => {
+  const verification = verifyAgentGymCanaryAction(
+    actionPlan(), actionReceipt(), stateObservation("agent-gym-executor://canary/default"), {
+      verification_ref: "agent-gym-action-verification://nightly/self",
+      verified_at: "2026-08-12T11:24:00.000Z",
+      verifier_ref: "agent-gym-executor://canary/default",
+    },
+  );
+  assert.equal(verification.verified, false);
+  assert.deepEqual(verification.blocker_codes, ["verification.non_independent_observer"]);
+});
+
+function actionReceipt() {
+  return recordAgentGymCanaryAction(actionPlan(), {
+    completed_at: "2026-08-12T11:22:00.000Z",
+    executor_ref: "agent-gym-executor://canary/default",
+    failure_codes: [],
+    observed_active_candidate_ref: "agent-gym-candidate://nightly/challenger",
+    observed_candidate_traffic_percent: 20,
+    receipt_ref: "agent-gym-canary-action-receipt://nightly/increase",
+    started_at: "2026-08-12T11:21:00.000Z",
+    status: "applied",
+  });
+}
+
+function stateObservation(observerRef: string) {
+  return recordAgentGymCanaryStateObservation(actionPlan(), {
+    active_candidate_ref: "agent-gym-candidate://nightly/challenger",
+    candidate_traffic_percent: 20,
+    evidence_refs: ["agent-gym-evidence://state/one"],
+    observation_ref: `agent-gym-state-observation://nightly/${observerRef.split("/").at(-1)}`,
+    observed_at: "2026-08-12T11:23:00.000Z",
+    observer_ref: observerRef,
+    reason_codes: [],
+    status: "observed",
+  });
+}
 
 function actionPlan(): AgentGymCanaryActionPlanV1 {
   const identity = {

--- a/apps/slack-companion/test/agent-gym-release-verification.test.ts
+++ b/apps/slack-companion/test/agent-gym-release-verification.test.ts
@@ -8,8 +8,10 @@ import {
   verifyAgentGymCanaryAction,
   advanceAgentGymRolloutState,
   decideAgentGymRolloutCompletion,
+  summarizeAgentGymRollout,
   validateAgentGymRolloutState,
   validateAgentGymRolloutCompletion,
+  validateAgentGymRolloutSummary,
   validateAgentGymCanaryActionVerification,
   validateAgentGymCanaryStateObservation,
   type AgentGymCanaryActionPlanV1,
@@ -115,6 +117,32 @@ test("rollout completion accepts independently verified full traffic", () => {
   assert.equal(decision.outcome, "completed");
   assert.equal(decision.terminal, true);
   assert.deepEqual(validateAgentGymRolloutCompletion(decision), decision);
+});
+
+test("rollout summaries seal the verified state chain and closure", () => {
+  const state = canaryRolloutState();
+  const completion = decideAgentGymRolloutCompletion(state, {
+    decided_at: "2026-08-12T11:26:00.000Z",
+    decision_ref: "agent-gym-rollout-completion://nightly/incomplete",
+  });
+  const summary = summarizeAgentGymRollout(
+    [state], completion, "agent-gym-rollout-summary://nightly/one",
+  );
+  assert.equal(summary.state_count, 1);
+  assert.equal(summary.outcome, "incomplete");
+  assert.equal(summary.terminal, false);
+  assert.deepEqual(validateAgentGymRolloutSummary(summary), summary);
+});
+
+test("rollout summaries reject a completion for another state", () => {
+  const state = canaryRolloutState();
+  const completion = decideAgentGymRolloutCompletion(activeRolloutState(), {
+    decided_at: "2026-08-12T11:26:00.000Z",
+    decision_ref: "agent-gym-rollout-completion://nightly/other",
+  });
+  assert.throws(() => summarizeAgentGymRollout(
+    [state], completion, "agent-gym-rollout-summary://nightly/mismatch",
+  ), /rollout summary is invalid/u);
 });
 
 function canaryRolloutState() {

--- a/apps/slack-companion/test/agent-gym-release-verification.test.ts
+++ b/apps/slack-companion/test/agent-gym-release-verification.test.ts
@@ -6,6 +6,8 @@ import {
   recordAgentGymCanaryAction,
   recordAgentGymCanaryStateObservation,
   verifyAgentGymCanaryAction,
+  advanceAgentGymRolloutState,
+  validateAgentGymRolloutState,
   validateAgentGymCanaryActionVerification,
   validateAgentGymCanaryStateObservation,
   type AgentGymCanaryActionPlanV1,
@@ -63,6 +65,45 @@ test("an action executor cannot independently verify its own state", () => {
   assert.equal(verification.verified, false);
   assert.deepEqual(verification.blocker_codes, ["verification.non_independent_observer"]);
 });
+
+test("rollout state advances only from verified observed actions", () => {
+  const state = advanceAgentGymRolloutState(
+    actionPlan(), actionReceipt(), independentVerification(), undefined, {
+      effective_at: "2026-08-12T11:25:00.000Z",
+      state_ref: "agent-gym-rollout-state://nightly/one",
+    },
+  );
+  assert.equal(state.phase, "canary");
+  assert.equal(state.candidate_traffic_percent, 20);
+  assert.equal(state.sequence, 1);
+  assert.deepEqual(validateAgentGymRolloutState(state), state);
+});
+
+test("unverified actions cannot advance rollout state", () => {
+  const selfVerification = verifyAgentGymCanaryAction(
+    actionPlan(), actionReceipt(), stateObservation("agent-gym-executor://canary/default"), {
+      verification_ref: "agent-gym-action-verification://nightly/self-state",
+      verified_at: "2026-08-12T11:24:00.000Z",
+      verifier_ref: "agent-gym-executor://canary/default",
+    },
+  );
+  assert.throws(() => advanceAgentGymRolloutState(
+    actionPlan(), actionReceipt(), selfVerification, undefined, {
+      effective_at: "2026-08-12T11:25:00.000Z",
+      state_ref: "agent-gym-rollout-state://nightly/unverified",
+    },
+  ), /rollout state is invalid/u);
+});
+
+function independentVerification() {
+  return verifyAgentGymCanaryAction(
+    actionPlan(), actionReceipt(), stateObservation("agent-gym-observer://verification/one"), {
+      verification_ref: "agent-gym-action-verification://nightly/one",
+      verified_at: "2026-08-12T11:24:00.000Z",
+      verifier_ref: "agent-gym-observer://verification/one",
+    },
+  );
+}
 
 function actionReceipt() {
   return recordAgentGymCanaryAction(actionPlan(), {

--- a/apps/slack-companion/test/agent-gym-release-verification.test.ts
+++ b/apps/slack-companion/test/agent-gym-release-verification.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  digestAgentGymJson,
+  recordAgentGymCanaryStateObservation,
+  validateAgentGymCanaryStateObservation,
+  type AgentGymCanaryActionPlanV1,
+} from "../src/index.js";
+
+test("canary state observations retain fresh independent evidence", () => {
+  const observation = recordAgentGymCanaryStateObservation(actionPlan(), {
+    active_candidate_ref: "agent-gym-candidate://nightly/challenger",
+    candidate_traffic_percent: 20,
+    evidence_refs: ["agent-gym-evidence://state/one"],
+    observation_ref: "agent-gym-state-observation://nightly/one",
+    observed_at: "2026-08-12T11:23:00.000Z",
+    observer_ref: "agent-gym-observer://verification/one",
+    reason_codes: [],
+    status: "observed",
+  });
+  assert.equal(observation.status, "observed");
+  assert.deepEqual(validateAgentGymCanaryStateObservation(observation), observation);
+});
+
+test("unavailable state observations cannot guess active state", () => {
+  assert.throws(() => recordAgentGymCanaryStateObservation(actionPlan(), {
+    active_candidate_ref: "agent-gym-candidate://nightly/challenger",
+    candidate_traffic_percent: 20,
+    evidence_refs: [],
+    observation_ref: "agent-gym-state-observation://nightly/unavailable",
+    observed_at: "2026-08-12T11:23:00.000Z",
+    observer_ref: "agent-gym-observer://verification/one",
+    reason_codes: ["observation.source_unavailable"],
+    status: "unavailable",
+  }), /state observation is invalid/u);
+});
+
+function actionPlan(): AgentGymCanaryActionPlanV1 {
+  const identity = {
+    action_ref: "agent-gym-canary-action://nightly/increase",
+    gate_decision_digest: digest("a"),
+    target_ref: "agent-gym-target://slack-companion/default",
+    transition_digest: digest("e"),
+  };
+  const body = {
+    action: "increase_traffic" as const,
+    action_ref: identity.action_ref,
+    candidate_ref: "agent-gym-candidate://nightly/challenger",
+    expires_at: "2026-08-12T11:30:00.000Z",
+    from_traffic_percent: 10,
+    gate_decision_digest: identity.gate_decision_digest,
+    idempotency_key: digestAgentGymJson(identity),
+    planned_at: "2026-08-12T11:20:00.000Z",
+    policy_digest: digest("d"),
+    policy_ref: "agent-gym-canary-action-policy://nightly/default",
+    rollback_candidate_ref: null,
+    schema_version: "agent-gym-canary-action-plan/v1" as const,
+    target_ref: identity.target_ref,
+    to_traffic_percent: 20,
+    transition_digest: identity.transition_digest,
+  };
+  return { ...body, plan_digest: digestAgentGymJson(body) };
+}
+
+function digest(character: string): string {
+  return `sha256:${character.repeat(64)}`;
+}

--- a/apps/slack-companion/test/agent-gym-release-verification.test.ts
+++ b/apps/slack-companion/test/agent-gym-release-verification.test.ts
@@ -7,7 +7,9 @@ import {
   recordAgentGymCanaryStateObservation,
   verifyAgentGymCanaryAction,
   advanceAgentGymRolloutState,
+  decideAgentGymRolloutCompletion,
   validateAgentGymRolloutState,
+  validateAgentGymRolloutCompletion,
   validateAgentGymCanaryActionVerification,
   validateAgentGymCanaryStateObservation,
   type AgentGymCanaryActionPlanV1,
@@ -94,6 +96,54 @@ test("unverified actions cannot advance rollout state", () => {
     },
   ), /rollout state is invalid/u);
 });
+
+test("rollout completion keeps partial traffic explicitly incomplete", () => {
+  const decision = decideAgentGymRolloutCompletion(canaryRolloutState(), {
+    decided_at: "2026-08-12T11:26:00.000Z",
+    decision_ref: "agent-gym-rollout-completion://nightly/incomplete",
+  });
+  assert.equal(decision.outcome, "incomplete");
+  assert.equal(decision.terminal, false);
+  assert.deepEqual(decision.blocker_codes, ["rollout.canary_in_progress"]);
+});
+
+test("rollout completion accepts independently verified full traffic", () => {
+  const decision = decideAgentGymRolloutCompletion(activeRolloutState(), {
+    decided_at: "2026-08-12T11:26:00.000Z",
+    decision_ref: "agent-gym-rollout-completion://nightly/complete",
+  });
+  assert.equal(decision.outcome, "completed");
+  assert.equal(decision.terminal, true);
+  assert.deepEqual(validateAgentGymRolloutCompletion(decision), decision);
+});
+
+function canaryRolloutState() {
+  return advanceAgentGymRolloutState(
+    actionPlan(), actionReceipt(), independentVerification(), undefined, {
+      effective_at: "2026-08-12T11:25:00.000Z",
+      state_ref: "agent-gym-rollout-state://nightly/one",
+    },
+  );
+}
+
+function activeRolloutState() {
+  const body = {
+    action: "complete_rollout" as const,
+    action_receipt_digest: digest("1"),
+    active_candidate_ref: "agent-gym-candidate://nightly/challenger",
+    candidate_ref: "agent-gym-candidate://nightly/challenger",
+    candidate_traffic_percent: 100,
+    effective_at: "2026-08-12T11:25:00.000Z",
+    phase: "active" as const,
+    previous_state_digest: digest("2"),
+    schema_version: "agent-gym-rollout-state/v1" as const,
+    sequence: 2,
+    state_ref: "agent-gym-rollout-state://nightly/active",
+    target_ref: "agent-gym-target://slack-companion/default",
+    verification_digest: digest("3"),
+  };
+  return { ...body, state_digest: digestAgentGymJson(body) };
+}
 
 function independentVerification() {
   return verifyAgentGymCanaryAction(


### PR DESCRIPTION
## Summary
- record fresh provider-neutral state observations after traffic actions
- require executor-independent verification before rollout state can advance
- gate terminal completion and seal the complete verified rollout state chain

## Validation
- `npm run typecheck` in `apps/slack-companion`
- `npm test` in `apps/slack-companion` (687 tests)

## Delivery
- Portable Agent Gym contracts and deterministic verification logic only
- No environment configuration, credentials, infrastructure, routes, or deployment changes
- Practice Registry connector unavailable; repository checks remain authoritative for this PR
