### PR TITLE
fix: make Rust cutover producer records idempotent

### DIFF
--- a/crates/source-runtime-next/src/append_log.rs
+++ b/crates/source-runtime-next/src/append_log.rs
@@ -20,6 +20,7 @@ use sha2::{Digest, Sha256};
 use crate::{CollectedBatch, CollectedScope, SourceRecord};
 
 const SOURCE_RUNTIME_ID_ATTRIBUTE: &str = "source_runtime_id";
+const SOURCE_COLLECTION_ID_ATTRIBUTE: &str = "source_collection_id";
 const CREDENTIAL_EVENT_KIND: &str = "security.credential.lifecycle";
 const CERTIFICATE_EVENT_KIND: &str = "security.certificate.lifecycle";
 const CREDENTIAL_SCHEMA_REF: &str = "cerebro/security/credential-lifecycle/v1";
@@ -283,14 +284,16 @@ impl CommittedSourceEvent {
         &self.payload
     }
 
-    /// Hash all identity, time, metadata, and canonical payload fields.
+    /// Hash all immutable identity, time, metadata, and canonical payload fields.
     ///
     /// Length-prefixing each field prevents concatenation ambiguity. The
     /// resulting lowercase SHA-256 digest is stable across map insertion order.
+    /// Runtime and collection IDs are delivery provenance: materialization adds
+    /// them after a source chooses its immutable observation ID, and later
+    /// redelivery can legitimately use a different runtime or collection.
     pub fn record_digest(&self) -> String {
         let mut hasher = Sha256::new();
         hash_field(&mut hasher, self.tenant_id.as_str().as_bytes());
-        hash_field(&mut hasher, self.source_runtime_id.as_str().as_bytes());
         hash_field(&mut hasher, self.observation_id.as_str().as_bytes());
         hash_field(&mut hasher, self.source_id.as_bytes());
         hash_field(&mut hasher, self.family_id.as_bytes());
@@ -298,6 +301,12 @@ impl CommittedSourceEvent {
         hash_field(&mut hasher, self.schema_ref.as_bytes());
         hash_field(&mut hasher, self.observed_at_unix_ms.to_string().as_bytes());
         for (key, value) in &self.attributes {
+            if matches!(
+                key.as_str(),
+                SOURCE_RUNTIME_ID_ATTRIBUTE | SOURCE_COLLECTION_ID_ATTRIBUTE
+            ) {
+                continue;
+            }
             hash_field(&mut hasher, key.as_bytes());
             hash_field(&mut hasher, value.as_bytes());
         }
@@ -638,6 +647,139 @@ mod tests {
         let second = CommittedSourceEvent::from_input(input).unwrap();
         assert_eq!(first.record_digest(), second.record_digest());
         assert_eq!(first.payload_digest(), second.payload_digest());
+    }
+
+    #[test]
+    fn record_digest_excludes_only_exact_delivery_provenance() {
+        let mut first_wire = source_wire();
+        first_wire.attributes.insert(
+            SOURCE_COLLECTION_ID_ATTRIBUTE.to_owned(),
+            "collection-one".to_owned(),
+        );
+        let first = CommittedSourceEvent::decode(&encode(first_wire))
+            .unwrap()
+            .unwrap();
+
+        let mut second_wire = source_wire();
+        second_wire.attributes.insert(
+            SOURCE_RUNTIME_ID_ATTRIBUTE.to_owned(),
+            "box-replacement".to_owned(),
+        );
+        second_wire.attributes.insert(
+            SOURCE_COLLECTION_ID_ATTRIBUTE.to_owned(),
+            "collection-two".to_owned(),
+        );
+        let second = CommittedSourceEvent::decode(&encode(second_wire))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(first.observation_id(), second.observation_id());
+        assert_ne!(first.source_runtime_id(), second.source_runtime_id());
+        assert_ne!(first.attributes(), second.attributes());
+        assert_ne!(first.attributes_digest(), second.attributes_digest());
+        assert_eq!(first.record_digest(), second.record_digest());
+
+        for key in [
+            "source_runtime",
+            "source_runtime_id_suffix",
+            "source_collection",
+            "source_collection_id_suffix",
+        ] {
+            let mut changed = first.clone();
+            changed
+                .attributes
+                .insert(key.to_owned(), "changed".to_owned());
+            assert_ne!(
+                first.record_digest(),
+                changed.record_digest(),
+                "non-provenance attribute {key:?} was excluded"
+            );
+        }
+    }
+
+    #[test]
+    fn every_immutable_record_field_remains_digest_bound() {
+        let mut wire = source_wire();
+        wire.source_id = "okta".to_owned();
+        wire.kind = "okta.threat_insight".to_owned();
+        wire.schema_ref = "okta/threat_insight/v1".to_owned();
+        wire.payload =
+            br#"{"action":"block","domain":"example.okta.test","exclude_zones":["zone-a"]}"#
+                .to_vec();
+        wire.attributes = HashMap::from([
+            (
+                SOURCE_RUNTIME_ID_ATTRIBUTE.to_owned(),
+                "writer-okta".to_owned(),
+            ),
+            (
+                SOURCE_COLLECTION_ID_ATTRIBUTE.to_owned(),
+                "collection-one".to_owned(),
+            ),
+            ("action".to_owned(), "block".to_owned()),
+            ("domain".to_owned(), "example.okta.test".to_owned()),
+            ("exclude_zone_count".to_owned(), "1".to_owned()),
+            ("family".to_owned(), "threat_insight".to_owned()),
+            ("resource_id".to_owned(), "threat_insight_config".to_owned()),
+            (
+                "resource_type".to_owned(),
+                "ThreatInsightConfiguration".to_owned(),
+            ),
+        ]);
+        let original = CommittedSourceEvent::decode(&encode(wire))
+            .unwrap()
+            .unwrap();
+
+        let mut changes: Vec<(&str, CommittedSourceEvent)> = Vec::new();
+        let mut changed = original.clone();
+        changed.tenant_id = TenantId::parse("tenant-b").unwrap();
+        changes.push(("tenant_id", changed));
+        let mut changed = original.clone();
+        changed.observation_id = ObservationId::parse("event-2").unwrap();
+        changes.push(("observation_id", changed));
+        let mut changed = original.clone();
+        changed.source_id = "github".to_owned();
+        changes.push(("source_id", changed));
+        let mut changed = original.clone();
+        changed.family_id = "applications".to_owned();
+        changes.push(("family_id", changed));
+        let mut changed = original.clone();
+        changed.event_kind = "okta.applications".to_owned();
+        changes.push(("event_kind", changed));
+        let mut changed = original.clone();
+        changed.schema_ref = "okta/threat_insight/v2".to_owned();
+        changes.push(("schema_ref", changed));
+        let mut changed = original.clone();
+        changed.observed_at_unix_ms += 1;
+        changes.push(("observed_at", changed));
+        for key in [
+            "action",
+            "domain",
+            "exclude_zone_count",
+            "family",
+            "resource_id",
+            "resource_type",
+        ] {
+            let mut changed = original.clone();
+            changed
+                .attributes
+                .insert(key.to_owned(), format!("changed-{key}"));
+            changes.push((key, changed));
+        }
+        let mut changed = original.clone();
+        changed.payload = serde_json::json!({
+            "action": "none",
+            "domain": "example.okta.test",
+            "exclude_zones": ["zone-a"]
+        });
+        changes.push(("payload", changed));
+
+        for (field, changed) in changes {
+            assert_ne!(
+                original.record_digest(),
+                changed.record_digest(),
+                "changed {field} reused the immutable record digest"
+            );
+        }
     }
 
     #[test]

--- a/crates/source-runtime-next/src/mapper.rs
+++ b/crates/source-runtime-next/src/mapper.rs
@@ -661,14 +661,39 @@ fn label_for(
         "secret" => &["secret_name", "resource_name", "name"],
         _ => &["resource_name", "name", "display_name"],
     };
-    first(projected, keys)
+    let projected_label = if template == "identity_application" {
+        first_valid_entity_label(projected, keys)
+    } else {
+        first(projected, keys)
+    };
+    projected_label
         .map(str::to_owned)
         .or_else(|| {
             family
                 .name_field()
                 .and_then(|path| scalar_at_path(&record.payload, path))
+                .filter(|label| template != "identity_application" || valid_entity_label(label))
         })
         .unwrap_or_else(|| record.provider_id.clone())
+}
+
+fn first_valid_entity_label<'a>(
+    values: &'a BTreeMap<String, String>,
+    keys: &[&str],
+) -> Option<&'a str> {
+    keys.iter().find_map(|key| {
+        values
+            .get(*key)
+            .map(String::as_str)
+            .filter(|label| valid_entity_label(label))
+    })
+}
+
+fn valid_entity_label(label: &str) -> bool {
+    !label.trim().is_empty()
+        && label.trim() == label
+        && label.len() <= 1_024
+        && !label.chars().any(char::is_control)
 }
 
 fn first<'a>(values: &'a BTreeMap<String, String>, keys: &[&str]) -> Option<&'a str> {
