### PR TITLE
fix: project compatible Rust source events

### DIFF
--- a/crates/cerebro-platform/src/append_log_consumer.rs
+++ b/crates/cerebro-platform/src/append_log_consumer.rs
@@ -685,45 +685,6 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
                         .map_err(consumer_io)?;
                 }
                 FailureDisposition::Reject => {
-                    if let Some(reason) = replay_legacy_projection_skip(
-                        config.mode,
-                        &event_source,
-                        &event_family,
-                        &error,
-                    ) {
-                        record_progress(
-                            &runtime,
-                            &config,
-                            stream_sequence,
-                            ConsumerMessageOutcome::Skipped(skip_category(reason)),
-                            Some((&event_source, &event_family)),
-                            None,
-                            &mut counters,
-                        )
-                        .await?;
-                        diagnostics.emit(
-                            &config,
-                            stream_sequence,
-                            &event_source,
-                            &event_family,
-                            "compatibility_skip",
-                            projection_skip_category(reason),
-                            &message_sha256,
-                            Some(&record_digest),
-                        )?;
-                        message.double_ack().await.map_err(consumer_io)?;
-                        if replay_drained(&config, end_sequence, stream_sequence, pending) {
-                            return finish_replay(
-                                &runtime,
-                                &config,
-                                start_sequence,
-                                end_sequence.expect("replay has an end fence"),
-                                &counters,
-                            )
-                            .await;
-                        }
-                        continue;
-                    }
                     record_progress(
                         &runtime,
                         &config,
@@ -1293,10 +1254,6 @@ fn decode_skip_category(reason: &str) -> &'static str {
     }
 }
 
-fn projection_skip_category(_reason: &str) -> &'static str {
-    "unsupported_legacy_record"
-}
-
 fn skip_category(reason: &str) -> ConsumerSkipCategory {
     match reason {
         "legacy_invalid_observation_id" => ConsumerSkipCategory::LegacyInvalidObservationId,
@@ -1414,18 +1371,6 @@ fn legacy_decode_skip(
             Some("legacy_missing_source_owned_kind")
         }
         (
-            "gcp",
-            "iam_role_assignment" | "effective_permission",
-            EventDecodeError::Boundary(AppendLogDecodeError::InvalidModel(message)),
-        )
-        | (
-            "aws",
-            "public_endpoint",
-            EventDecodeError::Boundary(AppendLogDecodeError::InvalidModel(message)),
-        ) if mode == ConsumerMode::Replay && message == "observation id is invalid" => {
-            Some("legacy_invalid_observation_id")
-        }
-        (
             "cerebro",
             "health.jetstream_canary",
             EventDecodeError::CatalogOwnedWithoutEnvelope { .. },
@@ -1433,19 +1378,6 @@ fn legacy_decode_skip(
             Some("legacy_catalog_canary_without_source_envelope")
         }
         _ => None,
-    }
-}
-
-fn replay_legacy_projection_skip(
-    mode: ConsumerMode,
-    source_id: &str,
-    family_id: &str,
-    _error: &crate::ProjectionFailure,
-) -> Option<&'static str> {
-    if mode == ConsumerMode::Replay && source_id == "okta" && family_id == "threat_insight" {
-        Some("legacy_retired_family_projection_incompatible")
-    } else {
-        None
     }
 }
 
