### PR TITLE
Give Slack runtime failures bounded recovery

### DIFF
--- a/apps/slack-companion-host/src/runtime/slack-runtime.ts
+++ b/apps/slack-companion-host/src/runtime/slack-runtime.ts
@@ -2517,26 +2517,39 @@ function sourceRecoveryAction(state: CerebroAskError["sourceState"]): string {
 }
 
 function agentRuntimeFailureText(state: CerebroAskError["sourceState"]): string {
-  const details: Record<CerebroAskError["sourceState"], string> = {
-    not_configured:
-      "My live operating tools are not configured in this Slack environment.",
-    not_found:
-      "The live operating endpoint was not found in this Slack environment.",
-    timed_out:
-      "I did not finish the current evidence check before its deadline.",
-    unauthorized:
-      "My live operating tools rejected the current read binding.",
-    unavailable:
-      "I cannot reach my live operating tools right now.",
+  const failure: Record<CerebroAskError["sourceState"], {
+    detail: string;
+    nextAction: string;
+  }> = {
+    not_configured: {
+      detail: "The Rust agent runtime is not configured in this Slack environment, so no live check started.",
+      nextAction: "Ask the Cerebro runtime owner to configure the Rust agent endpoint before retrying; repeated Slack retries will not help.",
+    },
+    not_found: {
+      detail: "The Slack host could not find the configured Rust agent endpoint, so no terminal answer was available.",
+      nextAction: "Ask the Cerebro runtime owner to restore the configured endpoint before retrying; repeated Slack retries will not help.",
+    },
+    timed_out: {
+      detail: "The Rust agent turn exceeded its Slack deadline before it returned a terminal answer.",
+      nextAction: "Retry with one named asset, identity, finding, or source. If that narrower request also times out, stop retrying and report this thread timestamp to the Cerebro runtime owner.",
+    },
+    unauthorized: {
+      detail: "The Rust agent runtime rejected the current read binding, so no current-evidence answer was available.",
+      nextAction: "Ask the Cerebro runtime owner to restore the read binding before retrying; repeated Slack retries will not help.",
+    },
+    unavailable: {
+      detail: "The Slack host could not reach the Rust agent runtime, so no terminal answer was available.",
+      nextAction: "Retry once in this thread. If it fails immediately again, stop retrying and report this thread timestamp to the Cerebro runtime owner.",
+    },
   };
   return [
     "**Live check blocked**",
     "",
-    details[state],
+    failure[state].detail,
     "",
-    "I can still use this thread's context, answer general security questions, explain what I would check, and retain the request. I will not claim current system state until a live observation succeeds.",
+    "No current system claim was accepted from this turn. This thread retains your request, but every Cerebro answer still requires the Rust agent runtime.",
     "",
-    "Next action: resume this retained request when the operating runtime is healthy; you do not need to restate it.",
+    `Next action: ${failure[state].nextAction}`,
   ].join("\n");
 }
 

--- a/apps/slack-companion-host/test/runtime-host.test.ts
+++ b/apps/slack-companion-host/test/runtime-host.test.ts
@@ -1594,6 +1594,57 @@ test("Rust agent body timeout is reported as timed out", async () => {
   );
 });
 
+test("Rust runtime failures give operators bounded state-specific recovery", async () => {
+  const root = await mkdtemp(join(tmpdir(), "cerebro-slack-runtime-"));
+  try {
+    const failureCases = [
+      {
+        expected: /Retry with one named asset, identity, finding, or source/u,
+        signal: AbortSignal.abort(),
+      },
+      {
+        expected: /Retry once in this thread/u,
+        signal: new AbortController().signal,
+      },
+    ];
+
+    for (const [index, failureCase] of failureCases.entries()) {
+      const service = new AssistantQuestionService(
+        createAssistantTurnHost(new FileOutcomeStore(join(root, String(index)))),
+        new CerebroAskClient({
+          agentRuntimeUrl: "http://127.0.0.1:8091",
+          answerAuthority: testAnswerAuthority,
+          apiKey: "unused",
+          baseUrl: "https://legacy.example.com",
+          fetchImpl: async () => {
+            throw new Error("runtime unavailable");
+          },
+          tenantId: "writer",
+        }),
+        {
+          clock: () => new Date("2026-07-29T20:00:00.000Z"),
+          timeoutSignal: () => failureCase.signal,
+        },
+      );
+
+      const result = await service.answer({
+        actorRef: "slack-user:U-ONE",
+        requestKey: `T-ONE:C-ONE:thread-one:event-${index}`,
+        text: "<@BOT> Identify the current connector risk.",
+        threadRef: "slack-thread:T-ONE:C-ONE:thread-one",
+      });
+
+      assert.equal(result.pending.outcome_state, "blocked");
+      assert.match(result.text, failureCase.expected);
+      assert.match(result.text, /every Cerebro answer still requires the Rust agent runtime/u);
+      assert.doesNotMatch(result.text, /I can still use this thread's context/u);
+      assert.doesNotMatch(result.text, /when the operating runtime is healthy/u);
+    }
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
 test("blocked Rust agent turns do not record a useful answer timestamp", async () => {
   const root = await mkdtemp(join(tmpdir(), "cerebro-slack-runtime-"));
   try {


### PR DESCRIPTION
## Summary
- name the exact Rust runtime failure boundary in Slack
- provide a bounded retry and stop rule for each failure state
- remove the unsupported promise that thread-only answers remain available without the runtime

## Validation
- `npm run typecheck --workspace @writer/cerebro-slack-companion-host`
- `npm run build --workspace @writer/cerebro-slack-companion-host`
- `npm test --workspace @writer/cerebro-slack-companion-host` (141 passed)
- `git diff --check`