### PR TITLE
perf: batch graph rule evidence persistence

### DIFF
--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -213,6 +213,7 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 		return result, s.finishFailedGraphRun(ctx, run, result.RowsRead, nil, evaluationErr)
 	}
 	evidenceIDs := map[string]struct{}{}
+	pendingEvidence := make([]*cerebrov1.FindingEvidence, 0, len(emitted))
 	emittedFindingIDs := map[string]struct{}{}
 	for _, record := range emitted {
 		if record == nil {
@@ -237,12 +238,8 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 			return result, s.finishFailedGraphRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
 		}
 		if _, seen := evidenceIDs[evidence.GetId()]; !seen {
-			if err := s.evidenceStore.PutFindingEvidence(ctx, evidence); err != nil {
-				evaluationErr := fmt.Errorf("persist evidence for graph rule %q finding %q: %w", spec.GetId(), stored.ID, err)
-				return result, s.finishFailedGraphRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
-			}
 			evidenceIDs[evidence.GetId()] = struct{}{}
-			result.Evidence = append(result.Evidence, evidence)
+			pendingEvidence = append(pendingEvidence, evidence)
 		}
 		if err := s.projectFindingAnchor(ctx, stored); err != nil {
 			evaluationErr := fmt.Errorf("project graph rule %q finding %q anchor: %w", spec.GetId(), stored.ID, err)
@@ -259,6 +256,20 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 			}
 		}
 	}
+	if batchStore, ok := s.evidenceStore.(ports.FindingEvidenceBatchStore); ok {
+		if err := batchStore.PutFindingEvidenceBatch(ctx, pendingEvidence); err != nil {
+			evaluationErr := fmt.Errorf("persist evidence batch for graph rule %q: %w", spec.GetId(), err)
+			return result, s.finishFailedGraphRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
+		}
+	} else {
+		for _, evidence := range pendingEvidence {
+			if err := s.evidenceStore.PutFindingEvidence(ctx, evidence); err != nil {
+				evaluationErr := fmt.Errorf("persist evidence for graph rule %q finding %q: %w", spec.GetId(), evidence.GetFindingId(), err)
+				return result, s.finishFailedGraphRun(ctx, run, result.RowsRead, findingIDs(result.Findings), evaluationErr)
+			}
+		}
+	}
+	result.Evidence = append(result.Evidence, pendingEvidence...)
 	resolveStale := !result.Truncated && s.canResolveFromFindingEvaluationRun(run, true)
 	var scopeFilter *staleScopeFilter
 	if result.Truncated && !rowLimitTruncated && s.canResolveFromFindingEvaluationRun(run, true) {

--- a/internal/findings/graph_rule_test.go
+++ b/internal/findings/graph_rule_test.go
@@ -125,9 +125,24 @@ func newGraphRuleStubRuntimeStore(runtime *cerebrov1.SourceRuntime) *stubRuntime
 	return &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{runtime.GetId(): runtime}}
 }
 
