### PR TITLE
feat(slack): gate hosted repeat stability

### DIFF
--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb-comparison.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb-comparison.ts
@@ -19,6 +19,7 @@ export interface HostedHillclimbComparisonV1 {
   readonly model_token_count_delta: number;
   readonly previous_evaluated_at: string;
   readonly promotion_stable: boolean;
+  readonly quality_stable: boolean;
   readonly regression_count_delta: number;
   readonly schema_version: "slack-working-state-hosted-hillclimb-comparison/v1";
 }
@@ -91,6 +92,10 @@ export function compareHostedSlackWorkingStateHillclimbs(
     previous_evaluated_at: previous.evaluated_at,
     promotion_stable:
       previous.promotion.promotion_ready === current.promotion.promotion_ready,
+    quality_stable:
+      current.promotion.regression_count <= previous.promotion.regression_count
+      && current.judge.repair_count <= previous.judge.repair_count
+      && current.promotion.blockers.every((blocker) => previousBlockers.has(blocker)),
     regression_count_delta:
       current.promotion.regression_count - previous.promotion.regression_count,
     schema_version: "slack-working-state-hosted-hillclimb-comparison/v1",

--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb-comparison.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb-comparison.ts
@@ -14,6 +14,7 @@ export interface HostedHillclimbComparisonV1 {
     readonly semantic_state_contract_rate: number;
   };
   readonly current_evaluated_at: string;
+  readonly efficiency_stable: boolean;
   readonly judge_repair_count_delta: number;
   readonly judge_p95_latency_ms_delta: number;
   readonly model_token_count_delta: number;
@@ -83,6 +84,7 @@ export function compareHostedSlackWorkingStateHillclimbs(
       ),
     }),
     current_evaluated_at: current.evaluated_at,
+    efficiency_stable: modelTokenCount(current) <= modelTokenCount(previous),
     judge_repair_count_delta: current.judge.repair_count - previous.judge.repair_count,
     judge_p95_latency_ms_delta: delta(
       previous.judge.p95_latency_ms,

--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb-repeat-window.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb-repeat-window.ts
@@ -1,0 +1,32 @@
+import type { HostedHillclimbComparisonV1 } from "./hosted-hillclimb-comparison.js";
+
+export interface HostedHillclimbRepeatWindowV1 {
+  readonly comparison_count: number;
+  readonly first_evaluated_at: string;
+  readonly last_evaluated_at: string;
+  readonly schema_version: "slack-working-state-hosted-hillclimb-repeat-window/v1";
+}
+
+/** Seals a contiguous chronological sequence of content-free repeat comparisons. */
+export function buildHostedHillclimbRepeatWindow(
+  comparisons: readonly HostedHillclimbComparisonV1[],
+): HostedHillclimbRepeatWindowV1 {
+  if (comparisons.length === 0) {
+    throw new Error("Hosted hillclimb repeat window requires at least one comparison.");
+  }
+  for (const [index, comparison] of comparisons.entries()) {
+    if (comparison.schema_version !== "slack-working-state-hosted-hillclimb-comparison/v1") {
+      throw new Error("Hosted hillclimb repeat window requires v1 comparisons.");
+    }
+    if (index > 0
+      && comparisons[index - 1]?.current_evaluated_at !== comparison.previous_evaluated_at) {
+      throw new Error("Hosted hillclimb repeat window requires a contiguous evaluation chain.");
+    }
+  }
+  return Object.freeze({
+    comparison_count: comparisons.length,
+    first_evaluated_at: comparisons[0]!.previous_evaluated_at,
+    last_evaluated_at: comparisons[comparisons.length - 1]!.current_evaluated_at,
+    schema_version: "slack-working-state-hosted-hillclimb-repeat-window/v1",
+  });
+}

--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb-repeat-window.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb-repeat-window.ts
@@ -10,11 +10,17 @@ export interface HostedHillclimbRepeatWindowV1 {
     readonly semantic_state_contract_rate: number;
   };
   readonly comparison_count: number;
+  readonly efficiency_regression_count: number;
   readonly first_evaluated_at: string;
   readonly last_evaluated_at: string;
   readonly maximum_absolute_judge_p95_latency_ms_delta: number;
   readonly maximum_absolute_model_token_count_delta: number;
+  readonly quality_instability_count: number;
   readonly schema_version: "slack-working-state-hosted-hillclimb-repeat-window/v1";
+  readonly stability: {
+    readonly blockers: readonly string[];
+    readonly stable: boolean;
+  };
 }
 
 /** Seals a contiguous chronological sequence of content-free repeat comparisons. */
