### PR TITLE
Narrow graph read compatibility interfaces

### DIFF
--- a/internal/bootstrap/decision_outcomes_test.go
+++ b/internal/bootstrap/decision_outcomes_test.go
@@ -188,7 +188,7 @@ func TestDecisionPacketDispositionAndOutcomeConnect(t *testing.T) {
 func TestLegacyKnownOutcomesRetainKnowledgePath(t *testing.T) {
 	writeLegacyDecision := func(t *testing.T, log *decisionOutcomeLog, decisionID string) string {
 		t.Helper()
-		writer := knowledge.New(nil, nil).WithAppendLog(log).WithDurabilityMode(knowledge.DurabilityRequired)
+		writer := knowledge.New(nil).WithAppendLog(log).WithDurabilityMode(knowledge.DurabilityRequired)
 		result, err := writer.WriteDecision(context.Background(), knowledge.DecisionWriteRequest{
 			ID: decisionID, DecisionType: "change", Status: "recorded", SourceSystem: "legacy",
 			TargetIDs:  []string{"urn:cerebro:tenant-1:resource:1"},

--- a/internal/bootstrap/feature_dependencies.go
+++ b/internal/bootstrap/feature_dependencies.go
@@ -36,7 +36,7 @@ func newSourceFeatureService(deps sourceFeatureDeps) *sourceops.Service {
 
 type reportFeatureDeps struct {
 	Findings     ports.FindingStore
-	GraphQueries ports.GraphQueryStore
+	GraphQueries ports.GraphNeighborhoodStore
 	Reports      ports.ReportStore
 }
 
@@ -112,7 +112,7 @@ type findingFeatureDeps struct {
 	Claims          ports.ClaimStore
 	Candidates      ports.FindingCandidateStore
 	ProjectionGraph ports.ProjectionGraphStore
-	GraphQueries    ports.GraphQueryStore
+	GraphQueries    ports.RawCypherQueryStore
 	AppendLog       ports.AppendLog
 	Rules           *findings.Registry
 }

--- a/internal/bootstrap/feature_dependencies.go
+++ b/internal/bootstrap/feature_dependencies.go
@@ -149,21 +149,19 @@ func newFindingWorkflowFeatureService(deps findingFeatureDeps) *findings.Service
 }
 
 type knowledgeFeatureDeps struct {
-	GraphQueries    ports.GraphQueryStore
 	ProjectionGraph ports.ProjectionGraphStore
 	AppendLog       ports.AppendLog
 }
 
 func newKnowledgeFeatureDeps(deps Dependencies) knowledgeFeatureDeps {
 	return knowledgeFeatureDeps{
-		GraphQueries:    dependencyGraphQueryStore(deps),
 		ProjectionGraph: sourceProjectionGraphStore(deps.GraphStore),
 		AppendLog:       deps.AppendLog,
 	}
 }
 
 func newKnowledgeFeatureService(deps knowledgeFeatureDeps) *knowledge.Service {
-	return knowledge.New(deps.GraphQueries, deps.ProjectionGraph).
+	return knowledge.New(deps.ProjectionGraph).
 		WithAppendLog(deps.AppendLog).
 		WithDurabilityMode(knowledge.DurabilityRequired)
 }

--- a/internal/bootstrap/feature_dependencies_test.go
+++ b/internal/bootstrap/feature_dependencies_test.go
@@ -21,7 +21,7 @@ func TestFeatureDependencyBundlesAreNilSafe(t *testing.T) {
 	if got := newFindingFeatureDeps(deps); got.Runtimes != nil || got.EventReplayer != nil || got.Findings != nil || got.EvaluationRuns != nil || got.Evidence != nil || got.Claims != nil || got.Candidates != nil || got.ProjectionGraph != nil || got.GraphQueries != nil || got.AppendLog != nil {
 		t.Fatalf("newFindingFeatureDeps() = %#v, want nil dependencies", got)
 	}
-	if got := newKnowledgeFeatureDeps(deps); got.GraphQueries != nil || got.ProjectionGraph != nil || got.AppendLog != nil {
+	if got := newKnowledgeFeatureDeps(deps); got.ProjectionGraph != nil || got.AppendLog != nil {
 		t.Fatalf("newKnowledgeFeatureDeps() = %#v, want nil dependencies", got)
 	}
 	if got := newGraphQueryFeatureDeps(deps); got.GraphQueries != nil {
@@ -59,9 +59,6 @@ func TestProductReadDependencyBundlesPreferConfiguredAuthority(t *testing.T) {
 	if got := newFindingFeatureDeps(deps).GraphQueries; got != authority {
 		t.Fatalf("finding graph queries = %#v, want configured authority", got)
 	}
-	if got := newKnowledgeFeatureDeps(deps).GraphQueries; got != authority {
-		t.Fatalf("knowledge graph queries = %#v, want configured authority", got)
-	}
 	if got := newGraphQueryFeatureDeps(deps).GraphQueries; got != authority {
 		t.Fatalf("graph query service = %#v, want configured authority", got)
 	}
@@ -81,9 +78,6 @@ func TestProductReadDependencyBundlesDoNotFallbackToLegacyGraphStore(t *testing.
 	}
 	if got := newFindingFeatureDeps(deps).GraphQueries; got != nil {
 		t.Fatalf("finding graph queries = %#v, want nil without configured authority", got)
-	}
-	if got := newKnowledgeFeatureDeps(deps).GraphQueries; got != nil {
-		t.Fatalf("knowledge graph queries = %#v, want nil without configured authority", got)
 	}
 	if got := newGraphQueryFeatureDeps(deps).GraphQueries; got != nil {
 		t.Fatalf("graph query service = %#v, want nil without configured authority", got)

--- a/internal/bootstrap/graph_provenance.go
+++ b/internal/bootstrap/graph_provenance.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/writer/cerebro/internal/graphprovenance"
+	"github.com/writer/cerebro/internal/ports"
 )
 
 func (a *App) handleGetGraphProvenance(w http.ResponseWriter, r *http.Request) {
@@ -13,7 +14,12 @@ func (a *App) handleGetGraphProvenance(w http.ResponseWriter, r *http.Request) {
 		writeGraphQueryError(w, err)
 		return
 	}
-	response, err := graphprovenance.New(dependencyGraphQueryStore(a.deps)).Get(r.Context(), graphprovenance.Request{URN: urn})
+	graphStore := dependencyGraphQueryStore(a.deps)
+	var catalogStore ports.EntityCatalogStore
+	if graphStore != nil {
+		catalogStore, _ = graphStore.(ports.EntityCatalogStore)
+	}
+	response, err := graphprovenance.New(catalogStore).Get(r.Context(), graphprovenance.Request{URN: urn})
 	if err != nil {
 		writeGraphQueryError(w, err)
 		return

--- a/internal/bootstrap/grc_vendor.go
+++ b/internal/bootstrap/grc_vendor.go
@@ -70,7 +70,7 @@ func (a *App) handleGRCVendors(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	vendors, err := grcvendor.New(dependencyGraphQueryStore(a.deps)).ListVendors(r.Context(), grcvendor.ListVendorsRequest{
+	vendors, err := grcvendor.New(dependencyGRCVendorGraphStore(a.deps)).ListVendors(r.Context(), grcvendor.ListVendorsRequest{
 		TenantID:    scope.TenantID,
 		RuntimeID:   scope.RuntimeID,
 		RuntimeIDs:  scope.RuntimeIDs,
@@ -102,6 +102,15 @@ func (a *App) handleGRCVendors(w http.ResponseWriter, r *http.Request) {
 		Vendors:     vendors,
 		GeneratedAt: time.Now().UTC(),
 	})
+}
+
+func dependencyGRCVendorGraphStore(deps Dependencies) grcvendor.GraphStore {
+	graphStore := dependencyGraphQueryStore(deps)
+	if graphStore == nil {
+		return nil
+	}
+	store, _ := graphStore.(grcvendor.GraphStore)
+	return store
 }
 
 func (a *App) handleGRCVendorDetail(w http.ResponseWriter, r *http.Request) {
@@ -141,7 +150,7 @@ func (a *App) grcVendorDetailResponse(r *http.Request) (grcVendorDetailResponse,
 	if err != nil {
 		return grcVendorDetailResponse{}, err
 	}
-	detail, err := grcvendor.New(dependencyGraphQueryStore(a.deps)).GetVendor(r.Context(), grcvendor.VendorDetailRequest{
+	detail, err := grcvendor.New(dependencyGRCVendorGraphStore(a.deps)).GetVendor(r.Context(), grcvendor.VendorDetailRequest{
 		URN:        urn,
 		VendorID:   vendorID,
 		TenantID:   scope.TenantID,
@@ -213,7 +222,7 @@ func (a *App) handleGRCVendorDiscoveries(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	decisionState := strings.TrimSpace(r.URL.Query().Get("decision_state"))
-	discoveries, err := grcvendor.New(dependencyGraphQueryStore(a.deps)).ListDiscoveries(r.Context(), grcvendor.ListDiscoveriesRequest{
+	discoveries, err := grcvendor.New(dependencyGRCVendorGraphStore(a.deps)).ListDiscoveries(r.Context(), grcvendor.ListDiscoveriesRequest{
 		TenantID:      scope.TenantID,
 		RuntimeID:     scope.RuntimeID,
 		RuntimeIDs:    scope.RuntimeIDs,

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -94,7 +94,7 @@ type mcpGraphStoreNeighborhoodResult struct {
 	err          error
 }
 
-func fetchMCPGraphStoreNeighborhoods(ctx context.Context, graphStore ports.GraphQueryStore, roots []string, limit int) []mcpGraphStoreNeighborhoodResult {
+func fetchMCPGraphStoreNeighborhoods(ctx context.Context, graphStore ports.GraphNeighborhoodStore, roots []string, limit int) []mcpGraphStoreNeighborhoodResult {
 	if graphStore == nil || len(roots) == 0 {
 		return nil
 	}

--- a/internal/complianceimpact/projected_graph.go
+++ b/internal/complianceimpact/projected_graph.go
@@ -110,10 +110,10 @@ func (p *GraphProjector) ProjectFact(ctx context.Context, fact complianceintegra
 // Cypher. It is intentionally independent from the Neo4j driver so tests and
 // alternate graph stores can implement the same port.
 type ProjectedGraph struct {
-	queries ports.GraphQueryStore
+	queries ports.RawCypherQueryStore
 }
 
-func NewProjectedGraph(queries ports.GraphQueryStore) (*ProjectedGraph, error) {
+func NewProjectedGraph(queries ports.RawCypherQueryStore) (*ProjectedGraph, error) {
 	if queries == nil {
 		return nil, ErrInvalidGraph
 	}

--- a/internal/decisionops/service_test.go
+++ b/internal/decisionops/service_test.go
@@ -91,7 +91,7 @@ func TestRecordDecisionAndOutcomeRemainDurableWithoutGraph(t *testing.T) {
 		ScopeURN: "urn:cerebro:tenant-1:finding:1",
 	}}
 	log := &replayLog{}
-	writer := knowledge.New(nil, nil).WithAppendLog(log).WithDurabilityMode(knowledge.DurabilityRequired)
+	writer := knowledge.New(nil).WithAppendLog(log).WithDurabilityMode(knowledge.DurabilityRequired)
 	service := New(receipts, log, writer, &sequenceClock{values: []time.Time{start, start.Add(2 * time.Hour)}})
 
 	decision, err := service.RecordDecision(context.Background(), RecordDecisionRequest{
@@ -136,7 +136,7 @@ func TestAuthenticatedPacketDecisionClassification(t *testing.T) {
 		ScopeURN: "urn:cerebro:tenant-1:finding:1",
 	}}
 	log := &replayLog{}
-	writer := knowledge.New(nil, nil).WithAppendLog(log).WithDurabilityMode(knowledge.DurabilityRequired)
+	writer := knowledge.New(nil).WithAppendLog(log).WithDurabilityMode(knowledge.DurabilityRequired)
 	service := New(receipts, log, writer, &sequenceClock{values: []time.Time{start}})
 	if _, err := service.IsAuthenticatedPacketDecision(context.Background(), "tenant-1", "urn:cerebro:tenant-1:decision:future"); !errors.Is(err, ErrDecisionNotFound) {
 		t.Fatalf("missing decision error = %v, want %v", err, ErrDecisionNotFound)
@@ -204,7 +204,7 @@ func TestChangeDecisionCompletionMetricIsEmittedOnce(t *testing.T) {
 		PacketDigest: "sha256:packet", ScopeURN: "urn:cerebro:tenant-1:change:1",
 	}}
 	log := &replayLog{}
-	writer := knowledge.New(nil, nil).WithAppendLog(log).WithDurabilityMode(knowledge.DurabilityRequired)
+	writer := knowledge.New(nil).WithAppendLog(log).WithDurabilityMode(knowledge.DurabilityRequired)
 	service := New(receipts, log, writer, &sequenceClock{values: []time.Time{start, start.Add(time.Minute)}})
 	decision, err := service.RecordDecision(context.Background(), RecordDecisionRequest{
 		TenantID: "tenant-1", ActorID: "operator-1", PacketID: "dpr_1",
@@ -252,7 +252,7 @@ func decisionMetricTotal(metrics metricdata.ResourceMetrics, name string) int64 
 func TestRecordOutcomeRejectsLegacyDecisionWithForgedPacketMetadata(t *testing.T) {
 	start := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
 	log := &replayLog{}
-	writer := knowledge.New(nil, nil).WithAppendLog(log).WithDurabilityMode(knowledge.DurabilityRequired)
+	writer := knowledge.New(nil).WithAppendLog(log).WithDurabilityMode(knowledge.DurabilityRequired)
 	forged, err := writer.WriteDecision(context.Background(), knowledge.DecisionWriteRequest{
 		ID: "forged-decision", DecisionType: "evidence-backed-finding_to_verified_fix",
 		Status: string(decisionworkflow.DispositionAccepted), MadeBy: "forged-operator",
@@ -292,7 +292,7 @@ func TestVerifiedClosureRequiresIndependentActor(t *testing.T) {
 		DecisionState: string(decisionworkflow.DecisionSupported), PacketDigest: "sha256:packet",
 	}}
 	log := &replayLog{}
-	writer := knowledge.New(nil, nil).WithAppendLog(log).WithDurabilityMode(knowledge.DurabilityRequired)
+	writer := knowledge.New(nil).WithAppendLog(log).WithDurabilityMode(knowledge.DurabilityRequired)
 	service := New(receipts, log, writer, &sequenceClock{values: []time.Time{start}})
 	decision, err := service.RecordDecision(context.Background(), RecordDecisionRequest{
 		TenantID: "tenant-1", ActorID: "operator-1", PacketID: "dpr_1", Disposition: decisionworkflow.DispositionAccepted,
@@ -310,7 +310,7 @@ func TestVerifiedClosureRequiresIndependentActor(t *testing.T) {
 }
 
 func TestRecordDecisionRejectsUnboundedDispositionReason(t *testing.T) {
-	service := New(&receiptStore{}, nil, knowledge.New(nil, nil), nil)
+	service := New(&receiptStore{}, nil, knowledge.New(nil), nil)
 	_, err := service.RecordDecision(context.Background(), RecordDecisionRequest{
 		TenantID: "tenant-1", ActorID: "operator-1", PacketID: "dpr_1",
 		Disposition: decisionworkflow.DispositionAccepted, Reason: decisionworkflow.DismissalAcceptedRisk,
@@ -328,7 +328,7 @@ func TestAuditDeliveryRequiresReceipt(t *testing.T) {
 		DecisionState: string(decisionworkflow.DecisionSupported), PacketDigest: "sha256:packet",
 	}}
 	log := &replayLog{}
-	writer := knowledge.New(nil, nil).WithAppendLog(log).WithDurabilityMode(knowledge.DurabilityRequired)
+	writer := knowledge.New(nil).WithAppendLog(log).WithDurabilityMode(knowledge.DurabilityRequired)
 	service := New(receipts, log, writer, &sequenceClock{values: []time.Time{start}})
 	decision, err := service.RecordDecision(context.Background(), RecordDecisionRequest{
 		TenantID: "tenant-1", ActorID: "operator-1", PacketID: "dpr_1", Disposition: decisionworkflow.DispositionAccepted,

--- a/internal/findings/graph.go
+++ b/internal/findings/graph.go
@@ -281,7 +281,7 @@ func (s *Service) recordFindingStatusWorkflow(ctx context.Context, finding *port
 	if rationale := strings.TrimSpace(finding.StatusReason); rationale != "" {
 		workflowMetadata["rationale"] = rationale
 	}
-	service := knowledge.New(s.graphQuery, s.graph).
+	service := knowledge.New(s.graph).
 		WithAppendLog(s.appendLog).
 		WithDurabilityMode(knowledge.DurabilityRequired)
 	decision, err := service.WriteDecision(ctx, knowledge.DecisionWriteRequest{

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -1143,7 +1143,7 @@ func rowValueEmpty(value any) bool {
 	}
 }
 
-func scopedNeighborhood(ctx context.Context, store ports.GraphQueryStore, scopeURN string) *ports.EntityNeighborhood {
+func scopedNeighborhood(ctx context.Context, store ports.GraphNeighborhoodStore, scopeURN string) *ports.EntityNeighborhood {
 	scopeURN = strings.TrimSpace(scopeURN)
 	if scopeURN == "" || store == nil {
 		return nil

--- a/internal/graphagent/probe.go
+++ b/internal/graphagent/probe.go
@@ -133,7 +133,7 @@ func resetGraphProbeCountsCacheForTest() {
 	graphProbeCountsCache.entries = map[string]graphProbeCountsCacheEntry{}
 }
 
-func probeCounts(ctx context.Context, store ports.GraphQueryStore, params map[string]any, query string, probe *GraphProbe) []GraphProbeCount {
+func probeCounts(ctx context.Context, store ports.RawCypherQueryStore, params map[string]any, query string, probe *GraphProbe) []GraphProbeCount {
 	rows, err := store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{Query: query, Params: params, RowLimit: 20})
 	if err != nil {
 		if probe != nil {

--- a/internal/graphagent/validator.go
+++ b/internal/graphagent/validator.go
@@ -30,11 +30,11 @@ type ValidatorOptions struct {
 }
 
 type Validator struct {
-	store   ports.GraphQueryStore
+	store   ports.RawCypherQueryStore
 	options ValidatorOptions
 }
 
-func NewValidator(store ports.GraphQueryStore, options ValidatorOptions) *Validator {
+func NewValidator(store ports.RawCypherQueryStore, options ValidatorOptions) *Validator {
 	if options.MaxRows <= 0 {
 		options.MaxRows = defaultMaxRows
 	}

--- a/internal/graphprovenance/provenance.go
+++ b/internal/graphprovenance/provenance.go
@@ -38,10 +38,10 @@ type Provenance struct {
 }
 
 type Service struct {
-	store ports.GraphQueryStore
+	store ports.EntityCatalogStore
 }
 
-func New(store ports.GraphQueryStore) *Service {
+func New(store ports.EntityCatalogStore) *Service {
 	return &Service{store: store}
 }
 
@@ -54,11 +54,7 @@ func (s *Service) Get(ctx context.Context, request Request) (Response, error) {
 		return Response{}, graphquery.ErrRuntimeUnavailable
 	}
 	tenantID := TenantIDFromURN(urn)
-	store, ok := s.store.(ports.EntityCatalogStore)
-	if !ok {
-		return Response{}, ports.ErrGraphTypedOperationRequired
-	}
-	page, err := store.ListEntities(ctx, ports.EntityCatalogPageRequest{Filter: ports.EntityCatalogFilter{TenantID: tenantID, ExactAgentKey: urn}, Limit: 1})
+	page, err := s.store.ListEntities(ctx, ports.EntityCatalogPageRequest{Filter: ports.EntityCatalogFilter{TenantID: tenantID, ExactAgentKey: urn}, Limit: 1})
 	if err != nil {
 		return Response{}, err
 	}

--- a/internal/graphprovenance/provenance_test.go
+++ b/internal/graphprovenance/provenance_test.go
@@ -65,21 +65,8 @@ func TestServiceGetRejectsKindOnlyURN(t *testing.T) {
 
 type recordingStore struct {
 	rows           []ports.CypherRow
-	request        ports.CypherQueryRequest
 	called         bool
 	catalogRequest ports.EntityCatalogPageRequest
-}
-
-func (s *recordingStore) Ping(context.Context) error { return nil }
-
-func (s *recordingStore) GetEntityNeighborhood(context.Context, string, int) (*ports.EntityNeighborhood, error) {
-	return nil, ports.ErrGraphEntityNotFound
-}
-
-func (s *recordingStore) ExecuteReadCypher(_ context.Context, request ports.CypherQueryRequest) ([]ports.CypherRow, error) {
-	s.called = true
-	s.request = request
-	return s.rows, nil
 }
 
 func (s *recordingStore) ListEntities(_ context.Context, request ports.EntityCatalogPageRequest) (*ports.EntityCatalogPage, error) {

--- a/internal/grcpolicylifecycle/lifecycle.go
+++ b/internal/grcpolicylifecycle/lifecycle.go
@@ -694,7 +694,7 @@ type grcPolicyGraphRelation struct {
 	Attrs    map[string]string
 }
 
-func Build(ctx context.Context, store ports.GraphQueryStore, scope Scope) (Response, error) {
+func Build(ctx context.Context, store ports.RawCypherQueryStore, scope Scope) (Response, error) {
 	limit := int(scope.Limit)
 	if limit <= 0 {
 		limit = grcPolicyLifecycleDefaultLimit

--- a/internal/grcvendor/service.go
+++ b/internal/grcvendor/service.go
@@ -62,8 +62,13 @@ var (
 // Service reads the vendor GRC graph projection without owning a separate
 // source, source-provider writer, or normalization path.
 type Service struct {
-	store ports.GraphQueryStore
+	store GraphStore
 	now   func() time.Time
+}
+
+type GraphStore interface {
+	ports.EntityCatalogStore
+	ports.GraphNeighborhoodStore
 }
 
 type ListVendorsRequest struct {
@@ -457,7 +462,7 @@ type RelatedRecord struct {
 	Attributes map[string]string `json:"attributes,omitempty"`
 }
 
-func New(store ports.GraphQueryStore) *Service {
+func New(store GraphStore) *Service {
 	return &Service{store: store, now: time.Now}
 }
 

--- a/internal/knowledge/service.go
+++ b/internal/knowledge/service.go
@@ -148,8 +148,7 @@ type OutcomeWriteResult struct {
 }
 
 // New constructs one platform knowledge write service.
-func New(query ports.RawCypherQueryStore, graph ports.ProjectionGraphStore) *Service {
-	_ = query // Retained in the constructor for compatibility; graph lookup is not a durability precondition.
+func New(graph ports.ProjectionGraphStore) *Service {
 	return &Service{graph: graph, durabilityMode: DurabilityRequired}
 }
 

--- a/internal/knowledge/service_test.go
+++ b/internal/knowledge/service_test.go
@@ -115,7 +115,7 @@ func TestWriteDecisionRecordsDecisionTargetsEvidenceAndActions(t *testing.T) {
 			},
 		},
 	}
-	service := New(store, store).WithDurabilityMode(DurabilityLegacyProjectionOnly)
+	service := New(store).WithDurabilityMode(DurabilityLegacyProjectionOnly)
 
 	result, err := service.WriteDecision(context.Background(), DecisionWriteRequest{
 		DecisionType:  "finding-triage",
@@ -168,7 +168,7 @@ func TestWriteOutcomeRecordsOutcomeAgainstDecision(t *testing.T) {
 			},
 		},
 	}
-	service := New(store, store).WithDurabilityMode(DurabilityLegacyProjectionOnly)
+	service := New(store).WithDurabilityMode(DurabilityLegacyProjectionOnly)
 	decision, err := service.WriteDecision(context.Background(), DecisionWriteRequest{
 		ID:           "decision-1",
 		DecisionType: "finding-triage",
@@ -210,7 +210,7 @@ func TestWriteActionRecordsTargetsAndDecisionLink(t *testing.T) {
 			},
 		},
 	}
-	service := New(store, store).WithDurabilityMode(DurabilityLegacyProjectionOnly)
+	service := New(store).WithDurabilityMode(DurabilityLegacyProjectionOnly)
 	decision, err := service.WriteDecision(context.Background(), DecisionWriteRequest{
 		ID:           "decision-1",
 		DecisionType: "finding-triage",
@@ -273,7 +273,7 @@ func TestWriteDecisionAppendsWorkflowEventBeforeProjection(t *testing.T) {
 		},
 	}
 	appendLog := &recordingAppendLog{}
-	service := New(store, store).WithAppendLog(appendLog)
+	service := New(store).WithAppendLog(appendLog)
 	result, err := service.WriteDecision(context.Background(), DecisionWriteRequest{
 		ID:           "decision-1",
 		DecisionType: "finding-triage",
@@ -307,7 +307,7 @@ func TestWriteDecisionAppendFailurePreventsGraphProjection(t *testing.T) {
 		},
 	}
 	appendErr := errors.New("append failed")
-	service := New(store, store).WithAppendLog(&recordingAppendLog{err: appendErr})
+	service := New(store).WithAppendLog(&recordingAppendLog{err: appendErr})
 	if _, err := service.WriteDecision(context.Background(), DecisionWriteRequest{
 		ID:           "decision-1",
 		DecisionType: "finding-triage",
@@ -333,7 +333,7 @@ func TestWriteActionProjectionFailureReturnsDurableResult(t *testing.T) {
 			},
 		},
 	}
-	service := New(store, store).WithDurabilityMode(DurabilityLegacyProjectionOnly)
+	service := New(store).WithDurabilityMode(DurabilityLegacyProjectionOnly)
 	decision, err := service.WriteDecision(context.Background(), DecisionWriteRequest{
 		ID:           "decision-1",
 		DecisionType: "finding-triage",
@@ -367,7 +367,7 @@ func TestWriteActionProjectionFailureReturnsDurableResult(t *testing.T) {
 }
 
 func TestWriteDecisionRequiresAppendLogInDurableMode(t *testing.T) {
-	service := New(nil, nil).WithDurabilityMode(DurabilityRequired)
+	service := New(nil).WithDurabilityMode(DurabilityRequired)
 	if _, err := service.WriteDecision(context.Background(), DecisionWriteRequest{
 		DecisionType: "finding-triage",
 		TargetIDs:    []string{"urn:cerebro:writer:okta_resource:policyrule:pol-1"},
@@ -378,7 +378,7 @@ func TestWriteDecisionRequiresAppendLogInDurableMode(t *testing.T) {
 
 func TestWriteDecisionRecordsWithoutGraphWhenAppendLogIsAvailable(t *testing.T) {
 	appendLog := &recordingAppendLog{}
-	result, err := New(nil, nil).
+	result, err := New(nil).
 		WithAppendLog(appendLog).
 		WithDurabilityMode(DurabilityRequired).
 		WriteDecision(context.Background(), DecisionWriteRequest{
@@ -399,7 +399,7 @@ func TestWriteDecisionRecordsWithoutGraphWhenAppendLogIsAvailable(t *testing.T) 
 func TestLegacyProjectionOnlyReportsMissingDurability(t *testing.T) {
 	targetURN := "urn:cerebro:writer:okta_resource:policyrule:pol-1"
 	store := &stubGraphStore{entities: map[string]*ports.ProjectedEntity{targetURN: {URN: targetURN}}}
-	result, err := New(store, store).WithDurabilityMode(DurabilityLegacyProjectionOnly).WriteDecision(context.Background(), DecisionWriteRequest{
+	result, err := New(store).WithDurabilityMode(DurabilityLegacyProjectionOnly).WriteDecision(context.Background(), DecisionWriteRequest{
 		DecisionType: "finding-triage",
 		TargetIDs:    []string{targetURN},
 	})
@@ -413,7 +413,7 @@ func TestLegacyProjectionOnlyReportsMissingDurability(t *testing.T) {
 
 func TestCrossTenantReferenceNeverEntersAppendLog(t *testing.T) {
 	appendLog := &recordingAppendLog{}
-	_, err := New(nil, nil).
+	_, err := New(nil).
 		WithAppendLog(appendLog).
 		WithDurabilityMode(DurabilityRequired).
 		WriteDecision(context.Background(), DecisionWriteRequest{
@@ -432,7 +432,7 @@ func TestCrossTenantReferenceNeverEntersAppendLog(t *testing.T) {
 
 func TestDecisionRetryKeepsLogicalEventIdentity(t *testing.T) {
 	appendLog := &recordingAppendLog{}
-	service := New(nil, nil).WithAppendLog(appendLog)
+	service := New(nil).WithAppendLog(appendLog)
 	request := DecisionWriteRequest{
 		ID:           "decision-1",
 		DecisionType: "finding-triage",
@@ -458,7 +458,7 @@ func TestPacketDecisionIdentityNamespaceIsServerOwned(t *testing.T) {
 	store := &stubGraphStore{entities: map[string]*ports.ProjectedEntity{
 		targetURN: {URN: targetURN, TenantID: "writer", SourceID: "test", EntityType: "resource", Label: "Service 1"},
 	}}
-	service := New(store, store).WithAppendLog(appendLog)
+	service := New(store).WithAppendLog(appendLog)
 	request := DecisionWriteRequest{
 		ID:           "urn:cerebro:writer:packet_decision:dpr-1-accepted",
 		DecisionType: "finding-triage",
@@ -501,7 +501,7 @@ func TestKnowledgeValidationErrorsAreInvalidRequests(t *testing.T) {
 			},
 		},
 	}
-	service := New(store, store).WithDurabilityMode(DurabilityLegacyProjectionOnly)
+	service := New(store).WithDurabilityMode(DurabilityLegacyProjectionOnly)
 	for _, tt := range []struct {
 		name string
 		run  func() error

--- a/internal/policycandidate/grounding.go
+++ b/internal/policycandidate/grounding.go
@@ -24,7 +24,7 @@ RETURN source.urn AS from_urn, target.urn AS to_urn, edge.relation AS relation, 
 ORDER BY from_urn, relation, to_urn
 LIMIT $row_limit`
 
-func groundGraphEvidence(ctx context.Context, graph ports.GraphQueryStore, tenantID string, evidence policyauthor.GraphEvidence, request GroundingRequest, now func() time.Time) (*GroundingReceipt, error) {
+func groundGraphEvidence(ctx context.Context, graph ports.RawCypherQueryStore, tenantID string, evidence policyauthor.GraphEvidence, request GroundingRequest, now func() time.Time) (*GroundingReceipt, error) {
 	if err := validateMultiHopEvidence(evidence); err != nil {
 		return nil, err
 	}

--- a/internal/policycandidate/service.go
+++ b/internal/policycandidate/service.go
@@ -25,7 +25,7 @@ type Service struct {
 	Experiments ExperimentStore
 	Datasets    PolicyEvaluationDatasetStore
 	Author      *agentauthoring.Service
-	Graph       ports.GraphQueryStore
+	Graph       ports.RawCypherQueryStore
 	Catalog     CoverageCatalog
 	Now         func() time.Time
 }

--- a/internal/reports/service.go
+++ b/internal/reports/service.go
@@ -58,12 +58,12 @@ var (
 // Service exposes the first durable report-run foundation.
 type Service struct {
 	findingStore ports.FindingStore
-	graphStore   ports.GraphQueryStore
+	graphStore   ports.GraphNeighborhoodStore
 	reportStore  ports.ReportStore
 }
 
 // New constructs the report service.
-func New(findingStore ports.FindingStore, graphStore ports.GraphQueryStore, reportStore ports.ReportStore) *Service {
+func New(findingStore ports.FindingStore, graphStore ports.GraphNeighborhoodStore, reportStore ports.ReportStore) *Service {
 	return &Service{
 		findingStore: findingStore,
 		graphStore:   graphStore,

--- a/internal/runtimeorchestration/security_path_capture.go
+++ b/internal/runtimeorchestration/security_path_capture.go
@@ -42,7 +42,7 @@ type runtimeSyncService interface {
 }
 
 type SecurityPathDependencies struct {
-	GraphQueries ports.GraphQueryStore
+	GraphQueries ports.RawCypherQueryStore
 	GraphIngest  graphIngestService
 	Checkpoints  CheckpointStore
 	RuntimeStore ports.SourceRuntimeStore

--- a/internal/sourcehttp/organizationalgraph/query.go
+++ b/internal/sourcehttp/organizationalgraph/query.go
@@ -1,5 +1,5 @@
 // Package organizationalgraph makes the Rust-owned generated graph contract
-// the product read authority. A legacy store is optional and exists only for
+// the product read authority. A raw Cypher compatibility store is optional for
 // callers that have not yet moved from raw Cypher to typed operations.
 package organizationalgraph
 
@@ -54,12 +54,12 @@ func ReadinessStore(compatibility, authority ports.GraphStore) ports.GraphStore 
 	return compatibility
 }
 
-func NewQueryStore(rawCypher ports.GraphQueryStore, baseURL, sharedSecret string, timeout time.Duration) (*QueryStore, error) {
+func NewQueryStore(rawCypher ports.RawCypherQueryStore, baseURL, sharedSecret string, timeout time.Duration) (*QueryStore, error) {
 	return newQueryStore(rawCypher, baseURL, sharedSecret, timeout)
 }
 
 // NewConfiguredQueryStore selects one validated deployment read strategy.
-func NewConfiguredQueryStore(rawCypher ports.GraphQueryStore, baseURL, sharedSecret string, timeout time.Duration, mode string) (*QueryStore, error) {
+func NewConfiguredQueryStore(rawCypher ports.RawCypherQueryStore, baseURL, sharedSecret string, timeout time.Duration, mode string) (*QueryStore, error) {
 	return NewConfiguredQueryStoreWithCompatibility(
 		rawCypher,
 		baseURL,

--- a/tools/archtests/rust_organizational_platform_test.go
+++ b/tools/archtests/rust_organizational_platform_test.go
@@ -209,6 +209,46 @@ func TestRustOrganizationalPlatformBoundary(t *testing.T) {
 	if strings.Contains(grcPolicyLifecycle, "func Build(ctx context.Context, store ports.GraphQueryStore") {
 		t.Error("GRC policy lifecycle restored full graph query dependency")
 	}
+	reportService := readText(t, filepath.Join(root, "internal/reports/service.go"))
+	if strings.Contains(reportService, "graphStore   ports.GraphQueryStore") {
+		t.Error("reports service restored full graph query dependency")
+	}
+	complianceImpactGraph := readText(t, filepath.Join(root, "internal/complianceimpact/projected_graph.go"))
+	if strings.Contains(complianceImpactGraph, "queries ports.GraphQueryStore") {
+		t.Error("compliance impact graph restored full graph query dependency")
+	}
+	policyCandidateService := readText(t, filepath.Join(root, "internal/policycandidate/service.go"))
+	if strings.Contains(policyCandidateService, "Graph       ports.GraphQueryStore") {
+		t.Error("policy candidate service restored full graph query dependency")
+	}
+	policyCandidateGrounding := readText(t, filepath.Join(root, "internal/policycandidate/grounding.go"))
+	if strings.Contains(policyCandidateGrounding, "graph ports.GraphQueryStore") {
+		t.Error("policy candidate grounding restored full graph query dependency")
+	}
+	grcVendorService := readText(t, filepath.Join(root, "internal/grcvendor/service.go"))
+	if strings.Contains(grcVendorService, "store ports.GraphQueryStore") {
+		t.Error("GRC vendor service restored full graph query dependency")
+	}
+	mcpSource := readText(t, filepath.Join(root, "internal/bootstrap/mcp.go"))
+	if strings.Contains(mcpSource, "fetchMCPGraphStoreNeighborhoods(ctx context.Context, graphStore ports.GraphQueryStore") {
+		t.Error("MCP graph neighborhood helper restored full graph query dependency")
+	}
+	securityPathCapture := readText(t, filepath.Join(root, "internal/runtimeorchestration/security_path_capture.go"))
+	if strings.Contains(securityPathCapture, "GraphQueries ports.GraphQueryStore") {
+		t.Error("security path capture restored full graph query dependency")
+	}
+	graphAgentValidator := readText(t, filepath.Join(root, "internal/graphagent/validator.go"))
+	if strings.Contains(graphAgentValidator, "store   ports.GraphQueryStore") || strings.Contains(graphAgentValidator, "func NewValidator(store ports.GraphQueryStore") {
+		t.Error("graph agent validator restored full graph query dependency")
+	}
+	graphAgentProbe := readText(t, filepath.Join(root, "internal/graphagent/probe.go"))
+	if strings.Contains(graphAgentProbe, "func probeCounts(ctx context.Context, store ports.GraphQueryStore") {
+		t.Error("graph agent probe counts restored full graph query dependency")
+	}
+	graphAgentAsk := readText(t, filepath.Join(root, "internal/graphagent/ask.go"))
+	if strings.Contains(graphAgentAsk, "func scopedNeighborhood(ctx context.Context, store ports.GraphQueryStore") {
+		t.Error("graph agent scoped neighborhood restored full graph query dependency")
+	}
 
 	goNeo4jStore := readText(t, filepath.Join(root, "internal/graphstore/neo4j/store.go"))
 	for _, removedTypedRead := range []string{

--- a/tools/archtests/rust_organizational_platform_test.go
+++ b/tools/archtests/rust_organizational_platform_test.go
@@ -188,6 +188,28 @@ func TestRustOrganizationalPlatformBoundary(t *testing.T) {
 		}
 	}
 
+	queryAdapterSource := readText(t, filepath.Join(root, "internal/sourcehttp/organizationalgraph/query.go"))
+	for _, widenedRawCypherBoundary := range []string{
+		"func NewQueryStore(rawCypher ports.GraphQueryStore",
+		"func NewConfiguredQueryStore(rawCypher ports.GraphQueryStore",
+	} {
+		if strings.Contains(queryAdapterSource, widenedRawCypherBoundary) {
+			t.Errorf("Rust graph query adapter widened raw-Cypher compatibility boundary %q", widenedRawCypherBoundary)
+		}
+	}
+	knowledgeService := readText(t, filepath.Join(root, "internal/knowledge/service.go"))
+	if strings.Contains(knowledgeService, "func New(query ports.RawCypherQueryStore") {
+		t.Error("knowledge writer restored unused graph query dependency")
+	}
+	provenanceService := readText(t, filepath.Join(root, "internal/graphprovenance/provenance.go"))
+	if strings.Contains(provenanceService, "store ports.GraphQueryStore") {
+		t.Error("graph provenance restored full graph query dependency")
+	}
+	grcPolicyLifecycle := readText(t, filepath.Join(root, "internal/grcpolicylifecycle/lifecycle.go"))
+	if strings.Contains(grcPolicyLifecycle, "func Build(ctx context.Context, store ports.GraphQueryStore") {
+		t.Error("GRC policy lifecycle restored full graph query dependency")
+	}
+
 	goNeo4jStore := readText(t, filepath.Join(root, "internal/graphstore/neo4j/store.go"))
 	for _, removedTypedRead := range []string{
 		"func (s *Store) GetEntityNeighborhood(",


### PR DESCRIPTION
## Summary
- narrow graph read constructors and services to raw Cypher, catalog, or neighborhood-only ports where they do not need the full graph query composite
- keep the full graph query composite only for services that still use both typed neighborhoods and raw Cypher
- add architecture guards so narrowed boundaries do not widen back accidentally

## Tests
- go test ./internal/reports ./internal/complianceimpact ./internal/policycandidate ./internal/grcvendor ./internal/bootstrap ./internal/sourcehttp/organizationalgraph ./internal/knowledge ./internal/graphprovenance ./internal/grcpolicylifecycle ./internal/runtimeorchestration ./internal/graphagent ./tools/archtests -count=1
- make check-structural check-structural-test check-arch
- make lint-shard LINT_PACKAGES="./internal/..." LINT_SHARD_TOTAL=4 LINT_SHARD_INDEX=0
- make lint-shard LINT_PACKAGES="./internal/..." LINT_SHARD_TOTAL=4 LINT_SHARD_INDEX=1
- make lint-shard LINT_PACKAGES="./internal/..." LINT_SHARD_TOTAL=4 LINT_SHARD_INDEX=2
- make lint-shard LINT_PACKAGES="./internal/..." LINT_SHARD_TOTAL=4 LINT_SHARD_INDEX=3
- make lint-bootstrap
- git diff --check