+type batchEvidenceFindingStore struct {
+	stubFindingStore
+	batchEvidenceCalls int
+}
+
+func (s *batchEvidenceFindingStore) PutFindingEvidenceBatch(ctx context.Context, evidence []*cerebrov1.FindingEvidence) error {
+	s.batchEvidenceCalls++
+	for _, item := range evidence {
+		if err := s.PutFindingEvidence(ctx, item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func TestEvaluateSourceRuntimeGraphRulesEmitsAndPersistsFindings(t *testing.T) {
 	runtime := &cerebrov1.SourceRuntime{Id: "runtime-okta", SourceId: "okta", TenantId: "writer"}
-	store := &stubFindingStore{}
+	store := &batchEvidenceFindingStore{}
 	graphStore := &stubGraphStore{
 		cypherRows: []ports.CypherRow{
 			{Values: map[string]any{"label": "alice@writer.com"}},
@@ -206,6 +221,9 @@ func TestEvaluateSourceRuntimeGraphRulesEmitsAndPersistsFindings(t *testing.T) {
 	}
 	if got := len(evaluation.Evidence); got != 1 {
 		t.Fatalf("len(Evidence) = %d, want 1", got)
+	}
+	if store.batchEvidenceCalls != 1 {
+		t.Fatalf("batch evidence calls = %d, want 1", store.batchEvidenceCalls)
 	}
 	if got := len(evaluation.Evidence[0].GetGraphRows()); got != 1 {
 		t.Fatalf("len(Evidence[0].GraphRows) = %d, want 1", got)

--- a/internal/ports/findings.go
+++ b/internal/ports/findings.go
@@ -536,6 +536,11 @@ type FindingEvidenceStore interface {
 	ListFindingEvidence(context.Context, ListFindingEvidenceRequest) ([]*cerebrov1.FindingEvidence, error)
 }
 
+// FindingEvidenceBatchStore persists a deterministic evidence batch in one store transaction.
+type FindingEvidenceBatchStore interface {
+	PutFindingEvidenceBatch(context.Context, []*cerebrov1.FindingEvidence) error
+}
+
 // FindingCandidateStore persists non-production candidate finding outputs.
 type FindingCandidateStore interface {
 	StateStore

--- a/internal/sourceruntime/processing_benchmark_test.go
+++ b/internal/sourceruntime/processing_benchmark_test.go
@@ -102,7 +102,7 @@ func BenchmarkSyncProcessingPipeline(b *testing.B) {
 					"processing-benchmark": {Id: "processing-benchmark", SourceId: "processing_benchmark", TenantId: "benchmark"},
 				}
 				response, syncErr := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{
-					Id: "processing-benchmark", PageLimit: uint32(workload.pages),
+					Id: "processing-benchmark", PageLimit: boundedUint32(workload.pages),
 				})
 				if syncErr != nil {
 					b.Fatal(syncErr)

--- a/internal/statestore/postgres/findingevidence.go
+++ b/internal/statestore/postgres/findingevidence.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -104,6 +105,31 @@ func findingEvidenceAdvisoryLockSQL() string {
 	return `SELECT pg_advisory_xact_lock(hashtext('finding_evidence'), hashtext($1))`
 }
 
+func validateFindingEvidence(evidence *cerebrov1.FindingEvidence) error {
+	if evidence == nil {
+		return errors.New("finding evidence is required")
+	}
+	for _, required := range []struct{ value, message string }{
+		{strings.TrimSpace(evidence.GetId()), "finding evidence id is required"},
+		{strings.TrimSpace(evidence.GetRuntimeId()), "finding evidence runtime id is required"},
+		{strings.TrimSpace(evidence.GetRuleId()), "finding evidence rule id is required"},
+		{strings.TrimSpace(evidence.GetFindingId()), "finding evidence finding id is required"},
+		{strings.TrimSpace(evidence.GetRunId()), "finding evidence run id is required"},
+	} {
+		if required.value == "" {
+			return errors.New(required.message)
+		}
+	}
+	createdAt := evidence.GetCreatedAt()
+	if createdAt == nil || createdAt.AsTime().IsZero() {
+		return errors.New("finding evidence created_at is required")
+	}
+	if evidence.GetLastObservedAt() == nil || evidence.GetLastObservedAt().AsTime().IsZero() {
+		evidence.LastObservedAt = createdAt
+	}
+	return nil
+}
+
 // PutFindingEvidence upserts one durable finding evidence record.
 func (s *Store) PutFindingEvidence(ctx context.Context, evidence *cerebrov1.FindingEvidence) error {
 	if evidence == nil {
@@ -142,7 +168,6 @@ func (s *Store) PutFindingEvidence(ctx context.Context, evidence *cerebrov1.Find
 	if err := s.ensureFindingEvidenceTables(ctx); err != nil {
 		return err
 	}
-	evidence = findingevidence.Normalize(evidence)
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin finding evidence upsert: %w", err)
@@ -152,6 +177,65 @@ func (s *Store) PutFindingEvidence(ctx context.Context, evidence *cerebrov1.Find
 			_ = tx.Rollback()
 		}
 	}()
+	if err := putFindingEvidenceTx(ctx, tx, evidence); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit finding evidence %q: %w", id, err)
+	}
+	tx = nil
+	return nil
+}
+
+// PutFindingEvidenceBatch upserts a stable, ID-ordered evidence batch in one
+// transaction. Ordering advisory locks prevents cross-batch deadlocks while the
+// per-record merge contract remains identical to PutFindingEvidence.
+func (s *Store) PutFindingEvidenceBatch(ctx context.Context, evidence []*cerebrov1.FindingEvidence) error {
+	if len(evidence) == 0 {
+		return nil
+	}
+	if s == nil || s.db == nil {
+		return errors.New("postgres is not configured")
+	}
+	if err := s.ensureFindingEvidenceTables(ctx); err != nil {
+		return err
+	}
+	ordered := append([]*cerebrov1.FindingEvidence(nil), evidence...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i] == nil {
+			return true
+		}
+		if ordered[j] == nil {
+			return false
+		}
+		return strings.TrimSpace(ordered[i].GetId()) < strings.TrimSpace(ordered[j].GetId())
+	})
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin finding evidence batch upsert: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, item := range ordered {
+		if err := validateFindingEvidence(item); err != nil {
+			return err
+		}
+		if err := putFindingEvidenceTx(ctx, tx, item); err != nil {
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit finding evidence batch: %w", err)
+	}
+	return nil
+}
+
+func putFindingEvidenceTx(ctx context.Context, tx *sql.Tx, evidence *cerebrov1.FindingEvidence) error {
+	evidence = findingevidence.Normalize(evidence)
+	id := strings.TrimSpace(evidence.GetId())
+	runtimeID := strings.TrimSpace(evidence.GetRuntimeId())
+	ruleID := strings.TrimSpace(evidence.GetRuleId())
+	findingID := strings.TrimSpace(evidence.GetFindingId())
+	runID := strings.TrimSpace(evidence.GetRunId())
 	// Serialize same-ID first writes before the preflight read so history merges cannot race.
 	if _, err := tx.ExecContext(ctx, findingEvidenceAdvisoryLockSQL(), id); err != nil {
 		return fmt.Errorf("lock finding evidence %q: %w", id, err)
@@ -219,10 +303,6 @@ func (s *Store) PutFindingEvidence(ctx context.Context, evidence *cerebrov1.Find
 	); err != nil {
 		return fmt.Errorf("upsert finding evidence %q: %w", id, err)
 	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit finding evidence %q: %w", id, err)
-	}
-	tx = nil
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- add an optional batch evidence persistence capability
- persist each graph rule evidence set in one PostgreSQL transaction
- acquire advisory locks in stable evidence-ID order and preserve the existing history merge
- retain per-record persistence for stores without the batch capability

Finding upserts remain ordered because identity reconciliation, risk scoring, and graph projection are stateful.

## Validation
- `go test ./internal/statestore/postgres ./internal/findings`
- `git diff --check`