### PR TITLE
Split graphquery store capabilities

### DIFF
--- a/internal/graphquery/attack_path.go
+++ b/internal/graphquery/attack_path.go
@@ -16,7 +16,7 @@ type AttackPath = attackpath.Path
 type AttackPathEdge = attackpath.Edge
 
 func (s *Service) GetAttackPaths(ctx context.Context, request AttackPathRequest) (*AttackPathResult, error) {
-	if s == nil || s.store == nil {
+	if s == nil || s.rawCypher == nil {
 		return nil, ErrRuntimeUnavailable
 	}
 	tenantID := strings.TrimSpace(request.TenantID)
@@ -24,5 +24,5 @@ func (s *Service) GetAttackPaths(ctx context.Context, request AttackPathRequest)
 		return nil, fmt.Errorf("%w: tenant_id is required", ErrInvalidRequest)
 	}
 	request.TenantID = tenantID
-	return attackpath.New(s.store).Traverse(ctx, request)
+	return attackpath.New(s.rawCypher).Traverse(ctx, request)
 }

--- a/internal/graphquery/aws_exposure.go
+++ b/internal/graphquery/aws_exposure.go
@@ -96,19 +96,15 @@ type ExposureCoverageCompleteness struct {
 }
 
 func (s *Service) GetAWSPublicEndpointInsights(ctx context.Context, request AWSPublicEndpointInsightsRequest) (*AWSPublicEndpointInsightsResult, error) {
-	if s == nil || s.store == nil {
+	if s == nil || s.exposure == nil {
 		return nil, ErrRuntimeUnavailable
 	}
 	tenantID := strings.TrimSpace(request.TenantID)
 	if tenantID == "" {
 		return nil, fmt.Errorf("%w: tenant_id is required", ErrInvalidRequest)
 	}
-	store, ok := s.store.(ports.ExposureCoverageStore)
-	if !ok {
-		return nil, fmt.Errorf("%w: typed exposure coverage is unavailable", ErrRuntimeUnavailable)
-	}
 	limit := normalizeAWSExposureLimit(request.Limit)
-	typed, err := store.CompareExposureCoverage(ctx, ports.ExposureCoverageRequest{
+	typed, err := s.exposure.CompareExposureCoverage(ctx, ports.ExposureCoverageRequest{
 		TenantID: tenantID,
 		Profile: ports.ExposureCoverageProfile{
 			PrimarySourceID:              "aws",

--- a/internal/graphquery/crown_jewel_rank.go
+++ b/internal/graphquery/crown_jewel_rank.go
@@ -81,7 +81,7 @@ type CrownJewelRank struct {
 }
 
 func (s *Service) GetCrownJewelRanks(ctx context.Context, request CrownJewelRankRequest) (*CrownJewelRankResult, error) {
-	if s == nil || s.store == nil {
+	if s == nil || s.rawCypher == nil {
 		return nil, ErrRuntimeUnavailable
 	}
 	tenantID := strings.TrimSpace(request.TenantID)
@@ -103,7 +103,7 @@ func (s *Service) GetCrownJewelRanks(ctx context.Context, request CrownJewelRank
 		},
 	}
 
-	seedRows, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{Query: crownJewelSeedQuery, Params: params, RowLimit: seedLimit})
+	seedRows, err := s.rawCypher.ExecuteReadCypher(ctx, ports.CypherQueryRequest{Query: crownJewelSeedQuery, Params: params, RowLimit: seedLimit})
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (s *Service) GetCrownJewelRanks(ctx context.Context, request CrownJewelRank
 	}
 	params["path_limit_per_seed"] = int64(crownJewelLimitPerSeed(len(seeds)))
 
-	edgeRows, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{Query: crownJewelEdgeQuery(depth), Params: params, RowLimit: ports.MaxCypherQueryRows})
+	edgeRows, err := s.rawCypher.ExecuteReadCypher(ctx, ports.CypherQueryRequest{Query: crownJewelEdgeQuery(depth), Params: params, RowLimit: ports.MaxCypherQueryRows})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/graphquery/effective_access.go
+++ b/internal/graphquery/effective_access.go
@@ -321,7 +321,7 @@ func EffectiveAccessPathRequestFromQuery(values url.Values) (EffectiveAccessPath
 }
 
 func (s *Service) GetEffectiveAccessPaths(ctx context.Context, request EffectiveAccessPathRequest) (*EffectiveAccessPathResult, error) {
-	if s == nil || s.store == nil {
+	if s == nil || s.rawCypher == nil {
 		return nil, ErrRuntimeUnavailable
 	}
 	tenantID := strings.TrimSpace(request.TenantID)
@@ -352,7 +352,7 @@ func (s *Service) GetEffectiveAccessPaths(ctx context.Context, request Effective
 		capabilityID = normalizeEffectiveCapabilityID(capability)
 	}
 	limit := normalizeEffectiveAccessPathLimit(request.Limit)
-	rows, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
+	rows, err := s.rawCypher.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
 		Query: effectiveAccessPathQuery,
 		Params: map[string]any{
 			"application_urn": applicationURN,

--- a/internal/graphquery/impact.go
+++ b/internal/graphquery/impact.go
@@ -47,7 +47,7 @@ type ImpactResult struct {
 }
 
 func (s *Service) GetImpact(ctx context.Context, request ImpactRequest) (*ImpactResult, error) {
-	if s == nil || s.store == nil {
+	if s == nil || s.neighborhoods == nil {
 		return nil, ErrRuntimeUnavailable
 	}
 	rootURN, err := impactRootURN(request)
@@ -138,7 +138,7 @@ func (s *Service) collectImpactGraph(ctx context.Context, rootURN string, depth 
 
 func (s *Service) collectImpactNeighborhoods(ctx context.Context, roots []string, limit int) ([]*ports.EntityNeighborhood, error) {
 	results := make([]*ports.EntityNeighborhood, len(roots))
-	if batchStore, ok := s.store.(ports.GraphNeighborhoodBatchStore); ok {
+	if batchStore, ok := s.neighborhoods.(ports.GraphNeighborhoodBatchStore); ok {
 		neighborhoods, err := batchStore.GetEntityNeighborhoods(ctx, roots, limit)
 		if err != nil {
 			return nil, err
@@ -153,7 +153,7 @@ func (s *Service) collectImpactNeighborhoods(ctx context.Context, roots []string
 		return results, nil
 	}
 	if len(roots) == 1 {
-		neighborhood, err := s.store.GetEntityNeighborhood(ctx, roots[0], limit)
+		neighborhood, err := s.neighborhoods.GetEntityNeighborhood(ctx, roots[0], limit)
 		if err != nil {
 			return nil, err
 		}
@@ -165,7 +165,7 @@ func (s *Service) collectImpactNeighborhoods(ctx context.Context, roots []string
 	for index, urn := range roots {
 		index, urn := index, urn
 		group.Go(func() error {
-			neighborhood, err := s.store.GetEntityNeighborhood(groupCtx, urn, limit)
+			neighborhood, err := s.neighborhoods.GetEntityNeighborhood(groupCtx, urn, limit)
 			if err != nil {
 				return err
 			}

--- a/internal/graphquery/inventory.go
+++ b/internal/graphquery/inventory.go
@@ -105,19 +105,15 @@ type InventorySignal struct {
 }
 
 func (s *Service) ListInventoryCategories(ctx context.Context, request InventoryCategoryRequest) ([]InventoryCategory, error) {
-	if s == nil || s.store == nil {
+	if s == nil || s.catalog == nil {
 		return nil, ErrRuntimeUnavailable
 	}
 	tenantID := strings.TrimSpace(request.TenantID)
 	if tenantID == "" {
 		return nil, fmt.Errorf("%w: tenant_id is required", ErrInvalidRequest)
 	}
-	store, ok := s.store.(ports.EntityCatalogStore)
-	if !ok {
-		return nil, ErrRuntimeUnavailable
-	}
 	filter := inventoryCatalogFilter(tenantID, request.SourceID, request.Surface)
-	page, err := store.CountEntityKinds(ctx, ports.EntityKindCountRequest{Filter: filter, Limit: maxInventoryLimit})
+	page, err := s.catalog.CountEntityKinds(ctx, ports.EntityKindCountRequest{Filter: filter, Limit: maxInventoryLimit})
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +161,7 @@ func (s *Service) ListInventoryCategories(ctx context.Context, request Inventory
 }
 
 func (s *Service) ListInventoryAssets(ctx context.Context, request InventoryAssetRequest) ([]InventoryAsset, error) {
-	if s == nil || s.store == nil {
+	if s == nil || s.catalog == nil {
 		return nil, ErrRuntimeUnavailable
 	}
 	entityTypes := inventoryEntityTypesForFilter(request.CategoryID, request.EntityType)
@@ -173,17 +169,13 @@ func (s *Service) ListInventoryAssets(ctx context.Context, request InventoryAsse
 	if tenantID == "" {
 		return nil, fmt.Errorf("%w: tenant_id is required", ErrInvalidRequest)
 	}
-	store, ok := s.store.(ports.EntityCatalogStore)
-	if !ok {
-		return nil, ErrRuntimeUnavailable
-	}
 	filter := inventoryCatalogFilter(tenantID, request.SourceID, request.Surface)
 	filter.Query = strings.TrimSpace(request.Query)
 	if len(entityTypes) > 0 {
 		filter.IncludeKinds = entityTypes
 		filter.IncludeKindPrefixes = nil
 	}
-	page, err := store.ListEntities(ctx, ports.EntityCatalogPageRequest{Filter: filter, Limit: normalizeInventoryLimit(request.Limit)})
+	page, err := s.catalog.ListEntities(ctx, ports.EntityCatalogPageRequest{Filter: filter, Limit: normalizeInventoryLimit(request.Limit)})
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +193,7 @@ func (s *Service) ListInventoryAssets(ctx context.Context, request InventoryAsse
 }
 
 func (s *Service) GetInventoryAsset(ctx context.Context, request InventoryAssetDetailRequest) (*InventoryAssetDetail, error) {
-	if s == nil || s.store == nil {
+	if s == nil || s.catalog == nil {
 		return nil, ErrRuntimeUnavailable
 	}
 	urn := strings.TrimSpace(request.URN)
@@ -211,12 +203,8 @@ func (s *Service) GetInventoryAsset(ctx context.Context, request InventoryAssetD
 	if err := validateCerebroURN(urn); err != nil {
 		return nil, err
 	}
-	store, ok := s.store.(ports.EntityCatalogStore)
-	if !ok {
-		return nil, ErrRuntimeUnavailable
-	}
 	tenantID := cerebrourn.TenantID(urn)
-	page, err := store.ListEntities(ctx, ports.EntityCatalogPageRequest{Filter: ports.EntityCatalogFilter{TenantID: tenantID, ExactAgentKey: urn}, Limit: 1})
+	page, err := s.catalog.ListEntities(ctx, ports.EntityCatalogPageRequest{Filter: ports.EntityCatalogFilter{TenantID: tenantID, ExactAgentKey: urn}, Limit: 1})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/graphquery/person_access.go
+++ b/internal/graphquery/person_access.go
@@ -50,7 +50,7 @@ type PersonAccessPath struct {
 }
 
 func (s *Service) GetPersonAccessPaths(ctx context.Context, request PersonAccessPathRequest) (*PersonAccessPathResult, error) {
-	if s == nil || s.store == nil {
+	if s == nil || s.rawCypher == nil {
 		return nil, ErrRuntimeUnavailable
 	}
 	tenantID := strings.TrimSpace(request.TenantID)
@@ -78,7 +78,7 @@ func (s *Service) GetPersonAccessPaths(ctx context.Context, request PersonAccess
 		"sample_limit":     int64(limit),
 		"tenant_id":        tenantID,
 	}
-	rows, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
+	rows, err := s.rawCypher.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
 		Query:    personAccessPathQuery(normalizePersonAccessPathDepth(request.Depth)),
 		Params:   params,
 		RowLimit: limit,

--- a/internal/graphquery/service.go
+++ b/internal/graphquery/service.go
@@ -24,7 +24,10 @@ var (
 
 // Service exposes the first bounded graph neighborhood query.
 type Service struct {
-	store ports.GraphQueryStore
+	neighborhoods ports.GraphNeighborhoodStore
+	rawCypher     ports.RawCypherQueryStore
+	catalog       ports.EntityCatalogStore
+	exposure      ports.ExposureCoverageStore
 }
 
 // NeighborhoodRequest scopes one bounded root-centered graph query.
@@ -34,13 +37,23 @@ type NeighborhoodRequest struct {
 }
 
 // New constructs a bounded graph neighborhood service.
-func New(store ports.GraphQueryStore) *Service {
-	return &Service{store: store}
+func New(store ports.GraphNeighborhoodStore) *Service {
+	service := &Service{neighborhoods: store}
+	if rawCypher, ok := store.(ports.RawCypherQueryStore); ok {
+		service.rawCypher = rawCypher
+	}
+	if catalog, ok := store.(ports.EntityCatalogStore); ok {
+		service.catalog = catalog
+	}
+	if exposure, ok := store.(ports.ExposureCoverageStore); ok {
+		service.exposure = exposure
+	}
+	return service
 }
 
 // GetEntityNeighborhood loads one bounded root-centered graph neighborhood.
 func (s *Service) GetEntityNeighborhood(ctx context.Context, request NeighborhoodRequest) (*ports.EntityNeighborhood, error) {
-	if s == nil || s.store == nil {
+	if s == nil || s.neighborhoods == nil {
 		return nil, ErrRuntimeUnavailable
 	}
 	if strings.TrimSpace(request.RootURN) == "" {
@@ -50,7 +63,7 @@ func (s *Service) GetEntityNeighborhood(ctx context.Context, request Neighborhoo
 	if err := validateCerebroURN(rootURN); err != nil {
 		return nil, err
 	}
-	return s.store.GetEntityNeighborhood(ctx, rootURN, normalizeNeighborhoodLimit(request.Limit))
+	return s.neighborhoods.GetEntityNeighborhood(ctx, rootURN, normalizeNeighborhoodLimit(request.Limit))
 }
 
 // validateCerebroURN rejects malformed root URN inputs so the API can surface

--- a/tools/archtests/rust_organizational_platform_test.go
+++ b/tools/archtests/rust_organizational_platform_test.go
@@ -249,6 +249,10 @@ func TestRustOrganizationalPlatformBoundary(t *testing.T) {
 	if strings.Contains(graphAgentAsk, "func scopedNeighborhood(ctx context.Context, store ports.GraphQueryStore") {
 		t.Error("graph agent scoped neighborhood restored full graph query dependency")
 	}
+	graphQueryService := readText(t, filepath.Join(root, "internal/graphquery/service.go"))
+	if strings.Contains(graphQueryService, "store ports.GraphQueryStore") || strings.Contains(graphQueryService, "func New(store ports.GraphQueryStore") {
+		t.Error("graphquery service restored full graph query dependency")
+	}
 
 	goNeo4jStore := readText(t, filepath.Join(root, "internal/graphstore/neo4j/store.go"))
 	for _, removedTypedRead := range []string{


### PR DESCRIPTION
## Summary
- split the graphquery service internals into neighborhood, raw-Cypher, catalog, and exposure-coverage capability fields
- keep existing constructor behavior by deriving those capabilities from the configured graph read authority
- add an architecture guard so the service does not regain the full graph query composite dependency

## Tests
- go test ./internal/graphquery ./internal/bootstrap ./tools/archtests -count=1
- git diff --check
