### PR TITLE
fix: restore Slack authority Rust build

### DIFF
--- a/crates/cerebro-platform/src/slack_authority.rs
+++ b/crates/cerebro-platform/src/slack_authority.rs
@@ -726,6 +726,7 @@ mod tests {
         assert_eq!(claim.status(), StatusCode::SERVICE_UNAVAILABLE);
 
         let receipt = app
+            .clone()
             .oneshot(
                 Request::post("/v1/wakes/deliveries")
                     .header(CONTENT_TYPE, "application/json")


### PR DESCRIPTION
## State
`main` currently fails the Rust graph-actions job with E0382 because the new fail-closed route test consumes the Axum router before its final request.

## Fix
Clone the router for the wake-delivery request so the same shared test state remains available for the turn-delivery assertion.

## Validation
- original hosted failure: `use of moved value: app` at `slack_authority.rs:770`
- corrected head is compiling in a clean DDESK checkout
- `rustfmt --edition 2024 --check crates/cerebro-platform/src/slack_authority.rs`
- `git diff --check`

No coverage threshold or production behavior changes.