### PR TITLE
feat(slack): admit regression replay cases

### DIFF
--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -53,6 +53,7 @@ export * from "./rollback-state-observation.js";
 export * from "./rollback-verification.js";
 export * from "./rollback-incident.js";
 export * from "./regression-learning-candidate.js";
+export * from "./regression-sanitization.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -56,6 +56,7 @@ export * from "./regression-learning-candidate.js";
 export * from "./regression-sanitization.js";
 export * from "./regression-duplicate-report.js";
 export * from "./regression-fixture.js";
+export * from "./regression-corpus-augmentation.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -54,6 +54,7 @@ export * from "./rollback-verification.js";
 export * from "./rollback-incident.js";
 export * from "./regression-learning-candidate.js";
 export * from "./regression-sanitization.js";
+export * from "./regression-duplicate-report.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -55,6 +55,7 @@ export * from "./rollback-incident.js";
 export * from "./regression-learning-candidate.js";
 export * from "./regression-sanitization.js";
 export * from "./regression-duplicate-report.js";
+export * from "./regression-fixture.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -57,6 +57,7 @@ export * from "./regression-sanitization.js";
 export * from "./regression-duplicate-report.js";
 export * from "./regression-fixture.js";
 export * from "./regression-corpus-augmentation.js";
+export * from "./regression-replay-request.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/regression-corpus-augmentation.ts
+++ b/apps/slack-companion/src/agent-gym/regression-corpus-augmentation.ts
@@ -1,0 +1,72 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { createAgentGymCorpusManifest } from "./corpus-manifest.js";
+import { agentGymFixtureScenarioDigest, validateAgentGymFixtureCase, type AgentGymFixtureCaseV1 } from "./fixture-case.js";
+import { validateAgentGymRegressionFixtureReceipt, type AgentGymRegressionFixtureReceiptV1 } from "./regression-fixture.js";
+
+export interface AgentGymRegressionCorpusAugmentationV1 {
+  readonly added_case_digest: string;
+  readonly added_case_ref: string;
+  readonly augmented_at: string;
+  readonly augmentation_digest: string;
+  readonly augmentation_ref: string;
+  readonly fixture_receipt_digest: string;
+  readonly next_case_count: number;
+  readonly next_corpus_digest: string;
+  readonly previous_case_count: number;
+  readonly previous_corpus_digest: string;
+  readonly schema_version: "agent-gym-regression-corpus-augmentation/v1";
+}
+
+/** Appends one admitted training regression while preserving the prior corpus identity. */
+export function augmentAgentGymRegressionCorpus(
+  previousFixturesValue: readonly AgentGymFixtureCaseV1[],
+  receiptValue: AgentGymRegressionFixtureReceiptV1,
+  input: Pick<AgentGymRegressionCorpusAugmentationV1, "augmentation_ref" | "augmented_at">,
+): AgentGymRegressionCorpusAugmentationV1 {
+  if (previousFixturesValue.length === 0 || previousFixturesValue.length >= 100_000) invalid();
+  const previousFixtures = previousFixturesValue.map(validateAgentGymFixtureCase);
+  const receipt = validateAgentGymRegressionFixtureReceipt(receiptValue);
+  reference(input.augmentation_ref); timestamp(input.augmented_at);
+  if (previousFixtures.some((fixture) => fixture.case_ref === receipt.fixture.case_ref
+    || agentGymFixtureScenarioDigest(fixture) === agentGymFixtureScenarioDigest(receipt.fixture))) invalid();
+  const previous = createAgentGymCorpusManifest(previousFixtures);
+  const next = createAgentGymCorpusManifest([...previousFixtures, receipt.fixture]);
+  const body = {
+    added_case_digest: receipt.fixture_digest,
+    added_case_ref: receipt.fixture.case_ref,
+    augmented_at: input.augmented_at,
+    augmentation_ref: input.augmentation_ref,
+    fixture_receipt_digest: receipt.receipt_digest,
+    next_case_count: next.case_count,
+    next_corpus_digest: next.corpus_digest,
+    previous_case_count: previous.case_count,
+    previous_corpus_digest: previous.corpus_digest,
+    schema_version: "agent-gym-regression-corpus-augmentation/v1" as const,
+  };
+  return Object.freeze({ ...body, augmentation_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRegressionCorpusAugmentation(
+  value: AgentGymRegressionCorpusAugmentationV1,
+): AgentGymRegressionCorpusAugmentationV1 {
+  if (value.schema_version !== "agent-gym-regression-corpus-augmentation/v1") invalid();
+  reference(value.added_case_ref); reference(value.augmentation_ref); timestamp(value.augmented_at);
+  for (const item of [value.added_case_digest, value.fixture_receipt_digest, value.next_corpus_digest,
+    value.previous_corpus_digest, value.augmentation_digest]) digest(item);
+  if (!Number.isSafeInteger(value.previous_case_count) || value.previous_case_count < 1
+    || value.next_case_count !== value.previous_case_count + 1 || value.next_case_count > 100_000
+    || value.next_corpus_digest === value.previous_corpus_digest) invalid();
+  const { augmentation_digest: _digest, ...body } = value;
+  if (digestAgentGymJson(body) !== value.augmentation_digest) invalid();
+  return Object.freeze({ ...value });
+}
+
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym regression corpus augmentation is invalid."); }

--- a/apps/slack-companion/src/agent-gym/regression-duplicate-report.ts
+++ b/apps/slack-companion/src/agent-gym/regression-duplicate-report.ts
@@ -1,0 +1,62 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { agentGymFixtureScenarioDigest, validateAgentGymFixtureCase, type AgentGymFixtureCaseV1 } from "./fixture-case.js";
+import { validateAgentGymRegressionSanitization, type AgentGymRegressionSanitizationV1 } from "./regression-sanitization.js";
+
+export interface AgentGymRegressionDuplicateReportV1 {
+  readonly admissible: boolean;
+  readonly duplicate_case_refs: readonly string[];
+  readonly inspected_case_count: number;
+  readonly report_digest: string;
+  readonly report_ref: string;
+  readonly sanitized_scenario_digest: string;
+  readonly sanitization_verification_digest: string;
+  readonly schema_version: "agent-gym-regression-duplicate-report/v1";
+}
+
+/** Detects scenario leakage before a sanitized regression enters any corpus. */
+export function inspectAgentGymRegressionDuplicates(
+  sanitizationValue: AgentGymRegressionSanitizationV1,
+  fixturesValue: readonly AgentGymFixtureCaseV1[],
+  reportRef: string,
+): AgentGymRegressionDuplicateReportV1 {
+  const sanitization = validateAgentGymRegressionSanitization(sanitizationValue);
+  reference(reportRef);
+  if (fixturesValue.length > 100_000) invalid();
+  const fixtures = fixturesValue.map(validateAgentGymFixtureCase);
+  if (new Set(fixtures.map((fixture) => fixture.case_ref)).size !== fixtures.length) invalid();
+  const duplicates = fixtures.filter((fixture) => agentGymFixtureScenarioDigest(fixture) === sanitization.sanitized_scenario_digest)
+    .map((fixture) => fixture.case_ref).sort();
+  const body = {
+    admissible: duplicates.length === 0,
+    duplicate_case_refs: duplicates,
+    inspected_case_count: fixtures.length,
+    report_ref: reportRef,
+    sanitized_scenario_digest: sanitization.sanitized_scenario_digest,
+    sanitization_verification_digest: sanitization.verification_digest,
+    schema_version: "agent-gym-regression-duplicate-report/v1" as const,
+  };
+  return freeze({ ...body, report_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRegressionDuplicateReport(value: AgentGymRegressionDuplicateReportV1): AgentGymRegressionDuplicateReportV1 {
+  if (value.schema_version !== "agent-gym-regression-duplicate-report/v1") invalid();
+  reference(value.report_ref); digest(value.sanitized_scenario_digest); digest(value.sanitization_verification_digest); digest(value.report_digest);
+  if (!Number.isSafeInteger(value.inspected_case_count) || value.inspected_case_count < 0 || value.inspected_case_count > 100_000
+    || !Array.isArray(value.duplicate_case_refs) || value.duplicate_case_refs.length > value.inspected_case_count
+    || new Set(value.duplicate_case_refs).size !== value.duplicate_case_refs.length
+    || value.duplicate_case_refs.some((ref, index) => (reference(ref), index > 0 && ref < (value.duplicate_case_refs[index - 1] ?? "")))
+    || value.admissible !== (value.duplicate_case_refs.length === 0)) invalid();
+  const { report_digest: _digest, ...body } = value;
+  if (digestAgentGymJson(body) !== value.report_digest) invalid();
+  return freeze(value);
+}
+
+function freeze(value: AgentGymRegressionDuplicateReportV1): AgentGymRegressionDuplicateReportV1 {
+  return Object.freeze({ ...value, duplicate_case_refs: Object.freeze([...value.duplicate_case_refs]) });
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym regression duplicate report is invalid."); }

--- a/apps/slack-companion/src/agent-gym/regression-fixture.ts
+++ b/apps/slack-companion/src/agent-gym/regression-fixture.ts
@@ -1,0 +1,86 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { agentGymFixtureCaseDigest, agentGymFixtureScenarioDigest, validateAgentGymFixtureCase, type AgentGymFixtureCaseV1 } from "./fixture-case.js";
+import { validateAgentGymRegressionDuplicateReport, type AgentGymRegressionDuplicateReportV1 } from "./regression-duplicate-report.js";
+import { validateAgentGymRegressionLearningCandidate, type AgentGymRegressionLearningCandidateV1 } from "./regression-learning-candidate.js";
+import { validateAgentGymRegressionSanitization, type AgentGymRegressionSanitizationV1 } from "./regression-sanitization.js";
+
+export interface AgentGymRegressionFixtureReceiptV1 {
+  readonly candidate_digest: string;
+  readonly duplicate_report_digest: string;
+  readonly fixture: AgentGymFixtureCaseV1;
+  readonly fixture_digest: string;
+  readonly receipt_digest: string;
+  readonly receipt_ref: string;
+  readonly sanitization_verification_digest: string;
+  readonly schema_version: "agent-gym-regression-fixture-receipt/v1";
+}
+
+/** Builds a training fixture only after sanitization and duplicate admission. */
+export function buildAgentGymRegressionFixture(
+  candidateValue: AgentGymRegressionLearningCandidateV1,
+  sanitizationValue: AgentGymRegressionSanitizationV1,
+  reportValue: AgentGymRegressionDuplicateReportV1,
+  fixtureValue: AgentGymFixtureCaseV1,
+  receiptRef: string,
+): AgentGymRegressionFixtureReceiptV1 {
+  const candidate = validateAgentGymRegressionLearningCandidate(candidateValue);
+  const sanitization = validateAgentGymRegressionSanitization(sanitizationValue);
+  const report = validateAgentGymRegressionDuplicateReport(reportValue);
+  const fixture = validateAgentGymFixtureCase(fixtureValue);
+  reference(receiptRef);
+  if (!report.admissible || sanitization.candidate_digest !== candidate.candidate_digest
+    || report.sanitization_verification_digest !== sanitization.verification_digest
+    || fixture.partition !== "train" || agentGymFixtureScenarioDigest(fixture) !== sanitization.sanitized_scenario_digest
+    || candidate.failure_labels.some((label) => !fixture.labels.includes(label))) invalid();
+  const fixtureDigest = agentGymFixtureCaseDigest(fixture);
+  const body = {
+    candidate_digest: candidate.candidate_digest,
+    duplicate_report_digest: report.report_digest,
+    fixture: fixtureBody(fixture),
+    fixture_digest: fixtureDigest,
+    receipt_ref: receiptRef,
+    sanitization_verification_digest: sanitization.verification_digest,
+    schema_version: "agent-gym-regression-fixture-receipt/v1" as const,
+  };
+  return Object.freeze({ ...body, receipt_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRegressionFixtureReceipt(value: AgentGymRegressionFixtureReceiptV1): AgentGymRegressionFixtureReceiptV1 {
+  if (value.schema_version !== "agent-gym-regression-fixture-receipt/v1") invalid();
+  reference(value.receipt_ref);
+  for (const item of [value.candidate_digest, value.duplicate_report_digest, value.fixture_digest,
+    value.sanitization_verification_digest, value.receipt_digest]) digest(item);
+  const fixture = validateAgentGymFixtureCase(value.fixture);
+  if (fixture.partition !== "train" || agentGymFixtureCaseDigest(fixture) !== value.fixture_digest) invalid();
+  const body = {
+    candidate_digest: value.candidate_digest, duplicate_report_digest: value.duplicate_report_digest,
+    fixture: fixtureBody(fixture), fixture_digest: value.fixture_digest, receipt_ref: value.receipt_ref,
+    sanitization_verification_digest: value.sanitization_verification_digest, schema_version: value.schema_version,
+  };
+  if (digestAgentGymJson(body) !== value.receipt_digest) invalid();
+  return Object.freeze({ ...value, fixture });
+}
+
+function fixtureBody(value: AgentGymFixtureCaseV1) {
+  return {
+    case_ref: value.case_ref,
+    expected_invariants: [...value.expected_invariants],
+    labels: [...value.labels],
+    partition: value.partition,
+    schema_version: value.schema_version,
+    slack_events: value.slack_events.map((event) => ({
+      event_ref: event.event_ref, kind: event.kind, occurred_at: event.occurred_at, payload: event.payload,
+    })),
+    tool_fixtures: value.tool_fixtures.map((tool) => ({
+      call_ref: tool.call_ref, ...(tool.error_code === undefined ? {} : { error_code: tool.error_code }),
+      input: tool.input, outcome: tool.outcome, ...(tool.output === undefined ? {} : { output: tool.output }), tool_id: tool.tool_id,
+    })),
+  };
+}
+
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym regression fixture receipt is invalid."); }

--- a/apps/slack-companion/src/agent-gym/regression-replay-request.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-request.ts
@@ -1,0 +1,73 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { validateAgentGymRegressionCorpusAugmentation, type AgentGymRegressionCorpusAugmentationV1 } from "./regression-corpus-augmentation.js";
+import { validateAgentGymRegressionFixtureReceipt, type AgentGymRegressionFixtureReceiptV1 } from "./regression-fixture.js";
+import { validateAgentGymRegressionLearningCandidate, type AgentGymRegressionLearningCandidateV1 } from "./regression-learning-candidate.js";
+
+export interface AgentGymRegressionReplayRequestV1 {
+  readonly augmentation_digest: string;
+  readonly baseline_candidate_ref: string;
+  readonly case_digest: string;
+  readonly case_ref: string;
+  readonly challenger_candidate_ref: string;
+  readonly fixture_receipt_digest: string;
+  readonly maximum_model_calls: number;
+  readonly planned_at: string;
+  readonly request_digest: string;
+  readonly request_ref: string;
+  readonly schema_version: "agent-gym-regression-replay-request/v1";
+}
+
+/** Requests paired replay after a regression is safely appended to training data. */
+export function requestAgentGymRegressionReplay(
+  candidateValue: AgentGymRegressionLearningCandidateV1,
+  fixtureReceiptValue: AgentGymRegressionFixtureReceiptV1,
+  augmentationValue: AgentGymRegressionCorpusAugmentationV1,
+  input: Pick<AgentGymRegressionReplayRequestV1,
+    "challenger_candidate_ref" | "maximum_model_calls" | "planned_at" | "request_ref">,
+): AgentGymRegressionReplayRequestV1 {
+  const candidate = validateAgentGymRegressionLearningCandidate(candidateValue);
+  const receipt = validateAgentGymRegressionFixtureReceipt(fixtureReceiptValue);
+  const augmentation = validateAgentGymRegressionCorpusAugmentation(augmentationValue);
+  reference(input.challenger_candidate_ref); reference(input.request_ref); timestamp(input.planned_at);
+  if (!Number.isSafeInteger(input.maximum_model_calls) || input.maximum_model_calls < 2 || input.maximum_model_calls > 10_000
+    || input.challenger_candidate_ref === candidate.expected_candidate_ref
+    || receipt.candidate_digest !== candidate.candidate_digest
+    || augmentation.fixture_receipt_digest !== receipt.receipt_digest
+    || augmentation.added_case_digest !== receipt.fixture_digest
+    || augmentation.added_case_ref !== receipt.fixture.case_ref) invalid();
+  const body = {
+    augmentation_digest: augmentation.augmentation_digest,
+    baseline_candidate_ref: candidate.expected_candidate_ref,
+    case_digest: receipt.fixture_digest,
+    case_ref: receipt.fixture.case_ref,
+    challenger_candidate_ref: input.challenger_candidate_ref,
+    fixture_receipt_digest: receipt.receipt_digest,
+    maximum_model_calls: input.maximum_model_calls,
+    planned_at: input.planned_at,
+    request_ref: input.request_ref,
+    schema_version: "agent-gym-regression-replay-request/v1" as const,
+  };
+  return Object.freeze({ ...body, request_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRegressionReplayRequest(value: AgentGymRegressionReplayRequestV1): AgentGymRegressionReplayRequestV1 {
+  if (value.schema_version !== "agent-gym-regression-replay-request/v1") invalid();
+  for (const ref of [value.baseline_candidate_ref, value.case_ref, value.challenger_candidate_ref, value.request_ref]) reference(ref);
+  for (const item of [value.augmentation_digest, value.case_digest, value.fixture_receipt_digest, value.request_digest]) digest(item);
+  timestamp(value.planned_at);
+  if (value.baseline_candidate_ref === value.challenger_candidate_ref || !Number.isSafeInteger(value.maximum_model_calls)
+    || value.maximum_model_calls < 2 || value.maximum_model_calls > 10_000) invalid();
+  const { request_digest: _digest, ...body } = value;
+  if (digestAgentGymJson(body) !== value.request_digest) invalid();
+  return Object.freeze({ ...value });
+}
+
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym regression replay request is invalid."); }

--- a/apps/slack-companion/src/agent-gym/regression-sanitization.ts
+++ b/apps/slack-companion/src/agent-gym/regression-sanitization.ts
@@ -1,0 +1,82 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import {
+  validateAgentGymRegressionLearningCandidate,
+  type AgentGymRegressionLearningCandidateV1,
+} from "./regression-learning-candidate.js";
+
+export interface AgentGymRegressionSanitizationV1 {
+  readonly candidate_digest: string;
+  readonly evidence_refs: readonly string[];
+  readonly prohibited_value_count: 0;
+  readonly redaction_count: number;
+  readonly sanitized_scenario_digest: string;
+  readonly sanitizer_ref: string;
+  readonly schema_version: "agent-gym-regression-sanitization/v1";
+  readonly source_content_digest: string;
+  readonly verified_at: string;
+  readonly verification_digest: string;
+  readonly verification_ref: string;
+}
+
+/** Seals proof that a regression scenario crossed the public corpus boundary safely. */
+export function verifyAgentGymRegressionSanitization(
+  candidateValue: AgentGymRegressionLearningCandidateV1,
+  input: Omit<AgentGymRegressionSanitizationV1, "candidate_digest" | "schema_version" | "verification_digest">,
+): AgentGymRegressionSanitizationV1 {
+  const candidate = validateAgentGymRegressionLearningCandidate(candidateValue);
+  validateInput(input);
+  if (Date.parse(input.verified_at) < Date.parse(candidate.proposed_at)) invalid();
+  const body = {
+    candidate_digest: candidate.candidate_digest,
+    evidence_refs: [...input.evidence_refs],
+    prohibited_value_count: input.prohibited_value_count,
+    redaction_count: input.redaction_count,
+    sanitized_scenario_digest: input.sanitized_scenario_digest,
+    sanitizer_ref: input.sanitizer_ref,
+    schema_version: "agent-gym-regression-sanitization/v1" as const,
+    source_content_digest: input.source_content_digest,
+    verified_at: input.verified_at,
+    verification_ref: input.verification_ref,
+  };
+  return freeze({ ...body, verification_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRegressionSanitization(value: AgentGymRegressionSanitizationV1): AgentGymRegressionSanitizationV1 {
+  if (value.schema_version !== "agent-gym-regression-sanitization/v1") invalid();
+  validateInput(value); digest(value.candidate_digest); digest(value.verification_digest);
+  const { verification_digest: _digest, ...body } = value;
+  if (digestAgentGymJson(body) !== value.verification_digest) invalid();
+  return freeze(value);
+}
+
+function validateInput(value: {
+  readonly evidence_refs: readonly string[];
+  readonly prohibited_value_count: number;
+  readonly redaction_count: number;
+  readonly sanitized_scenario_digest: string;
+  readonly sanitizer_ref: string;
+  readonly source_content_digest: string;
+  readonly verified_at: string;
+  readonly verification_ref: string;
+}): void {
+  references(value.evidence_refs); reference(value.sanitizer_ref); reference(value.verification_ref);
+  digest(value.sanitized_scenario_digest); digest(value.source_content_digest); timestamp(value.verified_at);
+  if (value.prohibited_value_count !== 0 || !Number.isSafeInteger(value.redaction_count)
+    || value.redaction_count < 0 || value.redaction_count > 1_000_000) invalid();
+}
+function freeze(value: AgentGymRegressionSanitizationV1): AgentGymRegressionSanitizationV1 {
+  return Object.freeze({ ...value, evidence_refs: Object.freeze([...value.evidence_refs]) });
+}
+function references(values: readonly string[]): void {
+  if (!Array.isArray(values) || values.length === 0 || values.length > 128 || new Set(values).size !== values.length) invalid();
+  for (const value of values) reference(value);
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid();
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym regression sanitization is invalid."); }

--- a/apps/slack-companion/test/agent-gym-regression-corpus.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-corpus.test.ts
@@ -4,9 +4,11 @@ import test from "node:test";
 import {
   digestAgentGymJson,
   agentGymFixtureScenarioDigest,
+  buildAgentGymRegressionFixture,
   inspectAgentGymRegressionDuplicates,
   validateAgentGymRegressionSanitization,
   validateAgentGymRegressionDuplicateReport,
+  validateAgentGymRegressionFixtureReceipt,
   type AgentGymFixtureCaseV1,
   verifyAgentGymRegressionSanitization,
   type AgentGymRegressionLearningCandidateV1,
@@ -54,6 +56,28 @@ test("regression duplicate reports name matching existing cases", () => {
   assert.deepEqual(report.duplicate_case_refs, [fixture.case_ref]);
 });
 
+test("regression fixtures bind sanitized admitted scenarios to training cases", () => {
+  const fixture = fixtureCase("agent-gym-case://regression/new", ["live_sample_failed", "regression"]);
+  const receipt = regressionFixtureReceipt(fixture);
+  assert.equal(receipt.fixture_digest.length, 71);
+  assert.deepEqual(validateAgentGymRegressionFixtureReceipt(receipt), receipt);
+});
+
+test("regression fixtures cannot place incident-derived cases in held-out data", () => {
+  const fixture = { ...fixtureCase("agent-gym-case://regression/invalid", ["live_sample_failed"]), partition: "held_out" as const };
+  const proof = sanitization(agentGymFixtureScenarioDigest(fixture));
+  const report = inspectAgentGymRegressionDuplicates(proof, [], "agent-gym-regression-duplicate-report://nightly/new");
+  assert.throws(() => buildAgentGymRegressionFixture(learningCandidate(), proof, report, fixture,
+    "agent-gym-regression-fixture-receipt://nightly/invalid"), /regression fixture receipt is invalid/u);
+});
+
+function regressionFixtureReceipt(fixture: AgentGymFixtureCaseV1) {
+  const proof = sanitization(agentGymFixtureScenarioDigest(fixture));
+  const report = inspectAgentGymRegressionDuplicates(proof, [], "agent-gym-regression-duplicate-report://nightly/new");
+  return buildAgentGymRegressionFixture(learningCandidate(), proof, report, fixture,
+    "agent-gym-regression-fixture-receipt://nightly/new");
+}
+
 function sanitization(scenarioDigest: string) {
   return verifyAgentGymRegressionSanitization(learningCandidate(), {
     evidence_refs: ["agent-gym-evidence://sanitization/one"], prohibited_value_count: 0, redaction_count: 3,
@@ -63,9 +87,9 @@ function sanitization(scenarioDigest: string) {
   });
 }
 
-function fixtureCase(): AgentGymFixtureCaseV1 {
+function fixtureCase(caseRef = "agent-gym-case://existing/one", labels = ["regression"]): AgentGymFixtureCaseV1 {
   return {
-    case_ref: "agent-gym-case://existing/one", expected_invariants: ["answer_is_grounded"], labels: ["regression"],
+    case_ref: caseRef, expected_invariants: ["answer_is_grounded"], labels,
     partition: "train", schema_version: "agent-gym-fixture-case/v1",
     slack_events: [{ event_ref: "agent-gym-event://existing/one", kind: "mention",
       occurred_at: "2026-08-12T11:00:00.000Z", payload: { text: "sanitized request" } }], tool_fixtures: [],

--- a/apps/slack-companion/test/agent-gym-regression-corpus.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-corpus.test.ts
@@ -4,11 +4,13 @@ import test from "node:test";
 import {
   digestAgentGymJson,
   agentGymFixtureScenarioDigest,
+  augmentAgentGymRegressionCorpus,
   buildAgentGymRegressionFixture,
   inspectAgentGymRegressionDuplicates,
   validateAgentGymRegressionSanitization,
   validateAgentGymRegressionDuplicateReport,
   validateAgentGymRegressionFixtureReceipt,
+  validateAgentGymRegressionCorpusAugmentation,
   type AgentGymFixtureCaseV1,
   verifyAgentGymRegressionSanitization,
   type AgentGymRegressionLearningCandidateV1,
@@ -71,6 +73,26 @@ test("regression fixtures cannot place incident-derived cases in held-out data",
     "agent-gym-regression-fixture-receipt://nightly/invalid"), /regression fixture receipt is invalid/u);
 });
 
+test("regression corpus augmentation binds the append-only manifest transition", () => {
+  const fixture = fixtureCase("agent-gym-case://regression/new", ["live_sample_failed"]);
+  const augmentation = augmentAgentGymRegressionCorpus([fixtureCase()], regressionFixtureReceipt(fixture), {
+    augmented_at: "2026-08-12T11:39:00.000Z",
+    augmentation_ref: "agent-gym-regression-corpus-augmentation://nightly/one",
+  });
+  assert.equal(augmentation.next_case_count, augmentation.previous_case_count + 1);
+  assert.deepEqual(validateAgentGymRegressionCorpusAugmentation(augmentation), augmentation);
+});
+
+test("regression corpus augmentation rejects scenario duplicates", () => {
+  const fixture = fixtureCase("agent-gym-case://regression/new", ["live_sample_failed"]);
+  assert.throws(() => augmentAgentGymRegressionCorpus([
+    { ...fixture, case_ref: "agent-gym-case://existing/same-scenario" },
+  ], regressionFixtureReceipt(fixture), {
+    augmented_at: "2026-08-12T11:39:00.000Z",
+    augmentation_ref: "agent-gym-regression-corpus-augmentation://nightly/invalid",
+  }), /corpus augmentation is invalid/u);
+});
+
 function regressionFixtureReceipt(fixture: AgentGymFixtureCaseV1) {
   const proof = sanitization(agentGymFixtureScenarioDigest(fixture));
   const report = inspectAgentGymRegressionDuplicates(proof, [], "agent-gym-regression-duplicate-report://nightly/new");
@@ -92,7 +114,7 @@ function fixtureCase(caseRef = "agent-gym-case://existing/one", labels = ["regre
     case_ref: caseRef, expected_invariants: ["answer_is_grounded"], labels,
     partition: "train", schema_version: "agent-gym-fixture-case/v1",
     slack_events: [{ event_ref: "agent-gym-event://existing/one", kind: "mention",
-      occurred_at: "2026-08-12T11:00:00.000Z", payload: { text: "sanitized request" } }], tool_fixtures: [],
+      occurred_at: "2026-08-12T11:00:00.000Z", payload: { case_ref: caseRef, text: "sanitized request" } }], tool_fixtures: [],
   };
 }
 

--- a/apps/slack-companion/test/agent-gym-regression-corpus.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-corpus.test.ts
@@ -3,7 +3,11 @@ import test from "node:test";
 
 import {
   digestAgentGymJson,
+  agentGymFixtureScenarioDigest,
+  inspectAgentGymRegressionDuplicates,
   validateAgentGymRegressionSanitization,
+  validateAgentGymRegressionDuplicateReport,
+  type AgentGymFixtureCaseV1,
   verifyAgentGymRegressionSanitization,
   type AgentGymRegressionLearningCandidateV1,
 } from "../src/index.js";
@@ -34,6 +38,39 @@ test("regression sanitization rejects remaining prohibited values", () => {
     verification_ref: "agent-gym-regression-sanitization://nightly/invalid",
   }), /regression sanitization is invalid/u);
 });
+
+test("regression duplicate reports admit a distinct scenario", () => {
+  const report = inspectAgentGymRegressionDuplicates(sanitization(digest("b")), [fixtureCase()],
+    "agent-gym-regression-duplicate-report://nightly/one");
+  assert.equal(report.admissible, true);
+  assert.deepEqual(validateAgentGymRegressionDuplicateReport(report), report);
+});
+
+test("regression duplicate reports name matching existing cases", () => {
+  const fixture = fixtureCase();
+  const report = inspectAgentGymRegressionDuplicates(sanitization(agentGymFixtureScenarioDigest(fixture)), [fixture],
+    "agent-gym-regression-duplicate-report://nightly/duplicate");
+  assert.equal(report.admissible, false);
+  assert.deepEqual(report.duplicate_case_refs, [fixture.case_ref]);
+});
+
+function sanitization(scenarioDigest: string) {
+  return verifyAgentGymRegressionSanitization(learningCandidate(), {
+    evidence_refs: ["agent-gym-evidence://sanitization/one"], prohibited_value_count: 0, redaction_count: 3,
+    sanitized_scenario_digest: scenarioDigest, sanitizer_ref: "agent-gym-sanitizer://portable/default",
+    source_content_digest: digest("c"), verified_at: "2026-08-12T11:38:00.000Z",
+    verification_ref: "agent-gym-regression-sanitization://nightly/one",
+  });
+}
+
+function fixtureCase(): AgentGymFixtureCaseV1 {
+  return {
+    case_ref: "agent-gym-case://existing/one", expected_invariants: ["answer_is_grounded"], labels: ["regression"],
+    partition: "train", schema_version: "agent-gym-fixture-case/v1",
+    slack_events: [{ event_ref: "agent-gym-event://existing/one", kind: "mention",
+      occurred_at: "2026-08-12T11:00:00.000Z", payload: { text: "sanitized request" } }], tool_fixtures: [],
+  };
+}
 
 function learningCandidate(): AgentGymRegressionLearningCandidateV1 {
   const body = {

--- a/apps/slack-companion/test/agent-gym-regression-corpus.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-corpus.test.ts
@@ -7,10 +7,12 @@ import {
   augmentAgentGymRegressionCorpus,
   buildAgentGymRegressionFixture,
   inspectAgentGymRegressionDuplicates,
+  requestAgentGymRegressionReplay,
   validateAgentGymRegressionSanitization,
   validateAgentGymRegressionDuplicateReport,
   validateAgentGymRegressionFixtureReceipt,
   validateAgentGymRegressionCorpusAugmentation,
+  validateAgentGymRegressionReplayRequest,
   type AgentGymFixtureCaseV1,
   verifyAgentGymRegressionSanitization,
   type AgentGymRegressionLearningCandidateV1,
@@ -91,6 +93,38 @@ test("regression corpus augmentation rejects scenario duplicates", () => {
     augmented_at: "2026-08-12T11:39:00.000Z",
     augmentation_ref: "agent-gym-regression-corpus-augmentation://nightly/invalid",
   }), /corpus augmentation is invalid/u);
+});
+
+test("regression replay requests compare fallback and challenger on the appended case", () => {
+  const fixture = fixtureCase("agent-gym-case://regression/new", ["live_sample_failed"]);
+  const receipt = regressionFixtureReceipt(fixture);
+  const augmentation = augmentAgentGymRegressionCorpus([fixtureCase()], receipt, {
+    augmented_at: "2026-08-12T11:39:00.000Z",
+    augmentation_ref: "agent-gym-regression-corpus-augmentation://nightly/one",
+  });
+  const request = requestAgentGymRegressionReplay(learningCandidate(), receipt, augmentation, {
+    challenger_candidate_ref: "agent-gym-candidate://nightly/next",
+    maximum_model_calls: 4,
+    planned_at: "2026-08-12T11:40:00.000Z",
+    request_ref: "agent-gym-regression-replay-request://nightly/one",
+  });
+  assert.equal(request.baseline_candidate_ref, "agent-gym-candidate://nightly/baseline");
+  assert.deepEqual(validateAgentGymRegressionReplayRequest(request), request);
+});
+
+test("regression replay requests reject the fallback as its own challenger", () => {
+  const fixture = fixtureCase("agent-gym-case://regression/new", ["live_sample_failed"]);
+  const receipt = regressionFixtureReceipt(fixture);
+  const augmentation = augmentAgentGymRegressionCorpus([fixtureCase()], receipt, {
+    augmented_at: "2026-08-12T11:39:00.000Z",
+    augmentation_ref: "agent-gym-regression-corpus-augmentation://nightly/one",
+  });
+  assert.throws(() => requestAgentGymRegressionReplay(learningCandidate(), receipt, augmentation, {
+    challenger_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    maximum_model_calls: 4,
+    planned_at: "2026-08-12T11:40:00.000Z",
+    request_ref: "agent-gym-regression-replay-request://nightly/invalid",
+  }), /regression replay request is invalid/u);
 });
 
 function regressionFixtureReceipt(fixture: AgentGymFixtureCaseV1) {

--- a/apps/slack-companion/test/agent-gym-regression-corpus.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-corpus.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  digestAgentGymJson,
+  validateAgentGymRegressionSanitization,
+  verifyAgentGymRegressionSanitization,
+  type AgentGymRegressionLearningCandidateV1,
+} from "../src/index.js";
+
+test("regression sanitization seals a public-safe scenario digest", () => {
+  const receipt = verifyAgentGymRegressionSanitization(learningCandidate(), {
+    evidence_refs: ["agent-gym-evidence://sanitization/one"],
+    prohibited_value_count: 0,
+    redaction_count: 3,
+    sanitized_scenario_digest: digest("b"),
+    sanitizer_ref: "agent-gym-sanitizer://portable/default",
+    source_content_digest: digest("c"),
+    verified_at: "2026-08-12T11:38:00.000Z",
+    verification_ref: "agent-gym-regression-sanitization://nightly/one",
+  });
+  assert.deepEqual(validateAgentGymRegressionSanitization(receipt), receipt);
+});
+
+test("regression sanitization rejects remaining prohibited values", () => {
+  assert.throws(() => verifyAgentGymRegressionSanitization(learningCandidate(), {
+    evidence_refs: ["agent-gym-evidence://sanitization/invalid"],
+    prohibited_value_count: 1 as 0,
+    redaction_count: 3,
+    sanitized_scenario_digest: digest("b"),
+    sanitizer_ref: "agent-gym-sanitizer://portable/default",
+    source_content_digest: digest("c"),
+    verified_at: "2026-08-12T11:38:00.000Z",
+    verification_ref: "agent-gym-regression-sanitization://nightly/invalid",
+  }), /regression sanitization is invalid/u);
+});
+
+function learningCandidate(): AgentGymRegressionLearningCandidateV1 {
+  const body = {
+    candidate_ref: "agent-gym-regression-learning-candidate://nightly/one",
+    evidence_refs: ["agent-gym-evidence://learning/regression-one"],
+    expected_candidate_ref: "agent-gym-candidate://nightly/baseline",
+    failure_labels: ["live_sample_failed"],
+    proposed_at: "2026-08-12T11:37:00.000Z",
+    rollback_incident_digest: digest("a"),
+    schema_version: "agent-gym-regression-learning-candidate/v1" as const,
+    source_case_ref: "agent-gym-source-case://post-rollout/regression-one",
+    target_ref: "agent-gym-target://slack-companion/default",
+  };
+  return { ...body, candidate_digest: digestAgentGymJson(body) };
+}
+
+function digest(character: string): string { return `sha256:${character.repeat(64)}`; }


### PR DESCRIPTION
## Summary

- require public-safe sanitization proof and reject duplicate scenarios
- build incident-derived fixtures only in the training partition
- append corpus receipts and request paired fallback/challenger replay

## Validation

- DDESK `npm run typecheck`
- DDESK `npm test` (717 tests, 62 suites, 0 failures)
- exact local, origin, and DDESK head `71a864ca7559fb3cab474b513a353c348b2574ec`

## Evidence gap

- Practice Registry MCP was unavailable; no Registry pass is claimed.