### PR TITLE
feat(slack): separate offline evaluation roles

### DIFF
--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb-comparison.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb-comparison.ts
@@ -1,0 +1,93 @@
+import type { HostedHillclimbReceipt } from "./hosted-hillclimb.js";
+
+export interface HostedHillclimbComparisonV1 {
+  readonly blocker_change: {
+    readonly added: readonly string[];
+    readonly resolved: readonly string[];
+  };
+  readonly candidate_delta: {
+    readonly authority_boundary_rate: number;
+    readonly context_recall_rate: number;
+    readonly evidence_context_retention_rate: number;
+    readonly expected_restatement_turns_per_case: number;
+    readonly p95_inference_latency_ms: number;
+    readonly semantic_state_contract_rate: number;
+  };
+  readonly current_evaluated_at: string;
+  readonly previous_evaluated_at: string;
+  readonly promotion_stable: boolean;
+  readonly regression_count_delta: number;
+  readonly schema_version: "slack-working-state-hosted-hillclimb-comparison/v1";
+}
+
+/** Compares repeat measurements only when corpus and model identities are unchanged. */
+export function compareHostedSlackWorkingStateHillclimbs(
+  previous: HostedHillclimbReceipt,
+  current: HostedHillclimbReceipt,
+): HostedHillclimbComparisonV1 {
+  if (previous.schema_version !== "slack-working-state-hosted-hillclimb-receipt/v1"
+    || current.schema_version !== "slack-working-state-hosted-hillclimb-receipt/v1") {
+    throw new Error("Hosted hillclimb comparison requires v1 receipts.");
+  }
+  if (previous.corpus_digest !== current.corpus_digest) {
+    throw new Error("Hosted hillclimb comparison requires the same corpus digest.");
+  }
+  if (previous.generator.model_id !== current.generator.model_id
+    || previous.judge.model_id !== current.judge.model_id) {
+    throw new Error("Hosted hillclimb comparison requires the same generator and judge models.");
+  }
+  const previousTime = Date.parse(previous.evaluated_at);
+  const currentTime = Date.parse(current.evaluated_at);
+  if (!Number.isFinite(previousTime) || !Number.isFinite(currentTime)
+    || currentTime <= previousTime) {
+    throw new Error("Hosted hillclimb comparison requires increasing evaluation times.");
+  }
+  const previousBlockers = new Set(previous.promotion.blockers);
+  const currentBlockers = new Set(current.promotion.blockers);
+  return Object.freeze({
+    blocker_change: Object.freeze({
+      added: Object.freeze([...currentBlockers].filter((value) => !previousBlockers.has(value)).sort()),
+      resolved: Object.freeze([...previousBlockers].filter((value) => !currentBlockers.has(value)).sort()),
+    }),
+    candidate_delta: Object.freeze({
+      authority_boundary_rate: delta(
+        previous.candidate.authority_boundary_rate,
+        current.candidate.authority_boundary_rate,
+      ),
+      context_recall_rate: delta(
+        previous.candidate.context_recall_rate,
+        current.candidate.context_recall_rate,
+      ),
+      evidence_context_retention_rate: delta(
+        previous.candidate.evidence_context_retention_rate,
+        current.candidate.evidence_context_retention_rate,
+      ),
+      expected_restatement_turns_per_case: delta(
+        previous.candidate.expected_restatement_turns_per_case,
+        current.candidate.expected_restatement_turns_per_case,
+      ),
+      p95_inference_latency_ms: delta(
+        previous.candidate.p95_inference_latency_ms,
+        current.candidate.p95_inference_latency_ms,
+      ),
+      semantic_state_contract_rate: delta(
+        previous.candidate.semantic_state_contract_rate,
+        current.candidate.semantic_state_contract_rate,
+      ),
+    }),
+    current_evaluated_at: current.evaluated_at,
+    previous_evaluated_at: previous.evaluated_at,
+    promotion_stable:
+      previous.promotion.promotion_ready === current.promotion.promotion_ready,
+    regression_count_delta:
+      current.promotion.regression_count - previous.promotion.regression_count,
+    schema_version: "slack-working-state-hosted-hillclimb-comparison/v1",
+  });
+}
+
+function delta(previous: number, current: number): number {
+  if (!Number.isFinite(previous) || !Number.isFinite(current)) {
+    throw new Error("Hosted hillclimb comparison metrics must be finite.");
+  }
+  return Math.round((current - previous) * 10_000) / 10_000;
+}

