### PR TITLE
perf: parallelize bounded graph rule reads

### DIFF
--- a/internal/findings/graph_rule_performance_test.go
+++ b/internal/findings/graph_rule_performance_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -39,6 +40,77 @@ func TestCloudExposureGraphRulesAnchorPublicPrincipalOnIndex(t *testing.T) {
 				t.Fatalf("query missing index-anchored public-principal predicate %q:\n%s", indexedAnchor, query)
 			}
 		})
+	}
+}
+
+type concurrentGraphQuery struct {
+	*stubGraphStore
+	started chan struct{}
+	release chan struct{}
+	active  atomic.Int32
+	maximum atomic.Int32
+}
+
+func (s *concurrentGraphQuery) ExecuteReadCypher(ctx context.Context, _ ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	active := s.active.Add(1)
+	defer s.active.Add(-1)
+	for {
+		maximum := s.maximum.Load()
+		if active <= maximum || s.maximum.CompareAndSwap(maximum, active) {
+			break
+		}
+	}
+	s.started <- struct{}{}
+	select {
+	case <-s.release:
+		return nil, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func TestEvaluateSourceRuntimeGraphRulesReadsConcurrentlyAndReturnsInRuleOrder(t *testing.T) {
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
+	store := &stubFindingStore{}
+	graphStore := &concurrentGraphQuery{
+		stubGraphStore: &stubGraphStore{},
+		started:        make(chan struct{}, 2),
+		release:        make(chan struct{}),
+	}
+	ruleA := &stubGraphRule{spec: &cerebrov1.RuleSpec{Id: "rule-a"}, sourceID: "okta", query: ports.CypherQueryRequest{Query: "MATCH (a) RETURN a"}}
+	ruleB := &stubGraphRule{spec: &cerebrov1.RuleSpec{Id: "rule-b"}, sourceID: "okta", query: ports.CypherQueryRequest{Query: "MATCH (b) RETURN b"}}
+	registry, err := NewRegistry(ruleA, ruleB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+
+	type evaluationResult struct {
+		result *EvaluateGraphRulesResult
+		err    error
+	}
+	completed := make(chan evaluationResult, 1)
+	go func() {
+		result, evaluateErr := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: runtime.GetId()})
+		completed <- evaluationResult{result: result, err: evaluateErr}
+	}()
+	for range 2 {
+		select {
+		case <-graphStore.started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("two graph reads did not overlap")
+		}
+	}
+	close(graphStore.release)
+	outcome := <-completed
+	if outcome.err != nil {
+		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", outcome.err)
+	}
+	if graphStore.maximum.Load() < 2 {
+		t.Fatalf("maximum concurrent graph reads = %d, want at least 2", graphStore.maximum.Load())
+	}
+	if len(outcome.result.Evaluations) != 2 || outcome.result.Evaluations[0].Rule.GetId() != "rule-a" || outcome.result.Evaluations[1].Rule.GetId() != "rule-b" {
+		t.Fatalf("evaluation order = %#v, want rule-a then rule-b", outcome.result.Evaluations)
 	}
 }
 

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -47,6 +48,28 @@ type EvaluateGraphRulesResult struct {
 
 // ErrGraphRuntimeUnavailable indicates that the graph query boundary is not configured.
 var ErrGraphRuntimeUnavailable = fmt.Errorf("%w: graph query boundary is not configured", ErrRuntimeUnavailable)
+
+const graphRuleReadConcurrency = 4
+
+type graphRulePersistenceTurn struct {
+	ready   <-chan struct{}
+	next    chan struct{}
+	release sync.Once
+}
+
+func (t *graphRulePersistenceTurn) wait() {
+	if t != nil && t.ready != nil {
+		<-t.ready
+	}
+}
+
+func (t *graphRulePersistenceTurn) finish() {
+	if t == nil {
+		return
+	}
+	t.wait()
+	t.release.Do(func() { close(t.next) })
+}
 
 // EvaluateSourceRuntimeGraphRules runs every registered GraphRule that supports one runtime.
 //
@@ -97,20 +120,39 @@ func (s *Service) EvaluateSourceRuntimeGraphRules(ctx context.Context, request E
 		Runtime:     runtime,
 		Evaluations: make([]*GraphRuleEvaluationResult, 0, len(candidates)),
 	}
+	evaluations := make([]*GraphRuleEvaluationResult, len(candidates))
+	errorsByRule := make([]error, len(candidates))
+	for start := 0; start < len(candidates); start += graphRuleReadConcurrency {
+		end := min(start+graphRuleReadConcurrency, len(candidates))
+		ready := make(chan struct{})
+		close(ready)
+		var group sync.WaitGroup
+		for index := start; index < end; index++ {
+			next := make(chan struct{})
+			turn := &graphRulePersistenceTurn{ready: ready, next: next}
+			ready = next
+			group.Add(1)
+			go func(index int, rule GraphRule, turn *graphRulePersistenceTurn) {
+				defer group.Done()
+				evaluations[index], errorsByRule[index] = s.evaluateGraphRule(ctx, runtime, rule, startedAt, dependencyRuntimes, turn)
+			}(index, candidates[index], turn)
+		}
+		group.Wait()
+	}
 	var firstErr error
-	for _, rule := range candidates {
-		evaluation, err := s.evaluateGraphRule(ctx, runtime, rule, startedAt, dependencyRuntimes)
+	for index, evaluation := range evaluations {
 		if evaluation != nil {
 			result.Evaluations = append(result.Evaluations, evaluation)
 		}
-		if err != nil && firstErr == nil {
-			firstErr = err
+		if errorsByRule[index] != nil && firstErr == nil {
+			firstErr = errorsByRule[index]
 		}
 	}
 	return result, firstErr
 }
 
-func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.SourceRuntime, rule GraphRule, startedAt time.Time, dependencyRuntimes []*cerebrov1.SourceRuntime) (evaluation *GraphRuleEvaluationResult, err error) {
+func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.SourceRuntime, rule GraphRule, startedAt time.Time, dependencyRuntimes []*cerebrov1.SourceRuntime, persistenceTurn *graphRulePersistenceTurn) (evaluation *GraphRuleEvaluationResult, err error) {
+	defer persistenceTurn.finish()
 	spec := rule.Spec()
 	ctx, span := telemetry.Start(ctx, "graph_rule.evaluate", telemetry.Attrs(
 		telemetry.Field{Key: "rule_id", Value: strings.TrimSpace(spec.GetId())},
@@ -172,8 +214,11 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 	if strings.TrimSpace(queryRequest.Query) != "" {
 		run.GraphRowLimit = proto.Uint32(boundedUint32(effectiveGraphRowLimit(queryRequest)))
 	}
-	if err := s.runStore.PutFindingEvaluationRun(ctx, run); err != nil {
-		return nil, fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), err)
+	s.graphRuleRunMu.Lock()
+	runPersistErr := s.runStore.PutFindingEvaluationRun(ctx, run)
+	s.graphRuleRunMu.Unlock()
+	if runPersistErr != nil {
+		return nil, fmt.Errorf("persist finding evaluation run %q: %w", run.GetId(), runPersistErr)
 	}
 	result := &GraphRuleEvaluationResult{
 		Rule: spec,
@@ -202,6 +247,7 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 		evaluationErr := fmt.Errorf("execute graph rule %q cypher: %w", spec.GetId(), err)
 		return result, s.finishFailedGraphRun(ctx, run, 0, nil, evaluationErr)
 	}
+	persistenceTurn.wait()
 	s.verifyGraphEvaluationSourceSnapshots(ctx, run)
 	result.RowsRead = boundedUint32(len(rows))
 	rowLimitTruncated := cypherRowsTruncated(queryRequest, len(rows))

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -82,6 +83,7 @@ type Service struct {
 	tombstoneEventStore       ports.FindingTombstoneEventStore
 	closeoutHeartbeatInterval time.Duration
 	graphRuleQueryTimeout     time.Duration
+	graphRuleRunMu            sync.Mutex
 	findingEvaluationLeaseTTL time.Duration
 	rules                     *Registry
 	ttlClock                  ttlClock


### PR DESCRIPTION
## Summary
- execute graph-rule Cypher reads in bounded groups of four
- keep run creation serialized and finding/evidence mutations in deterministic rule order
- preserve evaluation ordering and first-error selection
- prove reads overlap and run the concurrency path under the race detector

## Validation
- `go test ./internal/findings`
- `go test -race ./internal/findings -run "TestEvaluateSourceRuntimeGraphRulesReadsConcurrentlyAndReturnsInRuleOrder|TestEvaluateSourceRuntimeGraphRulesEnforcesPerRuleQueryTimeout"`
- `git diff --check`