### PR TITLE
feat(slack): run bounded regression campaigns

### DIFF
--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -75,6 +75,7 @@ export * from "./regression-replay-runtime-evaluation.js";
 export * from "./regression-replay-trial.js";
 export * from "./regression-campaign-plan.js";
 export * from "./regression-campaign-port.js";
+export * from "./regression-campaign-execution.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -74,6 +74,7 @@ export * from "./regression-replay-evaluator-execution.js";
 export * from "./regression-replay-runtime-evaluation.js";
 export * from "./regression-replay-trial.js";
 export * from "./regression-campaign-plan.js";
+export * from "./regression-campaign-port.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -73,6 +73,7 @@ export * from "./regression-replay-evaluator-inputs.js";
 export * from "./regression-replay-evaluator-execution.js";
 export * from "./regression-replay-runtime-evaluation.js";
 export * from "./regression-replay-trial.js";
+export * from "./regression-campaign-plan.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -72,6 +72,7 @@ export * from "./regression-replay-evaluator-port.js";
 export * from "./regression-replay-evaluator-inputs.js";
 export * from "./regression-replay-evaluator-execution.js";
 export * from "./regression-replay-runtime-evaluation.js";
+export * from "./regression-replay-trial.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/index.ts
+++ b/apps/slack-companion/src/agent-gym/index.ts
@@ -76,6 +76,7 @@ export * from "./regression-replay-trial.js";
 export * from "./regression-campaign-plan.js";
 export * from "./regression-campaign-port.js";
 export * from "./regression-campaign-execution.js";
+export * from "./regression-campaign-result.js";
 export * from "./fixture-case.js";
 export * from "./model-runtime.js";
 export * from "./model-budget.js";

