### PR TITLE
Keep Slack agent progress visibly live

### DIFF
--- a/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
+++ b/apps/slack-companion-host/src/runtime/cerebro-ask-client.ts
@@ -76,6 +76,12 @@ export interface CerebroAskClientOptions {
   apiKey: string;
   baseUrl: string;
   fetchImpl?: typeof fetch;
+  progressWatchdog?: {
+    clock?: () => Date;
+    heartbeatIntervalMs?: number;
+    pollIntervalMs?: number;
+    wait?: (milliseconds: number) => Promise<void>;
+  };
   tenantId: string;
 }
 
@@ -98,9 +104,25 @@ export class CerebroAnswerRejectedError extends Error {
 
 export class CerebroAskClient {
   private readonly fetchImpl: typeof fetch;
+  private readonly progressClock: () => Date;
+  private readonly progressHeartbeatIntervalMs: number;
+  private readonly progressPollIntervalMs: number;
+  private readonly progressWait: (milliseconds: number) => Promise<void>;
 
   constructor(private readonly options: CerebroAskClientOptions) {
     this.fetchImpl = options.fetchImpl ?? fetch;
+    this.progressClock = options.progressWatchdog?.clock ?? (() => new Date());
+    this.progressHeartbeatIntervalMs = positiveInterval(
+      options.progressWatchdog?.heartbeatIntervalMs,
+      30_000,
+      "progress heartbeat interval",
+    );
+    this.progressPollIntervalMs = positiveInterval(
+      options.progressWatchdog?.pollIntervalMs,
+      750,
+      "progress poll interval",
+    );
+    this.progressWait = options.progressWatchdog?.wait ?? delay;
   }
 
   get usesRustAgent(): boolean {
@@ -117,6 +139,7 @@ export class CerebroAskClient {
     requestId: string;
     signal: AbortSignal;
     threadRef: string;
+    deadlineAt?: string;
     onProgress?: (update: RustAgentProgressUpdate) => Promise<void>;
     workingState?: {
       active_lane?: CerebroAskResult["executionLane"];
@@ -276,6 +299,7 @@ export class CerebroAskClient {
 
   private async followAgentTurnProgress(
     input: {
+      deadlineAt?: string;
       onProgress?: (update: RustAgentProgressUpdate) => Promise<void>;
       requestId: string;
       signal: AbortSignal;
@@ -286,6 +310,8 @@ export class CerebroAskClient {
     if (!this.options.agentRuntimeUrl || !input.onProgress) return;
     let afterSequence = 0;
     let lastStatus = "";
+    const startedAt = this.progressClock();
+    let lastVisibleProgressAt = startedAt;
     const poll = async (): Promise<void> => {
       const query = new URLSearchParams({
         after_sequence: String(afterSequence),
@@ -299,24 +325,49 @@ export class CerebroAskClient {
       if (!response.ok) return;
       const progress = parseAgentTurnProgress(await response.json());
       afterSequence = progress.latestSequence;
+      let visibleProgress = false;
       for (const update of progress.updates) {
         if (update.status === lastStatus) continue;
         try {
           await input.onProgress?.(update);
           lastStatus = update.status;
+          visibleProgress = true;
         } catch {
           // A failed progress edit must not discard the terminal answer.
         }
       }
+      if (visibleProgress) {
+        lastVisibleProgressAt = this.progressClock();
+      }
+    };
+    const emitHeartbeatIfDue = async (): Promise<void> => {
+      const observedAt = this.progressClock();
+      if (
+        observedAt.getTime() - lastVisibleProgressAt.getTime()
+          >= this.progressHeartbeatIntervalMs
+      ) {
+        try {
+          await input.onProgress?.({
+            occurredAt: observedAt.toISOString(),
+            phase: "working",
+            sequence: afterSequence,
+            status: progressHeartbeatStatus(startedAt, observedAt, input.deadlineAt),
+          });
+          lastVisibleProgressAt = observedAt;
+        } catch {
+          // A failed liveness edit must not discard the terminal answer.
+        }
+      }
     };
     while (!turnComplete() && !input.signal.aborted) {
-      await delay(750);
+      await this.progressWait(this.progressPollIntervalMs);
       if (turnComplete() || input.signal.aborted) break;
       try {
         await poll();
       } catch {
         // Progress polling is best-effort; the exact turn remains authoritative.
       }
+      await emitHeartbeatIfDue();
     }
     if (!input.signal.aborted) {
       try {
@@ -668,6 +719,39 @@ function parseAgentTurnProgress(value: unknown): {
 
 function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function positiveInterval(value: number | undefined, fallback: number, label: string): number {
+  const interval = value ?? fallback;
+  if (!Number.isSafeInteger(interval) || interval <= 0) {
+    throw new TypeError(`The ${label} must be a positive integer.`);
+  }
+  return interval;
+}
+
+function progressHeartbeatStatus(
+  startedAt: Date,
+  observedAt: Date,
+  deadlineAt?: string,
+): string {
+  const elapsedMs = Math.max(0, observedAt.getTime() - startedAt.getTime());
+  const elapsed = progressDuration(elapsedMs);
+  if (deadlineAt !== undefined) {
+    const remainingMs = new Date(deadlineAt).getTime() - observedAt.getTime();
+    if (Number.isFinite(remainingMs) && remainingMs > 0) {
+      return `Still working — ${elapsed} elapsed. This turn will stop in ${progressDuration(remainingMs)} if it does not finish.`;
+    }
+  }
+  return `Still working — ${elapsed} elapsed. This turn remains bounded by its deadline.`;
+}
+
+function progressDuration(milliseconds: number): string {
+  const seconds = Math.max(1, Math.ceil(milliseconds / 1_000));
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes === 0) return `${seconds}s`;
+  if (remainingSeconds === 0) return `${minutes}m`;
+  return `${minutes}m ${remainingSeconds}s`;
 }
 
 function parseWakeRunResponse(value: unknown): RustWakeExecutionReceipt | undefined {

--- a/apps/slack-companion-host/src/runtime/slack-runtime.ts
+++ b/apps/slack-companion-host/src/runtime/slack-runtime.ts
@@ -308,6 +308,9 @@ export class AssistantQuestionService {
           : undefined;
         const turnRequestId = resumingApproval?.requestId ?? requestId;
         const turnQuestion = resumingApproval?.question ?? currentRequest;
+        const deadlineAt = new Date(
+          openedAt.getTime() + budget.latency_budget_ms,
+        ).toISOString();
         const answer = await this.askClient.runAgentTurn({
           actorRef: input.actorRef,
           assessmentAt: openedAt.toISOString(),
@@ -329,6 +332,7 @@ export class AssistantQuestionService {
           requestId: turnRequestId,
           signal: this.timeoutSignal(budget.latency_budget_ms),
           threadRef: input.threadRef,
+          deadlineAt,
           ...(input.onProgress === undefined ? {} : { onProgress: input.onProgress }),
           ...(input.workingState === undefined
             ? {}

--- a/apps/slack-companion-host/test/runtime-host.test.ts
+++ b/apps/slack-companion-host/test/runtime-host.test.ts
@@ -662,6 +662,134 @@ test("Slack delivers model-authored Rust progress while the turn is running", as
   );
 });
 
+test("Slack replaces unavailable Rust progress with recurring bounded liveness", async () => {
+  let now = new Date("2026-08-11T07:00:00Z");
+  let finishTurn: (() => void) | undefined;
+  const turnCanFinish = new Promise<void>((resolve) => {
+    finishTurn = resolve;
+  });
+  const updates: string[] = [];
+  const client = new CerebroAskClient({
+    agentRuntimeUrl: "http://127.0.0.1:8091",
+    answerAuthority: testAnswerAuthority,
+    apiKey: "unused",
+    baseUrl: "https://legacy.example.com",
+    fetchImpl: async (input) => {
+      if (new URL(String(input)).pathname === "/v1/turns/progress") {
+        return new Response(null, { status: 503 });
+      }
+      await turnCanFinish;
+      return Response.json({
+        evidence_refs: ["evidence://graph/current"],
+        final_state: "answered",
+        lane: "investigate",
+        markdown: "The current identity risk is verified.",
+        outcome: "delivered",
+        schema_version: "agent-turn-result/v1",
+        tool_call_count: 2,
+      });
+    },
+    progressWatchdog: {
+      clock: () => now,
+      heartbeatIntervalMs: 30_000,
+      pollIntervalMs: 10_000,
+      wait: async (milliseconds) => {
+        now = new Date(now.getTime() + milliseconds);
+      },
+    },
+    tenantId: "writer",
+  });
+
+  await client.runAgentTurn({
+    actorRef: "slack-user:U-ONE",
+    assessmentAt: "2026-08-11T07:00:00Z",
+    deadlineAt: "2026-08-11T07:05:00Z",
+    onProgress: async (update) => {
+      updates.push(update.status);
+      if (updates.length === 2) finishTurn?.();
+    },
+    question: "What is scariest in production?",
+    requestId: "request-progress-watchdog",
+    signal: new AbortController().signal,
+    threadRef: "slack-thread:T-ONE:C-ONE:thread-one",
+  });
+
+  assert.deepEqual(updates, [
+    "Still working — 30s elapsed. This turn will stop in 4m 30s if it does not finish.",
+    "Still working — 1m elapsed. This turn will stop in 4m if it does not finish.",
+  ]);
+});
+
+test("new Rust progress resets the Slack liveness watchdog", async () => {
+  let now = new Date("2026-08-11T07:00:00Z");
+  let progressRequests = 0;
+  let finishTurn: (() => void) | undefined;
+  const turnCanFinish = new Promise<void>((resolve) => {
+    finishTurn = resolve;
+  });
+  const updates: string[] = [];
+  const client = new CerebroAskClient({
+    agentRuntimeUrl: "http://127.0.0.1:8091",
+    answerAuthority: testAnswerAuthority,
+    apiKey: "unused",
+    baseUrl: "https://legacy.example.com",
+    fetchImpl: async (input) => {
+      if (new URL(String(input)).pathname === "/v1/turns/progress") {
+        progressRequests += 1;
+        return Response.json({
+          latest_sequence: 1,
+          schema_version: "agent-turn-progress/v1",
+          updates: progressRequests === 2
+            ? [{
+                occurred_at: "2026-08-11T07:00:20Z",
+                phase: "working",
+                sequence: 1,
+                status: "Checking the current access path.",
+              }]
+            : [],
+        });
+      }
+      await turnCanFinish;
+      return Response.json({
+        evidence_refs: ["evidence://graph/current"],
+        final_state: "answered",
+        lane: "investigate",
+        markdown: "The current access path is verified.",
+        outcome: "delivered",
+        schema_version: "agent-turn-result/v1",
+        tool_call_count: 2,
+      });
+    },
+    progressWatchdog: {
+      clock: () => now,
+      heartbeatIntervalMs: 30_000,
+      pollIntervalMs: 10_000,
+      wait: async (milliseconds) => {
+        now = new Date(now.getTime() + milliseconds);
+      },
+    },
+    tenantId: "writer",
+  });
+
+  await client.runAgentTurn({
+    actorRef: "slack-user:U-ONE",
+    assessmentAt: "2026-08-11T07:00:00Z",
+    onProgress: async (update) => {
+      updates.push(update.status);
+      if (updates.length === 2) finishTurn?.();
+    },
+    question: "Check the access path.",
+    requestId: "request-progress-reset",
+    signal: new AbortController().signal,
+    threadRef: "slack-thread:T-ONE:C-ONE:thread-one",
+  });
+
+  assert.deepEqual(updates, [
+    "Checking the current access path.",
+    "Still working — 50s elapsed. This turn remains bounded by its deadline.",
+  ]);
+});
+
 test("Slack acknowledges a pending Rust response only after transport delivery", async () => {
   const requests: Request[] = [];
   const client = new CerebroAskClient({


### PR DESCRIPTION
## Summary

- emit recurring elapsed-time liveness when agent progress is unchanged or temporarily unavailable
- show the enforced turn deadline without implying evidence availability
- reset the liveness interval when the agent reports new progress

## Tests

- `npm run check:workspaces`
- `npm run check --workspace @writer/cerebro-slack-companion-host`
- `make oss-audit`