### PR TITLE
Remove Go graph read fallback

### DIFF
--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -899,19 +899,8 @@ func sourceProjector(stateStore ports.StateStore, graphStore ports.GraphStore) p
 	return sourceprojection.New(state, graph)
 }
 
-func compatibilityGraphQueryStore(store ports.GraphStore) ports.GraphQueryStore {
-	queryStore, ok := store.(ports.GraphQueryStore)
-	if !ok {
-		return nil
-	}
-	return queryStore
-}
-
 func dependencyGraphQueryStore(deps bootstrap.Dependencies) ports.GraphQueryStore {
-	if deps.GraphQueries != nil {
-		return deps.GraphQueries
-	}
-	return compatibilityGraphQueryStore(deps.GraphStore)
+	return deps.GraphQueries
 }
 
 func appendLogSourceProjector(deps bootstrap.Dependencies) ports.SourceProjector {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -418,7 +418,7 @@ func TestPrepareGRCReadModelsSkipsStoresWithoutPreparer(t *testing.T) {
 	}
 }
 
-func TestDependencyGraphQueryStorePrefersConfiguredAuthority(t *testing.T) {
+func TestDependencyGraphQueryStoreRequiresConfiguredAuthority(t *testing.T) {
 	legacy := &graphTestStore{}
 	authority := &graphTestStore{}
 	deps := bootstrap.Dependencies{GraphStore: legacy, GraphQueries: authority}
@@ -427,8 +427,8 @@ func TestDependencyGraphQueryStorePrefersConfiguredAuthority(t *testing.T) {
 		t.Fatalf("dependencyGraphQueryStore() = %#v, want configured authority", got)
 	}
 	deps.GraphQueries = nil
-	if got := dependencyGraphQueryStore(deps); got != legacy {
-		t.Fatalf("dependencyGraphQueryStore() fallback = %#v, want compatibility store", got)
+	if got := dependencyGraphQueryStore(deps); got != nil {
+		t.Fatalf("dependencyGraphQueryStore() fallback = %#v, want nil without configured authority", got)
 	}
 }
 

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -2047,19 +2047,11 @@ func guardedLegacyGraphProjector(deps Dependencies) ports.SourceProjector {
 	return organizationalgraph.NewLegacyWriteGuard(legacy, deps.OrganizationalProjector)
 }
 
-func graphQueryStore(store ports.GraphStore) ports.GraphQueryStore {
-	queryStore, ok := store.(ports.GraphQueryStore)
-	if !ok || isNilInterface(queryStore) {
-		return nil
-	}
-	return queryStore
-}
-
 func dependencyGraphQueryStore(deps Dependencies) ports.GraphQueryStore {
 	if !isNilInterface(deps.GraphQueries) {
 		return deps.GraphQueries
 	}
-	return graphQueryStore(deps.GraphStore)
+	return nil
 }
 
 func askTrajectoryStore(store ports.StateStore) ports.AskTrajectoryStore {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -596,8 +596,11 @@ func TestWriteGraphErrorsDoNotExposeInternalMessages(t *testing.T) {
 
 func TestStoreBoundaryHelpersTreatTypedNilAsUnavailable(t *testing.T) {
 	var graph *stubGraphStore
-	if got := graphQueryStore(graph); got != nil {
-		t.Fatalf("graphQueryStore(typed nil) = %#v, want nil", got)
+	if got := dependencyGraphQueryStore(Dependencies{GraphQueries: graph}); got != nil {
+		t.Fatalf("dependencyGraphQueryStore(typed nil) = %#v, want nil", got)
+	}
+	if got := dependencyGraphQueryStore(Dependencies{GraphStore: &stubGraphStore{}}); got != nil {
+		t.Fatalf("dependencyGraphQueryStore(GraphStore only) = %#v, want nil", got)
 	}
 	if got := sourceProjectionGraphStore(graph); got != nil {
 		t.Fatalf("sourceProjectionGraphStore(typed nil) = %#v, want nil", got)

--- a/internal/bootstrap/feature_dependencies_test.go
+++ b/internal/bootstrap/feature_dependencies_test.go
@@ -69,3 +69,26 @@ func TestProductReadDependencyBundlesPreferConfiguredAuthority(t *testing.T) {
 		t.Fatalf("graph reasoning queries = %#v, want configured authority", got)
 	}
 }
+
+func TestProductReadDependencyBundlesDoNotFallbackToLegacyGraphStore(t *testing.T) {
+	deps := Dependencies{
+		GraphStore:    &stubGraphStore{},
+		GraphAgentLLM: graphagent.NewStubLLMClient(),
+	}
+
+	if got := newReportFeatureDeps(deps).GraphQueries; got != nil {
+		t.Fatalf("report graph queries = %#v, want nil without configured authority", got)
+	}
+	if got := newFindingFeatureDeps(deps).GraphQueries; got != nil {
+		t.Fatalf("finding graph queries = %#v, want nil without configured authority", got)
+	}
+	if got := newKnowledgeFeatureDeps(deps).GraphQueries; got != nil {
+		t.Fatalf("knowledge graph queries = %#v, want nil without configured authority", got)
+	}
+	if got := newGraphQueryFeatureDeps(deps).GraphQueries; got != nil {
+		t.Fatalf("graph query service = %#v, want nil without configured authority", got)
+	}
+	if got := newGraphReasoningFeatureDeps(deps).GraphQueries; got != nil {
+		t.Fatalf("graph reasoning queries = %#v, want nil without configured authority", got)
+	}
+}


### PR DESCRIPTION
## Summary
- require the configured graph query authority for product graph reads
- stop adapting the legacy graph store into the graph query path when the authority is absent
- add regressions for CLI and bootstrap feature dependency wiring

## Tests
- go test ./cmd/cerebro ./internal/bootstrap -run 'TestDependencyGraphQueryStore|TestProductReadDependencyBundles|TestStoreBoundaryHelpersTreatTypedNilAsUnavailable' -count=1 -v
- git diff --check