@@ -33,6 +39,13 @@ export function buildHostedHillclimbRepeatWindow(
       throw new Error("Hosted hillclimb repeat window requires a contiguous evaluation chain.");
     }
   }
+  const stabilityBlockers = [
+    ...(comparisons.length < 2 ? ["insufficient_repeat_comparisons"] : []),
+    ...(comparisons.some((comparison) => !comparison.promotion_stable)
+      ? ["promotion_state_changed"] : []),
+    ...(comparisons.some((comparison) => !comparison.quality_stable)
+      ? ["repeat_quality_regressed"] : []),
+  ];
   return Object.freeze({
     candidate_max_absolute_delta: Object.freeze({
       authority_boundary_rate: maximumAbsolute(comparisons.map(
@@ -55,6 +68,9 @@ export function buildHostedHillclimbRepeatWindow(
       )),
     }),
     comparison_count: comparisons.length,
+    efficiency_regression_count: comparisons.filter(
+      (comparison) => !comparison.efficiency_stable,
+    ).length,
     first_evaluated_at: comparisons[0]!.previous_evaluated_at,
     last_evaluated_at: comparisons[comparisons.length - 1]!.current_evaluated_at,
     maximum_absolute_judge_p95_latency_ms_delta: maximumAbsolute(comparisons.map(
@@ -63,7 +79,14 @@ export function buildHostedHillclimbRepeatWindow(
     maximum_absolute_model_token_count_delta: maximumAbsolute(comparisons.map(
       (comparison) => comparison.model_token_count_delta,
     )),
+    quality_instability_count: comparisons.filter(
+      (comparison) => !comparison.quality_stable,
+    ).length,
     schema_version: "slack-working-state-hosted-hillclimb-repeat-window/v1",
+    stability: Object.freeze({
+      blockers: Object.freeze(stabilityBlockers),
+      stable: stabilityBlockers.length === 0,
+    }),
   });
 }
 

--- a/apps/slack-companion/src/scratchpad/hosted-hillclimb-repeat-window.ts
+++ b/apps/slack-companion/src/scratchpad/hosted-hillclimb-repeat-window.ts
@@ -1,9 +1,19 @@
 import type { HostedHillclimbComparisonV1 } from "./hosted-hillclimb-comparison.js";
 
 export interface HostedHillclimbRepeatWindowV1 {
+  readonly candidate_max_absolute_delta: {
+    readonly authority_boundary_rate: number;
+    readonly context_recall_rate: number;
+    readonly evidence_context_retention_rate: number;
+    readonly expected_restatement_turns_per_case: number;
+    readonly p95_inference_latency_ms: number;
+    readonly semantic_state_contract_rate: number;
+  };
   readonly comparison_count: number;
   readonly first_evaluated_at: string;
   readonly last_evaluated_at: string;
+  readonly maximum_absolute_judge_p95_latency_ms_delta: number;
+  readonly maximum_absolute_model_token_count_delta: number;
   readonly schema_version: "slack-working-state-hosted-hillclimb-repeat-window/v1";
 }
 
@@ -24,9 +34,39 @@ export function buildHostedHillclimbRepeatWindow(
     }
   }
   return Object.freeze({
+    candidate_max_absolute_delta: Object.freeze({
+      authority_boundary_rate: maximumAbsolute(comparisons.map(
+        (comparison) => comparison.candidate_delta.authority_boundary_rate,
+      )),
+      context_recall_rate: maximumAbsolute(comparisons.map(
+        (comparison) => comparison.candidate_delta.context_recall_rate,
+      )),
+      evidence_context_retention_rate: maximumAbsolute(comparisons.map(
+        (comparison) => comparison.candidate_delta.evidence_context_retention_rate,
+      )),
+      expected_restatement_turns_per_case: maximumAbsolute(comparisons.map(
+        (comparison) => comparison.candidate_delta.expected_restatement_turns_per_case,
+      )),
+      p95_inference_latency_ms: maximumAbsolute(comparisons.map(
+        (comparison) => comparison.candidate_delta.p95_inference_latency_ms,
+      )),
+      semantic_state_contract_rate: maximumAbsolute(comparisons.map(
+        (comparison) => comparison.candidate_delta.semantic_state_contract_rate,
+      )),
+    }),
     comparison_count: comparisons.length,
     first_evaluated_at: comparisons[0]!.previous_evaluated_at,
     last_evaluated_at: comparisons[comparisons.length - 1]!.current_evaluated_at,
+    maximum_absolute_judge_p95_latency_ms_delta: maximumAbsolute(comparisons.map(
+      (comparison) => comparison.judge_p95_latency_ms_delta,
+    )),
+    maximum_absolute_model_token_count_delta: maximumAbsolute(comparisons.map(
+      (comparison) => comparison.model_token_count_delta,
+    )),
     schema_version: "slack-working-state-hosted-hillclimb-repeat-window/v1",
   });
+}
+
+function maximumAbsolute(values: readonly number[]): number {
+  return Math.max(...values.map((value) => Math.abs(value)));
 }

--- a/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
+++ b/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
@@ -109,6 +109,7 @@ test("compares repeat measurements without answer content", () => {
   assert.equal(comparison.model_token_count_delta, 35);
   assert.equal(comparison.promotion_stable, true);
   assert.equal(comparison.quality_stable, false);
+  assert.equal(comparison.efficiency_stable, false);
 });
 
 test("marks quality stable when repeats add no failures or repairs", () => {
@@ -117,6 +118,7 @@ test("marks quality stable when repeats add no failures or repairs", () => {
     receipt({ evaluatedAt: "2026-08-12T17:00:00.000Z" }),
   );
   assert.equal(comparison.quality_stable, true);
+  assert.equal(comparison.efficiency_stable, true);
 });
 
 test("rejects comparisons across corpora or reversed time", () => {

--- a/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
+++ b/apps/slack-companion/test/hosted-hillclimb-comparison.test.ts
@@ -108,6 +108,15 @@ test("compares repeat measurements without answer content", () => {
   assert.equal(comparison.judge_p95_latency_ms_delta, 150);
   assert.equal(comparison.model_token_count_delta, 35);
   assert.equal(comparison.promotion_stable, true);
+  assert.equal(comparison.quality_stable, false);
+});
+
+test("marks quality stable when repeats add no failures or repairs", () => {
+  const comparison = compareHostedSlackWorkingStateHillclimbs(
+    receipt({ blockers: ["old_blocker"], repairCount: 1, regressions: 1 }),
+    receipt({ evaluatedAt: "2026-08-12T17:00:00.000Z" }),
+  );
+  assert.equal(comparison.quality_stable, true);
 });
 
 test("rejects comparisons across corpora or reversed time", () => {

--- a/apps/slack-companion/test/hosted-hillclimb-repeat-window.test.ts
+++ b/apps/slack-companion/test/hosted-hillclimb-repeat-window.test.ts
@@ -9,6 +9,7 @@ import { buildHostedHillclimbRepeatWindow } from
 function comparison(
   previous: string,
   current: string,
+  tokenDelta = 0,
 ): HostedHillclimbComparisonV1 {
   return {
     blocker_change: { added: [], resolved: [] },
@@ -24,7 +25,7 @@ function comparison(
     efficiency_stable: true,
     judge_p95_latency_ms_delta: 0,
     judge_repair_count_delta: 0,
-    model_token_count_delta: 0,
+    model_token_count_delta: tokenDelta,
     previous_evaluated_at: previous,
     promotion_stable: true,
     quality_stable: true,
@@ -36,12 +37,22 @@ function comparison(
 test("seals a contiguous repeat comparison window", () => {
   const window = buildHostedHillclimbRepeatWindow([
     comparison("2026-08-12T16:00:00.000Z", "2026-08-12T17:00:00.000Z"),
-    comparison("2026-08-12T17:00:00.000Z", "2026-08-12T18:00:00.000Z"),
+    comparison("2026-08-12T17:00:00.000Z", "2026-08-12T18:00:00.000Z", -294),
   ]);
   assert.deepEqual(window, {
+    candidate_max_absolute_delta: {
+      authority_boundary_rate: 0,
+      context_recall_rate: 0,
+      evidence_context_retention_rate: 0,
+      expected_restatement_turns_per_case: 0,
+      p95_inference_latency_ms: 0,
+      semantic_state_contract_rate: 0,
+    },
     comparison_count: 2,
     first_evaluated_at: "2026-08-12T16:00:00.000Z",
     last_evaluated_at: "2026-08-12T18:00:00.000Z",
+    maximum_absolute_judge_p95_latency_ms_delta: 0,
+    maximum_absolute_model_token_count_delta: 294,
     schema_version: "slack-working-state-hosted-hillclimb-repeat-window/v1",
   });
 });

--- a/apps/slack-companion/test/hosted-hillclimb-repeat-window.test.ts
+++ b/apps/slack-companion/test/hosted-hillclimb-repeat-window.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { HostedHillclimbComparisonV1 } from
+  "../src/scratchpad/hosted-hillclimb-comparison.js";
+import { buildHostedHillclimbRepeatWindow } from
+  "../src/scratchpad/hosted-hillclimb-repeat-window.js";
+
+function comparison(
+  previous: string,
+  current: string,
+): HostedHillclimbComparisonV1 {
+  return {
+    blocker_change: { added: [], resolved: [] },
+    candidate_delta: {
+      authority_boundary_rate: 0,
+      context_recall_rate: 0,
+      evidence_context_retention_rate: 0,
+      expected_restatement_turns_per_case: 0,
+      p95_inference_latency_ms: 0,
+      semantic_state_contract_rate: 0,
+    },
+    current_evaluated_at: current,
+    efficiency_stable: true,
+    judge_p95_latency_ms_delta: 0,
+    judge_repair_count_delta: 0,
+    model_token_count_delta: 0,
+    previous_evaluated_at: previous,
+    promotion_stable: true,
+    quality_stable: true,
+    regression_count_delta: 0,
+    schema_version: "slack-working-state-hosted-hillclimb-comparison/v1",
+  };
+}
+
+test("seals a contiguous repeat comparison window", () => {
+  const window = buildHostedHillclimbRepeatWindow([
+    comparison("2026-08-12T16:00:00.000Z", "2026-08-12T17:00:00.000Z"),
+    comparison("2026-08-12T17:00:00.000Z", "2026-08-12T18:00:00.000Z"),
+  ]);
+  assert.deepEqual(window, {
+    comparison_count: 2,
+    first_evaluated_at: "2026-08-12T16:00:00.000Z",
+    last_evaluated_at: "2026-08-12T18:00:00.000Z",
+    schema_version: "slack-working-state-hosted-hillclimb-repeat-window/v1",
+  });
+});
+
+test("rejects an empty or discontinuous repeat window", () => {
+  assert.throws(() => buildHostedHillclimbRepeatWindow([]), /at least one/u);
+  assert.throws(
+    () => buildHostedHillclimbRepeatWindow([
+      comparison("2026-08-12T16:00:00.000Z", "2026-08-12T17:00:00.000Z"),
+      comparison("2026-08-12T18:00:00.000Z", "2026-08-12T19:00:00.000Z"),
+    ]),
+    /contiguous evaluation chain/u,
+  );
+});

--- a/apps/slack-companion/test/hosted-hillclimb-repeat-window.test.ts
+++ b/apps/slack-companion/test/hosted-hillclimb-repeat-window.test.ts
@@ -49,12 +49,31 @@ test("seals a contiguous repeat comparison window", () => {
       semantic_state_contract_rate: 0,
     },
     comparison_count: 2,
+    efficiency_regression_count: 0,
     first_evaluated_at: "2026-08-12T16:00:00.000Z",
     last_evaluated_at: "2026-08-12T18:00:00.000Z",
     maximum_absolute_judge_p95_latency_ms_delta: 0,
     maximum_absolute_model_token_count_delta: 294,
+    quality_instability_count: 0,
     schema_version: "slack-working-state-hosted-hillclimb-repeat-window/v1",
+    stability: { blockers: [], stable: true },
   });
+});
+
+test("holds stability until repeats are sufficient and quality remains stable", () => {
+  const oneComparison = comparison(
+    "2026-08-12T16:00:00.000Z",
+    "2026-08-12T17:00:00.000Z",
+  );
+  const window = buildHostedHillclimbRepeatWindow([{
+    ...oneComparison,
+    quality_stable: false,
+  }]);
+  assert.deepEqual(window.stability, {
+    blockers: ["insufficient_repeat_comparisons", "repeat_quality_regressed"],
+    stable: false,
+  });
+  assert.equal(window.quality_instability_count, 1);
 });
 
 test("rejects an empty or discontinuous repeat window", () => {


### PR DESCRIPTION
## What changed
- classify repeat quality stability from blocker, regression, and judge-repair evidence
- report repeat token-efficiency stability separately from promotion quality
- seal contiguous chronological comparison windows
- measure maximum candidate, judge-latency, and token variation
- require enough repeats with stable promotion and no quality regression

## Verification
- `npm run check --prefix apps/slack-companion`
- 757/757 Slack companion tests passing
- no Slack dependency in the evaluation path

No human reviewers were added.