### PR TITLE
Agent: make uncertain tool recovery explicit

### DIFF
--- a/crates/agent-runtime/src/lib.rs
+++ b/crates/agent-runtime/src/lib.rs
@@ -3555,6 +3555,22 @@ fn validate_tool_result(result: &ToolResult) -> Result<(), AgentRuntimeError> {
     }
     let mut evidence_refs = BTreeSet::new();
     for evidence in &result.evidence {
+        if result.state == ToolResultState::Failed
+            && (evidence.complete
+                || evidence.atoms.iter().any(|atom| {
+                    !matches!(
+                        &atom.assertion,
+                        session::EvidenceAssertion::ToolOutcome {
+                            state: ToolResultState::Failed,
+                            ..
+                        }
+                    )
+                }))
+        {
+            return Err(AgentRuntimeError::InvalidToolCall(
+                "failed tool result evidence must only attest the failed outcome".into(),
+            ));
+        }
         if matches!(
             result.state,
             ToolResultState::Partial | ToolResultState::OutcomeUnknown
@@ -4166,6 +4182,20 @@ mod grounding_tests {
         }
     }
 
+    fn validation_outcome_atom(state: ToolResultState) -> session::EvidenceAtom {
+        session::EvidenceAtom {
+            atom_ref: "evidence://validation/result#outcome".into(),
+            subject_ref: None,
+            assertion: session::EvidenceAssertion::ToolOutcome {
+                state,
+                summary: "The bounded tool call returned.".into(),
+            },
+            observed_at: "2026-07-31T00:00:00Z".into(),
+            fresh_until: None,
+            complete: true,
+        }
+    }
+
     #[test]
     fn scoped_questions_do_not_match_unscoped_conversation_guard() {
         for message in [
@@ -4250,6 +4280,38 @@ mod grounding_tests {
         let mut succeeded = validation_result(ToolResultState::Succeeded, None);
         succeeded.evidence = vec![validation_evidence(true)];
         assert!(validate_tool_result(&succeeded).is_ok());
+    }
+
+    #[test]
+    fn failed_results_only_carry_failure_evidence() {
+        let mut failed = validation_result(
+            ToolResultState::Failed,
+            Some("The bounded tool call failed."),
+        );
+        assert!(validate_tool_result(&failed).is_ok());
+
+        failed.evidence = vec![validation_evidence(false)];
+        assert!(validate_tool_result(&failed).is_ok());
+
+        failed.evidence[0].atoms = vec![validation_outcome_atom(ToolResultState::Failed)];
+        assert!(validate_tool_result(&failed).is_ok());
+
+        failed.evidence[0].atoms[0].assertion = session::EvidenceAssertion::Value {
+            predicate: "runtime_status".into(),
+            value: json!("healthy"),
+        };
+        assert!(matches!(
+            validate_tool_result(&failed),
+            Err(AgentRuntimeError::InvalidToolCall(reason))
+                if reason == "failed tool result evidence must only attest the failed outcome"
+        ));
+
+        failed.evidence[0].atoms = vec![validation_outcome_atom(ToolResultState::Succeeded)];
+        assert!(validate_tool_result(&failed).is_err());
+
+        failed.evidence[0].atoms = vec![validation_outcome_atom(ToolResultState::Failed)];
+        failed.evidence[0].complete = true;
+        assert!(validate_tool_result(&failed).is_err());
     }
 
     #[test]

--- a/crates/agent-runtime/src/lib.rs
+++ b/crates/agent-runtime/src/lib.rs
@@ -3555,6 +3555,15 @@ fn validate_tool_result(result: &ToolResult) -> Result<(), AgentRuntimeError> {
     }
     let mut evidence_refs = BTreeSet::new();
     for evidence in &result.evidence {
+        if matches!(
+            result.state,
+            ToolResultState::Partial | ToolResultState::OutcomeUnknown
+        ) && evidence.complete
+        {
+            return Err(AgentRuntimeError::InvalidToolCall(
+                "partial or unknown tool result cannot include complete evidence".into(),
+            ));
+        }
         parse_timestamp(&evidence.observed_at).map_err(|_| {
             AgentRuntimeError::InvalidToolCall("evidence observed_at is invalid".into())
         })?;
@@ -4146,6 +4155,17 @@ mod grounding_tests {
         }
     }
 
+    fn validation_evidence(complete: bool) -> EvidenceRecord {
+        EvidenceRecord {
+            evidence_ref: "evidence://validation/result".into(),
+            statement: "The bounded result was observed.".into(),
+            observed_at: "2026-07-31T00:00:00Z".into(),
+            fresh_until: None,
+            complete,
+            atoms: Vec::new(),
+        }
+    }
+
     #[test]
     fn scoped_questions_do_not_match_unscoped_conversation_guard() {
         for message in [
@@ -4210,6 +4230,26 @@ mod grounding_tests {
             Err(AgentRuntimeError::InvalidToolCall(reason))
                 if reason == "tool result fields are invalid"
         ));
+    }
+
+    #[test]
+    fn partial_and_unknown_results_cannot_claim_complete_evidence() {
+        for state in [ToolResultState::Partial, ToolResultState::OutcomeUnknown] {
+            let mut result = validation_result(state, Some("The result is not complete."));
+            result.evidence = vec![validation_evidence(false)];
+            assert!(validate_tool_result(&result).is_ok());
+
+            result.evidence[0].complete = true;
+            assert!(matches!(
+                validate_tool_result(&result),
+                Err(AgentRuntimeError::InvalidToolCall(reason))
+                    if reason == "partial or unknown tool result cannot include complete evidence"
+            ));
+        }
+
+        let mut succeeded = validation_result(ToolResultState::Succeeded, None);
+        succeeded.evidence = vec![validation_evidence(true)];
+        assert!(validate_tool_result(&succeeded).is_ok());
     }
 
     #[test]

--- a/crates/agent-runtime/src/lib.rs
+++ b/crates/agent-runtime/src/lib.rs
@@ -3800,17 +3800,30 @@ fn finalize_unknown_effect(
     let observation = observations.last().ok_or_else(|| {
         AgentRuntimeError::InvalidFinal("unknown effect has no observation".into())
     })?;
+    let durable_effect = observation.descriptor.authority_class == ToolAuthorityClass::Actuate
+        || observation.descriptor.effect_class != ToolEffectClass::Read;
+    let (headline, default_blocker, next_step) = if durable_effect {
+        (
+            "Outcome not confirmed",
+            "The effect outcome could not be confirmed.",
+            "Reconcile the existing effect receipt before retrying.",
+        )
+    } else {
+        (
+            "Result not confirmed",
+            "The observation did not return a confirmed result.",
+            "Run a fresh observation to obtain the current result.",
+        )
+    };
     let blocker = observation
         .result
         .blocker
         .as_deref()
-        .unwrap_or("The effect outcome could not be confirmed.");
+        .unwrap_or(default_blocker);
     Ok(AgentTurnOutcome::Delivered {
         schema_version: AGENT_TURN_RESULT_V1,
         lane,
-        markdown: format!(
-            "**Outcome not confirmed**\n\n{blocker}\n\n**Next**\n- Reconcile the existing effect receipt before retrying."
-        ),
+        markdown: format!("**{headline}**\n\n{blocker}\n\n**Next**\n- {next_step}"),
         final_state: FinalState::Blocked,
         evidence_refs: observation
             .result

--- a/crates/agent-runtime/src/lib.rs
+++ b/crates/agent-runtime/src/lib.rs
@@ -3539,6 +3539,20 @@ fn validate_tool_result(result: &ToolResult) -> Result<(), AgentRuntimeError> {
             "tool result fields are invalid".into(),
         ));
     }
+    match (result.state, result.blocker.as_ref()) {
+        (ToolResultState::Succeeded, Some(_)) => {
+            return Err(AgentRuntimeError::InvalidToolCall(
+                "succeeded tool result must not include a blocker".into(),
+            ));
+        }
+        (ToolResultState::Succeeded, None) => {}
+        (_, Some(_)) => {}
+        (_, None) => {
+            return Err(AgentRuntimeError::InvalidToolCall(
+                "non-succeeded tool result requires a blocker".into(),
+            ));
+        }
+    }
     let mut evidence_refs = BTreeSet::new();
     for evidence in &result.evidence {
         parse_timestamp(&evidence.observed_at).map_err(|_| {
@@ -4122,6 +4136,16 @@ mod grounding_tests {
         }
     }
 
+    fn validation_result(state: ToolResultState, blocker: Option<&str>) -> ToolResult {
+        ToolResult {
+            state,
+            summary: "The bounded tool call returned.".into(),
+            data: json!({}),
+            evidence: Vec::new(),
+            blocker: blocker.map(str::to_owned),
+        }
+    }
+
     #[test]
     fn scoped_questions_do_not_match_unscoped_conversation_guard() {
         for message in [
@@ -4155,6 +4179,37 @@ mod grounding_tests {
             };
             assert!(validate_route(&route_request(message), &decision).is_err());
         }
+    }
+
+    #[test]
+    fn tool_result_blocker_matches_terminal_state() {
+        assert!(validate_tool_result(&validation_result(ToolResultState::Succeeded, None)).is_ok());
+        assert!(
+            validate_tool_result(&validation_result(
+                ToolResultState::Partial,
+                Some("The bounded read omitted additional records."),
+            ))
+            .is_ok()
+        );
+
+        assert!(matches!(
+            validate_tool_result(&validation_result(ToolResultState::Failed, None)),
+            Err(AgentRuntimeError::InvalidToolCall(reason))
+                if reason == "non-succeeded tool result requires a blocker"
+        ));
+        assert!(matches!(
+            validate_tool_result(&validation_result(
+                ToolResultState::Succeeded,
+                Some("A stale blocker remained."),
+            )),
+            Err(AgentRuntimeError::InvalidToolCall(reason))
+                if reason == "succeeded tool result must not include a blocker"
+        ));
+        assert!(matches!(
+            validate_tool_result(&validation_result(ToolResultState::OutcomeUnknown, Some("   "))),
+            Err(AgentRuntimeError::InvalidToolCall(reason))
+                if reason == "tool result fields are invalid"
+        ));
     }
 
     #[test]

--- a/crates/agent-runtime/src/lib.rs
+++ b/crates/agent-runtime/src/lib.rs
@@ -58,6 +58,8 @@ pub const CRITIC_MAX_TOKENS: i32 = 16_384;
 pub const HARD_MAX_GENERATION_TOKENS: i32 = 131_072;
 const MAX_TEXT_BYTES: usize = 16 * 1024;
 const MAX_TOOL_DATA_BYTES: usize = 64 * 1024;
+const MAX_RECOVERY_KIND_BYTES: usize = 64;
+const MAX_RECOVERY_ACTION_BYTES: usize = 1_024;
 const MAX_HEADLINE_BYTES: usize = 160;
 const MAX_SUMMARY_BYTES: usize = 2_400;
 const MAX_SUPPLEMENT_BYTES: usize = 800;
@@ -3553,6 +3555,7 @@ fn validate_tool_result(result: &ToolResult) -> Result<(), AgentRuntimeError> {
             ));
         }
     }
+    validate_recovery_guidance(&result.data)?;
     let mut evidence_refs = BTreeSet::new();
     for evidence in &result.evidence {
         if result.state == ToolResultState::Failed
@@ -3595,6 +3598,43 @@ fn validate_tool_result(result: &ToolResult) -> Result<(), AgentRuntimeError> {
         }
     }
     Ok(())
+}
+
+fn validate_recovery_guidance(data: &Value) -> Result<(), AgentRuntimeError> {
+    let Value::Object(data) = data else {
+        return Ok(());
+    };
+    let fields = ["error_kind", "retryable", "operator_action"];
+    if !fields.iter().any(|field| data.contains_key(*field)) {
+        return Ok(());
+    }
+    let error_kind_valid = data
+        .get("error_kind")
+        .and_then(Value::as_str)
+        .is_some_and(|value| {
+            !value.is_empty()
+                && value.len() <= MAX_RECOVERY_KIND_BYTES
+                && value.chars().all(|character| {
+                    character.is_ascii_lowercase() || character.is_ascii_digit() || character == '_'
+                })
+        });
+    let retryable_valid = data.get("retryable").is_some_and(Value::is_boolean);
+    let operator_action_valid = data
+        .get("operator_action")
+        .and_then(Value::as_str)
+        .is_some_and(|value| {
+            bounded_display_text(value, MAX_RECOVERY_ACTION_BYTES)
+                && !value
+                    .chars()
+                    .any(|character| matches!(character, '\n' | '\r' | '\t'))
+        });
+    if error_kind_valid && retryable_valid && operator_action_valid {
+        Ok(())
+    } else {
+        Err(AgentRuntimeError::InvalidToolCall(
+            "tool result recovery guidance is incomplete or invalid".into(),
+        ))
+    }
 }
 
 fn validate_final(
@@ -4312,6 +4352,48 @@ mod grounding_tests {
         failed.evidence[0].atoms = vec![validation_outcome_atom(ToolResultState::Failed)];
         failed.evidence[0].complete = true;
         assert!(validate_tool_result(&failed).is_err());
+    }
+
+    #[test]
+    fn recovery_guidance_is_atomic_and_bounded() {
+        let mut failed = validation_result(
+            ToolResultState::Failed,
+            Some("The bounded tool call failed."),
+        );
+        assert!(validate_tool_result(&failed).is_ok());
+
+        failed.data = json!({
+            "error_kind": "backend_unavailable",
+            "retryable": true,
+            "operator_action": "Retry after the backend recovers."
+        });
+        assert!(validate_tool_result(&failed).is_ok());
+
+        for invalid in [
+            json!({"error_kind": "backend_unavailable", "retryable": true}),
+            json!({
+                "error_kind": "Backend Unavailable",
+                "retryable": true,
+                "operator_action": "Retry after the backend recovers."
+            }),
+            json!({
+                "error_kind": "backend_unavailable",
+                "retryable": "true",
+                "operator_action": "Retry after the backend recovers."
+            }),
+            json!({
+                "error_kind": "backend_unavailable",
+                "retryable": true,
+                "operator_action": "Retry now.\nThen inspect the result."
+            }),
+        ] {
+            failed.data = invalid;
+            assert!(matches!(
+                validate_tool_result(&failed),
+                Err(AgentRuntimeError::InvalidToolCall(reason))
+                    if reason == "tool result recovery guidance is incomplete or invalid"
+            ));
+        }
     }
 
     #[test]

--- a/crates/agent-runtime/tests/operator_agent.rs
+++ b/crates/agent-runtime/tests/operator_agent.rs
@@ -961,10 +961,10 @@ async fn repairs_a_raw_catalog_dump_into_a_direct_capability_answer() {
     let repaired = FinalDraft {
         state: FinalState::Partial,
         headline: "Source visibility is metadata-backed".into(),
-        summary: "I can inspect Source A records that have been collected into Cerebro, including the returned directory and audit evidence. I do not have direct administrative access to Source A from this evidence, and this bounded result does not prove complete source coverage.".into(),
+        summary: "I can inspect Source A records from the partial result collected into Cerebro, including the returned directory and audit evidence. I do not have direct administrative access to Source A from this partial evidence, and this incomplete bounded result does not prove complete source coverage.".into(),
         summary_evidence_refs: vec!["evidence://source-a".into()],
         checked: vec![claim(
-            "The bounded source search returned directory and audit evidence.",
+            "The bounded partial source search returned directory and audit evidence.",
             "evidence://source-a",
         )],
         changed: vec![],
@@ -972,7 +972,7 @@ async fn repairs_a_raw_catalog_dump_into_a_direct_capability_answer() {
         current_state: vec![],
         next_actions: vec![],
         coverage_notice: Some(
-            "The bounded result does not establish complete source coverage.".into(),
+            "The incomplete bounded result does not establish complete source coverage.".into(),
         ),
         question: None,
     };

--- a/crates/agent-runtime/tests/operator_agent.rs
+++ b/crates/agent-runtime/tests/operator_agent.rs
@@ -1432,6 +1432,63 @@ async fn stops_and_reconciles_outcome_unknown_without_retrying() {
 }
 
 #[tokio::test]
+async fn requests_a_fresh_observation_when_a_read_result_is_unknown() {
+    let lookup = ToolCall {
+        call_id: "lookup".into(),
+        tool_id: "runtime_status".into(),
+        purpose: "Read the current runtime status.".into(),
+        input: json!({"runtime_ref": "runtime://one"}),
+    };
+    let model = scripted(
+        ExecutionLane::Act,
+        VecDeque::from([ModelDecision::InvokeTool {
+            call: lookup.clone(),
+        }]),
+    );
+    let mut uncertain_evidence = evidence(
+        "evidence://uncertain-read",
+        "The observation ended before a current result was returned.",
+    );
+    uncertain_evidence.complete = false;
+    let tools = ScriptedTools {
+        descriptors: vec![tool(
+            "runtime_status",
+            ToolAuthorityClass::Observe,
+            ToolEffectClass::Read,
+        )],
+        results: Mutex::new(BTreeMap::from([(
+            lookup.call_id,
+            ToolResult {
+                state: ToolResultState::OutcomeUnknown,
+                summary: "The observation ended without a confirmed result.".into(),
+                data: json!({}),
+                evidence: vec![uncertain_evidence],
+                blocker: Some("The current runtime status was not returned.".into()),
+            },
+        )])),
+    };
+
+    let outcome = run_turn(&model, &tools, request("Check the current runtime status."))
+        .await
+        .unwrap();
+    let AgentTurnOutcome::Delivered {
+        final_state,
+        markdown,
+        tool_call_count,
+        ..
+    } = outcome
+    else {
+        panic!("expected blocked delivered result");
+    };
+    assert_eq!(final_state, FinalState::Blocked);
+    assert_eq!(tool_call_count, 1);
+    assert!(markdown.contains("Result not confirmed"));
+    assert!(markdown.contains("fresh observation"));
+    assert!(!markdown.to_ascii_lowercase().contains("receipt"));
+    assert!(!markdown.to_ascii_lowercase().contains("effect"));
+}
+
+#[tokio::test]
 async fn rejects_final_claims_that_cite_unobserved_evidence() {
     let lookup = ToolCall {
         call_id: "lookup".into(),

--- a/crates/agent-runtime/tests/operator_agent.rs
+++ b/crates/agent-runtime/tests/operator_agent.rs
@@ -986,6 +986,11 @@ async fn repairs_a_raw_catalog_dump_into_a_direct_capability_answer() {
             ModelDecision::Finish { draft: repaired },
         ]),
     );
+    let mut partial_evidence = evidence(
+        "evidence://source-a",
+        "The bounded source search returned directory and audit evidence.",
+    );
+    partial_evidence.complete = false;
     let tools = ScriptedTools {
         descriptors: vec![tool(
             "graph_search",
@@ -1004,10 +1009,7 @@ async fn repairs_a_raw_catalog_dump_into_a_direct_capability_answer() {
                     ],
                     "truncated": true
                 }),
-                evidence: vec![evidence(
-                    "evidence://source-a",
-                    "The bounded source search returned directory and audit evidence.",
-                )],
+                evidence: vec![partial_evidence],
                 blocker: Some("Additional matching records were outside the bounded read.".into()),
             },
         )])),
@@ -1394,6 +1396,11 @@ async fn stops_and_reconciles_outcome_unknown_without_retrying() {
             },
         ]),
     );
