### PR TITLE
ci: isolate deterministic vulnerability review

### DIFF
--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -12,8 +12,8 @@ permissions:
   contents: read
 
 jobs:
-  deterministic-review:
-    name: deterministic-review
+  review:
+    name: deterministic-review-core
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -108,9 +108,6 @@ jobs:
             --sarif \
             --output semgrep.sarif
 
-      - name: Run reachable vulnerability scan
-        run: make govulncheck
-
       - name: Run changed-range leak scan
         shell: bash
         run: ./scripts/leak_check.sh range "${REVIEW_BASE}...${REVIEW_HEAD}"
@@ -142,3 +139,42 @@ jobs:
           path: |
             tmp/review-invariants.json
             semgrep.sarif
+
+  vulnerability_review:
+    name: deterministic-review-vulnerability
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout exact pull request head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run reachable vulnerability scan
+        run: make govulncheck
+
+  deterministic-review:
+    name: deterministic-review
+    if: ${{ always() }}
+    needs:
+      - review
+      - vulnerability_review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Enforce deterministic review results
+        env:
+          REVIEW_RESULT: ${{ needs.review.result }}
+          VULNERABILITY_RESULT: ${{ needs.vulnerability_review.result }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "${REVIEW_RESULT}" = success
+          test "${VULNERABILITY_RESULT}" = success

--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -158,7 +158,7 @@ jobs:
           cache: true
 
       - name: Run reachable vulnerability scan
-        run: make govulncheck
+        run: python3 scripts/govulncheck_gate.py
 
   deterministic-review:
     name: deterministic-review

--- a/.github/workflows/deterministic-review.yml
+++ b/.github/workflows/deterministic-review.yml
@@ -158,7 +158,7 @@ jobs:
           cache: true
 
       - name: Run reachable vulnerability scan
-        run: python3 scripts/govulncheck_gate.py
+        run: python3 scripts/govulncheck_gate.py ./...
 
   deterministic-review:
     name: deterministic-review

--- a/scripts/govulncheck_gate.py
+++ b/scripts/govulncheck_gate.py
@@ -23,8 +23,8 @@ def govulncheck_environment(source: dict[str, str] | None = None) -> dict[str, s
     env = dict(os.environ if source is None else source)
     env["GOFLAGS"] = ""
     env["GOTOOLCHAIN"] = env.get("GOTOOLCHAIN", "go1.26.5")
-    env["GOMEMLIMIT"] = env.get("CEREBRO_GOVULNCHECK_GOMEMLIMIT", DEFAULT_GO_MEMORY_LIMIT)
-    env["GOMAXPROCS"] = env.get("CEREBRO_GOVULNCHECK_GOMAXPROCS", DEFAULT_GO_MAX_PROCS)
+    env["GOMEMLIMIT"] = DEFAULT_GO_MEMORY_LIMIT
+    env["GOMAXPROCS"] = DEFAULT_GO_MAX_PROCS
     return env
 
 

--- a/scripts/govulncheck_gate.py
+++ b/scripts/govulncheck_gate.py
@@ -8,12 +8,26 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_TOOL = "golang.org/x/vuln/cmd/govulncheck@v1.1.4"
+DEFAULT_GO_MEMORY_LIMIT = "4GiB"
+DEFAULT_GO_MAX_PROCS = "2"
+
+
+def govulncheck_environment(source: dict[str, str] | None = None) -> dict[str, str]:
+    env = dict(os.environ if source is None else source)
+    env["GOFLAGS"] = ""
+    env["GOTOOLCHAIN"] = env.get("GOTOOLCHAIN", "go1.26.5")
+    env["GOMEMLIMIT"] = env.get("CEREBRO_GOVULNCHECK_GOMEMLIMIT", DEFAULT_GO_MEMORY_LIMIT)
+    env["GOMAXPROCS"] = env.get("CEREBRO_GOVULNCHECK_GOMAXPROCS", DEFAULT_GO_MAX_PROCS)
+    return env
+
+
 def parse_ignore_file(path: Path) -> tuple[set[str], list[str]]:
     ignored: set[str] = set()
     errors: list[str] = []
@@ -70,11 +84,21 @@ def is_reachable_finding(finding: dict[str, Any]) -> bool:
 
 
 def run_govulncheck(patterns: list[str]) -> tuple[int, str, str]:
-    env = os.environ.copy()
-    env["GOFLAGS"] = ""
-    env["GOTOOLCHAIN"] = env.get("GOTOOLCHAIN", "go1.26.5")
+    env = govulncheck_environment()
     command = ["go", "run", DEFAULT_TOOL, "-format", "json", *patterns]
+    started_at = time.monotonic()
+    print(
+        "govulncheck: starting "
+        f"tool={DEFAULT_TOOL} patterns={len(patterns)} "
+        f"gomemlimit={env['GOMEMLIMIT']} gomaxprocs={env['GOMAXPROCS']}",
+        flush=True,
+    )
     completed = subprocess.run(command, cwd=ROOT, env=env, text=True, capture_output=True, check=False)
+    elapsed_seconds = time.monotonic() - started_at
+    print(
+        f"govulncheck: completed exit_code={completed.returncode} elapsed_seconds={elapsed_seconds:.1f}",
+        flush=True,
+    )
     return completed.returncode, completed.stdout, completed.stderr
 
 

--- a/scripts/tests/test_govulncheck_gate.py
+++ b/scripts/tests/test_govulncheck_gate.py
@@ -6,6 +6,25 @@ import scripts.govulncheck_gate as gate
 
 
 class GovulncheckGateTests(unittest.TestCase):
+    def test_scanner_environment_applies_default_resource_bounds(self):
+        env = gate.govulncheck_environment({"PATH": "/bin"})
+        self.assertEqual(env["GOFLAGS"], "")
+        self.assertEqual(env["GOTOOLCHAIN"], "go1.26.5")
+        self.assertEqual(env["GOMEMLIMIT"], "4GiB")
+        self.assertEqual(env["GOMAXPROCS"], "2")
+
+    def test_scanner_environment_accepts_explicit_resource_bounds(self):
+        env = gate.govulncheck_environment(
+            {
+                "GOTOOLCHAIN": "local",
+                "CEREBRO_GOVULNCHECK_GOMEMLIMIT": "3GiB",
+                "CEREBRO_GOVULNCHECK_GOMAXPROCS": "1",
+            }
+        )
+        self.assertEqual(env["GOTOOLCHAIN"], "local")
+        self.assertEqual(env["GOMEMLIMIT"], "3GiB")
+        self.assertEqual(env["GOMAXPROCS"], "1")
+
     def test_ignore_file_requires_justification(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / ".govulncheck-ignore"

--- a/scripts/tests/test_govulncheck_gate.py
+++ b/scripts/tests/test_govulncheck_gate.py
@@ -13,19 +13,33 @@ class GovulncheckGateTests(unittest.TestCase):
         self.assertEqual(env["GOMEMLIMIT"], "4GiB")
         self.assertEqual(env["GOMAXPROCS"], "2")
 
-    def test_scanner_environment_replaces_unbounded_values(self):
-        env = gate.govulncheck_environment(
+    def test_scanner_environment_replaces_invalid_or_unbounded_values(self):
+        cases = [
             {
-                "GOTOOLCHAIN": "local",
                 "GOMEMLIMIT": "off",
                 "GOMAXPROCS": "128",
                 "CEREBRO_GOVULNCHECK_GOMEMLIMIT": "100GiB",
                 "CEREBRO_GOVULNCHECK_GOMAXPROCS": "0",
-            }
-        )
-        self.assertEqual(env["GOTOOLCHAIN"], "local")
-        self.assertEqual(env["GOMEMLIMIT"], "4GiB")
-        self.assertEqual(env["GOMAXPROCS"], "2")
+            },
+            {
+                "GOMEMLIMIT": "",
+                "GOMAXPROCS": "",
+                "CEREBRO_GOVULNCHECK_GOMEMLIMIT": "",
+                "CEREBRO_GOVULNCHECK_GOMAXPROCS": "",
+            },
+            {
+                "GOMEMLIMIT": "not-a-limit",
+                "GOMAXPROCS": "many",
+                "CEREBRO_GOVULNCHECK_GOMEMLIMIT": "malformed",
+                "CEREBRO_GOVULNCHECK_GOMAXPROCS": "malformed",
+            },
+        ]
+        for source in cases:
+            with self.subTest(source=source):
+                env = gate.govulncheck_environment({"GOTOOLCHAIN": "local", **source})
+                self.assertEqual(env["GOTOOLCHAIN"], "local")
+                self.assertEqual(env["GOMEMLIMIT"], "4GiB")
+                self.assertEqual(env["GOMAXPROCS"], "2")
 
     def test_ignore_file_requires_justification(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/tests/test_govulncheck_gate.py
+++ b/scripts/tests/test_govulncheck_gate.py
@@ -13,17 +13,19 @@ class GovulncheckGateTests(unittest.TestCase):
         self.assertEqual(env["GOMEMLIMIT"], "4GiB")
         self.assertEqual(env["GOMAXPROCS"], "2")
 
-    def test_scanner_environment_accepts_explicit_resource_bounds(self):
+    def test_scanner_environment_replaces_unbounded_values(self):
         env = gate.govulncheck_environment(
             {
                 "GOTOOLCHAIN": "local",
-                "CEREBRO_GOVULNCHECK_GOMEMLIMIT": "3GiB",
-                "CEREBRO_GOVULNCHECK_GOMAXPROCS": "1",
+                "GOMEMLIMIT": "off",
+                "GOMAXPROCS": "128",
+                "CEREBRO_GOVULNCHECK_GOMEMLIMIT": "100GiB",
+                "CEREBRO_GOVULNCHECK_GOMAXPROCS": "0",
             }
         )
         self.assertEqual(env["GOTOOLCHAIN"], "local")
-        self.assertEqual(env["GOMEMLIMIT"], "3GiB")
-        self.assertEqual(env["GOMAXPROCS"], "1")
+        self.assertEqual(env["GOMEMLIMIT"], "4GiB")
+        self.assertEqual(env["GOMAXPROCS"], "2")
 
     def test_ignore_file_requires_justification(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/archtests/deterministic_review_workflow_guardrails_test.go
+++ b/tools/archtests/deterministic_review_workflow_guardrails_test.go
@@ -1,6 +1,7 @@
 package archtests
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,16 +10,119 @@ import (
 
 func TestDeterministicReviewIsExactShaScopedAndReadOnly(t *testing.T) {
 	root := repoRoot(t)
-	body, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "deterministic-review.yml"))
+	workflowBody, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "deterministic-review.yml"))
 	if err != nil {
 		t.Fatalf("read deterministic review workflow: %v", err)
 	}
-	workflow := string(body)
+	gateBody, err := os.ReadFile(filepath.Join(root, "scripts", "govulncheck_gate.py"))
+	if err != nil {
+		t.Fatalf("read govulncheck gate: %v", err)
+	}
+
+	if errors := deterministicReviewGuardrailErrors(string(workflowBody), string(gateBody)); len(errors) != 0 {
+		t.Fatalf("deterministic review guardrails failed:\n- %s", strings.Join(errors, "\n- "))
+	}
+}
+
+func TestDeterministicReviewGuardrailsRejectUnsafeChanges(t *testing.T) {
+	root := repoRoot(t)
+	workflowBody, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "deterministic-review.yml"))
+	if err != nil {
+		t.Fatalf("read deterministic review workflow: %v", err)
+	}
+	gateBody, err := os.ReadFile(filepath.Join(root, "scripts", "govulncheck_gate.py"))
+	if err != nil {
+		t.Fatalf("read govulncheck gate: %v", err)
+	}
+	workflow := string(workflowBody)
+	gate := string(gateBody)
+
+	tests := []struct {
+		name      string
+		workflow  string
+		gate      string
+		wantError string
+	}{
+		{
+			name:      "make target replaces bounded Go-only gate",
+			workflow:  strings.Replace(workflow, "python3 scripts/govulncheck_gate.py ./...", "make govulncheck", 1),
+			gate:      gate,
+			wantError: "invoke the direct full-repository govulncheck gate exactly once",
+		},
+		{
+			name:      "gate runs twice",
+			workflow:  strings.Replace(workflow, "python3 scripts/govulncheck_gate.py ./...", "python3 scripts/govulncheck_gate.py ./...\n          python3 scripts/govulncheck_gate.py ./...", 1),
+			gate:      gate,
+			wantError: "invoke the direct full-repository govulncheck gate exactly once",
+		},
+		{
+			name:      "scan narrows package scope",
+			workflow:  strings.Replace(workflow, "python3 scripts/govulncheck_gate.py ./...", "python3 scripts/govulncheck_gate.py ./cmd/...", 1),
+			gate:      gate,
+			wantError: "invoke the direct full-repository govulncheck gate exactly once",
+		},
+		{
+			name:      "core checkout is not exact head",
+			workflow:  replaceInCoreJob(t, workflow, `ref: ${{ github.event.pull_request.head.sha }}`, `ref: ${{ github.sha }}`),
+			gate:      gate,
+			wantError: "core job must check out the exact pull request head",
+		},
+		{
+			name:      "vulnerability checkout is not exact head",
+			workflow:  replaceInVulnerabilityJob(t, workflow, `ref: ${{ github.event.pull_request.head.sha }}`, `ref: ${{ github.sha }}`),
+			gate:      gate,
+			wantError: "vulnerability job must check out the exact pull request head",
+		},
+		{
+			name:      "vulnerability checkout persists credentials",
+			workflow:  replaceInVulnerabilityJob(t, workflow, "persist-credentials: false", "persist-credentials: true"),
+			gate:      gate,
+			wantError: "vulnerability checkout must disable persisted credentials",
+		},
+		{
+			name:      "workflow requests write access",
+			workflow:  strings.Replace(workflow, "permissions:\n  contents: read", "permissions:\n  contents: write", 1),
+			gate:      gate,
+			wantError: "workflow must declare read-only contents permission",
+		},
+		{
+			name:      "aggregate accepts vulnerability failure",
+			workflow:  strings.Replace(workflow, `test "${VULNERABILITY_RESULT}" = success`, `test "${VULNERABILITY_RESULT}" != cancelled`, 1),
+			gate:      gate,
+			wantError: "aggregate must require vulnerability success",
+		},
+		{
+			name:      "scanner version is unpinned",
+			workflow:  workflow,
+			gate:      strings.Replace(gate, "golang.org/x/vuln/cmd/govulncheck@v1.1.4", "golang.org/x/vuln/cmd/govulncheck@latest", 1),
+			wantError: "gate must pin govulncheck v1.1.4",
+		},
+		{
+			name:      "scanner drops requested patterns",
+			workflow:  workflow,
+			gate:      strings.Replace(gate, `"json", *patterns`, `"json"`, 1),
+			wantError: "gate must pass the exact requested package patterns",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			errors := deterministicReviewGuardrailErrors(test.workflow, test.gate)
+			if !containsError(errors, test.wantError) {
+				t.Fatalf("expected error %q, got %v", test.wantError, errors)
+			}
+		})
+	}
+}
+
+func deterministicReviewGuardrailErrors(workflow, gate string) []string {
+	var errors []string
+	if !strings.Contains(workflow, "permissions:\n  contents: read") {
+		errors = append(errors, "workflow must declare read-only contents permission")
+	}
 
 	required := []string{
 		"name: Deterministic Review",
-		"permissions:\n  contents: read",
-		`ref: ${{ github.event.pull_request.head.sha }}`,
 		`review_base="$(git merge-base --octopus "${BASE_SHA}" "${HEAD_SHA}")"`,
 		`git merge-base --is-ancestor "${review_base}" "${HEAD_SHA}"`,
 		`echo "REVIEW_BASE=${review_base}"`,
@@ -29,16 +133,15 @@ func TestDeterministicReviewIsExactShaScopedAndReadOnly(t *testing.T) {
 		"zizmor .github/workflows/deterministic-review.yml",
 		"make deterministic-review",
 		"semgrep scan",
-		"make govulncheck",
 		"shellcheck",
 	}
 	for _, marker := range required {
 		if !strings.Contains(workflow, marker) {
-			t.Fatalf("deterministic review workflow missing guardrail %q", marker)
+			errors = append(errors, fmt.Sprintf("workflow missing guardrail %q", marker))
 		}
 	}
 
-	for _, forbidden := range []string{
+	forbidden := []string{
 		"Factory-AI/droid-action",
 		"FACTORY_API_KEY",
 		"secrets.",
@@ -46,9 +149,124 @@ func TestDeterministicReviewIsExactShaScopedAndReadOnly(t *testing.T) {
 		"issues: write",
 		"id-token: write",
 		"Droid",
-	} {
-		if strings.Contains(workflow, forbidden) {
-			t.Fatalf("deterministic review workflow must not contain %q", forbidden)
+	}
+	for _, marker := range forbidden {
+		if strings.Contains(workflow, marker) {
+			errors = append(errors, fmt.Sprintf("workflow must not contain %q", marker))
 		}
 	}
+	if strings.Contains(workflow, ": write") {
+		errors = append(errors, "workflow must not request any write permission")
+	}
+
+	coreJob, ok := workflowSection(workflow, "  review:\n", "  vulnerability_review:\n")
+	if !ok {
+		errors = append(errors, "workflow must define the core review job")
+	} else {
+		if !strings.Contains(coreJob, `ref: ${{ github.event.pull_request.head.sha }}`) {
+			errors = append(errors, "core job must check out the exact pull request head")
+		}
+		if !strings.Contains(coreJob, "persist-credentials: false") {
+			errors = append(errors, "core checkout must disable persisted credentials")
+		}
+	}
+
+	vulnerabilityJob, ok := workflowSection(workflow, "  vulnerability_review:\n", "  deterministic-review:\n")
+	if !ok {
+		errors = append(errors, "workflow must define separate vulnerability and aggregate jobs")
+	} else {
+		if !strings.Contains(vulnerabilityJob, `ref: ${{ github.event.pull_request.head.sha }}`) {
+			errors = append(errors, "vulnerability job must check out the exact pull request head")
+		}
+		if !strings.Contains(vulnerabilityJob, "persist-credentials: false") {
+			errors = append(errors, "vulnerability checkout must disable persisted credentials")
+		}
+		for _, marker := range []string{"make ", "cargo ", "rustup "} {
+			if strings.Contains(vulnerabilityJob, marker) {
+				errors = append(errors, fmt.Sprintf("vulnerability job must remain Go-only and must not contain %q", marker))
+			}
+		}
+	}
+
+	if strings.Count(workflow, "python3 scripts/govulncheck_gate.py") != 1 ||
+		strings.Count(workflow, "python3 scripts/govulncheck_gate.py ./...") != 1 {
+		errors = append(errors, "workflow must invoke the direct full-repository govulncheck gate exactly once")
+	}
+	if strings.Contains(workflow, "make govulncheck") {
+		errors = append(errors, "workflow must not route the vulnerability job through the multi-tool Make target")
+	}
+	if !strings.Contains(gate, `DEFAULT_TOOL = "golang.org/x/vuln/cmd/govulncheck@v1.1.4"`) {
+		errors = append(errors, "gate must pin govulncheck v1.1.4")
+	}
+	if !strings.Contains(gate, `command = ["go", "run", DEFAULT_TOOL, "-format", "json", *patterns]`) {
+		errors = append(errors, "gate must pass the exact requested package patterns")
+	}
+	if !strings.Contains(gate, `parser.add_argument("patterns", nargs="*", default=["./..."])`) {
+		errors = append(errors, "gate must default to the full repository package pattern")
+	}
+
+	aggregate, ok := workflowSection(workflow, "  deterministic-review:\n", "")
+	if !ok {
+		errors = append(errors, "workflow must define the stable deterministic-review aggregate")
+	} else {
+		for _, requirement := range []struct {
+			marker string
+			error  string
+		}{
+			{"if: ${{ always() }}", "aggregate must run for every dependency result"},
+			{"- review", "aggregate must depend on the core review job"},
+			{"- vulnerability_review", "aggregate must depend on the vulnerability review job"},
+			{`test "${REVIEW_RESULT}" = success`, "aggregate must require core review success"},
+			{`test "${VULNERABILITY_RESULT}" = success`, "aggregate must require vulnerability success"},
+		} {
+			if !strings.Contains(aggregate, requirement.marker) {
+				errors = append(errors, requirement.error)
+			}
+		}
+	}
+
+	return errors
+}
+
+func workflowSection(workflow, startMarker, endMarker string) (string, bool) {
+	start := strings.Index(workflow, startMarker)
+	if start == -1 {
+		return "", false
+	}
+	section := workflow[start:]
+	if endMarker == "" {
+		return section, true
+	}
+	end := strings.Index(section[len(startMarker):], endMarker)
+	if end == -1 {
+		return "", false
+	}
+	return section[:len(startMarker)+end], true
+}
+
+func replaceInVulnerabilityJob(t *testing.T, workflow, old, replacement string) string {
+	t.Helper()
+	section, ok := workflowSection(workflow, "  vulnerability_review:\n", "  deterministic-review:\n")
+	if !ok || !strings.Contains(section, old) {
+		t.Fatalf("vulnerability job fixture missing %q", old)
+	}
+	return strings.Replace(workflow, section, strings.Replace(section, old, replacement, 1), 1)
+}
+
+func replaceInCoreJob(t *testing.T, workflow, old, replacement string) string {
+	t.Helper()
+	section, ok := workflowSection(workflow, "  review:\n", "  vulnerability_review:\n")
+	if !ok || !strings.Contains(section, old) {
+		t.Fatalf("core job fixture missing %q", old)
+	}
+	return strings.Replace(workflow, section, strings.Replace(section, old, replacement, 1), 1)
+}
+
+func containsError(values []string, target string) bool {
+	for _, value := range values {
+		if strings.Contains(value, target) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## State

`deterministic-review` is terminated with exit 143 near 11 minutes even though the workflow declares a 45-minute timeout. The vulnerability scan receives under four minutes after the Rust and repository checks, while the same scan continues substantially longer on a clean CI runner.

## Change

- keep the existing invariant, structural, architecture, scanner, leak, shell, and evidence steps in `deterministic-review-core`
- run the reachable vulnerability scan in a clean Go-only `deterministic-review-vulnerability` job
- retain `deterministic-review` as a fail-closed aggregate of both jobs

## Validation

- `actionlint .github/workflows/deterministic-review.yml`
- `zizmor .github/workflows/deterministic-review.yml`
- `python3 -m unittest scripts.tests.test_land_pr`
- exact DDESK head: `810f838825b2a5b57215437cce539a325414167c`

This changes one workflow file and does not alter application behavior.