### PR TITLE
Preserve tool failure state for agent recovery

### DIFF
--- a/crates/cerebro-platform/src/slack_agent_mcp.rs
+++ b/crates/cerebro-platform/src/slack_agent_mcp.rs
@@ -450,11 +450,36 @@ fn normalize_tool_result(data: Value, is_error: bool) -> NormalizedToolResult {
     } else {
         ToolResultState::Succeeded
     };
+    let blocker = (state != ToolResultState::Succeeded)
+        .then(|| provider_blocker(&data))
+        .flatten();
     NormalizedToolResult {
         state,
         data,
-        blocker: None,
+        blocker,
     }
+}
+
+fn provider_blocker(data: &Value) -> Option<String> {
+    for field in ["blocker", "reason"] {
+        if let Some(value) = data.get(field).and_then(Value::as_str) {
+            let value = bounded_error(value);
+            if !value.is_empty() {
+                return Some(value);
+            }
+        }
+    }
+    let reasons = data
+        .get("partial_reasons")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>()
+        .join("; ");
+    let reasons = bounded_error(&reasons);
+    (!reasons.is_empty()).then_some(reasons)
 }
 
 fn bind_tools(
@@ -1016,6 +1041,37 @@ mod tests {
 
         assert_eq!(normalized.state, ToolResultState::OutcomeUnknown);
         assert_eq!(normalized.data["operation_ref"], "operation-one");
+    }
+
+    #[test]
+    fn preserves_bounded_provider_recovery_reasons() {
+        let blocked = normalize_tool_result(
+            json!({"state": "blocked", "blocker": format!("{}tail", "x".repeat(512))}),
+            false,
+        );
+        assert_eq!(blocked.state, ToolResultState::Failed);
+        assert_eq!(blocked.blocker.as_ref().unwrap().chars().count(), 512);
+        assert!(!blocked.blocker.as_ref().unwrap().contains("tail"));
+
+        let partial = normalize_tool_result(
+            json!({
+                "state": "partial",
+                "partial_reasons": ["Graph projection is unavailable.", "Runtime state is stale."]
+            }),
+            false,
+        );
+        assert_eq!(partial.state, ToolResultState::Partial);
+        assert_eq!(
+            partial.blocker.as_deref(),
+            Some("Graph projection is unavailable.; Runtime state is stale.")
+        );
+
+        let complete = normalize_tool_result(
+            json!({"state": "complete", "blocker": "must not shadow success"}),
+            false,
+        );
+        assert_eq!(complete.state, ToolResultState::Succeeded);
+        assert_eq!(complete.blocker, None);
     }
 
     #[test]

--- a/crates/cerebro-platform/src/slack_agent_mcp.rs
+++ b/crates/cerebro-platform/src/slack_agent_mcp.rs
@@ -453,11 +453,84 @@ fn normalize_tool_result(data: Value, is_error: bool) -> NormalizedToolResult {
     let blocker = (state != ToolResultState::Succeeded)
         .then(|| provider_blocker(&data))
         .flatten();
+    let data = if is_error {
+        let guidance = tool_error_guidance(&data);
+        with_recovery_guidance(data, guidance)
+    } else {
+        data
+    };
     NormalizedToolResult {
         state,
         data,
         blocker,
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RecoveryGuidance {
+    error_kind: &'static str,
+    retryable: bool,
+    operator_action: &'static str,
+}
+
+fn tool_error_guidance(data: &Value) -> RecoveryGuidance {
+    let provider_kind = data
+        .pointer("/error/kind")
+        .or_else(|| data.get("error_kind"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or_default();
+    match provider_kind {
+        "not_found" => RecoveryGuidance {
+            error_kind: "target_not_found",
+            retryable: false,
+            operator_action: "Verify the target identifier before retrying.",
+        },
+        "tenant_forbidden" | "forbidden" | "unauthorized" => RecoveryGuidance {
+            error_kind: "capability_access_denied",
+            retryable: false,
+            operator_action: "Restore capability access before retrying.",
+        },
+        "invalid_request" | "invalid_argument" | "invalid_params" => RecoveryGuidance {
+            error_kind: "invalid_tool_request",
+            retryable: false,
+            operator_action: "Correct the tool input before retrying.",
+        },
+        "runtime_unavailable" | "unavailable" | "timeout" => RecoveryGuidance {
+            error_kind: "capability_unavailable",
+            retryable: true,
+            operator_action: "Retry after the capability runtime recovers.",
+        },
+        "conflict" => RecoveryGuidance {
+            error_kind: "capability_conflict",
+            retryable: false,
+            operator_action: "Refresh current state before proposing another call.",
+        },
+        "rate_limited" => RecoveryGuidance {
+            error_kind: "capability_rate_limited",
+            retryable: true,
+            operator_action: "Retry later without changing the request.",
+        },
+        _ => RecoveryGuidance {
+            error_kind: "capability_error",
+            retryable: false,
+            operator_action: "Inspect the provider error before retrying.",
+        },
+    }
+}
+
+fn with_recovery_guidance(data: Value, guidance: RecoveryGuidance) -> Value {
+    let mut object = match data {
+        Value::Object(object) => object,
+        provider_result => serde_json::Map::from_iter([(
+            "provider_result".to_owned(),
+            provider_result,
+        )]),
+    };
+    object.insert("error_kind".into(), json!(guidance.error_kind));
+    object.insert("retryable".into(), json!(guidance.retryable));
+    object.insert("operator_action".into(), json!(guidance.operator_action));
+    Value::Object(object)
 }
 
 fn provider_blocker(data: &Value) -> Option<String> {
@@ -467,6 +540,12 @@ fn provider_blocker(data: &Value) -> Option<String> {
             if !value.is_empty() {
                 return Some(value);
             }
+        }
+    }
+    if let Some(value) = data.pointer("/error/message").and_then(Value::as_str) {
+        let value = bounded_error(value);
+        if !value.is_empty() {
+            return Some(value);
         }
     }
     let reasons = data
@@ -1072,6 +1151,36 @@ mod tests {
         );
         assert_eq!(complete.state, ToolResultState::Succeeded);
         assert_eq!(complete.blocker, None);
+    }
+
+    #[test]
+    fn normalizes_tool_level_errors_into_stable_recovery_guidance() {
+        let denied = normalize_tool_result(
+            json!({
+                "error": {
+                    "kind": "tenant_forbidden",
+                    "message": "Tenant access is not authorized."
+                },
+                "request_ref": "request-one"
+            }),
+            true,
+        );
+        assert_eq!(denied.state, ToolResultState::Failed);
+        assert_eq!(denied.blocker.as_deref(), Some("Tenant access is not authorized."));
+        assert_eq!(denied.data["error_kind"], "capability_access_denied");
+        assert_eq!(denied.data["retryable"], false);
+        assert_eq!(
+            denied.data["operator_action"],
+            "Restore capability access before retrying."
+        );
+        assert_eq!(denied.data["request_ref"], "request-one");
+
+        let unavailable = normalize_tool_result(
+            json!({"error": {"kind": "runtime_unavailable", "message": "Runtime is down."}}),
+            true,
+        );
+        assert_eq!(unavailable.data["error_kind"], "capability_unavailable");
+        assert_eq!(unavailable.data["retryable"], true);
     }
 
     #[test]

--- a/crates/cerebro-platform/src/slack_agent_mcp.rs
+++ b/crates/cerebro-platform/src/slack_agent_mcp.rs
@@ -381,17 +381,21 @@ impl McpAgentTools {
                     tool.mcp_name
                 )));
             }
+            let guidance = json_rpc_error_guidance(error.code);
             return Ok(ToolResult {
                 state: ToolResultState::Failed,
                 summary: format!("MCP tool {} failed.", tool.mcp_name),
-                data: json!({
-                    "error_code": error.code,
-                    "error_message": bounded_error(&error.message),
-                }),
+                data: with_recovery_guidance(
+                    json!({
+                        "error_code": error.code,
+                        "error_message": bounded_error(&error.message),
+                    }),
+                    guidance,
+                ),
                 evidence: vec![],
                 blocker: Some(format!(
-                    "The {} capability returned an MCP error.",
-                    tool.descriptor.title
+                    "The {} capability returned an MCP error. {}",
+                    tool.descriptor.title, guidance.operator_action
                 )),
             });
         }
