### PR TITLE
feat(slack): run regression replays through model ports

### DIFF
--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -66,6 +66,7 @@ export * from "./regression-replay-admission.js";
 export * from "./regression-replay-request-pair.js";
 export * from "./regression-replay-parity.js";
 export * from "./regression-replay-execution.js";
+export * from "./regression-replay-runtime-result.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -64,6 +64,7 @@ export * from "./regression-replay-evaluation.js";
 export * from "./regression-replay-comparison.js";
 export * from "./regression-replay-admission.js";
 export * from "./regression-replay-request-pair.js";
+export * from "./regression-replay-parity.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -65,6 +65,7 @@ export * from "./regression-replay-comparison.js";
 export * from "./regression-replay-admission.js";
 export * from "./regression-replay-request-pair.js";
 export * from "./regression-replay-parity.js";
+export * from "./regression-replay-execution.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -63,6 +63,7 @@ export * from "./regression-replay-result.js";
 export * from "./regression-replay-evaluation.js";
 export * from "./regression-replay-comparison.js";
 export * from "./regression-replay-admission.js";
+export * from "./regression-replay-request-pair.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/regression-replay-execution.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-execution.ts
@@ -1,0 +1,44 @@
+import { AgentGymContractError } from "./contract-error.js";
+import { runAgentGymModelBatch, type AgentGymModelBatchResultV1 } from "./model-batch.js";
+import type { AgentGymModelBudgetV1 } from "./model-budget.js";
+import { agentGymModelRequestDigest, validateAgentGymModelRequest, type AgentGymModelInvocationRequestV1, type AgentGymModelPort } from "./model-runtime.js";
+import { validateAgentGymRegressionReplayParity, type AgentGymRegressionReplayParityV1 } from "./regression-replay-parity.js";
+import { validateAgentGymRegressionReplayPlan, type AgentGymRegressionReplayPlanV1 } from "./regression-replay-plan.js";
+import { validateAgentGymRegressionReplayRequestPair, type AgentGymRegressionReplayRequestPairV1 } from "./regression-replay-request-pair.js";
+
+export interface AgentGymRegressionReplayExecutionV1 {
+  readonly batch: AgentGymModelBatchResultV1;
+  readonly pair_digest: string;
+  readonly parity_report_digest: string;
+  readonly plan_digest: string;
+  readonly schema_version: "agent-gym-regression-replay-execution/v1";
+}
+
+/** Executes one fair paired replay through the provider-neutral model port. */
+export async function executeAgentGymRegressionReplay(
+  planValue: AgentGymRegressionReplayPlanV1,
+  pairValue: AgentGymRegressionReplayRequestPairV1,
+  parityValue: AgentGymRegressionReplayParityV1,
+  baselineValue: AgentGymModelInvocationRequestV1,
+  challengerValue: AgentGymModelInvocationRequestV1,
+  budget: AgentGymModelBudgetV1,
+  model: AgentGymModelPort,
+  evaluatedAt: string,
+  batchRef: string,
+): Promise<AgentGymRegressionReplayExecutionV1> {
+  const plan = validateAgentGymRegressionReplayPlan(planValue);
+  const pair = validateAgentGymRegressionReplayRequestPair(pairValue);
+  const parity = validateAgentGymRegressionReplayParity(parityValue);
+  const baseline = validateAgentGymModelRequest(baselineValue);
+  const challenger = validateAgentGymModelRequest(challengerValue);
+  if (!parity.passed || pair.plan_digest !== plan.plan_digest || parity.pair_digest !== pair.pair_digest
+    || agentGymModelRequestDigest(baseline) !== pair.baseline_request_digest
+    || agentGymModelRequestDigest(challenger) !== pair.challenger_request_digest) invalid();
+  const batch = await runAgentGymModelBatch(batchRef, [baseline, challenger], budget, model, evaluatedAt);
+  return Object.freeze({
+    batch, pair_digest: pair.pair_digest, parity_report_digest: parity.report_digest,
+    plan_digest: plan.plan_digest, schema_version: "agent-gym-regression-replay-execution/v1",
+  });
+}
+
+function invalid(): never { throw new AgentGymContractError("Agent gym regression replay execution is invalid."); }

