### PR TITLE
fix(rust): preserve legacy replay identities

### DIFF
--- a/crates/cerebro-platform/src/append_log_consumer.rs
+++ b/crates/cerebro-platform/src/append_log_consumer.rs
@@ -644,7 +644,7 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
         };
         let event_source = event.source_id().to_owned();
         let event_family = event.family_id().to_owned();
-        let record_digest = event.record_digest();
+        let record_digest = diagnostic_record_digest(&event);
         match runtime.project_committed_shadow(event).await {
             Ok(response) => {
                 if !response.projected {
@@ -1219,6 +1219,10 @@ fn digest_bytes(bytes: &[u8]) -> String {
         .map(|byte| format!("{byte:02x}"))
         .collect::<String>();
     format!("sha256:{hex}")
+}
+
+fn diagnostic_record_digest(event: &CommittedSourceEvent) -> String {
+    format!("sha256:{}", event.record_digest())
 }
 
 fn checkpoint_message_sha256(message_sha256: &str) -> &str {
@@ -2073,6 +2077,28 @@ mod tests {
         ] {
             assert!(!encoded.contains(forbidden), "unexpected {forbidden}");
         }
+    }
+
+    #[test]
+    fn committed_record_digest_uses_the_diagnostic_sha256_contract() {
+        let event = CommittedSourceEvent::decode(&encoded_event(
+            "box",
+            "box.content_assets",
+            "box/content_assets/v1",
+            br#"{"id":"file-1"}"#.to_vec(),
+        ))
+        .unwrap()
+        .unwrap();
+
+        let digest = diagnostic_record_digest(&event);
+        assert_eq!(digest, format!("sha256:{}", event.record_digest()));
+        assert_eq!(digest.len(), 71);
+        assert!(digest.starts_with("sha256:"));
+        assert!(
+            digest[7..]
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        );
     }
 
     #[test]

--- a/crates/cerebro-platform/src/threat_insight_projection.rs
+++ b/crates/cerebro-platform/src/threat_insight_projection.rs
@@ -54,9 +54,6 @@ pub(crate) fn project(event: CommittedSourceEvent) -> Result<(CollectedBatch, Gr
     require_attribute(&event, "action", &action)?;
     require_attribute(&event, "resource_id", RESOURCE_ID)?;
     require_attribute(&event, "resource_type", RESOURCE_TYPE)?;
-    if domain != tenant_id.as_str() {
-        return Err("Okta ThreatInsight domain does not match the event tenant".to_owned());
-    }
     let exclude_zone_count = event
         .attributes()
         .get("exclude_zone_count")
@@ -198,12 +195,19 @@ mod tests {
     use super::*;
 
     fn event(zones: serde_json::Value) -> CommittedSourceEvent {
-        event_with("example.okta.test", "block", "example.okta.test", zones)
+        event_with(
+            "example.okta.test",
+            "block",
+            "example.okta.test",
+            "example.okta.test",
+            zones,
+        )
     }
 
     fn event_with(
         tenant: &str,
         attribute_action: &str,
+        attribute_domain: &str,
         payload_domain: &str,
         zones: serde_json::Value,
     ) -> CommittedSourceEvent {
@@ -219,7 +223,7 @@ mod tests {
             observed_at_unix_ms: 1_720_000_000_123,
             attributes: BTreeMap::from([
                 ("action".to_owned(), attribute_action.to_owned()),
-                ("domain".to_owned(), tenant.to_owned()),
+                ("domain".to_owned(), attribute_domain.to_owned()),
                 ("exclude_zone_count".to_owned(), count.to_string()),
                 ("family".to_owned(), FAMILY_ID.to_owned()),
                 ("resource_id".to_owned(), RESOURCE_ID.to_owned()),
@@ -259,10 +263,27 @@ mod tests {
     }
 
     #[test]
+    fn provider_domain_can_differ_from_the_authoritative_runtime_tenant() {
+        let event = event_with(
+            "tenant-a",
+            "block",
+            "example.okta.test",
+            "example.okta.test",
+            serde_json::json!(["zone-a"]),
+        );
+        let (batch, delta) = project(event).unwrap();
+
+        assert_eq!(batch.scope.receipt().tenant_id().as_str(), "tenant-a");
+        assert_eq!(delta.entities().len(), 3);
+        assert_eq!(delta.assertions().len(), 3);
+    }
+
+    #[test]
     fn tenant_and_provenance_mismatches_fail_closed() {
         let wrong_domain = event_with(
             "example.okta.test",
             "block",
+            "example.okta.test",
             "other.okta.test",
             serde_json::json!(["zone-a"]),
         );
@@ -271,6 +292,7 @@ mod tests {
         let wrong_action = event_with(
             "example.okta.test",
             "audit",
+            "example.okta.test",
             "example.okta.test",
             serde_json::json!(["zone-a"]),
         );

--- a/crates/source-runtime-next/src/append_log.rs
+++ b/crates/source-runtime-next/src/append_log.rs
@@ -631,13 +631,9 @@ fn compatible_legacy_aws_public_endpoint_identity<'a>(
     if attributes.get("domain").map(String::as_str) != Some(account_id) {
         return None;
     }
-    let endpoint = match payload
+    let endpoint = payload
         .get("endpoint")
-        .and_then(serde_json::Value::as_object)
-    {
-        Some(endpoint) => endpoint,
-        None => return None,
-    };
+        .and_then(serde_json::Value::as_object)?;
     let identity_fields = [
         ("endpoint_id", "EndpointID"),
         ("resource_id", "ResourceID"),
@@ -646,10 +642,7 @@ fn compatible_legacy_aws_public_endpoint_identity<'a>(
     ];
     let mut identity = None;
     for (attribute_key, payload_key) in identity_fields {
-        let payload_value = match trimmed_json_string(endpoint, payload_key) {
-            Some(value) => value,
-            None => return None,
-        };
+        let payload_value = trimmed_json_string(endpoint, payload_key)?;
         let attribute_value = attributes.get(attribute_key).map(String::as_str);
         if attribute_value != (!payload_value.is_empty()).then_some(payload_value) {
             return None;
@@ -660,19 +653,14 @@ fn compatible_legacy_aws_public_endpoint_identity<'a>(
     }
     for (attribute_key, payload_key) in [("service", "Service"), ("resource_type", "ResourceType")]
     {
-        let payload_value = match trimmed_json_string(endpoint, payload_key) {
-            Some(value) => value,
-            None => return None,
-        };
+        let payload_value = trimmed_json_string(endpoint, payload_key)?;
         if attributes.get(attribute_key).map(String::as_str)
             != (!payload_value.is_empty()).then_some(payload_value)
         {
             return None;
         }
     }
-    let Some(identity) = identity else {
-        return None;
-    };
+    let identity = identity?;
     if identity.len() > MAX_LEGACY_IDENTITY_LEN {
         return None;
     }

--- a/crates/source-runtime-next/src/append_log.rs
+++ b/crates/source-runtime-next/src/append_log.rs
@@ -475,24 +475,38 @@ fn decode_observation_id(
 
     match ObservationId::parse(event_id) {
         Ok(observation_id) => Ok(observation_id),
-        Err(_)
-            if is_compatible_legacy_invalid_id(
-                event_id, source_id, event_kind, schema_ref, attributes, payload,
-            ) =>
-        {
-            let mut hasher = Sha256::new();
-            hash_field(
-                &mut hasher,
-                b"cerebro.compat-observation-id.invalid-character/v1",
-            );
-            hash_field(&mut hasher, tenant_id.as_str().as_bytes());
-            hash_field(&mut hasher, source_id.as_bytes());
-            hash_field(&mut hasher, event_kind.as_bytes());
-            hash_field(&mut hasher, schema_ref.as_bytes());
-            hash_field(&mut hasher, event_id.as_bytes());
-            compatibility_observation_id(hasher)
-        }
-        Err(error) => Err(model_error(error)),
+        Err(error) => match compatible_legacy_invalid_identity(
+            event_id, source_id, event_kind, schema_ref, attributes, payload,
+        ) {
+            Some(LegacyInvalidIdentity::PreservedEventId) => {
+                let mut hasher = Sha256::new();
+                hash_field(
+                    &mut hasher,
+                    b"cerebro.compat-observation-id.invalid-character/v1",
+                );
+                hash_field(&mut hasher, tenant_id.as_str().as_bytes());
+                hash_field(&mut hasher, source_id.as_bytes());
+                hash_field(&mut hasher, event_kind.as_bytes());
+                hash_field(&mut hasher, schema_ref.as_bytes());
+                hash_field(&mut hasher, event_id.as_bytes());
+                compatibility_observation_id(hasher)
+            }
+            Some(LegacyInvalidIdentity::AwsPublicEndpoint(raw_identity)) => {
+                let mut hasher = Sha256::new();
+                hash_field(
+                    &mut hasher,
+                    b"cerebro.compat-observation-id.aws-public-endpoint/v1",
+                );
+                hash_field(&mut hasher, tenant_id.as_str().as_bytes());
+                hash_field(&mut hasher, source_id.as_bytes());
+                hash_field(&mut hasher, event_kind.as_bytes());
+                hash_field(&mut hasher, schema_ref.as_bytes());
+                hash_field(&mut hasher, raw_identity.as_bytes());
+                hash_field(&mut hasher, event_id.as_bytes());
+                compatibility_observation_id(hasher)
+            }
+            None => Err(model_error(error)),
+        },
     }
 }
 
@@ -537,73 +551,92 @@ fn is_bounded_provider_domain(value: &str) -> bool {
             .is_some_and(u8::is_ascii_alphanumeric)
 }
 
-fn is_compatible_legacy_invalid_id(
+enum LegacyInvalidIdentity<'a> {
+    PreservedEventId,
+    AwsPublicEndpoint(&'a str),
+}
+
+fn compatible_legacy_invalid_identity<'a>(
     event_id: &str,
     source_id: &str,
     event_kind: &str,
     schema_ref: &str,
-    attributes: &HashMap<String, String>,
-    payload: &serde_json::Value,
-) -> bool {
+    attributes: &'a HashMap<String, String>,
+    payload: &'a serde_json::Value,
+) -> Option<LegacyInvalidIdentity<'a>> {
     if event_id.is_empty() {
-        return false;
+        return None;
     }
     match (source_id, event_kind, schema_ref) {
-        ("gcp", "gcp.iam_role_assignment", "gcp/iam_role_assignment/v1") => event_id
-            .strip_prefix("gcp-iam-role-assignment-")
-            .is_some_and(|suffix| {
-                event_id.len() <= 256
-                    && !suffix.is_empty()
-                    && event_id.contains('@')
-                    && event_id
-                        .bytes()
-                        .all(|byte| byte.is_ascii_alphanumeric() || b"-_.:/@+%".contains(&byte))
-            }),
-        ("gcp", "gcp.effective_permission", "gcp/effective_permission/v1") => event_id
-            .strip_prefix("gcp-effective-permission-")
-            .is_some_and(|suffix| {
-                event_id.len() <= 256
-                    && !suffix.is_empty()
-                    && event_id.contains('@')
-                    && event_id
-                        .bytes()
-                        .all(|byte| byte.is_ascii_alphanumeric() || b"-_.:/@+%".contains(&byte))
-            }),
-        ("aws", "aws.public_endpoint", "aws/public_endpoint/v1") => {
-            is_compatible_legacy_aws_public_endpoint_id(event_id, attributes, payload)
+        ("gcp", "gcp.iam_role_assignment", "gcp/iam_role_assignment/v1")
+            if event_id
+                .strip_prefix("gcp-iam-role-assignment-")
+                .is_some_and(|suffix| {
+                    event_id.len() <= 256
+                        && !suffix.is_empty()
+                        && event_id.contains('@')
+                        && event_id
+                            .bytes()
+                            .all(|byte| byte.is_ascii_alphanumeric() || b"-_.:/@+%".contains(&byte))
+                }) =>
+        {
+            Some(LegacyInvalidIdentity::PreservedEventId)
         }
-        _ => false,
+        ("gcp", "gcp.effective_permission", "gcp/effective_permission/v1")
+            if event_id
+                .strip_prefix("gcp-effective-permission-")
+                .is_some_and(|suffix| {
+                    event_id.len() <= 256
+                        && !suffix.is_empty()
+                        && event_id.contains('@')
+                        && event_id
+                            .bytes()
+                            .all(|byte| byte.is_ascii_alphanumeric() || b"-_.:/@+%".contains(&byte))
+                }) =>
+        {
+            Some(LegacyInvalidIdentity::PreservedEventId)
+        }
+        ("aws", "aws.public_endpoint", "aws/public_endpoint/v1") => {
+            let raw_identity =
+                compatible_legacy_aws_public_endpoint_identity(event_id, attributes, payload)?;
+            if preserves_existing_aws_wildcard_identity(event_id, raw_identity) {
+                Some(LegacyInvalidIdentity::PreservedEventId)
+            } else {
+                Some(LegacyInvalidIdentity::AwsPublicEndpoint(raw_identity))
+            }
+        }
+        _ => None,
     }
 }
 
-fn is_compatible_legacy_aws_public_endpoint_id(
+fn compatible_legacy_aws_public_endpoint_identity<'a>(
     event_id: &str,
-    attributes: &HashMap<String, String>,
-    payload: &serde_json::Value,
-) -> bool {
+    attributes: &'a HashMap<String, String>,
+    payload: &'a serde_json::Value,
+) -> Option<&'a str> {
     const LEGACY_EVENT_ID_PREFIX: &str = "aws-public-endpoint-";
     const MAX_LEGACY_IDENTITY_LEN: usize = 2_048;
     if !event_id.starts_with(LEGACY_EVENT_ID_PREFIX)
         || event_id.len() > LEGACY_EVENT_ID_PREFIX.len() + MAX_LEGACY_IDENTITY_LEN
     {
-        return false;
+        return None;
     }
     let account_id = match payload
         .get("account_id")
         .and_then(serde_json::Value::as_str)
     {
         Some(account_id) if !account_id.trim().is_empty() => account_id.trim(),
-        _ => return false,
+        _ => return None,
     };
     if attributes.get("domain").map(String::as_str) != Some(account_id) {
-        return false;
+        return None;
     }
     let endpoint = match payload
         .get("endpoint")
         .and_then(serde_json::Value::as_object)
     {
         Some(endpoint) => endpoint,
-        None => return false,
+        None => return None,
     };
     let identity_fields = [
         ("endpoint_id", "EndpointID"),
@@ -615,11 +648,11 @@ fn is_compatible_legacy_aws_public_endpoint_id(
     for (attribute_key, payload_key) in identity_fields {
         let payload_value = match trimmed_json_string(endpoint, payload_key) {
             Some(value) => value,
-            None => return false,
+            None => return None,
         };
         let attribute_value = attributes.get(attribute_key).map(String::as_str);
         if attribute_value != (!payload_value.is_empty()).then_some(payload_value) {
-            return false;
+            return None;
         }
         if identity.is_none() && !payload_value.is_empty() {
             identity = Some(payload_value);
@@ -629,21 +662,31 @@ fn is_compatible_legacy_aws_public_endpoint_id(
     {
         let payload_value = match trimmed_json_string(endpoint, payload_key) {
             Some(value) => value,
-            None => return false,
+            None => return None,
         };
         if attributes.get(attribute_key).map(String::as_str)
             != (!payload_value.is_empty()).then_some(payload_value)
         {
-            return false;
+            return None;
         }
     }
     let Some(identity) = identity else {
-        return false;
+        return None;
     };
     if identity.len() > MAX_LEGACY_IDENTITY_LEN {
-        return false;
+        return None;
     }
-    event_id == sanitize_legacy_aws_event_id(&format!("{LEGACY_EVENT_ID_PREFIX}{identity}"))
+    (event_id == sanitize_legacy_aws_event_id(&format!("{LEGACY_EVENT_ID_PREFIX}{identity}")))
+        .then_some(identity)
+}
+
+fn preserves_existing_aws_wildcard_identity(event_id: &str, raw_identity: &str) -> bool {
+    event_id.len() <= 256
+        && event_id.contains('*')
+        && event_id.strip_prefix("aws-public-endpoint-") == Some(raw_identity)
+        && event_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"-_.:/*".contains(&byte))
 }
 
 fn trimmed_json_string<'a>(
@@ -947,7 +990,10 @@ mod tests {
         let event = CommittedSourceEvent::decode(&encode(wire))
             .unwrap()
             .unwrap();
-        assert!(event.observation_id().as_str().starts_with("compat:v1:"));
+        assert_eq!(
+            event.observation_id().as_str(),
+            "compat:v1:c5346b4c728737c7f4a0a7b103df9c9daca8527f8c2e11a63bb3e0968c621c27"
+        );
     }
 
     #[test]
@@ -995,6 +1041,19 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_ne!(first.observation_id(), other_tenant.observation_id());
+    }
+
+    #[test]
+    fn legacy_aws_endpoint_identity_distinguishes_sanitizer_collisions() {
+        let slash = CommittedSourceEvent::decode(&encode(legacy_aws_endpoint_wire("blue/edge@id")))
+            .unwrap()
+            .unwrap();
+        let colon = CommittedSourceEvent::decode(&encode(legacy_aws_endpoint_wire("blue:edge@id")))
+            .unwrap()
+            .unwrap();
+
+        assert_ne!(slash.observation_id(), colon.observation_id());
+        assert_ne!(slash.record_digest(), colon.record_digest());
     }
 
     #[test]

--- a/crates/source-runtime-next/src/append_log.rs
+++ b/crates/source-runtime-next/src/append_log.rs
@@ -430,13 +430,20 @@ fn decode_observation_id(
     attributes: &HashMap<String, String>,
     payload: &serde_json::Value,
 ) -> Result<ObservationId, AppendLogDecodeError> {
-    if is_legacy_okta_threat_insight_id(
-        event_id,
-        tenant_id,
-        event_kind,
-        schema_ref,
-        observed_at_unix_ms,
-    ) {
+    if is_legacy_okta_threat_insight_candidate(event_id, source_id, event_kind, schema_ref) {
+        let provider_domain =
+            okta_threat_insight_provider_domain(attributes, payload).ok_or_else(|| {
+                AppendLogDecodeError::InvalidModel(
+                    "legacy Okta threat insight identity is inconsistent".to_owned(),
+                )
+            })?;
+        if event_id
+            != format!("{LEGACY_OKTA_THREAT_INSIGHT_PREFIX}{provider_domain}-{observed_at_unix_ms}")
+        {
+            return Err(AppendLogDecodeError::InvalidModel(
+                "legacy Okta threat insight identity is inconsistent".to_owned(),
+            ));
+        }
         let mut hasher = Sha256::new();
         hash_field(
             &mut hasher,
@@ -468,7 +475,11 @@ fn decode_observation_id(
 
     match ObservationId::parse(event_id) {
         Ok(observation_id) => Ok(observation_id),
-        Err(_) if is_compatible_legacy_invalid_id(event_id, source_id, event_kind, schema_ref) => {
+        Err(_)
+            if is_compatible_legacy_invalid_id(
+                event_id, source_id, event_kind, schema_ref, attributes, payload,
+            ) =>
+        {
             let mut hasher = Sha256::new();
             hash_field(
                 &mut hasher,
@@ -485,22 +496,45 @@ fn decode_observation_id(
     }
 }
 
-fn is_legacy_okta_threat_insight_id(
+fn is_legacy_okta_threat_insight_candidate(
     event_id: &str,
-    tenant_id: &TenantId,
+    source_id: &str,
     event_kind: &str,
     schema_ref: &str,
-    observed_at_unix_ms: i64,
 ) -> bool {
-    // The historical timestamp ID omitted action and excluded zones. Re-key it
-    // from canonical immutable material so two configurations cannot share a
-    // receipt key and an existing receipt under the old ID remains untouched.
-    event_kind == OKTA_THREAT_INSIGHT_KIND
+    source_id == "okta"
+        && event_kind == OKTA_THREAT_INSIGHT_KIND
         && schema_ref == OKTA_THREAT_INSIGHT_SCHEMA_REF
         && event_id.starts_with(LEGACY_OKTA_THREAT_INSIGHT_PREFIX)
         && !event_id.starts_with(CURRENT_OKTA_THREAT_INSIGHT_PREFIX)
-        && event_id
-            == format!("{LEGACY_OKTA_THREAT_INSIGHT_PREFIX}{tenant_id}-{observed_at_unix_ms}")
+}
+
+fn okta_threat_insight_provider_domain(
+    attributes: &HashMap<String, String>,
+    payload: &serde_json::Value,
+) -> Option<String> {
+    let attribute_domain = attributes.get("domain")?.trim();
+    let payload_domain = payload.get("domain")?.as_str()?.trim();
+    if attribute_domain != payload_domain || !is_bounded_provider_domain(attribute_domain) {
+        return None;
+    }
+    Some(attribute_domain.to_owned())
+}
+
+fn is_bounded_provider_domain(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 253
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-'))
+        && value
+            .as_bytes()
+            .first()
+            .is_some_and(u8::is_ascii_alphanumeric)
+        && value
+            .as_bytes()
+            .last()
+            .is_some_and(u8::is_ascii_alphanumeric)
 }
 
 fn is_compatible_legacy_invalid_id(
@@ -508,15 +542,18 @@ fn is_compatible_legacy_invalid_id(
     source_id: &str,
     event_kind: &str,
     schema_ref: &str,
+    attributes: &HashMap<String, String>,
+    payload: &serde_json::Value,
 ) -> bool {
-    if event_id.len() > 256 || event_id.is_empty() {
+    if event_id.is_empty() {
         return false;
     }
     match (source_id, event_kind, schema_ref) {
         ("gcp", "gcp.iam_role_assignment", "gcp/iam_role_assignment/v1") => event_id
             .strip_prefix("gcp-iam-role-assignment-")
             .is_some_and(|suffix| {
-                !suffix.is_empty()
+                event_id.len() <= 256
+                    && !suffix.is_empty()
                     && event_id.contains('@')
                     && event_id
                         .bytes()
@@ -525,23 +562,111 @@ fn is_compatible_legacy_invalid_id(
         ("gcp", "gcp.effective_permission", "gcp/effective_permission/v1") => event_id
             .strip_prefix("gcp-effective-permission-")
             .is_some_and(|suffix| {
-                !suffix.is_empty()
+                event_id.len() <= 256
+                    && !suffix.is_empty()
                     && event_id.contains('@')
                     && event_id
                         .bytes()
                         .all(|byte| byte.is_ascii_alphanumeric() || b"-_.:/@+%".contains(&byte))
             }),
-        ("aws", "aws.public_endpoint", "aws/public_endpoint/v1") => event_id
-            .strip_prefix("aws-public-endpoint-")
-            .is_some_and(|suffix| {
-                !suffix.is_empty()
-                    && event_id.contains('*')
-                    && event_id
-                        .bytes()
-                        .all(|byte| byte.is_ascii_alphanumeric() || b"-_.:/*".contains(&byte))
-            }),
+        ("aws", "aws.public_endpoint", "aws/public_endpoint/v1") => {
+            is_compatible_legacy_aws_public_endpoint_id(event_id, attributes, payload)
+        }
         _ => false,
     }
+}
+
+fn is_compatible_legacy_aws_public_endpoint_id(
+    event_id: &str,
+    attributes: &HashMap<String, String>,
+    payload: &serde_json::Value,
+) -> bool {
+    const LEGACY_EVENT_ID_PREFIX: &str = "aws-public-endpoint-";
+    const MAX_LEGACY_IDENTITY_LEN: usize = 2_048;
+    if !event_id.starts_with(LEGACY_EVENT_ID_PREFIX)
+        || event_id.len() > LEGACY_EVENT_ID_PREFIX.len() + MAX_LEGACY_IDENTITY_LEN
+    {
+        return false;
+    }
+    let account_id = match payload
+        .get("account_id")
+        .and_then(serde_json::Value::as_str)
+    {
+        Some(account_id) if !account_id.trim().is_empty() => account_id.trim(),
+        _ => return false,
+    };
+    if attributes.get("domain").map(String::as_str) != Some(account_id) {
+        return false;
+    }
+    let endpoint = match payload
+        .get("endpoint")
+        .and_then(serde_json::Value::as_object)
+    {
+        Some(endpoint) => endpoint,
+        None => return false,
+    };
+    let identity_fields = [
+        ("endpoint_id", "EndpointID"),
+        ("resource_id", "ResourceID"),
+        ("ip", "IP"),
+        ("host", "Host"),
+    ];
+    let mut identity = None;
+    for (attribute_key, payload_key) in identity_fields {
+        let payload_value = match trimmed_json_string(endpoint, payload_key) {
+            Some(value) => value,
+            None => return false,
+        };
+        let attribute_value = attributes.get(attribute_key).map(String::as_str);
+        if attribute_value != (!payload_value.is_empty()).then_some(payload_value) {
+            return false;
+        }
+        if identity.is_none() && !payload_value.is_empty() {
+            identity = Some(payload_value);
+        }
+    }
+    for (attribute_key, payload_key) in [("service", "Service"), ("resource_type", "ResourceType")]
+    {
+        let payload_value = match trimmed_json_string(endpoint, payload_key) {
+            Some(value) => value,
+            None => return false,
+        };
+        if attributes.get(attribute_key).map(String::as_str)
+            != (!payload_value.is_empty()).then_some(payload_value)
+        {
+            return false;
+        }
+    }
+    let Some(identity) = identity else {
+        return false;
+    };
+    if identity.len() > MAX_LEGACY_IDENTITY_LEN {
+        return false;
+    }
+    event_id == sanitize_legacy_aws_event_id(&format!("{LEGACY_EVENT_ID_PREFIX}{identity}"))
+}
+
+fn trimmed_json_string<'a>(
+    object: &'a serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Option<&'a str> {
+    match object.get(key) {
+        None => Some(""),
+        Some(serde_json::Value::String(value)) => Some(value.trim()),
+        Some(_) => None,
+    }
+}
+
+fn sanitize_legacy_aws_event_id(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| match character {
+            ' ' | '/' | ':' => '-',
+            other => other,
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_owned()
 }
 
 fn compatibility_observation_id(hasher: Sha256) -> Result<ObservationId, AppendLogDecodeError> {
@@ -661,6 +786,39 @@ mod tests {
                 ("provider_id".to_owned(), "file-1".to_owned()),
             ]),
         }
+    }
+
+    fn legacy_aws_endpoint_wire(identity: &str) -> CommittedSourceWire {
+        let identity = identity.trim();
+        let mut wire = source_wire();
+        wire.tenant_id = "tenant-a".to_owned();
+        wire.source_id = "aws".to_owned();
+        wire.kind = "aws.public_endpoint".to_owned();
+        wire.schema_ref = "aws/public_endpoint/v1".to_owned();
+        wire.id = sanitize_legacy_aws_event_id(&format!("aws-public-endpoint-{identity}"));
+        wire.attributes = HashMap::from([
+            (
+                SOURCE_RUNTIME_ID_ATTRIBUTE.to_owned(),
+                "aws-runtime".to_owned(),
+            ),
+            ("domain".to_owned(), "123456789012".to_owned()),
+            ("endpoint_id".to_owned(), identity.to_owned()),
+            ("resource_type".to_owned(), "route53_record".to_owned()),
+            ("service".to_owned(), "route53".to_owned()),
+        ]);
+        wire.payload = serde_json::to_vec(&serde_json::json!({
+            "account_id": "123456789012",
+            "endpoint": {
+                "EndpointID": identity,
+                "ResourceID": "",
+                "IP": "",
+                "Host": "",
+                "ResourceType": "route53_record",
+                "Service": "route53"
+            }
+        }))
+        .unwrap();
+        wire
     }
 
     #[test]
@@ -784,16 +942,132 @@ mod tests {
 
     #[test]
     fn legacy_aws_wildcard_endpoint_gets_a_collision_resistant_identity() {
-        let mut wire = source_wire();
-        wire.source_id = "aws".to_owned();
-        wire.kind = "aws.public_endpoint".to_owned();
-        wire.schema_ref = "aws/public_endpoint/v1".to_owned();
-        wire.id = "aws-public-endpoint-*.example.test".to_owned();
+        let wire = legacy_aws_endpoint_wire("*.example.test");
 
         let event = CommittedSourceEvent::decode(&encode(wire))
             .unwrap()
             .unwrap();
         assert!(event.observation_id().as_str().starts_with("compat:v1:"));
+    }
+
+    #[test]
+    fn legacy_aws_endpoint_identity_requires_exact_source_material() {
+        let mut wire = legacy_aws_endpoint_wire("blue@edge");
+
+        let event = CommittedSourceEvent::decode(&encode(wire.clone()))
+            .expect("producer-bound legacy endpoint should decode")
+            .expect("source event");
+        assert!(event.observation_id().as_str().starts_with("compat:v1:"));
+
+        wire.payload = serde_json::to_vec(&serde_json::json!({
+            "account_id": "123456789012",
+            "endpoint": {
+                "EndpointID": "other@edge",
+                "ResourceID": "",
+                "IP": "",
+                "Host": "",
+                "ResourceType": "route53_record",
+                "Service": "route53"
+            }
+        }))
+        .unwrap();
+        assert!(matches!(
+            CommittedSourceEvent::decode(&encode(wire)),
+            Err(AppendLogDecodeError::InvalidModel(message))
+                if message == "observation id is invalid"
+        ));
+    }
+
+    #[test]
+    fn legacy_aws_endpoint_identity_replays_stably_and_remains_tenant_scoped() {
+        let wire = legacy_aws_endpoint_wire("weighted@edge");
+        let first = CommittedSourceEvent::decode(&encode(wire.clone()))
+            .unwrap()
+            .unwrap();
+        let redelivery = CommittedSourceEvent::decode(&encode(wire.clone()))
+            .unwrap()
+            .unwrap();
+        assert_eq!(first.observation_id(), redelivery.observation_id());
+
+        let mut other_tenant = wire;
+        other_tenant.tenant_id = "tenant-b".to_owned();
+        let other_tenant = CommittedSourceEvent::decode(&encode(other_tenant))
+            .unwrap()
+            .unwrap();
+        assert_ne!(first.observation_id(), other_tenant.observation_id());
+    }
+
+    #[test]
+    fn legacy_aws_endpoint_identity_matches_go_trimming_and_sanitization() {
+        let mut wire = legacy_aws_endpoint_wire("weighted @ edge:/");
+        wire.id = "aws-public-endpoint-weighted-@-edge".to_owned();
+        wire.payload = serde_json::to_vec(&serde_json::json!({
+            "account_id": "123456789012",
+            "endpoint": {
+                "EndpointID": " weighted @ edge:/ ",
+                "ResourceID": "", "IP": "", "Host": "",
+                "ResourceType": "route53_record", "Service": "route53"
+            }
+        }))
+        .unwrap();
+        let event = CommittedSourceEvent::decode(&encode(wire))
+            .unwrap()
+            .unwrap();
+        assert!(event.observation_id().as_str().starts_with("compat:v1:"));
+    }
+
+    #[test]
+    fn legacy_aws_endpoint_identity_requires_account_and_endpoint_metadata_binding() {
+        let baseline = legacy_aws_endpoint_wire("weighted@edge");
+        let cases = [
+            (
+                "account",
+                serde_json::json!({
+                    "account_id": "210987654321",
+                    "endpoint": {
+                        "EndpointID": "weighted@edge",
+                        "ResourceID": "", "IP": "", "Host": "",
+                        "ResourceType": "route53_record", "Service": "route53"
+                    }
+                }),
+            ),
+            (
+                "service",
+                serde_json::json!({
+                    "account_id": "123456789012",
+                    "endpoint": {
+                        "EndpointID": "weighted@edge",
+                        "ResourceID": "", "IP": "", "Host": "",
+                        "ResourceType": "route53_record", "Service": "other"
+                    }
+                }),
+            ),
+            (
+                "missing endpoint",
+                serde_json::json!({"account_id": "123456789012"}),
+            ),
+        ];
+        for (field, payload) in cases {
+            let mut wire = baseline.clone();
+            wire.payload = serde_json::to_vec(&payload).unwrap();
+            assert!(
+                CommittedSourceEvent::decode(&encode(wire)).is_err(),
+                "changed {field} escaped producer binding"
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_aws_endpoint_identity_has_an_explicit_producer_bound() {
+        let maximum = format!("@{}", "a".repeat(2_047));
+        assert!(CommittedSourceEvent::decode(&encode(legacy_aws_endpoint_wire(&maximum))).is_ok());
+
+        let oversized = format!("@{}", "a".repeat(2_048));
+        assert!(matches!(
+            CommittedSourceEvent::decode(&encode(legacy_aws_endpoint_wire(&oversized))),
+            Err(AppendLogDecodeError::InvalidModel(message))
+                if message == "observation id is invalid"
+        ));
     }
 
     #[test]
@@ -954,7 +1228,7 @@ mod tests {
     fn legacy_threat_insight_zone_order_is_idempotent() {
         let mut first_wire = source_wire();
         first_wire.id = "okta-threat-insight-example.okta.test-1720000000123".to_owned();
-        first_wire.tenant_id = "example.okta.test".to_owned();
+        first_wire.tenant_id = "tenant-a".to_owned();
         first_wire.source_id = "okta".to_owned();
         first_wire.kind = "okta.threat_insight".to_owned();
         first_wire.schema_ref = "okta/threat_insight/v1".to_owned();
@@ -995,7 +1269,7 @@ mod tests {
     fn legacy_threat_insight_conflicting_material_remains_distinct() {
         let mut first_wire = source_wire();
         first_wire.id = "okta-threat-insight-example.okta.test-1720000000123".to_owned();
-        first_wire.tenant_id = "example.okta.test".to_owned();
+        first_wire.tenant_id = "tenant-a".to_owned();
         first_wire.source_id = "okta".to_owned();
         first_wire.kind = OKTA_THREAT_INSIGHT_KIND.to_owned();
         first_wire.schema_ref = OKTA_THREAT_INSIGHT_SCHEMA_REF.to_owned();
@@ -1031,6 +1305,32 @@ mod tests {
 
         assert_ne!(first.observation_id(), conflicting.observation_id());
         assert_ne!(first.record_digest(), conflicting.record_digest());
+    }
+
+    #[test]
+    fn legacy_threat_insight_requires_matching_provider_domains() {
+        let mut wire = source_wire();
+        wire.id = "okta-threat-insight-example.okta.test-1720000000123".to_owned();
+        wire.tenant_id = "tenant-a".to_owned();
+        wire.source_id = "okta".to_owned();
+        wire.kind = OKTA_THREAT_INSIGHT_KIND.to_owned();
+        wire.schema_ref = OKTA_THREAT_INSIGHT_SCHEMA_REF.to_owned();
+        wire.payload =
+            br#"{"action":"block","domain":"other.okta.test","exclude_zones":[]}"#.to_vec();
+        wire.attributes = HashMap::from([
+            (
+                SOURCE_RUNTIME_ID_ATTRIBUTE.to_owned(),
+                "okta-runtime".to_owned(),
+            ),
+            ("domain".to_owned(), "example.okta.test".to_owned()),
+            ("family".to_owned(), "threat_insight".to_owned()),
+        ]);
+
+        assert!(matches!(
+            CommittedSourceEvent::decode(&encode(wire)),
+            Err(AppendLogDecodeError::InvalidModel(message))
+                if message == "legacy Okta threat insight identity is inconsistent"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- derive legacy AWS public-endpoint compatibility IDs from the exact producer-owned payload and attributes
- derive legacy Okta threat-insight IDs from provider identity plus immutable configuration material
- emit source-record digests in the bounded diagnostic SHA-256 format

## Validation

- `rustfmt --edition 2024 --check crates/source-runtime-next/src/append_log.rs crates/cerebro-platform/src/append_log_consumer.rs`
- focused Rust tests are included for stable redelivery, tenant separation, producer-field mismatch rejection, length bounds, and diagnostic digest formatting
- full hosted validation requested by this pull request

Local compilation is intentionally deferred to hosted validation because the managed local Cargo capacity guard blocked before ENOSPC.