+    let mut uncertain_effect_evidence = evidence(
+        "evidence://uncertain-effect",
+        "The effect request was transmitted but no terminal receipt was observed.",
+    );
+    uncertain_effect_evidence.complete = false;
     let tools = ScriptedTools {
         descriptors: vec![tool(
             "runtime_config_update",
@@ -1406,10 +1413,7 @@ async fn stops_and_reconciles_outcome_unknown_without_retrying() {
                 state: ToolResultState::OutcomeUnknown,
                 summary: "The provider connection ended before a receipt was returned.".into(),
                 data: json!({}),
-                evidence: vec![evidence(
-                    "evidence://uncertain-effect",
-                    "The effect request was transmitted but no terminal receipt was observed.",
-                )],
+                evidence: vec![uncertain_effect_evidence],
                 blocker: Some("The effect may have happened, so retry is unsafe.".into()),
             },
         )])),

--- a/crates/cerebro-platform/src/slack_agent.rs
+++ b/crates/cerebro-platform/src/slack_agent.rs
@@ -5261,7 +5261,11 @@ fn source_runtime_failure() -> ToolResult {
     ToolResult {
         state: ToolResultState::Failed,
         summary: "The Rust source-runtime ledger read failed.".into(),
-        data: json!({"error_kind": "backend_unavailable"}),
+        data: json!({
+            "error_kind": "backend_unavailable",
+            "retryable": true,
+            "operator_action": "Retry after the source-runtime ledger recovers."
+        }),
         evidence: vec![],
         blocker: Some(
             "The source-runtime ledger could not complete this tenant-scoped read.".into(),
@@ -5280,7 +5284,19 @@ fn graph_failure(error: ContextError) -> ToolResult {
             ToolResultState::Succeeded => "The governed graph did not contain that entity.".into(),
             _ => "The governed graph read failed.".into(),
         },
-        data: json!({"error_kind": graph_error_kind(&error)}),
+        data: match state {
+            ToolResultState::Succeeded => json!({"result_kind": "not_found"}),
+            _ => json!({
+                "error_kind": graph_error_kind(&error),
+                "retryable": matches!(&error, ContextError::BackendUnavailable(_)),
+                "operator_action": match &error {
+                    ContextError::BackendUnavailable(_) => {
+                        "Retry after the governed graph backend recovers."
+                    }
+                    _ => "Correct the governed graph read input before retrying.",
+                }
+            }),
+        },
         evidence: vec![],
         blocker: (state == ToolResultState::Failed)
             .then(|| "The governed graph could not complete this bounded read.".into()),


### PR DESCRIPTION
## Summary

- distinguish uncertain read results from uncertain durable effects
- require blockers for incomplete outcomes and prevent complete evidence claims on partial or unknown results
- constrain failure evidence and validate atomic recovery guidance

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cerebro-agent-runtime` (136 unit, 31 integration, 1 doc test passed)
- `cargo test -p cerebro-platform` (251 unit and 6 runtime-contract tests passed; 7 external-service tests ignored)
- independent Bedrock quality judge: pass, no hard defects

## Delivery state

Draft pending hosted checks.