### PR TITLE
Measure Agent Gym repeat-run variance

### DIFF
--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb-comparison.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb-comparison.ts
@@ -14,6 +14,7 @@ export interface HostedHillclimbComparisonV1 {
     readonly semantic_state_contract_rate: number;
   };
   readonly current_evaluated_at: string;
+  readonly judge_repair_count_delta: number;
   readonly previous_evaluated_at: string;
   readonly promotion_stable: boolean;
   readonly regression_count_delta: number;
@@ -76,6 +77,7 @@ export function compareHostedSlackWorkingStateHillclimbs(
       ),
     }),
     current_evaluated_at: current.evaluated_at,
+    judge_repair_count_delta: current.judge.repair_count - previous.judge.repair_count,
     previous_evaluated_at: previous.evaluated_at,
     promotion_stable:
       previous.promotion.promotion_ready === current.promotion.promotion_ready,

--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb-comparison.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb-comparison.ts
@@ -16,6 +16,7 @@ export interface HostedHillclimbComparisonV1 {
   readonly current_evaluated_at: string;
   readonly judge_repair_count_delta: number;
   readonly judge_p95_latency_ms_delta: number;
+  readonly model_token_count_delta: number;
   readonly previous_evaluated_at: string;
   readonly promotion_stable: boolean;
   readonly regression_count_delta: number;
@@ -83,6 +84,7 @@ export function compareHostedSlackWorkingStateHillclimbs(
       previous.judge.p95_latency_ms,
       current.judge.p95_latency_ms,
     ),
+    model_token_count_delta: modelTokenCount(current) - modelTokenCount(previous),
     previous_evaluated_at: previous.evaluated_at,
     promotion_stable:
       previous.promotion.promotion_ready === current.promotion.promotion_ready,
@@ -90,6 +92,11 @@ export function compareHostedSlackWorkingStateHillclimbs(
       current.promotion.regression_count - previous.promotion.regression_count,
     schema_version: "slack-working-state-hosted-hillclimb-comparison/v1",
   });
+}
+
+function modelTokenCount(receipt: HostedHillclimbReceipt): number {
+  return receipt.baseline.total_tokens + receipt.candidate.total_tokens
+    + receipt.judge.total_tokens;
 }
 
 function delta(previous: number, current: number): number {

--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb-comparison.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb-comparison.ts
@@ -15,6 +15,7 @@ export interface HostedHillclimbComparisonV1 {
   };
   readonly current_evaluated_at: string;
   readonly judge_repair_count_delta: number;
+  readonly judge_p95_latency_ms_delta: number;
   readonly previous_evaluated_at: string;
   readonly promotion_stable: boolean;
   readonly regression_count_delta: number;
@@ -78,6 +79,10 @@ export function compareHostedSlackWorkingStateHillclimbs(
     }),
     current_evaluated_at: current.evaluated_at,
     judge_repair_count_delta: current.judge.repair_count - previous.judge.repair_count,
+    judge_p95_latency_ms_delta: delta(
+      previous.judge.p95_latency_ms,
+      current.judge.p95_latency_ms,
+    ),
     previous_evaluated_at: previous.evaluated_at,
     promotion_stable:
       previous.promotion.promotion_ready === current.promotion.promotion_ready,

--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb-comparison.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb-comparison.ts
@@ -39,6 +39,9 @@ export function compareHostedSlackWorkingStateHillclimbs(
     || previous.judge.model_id !== current.judge.model_id) {
     throw new Error("Hosted hillclimb comparison requires the same generator and judge models.");
   }
+  if (!sameExecutionBoundary(previous, current)) {
+    throw new Error("Hosted hillclimb comparison requires the same execution boundary.");
+  }
   const previousTime = Date.parse(previous.evaluated_at);
   const currentTime = Date.parse(current.evaluated_at);
   if (!Number.isFinite(previousTime) || !Number.isFinite(currentTime)
@@ -92,6 +95,22 @@ export function compareHostedSlackWorkingStateHillclimbs(
       current.promotion.regression_count - previous.promotion.regression_count,
     schema_version: "slack-working-state-hosted-hillclimb-comparison/v1",
   });
