### PR TITLE
Wire graph CLI neighborhood and impact reads to the authority handle

### DIFF
--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -52,12 +52,6 @@ type graphRelationCountsStore interface {
 	RelationCounts(context.Context, []string) (graphstore.RelationCounts, error)
 }
 
-type graphQueryStore interface {
-	Ping(context.Context) error
-	GetEntityNeighborhood(context.Context, string, int) (*ports.EntityNeighborhood, error)
-	ExecuteReadCypher(context.Context, ports.CypherQueryRequest) ([]ports.CypherRow, error)
-}
-
 type graphPathStore interface {
 	PathPatterns(context.Context, int) ([]graphstore.PathPattern, error)
 	SampleTraversals(context.Context, int) ([]graphstore.Traversal, error)
@@ -493,9 +487,9 @@ func runGraphInspect(args []string) error {
 		if err != nil {
 			return err
 		}
-		store, ok := deps.GraphStore.(graphQueryStore)
-		if !ok {
-			return fmt.Errorf("graph store does not support neighborhoods")
+		store := dependencyGraphQueryStore(deps)
+		if store == nil {
+			return fmt.Errorf("graph read store is required for neighborhoods")
 		}
 		neighborhood, err := store.GetEntityNeighborhood(ctx, rootURN, limit)
 		if err != nil {
@@ -817,9 +811,9 @@ func runGraphImpact(args []string) error {
 		return err
 	}
 	defer logClose(closeDeps)
-	store, ok := deps.GraphStore.(graphQueryStore)
-	if !ok {
-		return fmt.Errorf("graph store does not support impact traversals")
+	store := dependencyGraphQueryStore(deps)
+	if store == nil {
+		return fmt.Errorf("graph read store is required for impact traversals")
 	}
 	result, err := graphquery.New(store).GetImpact(ctx, request)
 	if err != nil {


### PR DESCRIPTION
## Summary

The `graph neighborhood` and `graph impact` debug CLI commands asserted `deps.GraphStore` (the Neo4j compatibility store) against a local interface requiring `GetEntityNeighborhood`. Since #2357 removed the Neo4j typed neighborhood reads, both commands have been dead — they always error with "graph store does not support ...".

This routes both through `dependencyGraphQueryStore(deps)` — the Rust authority read handle (`ports.GraphReadStore`) — and drops the now-unused local interface:

- `graph neighborhood` → `GetEntityNeighborhood` on the authority handle (Rust `Expand`).
- `graph impact` → `graphquery.New(store).GetImpact`; the composite value populates every optional capability #2361's constructor probes for (raw Cypher, catalog, exposure, batch neighborhoods).
- Both now fail with a clear "graph read store is required ..." when the organizational graph read endpoint is not configured, instead of asserting a capability Neo4j no longer has.

The remaining `graph` subcommands (`counts`, `paths`, `integrity`, `topology`, repairs) are Neo4j admin surfaces and are unchanged.

## Tests

- `go test ./cmd/cerebro -count=1` — pass
- `go build ./...` / `go vet ./cmd/cerebro` — clean
- `gofmt` / `make lint-shard LINT_PACKAGES="./cmd/cerebro" LINT_SHARD_TOTAL=1 LINT_SHARD_INDEX=0` — 0 issues

## Related

Survey of the remaining raw-Cypher consumers (attack paths, person/effective access, crown-jewel ranking, policy candidates, compliance impact, GRC lifecycle, graph-agent probe counts) shows each needs a Rust API extension first (relation whitelists on path queries, multi-anchor patterns, aggregations, attribute predicates, or URN-keyed `FindPaths` endpoints). The Go-side read cutover is otherwise complete with #2360-#2363; those migrations should be sequenced as Rust API work.
