### PR TITLE
Fix entity catalog hosted lint gates

### DIFF
--- a/crates/organizational-store/src/neo4j.rs
+++ b/crates/organizational-store/src/neo4j.rs
@@ -3061,6 +3061,7 @@ fn validate_catalog_request(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn validate_catalog_relation_request(
     tenant_id: &TenantId,
     agent_key: &str,

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -3846,23 +3846,6 @@ func mcpEnforceMaxBytes(value any, args map[string]any) error {
 	return fmt.Errorf("%w: response exceeds max_bytes; narrow filters, lower limit, or enable compact", errInvalidHTTPRequest)
 }
 
-func mcpAssetSearchResultFromRow(row ports.CypherRow) (mcpAssetSearchResult, error) {
-	values := row.Values
-	attributes, err := mcpStringMapFromJSON(mcpAnyString(values["attributes_json"]))
-	if err != nil {
-		return mcpAssetSearchResult{}, err
-	}
-	return mcpAssetSearchResult{
-		URN:        mcpAnyString(values["urn"]),
-		TenantID:   mcpAnyString(values["tenant_id"]),
-		RuntimeID:  mcpAnyString(values["runtime_id"]),
-		SourceID:   mcpAnyString(values["source_id"]),
-		EntityType: mcpAnyString(values["entity_type"]),
-		Label:      mcpAnyString(values["label"]),
-		Attributes: mcpRedactSensitiveAttributes(attributes),
-	}, nil
-}
-
 func (app *App) mcpListRiskFindings(r *http.Request, request ports.ListFindingsRequest) ([]*ports.FindingRecord, error) {
 	ctx := r.Context()
 	store := findingStore(app.deps.StateStore)
@@ -4108,22 +4091,6 @@ func mcpTopRiskReasons(counts map[string]int, limit int) []mcpRiskReasonCount {
 		reasons = reasons[:limit]
 	}
 	return reasons
-}
-
-func mcpStringMapFromJSON(raw string) (map[string]string, error) {
-	trimmed := strings.TrimSpace(raw)
-	if trimmed == "" {
-		return nil, nil
-	}
-	rawValues := map[string]any{}
-	if err := json.Unmarshal([]byte(trimmed), &rawValues); err != nil {
-		return nil, fmt.Errorf("%w: decode asset attributes", graphquery.ErrInvalidRequest)
-	}
-	values := make(map[string]string, len(rawValues))
-	for key, value := range rawValues {
-		values[key] = mcpAnyString(value)
-	}
-	return values, nil
 }
 
 func mcpRedactSensitiveAttributes(attributes map[string]string) map[string]string {


### PR DESCRIPTION
## Summary

- allow the bounded private entity-relation validator to use the same nine-field contract as its public store operation
- remove obsolete MCP raw-Cypher row conversion helpers left behind by the typed entity-catalog cutover

## Validation

- `make lint-shard LINT_PACKAGES="./internal/..." LINT_SHARD_TOTAL="4" LINT_SHARD_INDEX="1"`
- `go test ./internal/bootstrap -run TestMCPAssets -count=1`
- `git diff --check`