+}
+
+function sameExecutionBoundary(
+  previous: HostedHillclimbReceipt,
+  current: HostedHillclimbReceipt,
+): boolean {
+  return previous.generator.provider === current.generator.provider
+    && previous.generator.region === current.generator.region
+    && previous.generator.sampling_parameters === current.generator.sampling_parameters
+    && previous.judge.provider === current.judge.provider
+    && previous.judge.region === current.judge.region
+    && previous.judge.sampling_parameters === current.judge.sampling_parameters
+    && previous.evaluation_independence.distinct_model_id
+      === current.evaluation_independence.distinct_model_id
+    && previous.evaluation_independence.separate_model_ports
+      === current.evaluation_independence.separate_model_ports;
 }
 
 function modelTokenCount(receipt: HostedHillclimbReceipt): number {

--- a/apps/slack-companion/src/scratchpad/run-hillclimb-bedrock.ts
+++ b/apps/slack-companion/src/scratchpad/run-hillclimb-bedrock.ts
@@ -3,7 +3,7 @@ import { SLACK_WORKING_STATE_HILLCLIMB_CORPUS } from "./hillclimb-corpus.js";
 import { runHostedSlackWorkingStateHillclimb } from "./hosted-hillclimb.js";
 
 const DEPLOYED_OPUS_MODEL_ID = "us.anthropic.claude-opus-4-8";
-const INDEPENDENT_JUDGE_MODEL_ID = "us.anthropic.claude-sonnet-5";
+const INDEPENDENT_JUDGE_MODEL_ID = "us.anthropic.claude-opus-5";
 const region = required("CEREBRO_SLACK_HILLCLIMB_REGION");
 const generatorModelId = optional(
   "CEREBRO_SLACK_HILLCLIMB_GENERATOR_MODEL_ID",

--- a/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
+++ b/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
@@ -14,6 +14,7 @@ function receipt(overrides: {
   judgeLatency?: number;
   candidateTokens?: number;
   judgeTokens?: number;
+  region?: string;
   regressions?: number;
 } = {}): HostedHillclimbReceipt {
   return {
@@ -25,7 +26,7 @@ function receipt(overrides: {
     generator: {
       model_id: "us.anthropic.claude-opus-4-8",
       provider: "aws_bedrock",
-      region: "us-east-1",
+      region: overrides.region ?? "us-east-1",
       sampling_parameters: "provider_default",
     },
     goal: {
@@ -45,7 +46,7 @@ function receipt(overrides: {
       p95_latency_ms: overrides.judgeLatency ?? 200,
       provider: "aws_bedrock",
       repair_count: overrides.repairCount ?? 0,
-      region: "us-east-1",
+      region: overrides.region ?? "us-east-1",
       sampling_parameters: "provider_default",
       total_tokens: overrides.judgeTokens ?? 15,
     },
@@ -126,5 +127,18 @@ test("rejects comparisons across corpora or reversed time", () => {
       receipt({ evaluatedAt: "2026-08-12T15:00:00.000Z" }),
     ),
     /increasing evaluation times/u,
+  );
+});
+
+test("rejects comparisons across execution boundaries", () => {
+  assert.throws(
+    () => compareHostedSlackWorkingStateHillclimbs(
+      receipt(),
+      receipt({
+        evaluatedAt: "2026-08-12T17:00:00.000Z",
+        region: "us-west-2",
+      }),
+    ),
+    /same execution boundary/u,
   );
 });

--- a/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
+++ b/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
@@ -12,11 +12,13 @@ function receipt(overrides: {
   evaluatedAt?: string;
   repairCount?: number;
   judgeLatency?: number;
+  candidateTokens?: number;
+  judgeTokens?: number;
   regressions?: number;
 } = {}): HostedHillclimbReceipt {
   return {
     baseline: summary(0.1),
-    candidate: summary(overrides.contextRecall ?? 0.9),
+    candidate: summary(overrides.contextRecall ?? 0.9, overrides.candidateTokens),
     corpus_digest: overrides.corpusDigest ?? `sha256:${"a".repeat(64)}`,
     evaluated_at: overrides.evaluatedAt ?? "2026-08-12T16:00:00.000Z",
     evaluation_independence: { distinct_model_id: true, separate_model_ports: true },
@@ -45,7 +47,7 @@ function receipt(overrides: {
       repair_count: overrides.repairCount ?? 0,
       region: "us-east-1",
       sampling_parameters: "provider_default",
-      total_tokens: 15,
+      total_tokens: overrides.judgeTokens ?? 15,
     },
     promotion: {
       blockers: overrides.blockers ?? [],
@@ -62,7 +64,10 @@ function receipt(overrides: {
   };
 }
 
-function summary(contextRecall: number): HostedHillclimbReceipt["candidate"] {
+function summary(
+  contextRecall: number,
+  totalTokens = 150,
+): HostedHillclimbReceipt["candidate"] {
   return {
     authority_boundary_rate: 1,
     case_count: 22,
@@ -74,7 +79,7 @@ function summary(contextRecall: number): HostedHillclimbReceipt["candidate"] {
     output_tokens: 50,
     p95_inference_latency_ms: 3_000,
     semantic_state_contract_rate: 1,
-    total_tokens: 150,
+    total_tokens: totalTokens,
   };
 }
 
@@ -87,6 +92,8 @@ test("compares repeat measurements without answer content", () => {
       evaluatedAt: "2026-08-12T17:00:00.000Z",
       repairCount: 2,
       judgeLatency: 350,
+      candidateTokens: 175,
+      judgeTokens: 25,
       regressions: 2,
     }),
   );
@@ -98,6 +105,7 @@ test("compares repeat measurements without answer content", () => {
   assert.equal(comparison.regression_count_delta, 2);
   assert.equal(comparison.judge_repair_count_delta, 2);
   assert.equal(comparison.judge_p95_latency_ms_delta, 150);
+  assert.equal(comparison.model_token_count_delta, 35);
   assert.equal(comparison.promotion_stable, true);
 });
 

--- a/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
+++ b/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
@@ -10,6 +10,7 @@ function receipt(overrides: {
   contextRecall?: number;
   corpusDigest?: string;
   evaluatedAt?: string;
+  repairCount?: number;
   regressions?: number;
 } = {}): HostedHillclimbReceipt {
   return {
@@ -40,7 +41,7 @@ function receipt(overrides: {
       output_tokens: 5,
       p95_latency_ms: 200,
       provider: "aws_bedrock",
-      repair_count: 0,
+      repair_count: overrides.repairCount ?? 0,
       region: "us-east-1",
       sampling_parameters: "provider_default",
       total_tokens: 15,
@@ -83,6 +84,7 @@ test("compares repeat measurements without answer content", () => {
       blockers: ["new_blocker"],
       contextRecall: 1,
       evaluatedAt: "2026-08-12T17:00:00.000Z",
+      repairCount: 2,
       regressions: 2,
     }),
   );
@@ -92,6 +94,7 @@ test("compares repeat measurements without answer content", () => {
     resolved: ["old_blocker"],
   });
   assert.equal(comparison.regression_count_delta, 2);
+  assert.equal(comparison.judge_repair_count_delta, 2);
   assert.equal(comparison.promotion_stable, true);
 });
 

--- a/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
+++ b/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
@@ -36,7 +36,7 @@ function receipt(overrides: {
     judge: {
       input_tokens: 10,
       invocation_count: 1,
-      model_id: "us.anthropic.claude-sonnet-5",
+      model_id: "us.anthropic.claude-opus-5",
       output_tokens: 5,
       p95_latency_ms: 200,
       provider: "aws_bedrock",

--- a/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
+++ b/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
@@ -11,6 +11,7 @@ function receipt(overrides: {
   corpusDigest?: string;
   evaluatedAt?: string;
   repairCount?: number;
+  judgeLatency?: number;
   regressions?: number;
 } = {}): HostedHillclimbReceipt {
   return {
@@ -39,7 +40,7 @@ function receipt(overrides: {
       invocation_count: 1,
       model_id: "us.anthropic.claude-opus-5",
       output_tokens: 5,
-      p95_latency_ms: 200,
+      p95_latency_ms: overrides.judgeLatency ?? 200,
       provider: "aws_bedrock",
       repair_count: overrides.repairCount ?? 0,
       region: "us-east-1",
@@ -85,6 +86,7 @@ test("compares repeat measurements without answer content", () => {
       contextRecall: 1,
       evaluatedAt: "2026-08-12T17:00:00.000Z",
       repairCount: 2,
+      judgeLatency: 350,
       regressions: 2,
     }),
   );
@@ -95,6 +97,7 @@ test("compares repeat measurements without answer content", () => {
   });
   assert.equal(comparison.regression_count_delta, 2);
   assert.equal(comparison.judge_repair_count_delta, 2);
+  assert.equal(comparison.judge_p95_latency_ms_delta, 150);
   assert.equal(comparison.promotion_stable, true);
 });
 

--- a/apps/slack-companion/test/scratchpad-hillclimb.test.ts
+++ b/apps/slack-companion/test/scratchpad-hillclimb.test.ts
@@ -140,7 +140,7 @@ test("hosted hillclimb compares baseline and candidate through AWS model ports",
     SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
     {
       generator_model_id: "us.anthropic.claude-opus-4-8",
-      judge_model_id: "us.anthropic.claude-sonnet-5",
+      judge_model_id: "us.anthropic.claude-opus-5",
       region: "us-east-1",
     },
     { generator: generatorModel, judge: judgeModel },
@@ -164,7 +164,7 @@ test("hosted hillclimb compares baseline and candidate through AWS model ports",
   assert.equal(receipt.generator.provider, "aws_bedrock");
   assert.equal(receipt.generator.model_id, "us.anthropic.claude-opus-4-8");
   assert.equal(receipt.generator.sampling_parameters, "provider_default");
-  assert.equal(receipt.judge.model_id, "us.anthropic.claude-sonnet-5");
+  assert.equal(receipt.judge.model_id, "us.anthropic.claude-opus-5");
   assert.equal(receipt.judge.sampling_parameters, "provider_default");
   assert.deepEqual(receipt.evaluation_independence, {
     distinct_model_id: true,
@@ -186,15 +186,15 @@ test("hosted hillclimb compares baseline and candidate through AWS model ports",
   assert.equal(receipt.promotion.promotion_ready, true);
 });
 
-test("hosted hillclimb rejects a Nova generator before invocation", async () => {
+test("hosted hillclimb rejects a non-Opus generator before invocation", async () => {
   const generatorModel = new FakeHostedModel();
   const judgeModel = new FakeHostedModel();
   await assert.rejects(
     runHostedSlackWorkingStateHillclimb(
       SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
       {
-        generator_model_id: "us.amazon.nova-pro-v1:0",
-        judge_model_id: "us.anthropic.claude-sonnet-5",
+        generator_model_id: "us.anthropic.claude-haiku-4-5",
+        judge_model_id: "us.anthropic.claude-opus-5",
         region: "us-east-1",
       },
       { generator: generatorModel, judge: judgeModel },
@@ -213,7 +213,7 @@ test("hosted hillclimb fails closed on an invalid judge receipt", async () => {
       SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
       {
         generator_model_id: "us.anthropic.claude-opus-4-8",
-        judge_model_id: "us.anthropic.claude-sonnet-5",
+        judge_model_id: "us.anthropic.claude-opus-5",
         region: "us-east-1",
       },
       { generator: generatorModel, judge: judgeModel },
@@ -284,7 +284,7 @@ test("hosted hillclimb rejects a shared generator and judge port", async () => {
       SLACK_WORKING_STATE_HILLCLIMB_CORPUS,
       {
         generator_model_id: "us.anthropic.claude-opus-4-8",
-        judge_model_id: "us.anthropic.claude-sonnet-5",
+        judge_model_id: "us.anthropic.claude-opus-5",
         region: "us-east-1",
       },
       { generator: sharedModel, judge: sharedModel },


### PR DESCRIPTION
## Summary
- make Opus 5 the default hosted judge
- compare judge repair count, tail latency, and total model tokens across repeat runs
- reject comparisons across provider, region, sampling, or evaluator-independence boundaries

## Validation
- `npm run check --prefix apps/slack-companion`
- 753 tests passed
- same-corpus Opus campaign runs 31631483253 and 31632224376 remained promotion-ready

No reviewers were added.