### PR TITLE
Agent: fail closed on malformed tool results (DDESK tests unexecuted)

### DIFF
--- a/crates/agent-runtime/src/lib.rs
+++ b/crates/agent-runtime/src/lib.rs
@@ -3555,7 +3555,12 @@ fn validate_tool_result(result: &ToolResult) -> Result<(), AgentRuntimeError> {
             ));
         }
     }
-    validate_recovery_guidance(&result.data)?;
+    let has_recovery_guidance = validate_recovery_guidance(&result.data)?;
+    if result.state == ToolResultState::Failed && !has_recovery_guidance {
+        return Err(AgentRuntimeError::InvalidToolCall(
+            "failed tool result requires recovery guidance".into(),
+        ));
+    }
     let mut evidence_refs = BTreeSet::new();
     for evidence in &result.evidence {
         if result.state == ToolResultState::Failed
@@ -3600,13 +3605,13 @@ fn validate_tool_result(result: &ToolResult) -> Result<(), AgentRuntimeError> {
     Ok(())
 }
 
-fn validate_recovery_guidance(data: &Value) -> Result<(), AgentRuntimeError> {
+fn validate_recovery_guidance(data: &Value) -> Result<bool, AgentRuntimeError> {
     let Value::Object(data) = data else {
-        return Ok(());
+        return Ok(false);
     };
     let fields = ["error_kind", "retryable", "operator_action"];
     if !fields.iter().any(|field| data.contains_key(*field)) {
-        return Ok(());
+        return Ok(false);
     }
     let error_kind_valid = data
         .get("error_kind")
@@ -3629,7 +3634,7 @@ fn validate_recovery_guidance(data: &Value) -> Result<(), AgentRuntimeError> {
                     .any(|character| matches!(character, '\n' | '\r' | '\t'))
         });
     if error_kind_valid && retryable_valid && operator_action_valid {
-        Ok(())
+        Ok(true)
     } else {
         Err(AgentRuntimeError::InvalidToolCall(
             "tool result recovery guidance is incomplete or invalid".into(),
@@ -4205,7 +4210,15 @@ mod grounding_tests {
         ToolResult {
             state,
             summary: "The bounded tool call returned.".into(),
-            data: json!({}),
+            data: if state == ToolResultState::Failed {
+                json!({
+                    "error_kind": "bounded_tool_failure",
+                    "retryable": false,
+                    "operator_action": "Inspect the bounded tool failure before retrying."
+                })
+            } else {
+                json!({})
+            },
             evidence: Vec::new(),
             blocker: blocker.map(str::to_owned),
         }
@@ -4360,7 +4373,12 @@ mod grounding_tests {
             ToolResultState::Failed,
             Some("The bounded tool call failed."),
         );
-        assert!(validate_tool_result(&failed).is_ok());
+        failed.data = json!({});
+        assert!(matches!(
+            validate_tool_result(&failed),
+            Err(AgentRuntimeError::InvalidToolCall(reason))
+                if reason == "failed tool result requires recovery guidance"
+        ));
 
         failed.data = json!({
             "error_kind": "backend_unavailable",

--- a/crates/agent-runtime/src/lib.rs
+++ b/crates/agent-runtime/src/lib.rs
@@ -3561,6 +3561,18 @@ fn validate_tool_result(result: &ToolResult) -> Result<(), AgentRuntimeError> {
             "failed tool result requires recovery guidance".into(),
         ));
     }
+    if result.state == ToolResultState::OutcomeUnknown {
+        if !has_recovery_guidance {
+            return Err(AgentRuntimeError::InvalidToolCall(
+                "outcome-unknown tool result requires recovery guidance".into(),
+            ));
+        }
+        if result.data.get("retryable").and_then(Value::as_bool) != Some(false) {
+            return Err(AgentRuntimeError::InvalidToolCall(
+                "outcome-unknown recovery guidance must not be retryable".into(),
+            ));
+        }
+    }
     let mut evidence_refs = BTreeSet::new();
     for evidence in &result.evidence {
         if result.state == ToolResultState::Failed
@@ -4210,14 +4222,18 @@ mod grounding_tests {
         ToolResult {
             state,
             summary: "The bounded tool call returned.".into(),
-            data: if state == ToolResultState::Failed {
-                json!({
+            data: match state {
+                ToolResultState::Failed => json!({
                     "error_kind": "bounded_tool_failure",
                     "retryable": false,
                     "operator_action": "Inspect the bounded tool failure before retrying."
-                })
-            } else {
-                json!({})
+                }),
+                ToolResultState::OutcomeUnknown => json!({
+                    "error_kind": "bounded_outcome_unknown",
+                    "retryable": false,
+                    "operator_action": "Verify the current provider state before further action."
+                }),
+                _ => json!({}),
             },
             evidence: Vec::new(),
             blocker: blocker.map(str::to_owned),
@@ -4412,6 +4428,29 @@ mod grounding_tests {
                     if reason == "tool result recovery guidance is incomplete or invalid"
             ));
         }
+    }
+
+    #[test]
+    fn unknown_outcomes_require_non_retryable_recovery_guidance() {
+        let mut unknown = validation_result(
+            ToolResultState::OutcomeUnknown,
+            Some("The provider outcome was not confirmed."),
+        );
+        assert!(validate_tool_result(&unknown).is_ok());
+
+        unknown.data["retryable"] = json!(true);
+        assert!(matches!(
+            validate_tool_result(&unknown),
+            Err(AgentRuntimeError::InvalidToolCall(reason))
+                if reason == "outcome-unknown recovery guidance must not be retryable"
+        ));
+
+        unknown.data = json!({});
+        assert!(matches!(
+            validate_tool_result(&unknown),
+            Err(AgentRuntimeError::InvalidToolCall(reason))
+                if reason == "outcome-unknown tool result requires recovery guidance"
+        ));
     }
 
     #[test]

--- a/crates/agent-runtime/src/session.rs
+++ b/crates/agent-runtime/src/session.rs
@@ -5447,7 +5447,11 @@ fn failed_tool_result(
     Ok(ToolResult {
         state: ToolResultState::Failed,
         summary: summary.clone(),
-        data: Value::Null,
+        data: json!({
+            "error_kind": "capability_invocation_failed",
+            "retryable": false,
+            "operator_action": "Continue with another bounded capability or inspect provider availability before retrying."
+        }),
         evidence: vec![crate::EvidenceRecord {
             evidence_ref: evidence_ref.clone(),
             statement: summary.clone(),

--- a/crates/agent-runtime/src/session.rs
+++ b/crates/agent-runtime/src/session.rs
@@ -5447,7 +5447,7 @@ fn failed_tool_result(
     Ok(ToolResult {
         state: ToolResultState::Failed,
         summary: summary.clone(),
-        data: json!({
+        data: serde_json::json!({
             "error_kind": "capability_invocation_failed",
             "retryable": false,
             "operator_action": "Continue with another bounded capability or inspect provider availability before retrying."
@@ -5493,7 +5493,11 @@ fn uncertain_effect_result(
     ToolResult {
         state: ToolResultState::OutcomeUnknown,
         summary: summary.clone(),
-        data: Value::Null,
+        data: serde_json::json!({
+            "error_kind": "effect_outcome_unknown",
+            "retryable": false,
+            "operator_action": "Reconcile the provider state with a fresh observation before any further effect."
+        }),
         evidence: vec![crate::EvidenceRecord {
             evidence_ref: evidence_ref.clone(),
             statement: summary.clone(),

--- a/crates/agent-runtime/tests/operator_agent.rs
+++ b/crates/agent-runtime/tests/operator_agent.rs
@@ -1418,7 +1418,11 @@ async fn stops_and_reconciles_outcome_unknown_without_retrying() {
             ToolResult {
                 state: ToolResultState::OutcomeUnknown,
                 summary: "The provider connection ended before a receipt was returned.".into(),
-                data: json!({}),
+                data: json!({
+                    "error_kind": "provider_outcome_unknown",
+                    "retryable": false,
+                    "operator_action": "Reconcile the provider state before any further effect."
+                }),
                 evidence: vec![uncertain_effect_evidence],
                 blocker: Some("The effect may have happened, so retry is unsafe.".into()),
             },
@@ -1471,7 +1475,11 @@ async fn requests_a_fresh_observation_when_a_read_result_is_unknown() {
             ToolResult {
                 state: ToolResultState::OutcomeUnknown,
                 summary: "The observation ended without a confirmed result.".into(),
-                data: json!({}),
+                data: json!({
+                    "error_kind": "observation_outcome_unknown",
+                    "retryable": false,
+                    "operator_action": "Run a fresh bounded observation before drawing a conclusion."
+                }),
                 evidence: vec![uncertain_evidence],
                 blocker: Some("The current runtime status was not returned.".into()),
             },

--- a/crates/agent-runtime/tests/operator_agent.rs
+++ b/crates/agent-runtime/tests/operator_agent.rs
@@ -1147,7 +1147,13 @@ async fn repairs_internal_query_refusals_into_an_operator_facing_boundary() {
             ToolResult {
                 state: ToolResultState::Failed,
                 summary: "Graph reasoning returned a blocked result.".into(),
-                data: json!({"state": "blocked", "reason_code": "validator_refusal"}),
+                data: json!({
+                    "state": "blocked",
+                    "reason_code": "validator_refusal",
+                    "error_kind": "graph_reasoning_blocked",
+                    "retryable": false,
+                    "operator_action": "Continue with another bounded evidence capability."
+                }),
                 evidence: vec![],
                 blocker: Some(
                     "Graph reasoning did not produce a grounded answer. Continue with other bounded evidence capabilities."

--- a/crates/cerebro-platform/src/slack_agent_mcp.rs
+++ b/crates/cerebro-platform/src/slack_agent_mcp.rs
@@ -402,16 +402,13 @@ impl McpAgentTools {
         let result = response.result.ok_or_else(|| {
             AgentRuntimeError::InvalidToolCall("MCP tool response omitted its result".into())
         })?;
-        let is_error = result
-            .get("isError")
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
+        let (is_error, invalid_is_error) = provider_error_signal(&result);
         let semantic_envelope = semantic_evidence_envelope(&result)?;
         let data = result
             .get("structuredContent")
             .cloned()
             .unwrap_or_else(|| result.clone());
-        let normalized = normalize_tool_result(data, is_error);
+        let normalized = normalize_tool_result(data, is_error, invalid_is_error);
         if tool.descriptor.authority_class == ToolAuthorityClass::Actuate
             && normalized.state != ToolResultState::Succeeded
         {
@@ -521,7 +518,19 @@ struct NormalizedToolResult {
     blocker: Option<String>,
 }
 
-fn normalize_tool_result(data: Value, is_error: bool) -> NormalizedToolResult {
+fn provider_error_signal(result: &Value) -> (bool, Option<Value>) {
+    match result.get("isError") {
+        None => (false, None),
+        Some(Value::Bool(is_error)) => (*is_error, None),
+        Some(value) => (false, Some(value.clone())),
+    }
+}
+
+fn normalize_tool_result(
+    data: Value,
+    is_error: bool,
+    invalid_is_error: Option<Value>,
+) -> NormalizedToolResult {
     let (declared_state, invalid_state) = match data.get("state") {
         None => (ToolResultState::Succeeded, false),
         Some(Value::String(state)) => match state.as_str() {
@@ -533,7 +542,7 @@ fn normalize_tool_result(data: Value, is_error: bool) -> NormalizedToolResult {
         },
         Some(_) => (ToolResultState::Failed, true),
     };
-    let state = if is_error {
+    let state = if is_error || invalid_is_error.is_some() {
         ToolResultState::Failed
     } else {
         declared_state
@@ -543,8 +552,21 @@ fn normalize_tool_result(data: Value, is_error: bool) -> NormalizedToolResult {
         .flatten()
         .or_else(|| {
             invalid_state.then(|| "The provider returned an unsupported result state.".into())
+        })
+        .or_else(|| {
+            invalid_is_error
+                .is_some()
+                .then(|| "The provider returned a non-boolean isError signal.".into())
         });
-    let data = if is_error || state == ToolResultState::Failed {
+    let data = if let Some(invalid_is_error) = invalid_is_error {
+        json!({
+            "provider_result": data,
+            "invalid_is_error": invalid_is_error,
+            "error_kind": INVALID_PROVIDER_ERROR_SIGNAL_GUIDANCE.error_kind,
+            "retryable": INVALID_PROVIDER_ERROR_SIGNAL_GUIDANCE.retryable,
+            "operator_action": INVALID_PROVIDER_ERROR_SIGNAL_GUIDANCE.operator_action,
+        })
+    } else if is_error || state == ToolResultState::Failed {
         let guidance = if invalid_state {
             INVALID_PROVIDER_STATE_GUIDANCE
         } else {
@@ -572,6 +594,12 @@ const INVALID_PROVIDER_STATE_GUIDANCE: RecoveryGuidance = RecoveryGuidance {
     error_kind: "invalid_provider_result_state",
     retryable: false,
     operator_action: "Inspect the provider result contract before retrying.",
+};
+
+const INVALID_PROVIDER_ERROR_SIGNAL_GUIDANCE: RecoveryGuidance = RecoveryGuidance {
+    error_kind: "invalid_provider_error_signal",
+    retryable: false,
+    operator_action: "Inspect the provider result envelope before retrying.",
 };
 
 fn tool_error_guidance(data: &Value) -> RecoveryGuidance {
@@ -1256,6 +1284,7 @@ mod tests {
                 "operation_ref": "operation-one",
             }),
             false,
+            None,
         );
 
         assert_eq!(normalized.state, ToolResultState::OutcomeUnknown);
@@ -1266,7 +1295,7 @@ mod tests {
     fn fails_closed_on_invalid_provider_result_states() {
         for state in [json!("Complete"), json!("future_state"), json!(""), json!(7), Value::Null]
         {
-            let normalized = normalize_tool_result(json!({"state": state}), false);
+            let normalized = normalize_tool_result(json!({"state": state}), false, None);
             assert_eq!(normalized.state, ToolResultState::Failed);
             assert_eq!(
                 normalized.blocker.as_deref(),
@@ -1279,10 +1308,43 @@ mod tests {
             assert_eq!(normalized.data["retryable"], false);
         }
 
-        let absent = normalize_tool_result(json!({"records": []}), false);
+        let absent = normalize_tool_result(json!({"records": []}), false, None);
         assert_eq!(absent.state, ToolResultState::Succeeded);
-        let succeeded = normalize_tool_result(json!({"state": "succeeded"}), false);
+        let succeeded = normalize_tool_result(json!({"state": "succeeded"}), false, None);
         assert_eq!(succeeded.state, ToolResultState::Succeeded);
+    }
+
+    #[test]
+    fn fails_closed_on_non_boolean_provider_error_signals() {
+        for invalid in [json!("false"), json!(1), Value::Null, json!({"value": false})] {
+            let result = json!({"isError": invalid});
+            let (is_error, invalid_is_error) = provider_error_signal(&result);
+            assert!(!is_error);
+            assert!(invalid_is_error.is_some());
+
+            let normalized = normalize_tool_result(
+                json!({"state": "complete", "records": ["record-one"]}),
+                is_error,
+                invalid_is_error,
+            );
+            assert_eq!(normalized.state, ToolResultState::Failed);
+            assert_eq!(
+                normalized.blocker.as_deref(),
+                Some("The provider returned a non-boolean isError signal.")
+            );
+            assert_eq!(
+                normalized.data["error_kind"],
+                "invalid_provider_error_signal"
+            );
+            assert_eq!(normalized.data["retryable"], false);
+            assert_eq!(
+                normalized.data["provider_result"]["records"],
+                json!(["record-one"])
+            );
+        }
+
+        assert_eq!(provider_error_signal(&json!({"isError": true})), (true, None));
+        assert_eq!(provider_error_signal(&json!({})), (false, None));
     }
 
     #[test]
@@ -1290,6 +1352,7 @@ mod tests {
         let blocked = normalize_tool_result(
             json!({"state": "blocked", "blocker": format!("{}tail", "x".repeat(512))}),
             false,
+            None,
         );
         assert_eq!(blocked.state, ToolResultState::Failed);
         assert_eq!(blocked.blocker.as_ref().unwrap().chars().count(), 512);
@@ -1308,6 +1371,7 @@ mod tests {
                 "request_ref": "request-one"
             }),
             false,
+            None,
         );
         assert_eq!(unavailable.state, ToolResultState::Failed);
         assert_eq!(unavailable.data["error_kind"], "capability_unavailable");
@@ -1320,6 +1384,7 @@ mod tests {
                 "partial_reasons": ["Graph projection is unavailable.", "Runtime state is stale."]
             }),
             false,
+            None,
         );
         assert_eq!(partial.state, ToolResultState::Partial);
         assert_eq!(
@@ -1330,6 +1395,7 @@ mod tests {
         let complete = normalize_tool_result(
             json!({"state": "complete", "blocker": "must not shadow success"}),
             false,
+            None,
         );
         assert_eq!(complete.state, ToolResultState::Succeeded);
         assert_eq!(complete.blocker, None);
@@ -1346,6 +1412,7 @@ mod tests {
                 "request_ref": "request-one"
             }),
             true,
+            None,
         );
         assert_eq!(denied.state, ToolResultState::Failed);
         assert_eq!(
@@ -1363,6 +1430,7 @@ mod tests {
         let unavailable = normalize_tool_result(
             json!({"error": {"kind": "runtime_unavailable", "message": "Runtime is down."}}),
             true,
+            None,
         );
         assert_eq!(unavailable.data["error_kind"], "capability_unavailable");
         assert_eq!(unavailable.data["retryable"], true);

--- a/crates/cerebro-platform/src/slack_agent_mcp.rs
+++ b/crates/cerebro-platform/src/slack_agent_mcp.rs
@@ -522,21 +522,34 @@ struct NormalizedToolResult {
 }
 
 fn normalize_tool_result(data: Value, is_error: bool) -> NormalizedToolResult {
-    let declared_state = data.get("state").and_then(Value::as_str);
-    let state = if is_error || declared_state == Some("blocked") {
+    let (declared_state, invalid_state) = match data.get("state") {
+        None => (ToolResultState::Succeeded, false),
+        Some(Value::String(state)) => match state.as_str() {
+            "complete" | "succeeded" => (ToolResultState::Succeeded, false),
+            "partial" => (ToolResultState::Partial, false),
+            "blocked" => (ToolResultState::Failed, false),
+            "outcome_unknown" => (ToolResultState::OutcomeUnknown, false),
+            _ => (ToolResultState::Failed, true),
+        },
+        Some(_) => (ToolResultState::Failed, true),
+    };
+    let state = if is_error {
         ToolResultState::Failed
-    } else if declared_state == Some("partial") {
-        ToolResultState::Partial
-    } else if declared_state == Some("outcome_unknown") {
-        ToolResultState::OutcomeUnknown
     } else {
-        ToolResultState::Succeeded
+        declared_state
     };
     let blocker = (state != ToolResultState::Succeeded)
         .then(|| provider_blocker(&data))
-        .flatten();
+        .flatten()
+        .or_else(|| {
+            invalid_state.then(|| "The provider returned an unsupported result state.".into())
+        });
     let data = if is_error || state == ToolResultState::Failed {
-        let guidance = tool_error_guidance(&data);
+        let guidance = if invalid_state {
+            INVALID_PROVIDER_STATE_GUIDANCE
+        } else {
+            tool_error_guidance(&data)
+        };
         with_recovery_guidance(data, guidance)
     } else {
         data
@@ -554,6 +567,12 @@ struct RecoveryGuidance {
     retryable: bool,
     operator_action: &'static str,
 }
+
+const INVALID_PROVIDER_STATE_GUIDANCE: RecoveryGuidance = RecoveryGuidance {
+    error_kind: "invalid_provider_result_state",
+    retryable: false,
+    operator_action: "Inspect the provider result contract before retrying.",
+};
 
 fn tool_error_guidance(data: &Value) -> RecoveryGuidance {
     let provider_kind = data
@@ -1241,6 +1260,29 @@ mod tests {
 
         assert_eq!(normalized.state, ToolResultState::OutcomeUnknown);
         assert_eq!(normalized.data["operation_ref"], "operation-one");
+    }
+
+    #[test]
+    fn fails_closed_on_invalid_provider_result_states() {
+        for state in [json!("Complete"), json!("future_state"), json!(""), json!(7), Value::Null]
+        {
+            let normalized = normalize_tool_result(json!({"state": state}), false);
+            assert_eq!(normalized.state, ToolResultState::Failed);
+            assert_eq!(
+                normalized.blocker.as_deref(),
+                Some("The provider returned an unsupported result state.")
+            );
+            assert_eq!(
+                normalized.data["error_kind"],
+                "invalid_provider_result_state"
+            );
+            assert_eq!(normalized.data["retryable"], false);
+        }
+
+        let absent = normalize_tool_result(json!({"records": []}), false);
+        assert_eq!(absent.state, ToolResultState::Succeeded);
+        let succeeded = normalize_tool_result(json!({"state": "succeeded"}), false);
+        assert_eq!(succeeded.state, ToolResultState::Succeeded);
     }
 
     #[test]

--- a/crates/cerebro-platform/src/slack_agent_mcp.rs
+++ b/crates/cerebro-platform/src/slack_agent_mcp.rs
@@ -566,12 +566,17 @@ fn normalize_tool_result(
             "retryable": INVALID_PROVIDER_ERROR_SIGNAL_GUIDANCE.retryable,
             "operator_action": INVALID_PROVIDER_ERROR_SIGNAL_GUIDANCE.operator_action,
         })
+    } else if invalid_state {
+        json!({
+            "provider_result": data,
+            "error_kind": INVALID_PROVIDER_STATE_GUIDANCE.error_kind,
+            "retryable": INVALID_PROVIDER_STATE_GUIDANCE.retryable,
+            "operator_action": INVALID_PROVIDER_STATE_GUIDANCE.operator_action,
+        })
+    } else if state == ToolResultState::OutcomeUnknown {
+        with_recovery_guidance(data, OUTCOME_UNKNOWN_GUIDANCE)
     } else if is_error || state == ToolResultState::Failed {
-        let guidance = if invalid_state {
-            INVALID_PROVIDER_STATE_GUIDANCE
-        } else {
-            tool_error_guidance(&data)
-        };
+        let guidance = tool_error_guidance(&data);
         with_recovery_guidance(data, guidance)
     } else {
         data
@@ -600,6 +605,12 @@ const INVALID_PROVIDER_ERROR_SIGNAL_GUIDANCE: RecoveryGuidance = RecoveryGuidanc
     error_kind: "invalid_provider_error_signal",
     retryable: false,
     operator_action: "Inspect the provider result envelope before retrying.",
+};
+
+const OUTCOME_UNKNOWN_GUIDANCE: RecoveryGuidance = RecoveryGuidance {
+    error_kind: "provider_outcome_unknown",
+    retryable: false,
+    operator_action: "Verify the current provider state before further action.",
 };
 
 fn tool_error_guidance(data: &Value) -> RecoveryGuidance {
@@ -1289,13 +1300,27 @@ mod tests {
 
         assert_eq!(normalized.state, ToolResultState::OutcomeUnknown);
         assert_eq!(normalized.data["operation_ref"], "operation-one");
+        assert_eq!(normalized.data["error_kind"], "provider_outcome_unknown");
+        assert_eq!(normalized.data["retryable"], false);
     }
 
     #[test]
     fn fails_closed_on_invalid_provider_result_states() {
-        for state in [json!("Complete"), json!("future_state"), json!(""), json!(7), Value::Null]
-        {
-            let normalized = normalize_tool_result(json!({"state": state}), false, None);
+        for state in [
+            json!("Complete"),
+            json!("future_state"),
+            json!(""),
+            json!(7),
+            json!(true),
+            json!([]),
+            json!({"value": "complete"}),
+            Value::Null,
+        ] {
+            let normalized = normalize_tool_result(
+                json!({"state": state.clone(), "request_ref": "request-one"}),
+                false,
+                None,
+            );
             assert_eq!(normalized.state, ToolResultState::Failed);
             assert_eq!(
                 normalized.blocker.as_deref(),
@@ -1306,6 +1331,11 @@ mod tests {
                 "invalid_provider_result_state"
             );
             assert_eq!(normalized.data["retryable"], false);
+            assert_eq!(normalized.data["provider_result"]["state"], state);
+            assert_eq!(
+                normalized.data["provider_result"]["request_ref"],
+                "request-one"
+            );
         }
 
         let absent = normalize_tool_result(json!({"records": []}), false, None);
@@ -1316,7 +1346,12 @@ mod tests {
 
     #[test]
     fn fails_closed_on_non_boolean_provider_error_signals() {
-        for invalid in [json!("false"), json!(1), Value::Null, json!({"value": false})] {
+        for invalid in [
+            json!("false"),
+            json!(1),
+            Value::Null,
+            json!({"value": false}),
+        ] {
             let result = json!({"isError": invalid});
             let (is_error, invalid_is_error) = provider_error_signal(&result);
             assert!(!is_error);
@@ -1343,8 +1378,44 @@ mod tests {
             );
         }
 
-        assert_eq!(provider_error_signal(&json!({"isError": true})), (true, None));
+        assert_eq!(
+            provider_error_signal(&json!({"isError": true})),
+            (true, None)
+        );
         assert_eq!(provider_error_signal(&json!({})), (false, None));
+    }
+
+    #[test]
+    fn conservative_error_precedence_is_deterministic() {
+        let signaled_error = normalize_tool_result(
+            json!({"state": "complete", "request_ref": "request-one"}),
+            true,
+            None,
+        );
+        assert_eq!(signaled_error.state, ToolResultState::Failed);
+
+        let blocked = normalize_tool_result(json!({"state": "blocked"}), false, None);
+        assert_eq!(blocked.state, ToolResultState::Failed);
+
+        let unknown = normalize_tool_result(json!({"state": "outcome_unknown"}), false, None);
+        assert_eq!(unknown.state, ToolResultState::OutcomeUnknown);
+        assert_eq!(unknown.data["retryable"], false);
+
+        let both_malformed = normalize_tool_result(
+            json!({"state": "future_state", "request_ref": "request-two"}),
+            false,
+            Some(json!("false")),
+        );
+        assert_eq!(both_malformed.state, ToolResultState::Failed);
+        assert_eq!(
+            both_malformed.data["error_kind"],
+            "invalid_provider_error_signal"
+        );
+        assert_eq!(both_malformed.data["retryable"], false);
+        assert_eq!(
+            both_malformed.data["provider_result"]["request_ref"],
+            "request-two"
+        );
     }
 
     #[test]

--- a/crates/cerebro-platform/src/slack_agent_mcp.rs
+++ b/crates/cerebro-platform/src/slack_agent_mcp.rs
@@ -535,7 +535,7 @@ fn normalize_tool_result(data: Value, is_error: bool) -> NormalizedToolResult {
     let blocker = (state != ToolResultState::Succeeded)
         .then(|| provider_blocker(&data))
         .flatten();
-    let data = if is_error {
+    let data = if is_error || state == ToolResultState::Failed {
         let guidance = tool_error_guidance(&data);
         with_recovery_guidance(data, guidance)
     } else {
@@ -1252,6 +1252,25 @@ mod tests {
         assert_eq!(blocked.state, ToolResultState::Failed);
         assert_eq!(blocked.blocker.as_ref().unwrap().chars().count(), 512);
         assert!(!blocked.blocker.as_ref().unwrap().contains("tail"));
+        assert_eq!(blocked.data["error_kind"], "capability_error");
+        assert_eq!(blocked.data["retryable"], false);
+        assert_eq!(
+            blocked.data["operator_action"],
+            "Inspect the provider error before retrying."
+        );
+
+        let unavailable = normalize_tool_result(
+            json!({
+                "state": "blocked",
+                "error": {"kind": "runtime_unavailable", "message": "Runtime is down."},
+                "request_ref": "request-one"
+            }),
+            false,
+        );
+        assert_eq!(unavailable.state, ToolResultState::Failed);
+        assert_eq!(unavailable.data["error_kind"], "capability_unavailable");
+        assert_eq!(unavailable.data["retryable"], true);
+        assert_eq!(unavailable.data["request_ref"], "request-one");
 
         let partial = normalize_tool_result(
             json!({


### PR DESCRIPTION
## Summary

- Normalize provider-declared blocked tool results into failed outcomes with recovery guidance.
- Fail closed when structured result state or error signals are malformed.
- Require bounded recovery guidance for failed and unknown outcomes.
- Keep unknown outcomes non-retryable so callers cannot repeat side effects automatically.

This draft contains exactly five production-behavior commits.

## Validation state

- [x] `git diff --check origin/main...8162cf6975961b248c049c43b7d774d26b704db7`
- [x] Source and result-contract review
- [ ] DDESK execution tests — **UNEXECUTED** because managed repository-stream creation failed after capacity admission.
- [ ] Exact-head hosted CI — evidence gathering after this draft opens.
- [ ] Local-validation disposition recorded after hosted checks terminate.

This PR is not approval-ready or merge-ready. Hosted CI does not retroactively prove the unexecuted DDESK commands ran.

Prepared but unexecuted:

- `cargo fmt --all -- --check`
- `cargo test -p cerebro-agent-runtime`
- `cargo test -p cerebro-platform slack_agent_mcp::tests`
- `cargo test -p cerebro-platform slack_agent::tests`

## DDESK receipt

- Capacity planning reached State ready, Sync admitted, Bootstrap admitted, Disk none.
- A completed prior build's reproducible `target` output was moved—not deleted—to recoverable `/tmp/ddesk-capacity-repair-agentnorm-20260813-tools-context/target`.
- Recoverable move size: 6,063,943,680 bytes.
- Shared free space: 14,754,070,528 bytes before; 20,818,305,024 bytes after.
- The managed workspace initialized an empty unborn Git directory at `2026-08-13T06:25:19.363052799Z`, but no stream, session, sync, or run record was created.
- The post-push attempt ran for 60 seconds and returned `invalid repository streaming state`.
- Repair owner: Rawls (`/root/ddesk_repair`).

## Known Invariants

- Source connectors use `internal/sourcehttp` for outbound HTTP safety.
- Production body reads are bounded with `io.LimitReader` or streamed.
- Graph Ask queries stay tenant-scoped, read-only, row-limited, and validated.
- Ask deterministic post-processing is not applied to LLM fallback rows.
- Candidate finding lifecycle writes remain atomic and idempotent.
- Public request origin, DPoP `htu`, and trusted proxy handling use the canonical origin helpers.

## Deterministic Review

- Fast local invariant check: `make review-invariants` (unexecuted locally in this draft).
- Focus review on changed behavior and the invariants above.
- The required `deterministic-review` check must pass on the exact PR head.