@@ -914,6 +939,65 @@ mod tests {
                 .get("oauth_public_client")
                 .map(String::as_str),
             Some("false")
+        );
+    }
+
+    #[test]
+    fn application_label_selection_continues_to_the_first_valid_candidate() {
+        let keys = ["app_name", "app_label", "name", "app_id"];
+        for (name, fields, expected) in [
+            (
+                "empty",
+                BTreeMap::from([
+                    ("app_name".to_owned(), String::new()),
+                    ("app_label".to_owned(), "Payroll".to_owned()),
+                ]),
+                "Payroll",
+            ),
+            (
+                "whitespace",
+                BTreeMap::from([
+                    ("app_name".to_owned(), "  ".to_owned()),
+                    ("app_label".to_owned(), "Payroll".to_owned()),
+                ]),
+                "Payroll",
+            ),
+            (
+                "overlong",
+                BTreeMap::from([
+                    ("app_name".to_owned(), "x".repeat(1_025)),
+                    ("app_label".to_owned(), "Payroll".to_owned()),
+                ]),
+                "Payroll",
+            ),
+            (
+                "valid-high-priority",
+                BTreeMap::from([
+                    ("app_name".to_owned(), "Workday".to_owned()),
+                    ("app_label".to_owned(), "Payroll".to_owned()),
+                ]),
+                "Workday",
+            ),
+        ] {
+            assert_eq!(
+                first_valid_entity_label(&fields, &keys),
+                Some(expected),
+                "case {name}",
+            );
+        }
+    }
+
+    #[test]
+    fn application_label_selection_returns_none_when_every_candidate_is_invalid() {
+        let fields = BTreeMap::from([
+            ("app_name".to_owned(), String::new()),
+            ("app_label".to_owned(), " leading".to_owned()),
+            ("name".to_owned(), "line\nbreak".to_owned()),
+            ("app_id".to_owned(), "x".repeat(1_025)),
+        ]);
+        assert_eq!(
+            first_valid_entity_label(&fields, &["app_name", "app_label", "name", "app_id"]),
+            None,
         );
     }
 