--- a/apps/slack-companion/src/agent-gym/regression-replay-execution.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-execution.ts
@@ -1,12 +1,13 @@
 import { AgentGymContractError } from "./contract-error.js";
 import { runAgentGymModelBatch, type AgentGymModelBatchResultV1 } from "./model-batch.js";
-import type { AgentGymModelBudgetV1 } from "./model-budget.js";
+import { evaluateAgentGymModelBudget, type AgentGymModelBudgetEvaluationV1, type AgentGymModelBudgetV1 } from "./model-budget.js";
 import { agentGymModelRequestDigest, validateAgentGymModelRequest, type AgentGymModelInvocationRequestV1, type AgentGymModelPort } from "./model-runtime.js";
 import { validateAgentGymRegressionReplayParity, type AgentGymRegressionReplayParityV1 } from "./regression-replay-parity.js";
 import { validateAgentGymRegressionReplayPlan, type AgentGymRegressionReplayPlanV1 } from "./regression-replay-plan.js";
 import { validateAgentGymRegressionReplayRequestPair, type AgentGymRegressionReplayRequestPairV1 } from "./regression-replay-request-pair.js";
 
 export interface AgentGymRegressionReplayExecutionV1 {
+  readonly aggregate_budget: AgentGymModelBudgetEvaluationV1;
   readonly batch: AgentGymModelBatchResultV1;
   readonly pair_digest: string;
   readonly parity_report_digest: string;
@@ -32,11 +33,14 @@ export async function executeAgentGymRegressionReplay(
   const baseline = validateAgentGymModelRequest(baselineValue);
   const challenger = validateAgentGymModelRequest(challengerValue);
   if (!parity.passed || pair.plan_digest !== plan.plan_digest || parity.pair_digest !== pair.pair_digest
+    || !Number.isSafeInteger(budget.max_invocations) || budget.max_invocations < 2
+    || budget.max_invocations > plan.maximum_model_calls
     || agentGymModelRequestDigest(baseline) !== pair.baseline_request_digest
     || agentGymModelRequestDigest(challenger) !== pair.challenger_request_digest) invalid();
   const batch = await runAgentGymModelBatch(batchRef, [baseline, challenger], budget, model, evaluatedAt);
+  const aggregateBudget = evaluateAgentGymModelBudget(budget, batch.results.map((result) => result.response));
   return Object.freeze({
-    batch, pair_digest: pair.pair_digest, parity_report_digest: parity.report_digest,
+    aggregate_budget: aggregateBudget, batch, pair_digest: pair.pair_digest, parity_report_digest: parity.report_digest,
     plan_digest: plan.plan_digest, schema_version: "agent-gym-regression-replay-execution/v1",
   });
 }

--- a/apps/slack-companion/src/agent-gym/regression-replay-parity.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-parity.ts
@@ -1,0 +1,56 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { validateAgentGymRegressionReplayRequestPair, type AgentGymRegressionReplayRequestPairV1 } from "./regression-replay-request-pair.js";
+
+export interface AgentGymRegressionReplayParityV1 {
+  readonly blocker_codes: readonly string[];
+  readonly checked_at: string;
+  readonly max_output_tokens_equal: boolean;
+  readonly messages_equal: boolean;
+  readonly pair_digest: string;
+  readonly passed: boolean;
+  readonly report_digest: string;
+  readonly report_ref: string;
+  readonly schema_version: "agent-gym-regression-replay-parity/v1";
+}
+
+/** Proves both candidates receive the same case messages and output allowance. */
+export function checkAgentGymRegressionReplayParity(
+  pairValue: AgentGymRegressionReplayRequestPairV1,
+  input: Pick<AgentGymRegressionReplayParityV1, "checked_at" | "report_ref">,
+): AgentGymRegressionReplayParityV1 {
+  const pair = validateAgentGymRegressionReplayRequestPair(pairValue);
+  reference(input.report_ref); timestamp(input.checked_at);
+  const messagesEqual = pair.baseline_messages_digest === pair.challenger_messages_digest;
+  const maxOutputTokensEqual = pair.baseline_max_output_tokens === pair.challenger_max_output_tokens;
+  const blockerCodes = Object.freeze([
+    ...(messagesEqual ? [] : ["case_messages_differ"]),
+    ...(maxOutputTokensEqual ? [] : ["max_output_tokens_differ"]),
+  ]);
+  const body = {
+    blocker_codes: blockerCodes, checked_at: input.checked_at, max_output_tokens_equal: maxOutputTokensEqual,
+    messages_equal: messagesEqual, pair_digest: pair.pair_digest, passed: blockerCodes.length === 0,
+    report_ref: input.report_ref, schema_version: "agent-gym-regression-replay-parity/v1" as const,
+  };
+  return Object.freeze({ ...body, report_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRegressionReplayParity(value: AgentGymRegressionReplayParityV1): AgentGymRegressionReplayParityV1 {
+  if (value.schema_version !== "agent-gym-regression-replay-parity/v1") invalid();
+  reference(value.report_ref); timestamp(value.checked_at); digest(value.pair_digest); digest(value.report_digest);
+  if (!Array.isArray(value.blocker_codes) || new Set(value.blocker_codes).size !== value.blocker_codes.length
+    || value.blocker_codes.some((code) => !["case_messages_differ", "max_output_tokens_differ"].includes(code))
+    || value.passed !== (value.blocker_codes.length === 0)
+    || value.messages_equal !== !value.blocker_codes.includes("case_messages_differ")
+    || value.max_output_tokens_equal !== !value.blocker_codes.includes("max_output_tokens_differ")) invalid();
+  const body = { blocker_codes: value.blocker_codes, checked_at: value.checked_at,
+    max_output_tokens_equal: value.max_output_tokens_equal, messages_equal: value.messages_equal,
+    pair_digest: value.pair_digest, passed: value.passed, report_ref: value.report_ref, schema_version: value.schema_version };
+  if (digestAgentGymJson(body) !== value.report_digest) invalid();
+  return Object.freeze({ ...value, blocker_codes: Object.freeze([...value.blocker_codes]) });
+}
+
+function reference(value: string): void { if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid(); }
+function timestamp(value: string): void { if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid(); }
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym regression replay parity is invalid."); }

--- a/apps/slack-companion/src/agent-gym/regression-replay-request-pair.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-request-pair.ts
@@ -6,9 +6,11 @@ import { validateAgentGymRegressionReplayPlan, type AgentGymRegressionReplayPlan
 export interface AgentGymRegressionReplayRequestPairV1 {
   readonly baseline_candidate_ref: string;
   readonly baseline_messages_digest: string;
+  readonly baseline_max_output_tokens: number;
   readonly baseline_request_digest: string;
   readonly challenger_candidate_ref: string;
   readonly challenger_messages_digest: string;
+  readonly challenger_max_output_tokens: number;
   readonly challenger_request_digest: string;
   readonly pair_digest: string;
   readonly pair_ref: string;
@@ -33,9 +35,11 @@ export function bindAgentGymRegressionReplayRequests(
   const body = {
     baseline_candidate_ref: baseline.candidate_ref,
     baseline_messages_digest: messagesDigest(baseline),
+    baseline_max_output_tokens: baseline.max_output_tokens,
     baseline_request_digest: agentGymModelRequestDigest(baseline),
     challenger_candidate_ref: challenger.candidate_ref,
     challenger_messages_digest: messagesDigest(challenger),
+    challenger_max_output_tokens: challenger.max_output_tokens,
     challenger_request_digest: agentGymModelRequestDigest(challenger),
     pair_ref: pairRef,
     plan_digest: plan.plan_digest,
@@ -52,7 +56,10 @@ export function validateAgentGymRegressionReplayRequestPair(
   for (const item of [value.baseline_messages_digest, value.baseline_request_digest,
     value.challenger_messages_digest, value.challenger_request_digest, value.pair_digest, value.plan_digest]) digest(item);
   if (value.baseline_candidate_ref === value.challenger_candidate_ref
-    || value.baseline_request_digest === value.challenger_request_digest) invalid();
+    || value.baseline_request_digest === value.challenger_request_digest
+    || !Number.isSafeInteger(value.baseline_max_output_tokens) || value.baseline_max_output_tokens < 1
+    || value.baseline_max_output_tokens > 32_768 || !Number.isSafeInteger(value.challenger_max_output_tokens)
+    || value.challenger_max_output_tokens < 1 || value.challenger_max_output_tokens > 32_768) invalid();
   const { pair_digest: _digest, ...body } = value;
   if (digestAgentGymJson(body) !== value.pair_digest) invalid();
   return Object.freeze({ ...value });

--- a/apps/slack-companion/src/agent-gym/regression-replay-request-pair.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-request-pair.ts
@@ -1,0 +1,66 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { agentGymModelRequestDigest, validateAgentGymModelRequest, type AgentGymModelInvocationRequestV1 } from "./model-runtime.js";
+import { validateAgentGymRegressionReplayPlan, type AgentGymRegressionReplayPlanV1 } from "./regression-replay-plan.js";
+
+export interface AgentGymRegressionReplayRequestPairV1 {
+  readonly baseline_candidate_ref: string;
+  readonly baseline_messages_digest: string;
+  readonly baseline_request_digest: string;
+  readonly challenger_candidate_ref: string;
+  readonly challenger_messages_digest: string;
+  readonly challenger_request_digest: string;
+  readonly pair_digest: string;
+  readonly pair_ref: string;
+  readonly plan_digest: string;
+  readonly schema_version: "agent-gym-regression-replay-request-pair/v1";
+}
+
+/** Binds the exact two model requests authorized by a regression replay plan. */
+export function bindAgentGymRegressionReplayRequests(
+  planValue: AgentGymRegressionReplayPlanV1,
+  baselineValue: AgentGymModelInvocationRequestV1,
+  challengerValue: AgentGymModelInvocationRequestV1,
+  pairRef: string,
+): AgentGymRegressionReplayRequestPairV1 {
+  const plan = validateAgentGymRegressionReplayPlan(planValue);
+  const baseline = validateAgentGymModelRequest(baselineValue);
+  const challenger = validateAgentGymModelRequest(challengerValue);
+  reference(pairRef);
+  if (baseline.invocation_ref !== plan.baseline_invocation_ref
+    || challenger.invocation_ref !== plan.challenger_invocation_ref
+    || baseline.candidate_ref === challenger.candidate_ref) invalid();
+  const body = {
+    baseline_candidate_ref: baseline.candidate_ref,
+    baseline_messages_digest: messagesDigest(baseline),
+    baseline_request_digest: agentGymModelRequestDigest(baseline),
+    challenger_candidate_ref: challenger.candidate_ref,
+    challenger_messages_digest: messagesDigest(challenger),
+    challenger_request_digest: agentGymModelRequestDigest(challenger),
+    pair_ref: pairRef,
+    plan_digest: plan.plan_digest,
+    schema_version: "agent-gym-regression-replay-request-pair/v1" as const,
+  };
+  return Object.freeze({ ...body, pair_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRegressionReplayRequestPair(
+  value: AgentGymRegressionReplayRequestPairV1,
+): AgentGymRegressionReplayRequestPairV1 {
+  if (value.schema_version !== "agent-gym-regression-replay-request-pair/v1") invalid();
+  for (const ref of [value.baseline_candidate_ref, value.challenger_candidate_ref, value.pair_ref]) reference(ref);
+  for (const item of [value.baseline_messages_digest, value.baseline_request_digest,
+    value.challenger_messages_digest, value.challenger_request_digest, value.pair_digest, value.plan_digest]) digest(item);
+  if (value.baseline_candidate_ref === value.challenger_candidate_ref
+    || value.baseline_request_digest === value.challenger_request_digest) invalid();
+  const { pair_digest: _digest, ...body } = value;
+  if (digestAgentGymJson(body) !== value.pair_digest) invalid();
+  return Object.freeze({ ...value });
+}
+
+function messagesDigest(request: AgentGymModelInvocationRequestV1): string {
+  return digestAgentGymJson(request.messages.map((message) => ({ role: message.role, text: message.text })));
+}
+function reference(value: string): void { if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid(); }
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym regression replay request pair is invalid."); }

--- a/apps/slack-companion/src/agent-gym/regression-replay-runtime-result.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-runtime-result.ts
@@ -1,0 +1,55 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import type { AgentGymModelInvocationReceiptV1 } from "./model-invocation.js";
+import { validateAgentGymRegressionReplayPlan, type AgentGymRegressionReplayPlanV1 } from "./regression-replay-plan.js";
+import { recordAgentGymRegressionReplayResult, type AgentGymRegressionReplayResultV1 } from "./regression-replay-result.js";
+import type { AgentGymRegressionReplayExecutionV1 } from "./regression-replay-execution.js";
+
+/** Converts a successful transient model execution into a text-free durable result. */
+export function recordExecutedAgentGymRegressionReplay(
+  planValue: AgentGymRegressionReplayPlanV1,
+  execution: AgentGymRegressionReplayExecutionV1,
+  input: Pick<AgentGymRegressionReplayResultV1, "completed_at" | "result_ref">,
+): AgentGymRegressionReplayResultV1 {
+  const plan = validateAgentGymRegressionReplayPlan(planValue);
+  if (execution.schema_version !== "agent-gym-regression-replay-execution/v1"
+    || execution.plan_digest !== plan.plan_digest || !execution.aggregate_budget.allowed
+    || execution.batch.results.length !== 2 || execution.batch.ledger.invocation_count !== 2
+    || execution.batch.ledger.blocked_invocation_count !== 0) invalid();
+  const baseline = execution.batch.results[0]!;
+  const challenger = execution.batch.results[1]!;
+  if (baseline.receipt.invocation_ref !== plan.baseline_invocation_ref
+    || challenger.receipt.invocation_ref !== plan.challenger_invocation_ref
+    || !baseline.receipt.budget.allowed || !challenger.receipt.budget.allowed) invalid();
+  return recordAgentGymRegressionReplayResult(plan, {
+    baseline: candidateResult(baseline.receipt), challenger: candidateResult(challenger.receipt),
+    completed_at: input.completed_at, result_ref: input.result_ref,
+  });
+}
+
+function candidateResult(receipt: AgentGymModelInvocationReceiptV1) {
+  return {
+    candidate_ref: receipt.candidate_ref, invocation_receipt_digest: receiptDigest(receipt),
+    invocation_ref: receipt.invocation_ref, latency_ms: receipt.latency_ms,
+    response_digest: receipt.response_digest, total_tokens: receipt.token_usage.total_tokens,
+  };
+}
+
+function receiptDigest(receipt: AgentGymModelInvocationReceiptV1): string {
+  const body = {
+    budget: { allowed: receipt.budget.allowed, blockers: [...receipt.budget.blockers],
+      input_tokens: receipt.budget.input_tokens, invocation_count: receipt.budget.invocation_count,
+      latency_ms: receipt.budget.latency_ms, output_tokens: receipt.budget.output_tokens,
+      schema_version: receipt.budget.schema_version, total_tokens: receipt.budget.total_tokens },
+    candidate_ref: receipt.candidate_ref, evaluated_at: receipt.evaluated_at,
+    invocation_ref: receipt.invocation_ref, latency_ms: receipt.latency_ms, model_id: receipt.model_id,
+    ...(receipt.provider_request_ref === undefined ? {} : { provider_request_ref: receipt.provider_request_ref }),
+    request_digest: receipt.request_digest, response_digest: receipt.response_digest,
+    response_source: receipt.response_source, schema_version: receipt.schema_version,
+    stop_reason: receipt.stop_reason, token_usage: { input_tokens: receipt.token_usage.input_tokens,
+      output_tokens: receipt.token_usage.output_tokens, total_tokens: receipt.token_usage.total_tokens },
+  };
+  return digestAgentGymJson(body);
+}
+
+function invalid(): never { throw new AgentGymContractError("Agent gym executed regression replay result is invalid."); }

--- a/apps/slack-companion/test/agent-gym-regression-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-runtime.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { bindAgentGymRegressionReplayRequests, validateAgentGymRegressionReplayRequestPair } from "../src/agent-gym/regression-replay-request-pair.js";
+import { checkAgentGymRegressionReplayParity, validateAgentGymRegressionReplayParity } from "../src/agent-gym/regression-replay-parity.js";
 import type { AgentGymRegressionReplayPlanV1 } from "../src/agent-gym/regression-replay-plan.js";
 import { digestAgentGymJson } from "../src/agent-gym/canonical-json.js";
 
@@ -36,4 +37,17 @@ test("rejects a request outside the replay plan", () => {
   assert.throws(() => bindAgentGymRegressionReplayRequests(plan(),
     { ...request("baseline"), invocation_ref: "agent-gym-invocation://baseline/other" }, request("challenger"),
     "agent-gym-request-pair://regression/invalid"));
+});
+
+test("requires both candidates to receive the same case and output allowance", () => {
+  const pair = bindAgentGymRegressionReplayRequests(plan(), request("baseline"), request("challenger"), "agent-gym-request-pair://regression/one");
+  const parity = checkAgentGymRegressionReplayParity(pair, { checked_at: "2026-08-12T13:02:00.000Z", report_ref: "agent-gym-parity://regression/one" });
+  assert.equal(validateAgentGymRegressionReplayParity(parity).passed, true);
+  const changed = bindAgentGymRegressionReplayRequests(plan(), request("baseline"), {
+    ...request("challenger"), max_output_tokens: 512,
+    messages: [{ role: "user" as const, text: "Use different evidence." }],
+  }, "agent-gym-request-pair://regression/changed");
+  assert.deepEqual(checkAgentGymRegressionReplayParity(changed, {
+    checked_at: "2026-08-12T13:02:00.000Z", report_ref: "agent-gym-parity://regression/changed",
+  }).blocker_codes, ["case_messages_differ", "max_output_tokens_differ"]);
 });

--- a/apps/slack-companion/test/agent-gym-regression-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-runtime.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { bindAgentGymRegressionReplayRequests, validateAgentGymRegressionReplayRequestPair } from "../src/agent-gym/regression-replay-request-pair.js";
+import type { AgentGymRegressionReplayPlanV1 } from "../src/agent-gym/regression-replay-plan.js";
+import { digestAgentGymJson } from "../src/agent-gym/canonical-json.js";
+
+const sha = (value: string): string => `sha256:${value.repeat(64).slice(0, 64)}`;
+
+function plan(): AgentGymRegressionReplayPlanV1 {
+  const body = {
+    baseline_invocation_ref: "agent-gym-invocation://baseline/one", case_digest: sha("a"),
+    case_ref: "agent-gym-case://regression/one", challenger_invocation_ref: "agent-gym-invocation://challenger/one",
+    maximum_model_calls: 2, plan_ref: "agent-gym-replay-plan://regression/one",
+    planned_at: "2026-08-12T13:01:00.000Z", replay_request_digest: sha("b"),
+    schema_version: "agent-gym-regression-replay-plan/v1" as const,
+  };
+  return { ...body, plan_digest: digestAgentGymJson(body) };
+}
+
+function request(role: "baseline" | "challenger") {
+  return {
+    candidate_ref: `agent-gym-candidate://${role}/one`, invocation_ref: `agent-gym-invocation://${role}/one`,
+    max_output_tokens: 256, messages: [{ role: "user" as const, text: "Summarize the regression evidence." }],
+    model_id: role === "baseline" ? "model-baseline" : "model-challenger",
+    schema_version: "agent-gym-model-request/v1" as const, system_prompt: `You are the ${role} candidate.`,
+  };
+}
+
+test("binds the exact two requests authorized by a replay plan", () => {
+  const pair = bindAgentGymRegressionReplayRequests(plan(), request("baseline"), request("challenger"), "agent-gym-request-pair://regression/one");
+  assert.equal(validateAgentGymRegressionReplayRequestPair(pair).plan_digest, plan().plan_digest);
+  assert.notEqual(pair.baseline_request_digest, pair.challenger_request_digest);
+});
+
+test("rejects a request outside the replay plan", () => {
+  assert.throws(() => bindAgentGymRegressionReplayRequests(plan(),
+    { ...request("baseline"), invocation_ref: "agent-gym-invocation://baseline/other" }, request("challenger"),
+    "agent-gym-request-pair://regression/invalid"));
+});

--- a/apps/slack-companion/test/agent-gym-regression-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-runtime.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { bindAgentGymRegressionReplayRequests, validateAgentGymRegressionReplayRequestPair } from "../src/agent-gym/regression-replay-request-pair.js";
 import { checkAgentGymRegressionReplayParity, validateAgentGymRegressionReplayParity } from "../src/agent-gym/regression-replay-parity.js";
 import { executeAgentGymRegressionReplay } from "../src/agent-gym/regression-replay-execution.js";
+import { recordExecutedAgentGymRegressionReplay } from "../src/agent-gym/regression-replay-runtime-result.js";
 import { agentGymModelRequestDigest } from "../src/agent-gym/model-runtime.js";
 import type { AgentGymRegressionReplayPlanV1 } from "../src/agent-gym/regression-replay-plan.js";
 import { digestAgentGymJson } from "../src/agent-gym/canonical-json.js";
@@ -40,6 +41,20 @@ const budget = {
   max_input_tokens: 1_000, max_invocations: 2, max_latency_ms: 1_000, max_output_tokens: 1_000,
   max_total_tokens: 2_000, schema_version: "agent-gym-model-budget/v1" as const,
 };
+
+async function runExecution(maxTotalTokens = 2_000) {
+  const { baseline, challenger, pair, parity } = pairAndParity();
+  const execution = await executeAgentGymRegressionReplay(plan(), pair, parity, baseline, challenger,
+    { ...budget, max_total_tokens: maxTotalTokens }, {
+      async invoke(modelRequest) {
+        return { invocation_ref: modelRequest.invocation_ref, latency_ms: 10, model_id: modelRequest.model_id,
+          output_text: `answer:${modelRequest.candidate_ref}`, request_digest: agentGymModelRequestDigest(modelRequest),
+          response_source: "recorded" as const, schema_version: "agent-gym-model-response/v1" as const,
+          stop_reason: "end_turn" as const, token_usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 } };
+      },
+    }, "2026-08-12T13:03:00.000Z", "agent-gym-model-batch://regression/runtime");
+  return execution;
+}
 
 test("binds the exact two requests authorized by a replay plan", () => {
   const pair = bindAgentGymRegressionReplayRequests(plan(), request("baseline"), request("challenger"), "agent-gym-request-pair://regression/one");
@@ -96,4 +111,20 @@ test("retains aggregate budget failure across otherwise allowed calls", async ()
     }, "2026-08-12T13:03:00.000Z", "agent-gym-model-batch://regression/budget");
   assert.equal(execution.aggregate_budget.allowed, false);
   assert.deepEqual(execution.aggregate_budget.blockers, ["model_total_tokens_exceeded"]);
+});
+
+test("records successful execution as text-free durable replay evidence", async () => {
+  const result = recordExecutedAgentGymRegressionReplay(plan(), await runExecution(), {
+    completed_at: "2026-08-12T13:04:00.000Z", result_ref: "agent-gym-replay-result://regression/runtime",
+  });
+  assert.equal(result.baseline.total_tokens, 15);
+  assert.equal(result.challenger.total_tokens, 15);
+  assert.equal(JSON.stringify(result).includes("answer:"), false);
+});
+
+test("does not record replay results that exceed the aggregate budget", async () => {
+  const execution = await runExecution(20);
+  assert.throws(() => recordExecutedAgentGymRegressionReplay(plan(), execution, {
+    completed_at: "2026-08-12T13:04:00.000Z", result_ref: "agent-gym-replay-result://regression/budget",
+  }), /executed regression replay result is invalid/u);
 });

--- a/apps/slack-companion/test/agent-gym-regression-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-runtime.test.ts
@@ -80,4 +80,20 @@ test("executes the exact pair through one provider-neutral model port", async ()
   }, "2026-08-12T13:03:00.000Z", "agent-gym-model-batch://regression/one");
   assert.deepEqual(seen, [baseline.invocation_ref, challenger.invocation_ref]);
   assert.equal(execution.batch.ledger.invocation_count, 2);
+  assert.equal(execution.aggregate_budget.allowed, true);
+});
+
+test("retains aggregate budget failure across otherwise allowed calls", async () => {
+  const { baseline, challenger, pair, parity } = pairAndParity();
+  const execution = await executeAgentGymRegressionReplay(plan(), pair, parity, baseline, challenger,
+    { ...budget, max_total_tokens: 20 }, {
+      async invoke(modelRequest) {
+        return { invocation_ref: modelRequest.invocation_ref, latency_ms: 10, model_id: modelRequest.model_id,
+          output_text: "bounded answer", request_digest: agentGymModelRequestDigest(modelRequest), response_source: "recorded",
+          schema_version: "agent-gym-model-response/v1", stop_reason: "end_turn",
+          token_usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 } };
+      },
+    }, "2026-08-12T13:03:00.000Z", "agent-gym-model-batch://regression/budget");
+  assert.equal(execution.aggregate_budget.allowed, false);
+  assert.deepEqual(execution.aggregate_budget.blockers, ["model_total_tokens_exceeded"]);
 });

--- a/apps/slack-companion/test/agent-gym-regression-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-runtime.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { bindAgentGymRegressionReplayRequests, validateAgentGymRegressionReplayRequestPair } from "../src/agent-gym/regression-replay-request-pair.js";
 import { checkAgentGymRegressionReplayParity, validateAgentGymRegressionReplayParity } from "../src/agent-gym/regression-replay-parity.js";
+import { executeAgentGymRegressionReplay } from "../src/agent-gym/regression-replay-execution.js";
+import { agentGymModelRequestDigest } from "../src/agent-gym/model-runtime.js";
 import type { AgentGymRegressionReplayPlanV1 } from "../src/agent-gym/regression-replay-plan.js";
 import { digestAgentGymJson } from "../src/agent-gym/canonical-json.js";
 
@@ -27,6 +29,18 @@ function request(role: "baseline" | "challenger") {
   };
 }
 
+function pairAndParity() {
+  const baseline = request("baseline"); const challenger = request("challenger");
+  const pair = bindAgentGymRegressionReplayRequests(plan(), baseline, challenger, "agent-gym-request-pair://regression/one");
+  const parity = checkAgentGymRegressionReplayParity(pair, { checked_at: "2026-08-12T13:02:00.000Z", report_ref: "agent-gym-parity://regression/one" });
+  return { baseline, challenger, pair, parity };
+}
+
+const budget = {
+  max_input_tokens: 1_000, max_invocations: 2, max_latency_ms: 1_000, max_output_tokens: 1_000,
+  max_total_tokens: 2_000, schema_version: "agent-gym-model-budget/v1" as const,
+};
+
 test("binds the exact two requests authorized by a replay plan", () => {
   const pair = bindAgentGymRegressionReplayRequests(plan(), request("baseline"), request("challenger"), "agent-gym-request-pair://regression/one");
   assert.equal(validateAgentGymRegressionReplayRequestPair(pair).plan_digest, plan().plan_digest);
@@ -50,4 +64,20 @@ test("requires both candidates to receive the same case and output allowance", (
   assert.deepEqual(checkAgentGymRegressionReplayParity(changed, {
     checked_at: "2026-08-12T13:02:00.000Z", report_ref: "agent-gym-parity://regression/changed",
   }).blocker_codes, ["case_messages_differ", "max_output_tokens_differ"]);
+});
+
+test("executes the exact pair through one provider-neutral model port", async () => {
+  const { baseline, challenger, pair, parity } = pairAndParity();
+  const seen: string[] = [];
+  const execution = await executeAgentGymRegressionReplay(plan(), pair, parity, baseline, challenger, budget, {
+    async invoke(modelRequest) {
+      seen.push(modelRequest.invocation_ref);
+      return { invocation_ref: modelRequest.invocation_ref, latency_ms: 10, model_id: modelRequest.model_id,
+        output_text: `answer:${modelRequest.candidate_ref}`, request_digest: agentGymModelRequestDigest(modelRequest),
+        response_source: "recorded", schema_version: "agent-gym-model-response/v1", stop_reason: "end_turn",
+        token_usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 } };
+    },
+  }, "2026-08-12T13:03:00.000Z", "agent-gym-model-batch://regression/one");
+  assert.deepEqual(seen, [baseline.invocation_ref, challenger.invocation_ref]);
+  assert.equal(execution.batch.ledger.invocation_count, 2);
 });


### PR DESCRIPTION
## Summary
- bind exact baseline and challenger model requests to replay plans
- require identical case messages and output allowances
- execute both requests through the provider-neutral model port
- enforce aggregate replay budgets
- record successful execution as text-free durable evidence

## Validation
- DDESK `npm run typecheck`
- DDESK `npm test` (729 tests, 62 suites, zero failures)

No deployment change: the runtime remains provider-neutral and the Bedrock adapter stays in the private host.