### PR TITLE
Pin containerized candidate signing

### DIFF
--- a/.github/scripts/cosign.sh
+++ b/.github/scripts/cosign.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly cosign_image="ghcr.io/sigstore/cosign/cosign@sha256:68839b7f13dac5a6744a5d8818e984dd39183374e37855c19e14d623d9bc9037"
+readonly docker_config="${HOME}/.docker"
+
+test -f "${docker_config}/config.json"
+
+docker_args=(
+  run
+  --rm
+  --user "$(id -u):$(id -g)"
+  --volume "${docker_config}:/cosign-docker:ro"
+  --env DOCKER_CONFIG=/cosign-docker
+  --env HOME=/tmp
+)
+
+if [[ -n "${GITHUB_WORKSPACE:-}" ]]; then
+  docker_args+=(
+    --volume "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}:ro"
+    --workdir "${GITHUB_WORKSPACE}"
+  )
+fi
+
+for variable in ACTIONS_ID_TOKEN_REQUEST_TOKEN ACTIONS_ID_TOKEN_REQUEST_URL; do
+  if [[ -n "${!variable:-}" ]]; then
+    docker_args+=(--env "${variable}")
+  fi
+done
+
+exec docker "${docker_args[@]}" "${cosign_image}" "$@"

--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -111,14 +111,11 @@ jobs:
           digest="$(docker buildx imagetools inspect "${IMAGE_BASE}:${IMAGE_TAG}" --format '{{.Manifest.Digest}}')"
           [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]
           echo "digest=${digest}" >>"${GITHUB_OUTPUT}"
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          cosign-release: v3.0.6
       - name: Sign the Rust image
         env:
           IMAGE_BASE: ghcr.io/${{ github.repository_owner }}/cerebro-rust
           DIGEST: ${{ steps.publish.outputs.digest }}
-        run: cosign sign --yes "${IMAGE_BASE}@${DIGEST}"
+        run: bash .github/scripts/cosign.sh sign --yes "${IMAGE_BASE}@${DIGEST}"
       - name: Attest Rust image provenance
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
@@ -145,15 +142,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          cosign-release: v3.0.6
       - name: Verify and pull the exact Rust candidate
         env:
           CANDIDATE_IMAGE: ghcr.io/${{ github.repository_owner }}/cerebro-rust@${{ needs.manifest.outputs.digest }}
         run: |
           set -euo pipefail
-          cosign verify \
+          bash .github/scripts/cosign.sh verify \
             --certificate-identity-regexp "^https://github.com/${GITHUB_REPOSITORY}/.github/workflows/rust-only-candidate.yml@refs/heads/main$" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             "${CANDIDATE_IMAGE}" >/dev/null
@@ -268,7 +262,7 @@ jobs:
         env:
           CANDIDATE_IMAGE: ghcr.io/${{ github.repository_owner }}/cerebro-rust@${{ needs.manifest.outputs.digest }}
         run: |
-          cosign attest --yes \
+          bash .github/scripts/cosign.sh attest --yes \
             --type "https://writer.com/cerebro/rust-only-e2e/v1" \
             --predicate .dist/rust-only-e2e/rust-only-e2e-receipt.json \
             "${CANDIDATE_IMAGE}"


### PR DESCRIPTION
The Rust-only candidate gate is blocked by repeated GitHub release-asset failures in the cosign installer: v2.6.1 connections died and v3.0.6 returned repeated HTTP 503 responses. Native candidate images succeeded, but signing never began.

This replaces release-asset installation with the official cosign v2.6.1 image pinned by immutable multi-architecture digest. A repository wrapper runs it as the hosted runner UID, mounts registry credentials and the workspace read-only, and forwards GitHub OIDC variables only when present. Signing, verification, and receipt attestation remain unchanged.

Validation:
- `bash -n .github/scripts/cosign.sh`
- `shellcheck .github/scripts/cosign.sh`
- workflow YAML parse
- `git diff --check`
- DDESK verification of signed candidate digest `sha256:384d749a9f42ff9cb1d5b3a4b40445cfef0c2540a48561a236fbb330c8eb6ebf` against the expected workflow identity