### PR TITLE
fix: persist categorized replay skip counters

### DIFF
--- a/crates/cerebro-platform/src/append_log_consumer.rs
+++ b/crates/cerebro-platform/src/append_log_consumer.rs
@@ -514,7 +514,9 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
                 &runtime,
                 &config,
                 stream_sequence,
-                ConsumerMessageOutcome::Skipped(ConsumerSkipCategory::LegacyRetiredFamily),
+                ConsumerMessageOutcome::Skipped(
+                    ConsumerSkipCategory::SubjectOutsideProjectionContract,
+                ),
                 None,
                 None,
                 &mut counters,
@@ -546,7 +548,9 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
                     &runtime,
                     &config,
                     stream_sequence,
-                    ConsumerMessageOutcome::Skipped(ConsumerSkipCategory::LegacyRetiredFamily),
+                    ConsumerMessageOutcome::Skipped(
+                        ConsumerSkipCategory::SourceOutsideCompiledCatalog,
+                    ),
                     Some((subject_source, subject_family)),
                     None,
                     &mut counters,
@@ -1063,12 +1067,11 @@ fn validate_receipt_skip_categories(
     messages_skipped: u64,
     categories: &BTreeMap<String, u64>,
 ) -> Result<(), Box<dyn Error>> {
-    if categories.len() > 3
+    if categories.len() > ConsumerSkipCategory::ALL.len()
         || categories.keys().any(|category| {
-            !matches!(
-                category.as_str(),
-                "legacy_retired_family" | "legacy_invalid_observation_id" | "legacy_canary"
-            )
+            !ConsumerSkipCategory::ALL
+                .iter()
+                .any(|known| known.as_str() == category)
         })
         || categories.values().any(|count| *count == 0)
         || categories
@@ -1297,9 +1300,12 @@ fn projection_skip_category(_reason: &str) -> &'static str {
 fn skip_category(reason: &str) -> ConsumerSkipCategory {
     match reason {
         "legacy_invalid_observation_id" => ConsumerSkipCategory::LegacyInvalidObservationId,
-        "legacy_catalog_canary_without_source_envelope" => ConsumerSkipCategory::LegacyCanary,
-        "legacy_missing_source_owned_kind" | "legacy_retired_family_projection_incompatible" => {
-            ConsumerSkipCategory::LegacyRetiredFamily
+        "legacy_catalog_canary_without_source_envelope" => {
+            ConsumerSkipCategory::LegacyCatalogCanaryWithoutSourceEnvelope
+        }
+        "legacy_missing_source_owned_kind" => ConsumerSkipCategory::LegacyMissingSourceOwnedKind,
+        "legacy_retired_family_projection_incompatible" => {
+            ConsumerSkipCategory::LegacyRetiredFamilyProjectionIncompatible
         }
         _ => unreachable!("closed legacy skip reason"),
     }
@@ -1729,7 +1735,7 @@ mod tests {
         }
         assert_eq!(
             skip_category("legacy_missing_source_owned_kind"),
-            ConsumerSkipCategory::LegacyRetiredFamily
+            ConsumerSkipCategory::LegacyMissingSourceOwnedKind
         );
         assert_eq!(
             skip_category("legacy_invalid_observation_id"),
@@ -1737,11 +1743,11 @@ mod tests {
         );
         assert_eq!(
             skip_category("legacy_catalog_canary_without_source_envelope"),
-            ConsumerSkipCategory::LegacyCanary
+            ConsumerSkipCategory::LegacyCatalogCanaryWithoutSourceEnvelope
         );
         assert_eq!(
             skip_category("legacy_retired_family_projection_incompatible"),
-            ConsumerSkipCategory::LegacyRetiredFamily
+            ConsumerSkipCategory::LegacyRetiredFamilyProjectionIncompatible
         );
     }
 
@@ -2010,7 +2016,7 @@ mod tests {
         };
         let skip_categories = BTreeMap::from([
             ("legacy_invalid_observation_id".to_owned(), 1),
-            ("legacy_retired_family".to_owned(), 1),
+            ("legacy_missing_source_owned_kind".to_owned(), 1),
         ]);
         let receipt = ConsumerReceipt {
             schema_version: "cerebro.organizational-consumer-run/v1",
@@ -2038,7 +2044,7 @@ mod tests {
             value["skip_categories"],
             serde_json::json!({
                 "legacy_invalid_observation_id": 1,
-                "legacy_retired_family": 1,
+                "legacy_missing_source_owned_kind": 1,
             })
         );
     }
@@ -2047,14 +2053,29 @@ mod tests {
     fn run_receipt_skip_categories_fail_closed() {
         let cases = [
             (2, BTreeMap::new()),
-            (2, BTreeMap::from([("legacy_canary".to_owned(), 1)])),
+            (
+                2,
+                BTreeMap::from([(
+                    "legacy_catalog_canary_without_source_envelope".to_owned(),
+                    1,
+                )]),
+            ),
             (1, BTreeMap::from([("unknown".to_owned(), 1)])),
             (
                 4,
                 BTreeMap::from([
-                    ("legacy_canary".to_owned(), 1),
+                    (
+                        "legacy_catalog_canary_without_source_envelope".to_owned(),
+                        1,
+                    ),
                     ("legacy_invalid_observation_id".to_owned(), 1),
-                    ("legacy_retired_family".to_owned(), 1),
+                    ("legacy_missing_source_owned_kind".to_owned(), 1),
+                    (
+                        "legacy_retired_family_projection_incompatible".to_owned(),
+                        1,
+                    ),
+                    ("source_outside_compiled_catalog".to_owned(), 1),
+                    ("subject_outside_projection_contract".to_owned(), 1),
                     ("unknown".to_owned(), 1),
                 ]),
             ),
@@ -2192,7 +2213,7 @@ mod tests {
     fn checkpoint_is_only_eligible_after_a_recognized_projection() {
         assert!(checkpoint_eligible(ConsumerMessageOutcome::Projected));
         assert!(!checkpoint_eligible(ConsumerMessageOutcome::Skipped(
-            ConsumerSkipCategory::LegacyRetiredFamily,
+            ConsumerSkipCategory::LegacyMissingSourceOwnedKind,
         )));
         assert!(!checkpoint_eligible(ConsumerMessageOutcome::Rejected));
         let raw = b"projected append-log bytes";

--- a/crates/cerebro-platform/src/append_log_consumer.rs
+++ b/crates/cerebro-platform/src/append_log_consumer.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     env,
     error::Error,
     io,
@@ -10,7 +11,9 @@ use async_nats::jetstream::{
     AckKind,
     consumer::{AckPolicy, DeliverPolicy, pull},
 };
-use cerebro_organizational_store::{ConsumerMessageOutcome, ConsumerRunProgress, PostgresLedger};
+use cerebro_organizational_store::{
+    ConsumerMessageOutcome, ConsumerRunReceiptState, ConsumerSkipCategory, PostgresLedger,
+};
 use cerebro_source_runtime_next::{AppendLogDecodeError, CommittedSourceEvent};
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -386,9 +389,10 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
     let start_sequence = stored_fence.start_sequence;
     let end_sequence = stored_fence.end_sequence;
     let mut counters = ConsumerCounters::default();
-    let persisted = load_counters(&runtime, &config).await?;
+    let persisted = load_receipt_state(&runtime, &config).await?;
+    let persisted_counters = ConsumerCounters::from(&persisted);
     let next_unprocessed =
-        next_unprocessed_sequence(start_sequence, persisted.last_delivered_sequence);
+        next_unprocessed_sequence(start_sequence, persisted_counters.last_delivered_sequence);
     if retention_gap(stream_state.first_sequence, next_unprocessed, end_sequence) {
         runtime
             .authority
@@ -405,8 +409,9 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
         &config,
         start_sequence,
         end_sequence,
-        persisted.covered_sequence,
-        &persisted,
+        persisted_counters.covered_sequence,
+        &persisted_counters,
+        &persisted.skip_categories,
         None,
     )?;
     let expected = config.pull_config();
@@ -446,14 +451,16 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
                 .authority
                 .finish_consumer_run(&config.durable_name, &config.run_id, "stopped", None)
                 .await?;
-            let persisted = load_counters(&runtime, &config).await?;
+            let persisted = load_receipt_state(&runtime, &config).await?;
+            let persisted_counters = ConsumerCounters::from(&persisted);
             emit_receipt(
                 "stopped",
                 &config,
                 start_sequence,
                 end_sequence,
-                persisted.covered_sequence,
-                &persisted,
+                persisted_counters.covered_sequence,
+                &persisted_counters,
+                &persisted.skip_categories,
                 None,
             )?;
             return Ok(());
@@ -465,14 +472,16 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
                     .authority
                     .finish_consumer_run(&config.durable_name, &config.run_id, "stopped", None)
                     .await?;
-                let persisted = load_counters(&runtime, &config).await?;
+                let persisted = load_receipt_state(&runtime, &config).await?;
+                let persisted_counters = ConsumerCounters::from(&persisted);
                 emit_receipt(
                     "stopped",
                     &config,
                     start_sequence,
                     end_sequence,
-                    persisted.covered_sequence,
-                    &persisted,
+                    persisted_counters.covered_sequence,
+                    &persisted_counters,
+                    &persisted.skip_categories,
                     None,
                 )?;
                 return Ok(());
@@ -508,7 +517,7 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
                 &runtime,
                 &config,
                 stream_sequence,
-                ConsumerMessageOutcome::Skipped,
+                ConsumerMessageOutcome::Skipped(ConsumerSkipCategory::LegacyRetiredFamily),
                 None,
                 None,
                 &mut counters,
@@ -540,7 +549,7 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
                     &runtime,
                     &config,
                     stream_sequence,
-                    ConsumerMessageOutcome::Skipped,
+                    ConsumerMessageOutcome::Skipped(ConsumerSkipCategory::LegacyRetiredFamily),
                     Some((subject_source, subject_family)),
                     None,
                     &mut counters,
@@ -567,7 +576,7 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
                         &runtime,
                         &config,
                         stream_sequence,
-                        ConsumerMessageOutcome::Skipped,
+                        ConsumerMessageOutcome::Skipped(skip_category(reason)),
                         Some((subject_source, subject_family)),
                         None,
                         &mut counters,
@@ -637,11 +646,10 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
         let record_digest = event.record_digest();
         match runtime.project_committed_shadow(event).await {
             Ok(response) => {
-                let outcome = if response.projected {
-                    ConsumerMessageOutcome::Projected
-                } else {
-                    ConsumerMessageOutcome::Skipped
-                };
+                if !response.projected {
+                    return Err("recognized append-log event was not projected".into());
+                }
+                let outcome = ConsumerMessageOutcome::Projected;
                 record_progress(
                     &runtime,
                     &config,
@@ -686,7 +694,7 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
                             &runtime,
                             &config,
                             stream_sequence,
-                            ConsumerMessageOutcome::Skipped,
+                            ConsumerMessageOutcome::Skipped(skip_category(reason)),
                             Some((&event_source, &event_family)),
                             None,
                             &mut counters,
@@ -848,28 +856,27 @@ struct ConsumerCounters {
     messages_rejected: u64,
 }
 
-impl From<ConsumerRunProgress> for ConsumerCounters {
-    fn from(value: ConsumerRunProgress) -> Self {
+impl From<&ConsumerRunReceiptState> for ConsumerCounters {
+    fn from(value: &ConsumerRunReceiptState) -> Self {
         Self {
-            last_delivered_sequence: value.last_delivered_sequence,
-            covered_sequence: value.covered_sequence,
-            messages_seen: value.messages_seen,
-            messages_projected: value.messages_projected,
-            messages_skipped: value.messages_skipped,
-            messages_rejected: value.messages_rejected,
+            last_delivered_sequence: value.progress.last_delivered_sequence,
+            covered_sequence: value.progress.covered_sequence,
+            messages_seen: value.progress.messages_seen,
+            messages_projected: value.progress.messages_projected,
+            messages_skipped: value.progress.messages_skipped,
+            messages_rejected: value.progress.messages_rejected,
         }
     }
 }
 
-async fn load_counters(
+async fn load_receipt_state(
     runtime: &ProjectionRuntime,
     config: &ConsumerConfig,
-) -> Result<ConsumerCounters, Box<dyn Error>> {
+) -> Result<ConsumerRunReceiptState, Box<dyn Error>> {
     Ok(runtime
         .authority
-        .consumer_run_progress(&config.durable_name, &config.run_id)
-        .await?
-        .into())
+        .consumer_run_receipt_state(&config.durable_name, &config.run_id)
+        .await?)
 }
 
 async fn record_progress(
@@ -897,7 +904,7 @@ async fn record_progress(
     counters.messages_seen += 1;
     match outcome {
         ConsumerMessageOutcome::Projected => counters.messages_projected += 1,
-        ConsumerMessageOutcome::Skipped => counters.messages_skipped += 1,
+        ConsumerMessageOutcome::Skipped(_) => counters.messages_skipped += 1,
         ConsumerMessageOutcome::Rejected => counters.messages_rejected += 1,
     }
     Ok(())
@@ -920,12 +927,13 @@ async fn finish_replay(
     end_sequence: u64,
     _counters: &ConsumerCounters,
 ) -> Result<(), Box<dyn Error>> {
-    let persisted_before_finish = load_counters(runtime, config).await?;
-    if persisted_before_finish.last_delivered_sequence < end_sequence {
+    let persisted_before_finish = load_receipt_state(runtime, config).await?;
+    let persisted_before_finish_counters = ConsumerCounters::from(&persisted_before_finish);
+    if persisted_before_finish_counters.last_delivered_sequence < end_sequence {
         let first_retained_sequence = current_first_sequence(config).await?;
         let next_unprocessed = next_unprocessed_sequence(
             start_sequence,
-            persisted_before_finish.last_delivered_sequence,
+            persisted_before_finish_counters.last_delivered_sequence,
         );
         if retention_gap(
             first_retained_sequence,
@@ -941,8 +949,9 @@ async fn finish_replay(
                 config,
                 start_sequence,
                 Some(end_sequence),
-                persisted_before_finish.covered_sequence,
-                &persisted_before_finish,
+                persisted_before_finish_counters.covered_sequence,
+                &persisted_before_finish_counters,
+                &persisted_before_finish.skip_categories,
                 Some("retention_gap"),
             )?;
             return Err(format!(
@@ -951,13 +960,14 @@ async fn finish_replay(
             .into());
         }
     }
-    let completion_basis = if persisted_before_finish.last_delivered_sequence >= end_sequence {
-        "delivered_end_sequence"
-    } else {
-        "zero_eligible_pending"
-    };
-    let status = if persisted_before_finish.messages_rejected == 0
-        && persisted_before_finish.messages_projected > 0
+    let completion_basis =
+        if persisted_before_finish_counters.last_delivered_sequence >= end_sequence {
+            "delivered_end_sequence"
+        } else {
+            "zero_eligible_pending"
+        };
+    let status = if persisted_before_finish_counters.messages_rejected == 0
+        && persisted_before_finish_counters.messages_projected > 0
     {
         "completed"
     } else {
@@ -972,7 +982,8 @@ async fn finish_replay(
             (status == "completed").then_some(end_sequence),
         )
         .await?;
-    let persisted = load_counters(runtime, config).await?;
+    let persisted = load_receipt_state(runtime, config).await?;
+    let persisted_counters = ConsumerCounters::from(&persisted);
     emit_receipt(
         status,
         config,
@@ -981,9 +992,10 @@ async fn finish_replay(
         if status == "completed" {
             end_sequence
         } else {
-            persisted.covered_sequence
+            persisted_counters.covered_sequence
         },
-        &persisted,
+        &persisted_counters,
+        &persisted.skip_categories,
         Some(completion_basis),
     )?;
     if status == "completed" {
@@ -1015,6 +1027,7 @@ struct ConsumerReceipt<'a> {
     last_delivered_sequence: u64,
     completion_basis: Option<&'a str>,
     counters: &'a ConsumerCounters,
+    skip_categories: &'a BTreeMap<String, u64>,
 }
 
 fn emit_receipt(
@@ -1024,8 +1037,10 @@ fn emit_receipt(
     end_sequence: Option<u64>,
     covered_sequence: u64,
     counters: &ConsumerCounters,
+    skip_categories: &BTreeMap<String, u64>,
     completion_basis: Option<&str>,
 ) -> Result<(), Box<dyn Error>> {
+    validate_receipt_skip_categories(counters.messages_skipped, skip_categories)?;
     println!(
         "{}",
         serde_json::to_string(&ConsumerReceipt {
@@ -1042,8 +1057,31 @@ fn emit_receipt(
             last_delivered_sequence: counters.last_delivered_sequence,
             completion_basis,
             counters,
+            skip_categories,
         })?
     );
+    Ok(())
+}
+
+fn validate_receipt_skip_categories(
+    messages_skipped: u64,
+    categories: &BTreeMap<String, u64>,
+) -> Result<(), Box<dyn Error>> {
+    if categories.len() > 3
+        || categories.keys().any(|category| {
+            !matches!(
+                category.as_str(),
+                "legacy_retired_family" | "legacy_invalid_observation_id" | "legacy_canary"
+            )
+        })
+        || categories.values().any(|count| *count == 0)
+        || categories
+            .values()
+            .try_fold(0_u64, |total, count| total.checked_add(*count))
+            != Some(messages_skipped)
+    {
+        return Err("consumer skip categories do not match messages_skipped".into());
+    }
     Ok(())
 }
 
@@ -1258,6 +1296,17 @@ fn decode_skip_category(reason: &str) -> &'static str {
 
 fn projection_skip_category(_reason: &str) -> &'static str {
     "unsupported_legacy_record"
+}
+
+fn skip_category(reason: &str) -> ConsumerSkipCategory {
+    match reason {
+        "legacy_invalid_observation_id" => ConsumerSkipCategory::LegacyInvalidObservationId,
+        "legacy_catalog_canary_without_source_envelope" => ConsumerSkipCategory::LegacyCanary,
+        "legacy_missing_source_owned_kind" | "legacy_retired_family_projection_incompatible" => {
+            ConsumerSkipCategory::LegacyRetiredFamily
+        }
+        _ => unreachable!("closed legacy skip reason"),
+    }
 }
 
 fn decode_error_category(error: &EventDecodeError) -> Option<&'static str> {
@@ -1682,6 +1731,22 @@ mod tests {
                 forward_reason
             );
         }
+        assert_eq!(
+            skip_category("legacy_missing_source_owned_kind"),
+            ConsumerSkipCategory::LegacyRetiredFamily
+        );
+        assert_eq!(
+            skip_category("legacy_invalid_observation_id"),
+            ConsumerSkipCategory::LegacyInvalidObservationId
+        );
+        assert_eq!(
+            skip_category("legacy_catalog_canary_without_source_envelope"),
+            ConsumerSkipCategory::LegacyCanary
+        );
+        assert_eq!(
+            skip_category("legacy_retired_family_projection_incompatible"),
+            ConsumerSkipCategory::LegacyRetiredFamily
+        );
     }
 
     #[test]
@@ -1947,6 +2012,10 @@ mod tests {
             messages_skipped: 2,
             messages_rejected: 0,
         };
+        let skip_categories = BTreeMap::from([
+            ("legacy_invalid_observation_id".to_owned(), 1),
+            ("legacy_retired_family".to_owned(), 1),
+        ]);
         let receipt = ConsumerReceipt {
             schema_version: "cerebro.organizational-consumer-run/v1",
             status: "completed",
@@ -1961,6 +2030,7 @@ mod tests {
             last_delivered_sequence: 41,
             completion_basis: Some("zero_eligible_pending"),
             counters: &counters,
+            skip_categories: &skip_categories,
         };
         let value = serde_json::to_value(receipt).unwrap();
         assert_eq!(value["status"], "completed");
@@ -1968,6 +2038,38 @@ mod tests {
         assert_eq!(value["covered_sequence"], 50);
         assert_eq!(value["counters"]["messages_skipped"], 2);
         assert_eq!(value["counters"]["messages_rejected"], 0);
+        assert_eq!(
+            value["skip_categories"],
+            serde_json::json!({
+                "legacy_invalid_observation_id": 1,
+                "legacy_retired_family": 1,
+            })
+        );
+    }
+
+    #[test]
+    fn run_receipt_skip_categories_fail_closed() {
+        let cases = [
+            (2, BTreeMap::new()),
+            (2, BTreeMap::from([("legacy_canary".to_owned(), 1)])),
+            (1, BTreeMap::from([("unknown".to_owned(), 1)])),
+            (
+                4,
+                BTreeMap::from([
+                    ("legacy_canary".to_owned(), 1),
+                    ("legacy_invalid_observation_id".to_owned(), 1),
+                    ("legacy_retired_family".to_owned(), 1),
+                    ("unknown".to_owned(), 1),
+                ]),
+            ),
+        ];
+        for (messages_skipped, categories) in cases {
+            assert!(
+                validate_receipt_skip_categories(messages_skipped, &categories).is_err(),
+                "unexpected categories {categories:?}"
+            );
+        }
+        assert!(validate_receipt_skip_categories(0, &BTreeMap::new()).is_ok());
     }
 
     #[test]
@@ -2093,7 +2195,9 @@ mod tests {
     #[test]
     fn checkpoint_is_only_eligible_after_a_recognized_projection() {
         assert!(checkpoint_eligible(ConsumerMessageOutcome::Projected));
-        assert!(!checkpoint_eligible(ConsumerMessageOutcome::Skipped));
+        assert!(!checkpoint_eligible(ConsumerMessageOutcome::Skipped(
+            ConsumerSkipCategory::LegacyRetiredFamily,
+        )));
         assert!(!checkpoint_eligible(ConsumerMessageOutcome::Rejected));
         let raw = b"projected append-log bytes";
         let actual = digest_bytes(raw);

--- a/crates/cerebro-platform/src/append_log_consumer.rs
+++ b/crates/cerebro-platform/src/append_log_consumer.rs
@@ -410,8 +410,7 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
         start_sequence,
         end_sequence,
         persisted_counters.covered_sequence,
-        &persisted_counters,
-        &persisted.skip_categories,
+        &persisted,
         None,
     )?;
     let expected = config.pull_config();
@@ -459,8 +458,7 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
                 start_sequence,
                 end_sequence,
                 persisted_counters.covered_sequence,
-                &persisted_counters,
-                &persisted.skip_categories,
+                &persisted,
                 None,
             )?;
             return Ok(());
@@ -480,8 +478,7 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
                     start_sequence,
                     end_sequence,
                     persisted_counters.covered_sequence,
-                    &persisted_counters,
-                    &persisted.skip_categories,
+                    &persisted,
                     None,
                 )?;
                 return Ok(());
@@ -950,8 +947,7 @@ async fn finish_replay(
                 start_sequence,
                 Some(end_sequence),
                 persisted_before_finish_counters.covered_sequence,
-                &persisted_before_finish_counters,
-                &persisted_before_finish.skip_categories,
+                &persisted_before_finish,
                 Some("retention_gap"),
             )?;
             return Err(format!(
@@ -994,8 +990,7 @@ async fn finish_replay(
         } else {
             persisted_counters.covered_sequence
         },
-        &persisted_counters,
-        &persisted.skip_categories,
+        &persisted,
         Some(completion_basis),
     )?;
     if status == "completed" {
@@ -1036,10 +1031,11 @@ fn emit_receipt(
     start_sequence: u64,
     end_sequence: Option<u64>,
     covered_sequence: u64,
-    counters: &ConsumerCounters,
-    skip_categories: &BTreeMap<String, u64>,
+    state: &ConsumerRunReceiptState,
     completion_basis: Option<&str>,
 ) -> Result<(), Box<dyn Error>> {
+    let counters = ConsumerCounters::from(state);
+    let skip_categories = &state.skip_categories;
     validate_receipt_skip_categories(counters.messages_skipped, skip_categories)?;
     println!(
         "{}",
@@ -1056,7 +1052,7 @@ fn emit_receipt(
             covered_sequence,
             last_delivered_sequence: counters.last_delivered_sequence,
             completion_basis,
-            counters,
+            counters: &counters,
             skip_categories,
         })?
     );

--- a/crates/organizational-store/src/lib.rs
+++ b/crates/organizational-store/src/lib.rs
@@ -49,9 +49,9 @@ pub use parity::{
 };
 pub use postgres::{
     ConsumerFamilyProgress, ConsumerMessageOutcome, ConsumerRunFence, ConsumerRunInspection,
-    ConsumerRunProgress, LegacyProjectionReceipt, POSTGRES_SCHEMA, PostgresLedger,
-    SourceCollectionReceipt, SourceEventReceipt, SourceRuntimeCollectionObservation,
-    SourceRuntimeObservation, StoredSourceRuntime,
+    ConsumerRunProgress, ConsumerRunReceiptState, ConsumerSkipCategory, LegacyProjectionReceipt,
+    POSTGRES_SCHEMA, PostgresLedger, SourceCollectionReceipt, SourceEventReceipt,
+    SourceRuntimeCollectionObservation, SourceRuntimeObservation, StoredSourceRuntime,
 };
 
 use std::{error::Error, fmt};

--- a/crates/organizational-store/src/postgres.rs
+++ b/crates/organizational-store/src/postgres.rs
@@ -330,6 +330,21 @@ CREATE TABLE IF NOT EXISTS organizational_consumer_family_progress (
     REFERENCES organizational_consumer_runs (consumer_name, run_id)
     ON DELETE CASCADE
 );
+CREATE TABLE IF NOT EXISTS organizational_consumer_skip_categories (
+  consumer_name TEXT NOT NULL,
+  run_id TEXT NOT NULL,
+  category TEXT NOT NULL CHECK (category IN (
+    'legacy_retired_family',
+    'legacy_invalid_observation_id',
+    'legacy_canary'
+  )),
+  messages_skipped BIGINT NOT NULL DEFAULT 0 CHECK (messages_skipped > 0),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (consumer_name, run_id, category),
+  FOREIGN KEY (consumer_name, run_id)
+    REFERENCES organizational_consumer_runs (consumer_name, run_id)
+    ON DELETE CASCADE
+);
 CREATE INDEX IF NOT EXISTS organizational_projection_pending_idx
   ON organizational_projection_outbox (graph_revision)
   WHERE projected_at IS NULL;
@@ -621,8 +636,77 @@ pub struct SourceEventReceipt {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ConsumerMessageOutcome {
     Projected,
-    Skipped,
+    Skipped(ConsumerSkipCategory),
     Rejected,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsumerSkipCategory {
+    LegacyRetiredFamily,
+    LegacyInvalidObservationId,
+    LegacyCanary,
+}
+
+impl ConsumerSkipCategory {
+    const ALL: [Self; 3] = [
+        Self::LegacyRetiredFamily,
+        Self::LegacyInvalidObservationId,
+        Self::LegacyCanary,
+    ];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LegacyRetiredFamily => "legacy_retired_family",
+            Self::LegacyInvalidObservationId => "legacy_invalid_observation_id",
+            Self::LegacyCanary => "legacy_canary",
+        }
+    }
+
+    fn parse(value: &str) -> Result<Self, StoreError> {
+        match value {
+            "legacy_retired_family" => Ok(Self::LegacyRetiredFamily),
+            "legacy_invalid_observation_id" => Ok(Self::LegacyInvalidObservationId),
+            "legacy_canary" => Ok(Self::LegacyCanary),
+            _ => Err(StoreError::Conflict(
+                "stored consumer skip category is invalid".to_owned(),
+            )),
+        }
+    }
+}
+
+fn validate_skip_categories(
+    messages_skipped: u64,
+    rows: Vec<(String, u64)>,
+) -> Result<BTreeMap<String, u64>, StoreError> {
+    if rows.len() > ConsumerSkipCategory::ALL.len() {
+        return Err(StoreError::Conflict(
+            "stored consumer skip category cardinality exceeds the closed catalog".to_owned(),
+        ));
+    }
+    let mut categories = BTreeMap::new();
+    let mut categorized = 0_u64;
+    for (name, count) in rows {
+        let category = ConsumerSkipCategory::parse(&name)?;
+        if count == 0
+            || categories
+                .insert(category.as_str().to_owned(), count)
+                .is_some()
+        {
+            return Err(StoreError::Conflict(
+                "stored consumer skip category counter is invalid".to_owned(),
+            ));
+        }
+        categorized = categorized.checked_add(count).ok_or_else(|| {
+            StoreError::Conflict("stored consumer skip category total overflowed".to_owned())
+        })?;
+    }
+    if categorized != messages_skipped {
+        return Err(StoreError::Conflict(
+            "stored consumer skip categories do not reconcile with messages_skipped".to_owned(),
+        ));
+    }
+    Ok(categories)
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -639,6 +723,12 @@ pub struct ConsumerRunProgress {
     pub messages_projected: u64,
     pub messages_skipped: u64,
     pub messages_rejected: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConsumerRunReceiptState {
+    pub progress: ConsumerRunProgress,
+    pub skip_categories: BTreeMap<String, u64>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -665,6 +755,7 @@ pub struct ConsumerRunInspection {
     pub updated_at_unix_ms: u64,
     pub completed_at_unix_ms: Option<u64>,
     pub progress: ConsumerRunProgress,
+    pub skip_categories: BTreeMap<String, u64>,
     pub families: Vec<ConsumerFamilyProgress>,
 }
 
@@ -865,11 +956,12 @@ impl PostgresLedger {
     ) -> Result<(), StoreError> {
         let stream_sequence = sequence_i64(stream_sequence)?;
         let graph_revision = graph_revision.map(sequence_i64).transpose()?;
-        let (projected, skipped, rejected): (i64, i64, i64) = match outcome {
-            ConsumerMessageOutcome::Projected => (1, 0, 0),
-            ConsumerMessageOutcome::Skipped => (0, 1, 0),
-            ConsumerMessageOutcome::Rejected => (0, 0, 1),
-        };
+        let (projected, skipped, rejected, skip_category): (i64, i64, i64, Option<&str>) =
+            match outcome {
+                ConsumerMessageOutcome::Projected => (1, 0, 0, None),
+                ConsumerMessageOutcome::Skipped(category) => (0, 1, 0, Some(category.as_str())),
+                ConsumerMessageOutcome::Rejected => (0, 0, 1, None),
+            };
         let mut client = self.client.lock().await;
         let transaction = client.transaction().await?;
         let changed = transaction
@@ -898,9 +990,10 @@ impl PostgresLedger {
                     "consumer run {consumer_name}/{run_id} rejected sequence {stream_sequence}"
                 )));
             }
-        } else if let Some((source_id, family_id)) = source_family {
-            transaction
-                .execute(
+        } else {
+            if let Some((source_id, family_id)) = source_family {
+                transaction
+                    .execute(
                     "INSERT INTO organizational_consumer_family_progress (consumer_name, run_id, source_id, family_id, messages_seen, messages_projected, messages_skipped, messages_rejected, last_sequence, latest_graph_revision) VALUES ($1, $2, $3, $4, 1, $5, $6, $7, $8, $9) ON CONFLICT (consumer_name, run_id, source_id, family_id) DO UPDATE SET messages_seen = organizational_consumer_family_progress.messages_seen + 1, messages_projected = organizational_consumer_family_progress.messages_projected + EXCLUDED.messages_projected, messages_skipped = organizational_consumer_family_progress.messages_skipped + EXCLUDED.messages_skipped, messages_rejected = organizational_consumer_family_progress.messages_rejected + EXCLUDED.messages_rejected, last_sequence = EXCLUDED.last_sequence, latest_graph_revision = COALESCE(EXCLUDED.latest_graph_revision, organizational_consumer_family_progress.latest_graph_revision), updated_at = NOW() WHERE organizational_consumer_family_progress.last_sequence < EXCLUDED.last_sequence",
                     &[
                         &consumer_name,
@@ -913,8 +1006,17 @@ impl PostgresLedger {
                         &stream_sequence,
                         &graph_revision,
                     ],
-                )
-                .await?;
+                    )
+                    .await?;
+            }
+            if let Some(category) = skip_category {
+                transaction
+                    .execute(
+                        "INSERT INTO organizational_consumer_skip_categories (consumer_name, run_id, category, messages_skipped) VALUES ($1, $2, $3, 1) ON CONFLICT (consumer_name, run_id, category) DO UPDATE SET messages_skipped = organizational_consumer_skip_categories.messages_skipped + 1, updated_at = NOW()",
+                        &[&consumer_name, &run_id, &category],
+                    )
+                    .await?;
+            }
         }
         transaction.commit().await?;
         Ok(())
@@ -955,23 +1057,56 @@ impl PostgresLedger {
         consumer_name: &str,
         run_id: &str,
     ) -> Result<ConsumerRunProgress, StoreError> {
-        let row = self
-            .client
-            .lock()
-            .await
+        Ok(self
+            .consumer_run_receipt_state(consumer_name, run_id)
+            .await?
+            .progress)
+    }
+
+    pub async fn consumer_run_receipt_state(
+        &self,
+        consumer_name: &str,
+        run_id: &str,
+    ) -> Result<ConsumerRunReceiptState, StoreError> {
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        let row = transaction
             .query_opt(
                 "SELECT last_delivered_sequence, covered_sequence, messages_seen, messages_projected, messages_skipped, messages_rejected FROM organizational_consumer_runs WHERE consumer_name = $1 AND run_id = $2",
                 &[&consumer_name, &run_id],
             )
             .await?
             .ok_or_else(|| StoreError::Conflict("consumer run was not found".to_owned()))?;
-        Ok(ConsumerRunProgress {
+        let skip_rows = transaction
+            .query(
+                "SELECT category, messages_skipped FROM organizational_consumer_skip_categories WHERE consumer_name = $1 AND run_id = $2 ORDER BY category",
+                &[&consumer_name, &run_id],
+            )
+            .await?;
+        transaction.commit().await?;
+        let progress = ConsumerRunProgress {
             last_delivered_sequence: stored_u64(&row, 0, "last_delivered_sequence")?,
             covered_sequence: stored_u64(&row, 1, "covered_sequence")?,
             messages_seen: stored_u64(&row, 2, "messages_seen")?,
             messages_projected: stored_u64(&row, 3, "messages_projected")?,
             messages_skipped: stored_u64(&row, 4, "messages_skipped")?,
             messages_rejected: stored_u64(&row, 5, "messages_rejected")?,
+        };
+        let skip_categories = validate_skip_categories(
+            progress.messages_skipped,
+            skip_rows
+                .into_iter()
+                .map(|row| {
+                    Ok((
+                        row.get::<_, String>(0),
+                        stored_u64(&row, 1, "category messages_skipped")?,
+                    ))
+                })
+                .collect::<Result<Vec<_>, StoreError>>()?,
+        )?;
+        Ok(ConsumerRunReceiptState {
+            progress,
+            skip_categories,
         })
     }
 
@@ -992,6 +1127,12 @@ impl PostgresLedger {
         let family_rows = transaction
             .query(
                 "SELECT source_id, family_id, messages_seen, messages_projected, messages_skipped, messages_rejected, last_sequence, latest_graph_revision FROM organizational_consumer_family_progress WHERE consumer_name = $1 AND run_id = $2 ORDER BY source_id, family_id",
+                &[&consumer_name, &run_id],
+            )
+            .await?;
+        let skip_rows = transaction
+            .query(
+                "SELECT category, messages_skipped FROM organizational_consumer_skip_categories WHERE consumer_name = $1 AND run_id = $2 ORDER BY category",
                 &[&consumer_name, &run_id],
             )
             .await?;
@@ -1019,6 +1160,26 @@ impl PostgresLedger {
             })
             .collect::<Result<Vec<_>, StoreError>>()?;
         let end_sequence: Option<i64> = row.get(2);
+        let progress = ConsumerRunProgress {
+            last_delivered_sequence: stored_u64(&row, 7, "last_delivered_sequence")?,
+            covered_sequence: stored_u64(&row, 8, "covered_sequence")?,
+            messages_seen: stored_u64(&row, 9, "messages_seen")?,
+            messages_projected: stored_u64(&row, 10, "messages_projected")?,
+            messages_skipped: stored_u64(&row, 11, "messages_skipped")?,
+            messages_rejected: stored_u64(&row, 12, "messages_rejected")?,
+        };
+        let skip_categories = validate_skip_categories(
+            progress.messages_skipped,
+            skip_rows
+                .into_iter()
+                .map(|row| {
+                    Ok((
+                        row.get::<_, String>(0),
+                        stored_u64(&row, 1, "category messages_skipped")?,
+                    ))
+                })
+                .collect::<Result<Vec<_>, StoreError>>()?,
+        )?;
         Ok(ConsumerRunInspection {
             consumer_name: consumer_name.to_owned(),
             run_id: run_id.to_owned(),
@@ -1038,14 +1199,8 @@ impl PostgresLedger {
                 .map_err(|_| {
                     StoreError::Conflict("stored completed timestamp is invalid".to_owned())
                 })?,
-            progress: ConsumerRunProgress {
-                last_delivered_sequence: stored_u64(&row, 7, "last_delivered_sequence")?,
-                covered_sequence: stored_u64(&row, 8, "covered_sequence")?,
-                messages_seen: stored_u64(&row, 9, "messages_seen")?,
-                messages_projected: stored_u64(&row, 10, "messages_projected")?,
-                messages_skipped: stored_u64(&row, 11, "messages_skipped")?,
-                messages_rejected: stored_u64(&row, 12, "messages_rejected")?,
-            },
+            progress,
+            skip_categories,
             families,
         })
     }
@@ -2988,6 +3143,7 @@ mod tests {
             "organizational_source_collection_latest_idx",
             "organizational_consumer_runs",
             "organizational_consumer_family_progress",
+            "organizational_consumer_skip_categories",
             "last_delivered_sequence BIGINT NOT NULL DEFAULT 0",
             "current_setting(''cerebro.tenant_id'', true)",
             "DEFERRABLE INITIALLY DEFERRED",
@@ -3044,6 +3200,81 @@ mod tests {
                 "claim replacement query missing {required}"
             );
         }
+    }
+
+    #[test]
+    fn consumer_skip_categories_are_closed_and_reconciled() {
+        let categories = validate_skip_categories(
+            4,
+            vec![
+                ("legacy_canary".to_owned(), 1),
+                ("legacy_invalid_observation_id".to_owned(), 2),
+                ("legacy_retired_family".to_owned(), 1),
+            ],
+        )
+        .unwrap();
+        assert_eq!(categories.values().sum::<u64>(), 4);
+        assert_eq!(categories.len(), ConsumerSkipCategory::ALL.len());
+
+        for rows in [
+            Vec::new(),
+            vec![("legacy_canary".to_owned(), 1)],
+            vec![("unknown".to_owned(), 2)],
+            vec![
+                ("legacy_canary".to_owned(), 1),
+                ("legacy_invalid_observation_id".to_owned(), 1),
+                ("legacy_retired_family".to_owned(), 1),
+                ("legacy_canary".to_owned(), 1),
+            ],
+        ] {
+            assert!(validate_skip_categories(2, rows).is_err());
+        }
+        assert!(validate_skip_categories(0, Vec::new()).is_ok());
+    }
+
+    #[test]
+    fn consumer_run_inspection_serializes_durable_skip_categories() {
+        let inspection = ConsumerRunInspection {
+            consumer_name: "organizational-graph-replay".to_owned(),
+            run_id: "replay-proof".to_owned(),
+            mode: "replay".to_owned(),
+            start_sequence: 1,
+            end_sequence: Some(50),
+            status: "completed".to_owned(),
+            started_at_unix_ms: 1,
+            updated_at_unix_ms: 2,
+            completed_at_unix_ms: Some(2),
+            progress: ConsumerRunProgress {
+                last_delivered_sequence: 50,
+                covered_sequence: 50,
+                messages_seen: 3,
+                messages_projected: 1,
+                messages_skipped: 2,
+                messages_rejected: 0,
+            },
+            skip_categories: BTreeMap::from([
+                ("legacy_canary".to_owned(), 1),
+                ("legacy_retired_family".to_owned(), 1),
+            ]),
+            families: Vec::new(),
+        };
+        let value = serde_json::to_value(inspection).unwrap();
+        assert_eq!(
+            value["skip_categories"],
+            serde_json::json!({
+                "legacy_canary": 1,
+                "legacy_retired_family": 1,
+            })
+        );
+        assert_eq!(
+            value["progress"]["messages_skipped"],
+            value["skip_categories"]
+                .as_object()
+                .unwrap()
+                .values()
+                .map(|count| count.as_u64().unwrap())
+                .sum::<u64>()
+        );
     }
 
     #[test]

--- a/crates/organizational-store/src/postgres.rs
+++ b/crates/organizational-store/src/postgres.rs
@@ -334,9 +334,12 @@ CREATE TABLE IF NOT EXISTS organizational_consumer_skip_categories (
   consumer_name TEXT NOT NULL,
   run_id TEXT NOT NULL,
   category TEXT NOT NULL CHECK (category IN (
-    'legacy_retired_family',
+    'subject_outside_projection_contract',
+    'source_outside_compiled_catalog',
+    'legacy_missing_source_owned_kind',
     'legacy_invalid_observation_id',
-    'legacy_canary'
+    'legacy_catalog_canary_without_source_envelope',
+    'legacy_retired_family_projection_incompatible'
   )),
   messages_skipped BIGINT NOT NULL DEFAULT 0 CHECK (messages_skipped > 0),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -643,31 +646,51 @@ pub enum ConsumerMessageOutcome {
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ConsumerSkipCategory {
-    LegacyRetiredFamily,
+    SubjectOutsideProjectionContract,
+    SourceOutsideCompiledCatalog,
+    LegacyMissingSourceOwnedKind,
     LegacyInvalidObservationId,
-    LegacyCanary,
+    LegacyCatalogCanaryWithoutSourceEnvelope,
+    LegacyRetiredFamilyProjectionIncompatible,
 }
 
 impl ConsumerSkipCategory {
-    const ALL: [Self; 3] = [
-        Self::LegacyRetiredFamily,
+    pub const ALL: [Self; 6] = [
+        Self::SubjectOutsideProjectionContract,
+        Self::SourceOutsideCompiledCatalog,
+        Self::LegacyMissingSourceOwnedKind,
         Self::LegacyInvalidObservationId,
-        Self::LegacyCanary,
+        Self::LegacyCatalogCanaryWithoutSourceEnvelope,
+        Self::LegacyRetiredFamilyProjectionIncompatible,
     ];
 
     pub const fn as_str(self) -> &'static str {
         match self {
-            Self::LegacyRetiredFamily => "legacy_retired_family",
+            Self::SubjectOutsideProjectionContract => "subject_outside_projection_contract",
+            Self::SourceOutsideCompiledCatalog => "source_outside_compiled_catalog",
+            Self::LegacyMissingSourceOwnedKind => "legacy_missing_source_owned_kind",
             Self::LegacyInvalidObservationId => "legacy_invalid_observation_id",
-            Self::LegacyCanary => "legacy_canary",
+            Self::LegacyCatalogCanaryWithoutSourceEnvelope => {
+                "legacy_catalog_canary_without_source_envelope"
+            }
+            Self::LegacyRetiredFamilyProjectionIncompatible => {
+                "legacy_retired_family_projection_incompatible"
+            }
         }
     }
 
     fn parse(value: &str) -> Result<Self, StoreError> {
         match value {
-            "legacy_retired_family" => Ok(Self::LegacyRetiredFamily),
+            "subject_outside_projection_contract" => Ok(Self::SubjectOutsideProjectionContract),
+            "source_outside_compiled_catalog" => Ok(Self::SourceOutsideCompiledCatalog),
+            "legacy_missing_source_owned_kind" => Ok(Self::LegacyMissingSourceOwnedKind),
             "legacy_invalid_observation_id" => Ok(Self::LegacyInvalidObservationId),
-            "legacy_canary" => Ok(Self::LegacyCanary),
+            "legacy_catalog_canary_without_source_envelope" => {
+                Ok(Self::LegacyCatalogCanaryWithoutSourceEnvelope)
+            }
+            "legacy_retired_family_projection_incompatible" => {
+                Ok(Self::LegacyRetiredFamilyProjectionIncompatible)
+            }
             _ => Err(StoreError::Conflict(
                 "stored consumer skip category is invalid".to_owned(),
             )),
@@ -3205,26 +3228,47 @@ mod tests {
     #[test]
     fn consumer_skip_categories_are_closed_and_reconciled() {
         let categories = validate_skip_categories(
-            4,
+            7,
             vec![
-                ("legacy_canary".to_owned(), 1),
+                (
+                    "legacy_catalog_canary_without_source_envelope".to_owned(),
+                    1,
+                ),
                 ("legacy_invalid_observation_id".to_owned(), 2),
-                ("legacy_retired_family".to_owned(), 1),
+                ("legacy_missing_source_owned_kind".to_owned(), 1),
+                (
+                    "legacy_retired_family_projection_incompatible".to_owned(),
+                    1,
+                ),
+                ("source_outside_compiled_catalog".to_owned(), 1),
+                ("subject_outside_projection_contract".to_owned(), 1),
             ],
         )
         .unwrap();
-        assert_eq!(categories.values().sum::<u64>(), 4);
+        assert_eq!(categories.values().sum::<u64>(), 7);
         assert_eq!(categories.len(), ConsumerSkipCategory::ALL.len());
 
         for rows in [
             Vec::new(),
-            vec![("legacy_canary".to_owned(), 1)],
+            vec![(
+                "legacy_catalog_canary_without_source_envelope".to_owned(),
+                1,
+            )],
             vec![("unknown".to_owned(), 2)],
             vec![
-                ("legacy_canary".to_owned(), 1),
+                (
+                    "legacy_catalog_canary_without_source_envelope".to_owned(),
+                    1,
+                ),
                 ("legacy_invalid_observation_id".to_owned(), 1),
-                ("legacy_retired_family".to_owned(), 1),
-                ("legacy_canary".to_owned(), 1),
+                ("legacy_missing_source_owned_kind".to_owned(), 1),
+                (
+                    "legacy_retired_family_projection_incompatible".to_owned(),
+                    1,
+                ),
+                ("source_outside_compiled_catalog".to_owned(), 1),
+                ("subject_outside_projection_contract".to_owned(), 1),
+                ("subject_outside_projection_contract".to_owned(), 1),
             ],
         ] {
             assert!(validate_skip_categories(2, rows).is_err());
@@ -3253,8 +3297,11 @@ mod tests {
                 messages_rejected: 0,
             },
             skip_categories: BTreeMap::from([
-                ("legacy_canary".to_owned(), 1),
-                ("legacy_retired_family".to_owned(), 1),
+                (
+                    "legacy_catalog_canary_without_source_envelope".to_owned(),
+                    1,
+                ),
+                ("legacy_missing_source_owned_kind".to_owned(), 1),
             ]),
             families: Vec::new(),
         };
@@ -3262,8 +3309,8 @@ mod tests {
         assert_eq!(
             value["skip_categories"],
             serde_json::json!({
-                "legacy_canary": 1,
-                "legacy_retired_family": 1,
+                "legacy_catalog_canary_without_source_envelope": 1,
+                "legacy_missing_source_owned_kind": 1,
             })
         );
         assert_eq!(

--- a/docs/operations/organizational-projection-replay.md
+++ b/docs/operations/organizational-projection-replay.md
@@ -84,7 +84,10 @@ collector events project through exact compiled native relationship and
 application templates. Replay compatibility applies only in replay mode. The
 forward consumer continues to reject every legacy shape.
 Every skipped message is also recorded in one closed, payload-free category:
-`legacy_retired_family`, `legacy_invalid_observation_id`, or `legacy_canary`.
+`subject_outside_projection_contract`, `source_outside_compiled_catalog`,
+`legacy_missing_source_owned_kind`, `legacy_invalid_observation_id`,
+`legacy_catalog_canary_without_source_envelope`, or
+`legacy_retired_family_projection_incompatible`.
 The terminal run receipt and `inspect-consumer-run` output expose these durable
 category counters as `skip_categories`. Their sum must equal
 `messages_skipped`; a missing, unknown, zero, or mismatched category counter

--- a/docs/operations/organizational-projection-replay.md
+++ b/docs/operations/organizational-projection-replay.md
@@ -83,8 +83,13 @@ without a source envelope, and permanent projection failures for the retired
 collector events project through exact compiled native relationship and
 application templates. Replay compatibility applies only in replay mode. The
 forward consumer continues to reject every legacy shape.
-Inspect the completed run and review the per-source-family skipped counters as
-the durable evidence for these records.
+Every skipped message is also recorded in one closed, payload-free category:
+`legacy_retired_family`, `legacy_invalid_observation_id`, or `legacy_canary`.
+The terminal run receipt and `inspect-consumer-run` output expose these durable
+category counters as `skip_categories`. Their sum must equal
+`messages_skipped`; a missing, unknown, zero, or mismatched category counter
+fails receipt generation closed. Per-source-family progress remains available
+for additional diagnosis, but it does not replace the categorized total.
 
 ## Repair an active-family rejection
 
@@ -136,7 +141,9 @@ consumer name, run ID, and start sequence.
 ## Completion and authority prerequisite
 
 The process emits `cerebro.organizational-consumer-run/v1` JSON and persists the
-same progress in `organizational_consumer_runs`.
+same progress in `organizational_consumer_runs`. The additive `skip_categories`
+object comes from `organizational_consumer_skip_categories`, which is updated in
+the same transaction as the cumulative skipped-message counter.
 
 A replay is materialization-complete only when all of these are true:
 
@@ -148,10 +155,11 @@ A replay is materialization-complete only when all of these are true:
   `start_sequence = end_sequence + 1`.
 - the replay `completed_at` precedes the forward run `started_at`.
 
-`messages_skipped` is explicit. It includes retained events outside the
-portable organizational projection contract and must be reviewed before using
-the replay as parity evidence. Service health, Neo4j connectivity, messages
-seen, or a drained consumer alone are not authority-readiness signals.
+`messages_skipped` is explicit and fully categorized. It includes retained
+events outside the portable organizational projection contract and must be
+reviewed before using the replay as parity evidence. Service health, Neo4j
+connectivity, messages seen, or a drained consumer alone are not
+authority-readiness signals.
 
 Emit the inspection payload from the same candidate:
 


### PR DESCRIPTION
## Summary

- persist skip counters under a closed, payload-free category catalog
- preserve each portable skip cause instead of collapsing subject-contract or compiled-catalog misses
- reconcile categorized counts with `messages_skipped` before emitting terminal or inspection receipts
- expose the additive `skip_categories` object on the existing v1 receipt schema

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p cerebro-organizational-store -p cerebro-platform`
- [x] `cargo clippy -p cerebro-organizational-store -p cerebro-platform --all-targets -- -D warnings`
- [ ] hosted checks and deterministic review

## Known Invariants

- Skip categories contain counts only; no message payloads or deployment identity.
- The category catalog contains exactly the portable subject, compiled-catalog, decode-compatibility, and projection-compatibility skip causes.
- Category persistence and aggregate progress update in one database transaction.
- Missing, unknown, zero-valued, over-cardinality, or mismatched stored categories fail receipt reads closed.
- Existing zero-skip runs remain readable; existing nonzero-skip rows without categorized counters intentionally fail closed.

## Deterministic Review

- Fast local invariant check: `make review-invariants`.
- Focus review on the closed category catalog, transactional persistence, receipt reconciliation, and additive v1 compatibility.
- The required `deterministic-review` check runs the exact PR range through invariant, contract, structural, architecture, scanner, vulnerability, leak, and workflow-permission gates.