### PR TITLE
feat(slack): execute paired regression replays

### DIFF
--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -62,6 +62,7 @@ export * from "./regression-replay-plan.js";
 export * from "./regression-replay-result.js";
 export * from "./regression-replay-evaluation.js";
 export * from "./regression-replay-comparison.js";
+export * from "./regression-replay-admission.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -61,6 +61,7 @@ export * from "./regression-replay-request.js";
 export * from "./regression-replay-plan.js";
 export * from "./regression-replay-result.js";
 export * from "./regression-replay-evaluation.js";
+export * from "./regression-replay-comparison.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -60,6 +60,7 @@ export * from "./regression-corpus-augmentation.js";
 export * from "./regression-replay-request.js";
 export * from "./regression-replay-plan.js";
 export * from "./regression-replay-result.js";
+export * from "./regression-replay-evaluation.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -59,6 +59,7 @@ export * from "./regression-fixture.js";
 export * from "./regression-corpus-augmentation.js";
 export * from "./regression-replay-request.js";
 export * from "./regression-replay-plan.js";
+export * from "./regression-replay-result.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -58,6 +58,7 @@ export * from "./regression-duplicate-report.js";
 export * from "./regression-fixture.js";
 export * from "./regression-corpus-augmentation.js";
 export * from "./regression-replay-request.js";
