### PR TITLE
perf: expose source page processing bottlenecks

### DIFF
--- a/internal/sourceruntime/eventadmission/native.go
+++ b/internal/sourceruntime/eventadmission/native.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/telemetry"
 	"github.com/writer/cerebro/internal/wasmhost"
 )
 
@@ -95,11 +96,26 @@ func (a *NativeAdmitter) Admit(ctx context.Context, events []*cerebrov1.EventEnv
 	a.mu.Unlock()
 	defer a.active.Done()
 
+	waitStarted := time.Now()
+	availableAtEnqueue := len(a.clients)
 	select {
 	case client := <-a.clients:
+		waitDuration := time.Since(waitStarted)
+		telemetry.Event(ctx, "source_runtime.event_admission_worker_acquired", telemetry.Attrs(
+			telemetry.Field{Key: "worker_pool_capacity", Value: cap(a.clients)},
+			telemetry.Field{Key: "workers_available_at_enqueue", Value: availableAtEnqueue},
+			telemetry.Field{Key: "queue_wait_duration_ms", Value: float64(waitDuration) / float64(time.Millisecond)},
+			telemetry.Field{Key: "queued", Value: availableAtEnqueue == 0},
+		))
 		defer func() { a.clients <- client }()
 		return admitNative(ctx, client, events, contracts)
 	case <-ctx.Done():
+		telemetry.Event(ctx, "source_runtime.event_admission_worker_wait_failed", telemetry.Attrs(
+			telemetry.Field{Key: "worker_pool_capacity", Value: cap(a.clients)},
+			telemetry.Field{Key: "workers_available_at_enqueue", Value: availableAtEnqueue},
+			telemetry.Field{Key: "queue_wait_duration_ms", Value: float64(time.Since(waitStarted)) / float64(time.Millisecond)},
+			telemetry.Field{Key: "error_kind", Value: "context_done"},
+		))
 		return Response{}, ctx.Err()
 	}
 }

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -416,10 +416,13 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 	originalCheckpoint := cloneCheckpoint(runtime.GetCheckpoint())
 	collectionID := sourceRuntimeCollectionID(runtime.GetId(), started)
 	for i := uint32(0); i < pageLimit; i++ {
+		pageStarted := time.Now()
+		phaseStarted := pageStarted
 		pull, err := readSourcePull(ctx, source, sourceConfig, cursor, originalCheckpoint)
 		if err != nil {
 			return nil, err
 		}
+		pullDuration := time.Since(phaseStarted)
 		pageNumber := i + 1
 		pageShortCircuitReason := string(pullShortCircuitReason(pull))
 		if pageShortCircuitReason != "" {
@@ -430,6 +433,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			reconciliationReason = pageReconciliationReason
 		}
 		eventsRead := boundedUint32(len(pull.Events))
+		phaseStarted = time.Now()
 		materializedEvents := make([]*cerebrov1.EventEnvelope, 0, len(pull.Events))
 		for _, event := range pull.Events {
 			syncedEvent := materializeEvent(runtime, collectionID, event)
@@ -438,6 +442,8 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			}
 			materializedEvents = append(materializedEvents, syncedEvent)
 		}
+		materializeDuration := time.Since(phaseStarted)
+		phaseStarted = time.Now()
 		admission, admissionErr := s.eventAdmitter.Admit(ctx, materializedEvents, eventContracts)
 		if admissionErr != nil {
 			if errors.Is(admissionErr, eventadmission.ErrBatchRejected) {
@@ -445,6 +451,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			}
 			return nil, fmt.Errorf("admit source event batch: %w", admissionErr)
 		}
