### PR TITLE
perf: expose load smoke saturation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,8 @@ LOAD_SMOKE_PATHS ?= /health
 LOAD_SMOKE_MAX_P95_MS ?= 750
 LOAD_SMOKE_MAX_ERROR_RATE ?= 0.01
 LOAD_SMOKE_MAX_5XX_RATE ?= 0
+LOAD_SMOKE_MAX_SCHEDULE_LAG_MS ?= 60000
+LOAD_SMOKE_MAX_MISSED_REQUEST_RATE ?= 1
 LOAD_SMOKE_JSON_OUT ?= tmp/load-smoke.json
 LOAD_SMOKE_MARKDOWN_OUT ?= tmp/load-smoke.md
 AGENT_ONBOARD_PLAN ?= examples/onboarding/cerebro-onboarding.yaml
@@ -866,6 +868,8 @@ load-smoke: ## Run bounded capacity/load smoke checks against CEREBRO_BASE_URL.
 		--max-p95-ms "$(LOAD_SMOKE_MAX_P95_MS)" \
 		--max-error-rate "$(LOAD_SMOKE_MAX_ERROR_RATE)" \
 		--max-5xx-rate "$(LOAD_SMOKE_MAX_5XX_RATE)" \
+		--max-schedule-lag-ms "$(LOAD_SMOKE_MAX_SCHEDULE_LAG_MS)" \
+		--max-missed-request-rate "$(LOAD_SMOKE_MAX_MISSED_REQUEST_RATE)" \
 		--json-out "$(LOAD_SMOKE_JSON_OUT)" \
 		--markdown-out "$(LOAD_SMOKE_MARKDOWN_OUT)"
 

--- a/docs/operations/headroom.md
+++ b/docs/operations/headroom.md
@@ -195,6 +195,13 @@ Outputs:
 - `tmp/load-smoke.json`: machine-readable summary with request counts, latency percentiles, status counts, and threshold failures.
 - `tmp/load-smoke.md`: human-readable artifact for release notes, incidents, or PR comments.
 
+The receipt also records offered requests, started requests, achieved RPS,
+maximum in-flight work, missed request rate, and request-start lag percentiles.
+These distinguish service latency from a saturated load generator. Set
+`--max-schedule-lag-ms` and `--max-missed-request-rate` to make those signals
+release gates; their defaults preserve existing smoke behavior while still
+recording the evidence.
+
 The GitHub Actions workflow [`load-smoke.yml`](../../.github/workflows/load-smoke.yml) supports:
 
 - daily scheduled execution when `CEREBRO_LOAD_SMOKE_BASE_URL` is configured as a repository secret;

--- a/scripts/load_smoke.py
+++ b/scripts/load_smoke.py
@@ -7,6 +7,7 @@ import argparse
 import concurrent.futures
 import dataclasses
 import json
+import math
 import os
 import pathlib
 import sys
@@ -28,6 +29,15 @@ class RequestResult:
     latency_ms: float
     response_bytes: int
     error_kind: str
+    schedule_lag_ms: float
+
+
+@dataclasses.dataclass(frozen=True)
+class ScheduleRun:
+    results: list[RequestResult]
+    planned_request_count: int
+    started_request_count: int
+    max_in_flight: int
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -55,6 +65,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-p95-ms", type=positive_float, default=float(os.environ.get("CEREBRO_LOAD_SMOKE_MAX_P95_MS", "750")), help="Fail when p95 latency exceeds this value")
     parser.add_argument("--max-error-rate", type=non_negative_float, default=float(os.environ.get("CEREBRO_LOAD_SMOKE_MAX_ERROR_RATE", "0.01")), help="Fail when non-success or transport errors exceed this fraction")
     parser.add_argument("--max-5xx-rate", type=non_negative_float, default=float(os.environ.get("CEREBRO_LOAD_SMOKE_MAX_5XX_RATE", "0")), help="Fail when 5xx responses exceed this fraction")