--- a/apps/slack-companion/src/agent-gym/regression-campaign-execution.ts
+++ b/apps/slack-companion/src/agent-gym/regression-campaign-execution.ts
@@ -1,0 +1,40 @@
+import { AgentGymContractError } from "./contract-error.js";
+import { validateAgentGymRegressionCampaignPlan, type AgentGymRegressionCampaignPlanV1 } from "./regression-campaign-plan.js";
+import { invalidAgentGymRegressionCampaignCase, validateAgentGymRegressionCampaignCaseOutput,
+  type AgentGymRegressionCampaignCaseOutputV1,
+  type AgentGymRegressionCampaignTrialPort } from "./regression-campaign-port.js";
+
+export interface AgentGymRegressionCampaignExecutionV1 {
+  readonly campaign_digest: string;
+  readonly completed_case_count: number;
+  readonly invalid_case_count: number;
+  readonly outputs: readonly AgentGymRegressionCampaignCaseOutputV1[];
+  readonly schema_version: "agent-gym-regression-campaign-execution/v1";
+}
+
+/** Runs every campaign case in stable order and records thrown work as invalid. */
+export async function executeAgentGymRegressionCampaign(
+  campaignValue: AgentGymRegressionCampaignPlanV1,
+  port: AgentGymRegressionCampaignTrialPort,
+): Promise<AgentGymRegressionCampaignExecutionV1> {
+  const campaign = validateAgentGymRegressionCampaignPlan(campaignValue);
+  if (port === null || typeof port !== "object" || typeof port.run !== "function") invalid();
+  const outputs: AgentGymRegressionCampaignCaseOutputV1[] = [];
+  for (const replay of campaign.cases) {
+    try {
+      outputs.push(validateAgentGymRegressionCampaignCaseOutput(
+        campaign, replay, await port.run(campaign, replay),
+      ));
+    } catch {
+      outputs.push(invalidAgentGymRegressionCampaignCase(replay, "case_execution_failed"));
+    }
+  }
+  return Object.freeze({ campaign_digest: campaign.campaign_digest,
+    completed_case_count: outputs.filter((output) => output.status === "completed").length,
+    invalid_case_count: outputs.filter((output) => output.status === "invalid").length,
+    outputs: Object.freeze(outputs), schema_version: "agent-gym-regression-campaign-execution/v1" });
+}
+
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym regression campaign execution is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/regression-campaign-plan.ts
+++ b/apps/slack-companion/src/agent-gym/regression-campaign-plan.ts
@@ -1,0 +1,134 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import type { AgentGymEvaluatorAdmissionDecisionV1 } from "./evaluator-admission.js";
+import { validateAgentGymRegressionReplayPlan, type AgentGymRegressionReplayPlanV1 } from "./regression-replay-plan.js";
+
+export interface AgentGymRegressionCampaignCaseV1 {
+  readonly case_digest: string;
+  readonly case_ref: string;
+  readonly maximum_model_calls: number;
+  readonly replay_plan_digest: string;
+  readonly replay_plan_ref: string;
+}
+
+export interface AgentGymRegressionCampaignPlanV1 {
+  readonly baseline_candidate_ref: string;
+  readonly campaign_digest: string;
+  readonly campaign_ref: string;
+  readonly cases: readonly AgentGymRegressionCampaignCaseV1[];
+  readonly challenger_candidate_ref: string;
+  readonly evaluator_admission_digest: string;
+  readonly evaluator_digests: readonly string[];
+  readonly maximum_invalid_cases: number;
+  readonly maximum_model_calls: number;
+  readonly planned_at: string;
+  readonly rubric_digest: string;
+  readonly schema_version: "agent-gym-regression-campaign-plan/v1";
+}
+
+/** Seals ordered replay work and shared evaluator identity before a campaign runs. */
+export function planAgentGymRegressionCampaign(
+  planValues: readonly AgentGymRegressionReplayPlanV1[],
+  admission: AgentGymEvaluatorAdmissionDecisionV1,
+  input: Pick<AgentGymRegressionCampaignPlanV1,
+    "baseline_candidate_ref" | "campaign_ref" | "challenger_candidate_ref"
+    | "maximum_invalid_cases" | "planned_at">,
+): AgentGymRegressionCampaignPlanV1 {
+  const plans = validatePlans(planValues);
+  validateAdmission(admission);
+  for (const ref of [input.baseline_candidate_ref, input.campaign_ref,
+    input.challenger_candidate_ref]) reference(ref);
+  timestamp(input.planned_at);
+  if (!admission.admitted || input.baseline_candidate_ref === input.challenger_candidate_ref
+    || Date.parse(input.planned_at) < Math.max(...plans.map((plan) => Date.parse(plan.planned_at)))
+    || !Number.isSafeInteger(input.maximum_invalid_cases) || input.maximum_invalid_cases < 0
+    || input.maximum_invalid_cases >= plans.length) invalid();
+  const cases = plans.map((plan) => Object.freeze({
+    case_digest: plan.case_digest, case_ref: plan.case_ref,
+    maximum_model_calls: plan.maximum_model_calls, replay_plan_digest: plan.plan_digest,
+    replay_plan_ref: plan.plan_ref,
+  }));
+  const maximumModelCalls = sum(cases.map((entry) => entry.maximum_model_calls));
+  const body = {
+    baseline_candidate_ref: input.baseline_candidate_ref, campaign_ref: input.campaign_ref,
+    cases: cases.map((entry) => ({ ...entry })), challenger_candidate_ref: input.challenger_candidate_ref,
+    evaluator_admission_digest: admission.decision_digest,
+    evaluator_digests: [...admission.evaluator_digests], maximum_invalid_cases: input.maximum_invalid_cases,
+    maximum_model_calls: maximumModelCalls, planned_at: input.planned_at,
+    rubric_digest: admission.rubric_digest, schema_version: "agent-gym-regression-campaign-plan/v1" as const,
+  };
+  return Object.freeze({ ...body, cases: Object.freeze(cases),
+    evaluator_digests: Object.freeze(body.evaluator_digests), campaign_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRegressionCampaignPlan(
+  value: AgentGymRegressionCampaignPlanV1,
+): AgentGymRegressionCampaignPlanV1 {
+  if (value.schema_version !== "agent-gym-regression-campaign-plan/v1") invalid();
+  for (const ref of [value.baseline_candidate_ref, value.campaign_ref,
+    value.challenger_candidate_ref]) reference(ref);
+  for (const item of [value.campaign_digest, value.evaluator_admission_digest,
+    value.rubric_digest]) digest(item);
+  timestamp(value.planned_at);
+  if (value.baseline_candidate_ref === value.challenger_candidate_ref
+    || !Array.isArray(value.cases) || value.cases.length < 1 || value.cases.length > 10_000
+    || !Array.isArray(value.evaluator_digests) || value.evaluator_digests.length < 1
+    || value.evaluator_digests.length > 2
+    || new Set(value.evaluator_digests).size !== value.evaluator_digests.length
+    || !Number.isSafeInteger(value.maximum_invalid_cases) || value.maximum_invalid_cases < 0
+    || value.maximum_invalid_cases >= value.cases.length) invalid();
+  value.evaluator_digests.forEach(digest);
+  const cases = value.cases.map(validateCase);
+  if (new Set(cases.map((entry) => entry.case_ref)).size !== cases.length
+    || new Set(cases.map((entry) => entry.replay_plan_digest)).size !== cases.length
+    || cases.some((entry, index) => index > 0 && cases[index - 1]!.case_ref >= entry.case_ref)
+    || sum(cases.map((entry) => entry.maximum_model_calls)) !== value.maximum_model_calls) invalid();
+  const { campaign_digest: _digest, ...rest } = value;
+  const body = { ...rest, cases: cases.map((entry) => ({ ...entry })),
+    evaluator_digests: [...value.evaluator_digests] };
+  if (digestAgentGymJson(body) !== value.campaign_digest) invalid();
+  return Object.freeze({ ...value, cases: Object.freeze(cases),
+    evaluator_digests: Object.freeze([...value.evaluator_digests]) });
+}
+
+function validatePlans(values: readonly AgentGymRegressionReplayPlanV1[]) {
+  if (!Array.isArray(values) || values.length < 1 || values.length > 10_000) invalid();
+  const plans = values.map(validateAgentGymRegressionReplayPlan)
+    .sort((left, right) => left.case_ref.localeCompare(right.case_ref));
+  if (new Set(plans.map((plan) => plan.case_ref)).size !== plans.length
+    || new Set(plans.map((plan) => plan.plan_digest)).size !== plans.length) invalid();
+  return plans;
+}
+function validateAdmission(value: AgentGymEvaluatorAdmissionDecisionV1): void {
+  if (value.schema_version !== "agent-gym-evaluator-admission-decision/v1") invalid();
+  timestamp(value.decided_at); reference(value.policy_ref); digest(value.decision_digest); digest(value.rubric_digest);
+  value.evaluator_digests.forEach(digest);
+  const body = { admitted: value.admitted, blocker_codes: value.blocker_codes,
+    calibration_digests: value.calibration_digests, decided_at: value.decided_at,
+    evaluator_digests: value.evaluator_digests, policy_ref: value.policy_ref,
+    rubric_digest: value.rubric_digest, schema_version: value.schema_version };
+  if (digestAgentGymJson(body) !== value.decision_digest
+    || value.admitted !== (value.blocker_codes.length === 0)) invalid();
+}
+function validateCase(value: AgentGymRegressionCampaignCaseV1) {
+  reference(value.case_ref); reference(value.replay_plan_ref);
+  digest(value.case_digest); digest(value.replay_plan_digest);
+  if (!Number.isSafeInteger(value.maximum_model_calls) || value.maximum_model_calls < 2
+    || value.maximum_model_calls > 10_000) invalid();
+  return Object.freeze({ ...value });
+}
+function sum(values: readonly number[]): number {
+  const value = values.reduce((total, current) => total + current, 0);
+  if (!Number.isSafeInteger(value) || value < 2 || value > 1_000_000) invalid();
+  return value;
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240
+    || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym regression campaign plan is invalid."); }

--- a/apps/slack-companion/src/agent-gym/regression-campaign-port.ts
+++ b/apps/slack-companion/src/agent-gym/regression-campaign-port.ts
@@ -1,0 +1,78 @@
+import { AgentGymContractError } from "./contract-error.js";
+import { validateAgentGymRegressionCampaignPlan, type AgentGymRegressionCampaignCaseV1,
+  type AgentGymRegressionCampaignPlanV1 } from "./regression-campaign-plan.js";
+import { validateAgentGymRegressionReplayTrial, type AgentGymRegressionReplayTrialV1 } from "./regression-replay-trial.js";
+
+export interface AgentGymRegressionCampaignCompletedCaseV1 {
+  readonly case_digest: string;
+  readonly case_ref: string;
+  readonly schema_version: "agent-gym-regression-campaign-case-output/v1";
+  readonly status: "completed";
+  readonly trial: AgentGymRegressionReplayTrialV1;
+}
+
+export interface AgentGymRegressionCampaignInvalidCaseV1 {
+  readonly blocker_code: string;
+  readonly case_digest: string;
+  readonly case_ref: string;
+  readonly schema_version: "agent-gym-regression-campaign-case-output/v1";
+  readonly status: "invalid";
+}
+
+export type AgentGymRegressionCampaignCaseOutputV1 =
+  | AgentGymRegressionCampaignCompletedCaseV1
+  | AgentGymRegressionCampaignInvalidCaseV1;
+
+export interface AgentGymRegressionCampaignTrialPort {
+  run(
+    campaign: AgentGymRegressionCampaignPlanV1,
+    replay: AgentGymRegressionCampaignCaseV1,
+  ): Promise<AgentGymRegressionCampaignCaseOutputV1>;
+}
+
+/** Validates one case output against its exact campaign and replay identities. */
+export function validateAgentGymRegressionCampaignCaseOutput(
+  campaignValue: AgentGymRegressionCampaignPlanV1,
+  replayValue: AgentGymRegressionCampaignCaseV1,
+  value: AgentGymRegressionCampaignCaseOutputV1,
+): AgentGymRegressionCampaignCaseOutputV1 {
+  const campaign = validateAgentGymRegressionCampaignPlan(campaignValue);
+  const replay = campaign.cases.find((entry) => entry.case_ref === replayValue.case_ref);
+  if (replay === undefined || replay.case_digest !== replayValue.case_digest
+    || replay.replay_plan_digest !== replayValue.replay_plan_digest
+    || value.schema_version !== "agent-gym-regression-campaign-case-output/v1"
+    || value.case_ref !== replay.case_ref || value.case_digest !== replay.case_digest) invalid();
+  if (value.status === "invalid") {
+    blocker(value.blocker_code);
+    return Object.freeze({ ...value });
+  }
+  if (value.status !== "completed") invalid();
+  const trial = validateAgentGymRegressionReplayTrial(value.trial);
+  if (trial.case_ref !== replay.case_ref || trial.case_digest !== replay.case_digest
+    || trial.plan_digest !== replay.replay_plan_digest
+    || trial.baseline_candidate_ref !== campaign.baseline_candidate_ref
+    || trial.challenger_candidate_ref !== campaign.challenger_candidate_ref
+    || trial.evaluator_admission_digest !== campaign.evaluator_admission_digest
+    || trial.rubric_digest !== campaign.rubric_digest
+    || trial.evaluator_digests.length !== campaign.evaluator_digests.length
+    || trial.evaluator_digests.some((digest, index) => digest !== campaign.evaluator_digests[index])) invalid();
+  return Object.freeze({ ...value, trial });
+}
+
+/** Records a stable, text-free invalid result when a provider or evaluator case fails. */
+export function invalidAgentGymRegressionCampaignCase(
+  replay: AgentGymRegressionCampaignCaseV1,
+  blockerCode: string,
+): AgentGymRegressionCampaignInvalidCaseV1 {
+  blocker(blockerCode);
+  return Object.freeze({ blocker_code: blockerCode, case_digest: replay.case_digest,
+    case_ref: replay.case_ref, schema_version: "agent-gym-regression-campaign-case-output/v1",
+    status: "invalid" });
+}
+
+function blocker(value: string): void {
+  if (typeof value !== "string" || !/^[a-z][a-z0-9_.-]{0,79}$/u.test(value)) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym regression campaign case output is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/regression-campaign-result.ts
+++ b/apps/slack-companion/src/agent-gym/regression-campaign-result.ts
@@ -1,0 +1,132 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import type { AgentGymRegressionCampaignExecutionV1 } from "./regression-campaign-execution.js";
+import { validateAgentGymRegressionCampaignPlan, type AgentGymRegressionCampaignPlanV1 } from "./regression-campaign-plan.js";
+import { validateAgentGymRegressionCampaignCaseOutput } from "./regression-campaign-port.js";
+import type { AgentGymJson } from "./fixture-case.js";
+
+export interface AgentGymRegressionCampaignCompletedResultCaseV1 {
+  readonly case_digest: string;
+  readonly case_ref: string;
+  readonly outcome: "equivalent" | "improved" | "regressed";
+  readonly status: "completed";
+  readonly trial_digest: string;
+}
+
+export interface AgentGymRegressionCampaignInvalidResultCaseV1 {
+  readonly blocker_code: string;
+  readonly case_digest: string;
+  readonly case_ref: string;
+  readonly status: "invalid";
+}
+
+export type AgentGymRegressionCampaignResultCaseV1 =
+  | AgentGymRegressionCampaignCompletedResultCaseV1
+  | AgentGymRegressionCampaignInvalidResultCaseV1;
+
+export interface AgentGymRegressionCampaignResultV1 {
+  readonly campaign_digest: string;
+  readonly cases: readonly AgentGymRegressionCampaignResultCaseV1[];
+  readonly completed_at: string;
+  readonly completed_case_count: number;
+  readonly equivalent_case_count: number;
+  readonly improved_case_count: number;
+  readonly invalid_case_count: number;
+  readonly regressed_case_count: number;
+  readonly result_digest: string;
+  readonly result_ref: string;
+  readonly schema_version: "agent-gym-regression-campaign-result/v1";
+  readonly status: "blocked" | "complete";
+}
+
+/** Seals complete campaign evidence and fails closed above the invalid-case budget. */
+export function recordAgentGymRegressionCampaignResult(
+  campaignValue: AgentGymRegressionCampaignPlanV1,
+  execution: AgentGymRegressionCampaignExecutionV1,
+  input: Pick<AgentGymRegressionCampaignResultV1, "completed_at" | "result_ref">,
+): AgentGymRegressionCampaignResultV1 {
+  const campaign = validateAgentGymRegressionCampaignPlan(campaignValue);
+  reference(input.result_ref); timestamp(input.completed_at);
+  if (execution.schema_version !== "agent-gym-regression-campaign-execution/v1"
+    || execution.campaign_digest !== campaign.campaign_digest
+    || execution.outputs.length !== campaign.cases.length) invalid();
+  const outputs = execution.outputs.map((output, index) =>
+    validateAgentGymRegressionCampaignCaseOutput(campaign, campaign.cases[index]!, output));
+  if (outputs.some((output, index) => output.case_ref !== campaign.cases[index]!.case_ref)
+    || outputs.some((output) => output.status === "completed"
+      && Date.parse(input.completed_at) < Date.parse(output.trial.completed_at))) invalid();
+  const cases = outputs.map((output): AgentGymRegressionCampaignResultCaseV1 => output.status === "completed"
+    ? Object.freeze({ case_digest: output.case_digest, case_ref: output.case_ref,
+      outcome: output.trial.outcome, status: output.status, trial_digest: output.trial.trial_digest })
+    : Object.freeze({ blocker_code: output.blocker_code, case_digest: output.case_digest,
+      case_ref: output.case_ref, status: output.status }));
+  const counts = count(cases);
+  if (counts.completed_case_count !== execution.completed_case_count
+    || counts.invalid_case_count !== execution.invalid_case_count) invalid();
+  const body = { campaign_digest: campaign.campaign_digest, cases: cases.map(caseBody),
+    completed_at: input.completed_at, ...counts, result_ref: input.result_ref,
+    schema_version: "agent-gym-regression-campaign-result/v1" as const,
+    status: counts.invalid_case_count > campaign.maximum_invalid_cases ? "blocked" as const : "complete" as const };
+  return Object.freeze({ ...body, cases: Object.freeze(cases), result_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRegressionCampaignResult(
+  value: AgentGymRegressionCampaignResultV1,
+): AgentGymRegressionCampaignResultV1 {
+  if (value.schema_version !== "agent-gym-regression-campaign-result/v1") invalid();
+  reference(value.result_ref); timestamp(value.completed_at);
+  digest(value.campaign_digest); digest(value.result_digest);
+  if (!Array.isArray(value.cases) || value.cases.length < 1 || value.cases.length > 10_000
+    || !["blocked", "complete"].includes(value.status)) invalid();
+  const cases = value.cases.map(validateCase);
+  if (new Set(cases.map((entry) => entry.case_ref)).size !== cases.length
+    || cases.some((entry, index) => index > 0 && cases[index - 1]!.case_ref >= entry.case_ref)) invalid();
+  const counts = count(cases);
+  for (const key of Object.keys(counts) as (keyof typeof counts)[]) {
+    if (value[key] !== counts[key]) invalid();
+  }
+  const { result_digest: _digest, ...rest } = value;
+  const body = { ...rest, cases: cases.map(caseBody) };
+  if (digestAgentGymJson(body) !== value.result_digest) invalid();
+  return Object.freeze({ ...value, cases: Object.freeze(cases) });
+}
+
+function validateCase(value: AgentGymRegressionCampaignResultCaseV1) {
+  reference(value.case_ref); digest(value.case_digest);
+  if (value.status === "completed") {
+    if (!["equivalent", "improved", "regressed"].includes(value.outcome)) invalid();
+    digest(value.trial_digest);
+  } else if (value.status === "invalid") {
+    if (!/^[a-z][a-z0-9_.-]{0,79}$/u.test(value.blocker_code)) invalid();
+  } else invalid();
+  return Object.freeze({ ...value });
+}
+function caseBody(value: AgentGymRegressionCampaignResultCaseV1): AgentGymJson {
+  return value.status === "completed"
+    ? { case_digest: value.case_digest, case_ref: value.case_ref, outcome: value.outcome,
+      status: value.status, trial_digest: value.trial_digest }
+    : { blocker_code: value.blocker_code, case_digest: value.case_digest,
+      case_ref: value.case_ref, status: value.status };
+}
+function count(cases: readonly AgentGymRegressionCampaignResultCaseV1[]) {
+  return {
+    completed_case_count: cases.filter((entry) => entry.status === "completed").length,
+    equivalent_case_count: cases.filter((entry) => entry.status === "completed"
+      && entry.outcome === "equivalent").length,
+    improved_case_count: cases.filter((entry) => entry.status === "completed"
+      && entry.outcome === "improved").length,
+    invalid_case_count: cases.filter((entry) => entry.status === "invalid").length,
+    regressed_case_count: cases.filter((entry) => entry.status === "completed"
+      && entry.outcome === "regressed").length,
+  };
+}
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240
+    || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function digest(value: string): void { if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid(); }
+function invalid(): never { throw new AgentGymContractError("Agent gym regression campaign result is invalid."); }

--- a/apps/slack-companion/src/agent-gym/regression-replay-trial.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-trial.ts
@@ -1,0 +1,101 @@
+import { digestAgentGymJson } from "./canonical-json.js";
+import { AgentGymContractError } from "./contract-error.js";
+import { validateAgentGymRegressionReplayComparison, type AgentGymRegressionReplayComparisonV1 } from "./regression-replay-comparison.js";
+import { validateAgentGymRegressionReplayEvaluation, type AgentGymRegressionReplayEvaluationV1 } from "./regression-replay-evaluation.js";
+import { validateAgentGymRegressionReplayEvaluatorBinding, type AgentGymRegressionReplayEvaluatorBindingV1 } from "./regression-replay-evaluator-binding.js";
+import { validateAgentGymRegressionReplayPlan, type AgentGymRegressionReplayPlanV1 } from "./regression-replay-plan.js";
+import { validateAgentGymRegressionReplayResult, type AgentGymRegressionReplayResultV1 } from "./regression-replay-result.js";
+
+export interface AgentGymRegressionReplayTrialV1 {
+  readonly baseline_candidate_ref: string;
+  readonly case_digest: string;
+  readonly case_ref: string;
+  readonly challenger_candidate_ref: string;
+  readonly comparison_digest: string;
+  readonly completed_at: string;
+  readonly evaluation_digest: string;
+  readonly evaluator_binding_digest: string;
+  readonly outcome: AgentGymRegressionReplayComparisonV1["outcome"];
+  readonly plan_digest: string;
+  readonly replay_result_digest: string;
+  readonly schema_version: "agent-gym-regression-replay-trial/v1";
+  readonly trial_digest: string;
+  readonly trial_ref: string;
+}
+
+/** Seals one complete, text-free replay chain for campaign aggregation. */
+export function sealAgentGymRegressionReplayTrial(
+  planValue: AgentGymRegressionReplayPlanV1,
+  resultValue: AgentGymRegressionReplayResultV1,
+  bindingValue: AgentGymRegressionReplayEvaluatorBindingV1,
+  evaluationValue: AgentGymRegressionReplayEvaluationV1,
+  comparisonValue: AgentGymRegressionReplayComparisonV1,
+  input: Pick<AgentGymRegressionReplayTrialV1, "completed_at" | "trial_ref">,
+): AgentGymRegressionReplayTrialV1 {
+  const plan = validateAgentGymRegressionReplayPlan(planValue);
+  const result = validateAgentGymRegressionReplayResult(resultValue);
+  const binding = validateAgentGymRegressionReplayEvaluatorBinding(bindingValue);
+  const evaluation = validateAgentGymRegressionReplayEvaluation(evaluationValue);
+  const comparison = validateAgentGymRegressionReplayComparison(comparisonValue);
+  reference(input.trial_ref);
+  timestamp(input.completed_at);
+  if (result.plan_digest !== plan.plan_digest
+    || result.case_ref !== plan.case_ref || result.case_digest !== plan.case_digest
+    || binding.replay_result_digest !== result.result_digest
+    || binding.baseline_candidate_ref !== result.baseline.candidate_ref
+    || binding.challenger_candidate_ref !== result.challenger.candidate_ref
+    || evaluation.replay_result_digest !== result.result_digest
+    || comparison.replay_result_digest !== result.result_digest
+    || comparison.evaluation_digest !== evaluation.evaluation_digest
+    || comparison.baseline_candidate_ref !== result.baseline.candidate_ref
+    || comparison.challenger_candidate_ref !== result.challenger.candidate_ref
+    || Date.parse(input.completed_at) < Date.parse(comparison.compared_at)) invalid();
+  const body = {
+    baseline_candidate_ref: result.baseline.candidate_ref,
+    case_digest: result.case_digest,
+    case_ref: result.case_ref,
+    challenger_candidate_ref: result.challenger.candidate_ref,
+    comparison_digest: comparison.comparison_digest,
+    completed_at: input.completed_at,
+    evaluation_digest: evaluation.evaluation_digest,
+    evaluator_binding_digest: binding.binding_digest,
+    outcome: comparison.outcome,
+    plan_digest: plan.plan_digest,
+    replay_result_digest: result.result_digest,
+    schema_version: "agent-gym-regression-replay-trial/v1" as const,
+    trial_ref: input.trial_ref,
+  };
+  return Object.freeze({ ...body, trial_digest: digestAgentGymJson(body) });
+}
+
+export function validateAgentGymRegressionReplayTrial(
+  value: AgentGymRegressionReplayTrialV1,
+): AgentGymRegressionReplayTrialV1 {
+  if (value.schema_version !== "agent-gym-regression-replay-trial/v1") invalid();
+  for (const ref of [value.baseline_candidate_ref, value.case_ref,
+    value.challenger_candidate_ref, value.trial_ref]) reference(ref);
+  for (const item of [value.case_digest, value.comparison_digest, value.evaluation_digest,
+    value.evaluator_binding_digest, value.plan_digest, value.replay_result_digest,
+    value.trial_digest]) digest(item);
+  timestamp(value.completed_at);
+  if (value.baseline_candidate_ref === value.challenger_candidate_ref
+    || !["equivalent", "improved", "regressed"].includes(value.outcome)) invalid();
+  const { trial_digest: _digest, ...body } = value;
+  if (digestAgentGymJson(body) !== value.trial_digest) invalid();
+  return Object.freeze({ ...value });
+}
+
+function reference(value: string): void {
+  if (typeof value !== "string" || value.length > 240
+    || !/^[a-z][a-z0-9+.-]*:\/\/\S+$/u.test(value)) invalid();
+}
+function timestamp(value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(value)
+    || !Number.isFinite(Date.parse(value))) invalid();
+}
+function digest(value: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) invalid();
+}
+function invalid(): never {
+  throw new AgentGymContractError("Agent gym regression replay trial is invalid.");
+}

--- a/apps/slack-companion/src/agent-gym/regression-replay-trial.ts
+++ b/apps/slack-companion/src/agent-gym/regression-replay-trial.ts
@@ -14,10 +14,13 @@ export interface AgentGymRegressionReplayTrialV1 {
   readonly comparison_digest: string;
   readonly completed_at: string;
   readonly evaluation_digest: string;
+  readonly evaluator_admission_digest: string;
   readonly evaluator_binding_digest: string;
+  readonly evaluator_digests: readonly string[];
   readonly outcome: AgentGymRegressionReplayComparisonV1["outcome"];
   readonly plan_digest: string;
   readonly replay_result_digest: string;
+  readonly rubric_digest: string;
   readonly schema_version: "agent-gym-regression-replay-trial/v1";
   readonly trial_digest: string;
   readonly trial_ref: string;
@@ -58,14 +61,18 @@ export function sealAgentGymRegressionReplayTrial(
     comparison_digest: comparison.comparison_digest,
     completed_at: input.completed_at,
     evaluation_digest: evaluation.evaluation_digest,
+    evaluator_admission_digest: binding.evaluator_admission_digest,
     evaluator_binding_digest: binding.binding_digest,
+    evaluator_digests: [...binding.evaluator_digests],
     outcome: comparison.outcome,
     plan_digest: plan.plan_digest,
     replay_result_digest: result.result_digest,
+    rubric_digest: binding.rubric_digest,
     schema_version: "agent-gym-regression-replay-trial/v1" as const,
     trial_ref: input.trial_ref,
   };
-  return Object.freeze({ ...body, trial_digest: digestAgentGymJson(body) });
+  return Object.freeze({ ...body, evaluator_digests: Object.freeze(body.evaluator_digests),
+    trial_digest: digestAgentGymJson(body) });
 }
 
 export function validateAgentGymRegressionReplayTrial(
@@ -75,14 +82,18 @@ export function validateAgentGymRegressionReplayTrial(
   for (const ref of [value.baseline_candidate_ref, value.case_ref,
     value.challenger_candidate_ref, value.trial_ref]) reference(ref);
   for (const item of [value.case_digest, value.comparison_digest, value.evaluation_digest,
-    value.evaluator_binding_digest, value.plan_digest, value.replay_result_digest,
-    value.trial_digest]) digest(item);
+    value.evaluator_admission_digest, value.evaluator_binding_digest, value.plan_digest,
+    value.replay_result_digest, value.rubric_digest, value.trial_digest]) digest(item);
+  if (!Array.isArray(value.evaluator_digests) || value.evaluator_digests.length < 1
+    || value.evaluator_digests.length > 2
+    || new Set(value.evaluator_digests).size !== value.evaluator_digests.length) invalid();
+  value.evaluator_digests.forEach(digest);
   timestamp(value.completed_at);
   if (value.baseline_candidate_ref === value.challenger_candidate_ref
     || !["equivalent", "improved", "regressed"].includes(value.outcome)) invalid();
   const { trial_digest: _digest, ...body } = value;
   if (digestAgentGymJson(body) !== value.trial_digest) invalid();
-  return Object.freeze({ ...value });
+  return Object.freeze({ ...value, evaluator_digests: Object.freeze([...value.evaluator_digests]) });
 }
 
 function reference(value: string): void {

--- a/apps/slack-companion/test/agent-gym-regression-campaign-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-campaign-runtime.test.ts
@@ -7,6 +7,7 @@ import { sealAgentGymRegressionReplayTrial, validateAgentGymRegressionReplayTria
 import { planAgentGymRegressionCampaign, validateAgentGymRegressionCampaignPlan } from "../src/agent-gym/regression-campaign-plan.js";
 import { invalidAgentGymRegressionCampaignCase, validateAgentGymRegressionCampaignCaseOutput } from "../src/agent-gym/regression-campaign-port.js";
 import { executeAgentGymRegressionCampaign } from "../src/agent-gym/regression-campaign-execution.js";
+import { recordAgentGymRegressionCampaignResult, validateAgentGymRegressionCampaignResult } from "../src/agent-gym/regression-campaign-result.js";
 
 const sha = (value: string): string => `sha256:${value.repeat(64).slice(0, 64)}`;
 
@@ -149,6 +150,33 @@ test("keeps provider failures as invalid campaign cases", async () => {
   assert.equal(execution.invalid_case_count, 1);
   assert.equal(execution.outputs[0]?.status, "invalid");
   assert.equal(JSON.stringify(execution).includes("provider response"), false);
+});
+
+test("records complete campaign outcomes as text-free durable evidence", async () => {
+  const { campaign, trial } = campaignBundle();
+  const execution = await executeAgentGymRegressionCampaign(campaign, { async run(_campaign, replay) {
+    return { case_digest: replay.case_digest, case_ref: replay.case_ref,
+      schema_version: "agent-gym-regression-campaign-case-output/v1", status: "completed", trial };
+  } });
+  const result = recordAgentGymRegressionCampaignResult(campaign, execution, {
+    completed_at: "2026-08-12T15:06:00.000Z", result_ref: "agent-gym-regression-campaign-result://one",
+  });
+  assert.equal(validateAgentGymRegressionCampaignResult(result).status, "complete");
+  assert.equal(result.improved_case_count, 1);
+  assert.equal(JSON.stringify(result).includes("output_text"), false);
+});
+
+test("blocks campaigns above their invalid-case budget", async () => {
+  const { campaign } = campaignBundle();
+  const execution = await executeAgentGymRegressionCampaign(campaign, { async run() {
+    throw new Error("evaluator unavailable");
+  } });
+  const result = recordAgentGymRegressionCampaignResult(campaign, execution, {
+    completed_at: "2026-08-12T15:06:00.000Z", result_ref: "agent-gym-regression-campaign-result://blocked",
+  });
+  assert.equal(result.status, "blocked");
+  assert.equal(result.invalid_case_count, 1);
+  assert.equal(result.improved_case_count, 0);
 });
 
 test("rejects a runtime chain whose evaluator binding targets another result", () => {

--- a/apps/slack-companion/test/agent-gym-regression-campaign-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-campaign-runtime.test.ts
@@ -5,6 +5,7 @@ import { compareAgentGymRegressionReplay } from "../src/agent-gym/regression-rep
 import { evaluateAgentGymRegressionReplay } from "../src/agent-gym/regression-replay-evaluation.js";
 import { sealAgentGymRegressionReplayTrial, validateAgentGymRegressionReplayTrial } from "../src/agent-gym/regression-replay-trial.js";
 import { planAgentGymRegressionCampaign, validateAgentGymRegressionCampaignPlan } from "../src/agent-gym/regression-campaign-plan.js";
+import { invalidAgentGymRegressionCampaignCase, validateAgentGymRegressionCampaignCaseOutput } from "../src/agent-gym/regression-campaign-port.js";
 
 const sha = (value: string): string => `sha256:${value.repeat(64).slice(0, 64)}`;
 
@@ -29,7 +30,8 @@ function trialChain() {
   const result = { ...resultBody, result_digest: digestAgentGymJson(resultBody) };
   const bindingBody = { baseline_candidate_ref: result.baseline.candidate_ref,
     binding_ref: "agent-gym-evaluator-binding://campaign/one", bound_at: "2026-08-12T15:02:00.000Z",
-    challenger_candidate_ref: result.challenger.candidate_ref, evaluator_admission_digest: sha("1"),
+    challenger_candidate_ref: result.challenger.candidate_ref,
+    evaluator_admission_digest: evaluatorAdmission().decision_digest,
     evaluator_digests: [sha("2")], replay_result_digest: result.result_digest, rubric_digest: sha("3"),
     schema_version: "agent-gym-regression-replay-evaluator-binding/v1" as const };
   const binding = { ...bindingBody, binding_digest: digestAgentGymJson(bindingBody) };
@@ -52,6 +54,20 @@ function evaluatorAdmission() {
     policy_ref: "agent-gym-evaluator-policy://campaign/one", rubric_digest: sha("3"),
     schema_version: "agent-gym-evaluator-admission-decision/v1" as const };
   return { ...body, decision_digest: digestAgentGymJson(body) };
+}
+
+function campaignBundle() {
+  const chain = trialChain();
+  const campaign = planAgentGymRegressionCampaign([chain.plan], evaluatorAdmission(), {
+    baseline_candidate_ref: chain.result.baseline.candidate_ref,
+    campaign_ref: "agent-gym-regression-campaign://one",
+    challenger_candidate_ref: chain.result.challenger.candidate_ref,
+    maximum_invalid_cases: 0, planned_at: "2026-08-12T15:00:00.000Z",
+  });
+  const trial = sealAgentGymRegressionReplayTrial(chain.plan, chain.result, chain.binding,
+    chain.evaluation, chain.comparison, { completed_at: "2026-08-12T15:05:00.000Z",
+      trial_ref: "agent-gym-regression-trial://campaign/one" });
+  return { campaign, chain, trial };
 }
 
 test("seals one complete runtime chain without model output text", () => {
@@ -86,6 +102,29 @@ test("rejects campaign plans that tolerate every case being invalid", () => {
     challenger_candidate_ref: chain.result.challenger.candidate_ref,
     maximum_invalid_cases: 1, planned_at: "2026-08-12T15:00:00.000Z",
   }));
+});
+
+test("accepts only complete trials bound to the campaign identities", () => {
+  const { campaign, trial } = campaignBundle();
+  const replay = campaign.cases[0]!;
+  const output = validateAgentGymRegressionCampaignCaseOutput(campaign, replay, {
+    case_digest: replay.case_digest, case_ref: replay.case_ref,
+    schema_version: "agent-gym-regression-campaign-case-output/v1", status: "completed", trial,
+  });
+  assert.equal(output.status, "completed");
+  assert.throws(() => validateAgentGymRegressionCampaignCaseOutput(campaign, replay, {
+    case_digest: replay.case_digest, case_ref: replay.case_ref,
+    schema_version: "agent-gym-regression-campaign-case-output/v1", status: "completed",
+    trial: { ...trial, challenger_candidate_ref: "agent-gym-candidate://challenger/other" },
+  }));
+});
+
+test("records stable invalid case output without provider error text", () => {
+  const { campaign } = campaignBundle();
+  const replay = campaign.cases[0]!;
+  const output = invalidAgentGymRegressionCampaignCase(replay, "evaluator_output_invalid");
+  assert.equal(validateAgentGymRegressionCampaignCaseOutput(campaign, replay, output).status, "invalid");
+  assert.equal("message" in output, false);
 });
 
 test("rejects a runtime chain whose evaluator binding targets another result", () => {

--- a/apps/slack-companion/test/agent-gym-regression-campaign-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-campaign-runtime.test.ts
@@ -4,6 +4,7 @@ import { digestAgentGymJson } from "../src/agent-gym/canonical-json.js";
 import { compareAgentGymRegressionReplay } from "../src/agent-gym/regression-replay-comparison.js";
 import { evaluateAgentGymRegressionReplay } from "../src/agent-gym/regression-replay-evaluation.js";
 import { sealAgentGymRegressionReplayTrial, validateAgentGymRegressionReplayTrial } from "../src/agent-gym/regression-replay-trial.js";
+import { planAgentGymRegressionCampaign, validateAgentGymRegressionCampaignPlan } from "../src/agent-gym/regression-campaign-plan.js";
 
 const sha = (value: string): string => `sha256:${value.repeat(64).slice(0, 64)}`;
 
@@ -45,6 +46,14 @@ function trialChain() {
   return { binding, comparison, evaluation, plan, result };
 }
 
+function evaluatorAdmission() {
+  const body = { admitted: true, blocker_codes: [], calibration_digests: [],
+    decided_at: "2026-08-12T14:59:00.000Z", evaluator_digests: [sha("2")],
+    policy_ref: "agent-gym-evaluator-policy://campaign/one", rubric_digest: sha("3"),
+    schema_version: "agent-gym-evaluator-admission-decision/v1" as const };
+  return { ...body, decision_digest: digestAgentGymJson(body) };
+}
+
 test("seals one complete runtime chain without model output text", () => {
   const chain = trialChain();
   const trial = sealAgentGymRegressionReplayTrial(chain.plan, chain.result, chain.binding,
@@ -52,7 +61,31 @@ test("seals one complete runtime chain without model output text", () => {
       trial_ref: "agent-gym-regression-trial://campaign/one" });
   assert.equal(validateAgentGymRegressionReplayTrial(trial).outcome, "improved");
   assert.equal(trial.evaluator_binding_digest, chain.binding.binding_digest);
+  assert.equal(trial.evaluator_admission_digest, chain.binding.evaluator_admission_digest);
   assert.equal(JSON.stringify(trial).includes("output_text"), false);
+});
+
+test("plans ordered campaign cases under one admitted evaluator identity", () => {
+  const chain = trialChain();
+  const campaign = planAgentGymRegressionCampaign([chain.plan], evaluatorAdmission(), {
+    baseline_candidate_ref: chain.result.baseline.candidate_ref,
+    campaign_ref: "agent-gym-regression-campaign://one",
+    challenger_candidate_ref: chain.result.challenger.candidate_ref,
+    maximum_invalid_cases: 0, planned_at: "2026-08-12T15:00:00.000Z",
+  });
+  assert.equal(validateAgentGymRegressionCampaignPlan(campaign).cases[0]?.replay_plan_digest,
+    chain.plan.plan_digest);
+  assert.equal(campaign.maximum_model_calls, 2);
+});
+
+test("rejects campaign plans that tolerate every case being invalid", () => {
+  const chain = trialChain();
+  assert.throws(() => planAgentGymRegressionCampaign([chain.plan], evaluatorAdmission(), {
+    baseline_candidate_ref: chain.result.baseline.candidate_ref,
+    campaign_ref: "agent-gym-regression-campaign://invalid",
+    challenger_candidate_ref: chain.result.challenger.candidate_ref,
+    maximum_invalid_cases: 1, planned_at: "2026-08-12T15:00:00.000Z",
+  }));
 });
 
 test("rejects a runtime chain whose evaluator binding targets another result", () => {

--- a/apps/slack-companion/test/agent-gym-regression-campaign-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-campaign-runtime.test.ts
@@ -6,6 +6,7 @@ import { evaluateAgentGymRegressionReplay } from "../src/agent-gym/regression-re
 import { sealAgentGymRegressionReplayTrial, validateAgentGymRegressionReplayTrial } from "../src/agent-gym/regression-replay-trial.js";
 import { planAgentGymRegressionCampaign, validateAgentGymRegressionCampaignPlan } from "../src/agent-gym/regression-campaign-plan.js";
 import { invalidAgentGymRegressionCampaignCase, validateAgentGymRegressionCampaignCaseOutput } from "../src/agent-gym/regression-campaign-port.js";
+import { executeAgentGymRegressionCampaign } from "../src/agent-gym/regression-campaign-execution.js";
 
 const sha = (value: string): string => `sha256:${value.repeat(64).slice(0, 64)}`;
 
@@ -125,6 +126,29 @@ test("records stable invalid case output without provider error text", () => {
   const output = invalidAgentGymRegressionCampaignCase(replay, "evaluator_output_invalid");
   assert.equal(validateAgentGymRegressionCampaignCaseOutput(campaign, replay, output).status, "invalid");
   assert.equal("message" in output, false);
+});
+
+test("executes campaign cases in order through one portable trial port", async () => {
+  const { campaign, trial } = campaignBundle();
+  const seen: string[] = [];
+  const execution = await executeAgentGymRegressionCampaign(campaign, { async run(_campaign, replay) {
+    seen.push(replay.case_ref);
+    return { case_digest: replay.case_digest, case_ref: replay.case_ref,
+      schema_version: "agent-gym-regression-campaign-case-output/v1", status: "completed", trial };
+  } });
+  assert.deepEqual(seen, campaign.cases.map((entry) => entry.case_ref));
+  assert.equal(execution.completed_case_count, 1);
+  assert.equal(execution.invalid_case_count, 0);
+});
+
+test("keeps provider failures as invalid campaign cases", async () => {
+  const { campaign } = campaignBundle();
+  const execution = await executeAgentGymRegressionCampaign(campaign, { async run() {
+    throw new Error("provider response that must not persist");
+  } });
+  assert.equal(execution.invalid_case_count, 1);
+  assert.equal(execution.outputs[0]?.status, "invalid");
+  assert.equal(JSON.stringify(execution).includes("provider response"), false);
 });
 
 test("rejects a runtime chain whose evaluator binding targets another result", () => {

--- a/apps/slack-companion/test/agent-gym-regression-campaign-runtime.test.ts
+++ b/apps/slack-companion/test/agent-gym-regression-campaign-runtime.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { digestAgentGymJson } from "../src/agent-gym/canonical-json.js";
+import { compareAgentGymRegressionReplay } from "../src/agent-gym/regression-replay-comparison.js";
+import { evaluateAgentGymRegressionReplay } from "../src/agent-gym/regression-replay-evaluation.js";
+import { sealAgentGymRegressionReplayTrial, validateAgentGymRegressionReplayTrial } from "../src/agent-gym/regression-replay-trial.js";
+
+const sha = (value: string): string => `sha256:${value.repeat(64).slice(0, 64)}`;
+
+function trialChain() {
+  const planBody = {
+    baseline_invocation_ref: "agent-gym-invocation://baseline/campaign-one",
+    case_digest: sha("a"), case_ref: "agent-gym-case://campaign/one",
+    challenger_invocation_ref: "agent-gym-invocation://challenger/campaign-one",
+    maximum_model_calls: 2, plan_ref: "agent-gym-replay-plan://campaign/one",
+    planned_at: "2026-08-12T15:00:00.000Z", replay_request_digest: sha("b"),
+    schema_version: "agent-gym-regression-replay-plan/v1" as const,
+  };
+  const plan = { ...planBody, plan_digest: digestAgentGymJson(planBody) };
+  const candidate = (role: "baseline" | "challenger") => ({
+    candidate_ref: `agent-gym-candidate://${role}/campaign`, invocation_receipt_digest: sha(role === "baseline" ? "c" : "d"),
+    invocation_ref: `agent-gym-invocation://${role}/campaign-one`, latency_ms: role === "baseline" ? 20 : 15,
+    response_digest: sha(role === "baseline" ? "e" : "f"), total_tokens: role === "baseline" ? 30 : 25,
+  });
+  const resultBody = { baseline: candidate("baseline"), case_digest: plan.case_digest, case_ref: plan.case_ref,
+    challenger: candidate("challenger"), completed_at: "2026-08-12T15:01:00.000Z", plan_digest: plan.plan_digest,
+    result_ref: "agent-gym-replay-result://campaign/one", schema_version: "agent-gym-regression-replay-result/v1" as const };
+  const result = { ...resultBody, result_digest: digestAgentGymJson(resultBody) };
+  const bindingBody = { baseline_candidate_ref: result.baseline.candidate_ref,
+    binding_ref: "agent-gym-evaluator-binding://campaign/one", bound_at: "2026-08-12T15:02:00.000Z",
+    challenger_candidate_ref: result.challenger.candidate_ref, evaluator_admission_digest: sha("1"),
+    evaluator_digests: [sha("2")], replay_result_digest: result.result_digest, rubric_digest: sha("3"),
+    schema_version: "agent-gym-regression-replay-evaluator-binding/v1" as const };
+  const binding = { ...bindingBody, binding_digest: digestAgentGymJson(bindingBody) };
+  const evaluation = evaluateAgentGymRegressionReplay(result, {
+    baseline: { blocker_codes: [], candidate_ref: result.baseline.candidate_ref,
+      evidence_digest: sha("4"), safety_passed: true, score: 0.7 },
+    challenger: { blocker_codes: [], candidate_ref: result.challenger.candidate_ref,
+      evidence_digest: sha("5"), safety_passed: true, score: 0.9 },
+    evaluated_at: "2026-08-12T15:03:00.000Z", evaluation_ref: "agent-gym-replay-evaluation://campaign/one",
+  });
+  const comparison = compareAgentGymRegressionReplay(result, evaluation, {
+    compared_at: "2026-08-12T15:04:00.000Z", comparison_ref: "agent-gym-replay-comparison://campaign/one",
+  });
+  return { binding, comparison, evaluation, plan, result };
+}
+
+test("seals one complete runtime chain without model output text", () => {
+  const chain = trialChain();
+  const trial = sealAgentGymRegressionReplayTrial(chain.plan, chain.result, chain.binding,
+    chain.evaluation, chain.comparison, { completed_at: "2026-08-12T15:05:00.000Z",
+      trial_ref: "agent-gym-regression-trial://campaign/one" });
+  assert.equal(validateAgentGymRegressionReplayTrial(trial).outcome, "improved");
+  assert.equal(trial.evaluator_binding_digest, chain.binding.binding_digest);
+  assert.equal(JSON.stringify(trial).includes("output_text"), false);
+});
+
+test("rejects a runtime chain whose evaluator binding targets another result", () => {
+  const chain = trialChain();
+  assert.throws(() => sealAgentGymRegressionReplayTrial(chain.plan, chain.result,
+    { ...chain.binding, replay_result_digest: sha("9") }, chain.evaluation, chain.comparison,
+    { completed_at: "2026-08-12T15:05:00.000Z", trial_ref: "agent-gym-regression-trial://campaign/invalid" }));
+});


### PR DESCRIPTION
## Summary

- seal one complete text-free replay trial from plan through comparison
- plan ordered campaign cases under one admitted evaluator identity and shared model-call budget
- validate provider-neutral trial outputs against exact campaign identities
- execute every case deterministically while converting provider failures into bounded invalid evidence
- record campaign outcome counts and fail closed above the invalid-case budget

## Validation

- `npm run typecheck` in `apps/slack-companion` on DDESK
- `npm test` in `apps/slack-companion` on DDESK: 747 passed, 0 failed
- `git diff --check origin/main..HEAD`

## Scope

Portable Slack companion contracts only. Provider routes, credentials, Bedrock configuration, IAM, and deployment topology remain private.