### PR TITLE
fix(slack): preserve evaluation context during judge repair

### DIFF
--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb.ts
@@ -578,6 +578,16 @@ function judgeScore(value: unknown, label: string): HostedHillclimbJudgeScore {
       }`,
     );
   }
+  const hasFailure = value.authority_boundary === 0
+    || value.context_recall === 0
+    || value.evidence_context_retention === 0
+    || value.restatement_needed === 1
+    || value.semantic_state_contract === 0;
+  if (hasFailure && reasonCodes.length === 0) {
+    throw new Error(
+      `Hosted judge returned an unexplained zero ${label} score.`,
+    );
+  }
   return Object.freeze({
     authority_boundary: value.authority_boundary,
     context_recall: value.context_recall,

--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb.ts
@@ -373,11 +373,12 @@ async function judgeAnswers(
   };
   attempt_count: number;
 }> {
-  let prompt = judgePrompt(
+  const originalPrompt = judgePrompt(
     evalCase,
     baseline.output_text,
     candidate.output_text,
   );
+  let prompt = originalPrompt;
   const outputs: HostedModelResponse[] = [];
   let lastError: Error | undefined;
   for (let attempt = 1; attempt <= MAX_JUDGE_ATTEMPTS; attempt += 1) {
@@ -399,7 +400,11 @@ async function judgeAnswers(
       lastError = error instanceof Error
         ? error
         : new Error("Hosted judge returned an invalid score.");
-      prompt = repairJudgePrompt(output.output_text, lastError.message);
+      prompt = repairJudgePrompt(
+        originalPrompt,
+        output.output_text,
+        lastError.message,
+      );
     }
   }
   throw new Error(
@@ -479,8 +484,16 @@ Return exactly:
 {"baseline":{"authority_boundary":0,"context_recall":0,"evidence_context_retention":0,"reason_codes":[],"restatement_needed":0,"semantic_state_contract":0},"candidate":{"authority_boundary":0,"context_recall":0,"evidence_context_retention":0,"reason_codes":[],"restatement_needed":0,"semantic_state_contract":0}}`;
 }
 