+    parser.add_argument("--max-schedule-lag-ms", type=non_negative_float, default=float(os.environ.get("CEREBRO_LOAD_SMOKE_MAX_SCHEDULE_LAG_MS", "60000")), help="Fail when p95 request-start lag exceeds this value")
+    parser.add_argument("--max-missed-request-rate", type=unit_float, default=float(os.environ.get("CEREBRO_LOAD_SMOKE_MAX_MISSED_REQUEST_RATE", "1")), help="Fail when concurrency pressure prevents more than this fraction of planned requests from starting")
     parser.add_argument("--min-requests", type=positive_int, default=1, help="Fail when fewer requests completed")
     parser.add_argument("--header", action="append", default=[], help="Extra HTTP header as 'Name: value'; repeatable")
     parser.add_argument("--bearer-token", default=first_env("CEREBRO_LOAD_SMOKE_BEARER_TOKEN", "CEREBRO_MCP_BEARER_TOKEN"), help="Optional bearer/API token; never printed")
@@ -72,7 +84,7 @@ def execute(args: argparse.Namespace) -> dict:
         headers["Authorization"] = f"Bearer {args.bearer_token}"
 
     started_at = time.time()
-    results = run_schedule(
+    schedule = run_schedule(
         base_url=base_url,
         paths=paths,
         headers=headers,
@@ -86,7 +98,8 @@ def execute(args: argparse.Namespace) -> dict:
     summary = summarize(
         base_url=base_url,
         paths=paths,
-        results=results,
+        results=schedule.results,
+        schedule=schedule,
         args=args,
         started_at=started_at,
         finished_at=finished_at,
@@ -104,7 +117,7 @@ def run_schedule(
     concurrency: int,
     timeout_seconds: float,
     max_read_bytes: int,
-) -> list[RequestResult]:
+) -> ScheduleRun:
     interval = 1.0 / rps
     started = time.monotonic()
     deadline = started + duration_seconds
@@ -112,6 +125,7 @@ def run_schedule(
     request_index = 0
     results: list[RequestResult] = []
     pending: set[concurrent.futures.Future[RequestResult]] = set()
+    max_in_flight = 0
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as pool:
         while time.monotonic() < deadline:
@@ -123,13 +137,20 @@ def run_schedule(
                 drain_ready(pending, results, timeout=0.05)
                 continue
             path = paths[request_index % len(paths)]
-            pending.add(pool.submit(fetch_once, base_url, path, dict(headers), timeout_seconds, max_read_bytes))
+            schedule_lag_ms = max(0.0, (now - next_request_at) * 1000.0)
+            pending.add(pool.submit(fetch_once, base_url, path, dict(headers), timeout_seconds, max_read_bytes, schedule_lag_ms))
+            max_in_flight = max(max_in_flight, len(pending))
             request_index += 1
             next_request_at += interval
 
         while pending:
             drain_ready(pending, results, timeout=0.1)
-    return results
+    return ScheduleRun(
+        results=results,
+        planned_request_count=max(1, math.ceil(duration_seconds * rps)),
+        started_request_count=request_index,
+        max_in_flight=max_in_flight,
+    )
 
 
 def drain_ready(pending: set[concurrent.futures.Future[RequestResult]], results: list[RequestResult], *, timeout: float) -> None:
@@ -144,7 +165,7 @@ def drain_ready(pending: set[concurrent.futures.Future[RequestResult]], results:
         results.append(future.result())
 
 
-def fetch_once(base_url: str, path: str, headers: dict[str, str], timeout_seconds: float, max_read_bytes: int) -> RequestResult:
+def fetch_once(base_url: str, path: str, headers: dict[str, str], timeout_seconds: float, max_read_bytes: int, schedule_lag_ms: float = 0.0) -> RequestResult:
     url = urllib.parse.urljoin(base_url.rstrip("/") + "/", path.lstrip("/"))
     request_headers = {
         "Accept": "application/json, text/plain, */*",
@@ -175,10 +196,10 @@ def fetch_once(base_url: str, path: str, headers: dict[str, str], timeout_second
     except OSError as exc:
         error_kind = exc.__class__.__name__
     latency_ms = (time.perf_counter() - started) * 1000.0
-    return RequestResult(path=path, status_code=status_code, latency_ms=latency_ms, response_bytes=response_bytes, error_kind=error_kind)
+    return RequestResult(path=path, status_code=status_code, latency_ms=latency_ms, response_bytes=response_bytes, error_kind=error_kind, schedule_lag_ms=schedule_lag_ms)
 
 
-def summarize(*, base_url: str, paths: list[str], results: list[RequestResult], args: argparse.Namespace, started_at: float, finished_at: float) -> dict:
+def summarize(*, base_url: str, paths: list[str], results: list[RequestResult], schedule: ScheduleRun, args: argparse.Namespace, started_at: float, finished_at: float) -> dict:
     total = len(results)
     status_counts: Counter[str] = Counter()
     path_counts: Counter[str] = Counter()
@@ -187,6 +208,7 @@ def summarize(*, base_url: str, paths: list[str], results: list[RequestResult], 
     http_5xx_count = 0
     transport_error_count = 0
     latencies = sorted(result.latency_ms for result in results)
+    schedule_lags = sorted(result.schedule_lag_ms for result in results)
     for result in results:
         path_counts[result.path] += 1
         if result.status_code is None:
@@ -200,11 +222,16 @@ def summarize(*, base_url: str, paths: list[str], results: list[RequestResult], 
         if args.success_status_min <= result.status_code <= args.success_status_max:
             success_count += 1
     error_count = total - success_count
+    missed_request_count = max(0, schedule.planned_request_count - schedule.started_request_count)
+    missed_request_rate = rate(missed_request_count, schedule.planned_request_count)
+    schedule_p95_ms = percentile(schedule_lags, 95)
     failures = evaluate_failures(
         total=total,
         p95_ms=percentile(latencies, 95),
         error_rate=rate(error_count, total),
         http_5xx_rate=rate(http_5xx_count, total),
+        schedule_p95_ms=schedule_p95_ms,
+        missed_request_rate=missed_request_rate,
         args=args,
     )
     return {
@@ -229,6 +256,22 @@ def summarize(*, base_url: str, paths: list[str], results: list[RequestResult], 
             "max_p95_ms": args.max_p95_ms,
             "max_error_rate": args.max_error_rate,
             "max_5xx_rate": args.max_5xx_rate,
+            "max_schedule_lag_ms": args.max_schedule_lag_ms,
+            "max_missed_request_rate": args.max_missed_request_rate,
+        },
+        "load_generation": {
+            "planned_request_count": schedule.planned_request_count,
+            "started_request_count": schedule.started_request_count,
+            "missed_request_count": missed_request_count,
+            "missed_request_rate": missed_request_rate,
+            "achieved_rps": round(rate(total, finished_at - started_at), 3),
+            "max_in_flight": schedule.max_in_flight,
+            "schedule_lag_ms": {
+                "p50": percentile(schedule_lags, 50),
+                "p95": schedule_p95_ms,
+                "p99": percentile(schedule_lags, 99),
+                "max": round(schedule_lags[-1], 3) if schedule_lags else None,
+            },
         },
         "request_count": total,
         "success_count": success_count,
@@ -250,7 +293,7 @@ def summarize(*, base_url: str, paths: list[str], results: list[RequestResult], 
     }
 
 
-def evaluate_failures(*, total: int, p95_ms: float | None, error_rate: float, http_5xx_rate: float, args: argparse.Namespace) -> list[str]:
+def evaluate_failures(*, total: int, p95_ms: float | None, error_rate: float, http_5xx_rate: float, schedule_p95_ms: float | None, missed_request_rate: float, args: argparse.Namespace) -> list[str]:
     failures: list[str] = []
     if total < args.min_requests:
         failures.append(f"completed {total} requests, below minimum {args.min_requests}")
@@ -262,6 +305,10 @@ def evaluate_failures(*, total: int, p95_ms: float | None, error_rate: float, ht
         failures.append(f"error rate {error_rate:.4f} exceeds {args.max_error_rate:.4f}")
     if http_5xx_rate > args.max_5xx_rate:
         failures.append(f"5xx rate {http_5xx_rate:.4f} exceeds {args.max_5xx_rate:.4f}")
+    if schedule_p95_ms is not None and schedule_p95_ms > args.max_schedule_lag_ms:
+        failures.append(f"p95 request-start lag {schedule_p95_ms:.1f}ms exceeds {args.max_schedule_lag_ms:.1f}ms")
+    if missed_request_rate > args.max_missed_request_rate:
+        failures.append(f"missed request rate {missed_request_rate:.4f} exceeds {args.max_missed_request_rate:.4f}")
     return failures
 
 
@@ -293,6 +340,8 @@ def render_console_summary(summary: dict) -> str:
 def render_markdown(summary: dict) -> str:
     latency = summary["latency_ms"]
     failures = summary["failures"] or ["none"]
+    load_generation = summary["load_generation"]
+    schedule_lag = load_generation["schedule_lag_ms"]
     lines = [
         "# Cerebro Load Smoke",
         "",
@@ -303,6 +352,11 @@ def render_markdown(summary: dict) -> str:
         f"- Error rate: {summary['error_rate']:.4f}",
         f"- 5xx rate: {summary['http_5xx_rate']:.4f}",
         f"- Latency ms: p50={latency['p50']}, p95={latency['p95']}, p99={latency['p99']}, max={latency['max']}",
+        f"- Offered requests: {load_generation['planned_request_count']}",
+        f"- Started requests: {load_generation['started_request_count']}",
+        f"- Missed request rate: {load_generation['missed_request_rate']:.4f}",
+        f"- Achieved RPS: {load_generation['achieved_rps']}",
+        f"- Request-start lag ms: p50={schedule_lag['p50']}, p95={schedule_lag['p95']}, p99={schedule_lag['p99']}, max={schedule_lag['max']}",
         "",
         "## Failures",
         "",
@@ -410,6 +464,13 @@ def non_negative_float(value: str) -> float:
     parsed = float(value)
     if parsed < 0:
         raise argparse.ArgumentTypeError("must be non-negative")
+    return parsed
+
+
+def unit_float(value: str) -> float:
+    parsed = float(value)
+    if not 0 <= parsed <= 1:
+        raise argparse.ArgumentTypeError("must be between 0 and 1")
     return parsed
 
 

--- a/scripts/tests/test_load_smoke.py
+++ b/scripts/tests/test_load_smoke.py
@@ -79,6 +79,38 @@ class LoadSmokeTests(unittest.TestCase):
 
             self.assertEqual(code, 1)
 
+    def test_reports_load_generator_saturation(self):
+        with load_smoke_server() as base_url, tempfile.TemporaryDirectory() as tmp:
+            json_out = Path(tmp) / "summary.json"
+
+            code = load_smoke.main([
+                "--base-url",
+                base_url,
+                "--path",
+                "/slow",
+                "--duration",
+                "0.25",
+                "--rps",
+                "100",
+                "--concurrency",
+                "1",
+                "--max-p95-ms",
+                "1000",
+                "--max-missed-request-rate",
+                "0",
+                "--json-out",
+                str(json_out),
+            ])
+
+            self.assertEqual(code, 1)
+            summary = json.loads(json_out.read_text(encoding="utf-8"))
+            generation = summary["load_generation"]
+            self.assertEqual(generation["planned_request_count"], 25)
+            self.assertLess(generation["started_request_count"], 25)
+            self.assertGreater(generation["missed_request_rate"], 0)
+            self.assertGreater(generation["schedule_lag_ms"]["p95"], 0)
+            self.assertTrue(any(failure.startswith("missed request rate") for failure in summary["failures"]))
+
     def test_rejects_full_url_path(self):
         code = load_smoke.main([
             "--base-url",


### PR DESCRIPTION
## Summary

- report offered, started, and missed requests from the bounded load smoke
- record achieved RPS, maximum in-flight work, and request-start lag percentiles
- add configurable gates for generator saturation and coordinated omission

## Test

- make script-test