### PR TITLE
Require graph read endpoint for authority mode

### DIFF
--- a/internal/bootstrap/agent_graph_reasoning_test.go
+++ b/internal/bootstrap/agent_graph_reasoning_test.go
@@ -35,7 +35,7 @@ LIMIT 25`,
 		},
 		Summary: "Review `urn:cerebro:writer:asset:alpha` first.",
 	}
-	app := New(graphReasoningAuthConfig(), Dependencies{GraphStore: graphStore, GraphAgentLLM: llm}, nil)
+	app := New(graphReasoningAuthConfig(), Dependencies{GraphStore: graphStore, GraphQueries: graphStore, GraphAgentLLM: llm}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -108,7 +108,8 @@ func TestHandleAgentPlatformGraphReasonAllowsAllowedTenantPrincipal(t *testing.T
 			}},
 		},
 	}, Dependencies{
-		GraphStore: graphStore,
+		GraphStore:   graphStore,
+		GraphQueries: graphStore,
 		GraphAgentLLM: &graphagent.StubLLMClient{
 			DraftResponse: &graphagent.DraftResponse{
 				Rationale: "Reasoning over scoped graph rows.",

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -2920,7 +2920,7 @@ func TestScopedCosmoCredentialAllowsOnlyReadRoutes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newFixtureRegistry() error = %v", err)
 	}
-	app := New(cfg, Dependencies{GraphStore: graph, StateStore: store}, registry)
+	app := New(cfg, Dependencies{GraphStore: graph, GraphQueries: graph, StateStore: store}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -3071,7 +3071,7 @@ func TestScopedCosmoCredentialEnforcesConnectProcedures(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newFixtureRegistry() error = %v", err)
 	}
-	app := New(cfg, Dependencies{GraphStore: graph, StateStore: store}, registry)
+	app := New(cfg, Dependencies{GraphStore: graph, GraphQueries: graph, StateStore: store}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -3191,7 +3191,7 @@ func TestCapabilityTokenRequiresSecurityGroup(t *testing.T) {
 			},
 		},
 	}
-	app := New(cfg, Dependencies{GraphStore: graph}, nil)
+	app := New(cfg, Dependencies{GraphStore: graph, GraphQueries: graph}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -4069,7 +4069,7 @@ func TestGraphPackageImpactEndpointReturnsCanonicalPackageRoot(t *testing.T) {
 			},
 		},
 	}
-	app := New(config.Config{}, Dependencies{GraphStore: graph}, nil)
+	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphQueries: graph}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -4122,7 +4122,7 @@ func TestGraphAWSPublicEndpointInsightsEndpoint(t *testing.T) {
 			Corroborating: ports.ExposureCoverageEntity{URN: "urn:cerebro:writer:external_asset:app.example.com", EntityType: "external.asset", Label: "app.example.com"},
 		}},
 	}}
-	app := New(config.Config{}, Dependencies{GraphStore: graph}, nil)
+	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphQueries: graph}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -4178,7 +4178,7 @@ func TestGraphPersonAccessPathsEndpoint(t *testing.T) {
 			"relation_chain":        []any{"assigned_to"},
 		}}},
 	}}
-	app := New(config.Config{}, Dependencies{GraphStore: graph}, nil)
+	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphQueries: graph}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -4294,7 +4294,7 @@ func TestGraphEffectiveAccessPathsEndpoint(t *testing.T) {
 			},
 		}}},
 	}}
-	app := New(config.Config{}, Dependencies{GraphStore: graph}, nil)
+	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphQueries: graph}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -4363,7 +4363,7 @@ func TestGraphCrownJewelRankingsEndpoint(t *testing.T) {
 			"to_label":         "prod-secrets",
 		}}},
 	}}
-	app := New(config.Config{}, Dependencies{GraphStore: graph}, nil)
+	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphQueries: graph}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -5398,8 +5398,9 @@ func TestGraphIngestEndpoints(t *testing.T) {
 	}}
 	graphStore := &stubGraphStore{}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		StateStore: runtimeStore,
-		GraphStore: graphStore,
+		StateStore:   runtimeStore,
+		GraphStore:   graphStore,
+		GraphQueries: graphStore,
 	}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
@@ -5610,8 +5611,9 @@ func TestGraphIngestArchetypeRuntimeProjectsFindingsEndToEnd(t *testing.T) {
 	}}
 	graphStore := &stubGraphStore{}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		StateStore: runtimeStore,
-		GraphStore: graphStore,
+		StateStore:   runtimeStore,
+		GraphStore:   graphStore,
+		GraphQueries: graphStore,
 	}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
@@ -5972,9 +5974,10 @@ func TestFindingEndpoints(t *testing.T) {
 	}
 	graphStore := &stubGraphStore{}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		AppendLog:  appendLog,
-		StateStore: runtimeStore,
-		GraphStore: graphStore,
+		AppendLog:    appendLog,
+		StateStore:   runtimeStore,
+		GraphStore:   graphStore,
+		GraphQueries: graphStore,
 	}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
@@ -7448,7 +7451,7 @@ func TestPlatformKnowledgeDecisionAndOutcomeEndpoints(t *testing.T) {
 func TestPlatformKnowledgeDecisionRequiresDurableAppendLog(t *testing.T) {
 	targetURN := "urn:cerebro:writer:resource:service-1"
 	graphStore := &stubGraphStore{entities: map[string]*ports.ProjectedEntity{targetURN: {URN: targetURN}}}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphQueries: graphStore}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -7470,7 +7473,7 @@ func TestPlatformKnowledgeDecisionReturnsDurableProjectionFailure(t *testing.T) 
 	targetURN := "urn:cerebro:writer:resource:service-1"
 	graphStore := &stubGraphStore{entities: map[string]*ports.ProjectedEntity{targetURN: {URN: targetURN}}, err: errors.New("graph unavailable")}
 	appendLog := &recordingAppendLog{}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, AppendLog: appendLog}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphQueries: graphStore, AppendLog: appendLog}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -7902,9 +7905,10 @@ func TestGraphNeighborhoodEndpoints(t *testing.T) {
 		},
 	}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		AppendLog:  &recordingAppendLog{},
-		StateStore: &stubRuntimeStore{},
-		GraphStore: graphStore,
+		AppendLog:    &recordingAppendLog{},
+		StateStore:   &stubRuntimeStore{},
+		GraphStore:   graphStore,
+		GraphQueries: graphStore,
 	}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
@@ -8046,9 +8050,10 @@ func TestReportEndpoints(t *testing.T) {
 		},
 	}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		AppendLog:  &recordingAppendLog{},
-		StateStore: runtimeStore,
-		GraphStore: graphStore,
+		AppendLog:    &recordingAppendLog{},
+		StateStore:   runtimeStore,
+		GraphStore:   graphStore,
+		GraphQueries: graphStore,
 	}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()

--- a/internal/bootstrap/compliance_impact_runtime_test.go
+++ b/internal/bootstrap/compliance_impact_runtime_test.go
@@ -13,8 +13,9 @@ import (
 
 func TestComplianceImpactServiceComposition(t *testing.T) {
 	t.Parallel()
+	graph := &impactGraphStub{}
 	app := &App{deps: Dependencies{
-		StateStore: &monitorStateStub{}, GraphStore: &impactGraphStub{}, AppendLog: bootstrapAppendOnlyLog{},
+		StateStore: &monitorStateStub{}, GraphStore: graph, GraphQueries: graph, AppendLog: bootstrapAppendOnlyLog{},
 	}}
 	monitors, projector, scheduler := app.newComplianceImpactServices(nil, nil)
 	if monitors == nil || projector == nil || scheduler == nil {
@@ -22,13 +23,16 @@ func TestComplianceImpactServiceComposition(t *testing.T) {
 	}
 
 	app.deps.GraphStore = nil
+	app.deps.GraphQueries = nil
 	monitors, projector, scheduler = app.newComplianceImpactServices(nil, nil)
 	if monitors == nil || projector != nil || scheduler != nil {
 		t.Fatalf("without graph monitors=%v projector=%v scheduler=%v", monitors != nil, projector != nil, scheduler != nil)
 	}
 
 	app.deps.StateStore = nonEvidenceStateStub{}
-	app.deps.GraphStore = &impactGraphStub{}
+	graph = &impactGraphStub{}
+	app.deps.GraphStore = graph
+	app.deps.GraphQueries = graph
 	monitors, projector, scheduler = app.newComplianceImpactServices(nil, nil)
 	if monitors != nil || projector == nil || scheduler != nil {
 		t.Fatalf("without monitor store monitors=%v projector=%v scheduler=%v", monitors != nil, projector != nil, scheduler != nil)

--- a/internal/bootstrap/dependencies.go
+++ b/internal/bootstrap/dependencies.go
@@ -95,6 +95,9 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 	if readBaseURL == "" {
 		readBaseURL = cfg.OrganizationalGraph.BaseURL
 	}
+	if cfg.OrganizationalGraph.ReadMode != "" && readBaseURL == "" {
+		return fail(fmt.Errorf("organizational graph read endpoint is required in %s mode", cfg.OrganizationalGraph.ReadMode))
+	}
 	if projectionBaseURL != "" {
 		projectionClient, err := organizationalgraph.NewProjectionClient(projectionBaseURL, cfg.OrganizationalGraph.SharedSecret, cfg.OrganizationalGraph.Timeout)
 		if err != nil {

--- a/internal/bootstrap/dependencies_test.go
+++ b/internal/bootstrap/dependencies_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,6 +31,20 @@ func TestOpenDependenciesAllowsUnconfiguredStores(t *testing.T) {
 	}
 	if err := closeAll(); err != nil {
 		t.Fatalf("closeAll() error = %v", err)
+	}
+}
+
+func TestOpenDependenciesRejectsGraphReadModeWithoutEndpoint(t *testing.T) {
+	_, closeAll, err := OpenDependencies(context.Background(), config.Config{
+		OrganizationalGraph: config.OrganizationalGraphConfig{ReadMode: "authority"},
+	})
+	if closeAll != nil {
+		if closeErr := closeAll(); closeErr != nil {
+			t.Fatalf("closeAll() error = %v", closeErr)
+		}
+	}
+	if err == nil || !strings.Contains(err.Error(), "organizational graph read endpoint is required in authority mode") {
+		t.Fatalf("OpenDependencies() error = %v, want missing authority endpoint", err)
 	}
 }
 

--- a/internal/bootstrap/graph_provenance_test.go
+++ b/internal/bootstrap/graph_provenance_test.go
@@ -22,7 +22,7 @@ func TestHandleGetGraphProvenance(t *testing.T) {
 			"attributes_json": `{"event_id":"evt-1","observed_at":"2026-06-15T12:00:00Z","projection_class":"durable_state","projection_reason":"projected_current_state"}`,
 		}},
 	}}}
-	app := New(graphReasoningAuthConfig(), Dependencies{GraphStore: graphStore}, nil)
+	app := New(graphReasoningAuthConfig(), Dependencies{GraphStore: graphStore, GraphQueries: graphStore}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 

--- a/internal/bootstrap/grc_ask_test.go
+++ b/internal/bootstrap/grc_ask_test.go
@@ -38,7 +38,7 @@ LIMIT 25`,
 		},
 		Summary: "Review `urn:cerebro:example:asset:alpha` first.",
 	}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphAgentLLM: llm}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphQueries: graphStore, GraphAgentLLM: llm}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -91,7 +91,7 @@ LIMIT 25`,
 		},
 		Summary: "Review `urn:cerebro:example:asset:alpha` first.",
 	}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphAgentLLM: llm}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphQueries: graphStore, GraphAgentLLM: llm}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -108,8 +108,10 @@ LIMIT 25`,
 }
 
 func TestGRCAskTelemetryIncludesQueryPlanDiagnostics(t *testing.T) {
+	graphStore := &stubGraphStore{}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		GraphStore: &stubGraphStore{},
+		GraphStore:   graphStore,
+		GraphQueries: graphStore,
 		GraphAgentLLM: &graphagent.StubLLMClient{DraftResponse: &graphagent.DraftResponse{
 			Rationale: "Planning filtered high-risk findings.",
 			Plan:      &graphagent.AskQueryPlan{Intent: graphagent.IntentTopRiskFindings, Filters: map[string]string{"owner": "security"}},
@@ -218,8 +220,10 @@ func TestGRCAskMissingStartupLLMReturnsUnavailable(t *testing.T) {
 }
 
 func TestGRCAskDraftFailureReturnsServiceUnavailable(t *testing.T) {
+	graphStore := &stubGraphStore{}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		GraphStore:    &stubGraphStore{},
+		GraphStore:    graphStore,
+		GraphQueries:  graphStore,
 		GraphAgentLLM: &graphagent.StubLLMClient{DraftErr: errors.New("bedrock unavailable")},
 	}, nil)
 	server := httptest.NewServer(app.Handler())
@@ -267,8 +271,10 @@ func TestGRCAskDraftFailureReturnsServiceUnavailable(t *testing.T) {
 }
 
 func TestGRCAskLLMAuthenticationFailureUsesSpecificErrorCode(t *testing.T) {
+	graphStore := &stubGraphStore{}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		GraphStore: &stubGraphStore{},
+		GraphStore:   graphStore,
+		GraphQueries: graphStore,
 		GraphAgentLLM: &graphagent.StubLLMClient{DraftErr: errors.Join(
 			graphagent.ErrLLMAuthenticationFailed,
 			errors.New("openrouter authentication failed; check CEREBRO_OPENROUTER_API_KEY"),
@@ -310,8 +316,10 @@ func TestGRCAskLLMAuthenticationFailureUsesSpecificErrorCode(t *testing.T) {
 }
 
 func TestGRCAskLLMAccessDeniedUsesSpecificErrorCode(t *testing.T) {
+	graphStore := &stubGraphStore{}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		GraphStore: &stubGraphStore{},
+		GraphStore:   graphStore,
+		GraphQueries: graphStore,
 		GraphAgentLLM: &graphagent.StubLLMClient{DraftErr: errors.Join(
 			graphagent.ErrLLMAccessDenied,
 			errors.New("bedrock access denied; grant bedrock:InvokeModel"),
@@ -353,8 +361,10 @@ func TestGRCAskLLMAccessDeniedUsesSpecificErrorCode(t *testing.T) {
 }
 
 func TestGRCAskExplainFailureReturnsServiceUnavailable(t *testing.T) {
+	graphStore := &stubGraphStore{err: errors.New("neo4j unavailable")}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		GraphStore:    &stubGraphStore{err: errors.New("neo4j unavailable")},
+		GraphStore:    graphStore,
+		GraphQueries:  graphStore,
 		GraphAgentLLM: graphagent.NewStubLLMClient(),
 	}, nil)
 	server := httptest.NewServer(app.Handler())

--- a/internal/bootstrap/grc_policy_lifecycle_test.go
+++ b/internal/bootstrap/grc_policy_lifecycle_test.go
@@ -124,7 +124,7 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 			grcPolicyLifecycleTestRelation(reminder, fabriccontract.RelationAssignedTo, nil, group),
 		},
 	}}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graph}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graph, GraphQueries: graph}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -1179,7 +1179,7 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 		},
 	}
 	appendLog := &recordingAppendLog{}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store, GraphStore: graphStore, AppendLog: appendLog}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store, GraphStore: graphStore, GraphQueries: graphStore, AppendLog: appendLog}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -1495,7 +1495,7 @@ func TestGRCEntityImpactResolvesLegacyGitHubRepoURN(t *testing.T) {
 			},
 		},
 	}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store, GraphStore: graphStore}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store, GraphStore: graphStore, GraphQueries: graphStore}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -3232,7 +3232,7 @@ func newMCPTestServerWithGraphReasoningAndSources(t *testing.T, store *stubRunti
 				TenantID:  "writer",
 			}},
 		},
