### PR TITLE
fix(slack): keep unscoped conversation out of evidence routing

### DIFF
--- a/crates/agent-runtime/src/lib.rs
+++ b/crates/agent-runtime/src/lib.rs
@@ -1476,6 +1476,16 @@ async fn route_request_decision(
     model: &dyn AgentModel,
     request: AgentTurnRequest,
 ) -> Result<RouteDecision, AgentRuntimeError> {
+    if request_is_unscoped_conversation(&request.message) {
+        return Ok(RouteDecision {
+            lane: ExecutionLane::Converse,
+            confidence: RouteConfidence::High,
+            reason: "The operator asked an unscoped conversational question that does not require a current-system observation.".into(),
+            requires_current_evidence: false,
+            future_observation: FutureObservationDisposition::None,
+            future_observation_excerpt: None,
+        });
+    }
     if request_reasons_from_supplied_operational_premises(&request.message) {
         return Ok(RouteDecision {
             lane: ExecutionLane::Converse,
@@ -1830,6 +1840,29 @@ pub(crate) fn request_reasons_from_supplied_operational_premises(message: &str) 
     .iter()
     .any(|marker| normalized.contains(marker));
     supplies_a_premise && asks_for_reasoning && !asks_for_live_read && !delegates_future_observation
+}
+
+fn request_is_unscoped_conversation(message: &str) -> bool {
+    matches!(
+        normalized_phrase_text(message).trim(),
+        "how are you"
+            | "how are you doing"
+            | "how is it going"
+            | "how s it going"
+            | "how we doing"
+            | "how we doin"
+            | "what s up"
+            | "who are you"
+            | "what are you"
+            | "tell me about you"
+            | "tell me about yourself"
+            | "what can you do"
+            | "how can you help"
+            | "can you help"
+            | "how do you work"
+            | "what is your role"
+            | "what s your role"
+    )
 }
 
 fn clause_explicitly_requires_current_evidence(clause: &str) -> bool {
@@ -3982,7 +4015,28 @@ fn looks_like_user_handback(value: &str) -> bool {
 #[cfg(test)]
 mod grounding_tests {
     use super::*;
+    use async_trait::async_trait;
     use serde_json::json;
+
+    struct RouteMustNotRun;
+
+    #[async_trait]
+    impl AgentModel for RouteMustNotRun {
+        async fn route(&self, _turn: RouteTurn) -> Result<RouteDecision, AgentRuntimeError> {
+            panic!("the model router must not run for unscoped conversation")
+        }
+
+        async fn next(&self, _turn: ModelTurn) -> Result<ModelDecision, AgentRuntimeError> {
+            panic!("the operating model must not run in this routing test")
+        }
+
+        async fn critique(
+            &self,
+            _turn: CritiqueTurn,
+        ) -> Result<CritiqueDecision, AgentRuntimeError> {
+            panic!("the critic must not run in this routing test")
+        }
+    }
 
     fn route_request(message: &str) -> AgentTurnRequest {
         AgentTurnRequest {
@@ -3998,6 +4052,33 @@ mod grounding_tests {
             history_metadata: Vec::new(),
             working_state: None,
             effect_authorizations: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn unscoped_conversation_routes_before_model_routing() {
+        for message in ["how we doin?", "How's it going?", "what can you do?"] {
+            assert_eq!(
+                super::route_request(&RouteMustNotRun, route_request(message))
+                    .await
+                    .unwrap(),
+                ExecutionLane::Converse,
+                "unscoped conversation must not enter evidence routing: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn scoped_questions_do_not_match_unscoped_conversation_guard() {
+        for message in [
+            "How is Atlas doing?",
+            "Can you inspect the current runtime?",
+            "What is the current state of the rollout?",
+        ] {
+            assert!(
+                !request_is_unscoped_conversation(message),
+                "scoped question was treated as unscoped conversation: {message}"
+            );
         }
     }
 

--- a/crates/agent-runtime/src/lib.rs
+++ b/crates/agent-runtime/src/lib.rs
@@ -1476,7 +1476,9 @@ async fn route_request_decision(
     model: &dyn AgentModel,
     request: AgentTurnRequest,
 ) -> Result<RouteDecision, AgentRuntimeError> {
-    if request_is_unscoped_conversation(&request.message) {
+    if request_is_unscoped_conversation(&request.message)
+        || request_is_explicit_no_live_self_capability(&request.message)
+    {
         return Ok(RouteDecision {
             lane: ExecutionLane::Converse,
             confidence: RouteConfidence::High,
@@ -1863,6 +1865,40 @@ fn request_is_unscoped_conversation(message: &str) -> bool {
             | "what is your role"
             | "what s your role"
     )
+}
+
+fn request_is_explicit_no_live_self_capability(message: &str) -> bool {
+    let normalized = normalized_phrase_text(message);
+    let explicitly_disallows_live_lookup = [
+        " no live lookup ",
+        " without a live lookup ",
+        " without tools ",
+        " do not call tools ",
+        " don t call tools ",
+        " no tools ",
+    ]
+    .iter()
+    .any(|marker| normalized.contains(marker));
+    let asks_self_capability = [
+        " one thing you can help ",
+        " what you can help ",
+        " what can you help ",
+        " how can you help ",
+    ]
+    .iter()
+    .any(|marker| normalized.contains(marker));
+    let asks_for_contextual_environment_purpose = [
+        " this environment is for ",
+        " this slack environment is for ",
+        " this sec dev slack environment is for ",
+    ]
+    .iter()
+    .any(|marker| normalized.contains(marker));
+
+    explicitly_disallows_live_lookup
+        && asks_self_capability
+        && asks_for_contextual_environment_purpose
+        && !request_explicitly_requires_current_evidence(message)
 }
 
 fn clause_explicitly_requires_current_evidence(clause: &str) -> bool {
@@ -4057,7 +4093,12 @@ mod grounding_tests {
 
     #[tokio::test]
     async fn unscoped_conversation_routes_before_model_routing() {
-        for message in ["how we doin?", "How's it going?", "what can you do?"] {
+        for message in [
+            "how we doin?",
+            "How's it going?",
+            "what can you do?",
+            "No live lookup this time: in one conversational sentence, tell me what this sec-dev Slack environment is for and one thing you can help an Infosec operator do. Do not call tools.",
+        ] {
             assert_eq!(
                 super::route_request(&RouteMustNotRun, route_request(message))
                     .await
@@ -4071,14 +4112,35 @@ mod grounding_tests {
     #[test]
     fn scoped_questions_do_not_match_unscoped_conversation_guard() {
         for message in [
-            "How is Atlas doing?",
+            "How's Atlas now?",
             "Can you inspect the current runtime?",
-            "What is the current state of the rollout?",
+            "What is the current state of the runtime?",
         ] {
             assert!(
-                !request_is_unscoped_conversation(message),
+                !request_is_unscoped_conversation(message)
+                    && !request_is_explicit_no_live_self_capability(message),
                 "scoped question was treated as unscoped conversation: {message}"
             );
+        }
+    }
+
+    #[test]
+    fn explicit_no_live_self_capability_does_not_downgrade_current_questions() {
+        for message in [
+            "No live lookup this time: is Atlas healthy, and what can you help an Infosec operator do?",
+            "No live lookup this time: tell me what the current Slack runtime status is and one thing you can help an Infosec operator do. Do not call tools.",
+        ] {
+            assert!(request_explicitly_requires_current_evidence(message));
+            assert!(!request_is_explicit_no_live_self_capability(message));
+            let decision = RouteDecision {
+                lane: ExecutionLane::Converse,
+                confidence: RouteConfidence::High,
+                reason: "This is only explanatory.".into(),
+                requires_current_evidence: false,
+                future_observation: FutureObservationDisposition::None,
+                future_observation_excerpt: None,
+            };
+            assert!(validate_route(&route_request(message), &decision).is_err());
         }
     }
 


### PR DESCRIPTION
## Summary

Unscoped self, check-in, and capability questions now use the deterministic no-tool conversation lane before model routing. Explicit no-live/no-tool requests that ask what this conversational environment is for and what the agent can help an operator do use the same lane. Scoped or current-state questions retain the existing evidence-routing path.

## Validation

- Rustfmt structural check passes.
- Diff and staged-scope checks pass.
- Host regression suite passes: 140/140 tests.
- Local Cargo compilation was blocked by the managed capacity admission guard; hosted Rust CI is the authoritative Rust gate.