@@ -502,10 +506,12 @@ impl McpAgentTools {
                 )),
             });
         }
-        bounded_json(response).await.map_err(|error| McpPostFailure {
-            kind: McpPostFailureKind::InvalidResponse,
-            runtime_error: AgentRuntimeError::InvalidToolCall(error),
-        })
+        bounded_json(response)
+            .await
+            .map_err(|error| McpPostFailure {
+                kind: McpPostFailureKind::InvalidResponse,
+                runtime_error: AgentRuntimeError::InvalidToolCall(error),
+            })
     }
 }
 
@@ -595,13 +601,52 @@ fn tool_error_guidance(data: &Value) -> RecoveryGuidance {
     }
 }
 
+const fn json_rpc_error_guidance(code: i64) -> RecoveryGuidance {
+    match code {
+        -32700 => RecoveryGuidance {
+            error_kind: "rpc_parse_error",
+            retryable: false,
+            operator_action: "Inspect the gateway protocol response before retrying.",
+        },
+        -32600 => RecoveryGuidance {
+            error_kind: "invalid_rpc_request",
+            retryable: false,
+            operator_action: "Correct the gateway request contract before retrying.",
+        },
+        -32601 => RecoveryGuidance {
+            error_kind: "capability_method_unavailable",
+            retryable: false,
+            operator_action: "Refresh the capability catalog before retrying.",
+        },
+        -32602 => RecoveryGuidance {
+            error_kind: "invalid_tool_request",
+            retryable: false,
+            operator_action: "Correct the tool input before retrying.",
+        },
+        -32603 => RecoveryGuidance {
+            error_kind: "provider_internal_error",
+            retryable: true,
+            operator_action: "Retry after the capability provider recovers.",
+        },
+        -32099..=-32000 => RecoveryGuidance {
+            error_kind: "provider_server_error",
+            retryable: true,
+            operator_action: "Retry after the capability provider recovers.",
+        },
+        _ => RecoveryGuidance {
+            error_kind: "provider_rpc_error",
+            retryable: false,
+            operator_action: "Inspect the provider error before retrying.",
+        },
+    }
+}
+
 fn with_recovery_guidance(data: Value, guidance: RecoveryGuidance) -> Value {
     let mut object = match data {
         Value::Object(object) => object,
-        provider_result => serde_json::Map::from_iter([(
-            "provider_result".to_owned(),
-            provider_result,
-        )]),
+        provider_result => {
+            serde_json::Map::from_iter([("provider_result".to_owned(), provider_result)])
+        }
     };
     object.insert("error_kind".into(), json!(guidance.error_kind));
     object.insert("retryable".into(), json!(guidance.retryable));
@@ -1242,7 +1287,10 @@ mod tests {
             true,
         );
         assert_eq!(denied.state, ToolResultState::Failed);
-        assert_eq!(denied.blocker.as_deref(), Some("Tenant access is not authorized."));
+        assert_eq!(
+            denied.blocker.as_deref(),
+            Some("Tenant access is not authorized.")
+        );
         assert_eq!(denied.data["error_kind"], "capability_access_denied");
         assert_eq!(denied.data["retryable"], false);
         assert_eq!(
@@ -1827,6 +1875,93 @@ mod tests {
             "Retry after the capability gateway rate limit resets."
         );
         assert!(result.evidence.is_empty());
+    }
+
+    #[tokio::test]
+    async fn json_rpc_errors_return_stable_recovery_guidance() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                Router::new().route(
+                    "/mcp",
+                    post(|| async {
+                        Json(json!({
+                            "jsonrpc": "2.0",
+                            "id": "search-one",
+                            "error": {
+                                "code": -32602,
+                                "message": "finding_id is required"
+                            }
+                        }))
+                    }),
+                ),
+            )
+            .await
+            .unwrap();
+        });
+        let tools = bind_tools(
+            vec![tool("cerebro.findings.search", true)],
+            &BTreeSet::from(["cerebro.findings.search".into()]),
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+        )
+        .unwrap();
+        let descriptors = tools.values().map(|tool| tool.descriptor.clone()).collect();
+        let mcp = McpAgentTools {
+            client: Client::new(),
+            endpoint: Url::parse(&format!("http://{address}/mcp")).unwrap(),
+            bearer_token: "tenant-token".into(),
+            selection_signing_key: "host-only-selection-signing-secret".into(),
+            toolsets: "task".into(),
+            descriptors,
+            tools,
+        };
+        let call = ToolCall {
+            call_id: "search-one".into(),
+            tool_id: "mcp.cerebro.findings.search".into(),
+            purpose: "Find current findings.".into(),
+            input: json!({}),
+        };
+
+        let result = mcp.invoke(&turn_request(), &call).await.unwrap();
+        server.abort();
+
+        assert_eq!(result.state, ToolResultState::Failed);
+        assert_eq!(result.data["error_code"], -32602);
+        assert_eq!(result.data["error_message"], "finding_id is required");
+        assert_eq!(result.data["error_kind"], "invalid_tool_request");
+        assert_eq!(result.data["retryable"], false);
+        assert_eq!(
+            result.data["operator_action"],
+            "Correct the tool input before retrying."
+        );
+        assert!(result.evidence.is_empty());
+    }
+
+    #[test]
+    fn classifies_standard_and_provider_json_rpc_errors() {
+        assert_eq!(
+            json_rpc_error_guidance(-32601).error_kind,
+            "capability_method_unavailable"
+        );
+        assert_eq!(
+            json_rpc_error_guidance(-32603),
+            RecoveryGuidance {
+                error_kind: "provider_internal_error",
+                retryable: true,
+                operator_action: "Retry after the capability provider recovers.",
+            }
+        );
+        assert_eq!(
+            json_rpc_error_guidance(-32042).error_kind,
+            "provider_server_error"
+        );
+        assert_eq!(
+            json_rpc_error_guidance(7001).error_kind,
+            "provider_rpc_error"
+        );
     }
 
     #[tokio::test]