+		admissionDuration := time.Since(phaseStarted)
 		acceptedEvents := admission.Events
 		eventLimit := req.GetEventLimit()
 		if eventLimit > 0 && uint64(eventsAppended)+uint64(len(acceptedEvents)) > uint64(eventLimit) {
@@ -536,6 +543,8 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		pagesRead++
 		ledger, ledgerEnabled := s.store.(ports.SourceRuntimePageLedgerStore)
 		attemptID := sourceRuntimePageAttemptID(runtime.GetId(), pageNumber, started)
+		ledgerDuration := time.Duration(0)
+		phaseStarted = time.Now()
 		if ledgerEnabled {
 			if err := ledger.BeginSourceRuntimePage(ctx, ports.SourceRuntimePageAttempt{
 				AttemptID:      attemptID,
@@ -561,8 +570,10 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 				return nil, err
 			}
 		}
+		ledgerDuration += time.Since(phaseStarted)
 		pageEntitiesProjected := uint32(0)
 		pageLinksProjected := uint32(0)
+		phaseStarted = time.Now()
 		if batcher, ok := s.appendLog.(ports.AppendLogBatcher); ok {
 			if err := batcher.AppendBatch(ctx, acceptedEvents); err != nil {
 				return nil, fmt.Errorf("append source event batch: %w", err)
@@ -576,16 +587,20 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 				eventsAppended++
 			}
 		}
+		appendDuration := time.Since(phaseStarted)
 		for _, syncedEvent := range acceptedEvents {
 			if familyID := sourceEventFamilyID(syncedEvent); familyID != "" {
 				observedFamilies[familyID] = struct{}{}
 			}
 		}
+		phaseStarted = time.Now()
 		if ledgerEnabled {
 			if err := ledger.MarkSourceRuntimePageAppended(ctx, attemptID); err != nil {
 				return nil, err
 			}
 		}
+		ledgerDuration += time.Since(phaseStarted)
+		phaseStarted = time.Now()
 		if s.projector != nil {
 			for _, syncedEvent := range acceptedEvents {
 				result, err := s.projector.Project(ctx, syncedEvent)
@@ -598,6 +613,8 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 				pageLinksProjected += result.LinksProjected
 			}
 		}
+		projectionDuration := time.Since(phaseStarted)
+		phaseStarted = time.Now()
 		if ledgerEnabled {
 			if err := ledger.MarkSourceRuntimePageProjected(ctx, attemptID, ports.SourceRuntimePageProjection{
 				EntitiesProjected: pageEntitiesProjected,
@@ -606,6 +623,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 				return nil, err
 			}
 		}
+		ledgerDuration += time.Since(phaseStarted)
 		candidateRuntime.LastSyncedAt = timestamppb.Now()
 		updateRuntimeSyncStatus(candidateRuntime, runtimeSyncStatus{
 			Status:               "completed",
@@ -619,6 +637,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			ShortCircuitReason:   shortCircuitReason,
 			ReconciliationReason: reconciliationReason,
 		})
+		phaseStarted = time.Now()
 		if ledgerEnabled {
 			if err := ledger.CommitSourceRuntimePage(ctx, attemptID, candidateRuntime); err != nil {
 				return nil, err
@@ -628,6 +647,7 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 				return nil, err
 			}
 		}
+		commitDuration := time.Since(phaseStarted)
 		runtime = candidateRuntime
 		checkpointAdvanced = runtimeCheckpointAdvanced(originalCheckpoint, runtime.GetCheckpoint())
 		pageCommittedAttrs := withFamilyFreshnessTelemetry(telemetry.Attrs(
@@ -648,6 +668,22 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 			telemetry.Field{Key: "reconciliation_reason", Value: pageReconciliationReason},
 		), runtime.GetCheckpoint())
 		telemetry.Event(ctx, "source_runtime.page_committed", pageCommittedAttrs)
+		telemetry.Event(ctx, "source_runtime.page_processing", telemetry.Attrs(
+			telemetry.Field{Key: "runtime_id", Value: runtime.GetId()},
+			telemetry.Field{Key: "source_id", Value: runtime.GetSourceId()},
+			telemetry.Field{Key: "tenant_id", Value: runtime.GetTenantId()},
+			telemetry.Field{Key: "page", Value: pageNumber},
+			telemetry.Field{Key: "events_read", Value: eventsRead},
+			telemetry.Field{Key: "events_accepted", Value: boundedUint32(len(acceptedEvents))},
+			telemetry.Field{Key: "pull_duration_ms", Value: durationMilliseconds(pullDuration)},
+			telemetry.Field{Key: "materialize_duration_ms", Value: durationMilliseconds(materializeDuration)},
+			telemetry.Field{Key: "admission_duration_ms", Value: durationMilliseconds(admissionDuration)},
+			telemetry.Field{Key: "ledger_duration_ms", Value: durationMilliseconds(ledgerDuration)},
+			telemetry.Field{Key: "append_duration_ms", Value: durationMilliseconds(appendDuration)},
+			telemetry.Field{Key: "projection_duration_ms", Value: durationMilliseconds(projectionDuration)},
+			telemetry.Field{Key: "commit_duration_ms", Value: durationMilliseconds(commitDuration)},
+			telemetry.Field{Key: "total_duration_ms", Value: durationMilliseconds(time.Since(pageStarted))},
+		))
 		telemetry.IncrementMain(ctx, "source_runtime.page.committed.count", 1)
 		telemetry.AnnotateMain(ctx, pageCommittedAttrs.With(telemetry.Attrs(
 			telemetry.Field{Key: "source_runtime.page.last_committed_number", Value: pageNumber},
@@ -726,6 +762,10 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		ReconciliationReason: reconciliationReason,
 		EventLimitReached:    eventLimitReached,
 	}, nil
+}
+
+func durationMilliseconds(duration time.Duration) float64 {
+	return float64(duration) / float64(time.Millisecond)
 }
 
 func sourceRuntimeTelemetryErrorKind(err error) string {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -1400,6 +1400,44 @@ func TestSyncRuntimeAppendsEventsAndUpdatesProgress(t *testing.T) {
 	}
 }
 
+func TestSyncRuntimeEmitsPageProcessingReceipt(t *testing.T) {
+	registry, err := newFixtureRegistry()
+	if err != nil {
+		t.Fatalf("newFixtureRegistry() error = %v", err)
+	}
+	store := &runtimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-github": {Id: "writer-github", SourceId: "github", TenantId: "writer", Config: map[string]string{"token": "test"}},
+	}}
+	service := New(registry, store, &batchAppendLog{}, &projector{})
+
+	stderr := captureSourceRuntimeStderr(t, func() {
+		if _, syncErr := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "writer-github"}); syncErr != nil {
+			t.Fatalf("Sync() error = %v", syncErr)
+		}
+	})
+	payload := sourceRuntimeTelemetryEventPayload(t, stderr, "source_runtime.page_processing")
+	for key, want := range map[string]any{
+		"runtime_id":      "writer-github",
+		"source_id":       "github",
+		"tenant_id":       "writer",
+		"page":            float64(1),
+		"events_read":     float64(1),
+		"events_accepted": float64(1),
+	} {
+		if got := payload[key]; got != want {
+			t.Fatalf("page processing receipt %s = %#v, want %#v; payload=%#v", key, got, want, payload)
+		}
+	}
+	for _, key := range []string{
+		"pull_duration_ms", "materialize_duration_ms", "admission_duration_ms", "ledger_duration_ms",
+		"append_duration_ms", "projection_duration_ms", "commit_duration_ms", "total_duration_ms",
+	} {
+		if got, ok := payload[key].(float64); !ok || got < 0 {
+			t.Fatalf("page processing receipt %s = %#v, want non-negative duration", key, payload[key])
+		}
+	}
+}
+
 func TestMaterializeEventPinsSyncCollectionProvenance(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- emit one processing receipt per committed source page with pull, materialization, admission, ledger, append, projection, commit, and total durations
- record bounded native admission worker-pool wait time and saturation state
- cover the receipt contract with a source-runtime test

## Validation
- `go test ./internal/sourceruntime ./internal/sourceruntime/eventadmission`
- `git diff --check`