### PR TITLE
fix: bound processing benchmark page limit

### DIFF
--- a/internal/sourceruntime/processing_benchmark_test.go
+++ b/internal/sourceruntime/processing_benchmark_test.go
@@ -102,7 +102,7 @@ func BenchmarkSyncProcessingPipeline(b *testing.B) {
 					"processing-benchmark": {Id: "processing-benchmark", SourceId: "processing_benchmark", TenantId: "benchmark"},
 				}
 				response, syncErr := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{
-					Id: "processing-benchmark", PageLimit: uint32(workload.pages),
+					Id: "processing-benchmark", PageLimit: boundedUint32(workload.pages),
 				})
 				if syncErr != nil {
 					b.Fatal(syncErr)


### PR DESCRIPTION
## Summary
- route the deterministic benchmark page count through the existing bounded conversion helper
- clear the G115 integer-conversion finding surfaced by hosted security lint

## Validation
- `go test ./internal/sourceruntime -run "^$" -bench "^BenchmarkSyncProcessingPipeline$" -benchtime=1x`
- `git diff --check`