--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb.ts
@@ -169,6 +169,7 @@ const MAX_GENERATOR_TOKENS = 320;
 const MAX_JUDGE_TOKENS = 700;
 const MAX_JUDGE_ATTEMPTS = 3;
 const OPUS_MODEL_MARKER = "anthropic.claude-opus-";
+const CLAUDE_MODEL_MARKER = "anthropic.claude-";
 const MINIMUM_CANDIDATE_RATE = 0.9;
 const REQUIRED_AUTHORITY_RATE = 1;
 const MAXIMUM_RESTATEMENT_RATE = 0.1;
@@ -694,12 +695,19 @@ function validateOptions(options: HostedHillclimbOptions): void {
       throw new Error(`Hosted hillclimb ${label} is missing or unbounded.`);
     }
   }
-  if (
-    !isOpusModelId(options.generator_model_id)
-    || !isOpusModelId(options.judge_model_id)
-  ) {
+  if (!isOpusModelId(options.generator_model_id)) {
     throw new Error(
-      "Cerebro working-state hillclimbs require AWS-hosted Claude Opus models.",
+      "Cerebro working-state hillclimb generation requires an AWS-hosted Claude Opus model.",
+    );
+  }
+  if (!isClaudeModelId(options.judge_model_id)) {
+    throw new Error(
+      "Cerebro working-state hillclimb judging requires an AWS-hosted Claude model.",
+    );
+  }
+  if (options.generator_model_id === options.judge_model_id) {
+    throw new Error(
+      "Cerebro working-state hillclimb judging requires a model distinct from generation.",
     );
   }
 }
@@ -713,6 +721,20 @@ function isOpusModelId(modelId: string): boolean {
     return false;
   }
   const suffix = modelId.slice(markerIndex + OPUS_MODEL_MARKER.length);
