### PR TITLE
Check out candidate signing wrapper

### DIFF
--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -91,6 +91,10 @@ jobs:
     outputs:
       digest: ${{ steps.publish.outputs.digest }}
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+          persist-credentials: false
       - name: Log in to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:


### PR DESCRIPTION
The pinned-container signer launched successfully on main, but the manifest job exited 127 before Docker because it did not check out the repository and `.github/scripts/cosign.sh` was absent.

This checks out the exact resolved candidate SHA in the manifest job with persisted credentials disabled. Signing continues to use the immutable cosign image and unchanged OIDC permissions.

Validation:
- workflow YAML parse
- `git diff --check`
- executable wrapper exists at the checked-out revision
- exact failure identified in run 31642803433, job 94272413661