### PR TITLE
fix: unblock cutover release gates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/internal/bootstrap/graph_handlers.go
+++ b/internal/bootstrap/graph_handlers.go
@@ -141,12 +141,12 @@ func (a *App) handleReplayWorkflowEvents(w http.ResponseWriter, r *http.Request)
 }
 
 func (a *App) handleGetEntityNeighborhood(w http.ResponseWriter, r *http.Request) {
-	var err error
-	r, err = withParityCorrelation(r)
+	ctx, err := withParityCorrelation(r)
 	if err != nil {
 		writeGraphQueryError(w, fmt.Errorf("%w: %w", graphquery.ErrInvalidRequest, err))
 		return
 	}
+	r = r.WithContext(ctx) //nolint:contextcheck // ctx is derived from the inbound request context after validating parity headers.
 	request := &cerebrov1.GetEntityNeighborhoodRequest{}
 	if limit := r.URL.Query().Get("limit"); limit != "" {
 		body := []byte(`{"limit":` + limit + `}`)
@@ -156,11 +156,11 @@ func (a *App) handleGetEntityNeighborhood(w http.ResponseWriter, r *http.Request
 		}
 	}
 	request.RootUrn = r.URL.Query().Get("root_urn")
-	if err := authorizeCerebroURNTenant(r.Context(), request.GetRootUrn()); err != nil {
+	if err := authorizeCerebroURNTenant(r.Context(), request.GetRootUrn()); err != nil { //nolint:contextcheck // r carries the validated parity context above.
 		writeGraphQueryError(w, err)
 		return
 	}
-	response, err := a.graphQueryService().GetEntityNeighborhood(r.Context(), graphquery.NeighborhoodRequest{
+	response, err := a.graphQueryService().GetEntityNeighborhood(r.Context(), graphquery.NeighborhoodRequest{ //nolint:contextcheck // r carries the validated parity context above.
 		RootURN: request.GetRootUrn(),
 		Limit:   request.GetLimit(),
 	})

--- a/internal/bootstrap/parity_run.go
+++ b/internal/bootstrap/parity_run.go
@@ -1,13 +1,14 @@
 package bootstrap
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
 	"github.com/writer/cerebro/internal/parityrun"
 )
 
-func withParityCorrelation(r *http.Request) (*http.Request, error) {
+func withParityCorrelation(r *http.Request) (context.Context, error) {
 	runValues := r.Header.Values(parityrun.HeaderName)
 	observationValues := r.Header.Values(parityrun.ObservationHeaderName)
 	if len(runValues) > 1 || len(observationValues) > 1 {
@@ -24,5 +25,5 @@ func withParityCorrelation(r *http.Request) (*http.Request, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", errInvalidHTTPRequest, err)
 	}
-	return r.WithContext(ctx), nil
+	return ctx, nil
 }

--- a/internal/bootstrap/parity_run_test.go
+++ b/internal/bootstrap/parity_run_test.go
@@ -17,7 +17,7 @@ func TestWithParityCorrelationPropagatesValidatedHeaders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("withParityCorrelation() error = %v", err)
 	}
-	if values := parityrun.FromContext(got.Context()); values.RunID != "cutover-run-2026-08-13" || values.ObservationID == "" {
+	if values := parityrun.FromContext(got); values.RunID != "cutover-run-2026-08-13" || values.ObservationID == "" {
 		t.Fatalf("parityrun.FromContext() = %#v", values)
 	}
 }


### PR DESCRIPTION
Fixes the release-gate regressions exposed by the merged Rust cutover path.

- Preserve parity correlation context while satisfying context propagation lint.
- Update h2 to 0.4.16 for the current RustSec advisory.

Validation: focused Go tests, Go lint, Rust advisory/action/WASM checks, and focused Rust tests.