+export * from "./regression-replay-plan.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/regression-replay-admission.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-admission.ts
@@ -1,0 +1,85 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { validateAgentGymRegressionReplayComparison, type AgentGymRegressionReplayComparisonV1 } from "./regression-replay-comparison.js";
+import { validateAgentGymRegressionReplayEvaluation, type AgentGymRegressionReplayEvaluationV1 } from "./regression-replay-evaluation.js";
+
+export interface AgentGymRegressionReplayAdmissionPolicyV1 {
+  readonly maximum_latency_increase_ms: number;
+  readonly minimum_challenger_score: number;
+  readonly minimum_score_delta: number;
+  readonly policy_ref: string;
+  readonly schema_version: "agent-gym-regression-replay-admission-policy/v1";
+}
+
+export interface AgentGymRegressionReplayAdmissionV1 {
+  readonly admitted_at: string;
+  readonly admission_digest: string;
+  readonly admission_ref: string;
+  readonly blocker_codes: readonly string[];
+  readonly challenger_candidate_ref: string;
+  readonly comparison_digest: string;
+  readonly decision: "admitted" | "blocked";
+  readonly evaluation_digest: string;
+  readonly policy_digest: string;
+  readonly schema_version: "agent-gym-regression-replay-admission/v1";
+}
+
+/** Admits a challenger only when every regression, safety, quality, and latency gate passes. */
+export function admitAgentGymRegressionReplay(
+  comparisonValue: AgentGymRegressionReplayComparisonV1,
+  evaluationValue: AgentGymRegressionReplayEvaluationV1,
+  policyValue: AgentGymRegressionReplayAdmissionPolicyV1,
+  input: Pick<AgentGymRegressionReplayAdmissionV1, "admitted_at" | "admission_ref">,
+): AgentGymRegressionReplayAdmissionV1 {
+  const comparison = validateAgentGymRegressionReplayComparison(comparisonValue);
+  const evaluation = validateAgentGymRegressionReplayEvaluation(evaluationValue);
+  const policy = validatePolicy(policyValue);
+  reference(input.admission_ref); timestamp(input.admitted_at);
+  if (comparison.evaluation_digest !== evaluation.evaluation_digest
+    || comparison.challenger_candidate_ref !== evaluation.challenger.candidate_ref
+    || Date.parse(input.admitted_at) < Date.parse(comparison.compared_at)) invalid();
+  const blockers = new Set<string>(evaluation.challenger.blocker_codes);
+  if (!evaluation.challenger.safety_passed) blockers.add("challenger_safety_failed");
+  if (evaluation.challenger.score < policy.minimum_challenger_score) blockers.add("challenger_score_below_minimum");
+  if (comparison.score_delta < policy.minimum_score_delta) blockers.add("score_delta_below_minimum");
+  if (comparison.latency_delta_ms > policy.maximum_latency_increase_ms) blockers.add("latency_increase_exceeded");
+  if (comparison.outcome === "regressed") blockers.add("regression_detected");
+  const blockerCodes = Object.freeze([...blockers].sort());
+  const body = {
+    admitted_at: input.admitted_at, admission_ref: input.admission_ref, blocker_codes: blockerCodes,
+    challenger_candidate_ref: comparison.challenger_candidate_ref, comparison_digest: comparison.comparison_digest,
+    decision: blockerCodes.length === 0 ? "admitted" as const : "blocked" as const,
+    evaluation_digest: evaluation.evaluation_digest, policy_digest: digestAgentGymJson(policyBody(policy)),
+    schema_version: "agent-gym-regression-replay-admission/v1" as const,
+  };
+  return Object.freeze({ ...body, admission_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRegressionReplayAdmission(value: AgentGymRegressionReplayAdmissionV1): AgentGymRegressionReplayAdmissionV1 {
+  if (value.schema_version !== "agent-gym-regression-replay-admission/v1") invalid();
+  reference(value.admission_ref); reference(value.challenger_candidate_ref); timestamp(value.admitted_at);
+  for (const item of [value.admission_digest, value.comparison_digest, value.evaluation_digest, value.policy_digest]) digest(item);
+  if (!Array.isArray(value.blocker_codes) || value.blocker_codes.some((code) => !/^[a-z][a-z0-9_.-]{0,79}$/u.test(code))
+    || new Set(value.blocker_codes).size !== value.blocker_codes.length
+    || (value.decision === "admitted") !== (value.blocker_codes.length === 0)) invalid();
+  const body = { admitted_at: value.admitted_at, admission_ref: value.admission_ref,
+    blocker_codes: Object.freeze([...value.blocker_codes].sort()), challenger_candidate_ref: value.challenger_candidate_ref,
+    comparison_digest: value.comparison_digest, decision: value.decision, evaluation_digest: value.evaluation_digest,
+    policy_digest: value.policy_digest, schema_version: value.schema_version };
+  if (digestAgentGymJson(body) !== value.admission_digest) invalid();
+  return Object.freeze({ ...value, blocker_codes: body.blocker_codes });
+}
+
+function validatePolicy(value: AgentGymRegressionReplayAdmissionPolicyV1): AgentGymRegressionReplayAdmissionPolicyV1 {
+  if (value.schema_version !== "agent-gym-regression-replay-admission-policy/v1") invalid();
+  reference(value.policy_ref);
+  if (!Number.isSafeInteger(value.maximum_latency_increase_ms) || value.maximum_latency_increase_ms < 0
+    || !Number.isFinite(value.minimum_challenger_score) || value.minimum_challenger_score < 0 || value.minimum_challenger_score > 1
+    || !Number.isFinite(value.minimum_score_delta) || value.minimum_score_delta < -1 || value.minimum_score_delta > 1) invalid();
+  return Object.freeze({ ...value });
+}
+function policyBody(value: AgentGymRegressionReplayAdmissionPolicyV1) { return { maximum_latency_increase_ms: value.maximum_latency_increase_ms, minimum_challenger_score: value.minimum_challenger_score, minimum_score_delta: value.minimum_score_delta, policy_ref: value.policy_ref, schema_version: value.schema_version }; }
+function reference(value: string): void { if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid(); }
+function timestamp(value: string): void { if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid(); }
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym regression replay admission is invalid."); }

--- a/apps/slack-companion/src/agent-gym/regression-replay-comparison.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-comparison.ts
@@ -1,0 +1,65 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { validateAgentGymRegressionReplayEvaluation, type AgentGymRegressionReplayEvaluationV1 } from "./regression-replay-evaluation.js";
+import { validateAgentGymRegressionReplayResult, type AgentGymRegressionReplayResultV1 } from "./regression-replay-result.js";
+
+export interface AgentGymRegressionReplayComparisonV1 {
+  readonly baseline_candidate_ref: string;
+  readonly challenger_candidate_ref: string;
+  readonly compared_at: string;
+  readonly comparison_digest: string;
+  readonly comparison_ref: string;
+  readonly evaluation_digest: string;
+  readonly latency_delta_ms: number;
+  readonly outcome: "equivalent" | "improved" | "regressed";
+  readonly replay_result_digest: string;
+  readonly safety_regressed: boolean;
+  readonly schema_version: "agent-gym-regression-replay-comparison/v1";
+  readonly score_delta: number;
+}
+
+/** Produces a deterministic paired comparison from sealed result and evaluator evidence. */
+export function compareAgentGymRegressionReplay(
+  resultValue: AgentGymRegressionReplayResultV1,
+  evaluationValue: AgentGymRegressionReplayEvaluationV1,
+  input: Pick<AgentGymRegressionReplayComparisonV1, "compared_at" | "comparison_ref">,
+): AgentGymRegressionReplayComparisonV1 {
+  const result = validateAgentGymRegressionReplayResult(resultValue);
+  const evaluation = validateAgentGymRegressionReplayEvaluation(evaluationValue);
+  reference(input.comparison_ref); timestamp(input.compared_at);
+  if (evaluation.replay_result_digest !== result.result_digest
+    || evaluation.baseline.candidate_ref !== result.baseline.candidate_ref
+    || evaluation.challenger.candidate_ref !== result.challenger.candidate_ref
+    || Date.parse(input.compared_at) < Date.parse(evaluation.evaluated_at)) invalid();
+  const scoreDelta = rounded(evaluation.challenger.score - evaluation.baseline.score);
+  const safetyRegressed = evaluation.baseline.safety_passed && !evaluation.challenger.safety_passed;
+  const outcome: AgentGymRegressionReplayComparisonV1["outcome"] = safetyRegressed || scoreDelta < -0.001
+    ? "regressed" : scoreDelta > 0.001 ? "improved" : "equivalent";
+  const body = {
+    baseline_candidate_ref: result.baseline.candidate_ref, challenger_candidate_ref: result.challenger.candidate_ref,
+    compared_at: input.compared_at, comparison_ref: input.comparison_ref, evaluation_digest: evaluation.evaluation_digest,
+    latency_delta_ms: result.challenger.latency_ms - result.baseline.latency_ms, outcome,
+    replay_result_digest: result.result_digest, safety_regressed: safetyRegressed,
+    schema_version: "agent-gym-regression-replay-comparison/v1" as const, score_delta: scoreDelta,
+  };
+  return Object.freeze({ ...body, comparison_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRegressionReplayComparison(value: AgentGymRegressionReplayComparisonV1): AgentGymRegressionReplayComparisonV1 {
+  if (value.schema_version !== "agent-gym-regression-replay-comparison/v1") invalid();
+  for (const ref of [value.baseline_candidate_ref, value.challenger_candidate_ref, value.comparison_ref]) reference(ref);
+  for (const item of [value.comparison_digest, value.evaluation_digest, value.replay_result_digest]) digest(item);
+  timestamp(value.compared_at);
+  if (value.baseline_candidate_ref === value.challenger_candidate_ref || !Number.isSafeInteger(value.latency_delta_ms)
+    || !Number.isFinite(value.score_delta) || !["equivalent", "improved", "regressed"].includes(value.outcome)
+    || (value.safety_regressed && value.outcome !== "regressed")) invalid();
+  const { comparison_digest: _digest, ...body } = value;
+  if (digestAgentGymJson(body) !== value.comparison_digest) invalid();
+  return Object.freeze({ ...value });
+}
+
+function rounded(value: number): number { return Math.round(value * 1_000_000) / 1_000_000; }
+function reference(value: string): void { if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid(); }
+function timestamp(value: string): void { if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid(); }
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym regression replay comparison is invalid."); }

--- a/apps/slack-companion/src/agent-gym/regression-replay-evaluation.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-evaluation.ts
@@ -1,0 +1,72 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { validateAgentGymRegressionReplayResult, type AgentGymRegressionReplayResultV1 } from "./regression-replay-result.js";
+
+export interface AgentGymRegressionReplayCandidateEvaluationV1 {
+  readonly blocker_codes: readonly string[];
+  readonly candidate_ref: string;
+  readonly evidence_digest: string;
+  readonly safety_passed: boolean;
+  readonly score: number;
+}
+
+export interface AgentGymRegressionReplayEvaluationV1 {
+  readonly baseline: AgentGymRegressionReplayCandidateEvaluationV1;
+  readonly case_digest: string;
+  readonly challenger: AgentGymRegressionReplayCandidateEvaluationV1;
+  readonly evaluated_at: string;
+  readonly evaluation_digest: string;
+  readonly evaluation_ref: string;
+  readonly replay_result_digest: string;
+  readonly schema_version: "agent-gym-regression-replay-evaluation/v1";
+}
+
+/** Binds independent evaluator evidence to both replay candidates. */
+export function evaluateAgentGymRegressionReplay(
+  resultValue: AgentGymRegressionReplayResultV1,
+  input: Pick<AgentGymRegressionReplayEvaluationV1, "baseline" | "challenger" | "evaluated_at" | "evaluation_ref">,
+): AgentGymRegressionReplayEvaluationV1 {
+  const result = validateAgentGymRegressionReplayResult(resultValue);
+  reference(input.evaluation_ref); timestamp(input.evaluated_at);
+  evaluation(input.baseline); evaluation(input.challenger);
+  if (input.baseline.candidate_ref !== result.baseline.candidate_ref
+    || input.challenger.candidate_ref !== result.challenger.candidate_ref
+    || Date.parse(input.evaluated_at) < Date.parse(result.completed_at)) invalid();
+  const body = {
+    baseline: evaluationBody(input.baseline), case_digest: result.case_digest,
+    challenger: evaluationBody(input.challenger), evaluated_at: input.evaluated_at,
+    evaluation_ref: input.evaluation_ref, replay_result_digest: result.result_digest,
+    schema_version: "agent-gym-regression-replay-evaluation/v1" as const,
+  };
+  return Object.freeze({ ...body, evaluation_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRegressionReplayEvaluation(value: AgentGymRegressionReplayEvaluationV1): AgentGymRegressionReplayEvaluationV1 {
+  if (value.schema_version !== "agent-gym-regression-replay-evaluation/v1") invalid();
+  reference(value.evaluation_ref); timestamp(value.evaluated_at);
+  evaluation(value.baseline); evaluation(value.challenger);
+  for (const item of [value.case_digest, value.evaluation_digest, value.replay_result_digest]) digest(item);
+  if (value.baseline.candidate_ref === value.challenger.candidate_ref) invalid();
+  const body = { baseline: evaluationBody(value.baseline), case_digest: value.case_digest,
+    challenger: evaluationBody(value.challenger), evaluated_at: value.evaluated_at, evaluation_ref: value.evaluation_ref,
+    replay_result_digest: value.replay_result_digest, schema_version: value.schema_version };
+  if (digestAgentGymJson(body) !== value.evaluation_digest) invalid();
+  return Object.freeze({ ...value, baseline: evaluationBody(value.baseline), challenger: evaluationBody(value.challenger) });
+}
+
+function evaluation(value: AgentGymRegressionReplayCandidateEvaluationV1): void {
+  reference(value.candidate_ref); digest(value.evidence_digest);
+  if (!Number.isFinite(value.score) || value.score < 0 || value.score > 1 || typeof value.safety_passed !== "boolean"
+    || !Array.isArray(value.blocker_codes) || value.blocker_codes.length > 100
+    || value.blocker_codes.some((code) => !/^[a-z][a-z0-9_.-]{0,79}$/u.test(code))
+    || new Set(value.blocker_codes).size !== value.blocker_codes.length
+    || (value.safety_passed && value.blocker_codes.length > 0)) invalid();
+}
+function evaluationBody(value: AgentGymRegressionReplayCandidateEvaluationV1) {
+  return Object.freeze({ blocker_codes: Object.freeze([...value.blocker_codes].sort()), candidate_ref: value.candidate_ref,
+    evidence_digest: value.evidence_digest, safety_passed: value.safety_passed, score: value.score });
+}
+function reference(value: string): void { if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid(); }
+function timestamp(value: string): void { if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid(); }
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym regression replay evaluation is invalid."); }

--- a/apps/slack-companion/src/agent-gym/regression-replay-plan.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-plan.ts
@@ -1,0 +1,58 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { validateAgentGymRegressionReplayRequest, type AgentGymRegressionReplayRequestV1 } from "./regression-replay-request.js";
+
+export interface AgentGymRegressionReplayPlanV1 {
+  readonly baseline_invocation_ref: string;
+  readonly case_digest: string;
+  readonly case_ref: string;
+  readonly challenger_invocation_ref: string;
+  readonly maximum_model_calls: number;
+  readonly plan_digest: string;
+  readonly plan_ref: string;
+  readonly planned_at: string;
+  readonly replay_request_digest: string;
+  readonly schema_version: "agent-gym-regression-replay-plan/v1";
+}
+
+/** Seals the two provider-neutral invocations that may execute a regression replay. */
+export function planAgentGymRegressionReplay(
+  requestValue: AgentGymRegressionReplayRequestV1,
+  input: Pick<AgentGymRegressionReplayPlanV1,
+    "baseline_invocation_ref" | "challenger_invocation_ref" | "plan_ref" | "planned_at">,
+): AgentGymRegressionReplayPlanV1 {
+  const request = validateAgentGymRegressionReplayRequest(requestValue);
+  for (const ref of [input.baseline_invocation_ref, input.challenger_invocation_ref, input.plan_ref]) reference(ref);
+  timestamp(input.planned_at);
+  if (input.baseline_invocation_ref === input.challenger_invocation_ref
+    || Date.parse(input.planned_at) < Date.parse(request.planned_at)) invalid();
+  const body = {
+    baseline_invocation_ref: input.baseline_invocation_ref,
+    case_digest: request.case_digest,
+    case_ref: request.case_ref,
+    challenger_invocation_ref: input.challenger_invocation_ref,
+    maximum_model_calls: request.maximum_model_calls,
+    plan_ref: input.plan_ref,
+    planned_at: input.planned_at,
+    replay_request_digest: request.request_digest,
+    schema_version: "agent-gym-regression-replay-plan/v1" as const,
+  };
+  return Object.freeze({ ...body, plan_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRegressionReplayPlan(value: AgentGymRegressionReplayPlanV1): AgentGymRegressionReplayPlanV1 {
+  if (value.schema_version !== "agent-gym-regression-replay-plan/v1") invalid();
+  for (const ref of [value.baseline_invocation_ref, value.case_ref, value.challenger_invocation_ref, value.plan_ref]) reference(ref);
+  for (const item of [value.case_digest, value.plan_digest, value.replay_request_digest]) digest(item);
+  timestamp(value.planned_at);
+  if (value.baseline_invocation_ref === value.challenger_invocation_ref
+    || !Number.isSafeInteger(value.maximum_model_calls) || value.maximum_model_calls < 2 || value.maximum_model_calls > 10_000) invalid();
+  const { plan_digest: _digest, ...body } = value;
+  if (digestAgentGymJson(body) !== value.plan_digest) invalid();
+  return Object.freeze({ ...value });
+}
+
+function reference(value: string): void { if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid(); }
+function timestamp(value: string): void { if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid(); }
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym regression replay plan is invalid."); }

--- a/apps/slack-companion/src/agent-gym/regression-replay-result.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-result.ts
@@ -1,0 +1,82 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { validateAgentGymRegressionReplayPlan, type AgentGymRegressionReplayPlanV1 } from "./regression-replay-plan.js";
+
+export interface AgentGymRegressionReplayCandidateResultV1 {
+  readonly candidate_ref: string;
+  readonly invocation_receipt_digest: string;
+  readonly invocation_ref: string;
+  readonly latency_ms: number;
+  readonly response_digest: string;
+  readonly total_tokens: number;
+}
+
+export interface AgentGymRegressionReplayResultV1 {
+  readonly baseline: AgentGymRegressionReplayCandidateResultV1;
+  readonly case_digest: string;
+  readonly case_ref: string;
+  readonly challenger: AgentGymRegressionReplayCandidateResultV1;
+  readonly completed_at: string;
+  readonly plan_digest: string;
+  readonly result_digest: string;
+  readonly result_ref: string;
+  readonly schema_version: "agent-gym-regression-replay-result/v1";
+}
+
+/** Records the two response-bound outcomes without retaining model output text. */
+export function recordAgentGymRegressionReplayResult(
+  planValue: AgentGymRegressionReplayPlanV1,
+  input: Pick<AgentGymRegressionReplayResultV1, "baseline" | "challenger" | "completed_at" | "result_ref">,
+): AgentGymRegressionReplayResultV1 {
+  const plan = validateAgentGymRegressionReplayPlan(planValue);
+  reference(input.result_ref); timestamp(input.completed_at);
+  candidate(input.baseline); candidate(input.challenger);
+  if (input.baseline.invocation_ref !== plan.baseline_invocation_ref
+    || input.challenger.invocation_ref !== plan.challenger_invocation_ref
+    || input.baseline.candidate_ref === input.challenger.candidate_ref
+    || input.baseline.response_digest === input.challenger.response_digest
+    || Date.parse(input.completed_at) < Date.parse(plan.planned_at)) invalid();
+  const baseline = candidateBody(input.baseline);
+  const challenger = candidateBody(input.challenger);
+  const body = {
+    baseline, case_digest: plan.case_digest, case_ref: plan.case_ref,
+    challenger, completed_at: input.completed_at,
+    plan_digest: plan.plan_digest, result_ref: input.result_ref,
+    schema_version: "agent-gym-regression-replay-result/v1" as const,
+  };
+  return Object.freeze({ ...body, result_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRegressionReplayResult(value: AgentGymRegressionReplayResultV1): AgentGymRegressionReplayResultV1 {
+  if (value.schema_version !== "agent-gym-regression-replay-result/v1") invalid();
+  reference(value.case_ref); reference(value.result_ref); timestamp(value.completed_at);
+  candidate(value.baseline); candidate(value.challenger);
+  for (const item of [value.case_digest, value.plan_digest, value.result_digest]) digest(item);
+  if (value.baseline.candidate_ref === value.challenger.candidate_ref
+    || value.baseline.invocation_ref === value.challenger.invocation_ref
+    || value.baseline.response_digest === value.challenger.response_digest) invalid();
+  const body = {
+    baseline: candidateBody(value.baseline), case_digest: value.case_digest, case_ref: value.case_ref,
+    challenger: candidateBody(value.challenger), completed_at: value.completed_at, plan_digest: value.plan_digest,
+    result_ref: value.result_ref, schema_version: value.schema_version,
+  };
+  if (digestAgentGymJson(body) !== value.result_digest) invalid();
+  return Object.freeze({ ...value, baseline: Object.freeze({ ...value.baseline }), challenger: Object.freeze({ ...value.challenger }) });
+}
+
+function candidateBody(value: AgentGymRegressionReplayCandidateResultV1) {
+  return Object.freeze({ candidate_ref: value.candidate_ref, invocation_receipt_digest: value.invocation_receipt_digest,
+    invocation_ref: value.invocation_ref, latency_ms: value.latency_ms, response_digest: value.response_digest,
+    total_tokens: value.total_tokens });
+}
+
+function candidate(value: AgentGymRegressionReplayCandidateResultV1): void {
+  reference(value.candidate_ref); reference(value.invocation_ref);
+  digest(value.invocation_receipt_digest); digest(value.response_digest);
+  if (!Number.isSafeInteger(value.latency_ms) || value.latency_ms < 0
+    || !Number.isSafeInteger(value.total_tokens) || value.total_tokens < 0) invalid();
+}
+function reference(value: string): void { if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid(); }
+function timestamp(value: string): void { if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid(); }
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym regression replay result is invalid."); }

--- a/apps/slack-companion/test/agent-gym-regression-execution.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-execution.test.ts
@@ -4,6 +4,7 @@ import { digestAgentGymJson } from "../src/agent-gym/canonical-json.js";
 import { planAgentGymRegressionReplay, validateAgentGymRegressionReplayPlan } from "../src/agent-gym/regression-replay-plan.js";
 import { recordAgentGymRegressionReplayResult, validateAgentGymRegressionReplayResult } from "../src/agent-gym/regression-replay-result.js";
 import { evaluateAgentGymRegressionReplay, validateAgentGymRegressionReplayEvaluation } from "../src/agent-gym/regression-replay-evaluation.js";
+import { compareAgentGymRegressionReplay, validateAgentGymRegressionReplayComparison } from "../src/agent-gym/regression-replay-comparison.js";
 import type { AgentGymRegressionReplayRequestV1 } from "../src/agent-gym/regression-replay-request.js";
 
 const sha = (value: string): string => `sha256:${value.repeat(64).slice(0, 64)}`;
@@ -27,6 +28,16 @@ function replayResult() {
     challenger: { candidate_ref: "agent-gym-candidate://challenger/one", invocation_receipt_digest: sha("f"), invocation_ref: plan.challenger_invocation_ref, latency_ms: 100, response_digest: sha("1"), total_tokens: 72 },
     completed_at: "2026-08-12T13:02:00.000Z", result_ref: "agent-gym-replay-result://regression/one",
   });
+}
+
+function replayEvaluation() {
+  const result = replayResult();
+  const evaluation = evaluateAgentGymRegressionReplay(result, {
+    baseline: { blocker_codes: [], candidate_ref: result.baseline.candidate_ref, evidence_digest: sha("2"), safety_passed: true, score: 0.72 },
+    challenger: { blocker_codes: [], candidate_ref: result.challenger.candidate_ref, evidence_digest: sha("3"), safety_passed: true, score: 0.86 },
+    evaluated_at: "2026-08-12T13:03:00.000Z", evaluation_ref: "agent-gym-replay-evaluation://regression/one",
+  });
+  return { evaluation, result };
 }
 
 test("seals an exact paired regression replay plan", () => {
@@ -62,4 +73,14 @@ test("binds independent scores to both replay candidates", () => {
   });
   assert.equal(validateAgentGymRegressionReplayEvaluation(evaluation).challenger.score, 0.86);
   assert.throws(() => evaluateAgentGymRegressionReplay(result, { ...evaluation, challenger: { ...evaluation.challenger, safety_passed: true, blocker_codes: ["unsafe"] } }));
+});
+
+test("compares paired replay scores and latency deterministically", () => {
+  const { evaluation, result } = replayEvaluation();
+  const comparison = compareAgentGymRegressionReplay(result, evaluation, {
+    compared_at: "2026-08-12T13:04:00.000Z", comparison_ref: "agent-gym-replay-comparison://regression/one",
+  });
+  assert.equal(comparison.outcome, "improved");
+  assert.equal(comparison.latency_delta_ms, -20);
+  assert.equal(validateAgentGymRegressionReplayComparison(comparison).score_delta, 0.14);
 });

--- a/apps/slack-companion/test/agent-gym-regression-execution.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-execution.test.ts
@@ -5,6 +5,7 @@ import { planAgentGymRegressionReplay, validateAgentGymRegressionReplayPlan } fr
 import { recordAgentGymRegressionReplayResult, validateAgentGymRegressionReplayResult } from "../src/agent-gym/regression-replay-result.js";
 import { evaluateAgentGymRegressionReplay, validateAgentGymRegressionReplayEvaluation } from "../src/agent-gym/regression-replay-evaluation.js";
 import { compareAgentGymRegressionReplay, validateAgentGymRegressionReplayComparison } from "../src/agent-gym/regression-replay-comparison.js";
+import { admitAgentGymRegressionReplay, validateAgentGymRegressionReplayAdmission } from "../src/agent-gym/regression-replay-admission.js";
 import type { AgentGymRegressionReplayRequestV1 } from "../src/agent-gym/regression-replay-request.js";
 
 const sha = (value: string): string => `sha256:${value.repeat(64).slice(0, 64)}`;
@@ -83,4 +84,20 @@ test("compares paired replay scores and latency deterministically", () => {
   assert.equal(comparison.outcome, "improved");
   assert.equal(comparison.latency_delta_ms, -20);
   assert.equal(validateAgentGymRegressionReplayComparison(comparison).score_delta, 0.14);
+});
+
+test("admits only challengers that pass every regression gate", () => {
+  const { evaluation, result } = replayEvaluation();
+  const comparison = compareAgentGymRegressionReplay(result, evaluation, { compared_at: "2026-08-12T13:04:00.000Z", comparison_ref: "agent-gym-replay-comparison://regression/one" });
+  const admission = admitAgentGymRegressionReplay(comparison, evaluation, {
+    maximum_latency_increase_ms: 25, minimum_challenger_score: 0.8, minimum_score_delta: 0,
+    policy_ref: "agent-gym-admission-policy://regression/one", schema_version: "agent-gym-regression-replay-admission-policy/v1",
+  }, { admitted_at: "2026-08-12T13:05:00.000Z", admission_ref: "agent-gym-replay-admission://regression/one" });
+  assert.equal(validateAgentGymRegressionReplayAdmission(admission).decision, "admitted");
+  const blocked = admitAgentGymRegressionReplay(comparison, evaluation, {
+    maximum_latency_increase_ms: 25, minimum_challenger_score: 0.9, minimum_score_delta: 0.2,
+    policy_ref: "agent-gym-admission-policy://regression/strict", schema_version: "agent-gym-regression-replay-admission-policy/v1",
+  }, { admitted_at: "2026-08-12T13:05:00.000Z", admission_ref: "agent-gym-replay-admission://regression/blocked" });
+  assert.deepEqual(blocked.blocker_codes, ["challenger_score_below_minimum", "score_delta_below_minimum"]);
+  assert.equal(blocked.decision, "blocked");
 });

--- a/apps/slack-companion/test/agent-gym-regression-execution.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-execution.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { digestAgentGymJson } from "../src/agent-gym/canonical-json.js";
+import { planAgentGymRegressionReplay, validateAgentGymRegressionReplayPlan } from "../src/agent-gym/regression-replay-plan.js";
+import type { AgentGymRegressionReplayRequestV1 } from "../src/agent-gym/regression-replay-request.js";
+
+const sha = (value: string): string => `sha256:${value.repeat(64).slice(0, 64)}`;
+
+function request(): AgentGymRegressionReplayRequestV1 {
+  const body = {
+    augmentation_digest: sha("a"), baseline_candidate_ref: "agent-gym-candidate://baseline/one",
+    case_digest: sha("b"), case_ref: "agent-gym-case://regression/one",
+    challenger_candidate_ref: "agent-gym-candidate://challenger/one", fixture_receipt_digest: sha("c"),
+    maximum_model_calls: 2, planned_at: "2026-08-12T13:00:00.000Z",
+    request_ref: "agent-gym-replay-request://regression/one",
+    schema_version: "agent-gym-regression-replay-request/v1" as const,
+  };
+  return { ...body, request_digest: digestAgentGymJson(body) };
+}
+
+test("seals an exact paired regression replay plan", () => {
+  const plan = planAgentGymRegressionReplay(request(), {
+    baseline_invocation_ref: "agent-gym-invocation://baseline/one",
+    challenger_invocation_ref: "agent-gym-invocation://challenger/one",
+    plan_ref: "agent-gym-replay-plan://regression/one", planned_at: "2026-08-12T13:01:00.000Z",
+  });
+  assert.equal(validateAgentGymRegressionReplayPlan(plan).replay_request_digest, request().request_digest);
+  assert.throws(() => validateAgentGymRegressionReplayPlan({ ...plan, maximum_model_calls: 3 }));
+});

--- a/apps/slack-companion/test/agent-gym-regression-execution.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-execution.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { digestAgentGymJson } from "../src/agent-gym/canonical-json.js";
 import { planAgentGymRegressionReplay, validateAgentGymRegressionReplayPlan } from "../src/agent-gym/regression-replay-plan.js";
+import { recordAgentGymRegressionReplayResult, validateAgentGymRegressionReplayResult } from "../src/agent-gym/regression-replay-result.js";
 import type { AgentGymRegressionReplayRequestV1 } from "../src/agent-gym/regression-replay-request.js";
 
 const sha = (value: string): string => `sha256:${value.repeat(64).slice(0, 64)}`;
@@ -26,4 +27,18 @@ test("seals an exact paired regression replay plan", () => {
   });
   assert.equal(validateAgentGymRegressionReplayPlan(plan).replay_request_digest, request().request_digest);
   assert.throws(() => validateAgentGymRegressionReplayPlan({ ...plan, maximum_model_calls: 3 }));
+});
+
+test("records paired replay evidence without retaining model output", () => {
+  const plan = planAgentGymRegressionReplay(request(), {
+    baseline_invocation_ref: "agent-gym-invocation://baseline/one", challenger_invocation_ref: "agent-gym-invocation://challenger/one",
+    plan_ref: "agent-gym-replay-plan://regression/one", planned_at: "2026-08-12T13:01:00.000Z",
+  });
+  const result = recordAgentGymRegressionReplayResult(plan, {
+    baseline: { candidate_ref: "agent-gym-candidate://baseline/one", invocation_receipt_digest: sha("d"), invocation_ref: plan.baseline_invocation_ref, latency_ms: 120, response_digest: sha("e"), total_tokens: 80 },
+    challenger: { candidate_ref: "agent-gym-candidate://challenger/one", invocation_receipt_digest: sha("f"), invocation_ref: plan.challenger_invocation_ref, latency_ms: 100, response_digest: sha("1"), total_tokens: 72 },
+    completed_at: "2026-08-12T13:02:00.000Z", result_ref: "agent-gym-replay-result://regression/one",
+  });
+  assert.equal(validateAgentGymRegressionReplayResult(result).challenger.total_tokens, 72);
+  assert.throws(() => recordAgentGymRegressionReplayResult(plan, { ...result, challenger: { ...result.challenger, invocation_ref: plan.baseline_invocation_ref } }));
 });

--- a/apps/slack-companion/test/agent-gym-regression-execution.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-execution.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { digestAgentGymJson } from "../src/agent-gym/canonical-json.js";
 import { planAgentGymRegressionReplay, validateAgentGymRegressionReplayPlan } from "../src/agent-gym/regression-replay-plan.js";
 import { recordAgentGymRegressionReplayResult, validateAgentGymRegressionReplayResult } from "../src/agent-gym/regression-replay-result.js";
+import { evaluateAgentGymRegressionReplay, validateAgentGymRegressionReplayEvaluation } from "../src/agent-gym/regression-replay-evaluation.js";
 import type { AgentGymRegressionReplayRequestV1 } from "../src/agent-gym/regression-replay-request.js";
 
 const sha = (value: string): string => `sha256:${value.repeat(64).slice(0, 64)}`;
@@ -17,6 +18,15 @@ function request(): AgentGymRegressionReplayRequestV1 {
     schema_version: "agent-gym-regression-replay-request/v1" as const,
   };
   return { ...body, request_digest: digestAgentGymJson(body) };
+}
+
+function replayResult() {
+  const plan = planAgentGymRegressionReplay(request(), { baseline_invocation_ref: "agent-gym-invocation://baseline/one", challenger_invocation_ref: "agent-gym-invocation://challenger/one", plan_ref: "agent-gym-replay-plan://regression/one", planned_at: "2026-08-12T13:01:00.000Z" });
+  return recordAgentGymRegressionReplayResult(plan, {
+    baseline: { candidate_ref: "agent-gym-candidate://baseline/one", invocation_receipt_digest: sha("d"), invocation_ref: plan.baseline_invocation_ref, latency_ms: 120, response_digest: sha("e"), total_tokens: 80 },
+    challenger: { candidate_ref: "agent-gym-candidate://challenger/one", invocation_receipt_digest: sha("f"), invocation_ref: plan.challenger_invocation_ref, latency_ms: 100, response_digest: sha("1"), total_tokens: 72 },
+    completed_at: "2026-08-12T13:02:00.000Z", result_ref: "agent-gym-replay-result://regression/one",
+  });
 }
 
 test("seals an exact paired regression replay plan", () => {
@@ -41,4 +51,15 @@ test("records paired replay evidence without retaining model output", () => {
   });
   assert.equal(validateAgentGymRegressionReplayResult(result).challenger.total_tokens, 72);
   assert.throws(() => recordAgentGymRegressionReplayResult(plan, { ...result, challenger: { ...result.challenger, invocation_ref: plan.baseline_invocation_ref } }));
+});
+
+test("binds independent scores to both replay candidates", () => {
+  const result = replayResult();
+  const evaluation = evaluateAgentGymRegressionReplay(result, {
+    baseline: { blocker_codes: [], candidate_ref: result.baseline.candidate_ref, evidence_digest: sha("2"), safety_passed: true, score: 0.72 },
+    challenger: { blocker_codes: [], candidate_ref: result.challenger.candidate_ref, evidence_digest: sha("3"), safety_passed: true, score: 0.86 },
+    evaluated_at: "2026-08-12T13:03:00.000Z", evaluation_ref: "agent-gym-replay-evaluation://regression/one",
+  });
+  assert.equal(validateAgentGymRegressionReplayEvaluation(evaluation).challenger.score, 0.86);
+  assert.throws(() => evaluateAgentGymRegressionReplay(result, { ...evaluation, challenger: { ...evaluation.challenger, safety_passed: true, blocker_codes: ["unsafe"] } }));
 });


### PR DESCRIPTION
## Summary
- seal paired regression replay plans
- record response-bound replay evidence without retaining model output
- bind independent evaluator scores and deterministic comparisons
- block challenger admission when safety, quality, regression, or latency gates fail

## Validation
- DDESK `npm run typecheck`
- DDESK `npm test` (722 tests, 62 suites, zero failures)

No deployment change: these are provider-neutral portable contracts.