### PR TITLE
Repair Rust candidate cosign install

### DIFF
--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -113,7 +113,7 @@ jobs:
           echo "digest=${digest}" >>"${GITHUB_OUTPUT}"
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          cosign-release: v2.6.1
+          cosign-release: v3.0.6
       - name: Sign the Rust image
         env:
           IMAGE_BASE: ghcr.io/${{ github.repository_owner }}/cerebro-rust
@@ -147,7 +147,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          cosign-release: v2.6.1
+          cosign-release: v3.0.6
       - name: Verify and pull the exact Rust candidate
         env:
           CANDIDATE_IMAGE: ghcr.io/${{ github.repository_owner }}/cerebro-rust@${{ needs.manifest.outputs.digest }}


### PR DESCRIPTION
The Rust-only candidate E2E gate repeatedly stopped before runtime verification because the cosign installer could download its v3.0.6 bootstrap but lost the separate v2.6.1 release-asset connection.

This pins both candidate signing and E2E verification to v3.0.6. The installer can use its verified bootstrap directly, removing the failing second asset fetch without weakening signature or provenance verification.

Validation:
- `git diff --check`
- workflow YAML parse
- exact failure reproduced on run 31639702099 across three attempts