--- a/docs/engineering/source-cdk-extraction.md
+++ b/docs/engineering/source-cdk-extraction.md
@@ -38,7 +38,7 @@ A Deep source is exempt from the flat LOC ceiling but is instead held to the **D
 | `github` | 2009 | Split audit/event readers from repository/user normalization and shared pagination. |
 | `googleworkspace` | 814 | Extract API client setup and paginated directory readers. |
 | `grc` | 1195 | Keep control/evidence shaping out of source orchestration and push common mapping into shared helpers. |
-| `okta` | 2254 | Extract client, pagination, and identity/group/application readers into smaller units. |
+| `okta` | 2239 | Extract client, pagination, and identity/group/application readers into smaller units. |
 | `panopticon` | 763 | Separate request plumbing from emitted record construction. |
 | `sentinelone` | 2096 | Extract API paging, agent/application readers, and shared response normalization. |
 | `vulnview` | 1002 | Split feed/client access from vulnerability record normalization. |

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -1464,6 +1464,44 @@ func TestMaterializeEventPinsSyncCollectionProvenance(t *testing.T) {
 	}
 }
 
+func TestMaterializeEventKeepsImmutableMaterialAcrossCollections(t *testing.T) {
+	t.Parallel()
+
+	event := runtimeTestEvent("okta-threat-insight-sha256-stable", "okta", "okta.threat_insight")
+	event.TenantId = "provider-tenant"
+	event.Attributes["resource_id"] = "threat_insight_config"
+	first := materializeEvent(
+		&cerebrov1.SourceRuntime{Id: "writer-okta-primary", TenantId: "tenant-a"},
+		"collection-one",
+		event,
+	)
+	second := materializeEvent(
+		&cerebrov1.SourceRuntime{Id: "writer-okta-replacement", TenantId: "tenant-a"},
+		"collection-two",
+		event,
+	)
+
+	if first.GetId() != second.GetId() {
+		t.Fatalf("immutable event ID changed across collections: %q != %q", first.GetId(), second.GetId())
+	}
+	if first.GetTenantId() != "tenant-a" || second.GetTenantId() != "tenant-a" {
+		t.Fatalf("runtime tenant was not authoritative: first=%q second=%q", first.GetTenantId(), second.GetTenantId())
+	}
+	if first.GetAttributes()[ports.EventAttributeSourceRuntimeID] == second.GetAttributes()[ports.EventAttributeSourceRuntimeID] {
+		t.Fatalf("runtime provenance did not advance: first=%v second=%v", first.GetAttributes(), second.GetAttributes())
+	}
+	if first.GetAttributes()[ports.EventAttributeSourceCollectionID] == second.GetAttributes()[ports.EventAttributeSourceCollectionID] {
+		t.Fatalf("collection provenance did not advance: first=%v second=%v", first.GetAttributes(), second.GetAttributes())
+	}
+	delete(first.Attributes, ports.EventAttributeSourceCollectionID)
+	delete(second.Attributes, ports.EventAttributeSourceCollectionID)
+	delete(first.Attributes, ports.EventAttributeSourceRuntimeID)
+	delete(second.Attributes, ports.EventAttributeSourceRuntimeID)
+	if !proto.Equal(first, second) {
+		t.Fatalf("materialized immutable records differ beyond collection provenance: first=%v second=%v", first, second)
+	}
+}
+
 func TestSyncRuntimeOverwritesProviderSourceCollectionIDBeforePersistence(t *testing.T) {
 	event := runtimeTestEvent("spoofed-collection-event", "reserved_collection", "reserved_collection.event")
 	event.Attributes[ports.EventAttributeSourceCollectionID] = "provider-controlled-collection"

--- a/sources/internal/oktaasset/threat_insight.go
+++ b/sources/internal/oktaasset/threat_insight.go
@@ -6,7 +6,54 @@ import (
 	"fmt"
 	"sort"
 	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/writer/cerebro/internal/primitives"
 )
+
+// ThreatInsightOccurredAt returns the first positive provider timestamp,
+// normalized to the append log's millisecond precision.
+func ThreatInsightOccurredAt(lastUpdated string, created string) (time.Time, error) {
+	for _, value := range []*time.Time{ParseTime(lastUpdated), ParseTime(created)} {
+		if value != nil && !value.IsZero() {
+			normalized := time.UnixMilli(value.UnixMilli()).UTC()
+			if normalized.UnixMilli() > 0 {
+				return normalized, nil
+			}
+		}
+	}
+	return time.Time{}, fmt.Errorf("okta threat insight requires a positive created or lastUpdated timestamp")
+}
+
+// ThreatInsightEvent builds one immutable threat configuration observation.
+func ThreatInsightEvent(domain string, action string, zones []string, lastUpdated string, created string) (*primitives.Event, error) {
+	occurredAt, err := ThreatInsightOccurredAt(lastUpdated, created)
+	if err != nil {
+		return nil, err
+	}
+	payload, eventID, err := CanonicalThreatInsightMaterial(domain, action, zones, occurredAt)
+	if err != nil {
+		return nil, fmt.Errorf("marshal okta threat insight material: %w", err)
+	}
+	return &primitives.Event{
+		Id:         eventID,
+		TenantId:   domain,
+		SourceId:   "okta",
+		Kind:       "okta.threat_insight",
+		OccurredAt: timestamppb.New(occurredAt),
+		SchemaRef:  "okta/threat_insight/v1",
+		Payload:    payload,
+		Attributes: map[string]string{
+			"action":             action,
+			"domain":             domain,
+			"exclude_zone_count": fmt.Sprintf("%d", len(zones)),
+			"family":             "threat_insight",
+			"resource_id":        "threat_insight_config",
+			"resource_type":      "ThreatInsightConfiguration",
+		},
+	}, nil
+}
 
 // CanonicalThreatInsightMaterial returns the payload and immutable event ID
 // for the complete durable material of one threat configuration observation.

--- a/sources/internal/oktaasset/threat_insight.go
+++ b/sources/internal/oktaasset/threat_insight.go
@@ -16,7 +16,7 @@ func CanonicalThreatInsightMaterial(
 	zones []string,
 	occurredAt time.Time,
 ) ([]byte, string, error) {
-	canonicalZones := append([]string(nil), zones...)
+	canonicalZones := append([]string{}, zones...)
 	sort.Strings(canonicalZones)
 	payload, err := json.Marshal(map[string]any{
 		"domain":        domain,

--- a/sources/internal/oktaasset/threat_insight.go
+++ b/sources/internal/oktaasset/threat_insight.go
@@ -1,0 +1,61 @@
+package oktaasset
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// CanonicalThreatInsightMaterial returns the payload and immutable event ID
+// for the complete durable material of one threat configuration observation.
+func CanonicalThreatInsightMaterial(
+	domain string,
+	action string,
+	zones []string,
+	occurredAt time.Time,
+) ([]byte, string, error) {
+	canonicalZones := append([]string(nil), zones...)
+	sort.Strings(canonicalZones)
+	payload, err := json.Marshal(map[string]any{
+		"domain":        domain,
+		"action":        action,
+		"exclude_zones": canonicalZones,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	material, err := json.Marshal(struct {
+		TenantID            string          `json:"tenant_id"`
+		SourceID            string          `json:"source_id"`
+		Kind                string          `json:"kind"`
+		OccurredAtUnixMilli int64           `json:"occurred_at_unix_ms"`
+		SchemaRef           string          `json:"schema_ref"`
+		Payload             json.RawMessage `json:"payload"`
+		Action              string          `json:"attribute_action"`
+		Domain              string          `json:"attribute_domain"`
+		ExcludeZoneCount    int             `json:"attribute_exclude_zone_count"`
+		Family              string          `json:"attribute_family"`
+		ResourceID          string          `json:"attribute_resource_id"`
+		ResourceType        string          `json:"attribute_resource_type"`
+	}{
+		TenantID:            domain,
+		SourceID:            "okta",
+		Kind:                "okta.threat_insight",
+		OccurredAtUnixMilli: occurredAt.UnixMilli(),
+		SchemaRef:           "okta/threat_insight/v1",
+		Payload:             payload,
+		Action:              action,
+		Domain:              domain,
+		ExcludeZoneCount:    len(canonicalZones),
+		Family:              "threat_insight",
+		ResourceID:          "threat_insight_config",
+		ResourceType:        "ThreatInsightConfiguration",
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	digest := sha256.Sum256(material)
+	return payload, fmt.Sprintf("okta-threat-insight-sha256-%x", digest), nil
+}

--- a/sources/internal/oktaasset/threat_insight_test.go
+++ b/sources/internal/oktaasset/threat_insight_test.go
@@ -1,0 +1,15 @@
+package oktaasset
+
+import "testing"
+
+func TestThreatInsightOccurredAtFailsClosed(t *testing.T) {
+	for _, timestamps := range [][2]string{
+		{},
+		{"", "1970-01-01T00:00:00Z"},
+		{"invalid", "invalid"},
+	} {
+		if value, err := ThreatInsightOccurredAt(timestamps[0], timestamps[1]); err == nil {
+			t.Fatalf("ThreatInsightOccurredAt(%q, %q) = %v, want error", timestamps[0], timestamps[1], value)
+		}
+	}
+}

--- a/sources/okta/threat_insight.go
+++ b/sources/okta/threat_insight.go
@@ -3,9 +3,6 @@ package okta
 import (
 	"context"
 	"fmt"
-	"time"
-
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/primitives"
@@ -59,49 +56,11 @@ func (s *Source) threatInsightFamily() sourcecdk.Family[settings] {
 }
 
 func threatInsightEvent(settings settings, record threatInsightRecord) (*primitives.Event, error) {
-	occurredAt, err := threatInsightOccurredAt(record)
-	if err != nil {
-		return nil, err
-	}
-	payload, eventID, err := oktaasset.CanonicalThreatInsightMaterial(
+	return oktaasset.ThreatInsightEvent(
 		settings.domain,
 		record.Action,
 		record.ExcludeZones,
-		occurredAt,
+		record.LastUpdated,
+		record.Created,
 	)
-	if err != nil {
-		return nil, fmt.Errorf("marshal okta threat insight material: %w", err)
-	}
-	return &primitives.Event{
-		Id:         eventID,
-		TenantId:   settings.domain,
-		SourceId:   "okta",
-		Kind:       "okta.threat_insight",
-		OccurredAt: timestamppb.New(occurredAt),
-		SchemaRef:  "okta/threat_insight/v1",
-		Payload:    payload,
-		Attributes: map[string]string{
-			"action":             record.Action,
-			"domain":             settings.domain,
-			"exclude_zone_count": fmt.Sprintf("%d", len(record.ExcludeZones)),
-			"family":             familyThreatInsight,
-			"resource_id":        "threat_insight_config",
-			"resource_type":      "ThreatInsightConfiguration",
-		},
-	}, nil
-}
-
-func threatInsightOccurredAt(record threatInsightRecord) (time.Time, error) {
-	for _, value := range []*time.Time{
-		oktaasset.ParseTime(record.LastUpdated),
-		oktaasset.ParseTime(record.Created),
-	} {
-		if value != nil && !value.IsZero() {
-			normalized := time.UnixMilli(value.UnixMilli()).UTC()
-			if normalized.UnixMilli() > 0 {
-				return normalized, nil
-			}
-		}
-	}
-	return time.Time{}, fmt.Errorf("okta threat insight requires a positive created or lastUpdated timestamp")
 }

--- a/sources/okta/threat_insight.go
+++ b/sources/okta/threat_insight.go
@@ -2,8 +2,8 @@ package okta
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+	"time"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -44,31 +44,9 @@ func (s *Source) threatInsightFamily() sourcecdk.Family[settings] {
 			if err := s.getJSONWithRetry(ctx, settings, "/api/v1/threats/configuration", nil, &record, nil); err != nil {
 				return sourcecdk.Pull{}, wrapLookupError(oktaLabel("okta threat insight", settings), err)
 			}
-			occurredAt := firstRecordTime(oktaasset.ParseTime(record.LastUpdated), oktaasset.ParseTime(record.Created))
-			payload, err := json.Marshal(map[string]any{
-				"domain":        settings.domain,
-				"action":        record.Action,
-				"exclude_zones": record.ExcludeZones,
-			})
+			event, err := threatInsightEvent(settings, record)
 			if err != nil {
-				return sourcecdk.Pull{}, fmt.Errorf("marshal okta threat insight payload: %w", err)
-			}
-			event := &primitives.Event{
-				Id:         fmt.Sprintf("okta-threat-insight-%s-%d", settings.domain, occurredAt.UnixMilli()),
-				TenantId:   settings.domain,
-				SourceId:   "okta",
-				Kind:       "okta.threat_insight",
-				OccurredAt: timestamppb.New(occurredAt),
-				SchemaRef:  "okta/threat_insight/v1",
-				Payload:    payload,
-				Attributes: map[string]string{
-					"action":             record.Action,
-					"domain":             settings.domain,
-					"exclude_zone_count": fmt.Sprintf("%d", len(record.ExcludeZones)),
-					"family":             familyThreatInsight,
-					"resource_id":        "threat_insight_config",
-					"resource_type":      "ThreatInsightConfiguration",
-				},
+				return sourcecdk.Pull{}, err
 			}
 			return sourcecdk.Pull{
 				Events: []*primitives.Event{event},
@@ -78,4 +56,46 @@ func (s *Source) threatInsightFamily() sourcecdk.Family[settings] {
 			}, nil
 		},
 	}
+}
+
+func threatInsightEvent(settings settings, record threatInsightRecord) (*primitives.Event, error) {
+	occurredAt := threatInsightOccurredAt(record)
+	payload, eventID, err := oktaasset.CanonicalThreatInsightMaterial(
+		settings.domain,
+		record.Action,
+		record.ExcludeZones,
+		occurredAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("marshal okta threat insight material: %w", err)
+	}
+	return &primitives.Event{
+		Id:         eventID,
+		TenantId:   settings.domain,
+		SourceId:   "okta",
+		Kind:       "okta.threat_insight",
+		OccurredAt: timestamppb.New(occurredAt),
+		SchemaRef:  "okta/threat_insight/v1",
+		Payload:    payload,
+		Attributes: map[string]string{
+			"action":             record.Action,
+			"domain":             settings.domain,
+			"exclude_zone_count": fmt.Sprintf("%d", len(record.ExcludeZones)),
+			"family":             familyThreatInsight,
+			"resource_id":        "threat_insight_config",
+			"resource_type":      "ThreatInsightConfiguration",
+		},
+	}, nil
+}
+
+func threatInsightOccurredAt(record threatInsightRecord) time.Time {
+	for _, value := range []*time.Time{
+		oktaasset.ParseTime(record.LastUpdated),
+		oktaasset.ParseTime(record.Created),
+	} {
+		if value != nil && !value.IsZero() {
+			return time.UnixMilli(value.UnixMilli()).UTC()
+		}
+	}
+	return time.Unix(0, 0).UTC()
 }

--- a/sources/okta/threat_insight.go
+++ b/sources/okta/threat_insight.go
@@ -59,7 +59,10 @@ func (s *Source) threatInsightFamily() sourcecdk.Family[settings] {
 }
 
 func threatInsightEvent(settings settings, record threatInsightRecord) (*primitives.Event, error) {
-	occurredAt := threatInsightOccurredAt(record)
+	occurredAt, err := threatInsightOccurredAt(record)
+	if err != nil {
+		return nil, err
+	}
 	payload, eventID, err := oktaasset.CanonicalThreatInsightMaterial(
 		settings.domain,
 		record.Action,
@@ -88,14 +91,17 @@ func threatInsightEvent(settings settings, record threatInsightRecord) (*primiti
 	}, nil
 }
 
-func threatInsightOccurredAt(record threatInsightRecord) time.Time {
+func threatInsightOccurredAt(record threatInsightRecord) (time.Time, error) {
 	for _, value := range []*time.Time{
 		oktaasset.ParseTime(record.LastUpdated),
 		oktaasset.ParseTime(record.Created),
 	} {
 		if value != nil && !value.IsZero() {
-			return time.UnixMilli(value.UnixMilli()).UTC()
+			normalized := time.UnixMilli(value.UnixMilli()).UTC()
+			if normalized.UnixMilli() > 0 {
+				return normalized, nil
+			}
 		}
 	}
-	return time.Unix(0, 0).UTC()
+	return time.Time{}, fmt.Errorf("okta threat insight requires a positive created or lastUpdated timestamp")
 }

--- a/sources/okta/threat_insight_test.go
+++ b/sources/okta/threat_insight_test.go
@@ -1,0 +1,78 @@
+package okta
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestThreatInsightEventIdentityBindsCompleteDurableMaterial(t *testing.T) {
+	settings := settings{domain: "example.okta.test"}
+	base := threatInsightRecord{
+		Action:       "block",
+		ExcludeZones: []string{"zone-b", "zone-a"},
+		Created:      "2026-08-12T00:00:00Z",
+		LastUpdated:  "2026-08-12T01:00:00.123456Z",
+	}
+	first, err := threatInsightEvent(settings, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	same, err := threatInsightEvent(settings, threatInsightRecord{
+		Action:       base.Action,
+		ExcludeZones: []string{"zone-a", "zone-b"},
+		Created:      base.Created,
+		LastUpdated:  base.LastUpdated,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	changedTime, err := threatInsightEvent(settings, threatInsightRecord{
+		Action:       base.Action,
+		ExcludeZones: base.ExcludeZones,
+		Created:      base.Created,
+		LastUpdated:  "2026-08-13T01:00:00.123456Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	changedAction, err := threatInsightEvent(settings, threatInsightRecord{
+		Action:       "none",
+		ExcludeZones: base.ExcludeZones,
+		Created:      base.Created,
+		LastUpdated:  base.LastUpdated,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if first.Id != same.Id || !bytes.Equal(first.Payload, same.Payload) || first.OccurredAt.AsTime() != same.OccurredAt.AsTime() {
+		t.Fatalf("identical durable material was not idempotent: first=%#v same=%#v", first, same)
+	}
+	if first.Id == changedTime.Id {
+		t.Fatalf("changed occurred_at reused immutable event ID %q", first.Id)
+	}
+	if first.Id == changedAction.Id {
+		t.Fatalf("changed payload reused immutable event ID %q", first.Id)
+	}
+	if first.Attributes["resource_id"] != changedAction.Attributes["resource_id"] {
+		t.Fatalf("stable entity identity changed: %#v != %#v", first.Attributes, changedAction.Attributes)
+	}
+	if got := first.OccurredAt.AsTime().Nanosecond(); got%1_000_000 != 0 {
+		t.Fatalf("occurred_at nanoseconds = %d, want millisecond normalization", got)
+	}
+}
+
+func TestThreatInsightEventMissingTimestampsIsDeterministic(t *testing.T) {
+	settings := settings{domain: "example.okta.test"}
+	first, err := threatInsightEvent(settings, threatInsightRecord{Action: "block"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := threatInsightEvent(settings, threatInsightRecord{Action: "block"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Id != second.Id || first.OccurredAt.AsTime() != second.OccurredAt.AsTime() {
+		t.Fatalf("missing timestamp fallback is not idempotent: first=%#v second=%#v", first, second)
+	}
+}

--- a/sources/okta/threat_insight_test.go
+++ b/sources/okta/threat_insight_test.go
@@ -62,17 +62,15 @@ func TestThreatInsightEventIdentityBindsCompleteDurableMaterial(t *testing.T) {
 	}
 }
 
-func TestThreatInsightEventMissingTimestampsIsDeterministic(t *testing.T) {
+func TestThreatInsightEventMissingTimestampsFailsClosed(t *testing.T) {
 	settings := settings{domain: "example.okta.test"}
-	first, err := threatInsightEvent(settings, threatInsightRecord{Action: "block"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	second, err := threatInsightEvent(settings, threatInsightRecord{Action: "block"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if first.Id != second.Id || first.OccurredAt.AsTime() != second.OccurredAt.AsTime() {
-		t.Fatalf("missing timestamp fallback is not idempotent: first=%#v second=%#v", first, second)
+	for _, record := range []threatInsightRecord{
+		{Action: "block"},
+		{Action: "block", Created: "1970-01-01T00:00:00Z"},
+		{Action: "block", LastUpdated: "invalid", Created: "invalid"},
+	} {
+		if event, err := threatInsightEvent(settings, record); err == nil {
+			t.Fatalf("threatInsightEvent(%#v) = %#v, want timestamp error", record, event)
+		}
 	}
 }

--- a/sources/okta/threat_insight_test.go
+++ b/sources/okta/threat_insight_test.go
@@ -3,6 +3,8 @@ package okta
 import (
 	"bytes"
 	"testing"
+
+	"github.com/writer/cerebro/internal/primitives"
 )
 
 func TestThreatInsightEventIdentityBindsCompleteDurableMaterial(t *testing.T) {
@@ -13,37 +15,25 @@ func TestThreatInsightEventIdentityBindsCompleteDurableMaterial(t *testing.T) {
 		Created:      "2026-08-12T00:00:00Z",
 		LastUpdated:  "2026-08-12T01:00:00.123456Z",
 	}
-	first, err := threatInsightEvent(settings, base)
-	if err != nil {
-		t.Fatal(err)
-	}
-	same, err := threatInsightEvent(settings, threatInsightRecord{
+	first := mustThreatInsightEvent(t, settings, base)
+	same := mustThreatInsightEvent(t, settings, threatInsightRecord{
 		Action:       base.Action,
 		ExcludeZones: []string{"zone-a", "zone-b"},
 		Created:      base.Created,
 		LastUpdated:  base.LastUpdated,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	changedTime, err := threatInsightEvent(settings, threatInsightRecord{
+	changedTime := mustThreatInsightEvent(t, settings, threatInsightRecord{
 		Action:       base.Action,
 		ExcludeZones: base.ExcludeZones,
 		Created:      base.Created,
 		LastUpdated:  "2026-08-13T01:00:00.123456Z",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	changedAction, err := threatInsightEvent(settings, threatInsightRecord{
+	changedAction := mustThreatInsightEvent(t, settings, threatInsightRecord{
 		Action:       "none",
 		ExcludeZones: base.ExcludeZones,
 		Created:      base.Created,
 		LastUpdated:  base.LastUpdated,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	if first.Id != same.Id || !bytes.Equal(first.Payload, same.Payload) || first.OccurredAt.AsTime() != same.OccurredAt.AsTime() {
 		t.Fatalf("identical durable material was not idempotent: first=%#v same=%#v", first, same)
@@ -62,15 +52,11 @@ func TestThreatInsightEventIdentityBindsCompleteDurableMaterial(t *testing.T) {
 	}
 }
 
-func TestThreatInsightEventMissingTimestampsFailsClosed(t *testing.T) {
-	settings := settings{domain: "example.okta.test"}
-	for _, record := range []threatInsightRecord{
-		{Action: "block"},
-		{Action: "block", Created: "1970-01-01T00:00:00Z"},
-		{Action: "block", LastUpdated: "invalid", Created: "invalid"},
-	} {
-		if event, err := threatInsightEvent(settings, record); err == nil {
-			t.Fatalf("threatInsightEvent(%#v) = %#v, want timestamp error", record, event)
-		}
+func mustThreatInsightEvent(t *testing.T, settings settings, record threatInsightRecord) *primitives.Event {
+	t.Helper()
+	event, err := threatInsightEvent(settings, record)
+	if err != nil {
+		t.Fatal(err)
 	}
+	return event
 }

--- a/tools/archtests/source_packages_test.go
+++ b/tools/archtests/source_packages_test.go
@@ -36,7 +36,7 @@ var grandfatheredSourcePackageLOCBudgets = map[string]int{
 	"github":          2009,
 	"googleworkspace": 814,
 	"grc":             1195,
-	"okta":            2254,
+	"okta":            2239,
 	"panopticon":      763,
 	"sentinelone":     2096,
 	"vulnview":        1002,


### PR DESCRIPTION
## Summary

- bind Okta ThreatInsight event identity to complete durable material while preserving the stable resource identity
- exclude only runtime and collection delivery provenance from the immutable append-log record digest
- normalize threat timestamps to milliseconds and fail closed when Okta provides no positive timestamp
- skip invalid high-priority application labels and continue to the first valid candidate

## Validation

- `go test ./sources/okta ./internal/sourceruntime`
- direct `rustfmt --edition 2024 --check crates/source-runtime-next/src/append_log.rs crates/source-runtime-next/src/mapper.rs`
- `git diff --check`

## Evidence gate

This draft is a hosted Rust execution evidence lane. Local Rust tests are unexecuted: the Cargo wrapper stopped before compilation because safe build capacity was short by 16,263,543,398 bytes, and the DDESK stream returned `invalid repository streaming state`.

Invalid-ObservationId handling is intentionally unchanged. This PR must remain draft until independent exact-head review passes and the exact-head hosted matrix is terminal green. No Forward compatibility, authority, canary, or deployment behavior is changed here.