-	}, Dependencies{StateStore: store, GraphStore: graph, GraphAgentLLM: llm}, sources)
+	}, Dependencies{StateStore: store, GraphStore: graph, GraphQueries: graph, GraphAgentLLM: llm}, sources)
 	return httptest.NewServer(app.Handler())
 }
 

--- a/internal/bootstrap/policy_experiment_jobs_test.go
+++ b/internal/bootstrap/policy_experiment_jobs_test.go
@@ -130,7 +130,7 @@ func TestPolicyExperimentJobRunsCurrentGraphCanaryAndPersistsReceipt(t *testing.
 	statusReader := policyExperimentStatusReader{status: policycandidate.ExperimentCheckpointStatus{
 		RuntimeID: "runtime-canary", TenantID: "tenant-a", CheckpointID: checkpoint.ID, Found: true, Completed: true, CheckpointCurrent: true,
 	}}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0"}, Dependencies{StateStore: store, GraphStore: graph, PolicyExperimentCheckpoints: statusReader}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0"}, Dependencies{StateStore: store, GraphStore: graph, GraphQueries: graph, PolicyExperimentCheckpoints: statusReader}, nil)
 	result, _, err := app.runPolicyCandidateExperimentJob(context.Background(), &ports.Job{
 		ID: "job-canary", TenantID: "tenant-a", SubjectID: experiment.ID, Payload: map[string]any{"experiment_id": experiment.ID},
 	}, nil)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -692,13 +692,13 @@ func Load() (Config, error) {
 	if cfg.OrganizationalGraph.ProjectionBaseURL == "" {
 		cfg.OrganizationalGraph.ProjectionBaseURL = cfg.OrganizationalGraph.BaseURL
 	}
-	if cfg.OrganizationalGraph.ReadMode == "" {
+	if cfg.OrganizationalGraph.ReadMode == "" && cfg.OrganizationalGraph.ReadBaseURL != "" {
 		cfg.OrganizationalGraph.ReadMode = "authority"
 	}
-	explicitOrganizationalGraphReadMode := strings.TrimSpace(os.Getenv("CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE")) != ""
 	if cfg.OrganizationalGraph.ReadMode != "legacy" &&
 		cfg.OrganizationalGraph.ReadMode != "authority" &&
-		cfg.OrganizationalGraph.ReadMode != "shadow" {
+		cfg.OrganizationalGraph.ReadMode != "shadow" &&
+		cfg.OrganizationalGraph.ReadMode != "" {
 		return Config{}, fmt.Errorf("CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE must be legacy, shadow, or authority")
 	}
 	if cfg.OrganizationalGraph.ShadowPercent, err = parseIntEnv("CEREBRO_ORGANIZATIONAL_GRAPH_SHADOW_PERCENT", 0); err != nil {
@@ -710,8 +710,7 @@ func Load() (Config, error) {
 	if cfg.OrganizationalGraph.ReadMode == "shadow" && cfg.OrganizationalGraph.ReadBaseURL == "" {
 		return Config{}, fmt.Errorf("CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL is required in shadow mode")
 	}
-	if explicitOrganizationalGraphReadMode &&
-		cfg.OrganizationalGraph.ReadMode == "authority" &&
+	if cfg.OrganizationalGraph.ReadMode == "authority" &&
 		cfg.OrganizationalGraph.ReadBaseURL == "" {
 		return Config{}, fmt.Errorf("CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL is required in authority mode")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -185,6 +185,32 @@ func TestLoadDefaults(t *testing.T) {
 	}
 }
 
+func TestLoadLeavesRustGraphReadsUnconfiguredWithoutEndpoint(t *testing.T) {
+	clearDependencyEnv(t)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.OrganizationalGraph.ReadMode != "" || cfg.OrganizationalGraph.ReadBaseURL != "" {
+		t.Fatalf("OrganizationalGraph = %#v, want reads unconfigured without endpoint", cfg.OrganizationalGraph)
+	}
+}
+
+func TestLoadDefaultsRustGraphReadModeToAuthorityWhenEndpointConfigured(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL", "http://127.0.0.1:8081")
+	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET", "test-organizational-graph-secret-32-bytes")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.OrganizationalGraph.ReadMode != "authority" {
+		t.Fatalf("ReadMode = %q, want authority", cfg.OrganizationalGraph.ReadMode)
+	}
+}
+
 func TestLoadSeparatesRustGraphReadAndProjectionEndpoints(t *testing.T) {
 	clearDependencyEnv(t)
 	t.Setenv("CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL", "http://127.0.0.1:8081")


### PR DESCRIPTION
## Summary
- leave graph reads unconfigured until a read endpoint is configured
- fail dependency wiring when a graph read mode is set without a read endpoint
- update bootstrap fixtures to pass an explicit graph query store instead of relying on projection-store fallback behavior

## Tests
- `go test ./internal/config ./internal/bootstrap -count=1`
- `make lint-bootstrap`
- `git diff --check`
