### PR TITLE
Delete transitional ports.GraphQueryStore composite

### DIFF
--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -1185,4 +1185,4 @@ func (s *askStore) ExecuteReadCypher(_ context.Context, request ports.CypherQuer
 	return s.rows, nil
 }
 
-var _ ports.GraphQueryStore = (*askStore)(nil)
+var _ Store = (*askStore)(nil)

--- a/internal/graphagent/validator_test.go
+++ b/internal/graphagent/validator_test.go
@@ -675,4 +675,4 @@ func (s *validatorStore) ExplainReadCypher(_ context.Context, request ports.Cyph
 	return s.plan, nil
 }
 
-var _ ports.GraphQueryStore = (*validatorStore)(nil)
+var _ ports.RawCypherQueryStore = (*validatorStore)(nil)

--- a/internal/graphquery/aws_exposure_test.go
+++ b/internal/graphquery/aws_exposure_test.go
@@ -98,7 +98,7 @@ func TestGetAWSPublicEndpointInsightsUsesOneTypedBoundedRead(t *testing.T) {
 }
 
 func TestGetAWSPublicEndpointInsightsFailsClosedWithoutTypedStore(t *testing.T) {
-	store := struct{ ports.GraphQueryStore }{}
+	store := struct{ ports.GraphNeighborhoodStore }{}
 	_, err := New(store).GetAWSPublicEndpointInsights(context.Background(), AWSPublicEndpointInsightsRequest{TenantID: "writer"})
 	if !errors.Is(err, ErrRuntimeUnavailable) {
 		t.Fatalf("GetAWSPublicEndpointInsights() error = %v, want %v", err, ErrRuntimeUnavailable)

--- a/internal/ports/graphquery.go
+++ b/internal/ports/graphquery.go
@@ -79,14 +79,6 @@ type RawCypherQueryStore interface {
 	ExecuteReadCypher(context.Context, CypherQueryRequest) ([]CypherRow, error)
 }
 
-// GraphQueryStore is the transitional composite consumed by existing product
-// packages. The authority adapter serves typed reads from Rust and delegates
-// only raw Cypher through RawCypherQueryStore.
-type GraphQueryStore interface {
-	GraphNeighborhoodStore
-	RawCypherQueryStore
-}
-
 // GraphReadStore is the top-level graph read handle wired by bootstrap: Rust
 // authority typed reads (neighborhoods, batched neighborhoods, entity catalog,
 // exposure coverage) plus the retained raw-Cypher compatibility surface.


### PR DESCRIPTION
## Summary

Follow-up to #2360 / #2361 / #2362. With graphagent, graphquery, and the bootstrap top-level handle all cut over to narrowed capability interfaces, the transitional `ports.GraphQueryStore` composite (`GraphNeighborhoodStore + RawCypherQueryStore`) has no remaining consumers. This deletes it.

- `internal/ports/graphquery.go`: remove the type and its doc comment. `GraphReadStore` (the bootstrap top-level handle) and the narrow capability interfaces remain.
- Three test references re-pointed at the interfaces the stubs actually satisfy: `askStore` → graphagent `Store`, `validatorStore` → `ports.RawCypherQueryStore`, and the graphquery fail-closed stub embeds `ports.GraphNeighborhoodStore` (present for the constructor, absent for exposure — same semantics).
- The archtests guards naming `ports.GraphQueryStore` stay as tripwires against reintroducing the wide dependency.

## Tests

- `go build ./...` / `go vet ./...` — clean
- `go test ./internal/graphquery ./internal/graphagent ./internal/bootstrap ./internal/ports ./cmd/cerebro ./tools/archtests -count=1` — all pass
- `make lint-shard LINT_PACKAGES="./internal/graphquery ./internal/graphagent ./internal/ports" LINT_SHARD_TOTAL=1 LINT_SHARD_INDEX=0` — 0 issues
- `make check-structural check-structural-test check-arch` — pass
