### PR TITLE
feat(slack): evaluate regression replays through bounded ports

### DIFF
--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -67,6 +67,7 @@ export * from "./regression-replay-request-pair.js";
 export * from "./regression-replay-parity.js";
 export * from "./regression-replay-execution.js";
 export * from "./regression-replay-runtime-result.js";
+export * from "./regression-replay-evaluator-binding.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -70,6 +70,7 @@ export * from "./regression-replay-runtime-result.js";
 export * from "./regression-replay-evaluator-binding.js";
 export * from "./regression-replay-evaluator-port.js";
 export * from "./regression-replay-evaluator-inputs.js";
+export * from "./regression-replay-evaluator-execution.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -69,6 +69,7 @@ export * from "./regression-replay-execution.js";
 export * from "./regression-replay-runtime-result.js";
 export * from "./regression-replay-evaluator-binding.js";
 export * from "./regression-replay-evaluator-port.js";
+export * from "./regression-replay-evaluator-inputs.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -68,6 +68,7 @@ export * from "./regression-replay-parity.js";
 export * from "./regression-replay-execution.js";
 export * from "./regression-replay-runtime-result.js";
 export * from "./regression-replay-evaluator-binding.js";
+export * from "./regression-replay-evaluator-port.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -71,6 +71,7 @@ export * from "./regression-replay-evaluator-binding.js";
 export * from "./regression-replay-evaluator-port.js";
 export * from "./regression-replay-evaluator-inputs.js";
 export * from "./regression-replay-evaluator-execution.js";
