### PR TITLE
Split graphagent store capabilities

### DIFF
--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -45,10 +45,11 @@ type AskRequest struct {
 type Emitter func(Event) error
 
 type Service struct {
-	store     ports.GraphQueryStore
-	llm       LLMClient
-	validator *Validator
-	options   ServiceOptions
+	rawCypher     ports.RawCypherQueryStore
+	neighborhoods ports.GraphNeighborhoodStore
+	llm           LLMClient
+	validator     *Validator
+	options       ServiceOptions
 }
 
 func NewService(store ports.GraphQueryStore, llm LLMClient, options ValidatorOptions) *Service {
@@ -57,10 +58,11 @@ func NewService(store ports.GraphQueryStore, llm LLMClient, options ValidatorOpt
 
 func NewServiceWithOptions(store ports.GraphQueryStore, llm LLMClient, validatorOptions ValidatorOptions, serviceOptions ServiceOptions) *Service {
 	return &Service{
-		store:     store,
-		llm:       llm,
-		validator: NewValidator(store, validatorOptions),
-		options:   normalizeServiceOptions(serviceOptions),
+		rawCypher:     store,
+		neighborhoods: store,
+		llm:           llm,
+		validator:     NewValidator(store, validatorOptions),
+		options:       normalizeServiceOptions(serviceOptions),
 	}
 }
 
@@ -71,7 +73,7 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 	if err := ValidateRequest(request); err != nil {
 		return err
 	}
-	if s == nil || s.store == nil || s.llm == nil || s.validator == nil {
+	if s == nil || s.rawCypher == nil || s.neighborhoods == nil || s.llm == nil || s.validator == nil {
 		return ErrRuntimeUnavailable
 	}
 	started := time.Now()
@@ -95,7 +97,7 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 			return err
 		}
 		probeStarted := time.Now()
-		collected := collectGraphProbe(ctx, s.store, request, params)
+		collected := collectGraphProbe(ctx, s.rawCypher, s.neighborhoods, request, params)
 		timings.ProbeMS = time.Since(probeStarted).Milliseconds()
 		probe = &collected
 		if err := emit(Event{Name: EventGraphProbe, Data: GraphProbeEvent{Probe: collected}}); err != nil {
@@ -180,7 +182,7 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 		return err
 	}
 	execStarted := time.Now()
-	rows, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
+	rows, err := s.rawCypher.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
 		Query:    cypher,
 		Params:   params,
 		RowLimit: rowLimit,
@@ -212,7 +214,7 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 	}
 	rowsEvent := RowsEvent{
 		Rows:   rowMaps,
-		Graph:  scopedNeighborhood(ctx, s.store, request.ScopeURN),
+		Graph:  scopedNeighborhood(ctx, s.neighborhoods, request.ScopeURN),
 		ExecMS: timings.ExecuteMS,
 	}
 	if err := emit(Event{Name: EventRows, Data: rowsEvent}); err != nil {

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -44,6 +44,11 @@ type AskRequest struct {
 
 type Emitter func(Event) error
 
+type Store interface {
+	ports.RawCypherQueryStore
+	ports.GraphNeighborhoodStore
+}
+
 type Service struct {
 	rawCypher     ports.RawCypherQueryStore
 	neighborhoods ports.GraphNeighborhoodStore
@@ -52,11 +57,11 @@ type Service struct {
 	options       ServiceOptions
 }
 
-func NewService(store ports.GraphQueryStore, llm LLMClient, options ValidatorOptions) *Service {
+func NewService(store Store, llm LLMClient, options ValidatorOptions) *Service {
 	return NewServiceWithOptions(store, llm, options, ServiceOptions{})
 }
 
-func NewServiceWithOptions(store ports.GraphQueryStore, llm LLMClient, validatorOptions ValidatorOptions, serviceOptions ServiceOptions) *Service {
+func NewServiceWithOptions(store Store, llm LLMClient, validatorOptions ValidatorOptions, serviceOptions ServiceOptions) *Service {
 	return &Service{
 		rawCypher:     store,
 		neighborhoods: store,

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -419,14 +419,14 @@ func TestCollectGraphProbeCachesTenantCounts(t *testing.T) {
 	}
 	request := AskRequest{TenantID: "writer", Question: "What is risky?"}
 
-	first := collectGraphProbe(context.Background(), store, request, askParams(request))
+	first := collectGraphProbe(context.Background(), store, store, request, askParams(request))
 	if first.SourceCount != 3 {
 		t.Fatalf("first probe source count = %d, want 3", first.SourceCount)
 	}
 	if len(store.requests) != 2 {
 		t.Fatalf("store requests after first probe = %d, want 2", len(store.requests))
 	}
-	second := collectGraphProbe(context.Background(), store, request, askParams(request))
+	second := collectGraphProbe(context.Background(), store, store, request, askParams(request))
 	if second.SourceCount != 3 {
 		t.Fatalf("second probe source count = %d, want cached 3", second.SourceCount)
 	}

--- a/internal/graphagent/probe.go
+++ b/internal/graphagent/probe.go
@@ -46,21 +46,26 @@ type GraphProbeCount struct {
 	Count int64  `json:"count"`
 }
 
-func collectGraphProbe(ctx context.Context, store ports.GraphQueryStore, request AskRequest, params map[string]any) GraphProbe {
+func collectGraphProbe(ctx context.Context, rawCypher ports.RawCypherQueryStore, neighborhoods ports.GraphNeighborhoodStore, request AskRequest, params map[string]any) GraphProbe {
 	probe := GraphProbe{ScopeURN: strings.TrimSpace(request.ScopeURN)}
-	if store == nil {
+	if rawCypher == nil && neighborhoods == nil {
 		probe.Warnings = append(probe.Warnings, "graph_store_unavailable")
 		return probe
 	}
 	if probe.ScopeURN != "" {
-		neighborhood, err := store.GetEntityNeighborhood(ctx, probe.ScopeURN, 10)
-		if err != nil {
+		if neighborhoods == nil {
+			probe.Warnings = append(probe.Warnings, "scope_not_found")
+		} else if neighborhood, err := neighborhoods.GetEntityNeighborhood(ctx, probe.ScopeURN, 10); err != nil {
 			probe.Warnings = append(probe.Warnings, "scope_not_found")
 		} else if neighborhood != nil && neighborhood.Root != nil {
 			probe.ScopeFound = true
 			probe.ScopeType = neighborhood.Root.EntityType
 			probe.ScopeLabel = neighborhood.Root.Label
 		}
+	}
+	if rawCypher == nil {
+		probe.Warnings = append(probe.Warnings, "graph_store_unavailable")
+		return probe
 	}
 	if cached, ok := cachedGraphProbeCounts(request.TenantID); ok {
 		probe.EntityTypes = cached.EntityTypes
@@ -70,11 +75,11 @@ func collectGraphProbe(ctx context.Context, store ports.GraphQueryStore, request
 		return probe
 	}
 	warningsBeforeCounts := len(probe.Warnings)
-	probe.EntityTypes = probeCounts(ctx, store, params, `MATCH (n:Entity {tenant_id: $tenant_id})
+	probe.EntityTypes = probeCounts(ctx, rawCypher, params, `MATCH (n:Entity {tenant_id: $tenant_id})
 RETURN n.entity_type AS name, count(n) AS count
 ORDER BY count DESC, name
 LIMIT 20`, &probe)
-	probe.Relations = probeCounts(ctx, store, params, `MATCH (:Entity {tenant_id: $tenant_id})-[r:RELATION]->(:Entity {tenant_id: $tenant_id})
+	probe.Relations = probeCounts(ctx, rawCypher, params, `MATCH (:Entity {tenant_id: $tenant_id})-[r:RELATION]->(:Entity {tenant_id: $tenant_id})
 RETURN r.relation AS name, count(r) AS count
 ORDER BY count DESC, name
 LIMIT 20`, &probe)

--- a/internal/graphagent/recovery.go
+++ b/internal/graphagent/recovery.go
@@ -35,7 +35,7 @@ func (s *Service) recoverWeakRows(ctx context.Context, traceID string, started t
 	if !validation.OK {
 		return nil, "", validation, false, false, nil
 	}
-	recoveredRaw, err := s.store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
+	recoveredRaw, err := s.rawCypher.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
 		Query:    recoveredConversion.Cypher,
 		Params:   recoveredParams,
 		RowLimit: rowLimit,

--- a/tools/archtests/rust_organizational_platform_test.go
+++ b/tools/archtests/rust_organizational_platform_test.go
@@ -249,6 +249,9 @@ func TestRustOrganizationalPlatformBoundary(t *testing.T) {
 	if strings.Contains(graphAgentAsk, "func scopedNeighborhood(ctx context.Context, store ports.GraphQueryStore") {
 		t.Error("graph agent scoped neighborhood restored full graph query dependency")
 	}
+	if strings.Contains(graphAgentAsk, "store     ports.GraphQueryStore") {
+		t.Error("graph agent service restored stored full graph query dependency")
+	}
 
 	goNeo4jStore := readText(t, filepath.Join(root, "internal/graphstore/neo4j/store.go"))
 	for _, removedTypedRead := range []string{

--- a/tools/archtests/rust_organizational_platform_test.go
+++ b/tools/archtests/rust_organizational_platform_test.go
@@ -252,6 +252,9 @@ func TestRustOrganizationalPlatformBoundary(t *testing.T) {
 	if strings.Contains(graphAgentAsk, "store     ports.GraphQueryStore") {
 		t.Error("graph agent service restored stored full graph query dependency")
 	}
+	if strings.Contains(graphAgentAsk, "func NewService(store ports.GraphQueryStore") || strings.Contains(graphAgentAsk, "func NewServiceWithOptions(store ports.GraphQueryStore") {
+		t.Error("graph agent service restored full graph query constructor dependency")
+	}
 
 	goNeo4jStore := readText(t, filepath.Join(root, "internal/graphstore/neo4j/store.go"))
 	for _, removedTypedRead := range []string{


### PR DESCRIPTION
## Summary
- split graphagent service storage into raw-Cypher and neighborhood capability fields
- narrow the graphagent constructor to the exact raw-Cypher plus neighborhood capability interface
- add architecture guards for the narrowed service field and constructor boundary

## Tests
- go test ./internal/graphagent ./internal/bootstrap ./tools/archtests -count=1
- make lint-shard LINT_PACKAGES="./internal/graphagent" LINT_SHARD_TOTAL=1 LINT_SHARD_INDEX=0
- make check-structural check-structural-test check-arch
- git diff --check