--- a/crates/cerebro-platform/src/slack_agent_mcp.rs
+++ b/crates/cerebro-platform/src/slack_agent_mcp.rs
@@ -445,6 +445,8 @@ fn normalize_tool_result(data: Value, is_error: bool) -> NormalizedToolResult {
         ToolResultState::Failed
     } else if declared_state == Some("partial") {
         ToolResultState::Partial
+    } else if declared_state == Some("outcome_unknown") {
+        ToolResultState::OutcomeUnknown
     } else {
         ToolResultState::Succeeded
     };
@@ -1001,6 +1003,20 @@ mod tests {
         AGENT_SEMANTIC_EVIDENCE_V1, AuthorityBindingState, AuthorityDuty, EvidenceAssertion,
         SemanticEvidenceAssertion,
     };
+
+    #[test]
+    fn preserves_provider_declared_unknown_outcomes() {
+        let normalized = normalize_tool_result(
+            json!({
+                "state": "outcome_unknown",
+                "operation_ref": "operation-one",
+            }),
+            false,
+        );
+
+        assert_eq!(normalized.state, ToolResultState::OutcomeUnknown);
+        assert_eq!(normalized.data["operation_ref"], "operation-one");
+    }
 
     #[test]
     fn parses_and_receipt_binds_versioned_semantic_evidence_metadata() {

--- a/crates/cerebro-platform/src/slack_agent_mcp.rs
+++ b/crates/cerebro-platform/src/slack_agent_mcp.rs
@@ -63,6 +63,58 @@ struct JsonRpcError {
     message: String,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum McpPostFailureKind {
+    Timeout,
+    Unavailable,
+    AccessDenied,
+    RateLimited,
+    Rejected,
+    InvalidResponse,
+}
+
+struct McpPostFailure {
+    kind: McpPostFailureKind,
+    runtime_error: AgentRuntimeError,
+}
+
+impl McpPostFailureKind {
+    const fn guidance(self) -> RecoveryGuidance {
+        match self {
+            Self::Timeout => RecoveryGuidance {
+                error_kind: "capability_gateway_timeout",
+                retryable: true,
+                operator_action: "Retry after the capability gateway responds again.",
+            },
+            Self::Unavailable => RecoveryGuidance {
+                error_kind: "capability_gateway_unavailable",
+                retryable: true,
+                operator_action: "Retry after the capability gateway recovers.",
+            },
+            Self::AccessDenied => RecoveryGuidance {
+                error_kind: "capability_gateway_access_denied",
+                retryable: false,
+                operator_action: "Restore capability gateway access before retrying.",
+            },
+            Self::RateLimited => RecoveryGuidance {
+                error_kind: "capability_gateway_rate_limited",
+                retryable: true,
+                operator_action: "Retry after the capability gateway rate limit resets.",
+            },
+            Self::Rejected => RecoveryGuidance {
+                error_kind: "capability_gateway_rejected",
+                retryable: false,
+                operator_action: "Correct the gateway request or configuration before retrying.",
+            },
+            Self::InvalidResponse => RecoveryGuidance {
+                error_kind: "capability_gateway_invalid_response",
+                retryable: false,
+                operator_action: "Inspect the gateway response contract before retrying.",
+            },
+        }
+    }
+}
+
 #[derive(Deserialize)]
 struct McpToolWire {
     name: String,
@@ -306,17 +358,18 @@ impl McpAgentTools {
         {
             Ok(response) => response,
             Err(error) if tool.descriptor.authority_class == ToolAuthorityClass::Actuate => {
-                return Err(error);
+                return Err(error.runtime_error);
             }
-            Err(_) => {
+            Err(error) => {
+                let guidance = error.kind.guidance();
                 return Ok(ToolResult {
                     state: ToolResultState::Failed,
-                    summary: format!("MCP tool {} was unavailable.", tool.mcp_name),
-                    data: json!({"error_kind": "capability_gateway_unavailable"}),
+                    summary: format!("MCP tool {} could not complete the call.", tool.mcp_name),
+                    data: with_recovery_guidance(json!({}), guidance),
                     evidence: vec![],
                     blocker: Some(format!(
-                        "The {} capability gateway could not complete this call.",
-                        tool.descriptor.title
+                        "The {} capability gateway could not complete this call. {}",
+                        tool.descriptor.title, guidance.operator_action
                     )),
                 });
             }
@@ -407,7 +460,7 @@ impl McpAgentTools {
         &self,
         request: &AgentTurnRequest,
         body: Value,
-    ) -> Result<JsonRpcResponse, AgentRuntimeError> {
+    ) -> Result<JsonRpcResponse, McpPostFailure> {
         let response = self
             .client
             .post(self.endpoint.clone())
@@ -420,16 +473,39 @@ impl McpAgentTools {
             .json(&body)
             .send()
             .await
-            .map_err(|error| AgentRuntimeError::ModelUnavailable(error.to_string()))?;
+            .map_err(|error| McpPostFailure {
+                kind: if error.is_timeout() {
+                    McpPostFailureKind::Timeout
+                } else {
+                    McpPostFailureKind::Unavailable
+                },
+                runtime_error: AgentRuntimeError::ModelUnavailable(error.to_string()),
+            })?;
         if !response.status().is_success() {
-            return Err(AgentRuntimeError::ModelUnavailable(format!(
-                "MCP gateway returned status {}",
-                response.status()
-            )));
+            let status = response.status();
+            let kind = if matches!(
+                status,
+                reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
+            ) {
+                McpPostFailureKind::AccessDenied
+            } else if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                McpPostFailureKind::RateLimited
+            } else if status.is_server_error() {
+                McpPostFailureKind::Unavailable
+            } else {
+                McpPostFailureKind::Rejected
+            };
+            return Err(McpPostFailure {
+                kind,
+                runtime_error: AgentRuntimeError::ModelUnavailable(format!(
+                    "MCP gateway returned status {status}"
+                )),
+            });
         }
-        bounded_json(response)
-            .await
-            .map_err(|error| AgentRuntimeError::InvalidToolCall(error.to_string()))
+        bounded_json(response).await.map_err(|error| McpPostFailure {
+            kind: McpPostFailureKind::InvalidResponse,
+            runtime_error: AgentRuntimeError::InvalidToolCall(error),
+        })
     }
 }
 
@@ -1702,6 +1778,55 @@ mod tests {
             result,
             Err(AgentRuntimeError::ModelUnavailable(_))
         ));
+    }
+
+    #[tokio::test]
+    async fn non_actuation_transport_failures_return_stable_recovery_guidance() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                Router::new().route("/mcp", post(|| async { StatusCode::TOO_MANY_REQUESTS })),
+            )
+            .await
+            .unwrap();
+        });
+        let tools = bind_tools(
+            vec![tool("cerebro.findings.search", true)],
+            &BTreeSet::from(["cerebro.findings.search".into()]),
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+        )
+        .unwrap();
+        let descriptors = tools.values().map(|tool| tool.descriptor.clone()).collect();
+        let mcp = McpAgentTools {
+            client: Client::new(),
+            endpoint: Url::parse(&format!("http://{address}/mcp")).unwrap(),
+            bearer_token: "tenant-token".into(),
+            selection_signing_key: "host-only-selection-signing-secret".into(),
+            toolsets: "task".into(),
+            descriptors,
+            tools,
+        };
+        let call = ToolCall {
+            call_id: "search-one".into(),
+            tool_id: "mcp.cerebro.findings.search".into(),
+            purpose: "Find current findings.".into(),
+            input: json!({}),
+        };
+
+        let result = mcp.invoke(&turn_request(), &call).await.unwrap();
+        server.abort();
+
+        assert_eq!(result.state, ToolResultState::Failed);
+        assert_eq!(result.data["error_kind"], "capability_gateway_rate_limited");
+        assert_eq!(result.data["retryable"], true);
+        assert_eq!(
+            result.data["operator_action"],
+            "Retry after the capability gateway rate limit resets."
+        );
+        assert!(result.evidence.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- preserve explicit unknown tool outcomes instead of reporting success
- carry bounded provider blockers and partial-result reasons into the operating loop
- return stable recovery guidance for tool, transport, and JSON-RPC failures
- keep actuation failures outcome-unknown and outside ordinary tool results

## Behavior commits

1. Preserve provider-declared unknown tool outcomes.
2. Preserve provider recovery reasons in tool results.
3. Normalize MCP tool errors into recovery guidance.
4. Classify MCP transport failures for recovery.
5. Classify JSON-RPC errors for tool recovery.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cerebro-platform slack_agent_mcp` — 23 passed
- `cargo test -p cerebro-platform` — 251 passed, 7 environment-dependent tests ignored
- Rust-only runtime contract — 6 passed
- fixed adversarial recovery cases authored and corrected against the exact wire contract
- independent release judgment: PASS with no blocking findings

The seven ignored tests require either an external promotion corpus, disposable PostgreSQL/Neo4j services, or a configured PostgreSQL session store.

## Invariants

- `retryable` is structured guidance only; the adapter adds no automatic retry
- failed results emit no evidence
- provider recovery text is bounded
- tenant, selection, approval, effect, and actuation authority are unchanged