+  return suffix.length > 0 && [...suffix].every((character) =>
+    character === "."
+    || character === "-"
+    || character >= "0" && character <= "9"
+    || character >= "a" && character <= "z"
+  );
+}
+
+function isClaudeModelId(modelId: string): boolean {
+  const markerIndex = modelId.indexOf(CLAUDE_MODEL_MARKER);
+  if (markerIndex <= 0 || ![".", "/"].includes(modelId[markerIndex - 1]!)) {
+    return false;
+  }
+  const suffix = modelId.slice(markerIndex + CLAUDE_MODEL_MARKER.length);
   return suffix.length > 0 && [...suffix].every((character) =>
     character === "."
     || character === "-"

--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb.ts
@@ -32,6 +32,11 @@ export interface HostedModelPort {
   converse(request: HostedModelRequest): Promise<HostedModelResponse>;
 }
 
+export interface HostedHillclimbModelPorts {
+  readonly generator: HostedModelPort;
+  readonly judge: HostedModelPort;
+}
+
 export interface HostedHillclimbOptions {
   readonly generator_model_id: string;
   readonly judge_model_id: string;
@@ -173,7 +178,7 @@ const MAXIMUM_P95_INFERENCE_LATENCY_MS = 10_000;
 export async function runHostedSlackWorkingStateHillclimb(
   cases: readonly SlackWorkingStateEvalCaseV1[],
   options: HostedHillclimbOptions,
-  model: HostedModelPort,
+  models: HostedHillclimbModelPorts,
   evaluatedAt = new Date(),
 ): Promise<HostedHillclimbReceipt> {
   validateOptions(options);
@@ -187,15 +192,15 @@ export async function runHostedSlackWorkingStateHillclimb(
   const results: HostedHillclimbCaseResult[] = [];
   for (const evalCase of cases) {
     const [baseline, candidate] = await Promise.all([
-      generateAnswer(evalCase, "baseline", options.generator_model_id, model),
-      generateAnswer(evalCase, "candidate", options.generator_model_id, model),
+      generateAnswer(evalCase, "baseline", options.generator_model_id, models.generator),
+      generateAnswer(evalCase, "candidate", options.generator_model_id, models.generator),
     ]);
     const judge = await judgeAnswers(
       evalCase,
       baseline.output,
       candidate.output,
       options.judge_model_id,
-      model,
+      models.judge,
     );
     const baselinePassed = scorePassed(judge.scores.baseline);
     const candidatePassed = scorePassed(judge.scores.candidate);

--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb.ts
@@ -97,6 +97,10 @@ export interface HostedHillclimbReceipt {
   readonly candidate: HostedHillclimbSummary;
   readonly corpus_digest: string;
   readonly evaluated_at: string;
+  readonly evaluation_independence: {
+    readonly distinct_model_id: true;
+    readonly separate_model_ports: true;
+  };
   readonly generator: {
     readonly model_id: string;
     readonly provider: "aws_bedrock";
@@ -183,6 +187,11 @@ export async function runHostedSlackWorkingStateHillclimb(
   evaluatedAt = new Date(),
 ): Promise<HostedHillclimbReceipt> {
   validateOptions(options);
+  if (models.generator === models.judge) {
+    throw new Error(
+      "Cerebro working-state hillclimb judging requires a separate model port.",
+    );
+  }
   const structural = runSlackWorkingStateHillclimb(cases, evaluatedAt);
   if (!structural.promotion.promotion_ready) {
     throw new Error(
@@ -273,6 +282,10 @@ export async function runHostedSlackWorkingStateHillclimb(
     candidate,
     corpus_digest: structural.corpus_digest,
     evaluated_at: evaluatedAt.toISOString(),
+    evaluation_independence: Object.freeze({
+      distinct_model_id: true as const,
+      separate_model_ports: true as const,
+    }),
     generator: Object.freeze({
       model_id: options.generator_model_id,
       provider: "aws_bedrock" as const,

--- a/apps/slack-companion/src/scratchpad/run-hillclimb-bedrock.ts
+++ b/apps/slack-companion/src/scratchpad/run-hillclimb-bedrock.ts
@@ -19,7 +19,7 @@ try {
       judge_model_id: judgeModelId,
       region,
     },
-    model,
+    { generator: model, judge: model },
   );
   process.stdout.write(`${JSON.stringify(receipt, null, 2)}\n`);
   if (!receipt.promotion.promotion_ready) process.exitCode = 1;

--- a/apps/slack-companion/src/scratchpad/run-hillclimb-bedrock.ts
+++ b/apps/slack-companion/src/scratchpad/run-hillclimb-bedrock.ts
@@ -3,13 +3,15 @@ import { SLACK_WORKING_STATE_HILLCLIMB_CORPUS } from "./hillclimb-corpus.js";
 import { runHostedSlackWorkingStateHillclimb } from "./hosted-hillclimb.js";
 
 const DEPLOYED_OPUS_MODEL_ID = "us.anthropic.claude-opus-4-8";
+const INDEPENDENT_JUDGE_MODEL_ID = "us.anthropic.claude-sonnet-5";
 const region = required("CEREBRO_SLACK_HILLCLIMB_REGION");
 const generatorModelId = optional(
   "CEREBRO_SLACK_HILLCLIMB_GENERATOR_MODEL_ID",
 ) ?? DEPLOYED_OPUS_MODEL_ID;
 const judgeModelId = optional("CEREBRO_SLACK_HILLCLIMB_JUDGE_MODEL_ID")
-  ?? DEPLOYED_OPUS_MODEL_ID;
-const model = new BedrockHostedModel(region);
+  ?? INDEPENDENT_JUDGE_MODEL_ID;
+const generatorModel = new BedrockHostedModel(region);
+const judgeModel = new BedrockHostedModel(region);
 
 try {
   const receipt = await runHostedSlackWorkingStateHillclimb(
@@ -19,12 +21,13 @@ try {
       judge_model_id: judgeModelId,
       region,
     },
-    { generator: model, judge: model },
+    { generator: generatorModel, judge: judgeModel },
   );
   process.stdout.write(`${JSON.stringify(receipt, null, 2)}\n`);
   if (!receipt.promotion.promotion_ready) process.exitCode = 1;
 } finally {
-  model.destroy();
+  generatorModel.destroy();
+  judgeModel.destroy();
 }
 
 function required(name: string): string {

--- a/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
+++ b/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { compareHostedSlackWorkingStateHillclimbs } from
+  "../src/scratchpad/hosted-hillclimb-comparison.js";
+import type { HostedHillclimbReceipt } from "../src/scratchpad/hosted-hillclimb.js";
+
+function receipt(overrides: {
+  blockers?: string[];
+  contextRecall?: number;
+  corpusDigest?: string;
+  evaluatedAt?: string;
+  regressions?: number;
+} = {}): HostedHillclimbReceipt {
+  return {
+    baseline: summary(0.1),
+    candidate: summary(overrides.contextRecall ?? 0.9),
+    corpus_digest: overrides.corpusDigest ?? `sha256:${"a".repeat(64)}`,
+    evaluated_at: overrides.evaluatedAt ?? "2026-08-12T16:00:00.000Z",
+    evaluation_independence: { distinct_model_id: true, separate_model_ports: true },
+    generator: {
+      model_id: "us.anthropic.claude-opus-4-8",
+      provider: "aws_bedrock",
+      region: "us-east-1",
+      sampling_parameters: "provider_default",
+    },
+    goal: {
+      maximum_candidate_expected_restatement_turns_per_case: 0.1,
+      maximum_candidate_p95_inference_latency_ms: 10_000,
+      minimum_candidate_authority_boundary_rate: 1,
+      minimum_candidate_context_recall_rate: 0.9,
+      minimum_candidate_evidence_context_retention_rate: 0.9,
+      minimum_candidate_semantic_state_contract_rate: 0.9,
+      minimum_context_recall_gain: 0.25,
+    },
+    judge: {
+      input_tokens: 10,
+      invocation_count: 1,
+      model_id: "us.anthropic.claude-sonnet-5",
+      output_tokens: 5,
+      p95_latency_ms: 200,
+      provider: "aws_bedrock",
+      region: "us-east-1",
+      sampling_parameters: "provider_default",
+      total_tokens: 15,
+    },
+    promotion: {
+      blockers: overrides.blockers ?? [],
+      context_recall_gain: 0.8,
+      promotion_ready: (overrides.blockers ?? []).length === 0,
+      regression_count: overrides.regressions ?? 0,
+    },
+    results: [],
+    schema_version: "slack-working-state-hosted-hillclimb-receipt/v1",
+    structural_preflight: {
+      corpus_digest: overrides.corpusDigest ?? `sha256:${"a".repeat(64)}`,
+      promotion_ready: true,
+    },
+  };
+}
+
+function summary(contextRecall: number): HostedHillclimbReceipt["candidate"] {
+  return {
+    authority_boundary_rate: 1,
+    case_count: 22,
+    case_pass_rate: contextRecall,
+    context_recall_rate: contextRecall,
+    evidence_context_retention_rate: 1,
+    expected_restatement_turns_per_case: 0,
+    input_tokens: 100,
+    output_tokens: 50,
+    p95_inference_latency_ms: 3_000,
+    semantic_state_contract_rate: 1,
+    total_tokens: 150,
+  };
+}
+
+test("compares repeat measurements without answer content", () => {
+  const comparison = compareHostedSlackWorkingStateHillclimbs(
+    receipt({ blockers: ["old_blocker"] }),
+    receipt({
+      blockers: ["new_blocker"],
+      contextRecall: 1,
+      evaluatedAt: "2026-08-12T17:00:00.000Z",
+      regressions: 2,
+    }),
+  );
+  assert.equal(comparison.candidate_delta.context_recall_rate, 0.1);
+  assert.deepEqual(comparison.blocker_change, {
+    added: ["new_blocker"],
+    resolved: ["old_blocker"],
+  });
+  assert.equal(comparison.regression_count_delta, 2);
+  assert.equal(comparison.promotion_stable, true);
+});
+
+test("rejects comparisons across corpora or reversed time", () => {
+  assert.throws(
+    () => compareHostedSlackWorkingStateHillclimbs(
+      receipt(),
+      receipt({
+        corpusDigest: `sha256:${"b".repeat(64)}`,
+        evaluatedAt: "2026-08-12T17:00:00.000Z",
+      }),
+    ),
+    /same corpus digest/u,
+  );
+  assert.throws(
+    () => compareHostedSlackWorkingStateHillclimbs(
+      receipt(),
+      receipt({ evaluatedAt: "2026-08-12T15:00:00.000Z" }),
+    ),
+    /increasing evaluation times/u,
+  );
+});

--- a/apps/slack-companion/test/scratchpad-hillclimb.test.ts
+++ b/apps/slack-companion/test/scratchpad-hillclimb.test.ts
@@ -140,7 +140,7 @@ test("hosted hillclimb compares baseline and candidate through AWS model ports",
     SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
     {
       generator_model_id: "us.anthropic.claude-opus-4-8",
-      judge_model_id: "us.anthropic.claude-opus-4-8",
+      judge_model_id: "us.anthropic.claude-sonnet-5",
       region: "us-east-1",
     },
     { generator: generatorModel, judge: judgeModel },
@@ -164,7 +164,7 @@ test("hosted hillclimb compares baseline and candidate through AWS model ports",
   assert.equal(receipt.generator.provider, "aws_bedrock");
   assert.equal(receipt.generator.model_id, "us.anthropic.claude-opus-4-8");
   assert.equal(receipt.generator.sampling_parameters, "provider_default");
-  assert.equal(receipt.judge.model_id, "us.anthropic.claude-opus-4-8");
+  assert.equal(receipt.judge.model_id, "us.anthropic.claude-sonnet-5");
   assert.equal(receipt.judge.sampling_parameters, "provider_default");
   assert.equal(receipt.baseline.context_recall_rate, 0);
   assert.equal(receipt.baseline.expected_restatement_turns_per_case, 1);
@@ -189,12 +189,12 @@ test("hosted hillclimb rejects a Nova generator before invocation", async () => 
       SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
       {
         generator_model_id: "us.amazon.nova-pro-v1:0",
-        judge_model_id: "us.anthropic.claude-opus-4-8",
+        judge_model_id: "us.anthropic.claude-sonnet-5",
         region: "us-east-1",
       },
       { generator: generatorModel, judge: judgeModel },
     ),
-    /require AWS-hosted Claude Opus models/u,
+    /generation requires an AWS-hosted Claude Opus model/u,
   );
   assert.equal(generatorModel.generatorCalls, 0);
   assert.equal(judgeModel.judgeCalls, 0);
@@ -208,13 +208,32 @@ test("hosted hillclimb fails closed on an invalid judge receipt", async () => {
       SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
       {
         generator_model_id: "us.anthropic.claude-opus-4-8",
-        judge_model_id: "us.anthropic.claude-opus-4-8",
+        judge_model_id: "us.anthropic.claude-sonnet-5",
         region: "us-east-1",
       },
       { generator: generatorModel, judge: judgeModel },
     ),
     /Hosted judge returned no JSON object/u,
   );
+});
+
+test("hosted hillclimb rejects a judge that aliases the generator", async () => {
+  const generatorModel = new FakeHostedModel();
+  const judgeModel = new FakeHostedModel();
+  await assert.rejects(
+    runHostedSlackWorkingStateHillclimb(
+      SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
+      {
+        generator_model_id: "us.anthropic.claude-opus-4-8",
+        judge_model_id: "us.anthropic.claude-opus-4-8",
+        region: "us-east-1",
+      },
+      { generator: generatorModel, judge: judgeModel },
+    ),
+    /requires a model distinct from generation/u,
+  );
+  assert.equal(generatorModel.generatorCalls, 0);
+  assert.equal(judgeModel.judgeCalls, 0);
 });
 
 class FakeHostedModel implements HostedModelPort {

--- a/apps/slack-companion/test/scratchpad-hillclimb.test.ts
+++ b/apps/slack-companion/test/scratchpad-hillclimb.test.ts
@@ -166,6 +166,10 @@ test("hosted hillclimb compares baseline and candidate through AWS model ports",
   assert.equal(receipt.generator.sampling_parameters, "provider_default");
   assert.equal(receipt.judge.model_id, "us.anthropic.claude-sonnet-5");
   assert.equal(receipt.judge.sampling_parameters, "provider_default");
+  assert.deepEqual(receipt.evaluation_independence, {
+    distinct_model_id: true,
+    separate_model_ports: true,
+  });
   assert.equal(receipt.baseline.context_recall_rate, 0);
   assert.equal(receipt.baseline.expected_restatement_turns_per_case, 1);
   assert.equal(receipt.candidate.context_recall_rate, 1);
@@ -234,6 +238,24 @@ test("hosted hillclimb rejects a judge that aliases the generator", async () => 
   );
   assert.equal(generatorModel.generatorCalls, 0);
   assert.equal(judgeModel.judgeCalls, 0);
+});
+
+test("hosted hillclimb rejects a shared generator and judge port", async () => {
+  const sharedModel = new FakeHostedModel();
+  await assert.rejects(
+    runHostedSlackWorkingStateHillclimb(
+      SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
+      {
+        generator_model_id: "us.anthropic.claude-opus-4-8",
+        judge_model_id: "us.anthropic.claude-sonnet-5",
+        region: "us-east-1",
+      },
+      { generator: sharedModel, judge: sharedModel },
+    ),
+    /requires a separate model port/u,
+  );
+  assert.equal(sharedModel.generatorCalls, 0);
+  assert.equal(sharedModel.judgeCalls, 0);
 });
 
 class FakeHostedModel implements HostedModelPort {

--- a/apps/slack-companion/test/scratchpad-hillclimb.test.ts
+++ b/apps/slack-companion/test/scratchpad-hillclimb.test.ts
@@ -134,7 +134,8 @@ test("promotion stops when the candidate drops required evidence context", () =>
 });
 
 test("hosted hillclimb compares baseline and candidate through AWS model ports", async () => {
-  const model = new FakeHostedModel();
+  const generatorModel = new FakeHostedModel();
+  const judgeModel = new FakeHostedModel();
   const receipt = await runHostedSlackWorkingStateHillclimb(
     SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
     {
@@ -142,18 +143,20 @@ test("hosted hillclimb compares baseline and candidate through AWS model ports",
       judge_model_id: "us.anthropic.claude-opus-4-8",
       region: "us-east-1",
     },
-    model,
+    { generator: generatorModel, judge: judgeModel },
     new Date("2026-07-29T12:00:00.000Z"),
   );
 
-  assert.equal(model.generatorCalls, 44);
-  assert.equal(model.judgeCalls, 22);
-  assert.ok(model.generatorRequests.every((request) =>
+  assert.equal(generatorModel.generatorCalls, 44);
+  assert.equal(generatorModel.judgeCalls, 0);
+  assert.equal(judgeModel.generatorCalls, 0);
+  assert.equal(judgeModel.judgeCalls, 22);
+  assert.ok(generatorModel.generatorRequests.every((request) =>
     request.system.includes(
       "Never end a retained-state answer with a question or invitation.",
     )
   ));
-  assert.ok(model.generatorRequests.some((request) =>
+  assert.ok(generatorModel.generatorRequests.some((request) =>
     request.prompt.includes(
       "Do not ask a question, request confirmation, offer choices, or invite",
     )
@@ -179,7 +182,8 @@ test("hosted hillclimb compares baseline and candidate through AWS model ports",
 });
 
 test("hosted hillclimb rejects a Nova generator before invocation", async () => {
-  const model = new FakeHostedModel();
+  const generatorModel = new FakeHostedModel();
+  const judgeModel = new FakeHostedModel();
   await assert.rejects(
     runHostedSlackWorkingStateHillclimb(
       SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
@@ -188,16 +192,17 @@ test("hosted hillclimb rejects a Nova generator before invocation", async () => 
         judge_model_id: "us.anthropic.claude-opus-4-8",
         region: "us-east-1",
       },
-      model,
+      { generator: generatorModel, judge: judgeModel },
     ),
     /require AWS-hosted Claude Opus models/u,
   );
-  assert.equal(model.generatorCalls, 0);
-  assert.equal(model.judgeCalls, 0);
+  assert.equal(generatorModel.generatorCalls, 0);
+  assert.equal(judgeModel.judgeCalls, 0);
 });
 
 test("hosted hillclimb fails closed on an invalid judge receipt", async () => {
-  const model = new FakeHostedModel("not json");
+  const generatorModel = new FakeHostedModel();
+  const judgeModel = new FakeHostedModel("not json");
   await assert.rejects(
     runHostedSlackWorkingStateHillclimb(
       SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
@@ -206,7 +211,7 @@ test("hosted hillclimb fails closed on an invalid judge receipt", async () => {
         judge_model_id: "us.anthropic.claude-opus-4-8",
         region: "us-east-1",
       },
-      model,
+      { generator: generatorModel, judge: judgeModel },
     ),
     /Hosted judge returned no JSON object/u,
   );


### PR DESCRIPTION
## What changed

- separate generator and judge model ports in hosted offline evaluation
- require distinct model identities and runtime clients
- record evaluator-independence evidence in campaign receipts
- add same-corpus, same-model comparison for repeated runs

## Validation

- Slack companion typecheck and build
- Slack companion test suite
- focused independent-evaluator and repeat-run tests
- public repository hygiene audit

## Compatibility

The behavior remains offline and provider-hosted. It does not access Slack or add deployment configuration.