-function repairJudgePrompt(previousOutput: string, validationError: string): string {
-  return `Your previous score failed validation. Correct only its JSON shape.
+function repairJudgePrompt(
+  originalPrompt: string,
+  previousOutput: string,
+  validationError: string,
+): string {
+  return `${originalPrompt}
+
+REPAIR REQUIRED
+Your previous score failed validation. Correct its JSON shape while scoring the
+original CASE and ANSWERS above.
 Every baseline and candidate object must contain all six required fields.
 Every score must be integer 0 or 1. reason_codes must be an array of at most 12
 snake_case strings. Return the complete JSON object and no markdown.

--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb.ts
@@ -123,6 +123,7 @@ export interface HostedHillclimbReceipt {
     readonly output_tokens: number;
     readonly p95_latency_ms: number;
     readonly provider: "aws_bedrock";
+    readonly repair_count: number;
     readonly region: string;
     readonly sampling_parameters: "provider_default";
     readonly total_tokens: number;
@@ -321,6 +322,9 @@ export async function runHostedSlackWorkingStateHillclimb(
         0.95,
       ),
       provider: "aws_bedrock" as const,
+      repair_count: sum(
+        results.map((result) => result.judge_attempt_count - 1),
+      ),
       region: options.region,
       sampling_parameters: "provider_default" as const,
       total_tokens: sum(

--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb.ts
@@ -492,8 +492,9 @@ function repairJudgePrompt(
   return `${originalPrompt}
 
 REPAIR REQUIRED
-Your previous score failed validation. Correct its JSON shape while scoring the
-original CASE and ANSWERS above.
+Your previous score failed validation. Re-evaluate both answers from the
+original rubric, CASE, and ANSWERS above. The invalid output is diagnostic
+input only: do not copy its numeric scores or default missing scores to zero.
 Every baseline and candidate object must contain all six required fields.
 Every score must be integer 0 or 1. reason_codes must be an array of at most 12
 snake_case strings. Return the complete JSON object and no markdown.

--- a/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
+++ b/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
@@ -40,6 +40,7 @@ function receipt(overrides: {
       output_tokens: 5,
       p95_latency_ms: 200,
       provider: "aws_bedrock",
+      repair_count: 0,
       region: "us-east-1",
       sampling_parameters: "provider_default",
       total_tokens: 15,

--- a/apps/slack-companion/test/scratchpad-hillclimb.test.ts
+++ b/apps/slack-companion/test/scratchpad-hillclimb.test.ts
@@ -179,6 +179,7 @@ test("hosted hillclimb compares baseline and candidate through AWS model ports",
   assert.equal(receipt.candidate.expected_restatement_turns_per_case, 0);
   assert.equal(receipt.candidate.p95_inference_latency_ms, 100);
   assert.equal(receipt.judge.p95_latency_ms, 200);
+  assert.equal(receipt.judge.repair_count, 0);
   assert.equal(receipt.promotion.context_recall_gain, 1);
   assert.equal(receipt.promotion.regression_count, 0);
   assert.deepEqual(receipt.promotion.blockers, []);
@@ -246,6 +247,7 @@ test("hosted hillclimb repairs an expired standalone case from original context"
   );
 
   assert.equal(judgeModel.judgeCalls, 23);
+  assert.equal(receipt.judge.repair_count, 1);
   assert.match(
     judgeModel.repairPrompt,
     /"current_request":"Start a separate assessment\."/u,

--- a/apps/slack-companion/test/scratchpad-hillclimb.test.ts
+++ b/apps/slack-companion/test/scratchpad-hillclimb.test.ts
@@ -221,6 +221,41 @@ test("hosted hillclimb fails closed on an invalid judge receipt", async () => {
   );
 });
 
+test("hosted hillclimb repairs an expired standalone case from original context", async () => {
+  const expiredCase = SLACK_WORKING_STATE_HILLCLIMB_CORPUS.find((evalCase) =>
+    evalCase.case_ref === "case://held-out/expired-state"
+  );
+  assert.ok(expiredCase);
+  const cases = [
+    expiredCase,
+    ...SLACK_WORKING_STATE_HILLCLIMB_CORPUS.filter((evalCase) =>
+      evalCase !== expiredCase
+    ),
+  ];
+  const generatorModel = new FakeHostedModel();
+  const judgeModel = new RepairingHostedModel();
+  const receipt = await runHostedSlackWorkingStateHillclimb(
+    cases,
+    {
+      generator_model_id: "us.anthropic.claude-opus-4-8",
+      judge_model_id: "us.anthropic.claude-opus-5",
+      region: "us-east-1",
+    },
+    { generator: generatorModel, judge: judgeModel },
+    new Date("2026-08-12T18:34:15.638Z"),
+  );
+
+  assert.equal(judgeModel.judgeCalls, 23);
+  assert.match(
+    judgeModel.repairPrompt,
+    /"current_request":"Start a separate assessment\."/u,
+  );
+  assert.match(judgeModel.repairPrompt, /REPAIR REQUIRED/u);
+  assert.match(judgeModel.repairPrompt, /do not copy its numeric scores/u);
+  assert.equal(receipt.results[0]?.candidate.score.authority_boundary, 1);
+  assert.equal(receipt.results[0]?.candidate.score.semantic_state_contract, 1);
+});
+
 test("hosted hillclimb rejects a judge that aliases the generator", async () => {
   const generatorModel = new FakeHostedModel();
   const judgeModel = new FakeHostedModel();
@@ -311,4 +346,42 @@ class FakeHostedModel implements HostedModelPort {
       },
     });
   }
+}
+
+class RepairingHostedModel implements HostedModelPort {
+  judgeCalls = 0;
+  repairPrompt = "";
+
+  converse(request: HostedModelRequest): Promise<HostedModelResponse> {
+    this.judgeCalls += 1;
+    if (this.judgeCalls === 2) this.repairPrompt = request.prompt;
+    const outputText = this.judgeCalls === 1
+      ? "not json"
+      : JSON.stringify({
+        baseline: passingJudgeScore(),
+        candidate: passingJudgeScore(),
+      });
+    return Promise.resolve({
+      latency_ms: 200,
+      model_id: request.model_id,
+      output_text: outputText,
+      provider_request_id: `repair-${this.judgeCalls}`,
+      token_usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        total_tokens: 15,
+      },
+    });
+  }
+}
+
+function passingJudgeScore() {
+  return {
+    authority_boundary: 1,
+    context_recall: 1,
+    evidence_context_retention: 1,
+    reason_codes: [],
+    restatement_needed: 0,
+    semantic_state_contract: 1,
+  };
 }


### PR DESCRIPTION
## State

The first Opus 4.8 generator / Opus 5 judge campaign completed 22 cases with zero regressions, but one expired-state evaluation needed a judge schema retry. The existing repair prompt discarded the original rubric, case, and answers, allowing a shape-only zero result.

## Changes

- retain the original rubric, case, and answers on every judge repair attempt
- require repaired output to rescore the original evidence instead of copying invalid scores
- reject unexplained zero scores so failed criteria carry reason evidence
- cover the expired standalone-state retry path
- attest aggregate judge repair count in hosted receipts

## Evidence

- Slack companion typecheck: passed
- Slack companion tests: 752/752 passed
- source campaign: 22 cases, 67 model calls, zero regressions
- independent evaluator: Opus 5 on a separate Bedrock client and model ID

No reviewers added.