### PR TITLE
feat(slack): learn from verified rollbacks

### DIFF
--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -50,6 +50,7 @@ export * from "./post-rollout-gate.js";
 export * from "./rollback-trigger.js";
 export * from "./rollback-action-receipt.js";
 export * from "./rollback-state-observation.js";
+export * from "./rollback-verification.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -48,6 +48,7 @@ export * from "./post-rollout-observation.js";
 export * from "./post-rollout-window.js";
 export * from "./post-rollout-gate.js";
 export * from "./rollback-trigger.js";
+export * from "./rollback-action-receipt.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -52,6 +52,7 @@ export * from "./rollback-action-receipt.js";
 export * from "./rollback-state-observation.js";
 export * from "./rollback-verification.js";
 export * from "./rollback-incident.js";
+export * from "./regression-learning-candidate.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -49,6 +49,7 @@ export * from "./post-rollout-window.js";
 export * from "./post-rollout-gate.js";
 export * from "./rollback-trigger.js";
 export * from "./rollback-action-receipt.js";
+export * from "./rollback-state-observation.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -51,6 +51,7 @@ export * from "./rollback-trigger.js";
 export * from "./rollback-action-receipt.js";
 export * from "./rollback-state-observation.js";
 export * from "./rollback-verification.js";
+export * from "./rollback-incident.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/regression-learning-candidate.ts
+++ b/apps/slack-companion/src/agent-gym/regression-learning-candidate.ts
@@ -1,0 +1,72 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { validateAgentGymRollbackIncident, type AgentGymRollbackIncidentV1 } from "./rollback-incident.js";
+
+export interface AgentGymRegressionLearningCandidateV1 {
+  readonly candidate_digest: string;
+  readonly candidate_ref: string;
+  readonly evidence_refs: readonly string[];
+  readonly expected_candidate_ref: string;
+  readonly failure_labels: readonly string[];
+  readonly proposed_at: string;
+  readonly rollback_incident_digest: string;
+  readonly schema_version: "agent-gym-regression-learning-candidate/v1";
+  readonly source_case_ref: string;
+  readonly target_ref: string;
+}
+
+/** Proposes a replay candidate only from a mitigated, evidence-complete regression. */
+export function proposeAgentGymRegressionLearningCandidate(
+  incidentValue: AgentGymRollbackIncidentV1,
+  input: Pick<AgentGymRegressionLearningCandidateV1,
+    "candidate_ref" | "evidence_refs" | "proposed_at" | "source_case_ref">,
+): AgentGymRegressionLearningCandidateV1 {
+  const incident = validateAgentGymRollbackIncident(incidentValue);
+  reference(input.candidate_ref); reference(input.source_case_ref); references(input.evidence_refs); timestamp(input.proposed_at);
+  if (incident.status !== "mitigated" || Date.parse(input.proposed_at) < Date.parse(incident.recorded_at)) invalid();
+  const body = {
+    candidate_ref: input.candidate_ref,
+    evidence_refs: [...input.evidence_refs],
+    expected_candidate_ref: incident.fallback_candidate_ref,
+    failure_labels: [...incident.blocker_codes].sort(),
+    proposed_at: input.proposed_at,
+    rollback_incident_digest: incident.incident_digest,
+    schema_version: "agent-gym-regression-learning-candidate/v1" as const,
+    source_case_ref: input.source_case_ref,
+    target_ref: incident.target_ref,
+  };
+  return freeze({ ...body, candidate_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRegressionLearningCandidate(
+  value: AgentGymRegressionLearningCandidateV1,
+): AgentGymRegressionLearningCandidateV1 {
+  if (value.schema_version !== "agent-gym-regression-learning-candidate/v1") invalid();
+  for (const ref of [value.candidate_ref, value.expected_candidate_ref, value.source_case_ref, value.target_ref]) reference(ref);
+  references(value.evidence_refs); timestamp(value.proposed_at);
+  if (!Array.isArray(value.failure_labels) || value.failure_labels.length === 0 || value.failure_labels.length > 256
+    || new Set(value.failure_labels).size !== value.failure_labels.length
+    || value.failure_labels.some((label) => typeof label !== "string" || !label.trim() || label.length > 160)
+    || value.failure_labels.some((label, index) => index > 0 && label < (value.failure_labels[index - 1] ?? ""))) invalid();
+  digest(value.rollback_incident_digest); digest(value.candidate_digest);
+  const { candidate_digest: _digest, ...body } = value;
+  if (digestAgentGymJson(body) !== value.candidate_digest) invalid();
+  return freeze(value);
+}
+
+function freeze(value: AgentGymRegressionLearningCandidateV1): AgentGymRegressionLearningCandidateV1 {
+  return Object.freeze({ ...value, evidence_refs: Object.freeze([...value.evidence_refs]),
+    failure_labels: Object.freeze([...value.failure_labels]) });
+}
+function references(values: readonly string[]): void {
+  if (!Array.isArray(values) || values.length === 0 || values.length > 128 || new Set(values).size !== values.length) invalid();
+  for (const value of values) reference(value);
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym regression learning candidate is invalid."); }

--- a/apps/slack-companion/src/agent-gym/rollback-action-receipt.ts
+++ b/apps/slack-companion/src/agent-gym/rollback-action-receipt.ts
@@ -1,0 +1,90 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { validateAgentGymRollbackTrigger, type AgentGymRollbackTriggerV1 } from "./rollback-trigger.js";
+
+export type AgentGymRollbackActionOutcome = "applied" | "rejected" | "unknown";
+
+export interface AgentGymRollbackActionReceiptV1 {
+  readonly action_outcome: AgentGymRollbackActionOutcome;
+  readonly candidate_ref: string;
+  readonly completed_at: string;
+  readonly evidence_refs: readonly string[];
+  readonly executor_ref: string;
+  readonly external_receipt_ref: string | null;
+  readonly observed_candidate_ref: string | null;
+  readonly receipt_digest: string;
+  readonly receipt_ref: string;
+  readonly rollback_trigger_digest: string;
+  readonly schema_version: "agent-gym-rollback-action-receipt/v1";
+  readonly target_ref: string;
+}
+
+/** Records the executor outcome without treating a request as proof of rollback. */
+export function recordAgentGymRollbackActionReceipt(
+  triggerValue: AgentGymRollbackTriggerV1,
+  input: Omit<AgentGymRollbackActionReceiptV1,
+    "candidate_ref" | "receipt_digest" | "rollback_trigger_digest" | "schema_version" | "target_ref">,
+): AgentGymRollbackActionReceiptV1 {
+  const trigger = validateAgentGymRollbackTrigger(triggerValue);
+  validateInput(input);
+  if (Date.parse(input.completed_at) < Date.parse(trigger.triggered_at)
+    || (input.action_outcome === "applied" && input.observed_candidate_ref !== trigger.fallback_candidate_ref)
+    || (input.action_outcome === "rejected" && input.observed_candidate_ref === trigger.fallback_candidate_ref)
+    || (input.action_outcome === "unknown" && input.observed_candidate_ref !== null)) invalid();
+  const body = {
+    action_outcome: input.action_outcome,
+    candidate_ref: trigger.candidate_ref,
+    completed_at: input.completed_at,
+    evidence_refs: [...input.evidence_refs],
+    executor_ref: input.executor_ref,
+    external_receipt_ref: input.external_receipt_ref,
+    observed_candidate_ref: input.observed_candidate_ref,
+    receipt_ref: input.receipt_ref,
+    rollback_trigger_digest: trigger.trigger_digest,
+    schema_version: "agent-gym-rollback-action-receipt/v1" as const,
+    target_ref: trigger.target_ref,
+  };
+  return freeze({ ...body, receipt_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRollbackActionReceipt(
+  value: AgentGymRollbackActionReceiptV1,
+): AgentGymRollbackActionReceiptV1 {
+  if (value.schema_version !== "agent-gym-rollback-action-receipt/v1") invalid();
+  validateInput(value); reference(value.candidate_ref); reference(value.target_ref);
+  if (value.action_outcome === "unknown" && value.observed_candidate_ref !== null) invalid();
+  digest(value.rollback_trigger_digest); digest(value.receipt_digest);
+  const { receipt_digest: _digest, ...body } = value;
+  if (digestAgentGymJson(body) !== value.receipt_digest) invalid();
+  return freeze(value);
+}
+
+function validateInput(value: {
+  readonly action_outcome: AgentGymRollbackActionOutcome;
+  readonly completed_at: string;
+  readonly evidence_refs: readonly string[];
+  readonly executor_ref: string;
+  readonly external_receipt_ref: string | null;
+  readonly observed_candidate_ref: string | null;
+  readonly receipt_ref: string;
+}): void {
+  if (!["applied", "rejected", "unknown"].includes(value.action_outcome)) invalid();
+  timestamp(value.completed_at); reference(value.executor_ref); reference(value.receipt_ref);
+  nullableReference(value.external_receipt_ref); nullableReference(value.observed_candidate_ref);
+  if (!Array.isArray(value.evidence_refs) || value.evidence_refs.length === 0 || value.evidence_refs.length > 128
+    || new Set(value.evidence_refs).size !== value.evidence_refs.length) invalid();
+  for (const ref of value.evidence_refs) reference(ref);
+  if (value.action_outcome === "applied" && (value.external_receipt_ref === null || value.observed_candidate_ref === null)) invalid();
+}
+function freeze(value: AgentGymRollbackActionReceiptV1): AgentGymRollbackActionReceiptV1 {
+  return Object.freeze({ ...value, evidence_refs: Object.freeze([...value.evidence_refs]) });
+}
+function nullableReference(value: string | null): void { if (value !== null) reference(value); }
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym rollback action receipt is invalid."); }

--- a/apps/slack-companion/src/agent-gym/rollback-incident.ts
+++ b/apps/slack-companion/src/agent-gym/rollback-incident.ts
@@ -1,0 +1,91 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { validateAgentGymPostRolloutGate, type AgentGymPostRolloutGateV1 } from "./post-rollout-gate.js";
+import { validateAgentGymRollbackTrigger, type AgentGymRollbackTriggerV1 } from "./rollback-trigger.js";
+import { validateAgentGymRollbackVerification, type AgentGymRollbackVerificationV1 } from "./rollback-verification.js";
+
+export type AgentGymRollbackIncidentStatus = "mitigated" | "unresolved";
+
+export interface AgentGymRollbackIncidentV1 {
+  readonly blocker_codes: readonly string[];
+  readonly candidate_ref: string;
+  readonly evidence_refs: readonly string[];
+  readonly fallback_candidate_ref: string;
+  readonly incident_digest: string;
+  readonly incident_ref: string;
+  readonly post_rollout_gate_digest: string;
+  readonly recorded_at: string;
+  readonly rollback_trigger_digest: string;
+  readonly rollback_verification_digest: string;
+  readonly schema_version: "agent-gym-rollback-incident/v1";
+  readonly status: AgentGymRollbackIncidentStatus;
+  readonly target_ref: string;
+}
+
+/** Records the regression and independently observed mitigation as one portable incident. */
+export function recordAgentGymRollbackIncident(
+  gateValue: AgentGymPostRolloutGateV1,
+  triggerValue: AgentGymRollbackTriggerV1,
+  verificationValue: AgentGymRollbackVerificationV1,
+  input: Pick<AgentGymRollbackIncidentV1, "evidence_refs" | "incident_ref" | "recorded_at">,
+): AgentGymRollbackIncidentV1 {
+  const gate = validateAgentGymPostRolloutGate(gateValue);
+  const trigger = validateAgentGymRollbackTrigger(triggerValue);
+  const verification = validateAgentGymRollbackVerification(verificationValue);
+  references(input.evidence_refs); reference(input.incident_ref); timestamp(input.recorded_at);
+  if (gate.decision !== "rollback" || trigger.gate_digest !== gate.gate_digest
+    || verification.rollback_trigger_digest !== trigger.trigger_digest
+    || gate.candidate_ref !== trigger.candidate_ref || verification.candidate_ref !== trigger.candidate_ref
+    || gate.target_ref !== trigger.target_ref || verification.target_ref !== trigger.target_ref
+    || Date.parse(input.recorded_at) < Date.parse(verification.verified_at)) invalid();
+  const status = verification.outcome === "verified" ? "mitigated" as const : "unresolved" as const;
+  const blockerCodes = [...new Set([...gate.blocker_codes, ...verification.blocker_codes])].sort();
+  if (blockerCodes.length === 0) invalid();
+  const body = {
+    blocker_codes: blockerCodes,
+    candidate_ref: trigger.candidate_ref,
+    evidence_refs: [...input.evidence_refs],
+    fallback_candidate_ref: trigger.fallback_candidate_ref,
+    incident_ref: input.incident_ref,
+    post_rollout_gate_digest: gate.gate_digest,
+    recorded_at: input.recorded_at,
+    rollback_trigger_digest: trigger.trigger_digest,
+    rollback_verification_digest: verification.verification_digest,
+    schema_version: "agent-gym-rollback-incident/v1" as const,
+    status,
+    target_ref: trigger.target_ref,
+  };
+  return freeze({ ...body, incident_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRollbackIncident(value: AgentGymRollbackIncidentV1): AgentGymRollbackIncidentV1 {
+  if (value.schema_version !== "agent-gym-rollback-incident/v1" || !["mitigated", "unresolved"].includes(value.status)) invalid();
+  for (const ref of [value.candidate_ref, value.fallback_candidate_ref, value.incident_ref, value.target_ref]) reference(ref);
+  if (value.candidate_ref === value.fallback_candidate_ref) invalid();
+  references(value.evidence_refs); timestamp(value.recorded_at);
+  if (!Array.isArray(value.blocker_codes) || value.blocker_codes.length === 0 || value.blocker_codes.length > 256
+    || new Set(value.blocker_codes).size !== value.blocker_codes.length
+    || value.blocker_codes.some((code) => typeof code !== "string" || !code.trim() || code.length > 160)) invalid();
+  for (const digestValue of [value.post_rollout_gate_digest, value.rollback_trigger_digest,
+    value.rollback_verification_digest, value.incident_digest]) digest(digestValue);
+  const { incident_digest: _digest, ...body } = value;
+  if (digestAgentGymJson(body) !== value.incident_digest) invalid();
+  return freeze(value);
+}
+
+function freeze(value: AgentGymRollbackIncidentV1): AgentGymRollbackIncidentV1 {
+  return Object.freeze({ ...value, blocker_codes: Object.freeze([...value.blocker_codes]),
+    evidence_refs: Object.freeze([...value.evidence_refs]) });
+}
+function references(values: readonly string[]): void {
+  if (!Array.isArray(values) || values.length === 0 || values.length > 128 || new Set(values).size !== values.length) invalid();
+  for (const value of values) reference(value);
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym rollback incident is invalid."); }

--- a/apps/slack-companion/src/agent-gym/rollback-state-observation.ts
+++ b/apps/slack-companion/src/agent-gym/rollback-state-observation.ts
@@ -1,0 +1,88 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymRollbackActionReceipt,
+  type AgentGymRollbackActionReceiptV1,
+} from "./rollback-action-receipt.js";
+
+export type AgentGymRollbackStateAvailability = "available" | "unavailable";
+
+export interface AgentGymRollbackStateObservationV1 {
+  readonly availability: AgentGymRollbackStateAvailability;
+  readonly candidate_ref: string;
+  readonly evidence_refs: readonly string[];
+  readonly observation_digest: string;
+  readonly observation_ref: string;
+  readonly observed_at: string;
+  readonly observed_candidate_ref: string | null;
+  readonly observer_ref: string;
+  readonly rollback_action_receipt_digest: string;
+  readonly schema_version: "agent-gym-rollback-state-observation/v1";
+  readonly target_ref: string;
+}
+
+/** Records fresh rollback state from an observer independent of the executor. */
+export function observeAgentGymRollbackState(
+  receiptValue: AgentGymRollbackActionReceiptV1,
+  input: Omit<AgentGymRollbackStateObservationV1,
+    "candidate_ref" | "observation_digest" | "rollback_action_receipt_digest" | "schema_version" | "target_ref">,
+): AgentGymRollbackStateObservationV1 {
+  const receipt = validateAgentGymRollbackActionReceipt(receiptValue);
+  validateInput(input);
+  if (input.observer_ref === receipt.executor_ref || Date.parse(input.observed_at) <= Date.parse(receipt.completed_at)) invalid();
+  const body = {
+    availability: input.availability,
+    candidate_ref: receipt.candidate_ref,
+    evidence_refs: [...input.evidence_refs],
+    observation_ref: input.observation_ref,
+    observed_at: input.observed_at,
+    observed_candidate_ref: input.observed_candidate_ref,
+    observer_ref: input.observer_ref,
+    rollback_action_receipt_digest: receipt.receipt_digest,
+    schema_version: "agent-gym-rollback-state-observation/v1" as const,
+    target_ref: receipt.target_ref,
+  };
+  return freeze({ ...body, observation_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRollbackStateObservation(
+  value: AgentGymRollbackStateObservationV1,
+): AgentGymRollbackStateObservationV1 {
+  if (value.schema_version !== "agent-gym-rollback-state-observation/v1") invalid();
+  validateInput(value); reference(value.candidate_ref); reference(value.target_ref);
+  digest(value.rollback_action_receipt_digest); digest(value.observation_digest);
+  const { observation_digest: _digest, ...body } = value;
+  if (digestAgentGymJson(body) !== value.observation_digest) invalid();
+  return freeze(value);
+}
+
+function validateInput(value: {
+  readonly availability: AgentGymRollbackStateAvailability;
+  readonly evidence_refs: readonly string[];
+  readonly observation_ref: string;
+  readonly observed_at: string;
+  readonly observed_candidate_ref: string | null;
+  readonly observer_ref: string;
+}): void {
+  reference(value.observation_ref); reference(value.observer_ref); timestamp(value.observed_at);
+  if (!Array.isArray(value.evidence_refs) || value.evidence_refs.length === 0 || value.evidence_refs.length > 128
+    || new Set(value.evidence_refs).size !== value.evidence_refs.length) invalid();
+  for (const ref of value.evidence_refs) reference(ref);
+  if (value.availability === "available") {
+    if (value.observed_candidate_ref === null) invalid();
+    reference(value.observed_candidate_ref);
+  } else if (value.availability === "unavailable") {
+    if (value.observed_candidate_ref !== null) invalid();
+  } else invalid();
+}
+function freeze(value: AgentGymRollbackStateObservationV1): AgentGymRollbackStateObservationV1 {
+  return Object.freeze({ ...value, evidence_refs: Object.freeze([...value.evidence_refs]) });
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym rollback state observation is invalid."); }

--- a/apps/slack-companion/src/agent-gym/rollback-verification.ts
+++ b/apps/slack-companion/src/agent-gym/rollback-verification.ts
@@ -1,0 +1,102 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { validateAgentGymRollbackActionReceipt, type AgentGymRollbackActionReceiptV1 } from "./rollback-action-receipt.js";
+import { validateAgentGymRollbackStateObservation, type AgentGymRollbackStateObservationV1 } from "./rollback-state-observation.js";
+import { validateAgentGymRollbackTrigger, type AgentGymRollbackTriggerV1 } from "./rollback-trigger.js";
+
+export type AgentGymRollbackVerificationOutcome = "failed" | "indeterminate" | "verified";
+
+export interface AgentGymRollbackVerificationV1 {
+  readonly blocker_codes: readonly string[];
+  readonly candidate_ref: string;
+  readonly evidence_refs: readonly string[];
+  readonly expected_candidate_ref: string;
+  readonly observation_digest: string;
+  readonly outcome: AgentGymRollbackVerificationOutcome;
+  readonly rollback_action_receipt_digest: string;
+  readonly rollback_trigger_digest: string;
+  readonly schema_version: "agent-gym-rollback-verification/v1";
+  readonly target_ref: string;
+  readonly verification_digest: string;
+  readonly verification_ref: string;
+  readonly verified_at: string;
+}
+
+/** Verifies rollback from a fresh independent observation, not executor success. */
+export function verifyAgentGymRollback(
+  triggerValue: AgentGymRollbackTriggerV1,
+  receiptValue: AgentGymRollbackActionReceiptV1,
+  observationValue: AgentGymRollbackStateObservationV1,
+  input: Pick<AgentGymRollbackVerificationV1, "evidence_refs" | "verification_ref" | "verified_at">,
+): AgentGymRollbackVerificationV1 {
+  const trigger = validateAgentGymRollbackTrigger(triggerValue);
+  const receipt = validateAgentGymRollbackActionReceipt(receiptValue);
+  const observation = validateAgentGymRollbackStateObservation(observationValue);
+  references(input.evidence_refs); reference(input.verification_ref); timestamp(input.verified_at);
+  if (receipt.rollback_trigger_digest !== trigger.trigger_digest
+    || observation.rollback_action_receipt_digest !== receipt.receipt_digest
+    || receipt.candidate_ref !== trigger.candidate_ref || observation.candidate_ref !== trigger.candidate_ref
+    || receipt.target_ref !== trigger.target_ref || observation.target_ref !== trigger.target_ref
+    || Date.parse(input.verified_at) < Date.parse(observation.observed_at)) invalid();
+  let outcome: AgentGymRollbackVerificationOutcome;
+  let blockerCodes: string[];
+  if (observation.availability === "unavailable") {
+    outcome = "indeterminate";
+    blockerCodes = ["rollback_state_unavailable"];
+  } else if (observation.observed_candidate_ref === trigger.fallback_candidate_ref) {
+    outcome = "verified";
+    blockerCodes = [];
+  } else {
+    outcome = "failed";
+    blockerCodes = ["rollback_fallback_not_observed"];
+  }
+  const body = {
+    blocker_codes: blockerCodes,
+    candidate_ref: trigger.candidate_ref,
+    evidence_refs: [...input.evidence_refs],
+    expected_candidate_ref: trigger.fallback_candidate_ref,
+    observation_digest: observation.observation_digest,
+    outcome,
+    rollback_action_receipt_digest: receipt.receipt_digest,
+    rollback_trigger_digest: trigger.trigger_digest,
+    schema_version: "agent-gym-rollback-verification/v1" as const,
+    target_ref: trigger.target_ref,
+    verification_ref: input.verification_ref,
+    verified_at: input.verified_at,
+  };
+  return freeze({ ...body, verification_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRollbackVerification(value: AgentGymRollbackVerificationV1): AgentGymRollbackVerificationV1 {
+  if (value.schema_version !== "agent-gym-rollback-verification/v1") invalid();
+  for (const ref of [value.candidate_ref, value.expected_candidate_ref, value.target_ref, value.verification_ref]) reference(ref);
+  references(value.evidence_refs); timestamp(value.verified_at);
+  if (!Array.isArray(value.blocker_codes) || value.blocker_codes.length > 128
+    || new Set(value.blocker_codes).size !== value.blocker_codes.length
+    || value.blocker_codes.some((code) => typeof code !== "string" || !code.trim() || code.length > 160)
+    || (value.outcome === "verified" && value.blocker_codes.length !== 0)
+    || (value.outcome !== "verified" && value.blocker_codes.length === 0)
+    || !["failed", "indeterminate", "verified"].includes(value.outcome)) invalid();
+  for (const digestValue of [value.observation_digest, value.rollback_action_receipt_digest,
+    value.rollback_trigger_digest, value.verification_digest]) digest(digestValue);
+  const { verification_digest: _digest, ...body } = value;
+  if (digestAgentGymJson(body) !== value.verification_digest) invalid();
+  return freeze(value);
+}
+
+function freeze(value: AgentGymRollbackVerificationV1): AgentGymRollbackVerificationV1 {
+  return Object.freeze({ ...value, blocker_codes: Object.freeze([...value.blocker_codes]),
+    evidence_refs: Object.freeze([...value.evidence_refs]) });
+}
+function references(values: readonly string[]): void {
+  if (!Array.isArray(values) || values.length === 0 || values.length > 128 || new Set(values).size !== values.length) invalid();
+  for (const value of values) reference(value);
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym rollback verification is invalid."); }

--- a/apps/slack-companion/test/agent-gym-post-rollout.test.ts
+++ b/apps/slack-companion/test/agent-gym-post-rollout.test.ts
@@ -6,10 +6,12 @@ import {
   decideAgentGymPostRolloutGate,
   openAgentGymRollbackReserve,
   recordAgentGymPostRolloutObservation,
+  recordAgentGymRollbackActionReceipt,
   sealAgentGymPostRolloutWindow,
   triggerAgentGymRollback,
   validateAgentGymRollbackReserve,
   validateAgentGymRollbackTrigger,
+  validateAgentGymRollbackActionReceipt,
   validateAgentGymPostRolloutObservation,
   validateAgentGymPostRolloutWindow,
   validateAgentGymPostRolloutGate,
@@ -131,6 +133,41 @@ test("rollback triggers reject expired fallback reserves", () => {
     trigger_ref: "agent-gym-rollback-trigger://nightly/expired",
   }), /rollback trigger is invalid/u);
 });
+
+test("rollback action receipts retain the exact executor outcome", () => {
+  const receipt = recordAgentGymRollbackActionReceipt(rollbackTrigger(), {
+    action_outcome: "applied",
+    completed_at: "2026-08-12T11:33:00.000Z",
+    evidence_refs: ["agent-gym-evidence://rollback/action-one"],
+    executor_ref: "agent-gym-executor://rollout/default",
+    external_receipt_ref: "agent-gym-external-receipt://rollback/action-one",
+    observed_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    receipt_ref: "agent-gym-rollback-action-receipt://nightly/one",
+  });
+  assert.equal(receipt.action_outcome, "applied");
+  assert.deepEqual(validateAgentGymRollbackActionReceipt(receipt), receipt);
+});
+
+test("rollback action receipts cannot claim the failed candidate was applied", () => {
+  assert.throws(() => recordAgentGymRollbackActionReceipt(rollbackTrigger(), {
+    action_outcome: "applied",
+    completed_at: "2026-08-12T11:33:00.000Z",
+    evidence_refs: ["agent-gym-evidence://rollback/action-invalid"],
+    executor_ref: "agent-gym-executor://rollout/default",
+    external_receipt_ref: "agent-gym-external-receipt://rollback/action-invalid",
+    observed_candidate_ref: "agent-gym-candidate://nightly/challenger",
+    receipt_ref: "agent-gym-rollback-action-receipt://nightly/invalid",
+  }), /rollback action receipt is invalid/u);
+});
+
+function rollbackTrigger() {
+  return triggerAgentGymRollback(rollbackGate(), rollbackReserve(), {
+    evidence_refs: ["agent-gym-evidence://rollback/trigger-one"],
+    executor_action_ref: "agent-gym-executor-action://rollout/rollback-one",
+    triggered_at: "2026-08-12T11:32:00.000Z",
+    trigger_ref: "agent-gym-rollback-trigger://nightly/one",
+  });
+}
 
 function rollbackGate() {
   const window = sealAgentGymPostRolloutWindow([

--- a/apps/slack-companion/test/agent-gym-post-rollout.test.ts
+++ b/apps/slack-companion/test/agent-gym-post-rollout.test.ts
@@ -8,6 +8,7 @@ import {
   observeAgentGymRollbackState,
   recordAgentGymPostRolloutObservation,
   recordAgentGymRollbackActionReceipt,
+  recordAgentGymRollbackIncident,
   sealAgentGymPostRolloutWindow,
   triggerAgentGymRollback,
   verifyAgentGymRollback,
@@ -16,6 +17,7 @@ import {
   validateAgentGymRollbackActionReceipt,
   validateAgentGymRollbackStateObservation,
   validateAgentGymRollbackVerification,
+  validateAgentGymRollbackIncident,
   validateAgentGymPostRolloutObservation,
   validateAgentGymPostRolloutWindow,
   validateAgentGymPostRolloutGate,
@@ -214,6 +216,51 @@ test("rollback verification remains indeterminate when state is unavailable", ()
   });
   assert.equal(verification.outcome, "indeterminate");
 });
+
+test("rollback incidents close only after verified mitigation", () => {
+  const incident = recordAgentGymRollbackIncident(rollbackGate(), rollbackTrigger(), verifiedRollback(), {
+    evidence_refs: ["agent-gym-evidence://rollback/incident-one"],
+    incident_ref: "agent-gym-rollback-incident://nightly/one",
+    recorded_at: "2026-08-12T11:36:00.000Z",
+  });
+  assert.equal(incident.status, "mitigated");
+  assert.ok(incident.blocker_codes.includes("live_sample_failed"));
+  assert.deepEqual(validateAgentGymRollbackIncident(incident), incident);
+});
+
+test("rollback incidents remain unresolved without independent state", () => {
+  const incident = recordAgentGymRollbackIncident(rollbackGate(), rollbackTrigger(), indeterminateRollback(), {
+    evidence_refs: ["agent-gym-evidence://rollback/incident-unresolved"],
+    incident_ref: "agent-gym-rollback-incident://nightly/unresolved",
+    recorded_at: "2026-08-12T11:36:00.000Z",
+  });
+  assert.equal(incident.status, "unresolved");
+  assert.ok(incident.blocker_codes.includes("rollback_state_unavailable"));
+});
+
+function verifiedRollback() {
+  return verifyAgentGymRollback(rollbackTrigger(), appliedRollbackReceipt(), rollbackObservation(), {
+    evidence_refs: ["agent-gym-evidence://rollback/verification-one"],
+    verification_ref: "agent-gym-rollback-verification://nightly/one",
+    verified_at: "2026-08-12T11:35:00.000Z",
+  });
+}
+
+function indeterminateRollback() {
+  const observation = observeAgentGymRollbackState(appliedRollbackReceipt(), {
+    availability: "unavailable",
+    evidence_refs: ["agent-gym-evidence://rollback/state-unavailable"],
+    observation_ref: "agent-gym-rollback-state-observation://nightly/unavailable",
+    observed_at: "2026-08-12T11:34:00.000Z",
+    observed_candidate_ref: null,
+    observer_ref: "agent-gym-observer://rollout/independent",
+  });
+  return verifyAgentGymRollback(rollbackTrigger(), appliedRollbackReceipt(), observation, {
+    evidence_refs: ["agent-gym-evidence://rollback/verification-unavailable"],
+    verification_ref: "agent-gym-rollback-verification://nightly/unavailable",
+    verified_at: "2026-08-12T11:35:00.000Z",
+  });
+}
 
 function rollbackObservation() {
   return observeAgentGymRollbackState(appliedRollbackReceipt(), {

--- a/apps/slack-companion/test/agent-gym-post-rollout.test.ts
+++ b/apps/slack-companion/test/agent-gym-post-rollout.test.ts
@@ -10,10 +10,12 @@ import {
   recordAgentGymRollbackActionReceipt,
   sealAgentGymPostRolloutWindow,
   triggerAgentGymRollback,
+  verifyAgentGymRollback,
   validateAgentGymRollbackReserve,
   validateAgentGymRollbackTrigger,
   validateAgentGymRollbackActionReceipt,
   validateAgentGymRollbackStateObservation,
+  validateAgentGymRollbackVerification,
   validateAgentGymPostRolloutObservation,
   validateAgentGymPostRolloutWindow,
   validateAgentGymPostRolloutGate,
@@ -185,6 +187,44 @@ test("rollback executors cannot independently observe their own action", () => {
     observer_ref: "agent-gym-executor://rollout/default",
   }), /rollback state observation is invalid/u);
 });
+
+test("rollback verification closes only from independently observed fallback state", () => {
+  const verification = verifyAgentGymRollback(rollbackTrigger(), appliedRollbackReceipt(), rollbackObservation(), {
+    evidence_refs: ["agent-gym-evidence://rollback/verification-one"],
+    verification_ref: "agent-gym-rollback-verification://nightly/one",
+    verified_at: "2026-08-12T11:35:00.000Z",
+  });
+  assert.equal(verification.outcome, "verified");
+  assert.deepEqual(validateAgentGymRollbackVerification(verification), verification);
+});
+
+test("rollback verification remains indeterminate when state is unavailable", () => {
+  const observation = observeAgentGymRollbackState(appliedRollbackReceipt(), {
+    availability: "unavailable",
+    evidence_refs: ["agent-gym-evidence://rollback/state-unavailable"],
+    observation_ref: "agent-gym-rollback-state-observation://nightly/unavailable",
+    observed_at: "2026-08-12T11:34:00.000Z",
+    observed_candidate_ref: null,
+    observer_ref: "agent-gym-observer://rollout/independent",
+  });
+  const verification = verifyAgentGymRollback(rollbackTrigger(), appliedRollbackReceipt(), observation, {
+    evidence_refs: ["agent-gym-evidence://rollback/verification-unavailable"],
+    verification_ref: "agent-gym-rollback-verification://nightly/unavailable",
+    verified_at: "2026-08-12T11:35:00.000Z",
+  });
+  assert.equal(verification.outcome, "indeterminate");
+});
+
+function rollbackObservation() {
+  return observeAgentGymRollbackState(appliedRollbackReceipt(), {
+    availability: "available",
+    evidence_refs: ["agent-gym-evidence://rollback/state-one"],
+    observation_ref: "agent-gym-rollback-state-observation://nightly/one",
+    observed_at: "2026-08-12T11:34:00.000Z",
+    observed_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    observer_ref: "agent-gym-observer://rollout/independent",
+  });
+}
 
 function appliedRollbackReceipt() {
   return recordAgentGymRollbackActionReceipt(rollbackTrigger(), {

--- a/apps/slack-companion/test/agent-gym-post-rollout.test.ts
+++ b/apps/slack-companion/test/agent-gym-post-rollout.test.ts
@@ -6,6 +6,7 @@ import {
   decideAgentGymPostRolloutGate,
   openAgentGymRollbackReserve,
   observeAgentGymRollbackState,
+  proposeAgentGymRegressionLearningCandidate,
   recordAgentGymPostRolloutObservation,
   recordAgentGymRollbackActionReceipt,
   recordAgentGymRollbackIncident,
@@ -18,6 +19,7 @@ import {
   validateAgentGymRollbackStateObservation,
   validateAgentGymRollbackVerification,
   validateAgentGymRollbackIncident,
+  validateAgentGymRegressionLearningCandidate,
   validateAgentGymPostRolloutObservation,
   validateAgentGymPostRolloutWindow,
   validateAgentGymPostRolloutGate,
@@ -237,6 +239,40 @@ test("rollback incidents remain unresolved without independent state", () => {
   assert.equal(incident.status, "unresolved");
   assert.ok(incident.blocker_codes.includes("rollback_state_unavailable"));
 });
+
+test("mitigated regressions become sealed replay learning candidates", () => {
+  const candidate = proposeAgentGymRegressionLearningCandidate(mitigatedIncident(), {
+    candidate_ref: "agent-gym-regression-learning-candidate://nightly/one",
+    evidence_refs: ["agent-gym-evidence://learning/regression-one"],
+    proposed_at: "2026-08-12T11:37:00.000Z",
+    source_case_ref: "agent-gym-source-case://post-rollout/regression-one",
+  });
+  assert.equal(candidate.expected_candidate_ref, "agent-gym-candidate://nightly/baseline");
+  assert.ok(candidate.failure_labels.includes("live_sample_failed"));
+  assert.deepEqual(validateAgentGymRegressionLearningCandidate(candidate), candidate);
+});
+
+test("unresolved regressions cannot enter the learning corpus", () => {
+  const incident = recordAgentGymRollbackIncident(rollbackGate(), rollbackTrigger(), indeterminateRollback(), {
+    evidence_refs: ["agent-gym-evidence://rollback/incident-unresolved"],
+    incident_ref: "agent-gym-rollback-incident://nightly/unresolved",
+    recorded_at: "2026-08-12T11:36:00.000Z",
+  });
+  assert.throws(() => proposeAgentGymRegressionLearningCandidate(incident, {
+    candidate_ref: "agent-gym-regression-learning-candidate://nightly/invalid",
+    evidence_refs: ["agent-gym-evidence://learning/regression-invalid"],
+    proposed_at: "2026-08-12T11:37:00.000Z",
+    source_case_ref: "agent-gym-source-case://post-rollout/regression-invalid",
+  }), /regression learning candidate is invalid/u);
+});
+
+function mitigatedIncident() {
+  return recordAgentGymRollbackIncident(rollbackGate(), rollbackTrigger(), verifiedRollback(), {
+    evidence_refs: ["agent-gym-evidence://rollback/incident-one"],
+    incident_ref: "agent-gym-rollback-incident://nightly/one",
+    recorded_at: "2026-08-12T11:36:00.000Z",
+  });
+}
 
 function verifiedRollback() {
   return verifyAgentGymRollback(rollbackTrigger(), appliedRollbackReceipt(), rollbackObservation(), {

--- a/apps/slack-companion/test/agent-gym-post-rollout.test.ts
+++ b/apps/slack-companion/test/agent-gym-post-rollout.test.ts
@@ -5,6 +5,7 @@ import {
   digestAgentGymJson,
   decideAgentGymPostRolloutGate,
   openAgentGymRollbackReserve,
+  observeAgentGymRollbackState,
   recordAgentGymPostRolloutObservation,
   recordAgentGymRollbackActionReceipt,
   sealAgentGymPostRolloutWindow,
@@ -12,6 +13,7 @@ import {
   validateAgentGymRollbackReserve,
   validateAgentGymRollbackTrigger,
   validateAgentGymRollbackActionReceipt,
+  validateAgentGymRollbackStateObservation,
   validateAgentGymPostRolloutObservation,
   validateAgentGymPostRolloutWindow,
   validateAgentGymPostRolloutGate,
@@ -159,6 +161,42 @@ test("rollback action receipts cannot claim the failed candidate was applied", (
     receipt_ref: "agent-gym-rollback-action-receipt://nightly/invalid",
   }), /rollback action receipt is invalid/u);
 });
+
+test("rollback state observations use a fresh independent observer", () => {
+  const observation = observeAgentGymRollbackState(appliedRollbackReceipt(), {
+    availability: "available",
+    evidence_refs: ["agent-gym-evidence://rollback/state-one"],
+    observation_ref: "agent-gym-rollback-state-observation://nightly/one",
+    observed_at: "2026-08-12T11:34:00.000Z",
+    observed_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    observer_ref: "agent-gym-observer://rollout/independent",
+  });
+  assert.equal(observation.observed_candidate_ref, "agent-gym-candidate://nightly/baseline");
+  assert.deepEqual(validateAgentGymRollbackStateObservation(observation), observation);
+});
+
+test("rollback executors cannot independently observe their own action", () => {
+  assert.throws(() => observeAgentGymRollbackState(appliedRollbackReceipt(), {
+    availability: "available",
+    evidence_refs: ["agent-gym-evidence://rollback/state-invalid"],
+    observation_ref: "agent-gym-rollback-state-observation://nightly/invalid",
+    observed_at: "2026-08-12T11:34:00.000Z",
+    observed_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    observer_ref: "agent-gym-executor://rollout/default",
+  }), /rollback state observation is invalid/u);
+});
+
+function appliedRollbackReceipt() {
+  return recordAgentGymRollbackActionReceipt(rollbackTrigger(), {
+    action_outcome: "applied",
+    completed_at: "2026-08-12T11:33:00.000Z",
+    evidence_refs: ["agent-gym-evidence://rollback/action-one"],
+    executor_ref: "agent-gym-executor://rollout/default",
+    external_receipt_ref: "agent-gym-external-receipt://rollback/action-one",
+    observed_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    receipt_ref: "agent-gym-rollback-action-receipt://nightly/one",
+  });
+}
 
 function rollbackTrigger() {
   return triggerAgentGymRollback(rollbackGate(), rollbackReserve(), {


### PR DESCRIPTION
## Summary

- retain exact rollback executor outcomes and independent state observations
- verify rollback closure from fresh evidence and record unresolved incidents explicitly
- convert only mitigated regressions into sealed learning candidates

## Validation

- DDESK `npm run typecheck`
- DDESK `npm test` (707 tests, 62 suites, 0 failures)
- exact local, origin, and DDESK head `fe2f2cb3f0311807a12643a4e6813bc36c551fcd`

## Evidence gap

- Practice Registry MCP was unavailable; no Registry pass is claimed.