### PR TITLE
perf: batch graph cleanup and retractions

### DIFF
--- a/internal/graphingest/service.go
+++ b/internal/graphingest/service.go
@@ -897,12 +897,22 @@ func (s *Service) projectResponseCoalesced(ctx context.Context, request sourceRe
 		result.EventsRead++
 	}
 	if deleter, ok := graphStore.(ports.ProjectionEntityDeleter); ok {
+		orderedCleanupURNs := make([]string, 0, len(cleanupURNs))
 		for _, urn := range sortedMapKeys(cleanupURNs) {
 			if _, willUpsert := entities[urn]; willUpsert {
 				continue
 			}
-			if err := deleter.DeleteProjectedEntity(ctx, urn); err != nil {
-				return result, fmt.Errorf("delete coalesced projected entity %q: %w", urn, err)
+			orderedCleanupURNs = append(orderedCleanupURNs, urn)
+		}
+		if batchDeleter, ok := graphStore.(ports.ProjectionEntityBatchDeleter); ok {
+			if err := batchDeleter.DeleteProjectedEntities(ctx, orderedCleanupURNs); err != nil {
+				return result, fmt.Errorf("delete coalesced projected entities: %w", err)
+			}
+		} else {
+			for _, urn := range orderedCleanupURNs {
+				if err := deleter.DeleteProjectedEntity(ctx, urn); err != nil {
+					return result, fmt.Errorf("delete coalesced projected entity %q: %w", urn, err)
+				}
 			}
 		}
 	}
@@ -917,13 +927,22 @@ func (s *Service) projectResponseCoalesced(ctx context.Context, request sourceRe
 		}
 	}
 	if deleter, ok := graphStore.(ports.ProjectionLinkDeleter); ok {
-		var deleted uint32
+		orderedRetractions := make([]*ports.ProjectedLink, 0, len(retractedLinks))
 		for _, key := range sortedMapKeys(retractedLinks) {
-			if err := deleter.DeleteProjectedLink(ctx, retractedLinks[key]); err != nil {
-				return result, fmt.Errorf("delete coalesced projected link %q: %w", key, err)
-			}
-			deleted++
+			orderedRetractions = append(orderedRetractions, retractedLinks[key])
 		}
+		if batchDeleter, ok := graphStore.(ports.ProjectionLinkBatchDeleter); ok {
+			if err := batchDeleter.DeleteProjectedLinks(ctx, orderedRetractions); err != nil {
+				return result, fmt.Errorf("delete coalesced projected links: %w", err)
+			}
+		} else {
+			for index, link := range orderedRetractions {
+				if err := deleter.DeleteProjectedLink(ctx, link); err != nil {
+					return result, fmt.Errorf("delete coalesced projected link %q: %w", sortedMapKeys(retractedLinks)[index], err)
+				}
+			}
+		}
+		deleted := boundedUint32(len(orderedRetractions))
 		if len(retractedLinks) != 0 {
 			attrs := telemetry.Attrs(
 				telemetry.Field{Key: "tenant_id", Value: request.TenantID},

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -171,8 +171,10 @@ func (s *recordingProjectionGraphStore) UpsertProjectedLink(_ context.Context, l
 
 type batchRecordingProjectionGraphStore struct {
 	recordingProjectionGraphStore
-	batchEntityCalls int
-	batchLinkCalls   int
+	batchEntityCalls       int
+	batchLinkCalls         int
+	batchEntityDeleteCalls int
+	batchLinkDeleteCalls   int
 }
 
 func (s *batchRecordingProjectionGraphStore) UpsertProjectedEntities(ctx context.Context, entities []*ports.ProjectedEntity) error {
@@ -195,7 +197,29 @@ func (s *batchRecordingProjectionGraphStore) UpsertProjectedLinks(ctx context.Co
 	return nil
 }
 
+func (s *batchRecordingProjectionGraphStore) DeleteProjectedEntities(ctx context.Context, urns []string) error {
+	s.batchEntityDeleteCalls++
+	for _, urn := range urns {
+		if err := s.DeleteProjectedEntity(ctx, urn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *batchRecordingProjectionGraphStore) DeleteProjectedLinks(ctx context.Context, links []*ports.ProjectedLink) error {
+	s.batchLinkDeleteCalls++
+	for _, link := range links {
+		if err := s.DeleteProjectedLink(ctx, link); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 var _ ports.ProjectionGraphBatchStore = (*batchRecordingProjectionGraphStore)(nil)
+var _ ports.ProjectionEntityBatchDeleter = (*batchRecordingProjectionGraphStore)(nil)
+var _ ports.ProjectionLinkBatchDeleter = (*batchRecordingProjectionGraphStore)(nil)
 
 type checkpointProjectionGraphStore struct {
 	recordingProjectionGraphStore
@@ -1192,6 +1216,59 @@ func TestProjectResponseCoalescedDeletesProjectedRetractions(t *testing.T) {
 	if _, ok := store.links[key]; ok {
 		t.Fatalf("stale link remains after deletion")
 	}
+}
+
+func TestProjectResponseCoalescedUsesBatchDeleters(t *testing.T) {
+	staleURN := "urn:cerebro:writer:device:stale"
+	staleLink := &ports.ProjectedLink{
+		TenantID: "writer", SourceID: "endpoint", RuntimeID: "endpoint-runtime",
+		FromURN: "urn:cerebro:writer:device:active", Relation: "owned_by", ToURN: "urn:cerebro:writer:identity:user-1",
+	}
+	store := &batchRecordingProjectionGraphStore{recordingProjectionGraphStore: recordingProjectionGraphStore{
+		entities: map[string]*ports.ProjectedEntity{staleURN: {URN: staleURN}},
+		links:    map[string]*ports.ProjectedLink{staleLink.FromURN + "|" + staleLink.Relation + "|" + staleLink.ToURN: staleLink},
+	}}
+	projector := struct {
+		cleanupRecordProjector
+		retractionProjector
+	}{
+		cleanupRecordProjector: cleanupRecordProjector{
+			records: func(*cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+				return nil, nil, nil
+			},
+			cleanup: func(*cerebrov1.EventEnvelope) ([]string, error) { return []string{staleURN}, nil },
+		},
+		retractionProjector: retractionProjector{retractions: []*ports.ProjectedLink{staleLink}},
+	}
+	// Compose the optional cleanup and retraction capabilities explicitly because
+	// both must be visible on the same projector value.
+	combined := batchCleanupRetractionProjector{cleanup: projector.cleanupRecordProjector, retractions: projector.retractionProjector}
+	service := &Service{graphStore: store}
+	if _, err := service.projectResponseCoalesced(context.Background(), sourceRequest{TenantID: "writer"}, &cerebrov1.ReadSourceResponse{
+		Events: []*cerebrov1.EventEnvelope{{Id: "event-1", SourceId: "endpoint"}},
+	}, combined, nil); err != nil {
+		t.Fatalf("projectResponseCoalesced() error = %v", err)
+	}
+	if store.batchEntityDeleteCalls != 1 || store.batchLinkDeleteCalls != 1 {
+		t.Fatalf("batch delete calls = entities %d links %d, want 1 and 1", store.batchEntityDeleteCalls, store.batchLinkDeleteCalls)
+	}
+}
+
+type batchCleanupRetractionProjector struct {
+	cleanup     cleanupRecordProjector
+	retractions retractionProjector
+}
+
+func (p batchCleanupRetractionProjector) ProjectRecords(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return p.cleanup.ProjectRecords(event)
+}
+
+func (p batchCleanupRetractionProjector) ProjectCleanupRecords(event *cerebrov1.EventEnvelope) ([]string, error) {
+	return p.cleanup.ProjectCleanupRecords(event)
+}
+
+func (p batchCleanupRetractionProjector) ProjectRetractions(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedLink, error) {
+	return p.retractions.ProjectRetractions(event)
 }
 
 func TestProjectResponseCoalescedPreservesNewestObservationAttributes(t *testing.T) {

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -1351,6 +1351,78 @@ RETURN count(*)`, params)
 	return nil
 }
 
+// DeleteProjectedLinks retracts source-runtime assertions in one transaction and
+// reconciles each affected logical relationship after all assertions are gone.
+func (s *Store) DeleteProjectedLinks(ctx context.Context, links []*ports.ProjectedLink) error {
+	rows := make([]map[string]any, 0, len(links))
+	seen := map[string]struct{}{}
+	for _, link := range links {
+		fromURN, toURN, relation, err := validateProjectedLinkIdentity(link)
+		if err != nil {
+			return err
+		}
+		tenantID := strings.TrimSpace(link.TenantID)
+		sourceID := strings.TrimSpace(link.SourceID)
+		runtimeID := strings.TrimSpace(link.RuntimeID)
+		if tenantID != "" {
+			if err := ports.ValidateProjectedLinkTenantScope(link); err != nil {
+				return err
+			}
+		}
+		if tenantID == "" || sourceID == "" {
+			continue
+		}
+		key := strings.Join([]string{fromURN, relation, toURN, tenantID, sourceID, runtimeID}, "\x00")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		rows = append(rows, map[string]any{
+			"from_urn": fromURN, "to_urn": toURN, "relation": relation,
+			"tenant_id": tenantID, "source_id": sourceID, "runtime_id": runtimeID,
+		})
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	if err := s.requireConfigured(); err != nil {
+		return err
+	}
+	if err := s.ensureSchema(ctx); err != nil {
+		return err
+	}
+	_, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		result, err := tx.Run(ctx, `UNWIND $rows AS row
+MATCH (src:Entity {urn: row.from_urn})-[assertion:RELATION_ASSERTION {
+    relation: row.relation,
+    tenant_id: row.tenant_id,
+    source_id: row.source_id,
+    runtime_id: row.runtime_id
+}]->(dst:Entity {urn: row.to_urn})
+DELETE assertion
+RETURN DISTINCT row.from_urn, row.relation, row.to_urn, row.tenant_id`, map[string]any{"rows": rows})
+		if err != nil {
+			return nil, err
+		}
+		affected := make([]map[string]any, 0, len(rows))
+		for result.Next(ctx) {
+			record := result.Record()
+			affected = append(affected, map[string]any{
+				"from_urn": stringValue(record.Values[0]), "relation": stringValue(record.Values[1]),
+				"to_urn": stringValue(record.Values[2]), "tenant_id": stringValue(record.Values[3]),
+			})
+		}
+		if err := result.Err(); err != nil {
+			return nil, err
+		}
+		return nil, reconcileProjectedLogicalLinks(ctx, tx, affected)
+	})
+	if err != nil {
+		return fmt.Errorf("delete projected links: %w", err)
+	}
+	return nil
+}
+
 // DeleteProjectedEntity removes only an isolated entity. The identity-less API
 // cannot safely choose among source-runtime assertions, so shared or legacy
 // graph facts must be retracted through their scoped link APIs first.
@@ -1373,6 +1445,43 @@ DELETE e`, map[string]any{"urn": normalizedURN})
 	})
 	if err != nil {
 		return fmt.Errorf("delete projected entity %q: %w", normalizedURN, err)
+	}
+	return nil
+}
+
+// DeleteProjectedEntities removes isolated entities with one UNWIND query.
+func (s *Store) DeleteProjectedEntities(ctx context.Context, urns []string) error {
+	normalized := make([]string, 0, len(urns))
+	seen := map[string]struct{}{}
+	for _, urn := range urns {
+		urn = strings.TrimSpace(urn)
+		if urn == "" {
+			return errors.New("projected entity urn is required")
+		}
+		if _, ok := seen[urn]; ok {
+			continue
+		}
+		seen[urn] = struct{}{}
+		normalized = append(normalized, urn)
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	if err := s.requireConfigured(); err != nil {
+		return err
+	}
+	if err := s.ensureSchema(ctx); err != nil {
+		return err
+	}
+	_, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
+		return consume(ctx, tx, `UNWIND $urns AS urn
+MATCH (e:Entity {urn: urn})
+WHERE NOT (e)-[:RELATION]-()
+  AND NOT (e)-[:RELATION_ASSERTION]-()
+DELETE e`, map[string]any{"urns": normalized})
+	})
+	if err != nil {
+		return fmt.Errorf("delete projected entities: %w", err)
 	}
 	return nil
 }

--- a/internal/ports/projection.go
+++ b/internal/ports/projection.go
@@ -238,9 +238,19 @@ type ProjectionLinkDeleter interface {
 	DeleteProjectedLink(context.Context, *ProjectedLink) error
 }
 
+// ProjectionLinkBatchDeleter retracts normalized links in one bounded store operation.
+type ProjectionLinkBatchDeleter interface {
+	DeleteProjectedLinks(context.Context, []*ProjectedLink) error
+}
+
 // ProjectionEntityDeleter removes normalized entities from projection stores that support deletion.
 type ProjectionEntityDeleter interface {
 	DeleteProjectedEntity(context.Context, string) error
+}
+
+// ProjectionEntityBatchDeleter removes isolated normalized entities in one bounded store operation.
+type ProjectionEntityBatchDeleter interface {
+	DeleteProjectedEntities(context.Context, []string) error
 }
 
 // ProjectionCleaner removes stale or orphaned projection artifacts in scoped batches.


### PR DESCRIPTION
## Summary
- add optional batch deletion capabilities while retaining the single-item graph-store fallback
- retract scoped relationship assertions in one Neo4j transaction and reconcile affected logical links
- delete isolated projected entities with one bounded `UNWIND` operation
- verify graph ingest selects the batch cleanup path

## Validation
- `go test ./internal/graphingest ./internal/graphstore/neo4j`
- `git diff --check`