### PR TITLE
fix: remove retired MCP row parsers

### DIFF
--- a/crates/organizational-store/src/neo4j.rs
+++ b/crates/organizational-store/src/neo4j.rs
@@ -982,9 +982,11 @@ impl Neo4jProjector {
             relations,
             neighbor_kinds,
             limit,
-            after_agent_key,
-            after_relation,
-            after_direction,
+            CatalogRelationCursor {
+                agent_key: after_agent_key,
+                relation: after_relation,
+                direction: after_direction,
+            },
         )?;
         let mut transaction = self.graph.start_txn().await?;
         let revision = catalog_revision(&mut transaction, tenant_id).await?;
@@ -3061,6 +3063,13 @@ fn validate_catalog_request(
     Ok(())
 }
 
+#[derive(Clone, Copy)]
+struct CatalogRelationCursor<'a> {
+    agent_key: &'a str,
+    relation: &'a str,
+    direction: Option<EntityCatalogDirection>,
+}
+
 fn validate_catalog_relation_request(
     tenant_id: &TenantId,
     agent_key: &str,
@@ -3068,15 +3077,13 @@ fn validate_catalog_relation_request(
     relations: &[String],
     neighbor_kinds: &[String],
     limit: usize,
-    after_agent_key: &str,
-    after_relation: &str,
-    after_direction: Option<EntityCatalogDirection>,
+    cursor: CatalogRelationCursor<'_>,
 ) -> Result<(), StoreError> {
     validate_catalog_request(
         tenant_id,
         &EntityCatalogFilter::default(),
         limit,
-        after_agent_key,
+        cursor.agent_key,
     )?;
     validate_catalog_text("agent_key", agent_key, 4096, true)?;
     if !agent_key.starts_with(&format!("urn:cerebro:{}:", tenant_id.as_str())) {
@@ -3092,11 +3099,11 @@ fn validate_catalog_relation_request(
             "entity catalog directions are invalid".to_owned(),
         ));
     }
-    validate_catalog_text("after_relation", after_relation, 128, false)?;
+    validate_catalog_text("after_relation", cursor.relation, 128, false)?;
     let cursor_fields = (
-        !after_agent_key.is_empty(),
-        !after_relation.is_empty(),
-        after_direction.is_some(),
+        !cursor.agent_key.is_empty(),
+        !cursor.relation.is_empty(),
+        cursor.direction.is_some(),
     );
     if cursor_fields != (false, false, false) && cursor_fields != (true, true, true) {
         return Err(StoreError::Conflict(
@@ -4085,9 +4092,11 @@ mod tests {
                 &["associated_with".to_owned()],
                 &["contract".to_owned()],
                 100,
-                "urn:cerebro:writer:contract:one",
-                "",
-                None,
+                CatalogRelationCursor {
+                    agent_key: "urn:cerebro:writer:contract:one",
+                    relation: "",
+                    direction: None,
+                },
             )
             .is_err(),
             "all composite cursor fields are required"

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -3846,23 +3846,6 @@ func mcpEnforceMaxBytes(value any, args map[string]any) error {
 	return fmt.Errorf("%w: response exceeds max_bytes; narrow filters, lower limit, or enable compact", errInvalidHTTPRequest)
 }
 
-func mcpAssetSearchResultFromRow(row ports.CypherRow) (mcpAssetSearchResult, error) {
-	values := row.Values
-	attributes, err := mcpStringMapFromJSON(mcpAnyString(values["attributes_json"]))
-	if err != nil {
-		return mcpAssetSearchResult{}, err
-	}
-	return mcpAssetSearchResult{
-		URN:        mcpAnyString(values["urn"]),
-		TenantID:   mcpAnyString(values["tenant_id"]),
-		RuntimeID:  mcpAnyString(values["runtime_id"]),
-		SourceID:   mcpAnyString(values["source_id"]),
-		EntityType: mcpAnyString(values["entity_type"]),
-		Label:      mcpAnyString(values["label"]),
-		Attributes: mcpRedactSensitiveAttributes(attributes),
-	}, nil
-}
-
 func (app *App) mcpListRiskFindings(r *http.Request, request ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
 	ctx := r.Context()
 	store := findingStore(app.deps.StateStore)
@@ -4108,22 +4091,6 @@ func mcpTopRiskReasons(counts map[string]int, limit int) []mcpRiskReasonCount {
 		reasons = reasons[:limit]
 	}
 	return reasons
-}
-
-func mcpStringMapFromJSON(raw string) (map[string]string, error) {
-	trimmed := strings.TrimSpace(raw)
-	if trimmed == "" {
-		return nil, nil
-	}
-	rawValues := map[string]any{}
-	if err := json.Unmarshal([]byte(trimmed), &rawValues); err != nil {
-		return nil, fmt.Errorf("%w: decode asset attributes", graphquery.ErrInvalidRequest)
-	}
-	values := make(map[string]string, len(rawValues))
-	for key, value := range rawValues {
-		values[key] = mcpAnyString(value)
-	}
-	return values, nil
 }
 
 func mcpRedactSensitiveAttributes(attributes map[string]string) map[string]string {


### PR DESCRIPTION
## Summary
- remove two raw graph-row parsing helpers left unused after the entity-catalog cutover
- restore the internal lint gate for current `main` and queued changes

## Validation
- `go test ./internal/bootstrap -run TestMCP`
- `git diff --check`