+export * from "./regression-replay-runtime-evaluation.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/regression-replay-evaluator-binding.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-evaluator-binding.ts
@@ -1,0 +1,88 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import type { AgentGymEvaluatorAdmissionDecisionV1 } from "./evaluator-admission.js";
+import { defineAgentGymEvaluatorManifest, type AgentGymEvaluatorManifestV1 } from "./evaluator-manifest.js";
+import { defineAgentGymEvaluatorRubric, type AgentGymEvaluatorRubricV1 } from "./evaluator-rubric.js";
+import { validateAgentGymRegressionReplayResult, type AgentGymRegressionReplayResultV1 } from "./regression-replay-result.js";
+
+export interface AgentGymRegressionReplayEvaluatorBindingV1 {
+  readonly baseline_candidate_ref: string;
+  readonly binding_digest: string;
+  readonly binding_ref: string;
+  readonly bound_at: string;
+  readonly challenger_candidate_ref: string;
+  readonly evaluator_admission_digest: string;
+  readonly evaluator_digests: readonly string[];
+  readonly replay_result_digest: string;
+  readonly rubric_digest: string;
+  readonly schema_version: "agent-gym-regression-replay-evaluator-binding/v1";
+}
+
+/** Binds replay evaluation to an admitted rubric and exact evaluator implementations. */
+export function bindAgentGymRegressionReplayEvaluators(
+  resultValue: AgentGymRegressionReplayResultV1,
+  rubricValue: AgentGymEvaluatorRubricV1,
+  evaluatorValues: readonly AgentGymEvaluatorManifestV1[],
+  admissionValue: AgentGymEvaluatorAdmissionDecisionV1,
+  input: Pick<AgentGymRegressionReplayEvaluatorBindingV1, "binding_ref" | "bound_at">,
+): AgentGymRegressionReplayEvaluatorBindingV1 {
+  const result = validateAgentGymRegressionReplayResult(resultValue);
+  const rubric = validateRubric(rubricValue);
+  const evaluatorDigests = validateEvaluators(evaluatorValues, rubric.rubric_digest);
+  validateAdmission(admissionValue);
+  reference(input.binding_ref); timestamp(input.bound_at);
+  if (!admissionValue.admitted || admissionValue.rubric_digest !== rubric.rubric_digest
+    || admissionValue.evaluator_digests.length !== evaluatorDigests.length
+    || admissionValue.evaluator_digests.some((value, index) => value !== evaluatorDigests[index])
+    || Date.parse(input.bound_at) < Date.parse(admissionValue.decided_at)) invalid();
+  const body = {
+    baseline_candidate_ref: result.baseline.candidate_ref, binding_ref: input.binding_ref, bound_at: input.bound_at,
+    challenger_candidate_ref: result.challenger.candidate_ref, evaluator_admission_digest: admissionValue.decision_digest,
+    evaluator_digests: evaluatorDigests, replay_result_digest: result.result_digest, rubric_digest: rubric.rubric_digest,
+    schema_version: "agent-gym-regression-replay-evaluator-binding/v1" as const,
+  };
+  return Object.freeze({ ...body, evaluator_digests: Object.freeze(evaluatorDigests), binding_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRegressionReplayEvaluatorBinding(value: AgentGymRegressionReplayEvaluatorBindingV1): AgentGymRegressionReplayEvaluatorBindingV1 {
+  if (value.schema_version !== "agent-gym-regression-replay-evaluator-binding/v1") invalid();
+  for (const ref of [value.baseline_candidate_ref, value.binding_ref, value.challenger_candidate_ref]) reference(ref);
+  timestamp(value.bound_at);
+  for (const item of [value.binding_digest, value.evaluator_admission_digest, value.replay_result_digest, value.rubric_digest]) digest(item);
+  if (value.baseline_candidate_ref === value.challenger_candidate_ref || !Array.isArray(value.evaluator_digests)
+    || value.evaluator_digests.length < 1 || value.evaluator_digests.length > 2
+    || new Set(value.evaluator_digests).size !== value.evaluator_digests.length) invalid();
+  value.evaluator_digests.forEach(digest);
+  const { binding_digest: _digest, ...body } = value;
+  if (digestAgentGymJson(body) !== value.binding_digest) invalid();
+  return Object.freeze({ ...value, evaluator_digests: Object.freeze([...value.evaluator_digests]) });
+}
+
+function validateRubric(value: AgentGymEvaluatorRubricV1) {
+  const expected = defineAgentGymEvaluatorRubric({ metrics: value.metrics, rubric_ref: value.rubric_ref, schema_version: value.schema_version });
+  if (expected.rubric_digest !== value.rubric_digest) invalid(); return expected;
+}
+function validateEvaluators(values: readonly AgentGymEvaluatorManifestV1[], rubricDigest: string): string[] {
+  if (!Array.isArray(values) || values.length < 1 || values.length > 2) invalid();
+  const kinds = new Set<string>();
+  const digests = values.map((value) => {
+    const expected = defineAgentGymEvaluatorManifest({ evaluator_kind: value.evaluator_kind, evaluator_ref: value.evaluator_ref,
+      implementation_digest: value.implementation_digest, ...(value.model === undefined ? {} : { model: value.model }),
+      output_schema_digest: value.output_schema_digest, rubric_digest: value.rubric_digest, schema_version: value.schema_version });
+    if (expected.evaluator_digest !== value.evaluator_digest || value.rubric_digest !== rubricDigest || kinds.has(value.evaluator_kind)) invalid();
+    kinds.add(value.evaluator_kind); return value.evaluator_digest;
+  }).sort();
+  return digests;
+}
+function validateAdmission(value: AgentGymEvaluatorAdmissionDecisionV1): void {
+  if (value.schema_version !== "agent-gym-evaluator-admission-decision/v1") invalid();
+  timestamp(value.decided_at); reference(value.policy_ref); digest(value.decision_digest); digest(value.rubric_digest);
+  const body = { admitted: value.admitted, blocker_codes: value.blocker_codes, calibration_digests: value.calibration_digests,
+    decided_at: value.decided_at, evaluator_digests: value.evaluator_digests, policy_ref: value.policy_ref,
+    rubric_digest: value.rubric_digest, schema_version: value.schema_version };
+  if (digestAgentGymJson(body) !== value.decision_digest || value.admitted !== (value.blocker_codes.length === 0)) invalid();
+}
+function reference(value: string): void { if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid(); }
+function timestamp(value: string): void { if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value) || !Number.isFinite(Date.parse(value))) invalid(); }
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym regression replay evaluator binding is invalid."); }

--- a/apps/slack-companion/src/agent-gym/regression-replay-evaluator-execution.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-evaluator-execution.ts
@@ -1,0 +1,32 @@
+import { AgentGymContractError } from "./contract-error.js";
+import { validateAgentGymRegressionReplayEvaluatorInput, validateAgentGymRegressionReplayEvaluatorOutput,
+  type AgentGymRegressionReplayEvaluatorInputV1, type AgentGymRegressionReplayEvaluatorOutputV1,
+  type AgentGymRegressionReplayEvaluatorPort } from "./regression-replay-evaluator-port.js";
+
+export interface AgentGymRegressionReplayEvaluatorExecutionV1 {
+  readonly binding_digest: string;
+  readonly outputs: readonly [AgentGymRegressionReplayEvaluatorOutputV1, AgentGymRegressionReplayEvaluatorOutputV1];
+  readonly schema_version: "agent-gym-regression-replay-evaluator-execution/v1";
+}
+
+/** Evaluates baseline then challenger through the same admitted evaluator port. */
+export async function executeAgentGymRegressionReplayEvaluators(
+  inputValues: readonly [AgentGymRegressionReplayEvaluatorInputV1, AgentGymRegressionReplayEvaluatorInputV1],
+  evaluator: AgentGymRegressionReplayEvaluatorPort,
+): Promise<AgentGymRegressionReplayEvaluatorExecutionV1> {
+  if (!Array.isArray(inputValues) || inputValues.length !== 2) invalid();
+  const inputs = inputValues.map(validateAgentGymRegressionReplayEvaluatorInput);
+  if (inputs[0]!.binding_digest !== inputs[1]!.binding_digest
+    || inputs[0]!.candidate_ref === inputs[1]!.candidate_ref) invalid();
+  const outputs: AgentGymRegressionReplayEvaluatorOutputV1[] = [];
+  for (const input of inputs) {
+    const output = validateAgentGymRegressionReplayEvaluatorOutput(await evaluator.evaluate(input));
+    if (output.binding_digest !== input.binding_digest || output.candidate_ref !== input.candidate_ref) invalid();
+    outputs.push(output);
+  }
+  return Object.freeze({ binding_digest: inputs[0]!.binding_digest,
+    outputs: Object.freeze([outputs[0]!, outputs[1]!] as const),
+    schema_version: "agent-gym-regression-replay-evaluator-execution/v1" });
+}
+
+function invalid(): never { throw new AgentGymContractError("Agent gym regression replay evaluator execution is invalid."); }

--- a/apps/slack-companion/src/agent-gym/regression-replay-evaluator-inputs.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-evaluator-inputs.ts
@@ -1,0 +1,36 @@
+import { AgentGymContractError } from "./contract-error.js";
+import { validateAgentGymModelResponse } from "./model-runtime.js";
+import { validateAgentGymRegressionReplayEvaluatorBinding, type AgentGymRegressionReplayEvaluatorBindingV1 } from "./regression-replay-evaluator-binding.js";
+import { validateAgentGymRegressionReplayEvaluatorInput, type AgentGymRegressionReplayEvaluatorInputV1 } from "./regression-replay-evaluator-port.js";
+import type { AgentGymRegressionReplayExecutionV1 } from "./regression-replay-execution.js";
+import { validateAgentGymRegressionReplayResult, type AgentGymRegressionReplayResultV1 } from "./regression-replay-result.js";
+
+/** Projects exact transient model answers into evaluator inputs without persisting text. */
+export function buildAgentGymRegressionReplayEvaluatorInputs(
+  bindingValue: AgentGymRegressionReplayEvaluatorBindingV1,
+  resultValue: AgentGymRegressionReplayResultV1,
+  execution: AgentGymRegressionReplayExecutionV1,
+): readonly [AgentGymRegressionReplayEvaluatorInputV1, AgentGymRegressionReplayEvaluatorInputV1] {
+  const binding = validateAgentGymRegressionReplayEvaluatorBinding(bindingValue);
+  const result = validateAgentGymRegressionReplayResult(resultValue);
+  if (binding.replay_result_digest !== result.result_digest
+    || execution.schema_version !== "agent-gym-regression-replay-execution/v1"
+    || !execution.aggregate_budget.allowed || execution.batch.results.length !== 2) invalid();
+  const inputs = execution.batch.results.map((invocation, index) => {
+    const expected = index === 0 ? result.baseline : result.challenger;
+    const response = validateAgentGymModelResponse(invocation.response);
+    if (invocation.receipt.candidate_ref !== expected.candidate_ref
+      || invocation.receipt.invocation_ref !== expected.invocation_ref
+      || invocation.receipt.response_digest !== expected.response_digest
+      || response.invocation_ref !== invocation.receipt.invocation_ref) invalid();
+    return validateAgentGymRegressionReplayEvaluatorInput({
+      binding_digest: binding.binding_digest, candidate_ref: expected.candidate_ref, case_ref: result.case_ref,
+      evaluator_digests: binding.evaluator_digests, output_text: response.output_text,
+      response_digest: expected.response_digest, rubric_digest: binding.rubric_digest,
+      schema_version: "agent-gym-regression-replay-evaluator-input/v1",
+    });
+  });
+  return Object.freeze([inputs[0]!, inputs[1]!] as const);
+}
+
+function invalid(): never { throw new AgentGymContractError("Agent gym regression replay evaluator inputs are invalid."); }

--- a/apps/slack-companion/src/agent-gym/regression-replay-evaluator-port.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-evaluator-port.ts
@@ -1,0 +1,56 @@
+import { AgentGymContractError } from "./contract-error.js";
+
+export interface AgentGymRegressionReplayEvaluatorInputV1 {
+  readonly binding_digest: string;
+  readonly candidate_ref: string;
+  readonly case_ref: string;
+  readonly evaluator_digests: readonly string[];
+  readonly output_text: string;
+  readonly response_digest: string;
+  readonly rubric_digest: string;
+  readonly schema_version: "agent-gym-regression-replay-evaluator-input/v1";
+}
+
+export interface AgentGymRegressionReplayEvaluatorOutputV1 {
+  readonly binding_digest: string;
+  readonly blocker_codes: readonly string[];
+  readonly candidate_ref: string;
+  readonly evidence_digest: string;
+  readonly safety_passed: boolean;
+  readonly schema_version: "agent-gym-regression-replay-evaluator-output/v1";
+  readonly score: number;
+}
+
+export interface AgentGymRegressionReplayEvaluatorPort {
+  evaluate(input: AgentGymRegressionReplayEvaluatorInputV1): Promise<AgentGymRegressionReplayEvaluatorOutputV1>;
+}
+
+/** Validates one transient candidate answer before evaluator execution. */
+export function validateAgentGymRegressionReplayEvaluatorInput(value: AgentGymRegressionReplayEvaluatorInputV1): AgentGymRegressionReplayEvaluatorInputV1 {
+  if (value.schema_version !== "agent-gym-regression-replay-evaluator-input/v1") invalidInput();
+  reference(value.candidate_ref, invalidInput); reference(value.case_ref, invalidInput);
+  digest(value.binding_digest, invalidInput); digest(value.response_digest, invalidInput); digest(value.rubric_digest, invalidInput);
+  if (!Array.isArray(value.evaluator_digests) || value.evaluator_digests.length < 1 || value.evaluator_digests.length > 2
+    || new Set(value.evaluator_digests).size !== value.evaluator_digests.length) invalidInput();
+  value.evaluator_digests.forEach((item) => digest(item, invalidInput));
+  if (typeof value.output_text !== "string" || !value.output_text.trim() || value.output_text.length > 256_000
+    || /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/u.test(value.output_text)) invalidInput();
+  return Object.freeze({ ...value, evaluator_digests: Object.freeze([...value.evaluator_digests]) });
+}
+
+/** Fails malformed or internally inconsistent evaluator output closed. */
+export function validateAgentGymRegressionReplayEvaluatorOutput(value: AgentGymRegressionReplayEvaluatorOutputV1): AgentGymRegressionReplayEvaluatorOutputV1 {
+  if (value.schema_version !== "agent-gym-regression-replay-evaluator-output/v1") invalidOutput();
+  reference(value.candidate_ref, invalidOutput); digest(value.binding_digest, invalidOutput); digest(value.evidence_digest, invalidOutput);
+  if (!Number.isFinite(value.score) || value.score < 0 || value.score > 1 || typeof value.safety_passed !== "boolean"
+    || !Array.isArray(value.blocker_codes) || value.blocker_codes.length > 100
+    || new Set(value.blocker_codes).size !== value.blocker_codes.length
+    || value.blocker_codes.some((code) => !/^[a-z][a-z0-9_.-]{0,79}$/u.test(code))
+    || value.safety_passed !== (value.blocker_codes.length === 0)) invalidOutput();
+  return Object.freeze({ ...value, blocker_codes: Object.freeze([...value.blocker_codes].sort()) });
+}
+
+function reference(value: string, invalid: () => never): void { if (typeof value !== "string" || value.length > 240 || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid(); }
+function digest(value: string, invalid: () => never): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalidInput(): never { throw new AgentGymContractError("Agent gym regression replay evaluator input is invalid."); }
+function invalidOutput(): never { throw new AgentGymContractError("Agent gym regression replay evaluator output is invalid."); }

--- a/apps/slack-companion/src/agent-gym/regression-replay-runtime-evaluation.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-runtime-evaluation.ts
@@ -1,0 +1,37 @@
+import { AgentGymContractError } from "./contract-error.js";
+import { validateAgentGymRegressionReplayEvaluation, evaluateAgentGymRegressionReplay,
+  type AgentGymRegressionReplayEvaluationV1 } from "./regression-replay-evaluation.js";
+import { validateAgentGymRegressionReplayEvaluatorBinding, type AgentGymRegressionReplayEvaluatorBindingV1 } from "./regression-replay-evaluator-binding.js";
+import type { AgentGymRegressionReplayEvaluatorExecutionV1 } from "./regression-replay-evaluator-execution.js";
+import { validateAgentGymRegressionReplayEvaluatorOutput } from "./regression-replay-evaluator-port.js";
+import { validateAgentGymRegressionReplayResult, type AgentGymRegressionReplayResultV1 } from "./regression-replay-result.js";
+
+/** Seals validated paired evaluator output as text-free durable comparison evidence. */
+export function recordExecutedAgentGymRegressionReplayEvaluation(
+  resultValue: AgentGymRegressionReplayResultV1,
+  bindingValue: AgentGymRegressionReplayEvaluatorBindingV1,
+  execution: AgentGymRegressionReplayEvaluatorExecutionV1,
+  input: Pick<AgentGymRegressionReplayEvaluationV1, "evaluated_at" | "evaluation_ref">,
+): AgentGymRegressionReplayEvaluationV1 {
+  const result = validateAgentGymRegressionReplayResult(resultValue);
+  const binding = validateAgentGymRegressionReplayEvaluatorBinding(bindingValue);
+  if (binding.replay_result_digest !== result.result_digest
+    || execution.schema_version !== "agent-gym-regression-replay-evaluator-execution/v1"
+    || execution.binding_digest !== binding.binding_digest || execution.outputs.length !== 2) invalid();
+  const baseline = validateAgentGymRegressionReplayEvaluatorOutput(execution.outputs[0]);
+  const challenger = validateAgentGymRegressionReplayEvaluatorOutput(execution.outputs[1]);
+  if (baseline.candidate_ref !== result.baseline.candidate_ref
+    || challenger.candidate_ref !== result.challenger.candidate_ref
+    || baseline.binding_digest !== binding.binding_digest || challenger.binding_digest !== binding.binding_digest) invalid();
+  return validateAgentGymRegressionReplayEvaluation(evaluateAgentGymRegressionReplay(result, {
+    baseline: candidateEvaluation(baseline), challenger: candidateEvaluation(challenger),
+    evaluated_at: input.evaluated_at, evaluation_ref: input.evaluation_ref,
+  }));
+}
+
+function candidateEvaluation(output: ReturnType<typeof validateAgentGymRegressionReplayEvaluatorOutput>) {
+  return { blocker_codes: output.blocker_codes, candidate_ref: output.candidate_ref,
+    evidence_digest: output.evidence_digest, safety_passed: output.safety_passed, score: output.score };
+}
+
+function invalid(): never { throw new AgentGymContractError("Agent gym executed regression replay evaluation is invalid."); }

--- a/apps/slack-companion/test/agent-gym-regression-evaluator-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-evaluator-runtime.test.ts
@@ -4,6 +4,7 @@ import { defineAgentGymEvaluatorRubric } from "../src/agent-gym/evaluator-rubric
 import { defineAgentGymEvaluatorManifest } from "../src/agent-gym/evaluator-manifest.js";
 import { decideAgentGymEvaluatorAdmission } from "../src/agent-gym/evaluator-admission.js";
 import { bindAgentGymRegressionReplayEvaluators, validateAgentGymRegressionReplayEvaluatorBinding } from "../src/agent-gym/regression-replay-evaluator-binding.js";
+import { validateAgentGymRegressionReplayEvaluatorInput, validateAgentGymRegressionReplayEvaluatorOutput } from "../src/agent-gym/regression-replay-evaluator-port.js";
 import { recordAgentGymRegressionReplayResult } from "../src/agent-gym/regression-replay-result.js";
 import { digestAgentGymJson } from "../src/agent-gym/canonical-json.js";
 
@@ -18,9 +19,27 @@ function result() {
   return recordAgentGymRegressionReplayResult(plan, { baseline: { candidate_ref: "agent-gym-candidate://baseline/one", invocation_receipt_digest: sha("1"), invocation_ref: plan.baseline_invocation_ref, latency_ms: 10, response_digest: sha("2"), total_tokens: 20 }, challenger: { candidate_ref: "agent-gym-candidate://challenger/one", invocation_receipt_digest: sha("3"), invocation_ref: plan.challenger_invocation_ref, latency_ms: 9, response_digest: sha("4"), total_tokens: 18 }, completed_at: "2026-08-12T13:30:00.000Z", result_ref: "agent-gym-replay-result://regression/one" });
 }
 
+function binding() {
+  return bindAgentGymRegressionReplayEvaluators(result(), rubric, [evaluator], admission, { binding_ref: "agent-gym-evaluator-binding://regression/one", bound_at: "2026-08-12T14:01:00.000Z" });
+}
+
 test("binds replay scoring to admitted exact evaluator evidence", () => {
-  const binding = bindAgentGymRegressionReplayEvaluators(result(), rubric, [evaluator], admission, { binding_ref: "agent-gym-evaluator-binding://regression/one", bound_at: "2026-08-12T14:01:00.000Z" });
-  assert.equal(validateAgentGymRegressionReplayEvaluatorBinding(binding).evaluator_admission_digest, admission.decision_digest);
+  assert.equal(validateAgentGymRegressionReplayEvaluatorBinding(binding()).evaluator_admission_digest, admission.decision_digest);
+});
+
+test("validates bounded evaluator inputs and fail-closed outputs", () => {
+  const bound = binding();
+  const input = validateAgentGymRegressionReplayEvaluatorInput({ binding_digest: bound.binding_digest,
+    candidate_ref: bound.baseline_candidate_ref, case_ref: "agent-gym-case://regression/one",
+    evaluator_digests: bound.evaluator_digests, output_text: "A bounded candidate answer.", response_digest: sha("2"),
+    rubric_digest: bound.rubric_digest, schema_version: "agent-gym-regression-replay-evaluator-input/v1" });
+  assert.equal(input.output_text, "A bounded candidate answer.");
+  assert.equal(validateAgentGymRegressionReplayEvaluatorOutput({ binding_digest: bound.binding_digest, blocker_codes: [],
+    candidate_ref: bound.baseline_candidate_ref, evidence_digest: sha("5"), safety_passed: true,
+    schema_version: "agent-gym-regression-replay-evaluator-output/v1", score: 0.8 }).score, 0.8);
+  assert.throws(() => validateAgentGymRegressionReplayEvaluatorOutput({ binding_digest: bound.binding_digest,
+    blocker_codes: ["unsafe"], candidate_ref: bound.baseline_candidate_ref, evidence_digest: sha("5"), safety_passed: true,
+    schema_version: "agent-gym-regression-replay-evaluator-output/v1", score: 0.8 }));
 });
 
 test("rejects evaluator evidence that was not admitted", () => {

--- a/apps/slack-companion/test/agent-gym-regression-evaluator-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-evaluator-runtime.test.ts
@@ -7,6 +7,7 @@ import { bindAgentGymRegressionReplayEvaluators, validateAgentGymRegressionRepla
 import { validateAgentGymRegressionReplayEvaluatorInput, validateAgentGymRegressionReplayEvaluatorOutput } from "../src/agent-gym/regression-replay-evaluator-port.js";
 import { buildAgentGymRegressionReplayEvaluatorInputs } from "../src/agent-gym/regression-replay-evaluator-inputs.js";
 import { executeAgentGymRegressionReplayEvaluators } from "../src/agent-gym/regression-replay-evaluator-execution.js";
+import { recordExecutedAgentGymRegressionReplayEvaluation } from "../src/agent-gym/regression-replay-runtime-evaluation.js";
 import { bindAgentGymRegressionReplayRequests } from "../src/agent-gym/regression-replay-request-pair.js";
 import { checkAgentGymRegressionReplayParity } from "../src/agent-gym/regression-replay-parity.js";
 import { executeAgentGymRegressionReplay } from "../src/agent-gym/regression-replay-execution.js";
@@ -104,6 +105,36 @@ test("rejects evaluator output bound to another candidate", async () => {
       evidence_digest: sha("8"), safety_passed: true,
       schema_version: "agent-gym-regression-replay-evaluator-output/v1", score: 0.8 };
   } }), /evaluator execution is invalid/u);
+});
+
+test("records validated evaluator execution as durable paired evidence", async () => {
+  const { evaluatorBinding, execution, replayResult } = await runtimeBundle();
+  const inputs = buildAgentGymRegressionReplayEvaluatorInputs(evaluatorBinding, replayResult, execution);
+  const evaluated = await executeAgentGymRegressionReplayEvaluators(inputs, { async evaluate(input) {
+    const baseline = input.candidate_ref === replayResult.baseline.candidate_ref;
+    return { binding_digest: input.binding_digest, blocker_codes: baseline ? ["safety_regression"] : [],
+      candidate_ref: input.candidate_ref, evidence_digest: baseline ? sha("9") : sha("a"), safety_passed: !baseline,
+      schema_version: "agent-gym-regression-replay-evaluator-output/v1", score: baseline ? 0.4 : 0.95 };
+  } });
+  const durable = recordExecutedAgentGymRegressionReplayEvaluation(replayResult, evaluatorBinding, evaluated, {
+    evaluated_at: "2026-08-12T14:02:00.000Z", evaluation_ref: "agent-gym-replay-evaluation://regression/runtime",
+  });
+  assert.equal(durable.baseline.safety_passed, false);
+  assert.equal(durable.challenger.score, 0.95);
+  assert.equal(JSON.stringify(durable).includes("answer:"), false);
+});
+
+test("rejects evaluator execution for another binding", async () => {
+  const { evaluatorBinding, execution, replayResult } = await runtimeBundle();
+  const inputs = buildAgentGymRegressionReplayEvaluatorInputs(evaluatorBinding, replayResult, execution);
+  const evaluated = await executeAgentGymRegressionReplayEvaluators(inputs, { async evaluate(input) {
+    return { binding_digest: input.binding_digest, blocker_codes: [], candidate_ref: input.candidate_ref,
+      evidence_digest: sha("b"), safety_passed: true,
+      schema_version: "agent-gym-regression-replay-evaluator-output/v1", score: 0.8 };
+  } });
+  assert.throws(() => recordExecutedAgentGymRegressionReplayEvaluation(replayResult, evaluatorBinding,
+    { ...evaluated, binding_digest: sha("c") }, { evaluated_at: "2026-08-12T14:02:00.000Z",
+      evaluation_ref: "agent-gym-replay-evaluation://regression/invalid" }));
 });
 
 test("rejects evaluator evidence that was not admitted", () => {

--- a/apps/slack-companion/test/agent-gym-regression-evaluator-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-evaluator-runtime.test.ts
@@ -6,6 +6,7 @@ import { decideAgentGymEvaluatorAdmission } from "../src/agent-gym/evaluator-adm
 import { bindAgentGymRegressionReplayEvaluators, validateAgentGymRegressionReplayEvaluatorBinding } from "../src/agent-gym/regression-replay-evaluator-binding.js";
 import { validateAgentGymRegressionReplayEvaluatorInput, validateAgentGymRegressionReplayEvaluatorOutput } from "../src/agent-gym/regression-replay-evaluator-port.js";
 import { buildAgentGymRegressionReplayEvaluatorInputs } from "../src/agent-gym/regression-replay-evaluator-inputs.js";
+import { executeAgentGymRegressionReplayEvaluators } from "../src/agent-gym/regression-replay-evaluator-execution.js";
 import { bindAgentGymRegressionReplayRequests } from "../src/agent-gym/regression-replay-request-pair.js";
 import { checkAgentGymRegressionReplayParity } from "../src/agent-gym/regression-replay-parity.js";
 import { executeAgentGymRegressionReplay } from "../src/agent-gym/regression-replay-execution.js";
@@ -79,6 +80,30 @@ test("projects exact transient model answers into paired evaluator inputs", asyn
   const inputs = buildAgentGymRegressionReplayEvaluatorInputs(evaluatorBinding, replayResult, execution);
   assert.deepEqual(inputs.map((input) => input.candidate_ref), [replayResult.baseline.candidate_ref, replayResult.challenger.candidate_ref]);
   assert.equal(inputs[0].output_text, `answer:${replayResult.baseline.candidate_ref}`);
+});
+
+test("executes baseline and challenger through one evaluator port", async () => {
+  const { evaluatorBinding, execution, replayResult } = await runtimeBundle();
+  const inputs = buildAgentGymRegressionReplayEvaluatorInputs(evaluatorBinding, replayResult, execution);
+  const seen: string[] = [];
+  const evaluated = await executeAgentGymRegressionReplayEvaluators(inputs, { async evaluate(input) {
+    seen.push(input.candidate_ref);
+    return { binding_digest: input.binding_digest, blocker_codes: [], candidate_ref: input.candidate_ref,
+      evidence_digest: input.candidate_ref === replayResult.baseline.candidate_ref ? sha("6") : sha("7"),
+      safety_passed: true, schema_version: "agent-gym-regression-replay-evaluator-output/v1", score: 0.9 };
+  } });
+  assert.deepEqual(seen, [replayResult.baseline.candidate_ref, replayResult.challenger.candidate_ref]);
+  assert.deepEqual(evaluated.outputs.map((output) => output.score), [0.9, 0.9]);
+});
+
+test("rejects evaluator output bound to another candidate", async () => {
+  const { evaluatorBinding, execution, replayResult } = await runtimeBundle();
+  const inputs = buildAgentGymRegressionReplayEvaluatorInputs(evaluatorBinding, replayResult, execution);
+  await assert.rejects(executeAgentGymRegressionReplayEvaluators(inputs, { async evaluate(input) {
+    return { binding_digest: input.binding_digest, blocker_codes: [], candidate_ref: replayResult.baseline.candidate_ref,
+      evidence_digest: sha("8"), safety_passed: true,
+      schema_version: "agent-gym-regression-replay-evaluator-output/v1", score: 0.8 };
+  } }), /evaluator execution is invalid/u);
 });
 
 test("rejects evaluator evidence that was not admitted", () => {

--- a/apps/slack-companion/test/agent-gym-regression-evaluator-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-evaluator-runtime.test.ts
@@ -5,6 +5,12 @@ import { defineAgentGymEvaluatorManifest } from "../src/agent-gym/evaluator-mani
 import { decideAgentGymEvaluatorAdmission } from "../src/agent-gym/evaluator-admission.js";
 import { bindAgentGymRegressionReplayEvaluators, validateAgentGymRegressionReplayEvaluatorBinding } from "../src/agent-gym/regression-replay-evaluator-binding.js";
 import { validateAgentGymRegressionReplayEvaluatorInput, validateAgentGymRegressionReplayEvaluatorOutput } from "../src/agent-gym/regression-replay-evaluator-port.js";
+import { buildAgentGymRegressionReplayEvaluatorInputs } from "../src/agent-gym/regression-replay-evaluator-inputs.js";
+import { bindAgentGymRegressionReplayRequests } from "../src/agent-gym/regression-replay-request-pair.js";
+import { checkAgentGymRegressionReplayParity } from "../src/agent-gym/regression-replay-parity.js";
+import { executeAgentGymRegressionReplay } from "../src/agent-gym/regression-replay-execution.js";
+import { recordExecutedAgentGymRegressionReplay } from "../src/agent-gym/regression-replay-runtime-result.js";
+import { agentGymModelRequestDigest } from "../src/agent-gym/model-runtime.js";
 import { recordAgentGymRegressionReplayResult } from "../src/agent-gym/regression-replay-result.js";
 import { digestAgentGymJson } from "../src/agent-gym/canonical-json.js";
 
@@ -13,14 +19,40 @@ const rubric = defineAgentGymEvaluatorRubric({ metrics: [{ blocking: true, evalu
 const evaluator = defineAgentGymEvaluatorManifest({ evaluator_kind: "deterministic", evaluator_ref: "agent-gym-evaluator://regression/safety", implementation_digest: sha("a"), output_schema_digest: sha("b"), rubric_digest: rubric.rubric_digest, schema_version: "agent-gym-evaluator-manifest/v1" });
 const admission = decideAgentGymEvaluatorAdmission(rubric, [evaluator], [], { maximum_calibration_age_ms: 86_400_000, policy_ref: "agent-gym-evaluator-policy://regression/one", required_calibration_dataset_digest: sha("c"), required_calibration_policy_digest: sha("d"), schema_version: "agent-gym-evaluator-admission-policy/v1" }, "2026-08-12T14:00:00.000Z");
 
-function result() {
+function replayPlan() {
   const planBody = { baseline_invocation_ref: "agent-gym-invocation://baseline/one", case_digest: sha("e"), case_ref: "agent-gym-case://regression/one", challenger_invocation_ref: "agent-gym-invocation://challenger/one", maximum_model_calls: 2, plan_ref: "agent-gym-replay-plan://regression/one", planned_at: "2026-08-12T13:00:00.000Z", replay_request_digest: sha("f"), schema_version: "agent-gym-regression-replay-plan/v1" as const };
-  const plan = { ...planBody, plan_digest: digestAgentGymJson(planBody) };
+  return { ...planBody, plan_digest: digestAgentGymJson(planBody) };
+}
+
+function result() {
+  const plan = replayPlan();
   return recordAgentGymRegressionReplayResult(plan, { baseline: { candidate_ref: "agent-gym-candidate://baseline/one", invocation_receipt_digest: sha("1"), invocation_ref: plan.baseline_invocation_ref, latency_ms: 10, response_digest: sha("2"), total_tokens: 20 }, challenger: { candidate_ref: "agent-gym-candidate://challenger/one", invocation_receipt_digest: sha("3"), invocation_ref: plan.challenger_invocation_ref, latency_ms: 9, response_digest: sha("4"), total_tokens: 18 }, completed_at: "2026-08-12T13:30:00.000Z", result_ref: "agent-gym-replay-result://regression/one" });
 }
 
 function binding() {
   return bindAgentGymRegressionReplayEvaluators(result(), rubric, [evaluator], admission, { binding_ref: "agent-gym-evaluator-binding://regression/one", bound_at: "2026-08-12T14:01:00.000Z" });
+}
+
+async function runtimeBundle() {
+  const plan = replayPlan();
+  const request = (role: "baseline" | "challenger") => ({ candidate_ref: `agent-gym-candidate://${role}/one`,
+    invocation_ref: `agent-gym-invocation://${role}/one`, max_output_tokens: 256,
+    messages: [{ role: "user" as const, text: "Summarize the regression evidence." }], model_id: `model-${role}`,
+    schema_version: "agent-gym-model-request/v1" as const, system_prompt: `You are the ${role} candidate.` });
+  const baseline = request("baseline"); const challenger = request("challenger");
+  const pair = bindAgentGymRegressionReplayRequests(plan, baseline, challenger, "agent-gym-request-pair://regression/evaluator");
+  const parity = checkAgentGymRegressionReplayParity(pair, { checked_at: "2026-08-12T13:01:00.000Z", report_ref: "agent-gym-parity://regression/evaluator" });
+  const execution = await executeAgentGymRegressionReplay(plan, pair, parity, baseline, challenger,
+    { max_input_tokens: 1_000, max_invocations: 2, max_latency_ms: 1_000, max_output_tokens: 1_000,
+      max_total_tokens: 2_000, schema_version: "agent-gym-model-budget/v1" }, { async invoke(modelRequest) {
+      return { invocation_ref: modelRequest.invocation_ref, latency_ms: 10, model_id: modelRequest.model_id,
+        output_text: `answer:${modelRequest.candidate_ref}`, request_digest: agentGymModelRequestDigest(modelRequest),
+        response_source: "recorded" as const, schema_version: "agent-gym-model-response/v1" as const,
+        stop_reason: "end_turn" as const, token_usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 } };
+    } }, "2026-08-12T13:02:00.000Z", "agent-gym-model-batch://regression/evaluator");
+  const replayResult = recordExecutedAgentGymRegressionReplay(plan, execution, { completed_at: "2026-08-12T13:03:00.000Z", result_ref: "agent-gym-replay-result://regression/evaluator" });
+  const evaluatorBinding = bindAgentGymRegressionReplayEvaluators(replayResult, rubric, [evaluator], admission, { binding_ref: "agent-gym-evaluator-binding://regression/runtime", bound_at: "2026-08-12T14:01:00.000Z" });
+  return { evaluatorBinding, execution, replayResult };
 }
 
 test("binds replay scoring to admitted exact evaluator evidence", () => {
@@ -40,6 +72,13 @@ test("validates bounded evaluator inputs and fail-closed outputs", () => {
   assert.throws(() => validateAgentGymRegressionReplayEvaluatorOutput({ binding_digest: bound.binding_digest,
     blocker_codes: ["unsafe"], candidate_ref: bound.baseline_candidate_ref, evidence_digest: sha("5"), safety_passed: true,
     schema_version: "agent-gym-regression-replay-evaluator-output/v1", score: 0.8 }));
+});
+
+test("projects exact transient model answers into paired evaluator inputs", async () => {
+  const { evaluatorBinding, execution, replayResult } = await runtimeBundle();
+  const inputs = buildAgentGymRegressionReplayEvaluatorInputs(evaluatorBinding, replayResult, execution);
+  assert.deepEqual(inputs.map((input) => input.candidate_ref), [replayResult.baseline.candidate_ref, replayResult.challenger.candidate_ref]);
+  assert.equal(inputs[0].output_text, `answer:${replayResult.baseline.candidate_ref}`);
 });
 
 test("rejects evaluator evidence that was not admitted", () => {

--- a/apps/slack-companion/test/agent-gym-regression-evaluator-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-evaluator-runtime.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { defineAgentGymEvaluatorRubric } from "../src/agent-gym/evaluator-rubric.js";
+import { defineAgentGymEvaluatorManifest } from "../src/agent-gym/evaluator-manifest.js";
+import { decideAgentGymEvaluatorAdmission } from "../src/agent-gym/evaluator-admission.js";
+import { bindAgentGymRegressionReplayEvaluators, validateAgentGymRegressionReplayEvaluatorBinding } from "../src/agent-gym/regression-replay-evaluator-binding.js";
+import { recordAgentGymRegressionReplayResult } from "../src/agent-gym/regression-replay-result.js";
+import { digestAgentGymJson } from "../src/agent-gym/canonical-json.js";
+
+const sha = (value: string): string => `sha256:${value.repeat(64).slice(0, 64)}`;
+const rubric = defineAgentGymEvaluatorRubric({ metrics: [{ blocking: true, evaluator_kind: "deterministic", metric_id: "safety", minimum_score: 1, weight: 1 }], rubric_ref: "agent-gym-rubric://regression/runtime", schema_version: "agent-gym-evaluator-rubric/v1" });
+const evaluator = defineAgentGymEvaluatorManifest({ evaluator_kind: "deterministic", evaluator_ref: "agent-gym-evaluator://regression/safety", implementation_digest: sha("a"), output_schema_digest: sha("b"), rubric_digest: rubric.rubric_digest, schema_version: "agent-gym-evaluator-manifest/v1" });
+const admission = decideAgentGymEvaluatorAdmission(rubric, [evaluator], [], { maximum_calibration_age_ms: 86_400_000, policy_ref: "agent-gym-evaluator-policy://regression/one", required_calibration_dataset_digest: sha("c"), required_calibration_policy_digest: sha("d"), schema_version: "agent-gym-evaluator-admission-policy/v1" }, "2026-08-12T14:00:00.000Z");
+
+function result() {
+  const planBody = { baseline_invocation_ref: "agent-gym-invocation://baseline/one", case_digest: sha("e"), case_ref: "agent-gym-case://regression/one", challenger_invocation_ref: "agent-gym-invocation://challenger/one", maximum_model_calls: 2, plan_ref: "agent-gym-replay-plan://regression/one", planned_at: "2026-08-12T13:00:00.000Z", replay_request_digest: sha("f"), schema_version: "agent-gym-regression-replay-plan/v1" as const };
+  const plan = { ...planBody, plan_digest: digestAgentGymJson(planBody) };
+  return recordAgentGymRegressionReplayResult(plan, { baseline: { candidate_ref: "agent-gym-candidate://baseline/one", invocation_receipt_digest: sha("1"), invocation_ref: plan.baseline_invocation_ref, latency_ms: 10, response_digest: sha("2"), total_tokens: 20 }, challenger: { candidate_ref: "agent-gym-candidate://challenger/one", invocation_receipt_digest: sha("3"), invocation_ref: plan.challenger_invocation_ref, latency_ms: 9, response_digest: sha("4"), total_tokens: 18 }, completed_at: "2026-08-12T13:30:00.000Z", result_ref: "agent-gym-replay-result://regression/one" });
+}
+
+test("binds replay scoring to admitted exact evaluator evidence", () => {
+  const binding = bindAgentGymRegressionReplayEvaluators(result(), rubric, [evaluator], admission, { binding_ref: "agent-gym-evaluator-binding://regression/one", bound_at: "2026-08-12T14:01:00.000Z" });
+  assert.equal(validateAgentGymRegressionReplayEvaluatorBinding(binding).evaluator_admission_digest, admission.decision_digest);
+});
+
+test("rejects evaluator evidence that was not admitted", () => {
+  assert.throws(() => bindAgentGymRegressionReplayEvaluators(result(), rubric, [evaluator], { ...admission, admitted: false }, { binding_ref: "agent-gym-evaluator-binding://regression/invalid", bound_at: "2026-08-12T14:01:00.000Z" }));
+});


### PR DESCRIPTION
## Summary

- bind each admitted replay to exact evaluator and rubric digests
- project bounded transient evaluator inputs from correlated replay outputs
- execute baseline and challenger through one provider-neutral evaluator port
- persist only text-free, content-addressed evaluator evidence

## Validation

- `npm run typecheck` in `apps/slack-companion` on DDESK
- `npm test` in `apps/slack-companion` on DDESK: 737 passed, 0 failed
- `git diff --check origin/main..HEAD`

## Scope

Portable Slack companion contracts only. No credentials, provider routes, deployment topology, or environment authorization are included.