@@ -1683,30 +1615,6 @@ mod tests {
                 "legacy_missing_source_owned_kind",
             ),
             (
-                "gcp",
-                "iam_role_assignment",
-                EventDecodeError::Boundary(AppendLogDecodeError::InvalidModel(
-                    "observation id is invalid".to_owned(),
-                )),
-                "legacy_invalid_observation_id",
-            ),
-            (
-                "gcp",
-                "effective_permission",
-                EventDecodeError::Boundary(AppendLogDecodeError::InvalidModel(
-                    "observation id is invalid".to_owned(),
-                )),
-                "legacy_invalid_observation_id",
-            ),
-            (
-                "aws",
-                "public_endpoint",
-                EventDecodeError::Boundary(AppendLogDecodeError::InvalidModel(
-                    "observation id is invalid".to_owned(),
-                )),
-                "legacy_invalid_observation_id",
-            ),
-            (
                 "cerebro",
                 "health.jetstream_canary",
                 EventDecodeError::CatalogOwnedWithoutEnvelope {
@@ -1720,17 +1628,9 @@ mod tests {
                 legacy_decode_skip(ConsumerMode::Replay, source, family, &error),
                 Some(reason)
             );
-            let forward_reason = if matches!(
-                (source, family),
-                ("asset", "data_sensitivity") | ("cerebro", "health.jetstream_canary")
-            ) {
-                Some(reason)
-            } else {
-                None
-            };
             assert_eq!(
                 legacy_decode_skip(ConsumerMode::Forward, source, family, &error),
-                forward_reason
+                Some(reason)
             );
         }
         assert_eq!(
@@ -1749,6 +1649,27 @@ mod tests {
             skip_category("legacy_retired_family_projection_incompatible"),
             ConsumerSkipCategory::LegacyRetiredFamilyProjectionIncompatible
         );
+    }
+
+    #[test]
+    fn invalid_observation_ids_are_not_replay_only_skips() {
+        let error = EventDecodeError::Boundary(AppendLogDecodeError::InvalidModel(
+            "observation id is invalid".to_owned(),
+        ));
+        for (source, family) in [
+            ("gcp", "iam_role_assignment"),
+            ("gcp", "effective_permission"),
+            ("aws", "public_endpoint"),
+        ] {
+            assert_eq!(
+                legacy_decode_skip(ConsumerMode::Replay, source, family, &error),
+                None
+            );
+            assert_eq!(
+                legacy_decode_skip(ConsumerMode::Forward, source, family, &error),
+                None
+            );
+        }
     }
 
     #[test]
@@ -1793,61 +1714,6 @@ mod tests {
                 &EventDecodeError::Boundary(AppendLogDecodeError::Protobuf(
                     "invalid wire type".to_owned(),
                 )),
-            ),
-            None
-        );
-    }
-
-    #[test]
-    fn replay_skips_permanent_failures_only_for_the_retired_okta_family() {
-        let missing_catalog = crate::ProjectionFailure::Invalid(
-            "family okta.threat_insight is not in the compiled catalog".to_owned(),
-        );
-        let historical_shape = crate::ProjectionFailure::Invalid(
-            "historical threat insight shape cannot be projected".to_owned(),
-        );
-        assert_eq!(
-            replay_legacy_projection_skip(
-                ConsumerMode::Replay,
-                "okta",
-                "threat_insight",
-                &missing_catalog,
-            ),
-            Some("legacy_retired_family_projection_incompatible")
-        );
-        assert_eq!(
-            replay_legacy_projection_skip(
-                ConsumerMode::Replay,
-                "okta",
-                "threat_insight",
-                &historical_shape,
-            ),
-            Some("legacy_retired_family_projection_incompatible")
-        );
-        assert_eq!(
-            replay_legacy_projection_skip(
-                ConsumerMode::Forward,
-                "okta",
-                "threat_insight",
-                &missing_catalog,
-            ),
-            None
-        );
-        assert_eq!(
-            replay_legacy_projection_skip(
-                ConsumerMode::Replay,
-                "okta",
-                "group_membership",
-                &missing_catalog,
-            ),
-            None
-        );
-        assert_eq!(
-            replay_legacy_projection_skip(
-                ConsumerMode::Replay,
-                "okta",
-                "application",
-                &missing_catalog,
             ),
             None
         );

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -12,6 +12,7 @@ mod slack_agent_mcp;
 mod slack_agent_session;
 mod slack_authority;
 mod slack_mrkdwn;
+mod threat_insight_projection;
 
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -821,6 +822,24 @@ impl ProjectionRuntime {
         {
             return Ok(ProjectEventResponse {
                 authority: ProjectionAuthority::Rust,
+                projected: true,
+                graph_revision: Some(receipt.graph_revision),
+                entities_upserted: receipt.entities_upserted,
+                assertions_upserted: receipt.assertions_upserted,
+            });
+        }
+        if threat_insight_projection::matches(&event) {
+            let (batch, delta) =
+                threat_insight_projection::project(event).map_err(ProjectionFailure::Invalid)?;
+            let receipt = self
+                .store
+                .lock()
+                .await
+                .apply(&batch, delta)
+                .await
+                .map_err(ProjectionFailure::Store)?;
+            return Ok(ProjectEventResponse {
+                authority: authority.authority,
                 projected: true,
                 graph_revision: Some(receipt.graph_revision),
                 entities_upserted: receipt.entities_upserted,

--- a/crates/cerebro-platform/src/threat_insight_projection.rs
+++ b/crates/cerebro-platform/src/threat_insight_projection.rs
@@ -1,0 +1,279 @@
+use std::collections::BTreeSet;
+
+use cerebro_organizational_model::{
+    AssertionProvenance, Entity, EntityKind, GraphAssertion, GraphDelta, ObservationRef,
+    ProviderKind, RelationKind, RelationshipAssertion,
+};
+use cerebro_source_runtime_next::{CollectedBatch, CommittedSourceEvent};
+
+const SOURCE_ID: &str = "okta";
+const FAMILY_ID: &str = "threat_insight";
+const EVENT_KIND: &str = "okta.threat_insight";
+const SCHEMA_REF: &str = "okta/threat_insight/v1";
+const RESOURCE_ID: &str = "threat_insight_config";
+const RESOURCE_TYPE: &str = "ThreatInsightConfiguration";
+
+pub(crate) fn matches(event: &CommittedSourceEvent) -> bool {
+    event.source_id() == SOURCE_ID
+        && event.family_id() == FAMILY_ID
+        && event.event_kind() == EVENT_KIND
+        && event.schema_ref() == SCHEMA_REF
+}
+
+pub(crate) fn project(event: CommittedSourceEvent) -> Result<(CollectedBatch, GraphDelta), String> {
+    if !matches(&event) {
+        return Err("event is not the exact Okta ThreatInsight v1 contract".to_owned());
+    }
+    let tenant_id = event.tenant_id().clone();
+    let source_runtime_id = event.source_runtime_id().clone();
+    let observation_id = event.observation_id().clone();
+    let observed_at_unix_ms = event.observed_at_unix_ms();
+    let payload = event
+        .payload()
+        .as_object()
+        .ok_or("Okta ThreatInsight payload must be an object")?;
+    let domain = required_payload_string(payload, "domain")?.to_owned();
+    let action = required_payload_string(payload, "action")?.to_owned();
+    let zones = payload
+        .get("exclude_zones")
+        .and_then(serde_json::Value::as_array)
+        .ok_or("Okta ThreatInsight exclude_zones must be an array")?;
+    let mut unique_zones = BTreeSet::new();
+    for zone in zones {
+        let zone = zone
+            .as_str()
+            .ok_or("Okta ThreatInsight exclude_zones must contain only strings")?;
+        if zone.trim().is_empty() || zone.trim() != zone || zone.chars().any(char::is_control) {
+            return Err("Okta ThreatInsight network zone ID is invalid".to_owned());
+        }
+        unique_zones.insert(zone.to_owned());
+    }
+
+    require_attribute(&event, "family", FAMILY_ID)?;
+    require_attribute(&event, "domain", &domain)?;
+    require_attribute(&event, "action", &action)?;
+    require_attribute(&event, "resource_id", RESOURCE_ID)?;
+    require_attribute(&event, "resource_type", RESOURCE_TYPE)?;
+    if domain != tenant_id.as_str() {
+        return Err("Okta ThreatInsight domain does not match the event tenant".to_owned());
+    }
+    let exclude_zone_count = event
+        .attributes()
+        .get("exclude_zone_count")
+        .ok_or("Okta ThreatInsight event is missing exclude_zone_count")?
+        .parse::<usize>()
+        .map_err(|_| "Okta ThreatInsight exclude_zone_count is invalid")?;
+    if exclude_zone_count != zones.len() {
+        return Err("Okta ThreatInsight exclude_zone_count does not match the payload".to_owned());
+    }
+
+    let batch = event
+        .into_batch(EVENT_KIND.to_owned(), RESOURCE_ID.to_owned())
+        .map_err(|error| error.to_string())?;
+    let receipt = batch.scope.receipt().clone();
+    let organization = Entity::provider(
+        tenant_id.clone(),
+        source_runtime_id.clone(),
+        ProviderKind::parse("okta.org").map_err(|error| error.to_string())?,
+        domain.clone(),
+        EntityKind::Organization,
+        domain.clone(),
+    )
+    .and_then(|entity| entity.with_property("domain", domain.clone()))
+    .map_err(|error| error.to_string())?;
+    let threat_insight = Entity::provider(
+        tenant_id.clone(),
+        source_runtime_id.clone(),
+        ProviderKind::parse(EVENT_KIND).map_err(|error| error.to_string())?,
+        RESOURCE_ID,
+        EntityKind::Resource,
+        "ThreatInsight",
+    )
+    .and_then(|entity| entity.with_property("action", action))
+    .and_then(|entity| entity.with_property("domain", domain))
+    .and_then(|entity| entity.with_property("exclude_zone_count", exclude_zone_count.to_string()))
+    .and_then(|entity| entity.with_property("resource_type", RESOURCE_TYPE))
+    .map_err(|error| error.to_string())?;
+    let provenance = AssertionProvenance::direct(
+        vec![
+            ObservationRef::new(&receipt, observation_id, RESOURCE_ID)
+                .map_err(|error| error.to_string())?,
+        ],
+        "cerebro-okta-threat-insight",
+        env!("CARGO_PKG_VERSION"),
+    )
+    .map_err(|error| error.to_string())?;
+
+    let mut builder = receipt.begin_delta();
+    builder
+        .add_entity(organization.clone())
+        .map_err(|error| error.to_string())?;
+    builder
+        .add_entity(threat_insight.clone())
+        .map_err(|error| error.to_string())?;
+    builder
+        .add_assertion(GraphAssertion::Relationship(
+            RelationshipAssertion::new(
+                &organization,
+                RelationKind::Contains,
+                &threat_insight,
+                provenance.clone(),
+                observed_at_unix_ms,
+            )
+            .map_err(|error| error.to_string())?,
+        ))
+        .map_err(|error| error.to_string())?;
+
+    for zone in unique_zones {
+        let zone_entity = Entity::provider(
+            tenant_id.clone(),
+            source_runtime_id.clone(),
+            ProviderKind::parse("okta.network_zone").map_err(|error| error.to_string())?,
+            zone.clone(),
+            EntityKind::Resource,
+            zone.clone(),
+        )
+        .and_then(|entity| entity.with_property("network_zone_id", zone.clone()))
+        .and_then(|entity| entity.with_property("zone_id", zone))
+        .map_err(|error| error.to_string())?;
+        builder
+            .add_entity(zone_entity.clone())
+            .map_err(|error| error.to_string())?;
+        for (from, relation, to) in [
+            (&threat_insight, RelationKind::DependsOn, &zone_entity),
+            (&organization, RelationKind::Contains, &zone_entity),
+        ] {
+            builder
+                .add_assertion(GraphAssertion::Relationship(
+                    RelationshipAssertion::new(
+                        from,
+                        relation,
+                        to,
+                        provenance.clone(),
+                        observed_at_unix_ms,
+                    )
+                    .map_err(|error| error.to_string())?,
+                ))
+                .map_err(|error| error.to_string())?;
+        }
+    }
+    Ok((batch, builder.build()))
+}
+
+fn required_payload_string<'a>(
+    payload: &'a serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Result<&'a str, String> {
+    payload
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| {
+            !value.trim().is_empty()
+                && value.trim() == *value
+                && !value.chars().any(char::is_control)
+        })
+        .ok_or_else(|| format!("Okta ThreatInsight {field} is invalid"))
+}
+
+fn require_attribute(
+    event: &CommittedSourceEvent,
+    key: &str,
+    expected: &str,
+) -> Result<(), String> {
+    match event.attributes().get(key).map(String::as_str) {
+        Some(actual) if actual == expected => Ok(()),
+        _ => Err(format!(
+            "Okta ThreatInsight {key} does not match the event contract"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use cerebro_organizational_model::{ObservationId, SourceRuntimeId, TenantId};
+    use cerebro_source_runtime_next::{CommittedSourceEvent, CommittedSourceInput};
+
+    use super::*;
+
+    fn event(zones: serde_json::Value) -> CommittedSourceEvent {
+        event_with("example.okta.test", "block", "example.okta.test", zones)
+    }
+
+    fn event_with(
+        tenant: &str,
+        attribute_action: &str,
+        payload_domain: &str,
+        zones: serde_json::Value,
+    ) -> CommittedSourceEvent {
+        let count = zones.as_array().map_or(0, Vec::len);
+        CommittedSourceEvent::from_input(CommittedSourceInput {
+            tenant_id: TenantId::parse(tenant).unwrap(),
+            source_runtime_id: SourceRuntimeId::parse("okta-runtime").unwrap(),
+            observation_id: ObservationId::parse("compat:v1:threat-insight").unwrap(),
+            source_id: SOURCE_ID.to_owned(),
+            family_id: FAMILY_ID.to_owned(),
+            event_kind: EVENT_KIND.to_owned(),
+            schema_ref: SCHEMA_REF.to_owned(),
+            observed_at_unix_ms: 1_720_000_000_123,
+            attributes: BTreeMap::from([
+                ("action".to_owned(), attribute_action.to_owned()),
+                ("domain".to_owned(), tenant.to_owned()),
+                ("exclude_zone_count".to_owned(), count.to_string()),
+                ("family".to_owned(), FAMILY_ID.to_owned()),
+                ("resource_id".to_owned(), RESOURCE_ID.to_owned()),
+                ("resource_type".to_owned(), RESOURCE_TYPE.to_owned()),
+                ("source_runtime_id".to_owned(), "okta-runtime".to_owned()),
+            ]),
+            payload: serde_json::json!({
+                "action": "block",
+                "domain": payload_domain,
+                "exclude_zones": zones,
+            }),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn valid_legacy_contract_projects_entities_and_provenance() {
+        let (batch, delta) = project(event(serde_json::json!(["zone-b", "zone-a"]))).unwrap();
+
+        assert_eq!(batch.records.len(), 1);
+        assert_eq!(delta.entities().len(), 4);
+        assert_eq!(delta.assertions().len(), 5);
+        assert!(delta.assertions().iter().all(|assertion| {
+            assertion.provenance().observations()[0]
+                .observation_id()
+                .as_str()
+                == "compat:v1:threat-insight"
+        }));
+    }
+
+    #[test]
+    fn zone_order_is_projection_idempotent() {
+        let (_, first) = project(event(serde_json::json!(["zone-b", "zone-a"]))).unwrap();
+        let (_, second) = project(event(serde_json::json!(["zone-a", "zone-b"]))).unwrap();
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn tenant_and_provenance_mismatches_fail_closed() {
+        let wrong_domain = event_with(
+            "example.okta.test",
+            "block",
+            "other.okta.test",
+            serde_json::json!(["zone-a"]),
+        );
+        assert!(project(wrong_domain).unwrap_err().contains("domain"));
+
+        let wrong_action = event_with(
+            "example.okta.test",
+            "audit",
+            "example.okta.test",
+            serde_json::json!(["zone-a"]),
+        );
+        assert!(project(wrong_action).unwrap_err().contains("action"));
+    }
+}

--- a/crates/organizational-store/src/postgres.rs
+++ b/crates/organizational-store/src/postgres.rs
@@ -419,6 +419,17 @@ const START_CONSUMER_RUN_QUERY: &str = "INSERT INTO organizational_consumer_runs
 
 const SOURCE_COLLECTION_MANIFEST_QUERY: &str = "SELECT manifest_json FROM organizational_source_collection_receipts WHERE tenant_id = $1 AND source_runtime_id = $2 AND collection_id = $3";
 
+const RECORD_SOURCE_EVENT_QUERY: &str = r#"
+INSERT INTO organizational_source_event_receipts (
+  tenant_id, event_id, source_runtime_id, source_id, family_id, event_kind,
+  schema_ref, observed_at_unix_ms, attributes_digest, payload_digest, record_digest
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+ON CONFLICT (tenant_id, event_id) DO UPDATE
+SET record_digest = EXCLUDED.record_digest
+WHERE organizational_source_event_receipts.record_digest = EXCLUDED.record_digest
+RETURNING record_digest
+"#;
+
 const IDENTITY_CLAIM_REPLACEMENT_QUERY: &str = r#"
 SELECT assertion_id
 FROM organizational_assertions
@@ -1484,7 +1495,7 @@ WHERE id = $1
         set_tenant(&transaction, tenant_id).await?;
         let row = transaction
             .query_opt(
-                "INSERT INTO organizational_source_event_receipts (tenant_id, event_id, source_runtime_id, source_id, family_id, event_kind, schema_ref, observed_at_unix_ms, attributes_digest, payload_digest, record_digest) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) ON CONFLICT (tenant_id, event_id) DO UPDATE SET record_digest = EXCLUDED.record_digest WHERE organizational_source_event_receipts.record_digest = EXCLUDED.record_digest RETURNING record_digest",
+                RECORD_SOURCE_EVENT_QUERY,
                 &[
                     &tenant_id,
                     &event_id,
@@ -3405,6 +3416,15 @@ mod tests {
                 "source collection lookup omitted {required}"
             );
         }
+    }
+
+    #[test]
+    fn source_event_receipts_remain_fail_closed_on_conflicting_records() {
+        assert!(RECORD_SOURCE_EVENT_QUERY.contains("ON CONFLICT (tenant_id, event_id)"));
+        assert!(RECORD_SOURCE_EVENT_QUERY.contains(
+            "WHERE organizational_source_event_receipts.record_digest = EXCLUDED.record_digest"
+        ));
+        assert!(RECORD_SOURCE_EVENT_QUERY.contains("RETURNING record_digest"));
     }
 
     #[test]

--- a/crates/source-runtime-next/src/append_log.rs
+++ b/crates/source-runtime-next/src/append_log.rs
@@ -25,6 +25,11 @@ const CREDENTIAL_EVENT_KIND: &str = "security.credential.lifecycle";
 const CERTIFICATE_EVENT_KIND: &str = "security.certificate.lifecycle";
 const CREDENTIAL_SCHEMA_REF: &str = "cerebro/security/credential-lifecycle/v1";
 const CERTIFICATE_SCHEMA_REF: &str = "cerebro/security/certificate-lifecycle/v1";
+const OKTA_THREAT_INSIGHT_KIND: &str = "okta.threat_insight";
+const OKTA_THREAT_INSIGHT_SCHEMA_REF: &str = "okta/threat_insight/v1";
+const LEGACY_OKTA_THREAT_INSIGHT_PREFIX: &str = "okta-threat-insight-";
+const CURRENT_OKTA_THREAT_INSIGHT_PREFIX: &str = "okta-threat-insight-sha256-";
+const COMPATIBILITY_OBSERVATION_ID_PREFIX: &str = "compat:v1:";
 
 #[derive(Clone, PartialEq, Message)]
 struct CommittedSourceWire {
@@ -214,7 +219,16 @@ impl CommittedSourceEvent {
         let tenant_id = TenantId::parse(tenant).map_err(model_error)?;
         let source_runtime_id =
             SourceRuntimeId::parse(required(runtime, "source_runtime_id")?).map_err(model_error)?;
-        let observation_id = ObservationId::parse(event_id).map_err(model_error)?;
+        let observation_id = decode_observation_id(
+            event_id,
+            &tenant_id,
+            &source_id,
+            kind,
+            wire.schema_ref.trim(),
+            observed_at_unix_ms,
+            &wire.attributes,
+            &payload,
+        )?;
         Ok(Some(Self {
             tenant_id,
             source_runtime_id,
@@ -310,7 +324,7 @@ impl CommittedSourceEvent {
             hash_field(&mut hasher, key.as_bytes());
             hash_field(&mut hasher, value.as_bytes());
         }
-        let payload = canonical_payload_bytes(&self.payload);
+        let payload = self.canonical_payload_bytes();
         hash_field(&mut hasher, &payload);
         finish_digest(hasher)
     }
@@ -328,7 +342,7 @@ impl CommittedSourceEvent {
     /// Hash only the canonical JSON payload.
     pub fn payload_digest(&self) -> String {
         let mut hasher = Sha256::new();
-        let payload = canonical_payload_bytes(&self.payload);
+        let payload = self.canonical_payload_bytes();
         hash_field(&mut hasher, &payload);
         finish_digest(hasher)
     }
@@ -339,6 +353,15 @@ impl CommittedSourceEvent {
     /// portable lifecycle projectors consume these preserved bytes instead.
     pub fn raw_payload(&self) -> &[u8] {
         &self.raw_payload
+    }
+
+    fn canonical_payload_bytes(&self) -> Vec<u8> {
+        canonical_event_payload_bytes(
+            &self.source_id,
+            &self.event_kind,
+            &self.schema_ref,
+            &self.payload,
+        )
     }
 
     /// Return whether this event is an accepted portable security lifecycle event.
@@ -391,6 +414,169 @@ impl CommittedSourceEvent {
 fn hash_field(hasher: &mut Sha256, value: &[u8]) {
     hasher.update(value.len().to_be_bytes());
     hasher.update(value);
+}
+
+#[allow(clippy::too_many_arguments)]
+// Translate only source contracts whose historical producer IDs cannot cross
+// the organizational-model boundary. Hashing the original coordinates avoids
+// lossy character replacement and keeps redelivery identity stable.
+fn decode_observation_id(
+    event_id: &str,
+    tenant_id: &TenantId,
+    source_id: &str,
+    event_kind: &str,
+    schema_ref: &str,
+    observed_at_unix_ms: i64,
+    attributes: &HashMap<String, String>,
+    payload: &serde_json::Value,
+) -> Result<ObservationId, AppendLogDecodeError> {
+    if is_legacy_okta_threat_insight_id(
+        event_id,
+        tenant_id,
+        event_kind,
+        schema_ref,
+        observed_at_unix_ms,
+    ) {
+        let mut hasher = Sha256::new();
+        hash_field(
+            &mut hasher,
+            b"cerebro.compat-observation-id.okta-threat-insight/v1",
+        );
+        hash_field(&mut hasher, tenant_id.as_str().as_bytes());
+        hash_field(&mut hasher, source_id.as_bytes());
+        hash_field(&mut hasher, event_kind.as_bytes());
+        hash_field(&mut hasher, schema_ref.as_bytes());
+        hash_field(&mut hasher, observed_at_unix_ms.to_string().as_bytes());
+        let mut attributes = attributes.iter().collect::<Vec<_>>();
+        attributes.sort_unstable_by(|left, right| left.0.cmp(right.0));
+        for (key, value) in attributes {
+            if matches!(
+                key.as_str(),
+                SOURCE_RUNTIME_ID_ATTRIBUTE | SOURCE_COLLECTION_ID_ATTRIBUTE
+            ) {
+                continue;
+            }
+            hash_field(&mut hasher, key.as_bytes());
+            hash_field(&mut hasher, value.as_bytes());
+        }
+        hash_field(
+            &mut hasher,
+            &canonical_event_payload_bytes(source_id, event_kind, schema_ref, payload),
+        );
+        return compatibility_observation_id(hasher);
+    }
+
+    match ObservationId::parse(event_id) {
+        Ok(observation_id) => Ok(observation_id),
+        Err(_) if is_compatible_legacy_invalid_id(event_id, source_id, event_kind, schema_ref) => {
+            let mut hasher = Sha256::new();
+            hash_field(
+                &mut hasher,
+                b"cerebro.compat-observation-id.invalid-character/v1",
+            );
+            hash_field(&mut hasher, tenant_id.as_str().as_bytes());
+            hash_field(&mut hasher, source_id.as_bytes());
+            hash_field(&mut hasher, event_kind.as_bytes());
+            hash_field(&mut hasher, schema_ref.as_bytes());
+            hash_field(&mut hasher, event_id.as_bytes());
+            compatibility_observation_id(hasher)
+        }
+        Err(error) => Err(model_error(error)),
+    }
+}
+
+fn is_legacy_okta_threat_insight_id(
+    event_id: &str,
+    tenant_id: &TenantId,
+    event_kind: &str,
+    schema_ref: &str,
+    observed_at_unix_ms: i64,
+) -> bool {
+    // The historical timestamp ID omitted action and excluded zones. Re-key it
+    // from canonical immutable material so two configurations cannot share a
+    // receipt key and an existing receipt under the old ID remains untouched.
+    event_kind == OKTA_THREAT_INSIGHT_KIND
+        && schema_ref == OKTA_THREAT_INSIGHT_SCHEMA_REF
+        && event_id.starts_with(LEGACY_OKTA_THREAT_INSIGHT_PREFIX)
+        && !event_id.starts_with(CURRENT_OKTA_THREAT_INSIGHT_PREFIX)
+        && event_id
+            == format!("{LEGACY_OKTA_THREAT_INSIGHT_PREFIX}{tenant_id}-{observed_at_unix_ms}")
+}
+
+fn is_compatible_legacy_invalid_id(
+    event_id: &str,
+    source_id: &str,
+    event_kind: &str,
+    schema_ref: &str,
+) -> bool {
+    if event_id.len() > 256 || event_id.is_empty() {
+        return false;
+    }
+    match (source_id, event_kind, schema_ref) {
+        ("gcp", "gcp.iam_role_assignment", "gcp/iam_role_assignment/v1") => event_id
+            .strip_prefix("gcp-iam-role-assignment-")
+            .is_some_and(|suffix| {
+                !suffix.is_empty()
+                    && event_id.contains('@')
+                    && event_id
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || b"-_.:/@+%".contains(&byte))
+            }),
+        ("gcp", "gcp.effective_permission", "gcp/effective_permission/v1") => event_id
+            .strip_prefix("gcp-effective-permission-")
+            .is_some_and(|suffix| {
+                !suffix.is_empty()
+                    && event_id.contains('@')
+                    && event_id
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || b"-_.:/@+%".contains(&byte))
+            }),
+        ("aws", "aws.public_endpoint", "aws/public_endpoint/v1") => event_id
+            .strip_prefix("aws-public-endpoint-")
+            .is_some_and(|suffix| {
+                !suffix.is_empty()
+                    && event_id.contains('*')
+                    && event_id
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || b"-_.:/*".contains(&byte))
+            }),
+        _ => false,
+    }
+}
+
+fn compatibility_observation_id(hasher: Sha256) -> Result<ObservationId, AppendLogDecodeError> {
+    ObservationId::parse(format!(
+        "{COMPATIBILITY_OBSERVATION_ID_PREFIX}{}",
+        finish_digest(hasher)
+    ))
+    .map_err(model_error)
+}
+
+fn canonical_event_payload_bytes(
+    source_id: &str,
+    event_kind: &str,
+    schema_ref: &str,
+    payload: &serde_json::Value,
+) -> Vec<u8> {
+    let mut payload = payload.clone();
+    // The v1 API models excluded zones as a set. Its historical producer kept
+    // provider order, so equivalent deliveries need one semantic digest.
+    if source_id == "okta"
+        && event_kind == OKTA_THREAT_INSIGHT_KIND
+        && schema_ref == OKTA_THREAT_INSIGHT_SCHEMA_REF
+        && let Some(zones) = payload
+            .as_object_mut()
+            .and_then(|object| object.get_mut("exclude_zones"))
+            .and_then(serde_json::Value::as_array_mut)
+        && zones.iter().all(serde_json::Value::is_string)
+    {
+        zones.sort_unstable_by(|left, right| {
+            left.as_str()
+                .expect("checked string zone")
+                .cmp(right.as_str().expect("checked string zone"))
+        });
+    }
+    canonical_payload_bytes(&payload)
 }
 
 fn canonical_payload_bytes(value: &serde_json::Value) -> Vec<u8> {
@@ -493,6 +679,121 @@ mod tests {
         assert_eq!(event.observed_at_unix_ms(), 1_720_000_000_123);
         assert_eq!(event.attributes()["provider_id"], "file-1");
         assert_eq!(event.payload()["name"], "board.pdf");
+    }
+
+    #[test]
+    fn compatible_legacy_observation_id_decodes_to_stable_identity() {
+        let mut wire = source_wire();
+        wire.source_id = "gcp".to_owned();
+        wire.kind = "gcp.iam_role_assignment".to_owned();
+        wire.schema_ref = "gcp/iam_role_assignment/v1".to_owned();
+        wire.id = "gcp-iam-role-assignment-user+alias@example.test-roles-owner".to_owned();
+
+        let first = CommittedSourceEvent::decode(&encode(wire.clone()))
+            .expect("legacy compatibility ID should decode")
+            .expect("source event");
+        let second = CommittedSourceEvent::decode(&encode(wire))
+            .expect("redelivery should decode")
+            .expect("source event");
+
+        assert_eq!(first.observation_id(), second.observation_id());
+        assert_ne!(
+            first.observation_id().as_str(),
+            "gcp-iam-role-assignment-user+alias@example.test-roles-owner"
+        );
+        assert!(first.observation_id().as_str().starts_with("compat:v1:"));
+    }
+
+    #[test]
+    fn compatibility_identity_binds_tenant_and_contract_not_delivery_provenance() {
+        let mut first_wire = source_wire();
+        first_wire.source_id = "gcp".to_owned();
+        first_wire.kind = "gcp.effective_permission".to_owned();
+        first_wire.schema_ref = "gcp/effective_permission/v1".to_owned();
+        first_wire.id = "gcp-effective-permission-user@example.test-roles-owner".to_owned();
+        let first = CommittedSourceEvent::decode(&encode(first_wire.clone()))
+            .unwrap()
+            .unwrap();
+
+        let mut redelivery_wire = first_wire.clone();
+        redelivery_wire.attributes.insert(
+            SOURCE_RUNTIME_ID_ATTRIBUTE.to_owned(),
+            "gcp-replacement".to_owned(),
+        );
+        redelivery_wire.attributes.insert(
+            SOURCE_COLLECTION_ID_ATTRIBUTE.to_owned(),
+            "replacement-collection".to_owned(),
+        );
+        let redelivery = CommittedSourceEvent::decode(&encode(redelivery_wire))
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.observation_id(), redelivery.observation_id());
+        assert_eq!(first.record_digest(), redelivery.record_digest());
+        assert_ne!(first.attributes_digest(), redelivery.attributes_digest());
+
+        let mut other_tenant_wire = first_wire;
+        other_tenant_wire.tenant_id = "tenant-b".to_owned();
+        let other_tenant = CommittedSourceEvent::decode(&encode(other_tenant_wire))
+            .unwrap()
+            .unwrap();
+        assert_ne!(first.observation_id(), other_tenant.observation_id());
+        assert_ne!(first.record_digest(), other_tenant.record_digest());
+    }
+
+    #[test]
+    fn compatibility_identity_boundary_stays_closed() {
+        let cases = [
+            (
+                "box",
+                "box.content_assets",
+                "box/content_assets/v1",
+                "user@example.test",
+            ),
+            (
+                "gcp",
+                "gcp.project_bindings",
+                "gcp/project_bindings/v1",
+                "gcp-iam-role-assignment-user@example.test-roles-owner",
+            ),
+            (
+                "gcp",
+                "gcp.iam_role_assignment",
+                "gcp/iam_role_assignment/v1",
+                "gcp-iam-role-assignment-user\\alias@example.test-roles-owner",
+            ),
+            (
+                "aws",
+                "aws.public_endpoint",
+                "aws/public_endpoint/v1",
+                "aws-public-endpoint-host@example.test",
+            ),
+        ];
+        for (source, kind, schema, id) in cases {
+            let mut wire = source_wire();
+            wire.source_id = source.to_owned();
+            wire.kind = kind.to_owned();
+            wire.schema_ref = schema.to_owned();
+            wire.id = id.to_owned();
+            assert!(matches!(
+                CommittedSourceEvent::decode(&encode(wire)),
+                Err(AppendLogDecodeError::InvalidModel(message))
+                    if message == "observation id is invalid"
+            ));
+        }
+    }
+
+    #[test]
+    fn legacy_aws_wildcard_endpoint_gets_a_collision_resistant_identity() {
+        let mut wire = source_wire();
+        wire.source_id = "aws".to_owned();
+        wire.kind = "aws.public_endpoint".to_owned();
+        wire.schema_ref = "aws/public_endpoint/v1".to_owned();
+        wire.id = "aws-public-endpoint-*.example.test".to_owned();
+
+        let event = CommittedSourceEvent::decode(&encode(wire))
+            .unwrap()
+            .unwrap();
+        assert!(event.observation_id().as_str().starts_with("compat:v1:"));
     }
 
     #[test]
@@ -650,6 +951,107 @@ mod tests {
     }
 
     #[test]
+    fn legacy_threat_insight_zone_order_is_idempotent() {
+        let mut first_wire = source_wire();
+        first_wire.id = "okta-threat-insight-example.okta.test-1720000000123".to_owned();
+        first_wire.tenant_id = "example.okta.test".to_owned();
+        first_wire.source_id = "okta".to_owned();
+        first_wire.kind = "okta.threat_insight".to_owned();
+        first_wire.schema_ref = "okta/threat_insight/v1".to_owned();
+        first_wire.payload = br#"{"action":"block","domain":"example.okta.test","exclude_zones":["zone-b","zone-a"]}"#.to_vec();
+        first_wire.attributes = HashMap::from([
+            (
+                SOURCE_RUNTIME_ID_ATTRIBUTE.to_owned(),
+                "okta-runtime".to_owned(),
+            ),
+            ("action".to_owned(), "block".to_owned()),
+            ("domain".to_owned(), "example.okta.test".to_owned()),
+            ("exclude_zone_count".to_owned(), "2".to_owned()),
+            ("family".to_owned(), "threat_insight".to_owned()),
+            ("resource_id".to_owned(), "threat_insight_config".to_owned()),
+            (
+                "resource_type".to_owned(),
+                "ThreatInsightConfiguration".to_owned(),
+            ),
+        ]);
+
+        let mut second_wire = first_wire.clone();
+        second_wire.payload = br#"{"exclude_zones":["zone-a","zone-b"],"domain":"example.okta.test","action":"block"}"#.to_vec();
+
+        let first = CommittedSourceEvent::decode(&encode(first_wire))
+            .unwrap()
+            .unwrap();
+        let second = CommittedSourceEvent::decode(&encode(second_wire))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(first.observation_id(), second.observation_id());
+        assert!(first.observation_id().as_str().starts_with("compat:v1:"));
+        assert_eq!(first.record_digest(), second.record_digest());
+        assert_eq!(first.payload_digest(), second.payload_digest());
+    }
+
+    #[test]
+    fn legacy_threat_insight_conflicting_material_remains_distinct() {
+        let mut first_wire = source_wire();
+        first_wire.id = "okta-threat-insight-example.okta.test-1720000000123".to_owned();
+        first_wire.tenant_id = "example.okta.test".to_owned();
+        first_wire.source_id = "okta".to_owned();
+        first_wire.kind = OKTA_THREAT_INSIGHT_KIND.to_owned();
+        first_wire.schema_ref = OKTA_THREAT_INSIGHT_SCHEMA_REF.to_owned();
+        first_wire.payload =
+            br#"{"action":"block","domain":"example.okta.test","exclude_zones":["zone-a"]}"#
+                .to_vec();
+        first_wire.attributes = HashMap::from([
+            (
+                SOURCE_RUNTIME_ID_ATTRIBUTE.to_owned(),
+                "okta-runtime".to_owned(),
+            ),
+            ("action".to_owned(), "block".to_owned()),
+            ("domain".to_owned(), "example.okta.test".to_owned()),
+            ("exclude_zone_count".to_owned(), "1".to_owned()),
+            ("family".to_owned(), "threat_insight".to_owned()),
+            ("resource_id".to_owned(), "threat_insight_config".to_owned()),
+            (
+                "resource_type".to_owned(),
+                "ThreatInsightConfiguration".to_owned(),
+            ),
+        ]);
+        let mut conflicting_wire = first_wire.clone();
+        conflicting_wire.payload =
+            br#"{"action":"block","domain":"example.okta.test","exclude_zones":["zone-b"]}"#
+                .to_vec();
+
+        let first = CommittedSourceEvent::decode(&encode(first_wire))
+            .unwrap()
+            .unwrap();
+        let conflicting = CommittedSourceEvent::decode(&encode(conflicting_wire))
+            .unwrap()
+            .unwrap();
+
+        assert_ne!(first.observation_id(), conflicting.observation_id());
+        assert_ne!(first.record_digest(), conflicting.record_digest());
+    }
+
+    #[test]
+    fn current_threat_insight_content_identity_is_preserved() {
+        let mut wire = source_wire();
+        wire.id = format!("{CURRENT_OKTA_THREAT_INSIGHT_PREFIX}{}", "a".repeat(64));
+        wire.tenant_id = "example.okta.test".to_owned();
+        wire.source_id = "okta".to_owned();
+        wire.kind = OKTA_THREAT_INSIGHT_KIND.to_owned();
+        wire.schema_ref = OKTA_THREAT_INSIGHT_SCHEMA_REF.to_owned();
+
+        let event = CommittedSourceEvent::decode(&encode(wire))
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            event.observation_id().as_str(),
+            format!("{CURRENT_OKTA_THREAT_INSIGHT_PREFIX}{}", "a".repeat(64))
+        );
+    }
+
+    #[test]
     fn record_digest_excludes_only_exact_delivery_provenance() {
         let mut first_wire = source_wire();
         first_wire.attributes.insert(
@@ -695,6 +1097,21 @@ mod tests {
                 "non-provenance attribute {key:?} was excluded"
             );
         }
+    }
+
+    #[test]
+    fn reused_current_observation_id_with_different_material_conflicts() {
+        let first = CommittedSourceEvent::decode(&encode(source_wire()))
+            .unwrap()
+            .unwrap();
+        let mut conflicting_wire = source_wire();
+        conflicting_wire.payload = br#"{"id":"file-1","name":"different-board.pdf"}"#.to_vec();
+        let conflicting = CommittedSourceEvent::decode(&encode(conflicting_wire))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(first.observation_id(), conflicting.observation_id());
+        assert_ne!(first.record_digest(), conflicting.record_digest());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- derive stable compatibility identities for legacy source events
- keep replay and Forward projection identity handling consistent
- surface immutable stored-record conflicts instead of silently accepting them
- project compatible threat-insight records through the Rust path

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cerebro-organizational-store -p cerebro-platform -p cerebro-source-runtime-next`
- `cargo clippy -p cerebro-organizational-store -p cerebro-platform -p cerebro-source-runtime-next --all-targets -- -D warnings`
- `make review-invariants`