### PR TITLE
Queue candidate attestations to completion

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -14,11 +14,11 @@ permissions:
   contents: read
 
 concurrency:
-  # Candidate builds no longer use the stable release reservation:
-  # group: stable-release-tag-reservation
-  # cancel-in-progress: false
+  # A candidate receipt is a deployment prerequisite. Queue newer main commits
+  # behind the active attestation so normal merge traffic cannot repeatedly
+  # cancel the exact-image E2E job before it writes a receipt.
   group: candidate-build-main
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   resolve:

--- a/scripts/tests/test_release_workflow_serialization.py
+++ b/scripts/tests/test_release_workflow_serialization.py
@@ -17,12 +17,19 @@ class ReleaseWorkflowSerializationTest(unittest.TestCase):
         self.assertIn("cancel-in-progress: false", workflow)
         self.assertNotIn("group: release-${{ inputs.release_tag }}", workflow)
 
-    def test_release_tag_reservation_is_serialized_across_triggers(self) -> None:
+    def test_candidate_build_does_not_claim_stable_release_reservation(self) -> None:
         workflow = CUT_RELEASE_WORKFLOW.read_text(encoding="utf-8")
 
-        self.assertIn("group: stable-release-tag-reservation", workflow)
-        self.assertIn("cancel-in-progress: false", workflow)
-        self.assertNotIn("group: cut-release-${{", workflow)
+        concurrency = workflow.split("concurrency:\n", 1)[1].split("\njobs:\n", 1)[0]
+        self.assertNotIn("group: stable-release-tag-reservation", concurrency)
+
+    def test_candidate_attestations_are_queued_instead_of_cancelled(self) -> None:
+        workflow = CUT_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+        concurrency = workflow.split("concurrency:\n", 1)[1].split("\njobs:\n", 1)[0]
+        self.assertIn("group: candidate-build-main", concurrency)
+        self.assertIn("cancel-in-progress: false", concurrency)
+        self.assertNotIn("cancel-in-progress: true", concurrency)
 
     def test_candidate_web_images_use_native_architecture_runners(self) -> None:
         workflow = CUT_RELEASE_WORKFLOW.read_text(encoding="utf-8")

--- a/tools/archtests/packaging_contract_guardrails_test.go
+++ b/tools/archtests/packaging_contract_guardrails_test.go
@@ -246,8 +246,8 @@ func TestReleaseWorkflowsKeepCandidateAndStableBoundaries(t *testing.T) {
 		t.Fatal("candidate receipt must wait for CI, both image scans, and the exact-image Rust proof")
 	}
 	if !strings.Contains(candidate, "group: candidate-build-main") ||
-		!strings.Contains(candidate, "cancel-in-progress: true") {
-		t.Fatal("candidate workflow must cancel stale main builds")
+		!strings.Contains(candidate, "cancel-in-progress: false") {
+		t.Fatal("candidate workflow must queue main builds so active attestations reach a receipt")
 	}
 	resolveIndex := strings.Index(candidate, "  resolve:\n")
 	ciGateIndex := strings.Index(candidate, "  ci-gate:\n")


### PR DESCRIPTION
## Summary
- queue Candidate Build runs instead of cancelling active attestations when public main advances
- preserve the separate stable-release concurrency boundary
- enforce both invariants in Python and architecture tests

## Why
The candidate receipt is required by downstream deployment gates. Frequent merges to main were repeatedly cancelling the exact-image Rust E2E job after image publication but before the receipt could be written, so no candidate could become promotable.

## Validation
- `python3 -m unittest scripts.tests.test_release_workflow_serialization`
- `go test ./tools/archtests -run TestPackagingContractGuardrails -count=1`
- `git diff --check`