### PR TITLE
feat(slack): monitor agent gym rollouts

### DIFF
--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -47,6 +47,7 @@ export * from "./rollback-reserve.js";
 export * from "./post-rollout-observation.js";
 export * from "./post-rollout-window.js";
 export * from "./post-rollout-gate.js";
+export * from "./rollback-trigger.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -44,6 +44,7 @@ export * from "./rollout-state.js";
 export * from "./rollout-completion.js";
 export * from "./rollout-summary.js";
 export * from "./rollback-reserve.js";
+export * from "./post-rollout-observation.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -43,6 +43,7 @@ export * from "./canary-action-verification.js";
 export * from "./rollout-state.js";
 export * from "./rollout-completion.js";
 export * from "./rollout-summary.js";
+export * from "./rollback-reserve.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -45,6 +45,7 @@ export * from "./rollout-completion.js";
 export * from "./rollout-summary.js";
 export * from "./rollback-reserve.js";
 export * from "./post-rollout-observation.js";
+export * from "./post-rollout-window.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -46,6 +46,7 @@ export * from "./rollout-summary.js";
 export * from "./rollback-reserve.js";
 export * from "./post-rollout-observation.js";
 export * from "./post-rollout-window.js";
+export * from "./post-rollout-gate.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/post-rollout-gate.ts
+++ b/apps/slack-companion/src/agent-gym/post-rollout-gate.ts
@@ -1,0 +1,116 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymPostRolloutWindow,
+  type AgentGymPostRolloutWindowV1,
+} from "./post-rollout-window.js";
+
+export type AgentGymPostRolloutDecision = "healthy" | "hold" | "rollback";
+
+export interface AgentGymPostRolloutPolicyV1 {
+  readonly max_failed_rate: number;
+  readonly max_p95_latency_ms: number;
+  readonly min_mean_quality_score: number;
+  readonly min_observation_count: number;
+  readonly policy_ref: string;
+  readonly schema_version: "agent-gym-post-rollout-policy/v1";
+}
+
+export interface AgentGymPostRolloutGateV1 {
+  readonly blocker_codes: readonly string[];
+  readonly candidate_ref: string;
+  readonly decision: AgentGymPostRolloutDecision;
+  readonly decided_at: string;
+  readonly evidence_refs: readonly string[];
+  readonly gate_digest: string;
+  readonly gate_ref: string;
+  readonly policy: AgentGymPostRolloutPolicyV1;
+  readonly schema_version: "agent-gym-post-rollout-gate/v1";
+  readonly target_ref: string;
+  readonly window_digest: string;
+}
+
+/** Applies deterministic post-rollout thresholds without calling a provider. */
+export function decideAgentGymPostRolloutGate(
+  windowValue: AgentGymPostRolloutWindowV1,
+  input: Pick<AgentGymPostRolloutGateV1, "decided_at" | "evidence_refs" | "gate_ref" | "policy">,
+): AgentGymPostRolloutGateV1 {
+  const window = validateAgentGymPostRolloutWindow(windowValue);
+  policy(input.policy); reference(input.gate_ref); timestamp(input.decided_at); references(input.evidence_refs);
+  if (Date.parse(input.decided_at) < Date.parse(window.sealed_at)) invalid();
+  const blockers = [...window.blocker_codes];
+  if (window.observation_count < input.policy.min_observation_count) blockers.push("post_rollout_samples_insufficient");
+  const failedRate = window.failed_count / window.observation_count;
+  if (failedRate > input.policy.max_failed_rate) blockers.push("post_rollout_failure_rate_exceeded");
+  if (window.mean_quality_score < input.policy.min_mean_quality_score) blockers.push("post_rollout_quality_below_minimum");
+  if (window.p95_latency_ms > input.policy.max_p95_latency_ms) blockers.push("post_rollout_latency_exceeded");
+  const blockerCodes = [...new Set(blockers)].sort();
+  const hardRegression = blockerCodes.some((code) => code !== "post_rollout_samples_insufficient");
+  const body = {
+    blocker_codes: blockerCodes,
+    candidate_ref: window.candidate_ref,
+    decision: hardRegression ? "rollback" as const : blockerCodes.length > 0 ? "hold" as const : "healthy" as const,
+    decided_at: input.decided_at,
+    evidence_refs: [...input.evidence_refs],
+    gate_ref: input.gate_ref,
+    policy: policyBody(input.policy),
+    schema_version: "agent-gym-post-rollout-gate/v1" as const,
+    target_ref: window.target_ref,
+    window_digest: window.window_digest,
+  };
+  return freeze({ ...body, gate_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymPostRolloutGate(value: AgentGymPostRolloutGateV1): AgentGymPostRolloutGateV1 {
+  if (value.schema_version !== "agent-gym-post-rollout-gate/v1") invalid();
+  policy(value.policy); reference(value.candidate_ref); reference(value.target_ref); reference(value.gate_ref);
+  timestamp(value.decided_at); references(value.evidence_refs);
+  if (!Array.isArray(value.blocker_codes) || value.blocker_codes.length > 128
+    || new Set(value.blocker_codes).size !== value.blocker_codes.length
+    || value.blocker_codes.some((code) => typeof code !== "string" || !code.trim() || code.length > 160)
+    || (value.decision === "healthy" && value.blocker_codes.length !== 0)
+    || (value.decision !== "healthy" && value.blocker_codes.length === 0)
+    || !["healthy", "hold", "rollback"].includes(value.decision)) invalid();
+  digest(value.window_digest); digest(value.gate_digest);
+  const { gate_digest: _digest, policy: _policy, ...fields } = value;
+  const body = { ...fields, policy: policyBody(value.policy) };
+  if (digestAgentGymJson(body) !== value.gate_digest) invalid();
+  return freeze(value);
+}
+
+function policy(value: AgentGymPostRolloutPolicyV1): void {
+  if (value.schema_version !== "agent-gym-post-rollout-policy/v1") invalid();
+  reference(value.policy_ref);
+  if (!Number.isSafeInteger(value.min_observation_count) || value.min_observation_count < 1
+    || value.min_observation_count > 10_000 || !Number.isFinite(value.max_failed_rate)
+    || value.max_failed_rate < 0 || value.max_failed_rate > 1
+    || !Number.isFinite(value.min_mean_quality_score) || value.min_mean_quality_score < 0
+    || value.min_mean_quality_score > 1 || !Number.isSafeInteger(value.max_p95_latency_ms)
+    || value.max_p95_latency_ms < 0 || value.max_p95_latency_ms > 3_600_000) invalid();
+}
+function policyBody(value: AgentGymPostRolloutPolicyV1) {
+  return {
+    max_failed_rate: value.max_failed_rate,
+    max_p95_latency_ms: value.max_p95_latency_ms,
+    min_mean_quality_score: value.min_mean_quality_score,
+    min_observation_count: value.min_observation_count,
+    policy_ref: value.policy_ref,
+    schema_version: value.schema_version,
+  };
+}
+function freeze(value: AgentGymPostRolloutGateV1): AgentGymPostRolloutGateV1 {
+  return Object.freeze({ ...value, blocker_codes: Object.freeze([...value.blocker_codes]),
+    evidence_refs: Object.freeze([...value.evidence_refs]), policy: Object.freeze({ ...value.policy }) });
+}
+function references(values: readonly string[]): void {
+  if (!Array.isArray(values) || values.length === 0 || values.length > 128 || new Set(values).size !== values.length) invalid();
+  for (const value of values) reference(value);
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym post-rollout gate is invalid."); }

--- a/apps/slack-companion/src/agent-gym/post-rollout-observation.ts
+++ b/apps/slack-companion/src/agent-gym/post-rollout-observation.ts
@@ -1,0 +1,130 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymRolloutSummary,
+  type AgentGymRolloutSummaryV1,
+} from "./rollout-summary.js";
+
+export type AgentGymPostRolloutOutcome = "failed" | "passed";
+
+export interface AgentGymPostRolloutObservationV1 {
+  readonly blocker_codes: readonly string[];
+  readonly candidate_ref: string;
+  readonly evidence_refs: readonly string[];
+  readonly latency_ms: number;
+  readonly observation_digest: string;
+  readonly observation_ref: string;
+  readonly observed_at: string;
+  readonly outcome: AgentGymPostRolloutOutcome;
+  readonly quality_score: number;
+  readonly rollout_summary_digest: string;
+  readonly sample_ref: string;
+  readonly schema_version: "agent-gym-post-rollout-observation/v1";
+  readonly target_ref: string;
+}
+
+/** Records one post-rollout sample without embedding provider or Slack topology. */
+export function recordAgentGymPostRolloutObservation(
+  summaryValue: AgentGymRolloutSummaryV1,
+  input: Omit<AgentGymPostRolloutObservationV1,
+    "candidate_ref" | "observation_digest" | "rollout_summary_digest" | "schema_version" | "target_ref">,
+): AgentGymPostRolloutObservationV1 {
+  const summary = validateAgentGymRolloutSummary(summaryValue);
+  validateInput(input);
+  if (!summary.terminal || summary.outcome !== "completed"
+    || Date.parse(input.observed_at) < Date.parse(summary.completed_at)) invalid();
+  const body = {
+    blocker_codes: [...input.blocker_codes],
+    candidate_ref: summary.candidate_ref,
+    evidence_refs: [...input.evidence_refs],
+    latency_ms: input.latency_ms,
+    observation_ref: input.observation_ref,
+    observed_at: input.observed_at,
+    outcome: input.outcome,
+    quality_score: input.quality_score,
+    rollout_summary_digest: summary.summary_digest,
+    sample_ref: input.sample_ref,
+    schema_version: "agent-gym-post-rollout-observation/v1" as const,
+    target_ref: summary.target_ref,
+  };
+  return Object.freeze({
+    ...body,
+    blocker_codes: Object.freeze(body.blocker_codes),
+    evidence_refs: Object.freeze(body.evidence_refs),
+    observation_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymPostRolloutObservation(
+  value: AgentGymPostRolloutObservationV1,
+): AgentGymPostRolloutObservationV1 {
+  if (value.schema_version !== "agent-gym-post-rollout-observation/v1") invalid();
+  validateInput(value);
+  for (const ref of [value.candidate_ref, value.target_ref]) reference(ref);
+  digest(value.observation_digest);
+  digest(value.rollout_summary_digest);
+  const body = {
+    blocker_codes: value.blocker_codes,
+    candidate_ref: value.candidate_ref,
+    evidence_refs: value.evidence_refs,
+    latency_ms: value.latency_ms,
+    observation_ref: value.observation_ref,
+    observed_at: value.observed_at,
+    outcome: value.outcome,
+    quality_score: value.quality_score,
+    rollout_summary_digest: value.rollout_summary_digest,
+    sample_ref: value.sample_ref,
+    schema_version: value.schema_version,
+    target_ref: value.target_ref,
+  };
+  if (digestAgentGymJson(body) !== value.observation_digest) invalid();
+  return Object.freeze({
+    ...value,
+    blocker_codes: Object.freeze([...value.blocker_codes]),
+    evidence_refs: Object.freeze([...value.evidence_refs]),
+  });
+}
+
+function validateInput(value: {
+  readonly blocker_codes: readonly string[];
+  readonly evidence_refs: readonly string[];
+  readonly latency_ms: number;
+  readonly observation_ref: string;
+  readonly observed_at: string;
+  readonly outcome: AgentGymPostRolloutOutcome;
+  readonly quality_score: number;
+  readonly sample_ref: string;
+}): void {
+  reference(value.observation_ref);
+  reference(value.sample_ref);
+  timestamp(value.observed_at);
+  finite(value.quality_score, 0, 1);
+  if (!Number.isSafeInteger(value.latency_ms) || value.latency_ms < 0 || value.latency_ms > 3_600_000
+    || !Array.isArray(value.blocker_codes) || value.blocker_codes.length > 64
+    || new Set(value.blocker_codes).size !== value.blocker_codes.length
+    || !Array.isArray(value.evidence_refs) || value.evidence_refs.length > 64
+    || new Set(value.evidence_refs).size !== value.evidence_refs.length) invalid();
+  for (const code of value.blocker_codes) text(code);
+  for (const ref of value.evidence_refs) reference(ref);
+  if (value.outcome === "passed") {
+    if (value.blocker_codes.length !== 0 || value.evidence_refs.length === 0) invalid();
+  } else if (value.outcome === "failed") {
+    if (value.blocker_codes.length === 0) invalid();
+  } else invalid();
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function finite(value: number, minimum: number, maximum: number): void {
+  if (!Number.isFinite(value) || value < minimum || value > maximum) invalid();
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function text(value: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > 160
+    || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never { throw new AgentGymContractError("Agent gym post-rollout observation is invalid."); }

--- a/apps/slack-companion/src/agent-gym/post-rollout-window.ts
+++ b/apps/slack-companion/src/agent-gym/post-rollout-window.ts
@@ -1,0 +1,117 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymPostRolloutObservation,
+  type AgentGymPostRolloutObservationV1,
+} from "./post-rollout-observation.js";
+
+export interface AgentGymPostRolloutWindowV1 {
+  readonly blocker_codes: readonly string[];
+  readonly candidate_ref: string;
+  readonly evidence_refs: readonly string[];
+  readonly failed_count: number;
+  readonly mean_quality_score: number;
+  readonly observation_count: number;
+  readonly observation_digests: readonly string[];
+  readonly opened_at: string;
+  readonly p95_latency_ms: number;
+  readonly rollout_summary_digest: string;
+  readonly schema_version: "agent-gym-post-rollout-window/v1";
+  readonly sealed_at: string;
+  readonly target_ref: string;
+  readonly window_digest: string;
+  readonly window_ref: string;
+}
+
+/** Seals a chronological set of live observations into a portable monitoring window. */
+export function sealAgentGymPostRolloutWindow(
+  observationsValue: readonly AgentGymPostRolloutObservationV1[],
+  input: Pick<AgentGymPostRolloutWindowV1, "evidence_refs" | "sealed_at" | "window_ref">,
+): AgentGymPostRolloutWindowV1 {
+  if (observationsValue.length === 0 || observationsValue.length > 10_000) invalid();
+  const observations = observationsValue.map(validateAgentGymPostRolloutObservation);
+  reference(input.window_ref);
+  timestamp(input.sealed_at);
+  references(input.evidence_refs, true);
+  const first = observations[0];
+  if (!first) invalid();
+  for (let index = 0; index < observations.length; index += 1) {
+    const observation = observations[index];
+    const previous = observations[index - 1];
+    if (!observation || observation.candidate_ref !== first.candidate_ref
+      || observation.target_ref !== first.target_ref
+      || observation.rollout_summary_digest !== first.rollout_summary_digest
+      || (previous && Date.parse(observation.observed_at) <= Date.parse(previous.observed_at))) invalid();
+  }
+  const last = observations.at(-1);
+  if (!last || Date.parse(input.sealed_at) < Date.parse(last.observed_at)) invalid();
+  const blockerCodes = [...new Set(observations.flatMap((item) => item.blocker_codes))].sort();
+  const latencies = observations.map((item) => item.latency_ms).sort((left, right) => left - right);
+  const p95 = latencies[Math.ceil(latencies.length * 0.95) - 1];
+  if (p95 === undefined) invalid();
+  const body = {
+    blocker_codes: blockerCodes,
+    candidate_ref: first.candidate_ref,
+    evidence_refs: [...input.evidence_refs],
+    failed_count: observations.filter((item) => item.outcome === "failed").length,
+    mean_quality_score: Math.round(
+      observations.reduce((sum, item) => sum + item.quality_score, 0) / observations.length * 1_000_000,
+    ) / 1_000_000,
+    observation_count: observations.length,
+    observation_digests: observations.map((item) => item.observation_digest),
+    opened_at: first.observed_at,
+    p95_latency_ms: p95,
+    rollout_summary_digest: first.rollout_summary_digest,
+    schema_version: "agent-gym-post-rollout-window/v1" as const,
+    sealed_at: input.sealed_at,
+    target_ref: first.target_ref,
+    window_ref: input.window_ref,
+  };
+  return freeze({ ...body, window_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymPostRolloutWindow(
+  value: AgentGymPostRolloutWindowV1,
+): AgentGymPostRolloutWindowV1 {
+  if (value.schema_version !== "agent-gym-post-rollout-window/v1") invalid();
+  reference(value.candidate_ref); reference(value.target_ref); reference(value.window_ref);
+  timestamp(value.opened_at); timestamp(value.sealed_at);
+  if (Date.parse(value.sealed_at) < Date.parse(value.opened_at)) invalid();
+  references(value.evidence_refs, true); references(value.blocker_codes, false);
+  if (!Number.isSafeInteger(value.observation_count) || value.observation_count < 1
+    || !Number.isSafeInteger(value.failed_count) || value.failed_count < 0
+    || value.failed_count > value.observation_count
+    || !Number.isSafeInteger(value.p95_latency_ms) || value.p95_latency_ms < 0
+    || !Number.isFinite(value.mean_quality_score) || value.mean_quality_score < 0
+    || value.mean_quality_score > 1 || value.observation_digests.length !== value.observation_count
+    || new Set(value.observation_digests).size !== value.observation_digests.length) invalid();
+  for (const digest of [...value.observation_digests, value.rollout_summary_digest, value.window_digest]) digestValue(digest);
+  const { window_digest: _digest, ...body } = value;
+  if (digestAgentGymJson(body) !== value.window_digest) invalid();
+  return freeze(value);
+}
+
+function freeze(value: AgentGymPostRolloutWindowV1): AgentGymPostRolloutWindowV1 {
+  return Object.freeze({
+    ...value,
+    blocker_codes: Object.freeze([...value.blocker_codes]),
+    evidence_refs: Object.freeze([...value.evidence_refs]),
+    observation_digests: Object.freeze([...value.observation_digests]),
+  });
+}
+function references(values: readonly string[], required: boolean): void {
+  if (!Array.isArray(values) || (required && values.length === 0) || values.length > 128
+    || new Set(values).size !== values.length) invalid();
+  for (const value of values) required ? reference(value) : text(value);
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function text(value: string): void {
+  if (typeof value !== "string" || !value.trim() || value.length > 160 || /[\u0000-\u001f\u007f]/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function digestValue(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym post-rollout window is invalid."); }

--- a/apps/slack-companion/src/agent-gym/rollback-reserve.ts
+++ b/apps/slack-companion/src/agent-gym/rollback-reserve.ts
@@ -1,0 +1,100 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymRolloutSummary,
+  type AgentGymRolloutSummaryV1,
+} from "./rollout-summary.js";
+
+export interface AgentGymRollbackReserveV1 {
+  readonly candidate_ref: string;
+  readonly evidence_refs: readonly string[];
+  readonly expires_at: string;
+  readonly fallback_candidate_ref: string;
+  readonly opened_at: string;
+  readonly reserve_digest: string;
+  readonly reserve_ref: string;
+  readonly rollout_summary_digest: string;
+  readonly schema_version: "agent-gym-rollback-reserve/v1";
+  readonly target_ref: string;
+}
+
+/** Retains one evidenced fallback while a completed candidate is monitored. */
+export function openAgentGymRollbackReserve(
+  summaryValue: AgentGymRolloutSummaryV1,
+  input: Omit<AgentGymRollbackReserveV1,
+    "candidate_ref" | "reserve_digest" | "rollout_summary_digest" | "schema_version" | "target_ref">,
+): AgentGymRollbackReserveV1 {
+  const summary = validateAgentGymRolloutSummary(summaryValue);
+  validateInput(input);
+  if (!summary.terminal || summary.outcome !== "completed"
+    || summary.active_candidate_ref !== summary.candidate_ref
+    || input.fallback_candidate_ref === summary.candidate_ref
+    || Date.parse(input.opened_at) < Date.parse(summary.completed_at)
+    || Date.parse(input.expires_at) <= Date.parse(input.opened_at)) invalid();
+  const body = {
+    candidate_ref: summary.candidate_ref,
+    evidence_refs: [...input.evidence_refs],
+    expires_at: input.expires_at,
+    fallback_candidate_ref: input.fallback_candidate_ref,
+    opened_at: input.opened_at,
+    reserve_ref: input.reserve_ref,
+    rollout_summary_digest: summary.summary_digest,
+    schema_version: "agent-gym-rollback-reserve/v1" as const,
+    target_ref: summary.target_ref,
+  };
+  return Object.freeze({
+    ...body,
+    evidence_refs: Object.freeze(body.evidence_refs),
+    reserve_digest: digestAgentGymJson(body),
+  });
+}
+
+export function validateAgentGymRollbackReserve(
+  value: AgentGymRollbackReserveV1,
+): AgentGymRollbackReserveV1 {
+  if (value.schema_version !== "agent-gym-rollback-reserve/v1") invalid();
+  validateInput(value);
+  for (const ref of [value.candidate_ref, value.target_ref]) reference(ref);
+  if (value.fallback_candidate_ref === value.candidate_ref
+    || Date.parse(value.expires_at) <= Date.parse(value.opened_at)) invalid();
+  digest(value.reserve_digest);
+  digest(value.rollout_summary_digest);
+  const body = {
+    candidate_ref: value.candidate_ref,
+    evidence_refs: value.evidence_refs,
+    expires_at: value.expires_at,
+    fallback_candidate_ref: value.fallback_candidate_ref,
+    opened_at: value.opened_at,
+    reserve_ref: value.reserve_ref,
+    rollout_summary_digest: value.rollout_summary_digest,
+    schema_version: value.schema_version,
+    target_ref: value.target_ref,
+  };
+  if (digestAgentGymJson(body) !== value.reserve_digest) invalid();
+  return Object.freeze({ ...value, evidence_refs: Object.freeze([...value.evidence_refs]) });
+}
+
+function validateInput(value: {
+  readonly evidence_refs: readonly string[];
+  readonly expires_at: string;
+  readonly fallback_candidate_ref: string;
+  readonly opened_at: string;
+  readonly reserve_ref: string;
+}): void {
+  reference(value.fallback_candidate_ref);
+  reference(value.reserve_ref);
+  timestamp(value.opened_at);
+  timestamp(value.expires_at);
+  if (!Array.isArray(value.evidence_refs) || value.evidence_refs.length === 0
+    || value.evidence_refs.length > 64 || new Set(value.evidence_refs).size !== value.evidence_refs.length) invalid();
+  for (const ref of value.evidence_refs) reference(ref);
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function invalid(): never { throw new AgentGymContractError("Agent gym rollback reserve is invalid."); }

--- a/apps/slack-companion/src/agent-gym/rollback-trigger.ts
+++ b/apps/slack-companion/src/agent-gym/rollback-trigger.ts
@@ -1,0 +1,81 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymPostRolloutGate,
+  type AgentGymPostRolloutGateV1,
+} from "./post-rollout-gate.js";
+import {
+  validateAgentGymRollbackReserve,
+  type AgentGymRollbackReserveV1,
+} from "./rollback-reserve.js";
+
+export interface AgentGymRollbackTriggerV1 {
+  readonly candidate_ref: string;
+  readonly evidence_refs: readonly string[];
+  readonly executor_action_ref: string;
+  readonly fallback_candidate_ref: string;
+  readonly gate_digest: string;
+  readonly reserve_digest: string;
+  readonly schema_version: "agent-gym-rollback-trigger/v1";
+  readonly state: "requested";
+  readonly target_ref: string;
+  readonly triggered_at: string;
+  readonly trigger_digest: string;
+  readonly trigger_ref: string;
+}
+
+/** Produces a provider-neutral rollback request from a regression gate and retained fallback. */
+export function triggerAgentGymRollback(
+  gateValue: AgentGymPostRolloutGateV1,
+  reserveValue: AgentGymRollbackReserveV1,
+  input: Pick<AgentGymRollbackTriggerV1, "evidence_refs" | "executor_action_ref" | "trigger_ref" | "triggered_at">,
+): AgentGymRollbackTriggerV1 {
+  const gate = validateAgentGymPostRolloutGate(gateValue);
+  const reserve = validateAgentGymRollbackReserve(reserveValue);
+  references(input.evidence_refs); reference(input.executor_action_ref); reference(input.trigger_ref); timestamp(input.triggered_at);
+  if (gate.decision !== "rollback" || gate.candidate_ref !== reserve.candidate_ref
+    || gate.target_ref !== reserve.target_ref || Date.parse(input.triggered_at) < Date.parse(gate.decided_at)
+    || Date.parse(input.triggered_at) > Date.parse(reserve.expires_at)) invalid();
+  const body = {
+    candidate_ref: gate.candidate_ref,
+    evidence_refs: [...input.evidence_refs],
+    executor_action_ref: input.executor_action_ref,
+    fallback_candidate_ref: reserve.fallback_candidate_ref,
+    gate_digest: gate.gate_digest,
+    reserve_digest: reserve.reserve_digest,
+    schema_version: "agent-gym-rollback-trigger/v1" as const,
+    state: "requested" as const,
+    target_ref: gate.target_ref,
+    triggered_at: input.triggered_at,
+    trigger_ref: input.trigger_ref,
+  };
+  return freeze({ ...body, trigger_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRollbackTrigger(value: AgentGymRollbackTriggerV1): AgentGymRollbackTriggerV1 {
+  if (value.schema_version !== "agent-gym-rollback-trigger/v1" || value.state !== "requested") invalid();
+  for (const ref of [value.candidate_ref, value.executor_action_ref, value.fallback_candidate_ref,
+    value.target_ref, value.trigger_ref]) reference(ref);
+  if (value.candidate_ref === value.fallback_candidate_ref) invalid();
+  references(value.evidence_refs); timestamp(value.triggered_at);
+  for (const digest of [value.gate_digest, value.reserve_digest, value.trigger_digest]) digestValue(digest);
+  const { trigger_digest: _digest, ...body } = value;
+  if (digestAgentGymJson(body) !== value.trigger_digest) invalid();
+  return freeze(value);
+}
+
+function freeze(value: AgentGymRollbackTriggerV1): AgentGymRollbackTriggerV1 {
+  return Object.freeze({ ...value, evidence_refs: Object.freeze([...value.evidence_refs]) });
+}
+function references(values: readonly string[]): void {
+  if (!Array.isArray(values) || values.length === 0 || values.length > 128 || new Set(values).size !== values.length) invalid();
+  for (const value of values) reference(value);
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function digestValue(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym rollback trigger is invalid."); }

--- a/apps/slack-companion/test/agent-gym-post-rollout.test.ts
+++ b/apps/slack-companion/test/agent-gym-post-rollout.test.ts
@@ -5,8 +5,10 @@ import {
   digestAgentGymJson,
   openAgentGymRollbackReserve,
   recordAgentGymPostRolloutObservation,
+  sealAgentGymPostRolloutWindow,
   validateAgentGymRollbackReserve,
   validateAgentGymPostRolloutObservation,
+  validateAgentGymPostRolloutWindow,
   type AgentGymRolloutSummaryV1,
 } from "../src/index.js";
 
@@ -59,6 +61,43 @@ test("post-rollout failures require explicit blocker codes", () => {
     sample_ref: "agent-gym-live-sample://nightly/invalid",
   }), /post-rollout observation is invalid/u);
 });
+
+test("post-rollout windows aggregate chronological live observations", () => {
+  const observations = [liveObservation("one", "2026-08-12T11:28:00.000Z", 700, 0.95),
+    liveObservation("two", "2026-08-12T11:29:00.000Z", 1200, 0.85)];
+  const window = sealAgentGymPostRolloutWindow(observations, {
+    evidence_refs: ["agent-gym-evidence://post-rollout/window-one"],
+    sealed_at: "2026-08-12T11:30:00.000Z",
+    window_ref: "agent-gym-post-rollout-window://nightly/one",
+  });
+  assert.equal(window.observation_count, 2);
+  assert.equal(window.mean_quality_score, 0.9);
+  assert.equal(window.p95_latency_ms, 1200);
+  assert.deepEqual(validateAgentGymPostRolloutWindow(window), window);
+});
+
+test("post-rollout windows reject observations presented out of order", () => {
+  const observations = [liveObservation("two", "2026-08-12T11:29:00.000Z", 1200, 0.85),
+    liveObservation("one", "2026-08-12T11:28:00.000Z", 700, 0.95)];
+  assert.throws(() => sealAgentGymPostRolloutWindow(observations, {
+    evidence_refs: ["agent-gym-evidence://post-rollout/window-invalid"],
+    sealed_at: "2026-08-12T11:30:00.000Z",
+    window_ref: "agent-gym-post-rollout-window://nightly/invalid",
+  }), /post-rollout window is invalid/u);
+});
+
+function liveObservation(ref: string, observedAt: string, latencyMs: number, qualityScore: number) {
+  return recordAgentGymPostRolloutObservation(completedRollout(), {
+    blocker_codes: [],
+    evidence_refs: [`agent-gym-evidence://post-rollout/${ref}`],
+    latency_ms: latencyMs,
+    observation_ref: `agent-gym-post-rollout-observation://nightly/${ref}`,
+    observed_at: observedAt,
+    outcome: "passed",
+    quality_score: qualityScore,
+    sample_ref: `agent-gym-live-sample://nightly/${ref}`,
+  });
+}
 
 function completedRollout(): AgentGymRolloutSummaryV1 {
   const body = {

--- a/apps/slack-companion/test/agent-gym-post-rollout.test.ts
+++ b/apps/slack-companion/test/agent-gym-post-rollout.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  digestAgentGymJson,
+  openAgentGymRollbackReserve,
+  validateAgentGymRollbackReserve,
+  type AgentGymRolloutSummaryV1,
+} from "../src/index.js";
+
+test("rollback reserves retain an evidenced fallback for a completed rollout", () => {
+  const reserve = openAgentGymRollbackReserve(completedRollout(), {
+    evidence_refs: ["agent-gym-evidence://fallback/ready"],
+    expires_at: "2026-08-19T11:27:00.000Z",
+    fallback_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    opened_at: "2026-08-12T11:27:00.000Z",
+    reserve_ref: "agent-gym-rollback-reserve://nightly/one",
+  });
+  assert.equal(reserve.candidate_ref, "agent-gym-candidate://nightly/challenger");
+  assert.deepEqual(validateAgentGymRollbackReserve(reserve), reserve);
+});
+
+test("rollback reserves reject the active candidate as its own fallback", () => {
+  assert.throws(() => openAgentGymRollbackReserve(completedRollout(), {
+    evidence_refs: ["agent-gym-evidence://fallback/ready"],
+    expires_at: "2026-08-19T11:27:00.000Z",
+    fallback_candidate_ref: "agent-gym-candidate://nightly/challenger",
+    opened_at: "2026-08-12T11:27:00.000Z",
+    reserve_ref: "agent-gym-rollback-reserve://nightly/invalid",
+  }), /rollback reserve is invalid/u);
+});
+
+function completedRollout(): AgentGymRolloutSummaryV1 {
+  const body = {
+    active_candidate_ref: "agent-gym-candidate://nightly/challenger",
+    candidate_ref: "agent-gym-candidate://nightly/challenger",
+    completed_at: "2026-08-12T11:26:00.000Z",
+    completion_decision_digest: digest("a"),
+    outcome: "completed" as const,
+    schema_version: "agent-gym-rollout-summary/v1" as const,
+    started_at: "2026-08-12T11:25:00.000Z",
+    state_count: 1,
+    state_digests: [digest("b")],
+    summary_ref: "agent-gym-rollout-summary://nightly/completed",
+    target_ref: "agent-gym-target://slack-companion/default",
+    terminal: true,
+  };
+  return { ...body, summary_digest: digestAgentGymJson(body) };
+}
+
+function digest(character: string): string {
+  return `sha256:${character.repeat(64)}`;
+}

--- a/apps/slack-companion/test/agent-gym-post-rollout.test.ts
+++ b/apps/slack-companion/test/agent-gym-post-rollout.test.ts
@@ -3,12 +3,14 @@ import test from "node:test";
 
 import {
   digestAgentGymJson,
+  decideAgentGymPostRolloutGate,
   openAgentGymRollbackReserve,
   recordAgentGymPostRolloutObservation,
   sealAgentGymPostRolloutWindow,
   validateAgentGymRollbackReserve,
   validateAgentGymPostRolloutObservation,
   validateAgentGymPostRolloutWindow,
+  validateAgentGymPostRolloutGate,
   type AgentGymRolloutSummaryV1,
 } from "../src/index.js";
 
@@ -85,6 +87,50 @@ test("post-rollout windows reject observations presented out of order", () => {
     window_ref: "agent-gym-post-rollout-window://nightly/invalid",
   }), /post-rollout window is invalid/u);
 });
+
+test("post-rollout gates mark a threshold-compliant window healthy", () => {
+  const gate = decideAgentGymPostRolloutGate(liveWindow(), {
+    decided_at: "2026-08-12T11:31:00.000Z",
+    evidence_refs: ["agent-gym-evidence://post-rollout/gate-one"],
+    gate_ref: "agent-gym-post-rollout-gate://nightly/one",
+    policy: postRolloutPolicy(2),
+  });
+  assert.equal(gate.decision, "healthy");
+  assert.deepEqual(validateAgentGymPostRolloutGate(gate), gate);
+});
+
+test("post-rollout gates hold when the evidence window is undersampled", () => {
+  const gate = decideAgentGymPostRolloutGate(liveWindow(), {
+    decided_at: "2026-08-12T11:31:00.000Z",
+    evidence_refs: ["agent-gym-evidence://post-rollout/gate-hold"],
+    gate_ref: "agent-gym-post-rollout-gate://nightly/hold",
+    policy: postRolloutPolicy(3),
+  });
+  assert.equal(gate.decision, "hold");
+  assert.deepEqual(gate.blocker_codes, ["post_rollout_samples_insufficient"]);
+});
+
+function liveWindow() {
+  return sealAgentGymPostRolloutWindow([
+    liveObservation("one", "2026-08-12T11:28:00.000Z", 700, 0.95),
+    liveObservation("two", "2026-08-12T11:29:00.000Z", 1200, 0.85),
+  ], {
+    evidence_refs: ["agent-gym-evidence://post-rollout/window-one"],
+    sealed_at: "2026-08-12T11:30:00.000Z",
+    window_ref: "agent-gym-post-rollout-window://nightly/one",
+  });
+}
+
+function postRolloutPolicy(minimum: number) {
+  return {
+    max_failed_rate: 0,
+    max_p95_latency_ms: 1500,
+    min_mean_quality_score: 0.85,
+    min_observation_count: minimum,
+    policy_ref: "agent-gym-post-rollout-policy://nightly/default",
+    schema_version: "agent-gym-post-rollout-policy/v1" as const,
+  };
+}
 
 function liveObservation(ref: string, observedAt: string, latencyMs: number, qualityScore: number) {
   return recordAgentGymPostRolloutObservation(completedRollout(), {

--- a/apps/slack-companion/test/agent-gym-post-rollout.test.ts
+++ b/apps/slack-companion/test/agent-gym-post-rollout.test.ts
@@ -7,7 +7,9 @@ import {
   openAgentGymRollbackReserve,
   recordAgentGymPostRolloutObservation,
   sealAgentGymPostRolloutWindow,
+  triggerAgentGymRollback,
   validateAgentGymRollbackReserve,
+  validateAgentGymRollbackTrigger,
   validateAgentGymPostRolloutObservation,
   validateAgentGymPostRolloutWindow,
   validateAgentGymPostRolloutGate,
@@ -109,6 +111,61 @@ test("post-rollout gates hold when the evidence window is undersampled", () => {
   assert.equal(gate.decision, "hold");
   assert.deepEqual(gate.blocker_codes, ["post_rollout_samples_insufficient"]);
 });
+
+test("rollback triggers bind a regression gate to an unexpired fallback reserve", () => {
+  const trigger = triggerAgentGymRollback(rollbackGate(), rollbackReserve(), {
+    evidence_refs: ["agent-gym-evidence://rollback/trigger-one"],
+    executor_action_ref: "agent-gym-executor-action://rollout/rollback-one",
+    triggered_at: "2026-08-12T11:32:00.000Z",
+    trigger_ref: "agent-gym-rollback-trigger://nightly/one",
+  });
+  assert.equal(trigger.fallback_candidate_ref, "agent-gym-candidate://nightly/baseline");
+  assert.deepEqual(validateAgentGymRollbackTrigger(trigger), trigger);
+});
+
+test("rollback triggers reject expired fallback reserves", () => {
+  assert.throws(() => triggerAgentGymRollback(rollbackGate(), rollbackReserve(), {
+    evidence_refs: ["agent-gym-evidence://rollback/expired"],
+    executor_action_ref: "agent-gym-executor-action://rollout/rollback-expired",
+    triggered_at: "2026-08-20T11:32:00.000Z",
+    trigger_ref: "agent-gym-rollback-trigger://nightly/expired",
+  }), /rollback trigger is invalid/u);
+});
+
+function rollbackGate() {
+  const window = sealAgentGymPostRolloutWindow([
+    recordAgentGymPostRolloutObservation(completedRollout(), {
+      blocker_codes: ["live_sample_failed"],
+      evidence_refs: ["agent-gym-evidence://post-rollout/failure"],
+      latency_ms: 2200,
+      observation_ref: "agent-gym-post-rollout-observation://nightly/failure",
+      observed_at: "2026-08-12T11:28:00.000Z",
+      outcome: "failed",
+      quality_score: 0.4,
+      sample_ref: "agent-gym-live-sample://nightly/failure",
+    }),
+  ], {
+    evidence_refs: ["agent-gym-evidence://post-rollout/window-failure"],
+    sealed_at: "2026-08-12T11:30:00.000Z",
+    window_ref: "agent-gym-post-rollout-window://nightly/failure",
+  });
+  return decideAgentGymPostRolloutGate(window, {
+    decided_at: "2026-08-12T11:31:00.000Z",
+    evidence_refs: ["agent-gym-evidence://post-rollout/gate-failure"],
+    gate_ref: "agent-gym-post-rollout-gate://nightly/failure",
+    policy: postRolloutPolicy(1),
+  });
+}
+
+function rollbackReserve() {
+  return openAgentGymRollbackReserve(completedRollout(), {
+    evidence_refs: ["agent-gym-evidence://fallback/ready"],
+    expires_at: "2026-08-19T11:27:00.000Z",
+    fallback_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    opened_at: "2026-08-12T11:27:00.000Z",
+    reserve_ref: "agent-gym-rollback-reserve://nightly/one",
+  });
+}
 
 function liveWindow() {
   return sealAgentGymPostRolloutWindow([

--- a/apps/slack-companion/test/agent-gym-post-rollout.test.ts
+++ b/apps/slack-companion/test/agent-gym-post-rollout.test.ts
@@ -4,7 +4,9 @@ import test from "node:test";
 import {
   digestAgentGymJson,
   openAgentGymRollbackReserve,
+  recordAgentGymPostRolloutObservation,
   validateAgentGymRollbackReserve,
+  validateAgentGymPostRolloutObservation,
   type AgentGymRolloutSummaryV1,
 } from "../src/index.js";
 
@@ -28,6 +30,34 @@ test("rollback reserves reject the active candidate as its own fallback", () => 
     opened_at: "2026-08-12T11:27:00.000Z",
     reserve_ref: "agent-gym-rollback-reserve://nightly/invalid",
   }), /rollback reserve is invalid/u);
+});
+
+test("post-rollout observations bind live evidence to the completed candidate", () => {
+  const observation = recordAgentGymPostRolloutObservation(completedRollout(), {
+    blocker_codes: [],
+    evidence_refs: ["agent-gym-evidence://post-rollout/one"],
+    latency_ms: 900,
+    observation_ref: "agent-gym-post-rollout-observation://nightly/one",
+    observed_at: "2026-08-12T11:28:00.000Z",
+    outcome: "passed",
+    quality_score: 0.91,
+    sample_ref: "agent-gym-live-sample://nightly/one",
+  });
+  assert.equal(observation.candidate_ref, completedRollout().candidate_ref);
+  assert.deepEqual(validateAgentGymPostRolloutObservation(observation), observation);
+});
+
+test("post-rollout failures require explicit blocker codes", () => {
+  assert.throws(() => recordAgentGymPostRolloutObservation(completedRollout(), {
+    blocker_codes: [],
+    evidence_refs: [],
+    latency_ms: 900,
+    observation_ref: "agent-gym-post-rollout-observation://nightly/invalid",
+    observed_at: "2026-08-12T11:28:00.000Z",
+    outcome: "failed",
+    quality_score: 0.4,
+    sample_ref: "agent-gym-live-sample://nightly/invalid",
+  }), /post-rollout observation is invalid/u);
 });
 
 function completedRollout(): AgentGymRolloutSummaryV1 {


### PR DESCRIPTION
## Summary

- retain an evidenced fallback after a completed rollout
- record and seal post-rollout observations into deterministic monitoring windows
- gate regressions and produce provider-neutral rollback requests

## Validation

- DDESK `npm run typecheck`
- DDESK `npm test` (697 tests, 62 suites, 0 failures)
- exact local, origin, and DDESK head `079f0f63021a7a6f19c846b8e975bb00a9fa3560`

## Evidence gap

- Practice Registry MCP was unavailable; no Registry pass is claimed.