### PR TITLE
Split bootstrap graph read capabilities

### DIFF
--- a/cmd/cerebro/finding_rule_graph_evaluate.go
+++ b/cmd/cerebro/finding_rule_graph_evaluate.go
@@ -73,7 +73,7 @@ func runFindingRuleGraphEvaluate(args []string) error {
 		findingEvaluationRunStore(deps.StateStore),
 		findingEvidenceStore(deps.StateStore),
 		claimStore(deps.StateStore),
-	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithGraphQueryStore(dependencyGraphQueryStore(deps)).WithTrustedSourceResolution().WithAppendLog(deps.AppendLog)
+	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithGraphQueryStore(deps.GraphReads.RawCypher).WithTrustedSourceResolution().WithAppendLog(deps.AppendLog)
 	evaluation, err := service.EvaluateSourceRuntimeGraphRules(ctx, findings.EvaluateGraphRulesRequest{
 		RuntimeID: options.RuntimeID,
 		RuleIDs:   []string{options.RuleID},

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -899,10 +899,6 @@ func sourceProjector(stateStore ports.StateStore, graphStore ports.GraphStore) p
 	return sourceprojection.New(state, graph)
 }
 
-func dependencyGraphQueryStore(deps bootstrap.Dependencies) ports.GraphReadStore {
-	return deps.GraphQueries
-}
-
 func appendLogSourceProjector(deps bootstrap.Dependencies) ports.SourceProjector {
 	legacy := sourceProjector(deps.StateStore, deps.GraphStore)
 	if deps.OrganizationalProjector == nil {

--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -418,17 +418,17 @@ func TestPrepareGRCReadModelsSkipsStoresWithoutPreparer(t *testing.T) {
 	}
 }
 
-func TestDependencyGraphQueryStoreRequiresConfiguredAuthority(t *testing.T) {
+func TestDependencyGraphRawCypherStoreRequiresConfiguredAuthority(t *testing.T) {
 	legacy := &graphTestStore{}
 	authority := &graphTestStore{}
-	deps := bootstrap.Dependencies{GraphStore: legacy, GraphQueries: authority}
+	deps := bootstrap.Dependencies{GraphStore: legacy, GraphReads: bootstrap.NewGraphReadCapabilities(authority)}
 
-	if got := dependencyGraphQueryStore(deps); got != authority {
-		t.Fatalf("dependencyGraphQueryStore() = %#v, want configured authority", got)
+	if got := deps.GraphReads.RawCypher; got != authority {
+		t.Fatalf("dependencyGraphRawCypherStore() = %#v, want configured authority", got)
 	}
-	deps.GraphQueries = nil
-	if got := dependencyGraphQueryStore(deps); got != nil {
-		t.Fatalf("dependencyGraphQueryStore() fallback = %#v, want nil without configured authority", got)
+	deps.GraphReads = bootstrap.GraphReadCapabilities{}
+	if got := deps.GraphReads.RawCypher; got != nil {
+		t.Fatalf("dependencyGraphRawCypherStore() fallback = %#v, want nil without configured authority", got)
 	}
 }
 

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -392,7 +392,7 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 		findingEvaluationRunStore(deps.StateStore),
 		findingEvidenceStore(deps.StateStore),
 		claimStore(deps.StateStore),
-	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithGraphQueryStore(dependencyGraphQueryStore(deps)).WithTrustedSourceResolution().WithAppendLog(deps.AppendLog).WithGraphRuleQueryTimeout(graphRuleQueryBudgetForPhase(options.PhaseTimeout)).WithRuntimeIndexReplayPreparer(cfg.AppendLog.JetStreamRuntimeIndexEnabled, deps.AppendLog, deps.StateStore)
+	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithGraphQueryStore(deps.GraphReads.RawCypher).WithTrustedSourceResolution().WithAppendLog(deps.AppendLog).WithGraphRuleQueryTimeout(graphRuleQueryBudgetForPhase(options.PhaseTimeout)).WithRuntimeIndexReplayPreparer(cfg.AppendLog.JetStreamRuntimeIndexEnabled, deps.AppendLog, deps.StateStore)
 	graphService := graphingest.New(
 		registry,
 		lister,

--- a/internal/bootstrap/agent_graph_reasoning_test.go
+++ b/internal/bootstrap/agent_graph_reasoning_test.go
@@ -35,7 +35,7 @@ LIMIT 25`,
 		},
 		Summary: "Review `urn:cerebro:writer:asset:alpha` first.",
 	}
-	app := New(graphReasoningAuthConfig(), Dependencies{GraphStore: graphStore, GraphQueries: graphStore, GraphAgentLLM: llm}, nil)
+	app := New(graphReasoningAuthConfig(), Dependencies{GraphStore: graphStore, GraphReads: NewGraphReadCapabilities(graphStore), GraphAgentLLM: llm}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -108,8 +108,8 @@ func TestHandleAgentPlatformGraphReasonAllowsAllowedTenantPrincipal(t *testing.T
 			}},
 		},
 	}, Dependencies{
-		GraphStore:   graphStore,
-		GraphQueries: graphStore,
+		GraphStore: graphStore,
+		GraphReads: NewGraphReadCapabilities(graphStore),
 		GraphAgentLLM: &graphagent.StubLLMClient{
 			DraftResponse: &graphagent.DraftResponse{
 				Rationale: "Reasoning over scoped graph rows.",

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -77,7 +77,7 @@ type Dependencies struct {
 	AppendLog                   ports.AppendLog
 	StateStore                  ports.StateStore
 	GraphStore                  ports.GraphStore
-	GraphQueries                ports.GraphReadStore
+	GraphReads                  ports.GraphReadCapabilities
 	SecurityLifecycleQueries    securityLifecycleQueryReader
 	SourceCollectionReceipts    ports.SourceCollectionReader
 	OrganizationalProjector     *organizationalgraph.ProjectionClient
@@ -87,6 +87,12 @@ type Dependencies struct {
 	PolicyAuthoring             *agentauthoring.Service
 	PolicyExperiments           PolicyExperimentJobHandler
 	PolicyExperimentCheckpoints policycandidate.ExperimentCheckpointStatusReader
+}
+
+type GraphReadCapabilities = ports.GraphReadCapabilities
+
+func NewGraphReadCapabilities(store ports.GraphStore) GraphReadCapabilities {
+	return ports.NewGraphReadCapabilities(store)
 }
 
 // App is the minimal Connect/bootstrap composition root for the rewrite skeleton.
@@ -682,7 +688,7 @@ func (s *bootstrapService) CheckHealth(ctx context.Context, _ *connect.Request[c
 func (s *bootstrapService) ListReportDefinitions(_ context.Context, _ *connect.Request[cerebrov1.ListReportDefinitionsRequest]) (*connect.Response[cerebrov1.ListReportDefinitionsResponse], error) {
 	return connect.NewResponse(reports.New(
 		findingStore(s.deps.StateStore),
-		dependencyGraphQueryStore(s.deps),
+		s.deps.GraphReads.Neighborhoods,
 		reportStore(s.deps.StateStore),
 	).List()), nil
 }
@@ -697,7 +703,7 @@ func (s *bootstrapService) RunReport(ctx context.Context, req *connect.Request[c
 	}
 	response, err := reports.New(
 		findingStore(s.deps.StateStore),
-		dependencyGraphQueryStore(s.deps),
+		s.deps.GraphReads.Neighborhoods,
 		reportStore(s.deps.StateStore),
 	).Run(ctx, req.Msg)
 	if err != nil {
@@ -712,7 +718,7 @@ func (s *bootstrapService) RunReport(ctx context.Context, req *connect.Request[c
 func (s *bootstrapService) GetReportRun(ctx context.Context, req *connect.Request[cerebrov1.GetReportRunRequest]) (*connect.Response[cerebrov1.GetReportRunResponse], error) {
 	response, err := reports.New(
 		findingStore(s.deps.StateStore),
-		dependencyGraphQueryStore(s.deps),
+		s.deps.GraphReads.Neighborhoods,
 		reportStore(s.deps.StateStore),
 	).Get(ctx, req.Msg)
 	if err != nil {
@@ -1273,8 +1279,11 @@ func (s *bootstrapService) GetEntityNeighborhood(ctx context.Context, req *conne
 	if err := authorizeCerebroURNTenant(ctx, req.Msg.GetRootUrn()); err != nil {
 		return nil, graphQueryConnectError(err)
 	}
-	response, err := graphquery.New(
-		dependencyGraphQueryStore(s.deps),
+	response, err := graphquery.NewWithCapabilities(
+		s.deps.GraphReads.Neighborhoods,
+		s.deps.GraphReads.RawCypher,
+		s.deps.GraphReads.Catalog,
+		s.deps.GraphReads.Exposure,
 	).GetEntityNeighborhood(ctx, graphquery.NeighborhoodRequest{
 		RootURN: req.Msg.GetRootUrn(),
 		Limit:   req.Msg.GetLimit(),
@@ -1367,7 +1376,7 @@ func publicHealthResponse(ctx context.Context, deps Dependencies) *cerebrov1.Che
 	}{
 		{name: "append_log", dependency: deps.AppendLog},
 		{name: "state_store", dependency: deps.StateStore},
-		{name: "graph_store", dependency: organizationalgraph.ReadinessStore(deps.GraphStore, deps.GraphQueries)},
+		{name: "graph_store", dependency: organizationalgraph.ReadinessStore(deps.GraphStore, deps.GraphReads.ReadinessStore())},
 	}
 	components := make([]*cerebrov1.ComponentStatus, len(checks))
 	var wg sync.WaitGroup
@@ -2045,13 +2054,6 @@ func guardedLegacyGraphProjector(deps Dependencies) ports.SourceProjector {
 		return legacy
 	}
 	return organizationalgraph.NewLegacyWriteGuard(legacy, deps.OrganizationalProjector)
-}
-
-func dependencyGraphQueryStore(deps Dependencies) ports.GraphReadStore {
-	if !isNilInterface(deps.GraphQueries) {
-		return deps.GraphQueries
-	}
-	return nil
 }
 
 func askTrajectoryStore(store ports.StateStore) ports.AskTrajectoryStore {

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -596,11 +596,11 @@ func TestWriteGraphErrorsDoNotExposeInternalMessages(t *testing.T) {
 
 func TestStoreBoundaryHelpersTreatTypedNilAsUnavailable(t *testing.T) {
 	var graph *stubGraphStore
-	if got := dependencyGraphQueryStore(Dependencies{GraphQueries: graph}); got != nil {
-		t.Fatalf("dependencyGraphQueryStore(typed nil) = %#v, want nil", got)
+	if got := (Dependencies{GraphReads: NewGraphReadCapabilities(graph)}).GraphReads.Neighborhoods; got != nil {
+		t.Fatalf("GraphReads.Neighborhoods typed nil = %#v, want nil", got)
 	}
-	if got := dependencyGraphQueryStore(Dependencies{GraphStore: &stubGraphStore{}}); got != nil {
-		t.Fatalf("dependencyGraphQueryStore(GraphStore only) = %#v, want nil", got)
+	if got := (Dependencies{GraphStore: &stubGraphStore{}}).GraphReads.Neighborhoods; got != nil {
+		t.Fatalf("GraphReads.Neighborhoods GraphStore only = %#v, want nil", got)
 	}
 	if got := sourceProjectionGraphStore(graph); got != nil {
 		t.Fatalf("sourceProjectionGraphStore(typed nil) = %#v, want nil", got)
@@ -2932,7 +2932,7 @@ func TestScopedCosmoCredentialAllowsOnlyReadRoutes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newFixtureRegistry() error = %v", err)
 	}
-	app := New(cfg, Dependencies{GraphStore: graph, GraphQueries: graph, StateStore: store}, registry)
+	app := New(cfg, Dependencies{GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph), StateStore: store}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -3083,7 +3083,7 @@ func TestScopedCosmoCredentialEnforcesConnectProcedures(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newFixtureRegistry() error = %v", err)
 	}
-	app := New(cfg, Dependencies{GraphStore: graph, GraphQueries: graph, StateStore: store}, registry)
+	app := New(cfg, Dependencies{GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph), StateStore: store}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -3203,7 +3203,7 @@ func TestCapabilityTokenRequiresSecurityGroup(t *testing.T) {
 			},
 		},
 	}
-	app := New(cfg, Dependencies{GraphStore: graph, GraphQueries: graph}, nil)
+	app := New(cfg, Dependencies{GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph)}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -4081,7 +4081,7 @@ func TestGraphPackageImpactEndpointReturnsCanonicalPackageRoot(t *testing.T) {
 			},
 		},
 	}
-	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphQueries: graph}, nil)
+	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph)}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -4134,7 +4134,7 @@ func TestGraphAWSPublicEndpointInsightsEndpoint(t *testing.T) {
 			Corroborating: ports.ExposureCoverageEntity{URN: "urn:cerebro:writer:external_asset:app.example.com", EntityType: "external.asset", Label: "app.example.com"},
 		}},
 	}}
-	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphQueries: graph}, nil)
+	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph)}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -4190,7 +4190,7 @@ func TestGraphPersonAccessPathsEndpoint(t *testing.T) {
 			"relation_chain":        []any{"assigned_to"},
 		}}},
 	}}
-	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphQueries: graph}, nil)
+	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph)}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -4306,7 +4306,7 @@ func TestGraphEffectiveAccessPathsEndpoint(t *testing.T) {
 			},
 		}}},
 	}}
-	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphQueries: graph}, nil)
+	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph)}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -4375,7 +4375,7 @@ func TestGraphCrownJewelRankingsEndpoint(t *testing.T) {
 			"to_label":         "prod-secrets",
 		}}},
 	}}
-	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphQueries: graph}, nil)
+	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph)}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -4666,8 +4666,8 @@ func TestBootstrapHealthDegradesOnDependencyError(t *testing.T) {
 func TestBootstrapHealthDegradesWhenRustGraphReadAuthorityIsUnavailable(t *testing.T) {
 	const rawDependencyError = "rust graph unavailable at http://internal-graph:8081"
 	response := publicHealthResponse(context.Background(), Dependencies{
-		GraphStore:   &stubGraphStore{},
-		GraphQueries: &stubGraphStore{err: errors.New(rawDependencyError)},
+		GraphStore: &stubGraphStore{},
+		GraphReads: NewGraphReadCapabilities(&stubGraphStore{err: errors.New(rawDependencyError)}),
 	})
 	if response.GetStatus() != "degraded" {
 		t.Fatalf("health status = %q, want degraded", response.GetStatus())
@@ -5410,9 +5410,9 @@ func TestGraphIngestEndpoints(t *testing.T) {
 	}}
 	graphStore := &stubGraphStore{}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		StateStore:   runtimeStore,
-		GraphStore:   graphStore,
-		GraphQueries: graphStore,
+		StateStore: runtimeStore,
+		GraphStore: graphStore,
+		GraphReads: NewGraphReadCapabilities(graphStore),
 	}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
@@ -5623,9 +5623,9 @@ func TestGraphIngestArchetypeRuntimeProjectsFindingsEndToEnd(t *testing.T) {
 	}}
 	graphStore := &stubGraphStore{}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		StateStore:   runtimeStore,
-		GraphStore:   graphStore,
-		GraphQueries: graphStore,
+		StateStore: runtimeStore,
+		GraphStore: graphStore,
+		GraphReads: NewGraphReadCapabilities(graphStore),
 	}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
@@ -5986,10 +5986,10 @@ func TestFindingEndpoints(t *testing.T) {
 	}
 	graphStore := &stubGraphStore{}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		AppendLog:    appendLog,
-		StateStore:   runtimeStore,
-		GraphStore:   graphStore,
-		GraphQueries: graphStore,
+		AppendLog:  appendLog,
+		StateStore: runtimeStore,
+		GraphStore: graphStore,
+		GraphReads: NewGraphReadCapabilities(graphStore),
 	}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
@@ -7463,7 +7463,7 @@ func TestPlatformKnowledgeDecisionAndOutcomeEndpoints(t *testing.T) {
 func TestPlatformKnowledgeDecisionRequiresDurableAppendLog(t *testing.T) {
 	targetURN := "urn:cerebro:writer:resource:service-1"
 	graphStore := &stubGraphStore{entities: map[string]*ports.ProjectedEntity{targetURN: {URN: targetURN}}}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphQueries: graphStore}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphReads: NewGraphReadCapabilities(graphStore)}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -7485,7 +7485,7 @@ func TestPlatformKnowledgeDecisionReturnsDurableProjectionFailure(t *testing.T) 
 	targetURN := "urn:cerebro:writer:resource:service-1"
 	graphStore := &stubGraphStore{entities: map[string]*ports.ProjectedEntity{targetURN: {URN: targetURN}}, err: errors.New("graph unavailable")}
 	appendLog := &recordingAppendLog{}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphQueries: graphStore, AppendLog: appendLog}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphReads: NewGraphReadCapabilities(graphStore), AppendLog: appendLog}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -7917,10 +7917,10 @@ func TestGraphNeighborhoodEndpoints(t *testing.T) {
 		},
 	}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		AppendLog:    &recordingAppendLog{},
-		StateStore:   &stubRuntimeStore{},
-		GraphStore:   graphStore,
-		GraphQueries: graphStore,
+		AppendLog:  &recordingAppendLog{},
+		StateStore: &stubRuntimeStore{},
+		GraphStore: graphStore,
+		GraphReads: NewGraphReadCapabilities(graphStore),
 	}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
@@ -8062,10 +8062,10 @@ func TestReportEndpoints(t *testing.T) {
 		},
 	}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		AppendLog:    &recordingAppendLog{},
-		StateStore:   runtimeStore,
-		GraphStore:   graphStore,
-		GraphQueries: graphStore,
+		AppendLog:  &recordingAppendLog{},
+		StateStore: runtimeStore,
+		GraphStore: graphStore,
+		GraphReads: NewGraphReadCapabilities(graphStore),
 	}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()

--- a/internal/bootstrap/compliance_impact_runtime.go
+++ b/internal/bootstrap/compliance_impact_runtime.go
@@ -24,7 +24,7 @@ func (a *App) newComplianceImpactServices(jobs *platformjobs.Service, assessment
 	}
 
 	projectionStore, projectionOK := a.deps.GraphStore.(ports.ProjectionGraphStore)
-	queryStore := dependencyGraphQueryStore(a.deps)
+	queryStore := a.deps.GraphReads.RawCypher
 	if !projectionOK || isNilInterface(projectionStore) || isNilInterface(queryStore) {
 		return monitorService, nil, nil
 	}

--- a/internal/bootstrap/compliance_impact_runtime_test.go
+++ b/internal/bootstrap/compliance_impact_runtime_test.go
@@ -15,7 +15,7 @@ func TestComplianceImpactServiceComposition(t *testing.T) {
 	t.Parallel()
 	graph := &impactGraphStub{}
 	app := &App{deps: Dependencies{
-		StateStore: &monitorStateStub{}, GraphStore: graph, GraphQueries: graph, AppendLog: bootstrapAppendOnlyLog{},
+		StateStore: &monitorStateStub{}, GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph), AppendLog: bootstrapAppendOnlyLog{},
 	}}
 	monitors, projector, scheduler := app.newComplianceImpactServices(nil, nil)
 	if monitors == nil || projector == nil || scheduler == nil {
@@ -23,7 +23,7 @@ func TestComplianceImpactServiceComposition(t *testing.T) {
 	}
 
 	app.deps.GraphStore = nil
-	app.deps.GraphQueries = nil
+	app.deps.GraphReads = GraphReadCapabilities{}
 	monitors, projector, scheduler = app.newComplianceImpactServices(nil, nil)
 	if monitors == nil || projector != nil || scheduler != nil {
 		t.Fatalf("without graph monitors=%v projector=%v scheduler=%v", monitors != nil, projector != nil, scheduler != nil)
@@ -32,7 +32,7 @@ func TestComplianceImpactServiceComposition(t *testing.T) {
 	app.deps.StateStore = nonEvidenceStateStub{}
 	graph = &impactGraphStub{}
 	app.deps.GraphStore = graph
-	app.deps.GraphQueries = graph
+	app.deps.GraphReads = NewGraphReadCapabilities(graph)
 	monitors, projector, scheduler = app.newComplianceImpactServices(nil, nil)
 	if monitors != nil || projector == nil || scheduler != nil {
 		t.Fatalf("without monitor store monitors=%v projector=%v scheduler=%v", monitors != nil, projector != nil, scheduler != nil)
@@ -42,10 +42,10 @@ func TestComplianceImpactServiceComposition(t *testing.T) {
 func TestComplianceImpactUsesConfiguredReadAuthority(t *testing.T) {
 	t.Parallel()
 	app := &App{deps: Dependencies{
-		StateStore:   &monitorStateStub{},
-		GraphStore:   &projectionOnlyImpactGraphStub{},
-		GraphQueries: &queryOnlyImpactGraphStub{},
-		AppendLog:    bootstrapAppendOnlyLog{},
+		StateStore: &monitorStateStub{},
+		GraphStore: &projectionOnlyImpactGraphStub{},
+		GraphReads: GraphReadCapabilities{RawCypher: &queryOnlyImpactGraphStub{}},
+		AppendLog:  bootstrapAppendOnlyLog{},
 	}}
 
 	monitors, projector, scheduler := app.newComplianceImpactServices(nil, nil)
@@ -100,7 +100,7 @@ func (*monitorStateStub) Ping(context.Context) error { return nil }
 
 type impactGraphStub struct {
 	ports.ProjectionGraphStore
-	ports.GraphReadStore
+	ports.RawCypherQueryStore
 }
 
 func (*impactGraphStub) Ping(context.Context) error { return nil }
@@ -112,7 +112,7 @@ type projectionOnlyImpactGraphStub struct {
 func (*projectionOnlyImpactGraphStub) Ping(context.Context) error { return nil }
 
 type queryOnlyImpactGraphStub struct {
-	ports.GraphReadStore
+	ports.RawCypherQueryStore
 }
 
 func (*queryOnlyImpactGraphStub) Ping(context.Context) error { return nil }

--- a/internal/bootstrap/decision_packets.go
+++ b/internal/bootstrap/decision_packets.go
@@ -67,7 +67,7 @@ func (a *App) newDecisionPacketService() *decisionpacket.Service {
 	resolver := decisionpacket.PortsResolver{
 		Findings: findingStore(a.deps.StateStore), FindingEvidence: findingEvidenceStore(a.deps.StateStore),
 		Claims: claimStore(a.deps.StateStore), Evidence: evidenceLedgerStore(a.deps.StateStore),
-		AuditPackets: grcAuditPacketStore(a.deps.StateStore), Graph: dependencyGraphQueryStore(a.deps),
+		AuditPackets: grcAuditPacketStore(a.deps.StateStore), Graph: a.deps.GraphReads.Neighborhoods,
 		Coverage: decisionCoverageReader{store: coverageStore, sources: a.sources}, Actions: graphactions.DefaultRegistry(),
 	}
 	return decisionpacket.NewPersistentService(resolver, decisionpacket.SystemClock{}, receipts, a.cfg.StateStore.DecisionPacketRetention)

--- a/internal/bootstrap/dependencies.go
+++ b/internal/bootstrap/dependencies.go
@@ -120,7 +120,7 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 		if err != nil {
 			return fail(fmt.Errorf("open Rust organizational graph reads: %w", err))
 		}
-		deps.GraphQueries = queryStore
+		deps.GraphReads = NewGraphReadCapabilities(queryStore)
 		deps.SecurityLifecycleQueries = queryStore
 	}
 	if err := pingDependency(ctx, "append log", deps.AppendLog); err != nil {
@@ -129,7 +129,7 @@ func OpenDependencies(ctx context.Context, cfg config.Config) (Dependencies, fun
 	if err := pingDependency(ctx, "state store", deps.StateStore); err != nil {
 		return fail(err)
 	}
-	if err := pingDependency(ctx, "graph store", organizationalgraph.ReadinessStore(deps.GraphStore, deps.GraphQueries)); err != nil {
+	if err := pingDependency(ctx, "graph store", organizationalgraph.ReadinessStore(deps.GraphStore, deps.GraphReads.ReadinessStore())); err != nil {
 		return fail(err)
 	}
 	switch cfg.Cache.Driver {

--- a/internal/bootstrap/dependencies_test.go
+++ b/internal/bootstrap/dependencies_test.go
@@ -75,10 +75,10 @@ func TestOpenDependenciesAllowsRustGraphWithoutGoGraphStore(t *testing.T) {
 	if deps.GraphStore != nil {
 		t.Fatal("GraphStore != nil, want no Go graph store")
 	}
-	if deps.GraphQueries == nil {
-		t.Fatal("GraphQueries = nil, want Rust graph client")
+	if deps.GraphReads.RawCypher == nil {
+		t.Fatal("GraphReads.RawCypher = nil, want Rust graph client")
 	}
-	if _, err := deps.GraphQueries.ExecuteReadCypher(context.Background(), ports.CypherQueryRequest{Query: "RETURN 1"}); !errors.Is(err, ports.ErrGraphTypedOperationRequired) {
+	if _, err := deps.GraphReads.RawCypher.ExecuteReadCypher(context.Background(), ports.CypherQueryRequest{Query: "RETURN 1"}); !errors.Is(err, ports.ErrGraphTypedOperationRequired) {
 		t.Fatalf("ExecuteReadCypher() error = %v", err)
 	}
 }

--- a/internal/bootstrap/feature_dependencies.go
+++ b/internal/bootstrap/feature_dependencies.go
@@ -35,21 +35,21 @@ func newSourceFeatureService(deps sourceFeatureDeps) *sourceops.Service {
 }
 
 type reportFeatureDeps struct {
-	Findings     ports.FindingStore
-	GraphQueries ports.GraphNeighborhoodStore
-	Reports      ports.ReportStore
+	Findings           ports.FindingStore
+	GraphNeighborhoods ports.GraphNeighborhoodStore
+	Reports            ports.ReportStore
 }
 
 func newReportFeatureDeps(deps Dependencies) reportFeatureDeps {
 	return reportFeatureDeps{
-		Findings:     findingStore(deps.StateStore),
-		GraphQueries: dependencyGraphQueryStore(deps),
-		Reports:      reportStore(deps.StateStore),
+		Findings:           findingStore(deps.StateStore),
+		GraphNeighborhoods: deps.GraphReads.Neighborhoods,
+		Reports:            reportStore(deps.StateStore),
 	}
 }
 
 func newReportFeatureService(deps reportFeatureDeps) *reports.Service {
-	return reports.New(deps.Findings, deps.GraphQueries, deps.Reports)
+	return reports.New(deps.Findings, deps.GraphNeighborhoods, deps.Reports)
 }
 
 type runtimeFeatureDeps struct {
@@ -112,7 +112,7 @@ type findingFeatureDeps struct {
 	Claims          ports.ClaimStore
 	Candidates      ports.FindingCandidateStore
 	ProjectionGraph ports.ProjectionGraphStore
-	GraphQueries    ports.RawCypherQueryStore
+	GraphRawCypher  ports.RawCypherQueryStore
 	AppendLog       ports.AppendLog
 	Rules           *findings.Registry
 }
@@ -127,7 +127,7 @@ func newFindingFeatureDeps(deps Dependencies) findingFeatureDeps {
 		Claims:          claimStore(deps.StateStore),
 		Candidates:      findingCandidateStore(deps.StateStore),
 		ProjectionGraph: sourceProjectionGraphStore(deps.GraphStore),
-		GraphQueries:    dependencyGraphQueryStore(deps),
+		GraphRawCypher:  deps.GraphReads.RawCypher,
 		AppendLog:       deps.AppendLog,
 		Rules:           deps.FindingRules,
 	}
@@ -144,7 +144,7 @@ func newFindingCandidateFeatureService(deps findingFeatureDeps) *findings.Servic
 func newFindingWorkflowFeatureService(deps findingFeatureDeps) *findings.Service {
 	return newFindingCandidateFeatureService(deps).
 		WithGraphStore(deps.ProjectionGraph).
-		WithGraphQueryStore(deps.GraphQueries).WithTrustedSourceResolution().
+		WithGraphQueryStore(deps.GraphRawCypher).WithTrustedSourceResolution().
 		WithAppendLog(deps.AppendLog)
 }
 
@@ -176,15 +176,23 @@ func newDecisionOutcomeService(deps Dependencies) *decisionops.Service {
 }
 
 type graphQueryFeatureDeps struct {
-	GraphQueries ports.GraphReadStore
+	GraphNeighborhoods ports.GraphNeighborhoodStore
+	GraphRawCypher     ports.RawCypherQueryStore
+	GraphCatalog       ports.EntityCatalogStore
+	GraphExposure      ports.ExposureCoverageStore
 }
 
 func newGraphQueryFeatureDeps(deps Dependencies) graphQueryFeatureDeps {
-	return graphQueryFeatureDeps{GraphQueries: dependencyGraphQueryStore(deps)}
+	return graphQueryFeatureDeps{
+		GraphNeighborhoods: deps.GraphReads.Neighborhoods,
+		GraphRawCypher:     deps.GraphReads.RawCypher,
+		GraphCatalog:       deps.GraphReads.Catalog,
+		GraphExposure:      deps.GraphReads.Exposure,
+	}
 }
 
 func newGraphQueryFeatureService(deps graphQueryFeatureDeps) *graphquery.Service {
-	return graphquery.New(deps.GraphQueries)
+	return graphquery.NewWithCapabilities(deps.GraphNeighborhoods, deps.GraphRawCypher, deps.GraphCatalog, deps.GraphExposure)
 }
 
 type graphIngestFeatureDeps struct {
@@ -257,27 +265,29 @@ func newRuntimeResponseFeatureService(deps runtimeResponseFeatureDeps) *runtimer
 }
 
 type graphReasoningFeatureDeps struct {
-	GraphQueries    ports.GraphReadStore
-	GraphAgentLLM   graphagent.LLMClient
-	TrajectoryStore ports.AskTrajectoryStore
+	GraphNeighborhoods ports.GraphNeighborhoodStore
+	GraphRawCypher     ports.RawCypherQueryStore
+	GraphAgentLLM      graphagent.LLMClient
+	TrajectoryStore    ports.AskTrajectoryStore
 }
 
 func newGraphReasoningFeatureDeps(deps Dependencies) graphReasoningFeatureDeps {
 	return graphReasoningFeatureDeps{
-		GraphQueries:    dependencyGraphQueryStore(deps),
-		GraphAgentLLM:   deps.GraphAgentLLM,
-		TrajectoryStore: askTrajectoryStore(deps.StateStore),
+		GraphNeighborhoods: deps.GraphReads.Neighborhoods,
+		GraphRawCypher:     deps.GraphReads.RawCypher,
+		GraphAgentLLM:      deps.GraphAgentLLM,
+		TrajectoryStore:    askTrajectoryStore(deps.StateStore),
 	}
 }
 
 func newGraphReasoningFeatureService(deps graphReasoningFeatureDeps) (*graphagent.Service, error) {
-	if deps.GraphQueries == nil {
+	if deps.GraphRawCypher == nil || deps.GraphNeighborhoods == nil {
 		return nil, graphquery.ErrRuntimeUnavailable
 	}
 	if deps.GraphAgentLLM == nil {
 		return nil, errors.Join(graphagent.ErrRuntimeUnavailable, errors.New("graph agent llm is not configured"))
 	}
-	return graphagent.NewServiceWithOptions(deps.GraphQueries, deps.GraphAgentLLM, graphagent.ValidatorOptions{Explain: true}, graphagent.ServiceOptions{
+	return graphagent.NewServiceWithCapabilities(deps.GraphRawCypher, deps.GraphNeighborhoods, deps.GraphAgentLLM, graphagent.ValidatorOptions{Explain: true}, graphagent.ServiceOptions{
 		TrajectoryStore:             deps.TrajectoryStore,
 		EnableGraphProbes:           true,
 		EnableDeterministicFastPath: true,

--- a/internal/bootstrap/feature_dependencies_test.go
+++ b/internal/bootstrap/feature_dependencies_test.go
@@ -9,7 +9,7 @@ import (
 func TestFeatureDependencyBundlesAreNilSafe(t *testing.T) {
 	deps := Dependencies{}
 
-	if got := newReportFeatureDeps(deps); got.Findings != nil || got.GraphQueries != nil || got.Reports != nil {
+	if got := newReportFeatureDeps(deps); got.Findings != nil || got.GraphNeighborhoods != nil || got.Reports != nil {
 		t.Fatalf("newReportFeatureDeps() = %#v, want nil stores", got)
 	}
 	if got := newRuntimeFeatureDeps(deps, nil); got.Sources != nil || got.Runtimes != nil || got.AppendLog != nil || got.Projector != nil || got.RuntimeConfigStore != nil {
@@ -18,13 +18,13 @@ func TestFeatureDependencyBundlesAreNilSafe(t *testing.T) {
 	if got := newClaimFeatureDeps(deps); got.Runtimes != nil || got.Claims != nil || got.ProjectionState != nil || got.ProjectionGraph != nil {
 		t.Fatalf("newClaimFeatureDeps() = %#v, want nil stores", got)
 	}
-	if got := newFindingFeatureDeps(deps); got.Runtimes != nil || got.EventReplayer != nil || got.Findings != nil || got.EvaluationRuns != nil || got.Evidence != nil || got.Claims != nil || got.Candidates != nil || got.ProjectionGraph != nil || got.GraphQueries != nil || got.AppendLog != nil {
+	if got := newFindingFeatureDeps(deps); got.Runtimes != nil || got.EventReplayer != nil || got.Findings != nil || got.EvaluationRuns != nil || got.Evidence != nil || got.Claims != nil || got.Candidates != nil || got.ProjectionGraph != nil || got.GraphRawCypher != nil || got.AppendLog != nil {
 		t.Fatalf("newFindingFeatureDeps() = %#v, want nil dependencies", got)
 	}
 	if got := newKnowledgeFeatureDeps(deps); got.ProjectionGraph != nil || got.AppendLog != nil {
 		t.Fatalf("newKnowledgeFeatureDeps() = %#v, want nil dependencies", got)
 	}
-	if got := newGraphQueryFeatureDeps(deps); got.GraphQueries != nil {
+	if got := newGraphQueryFeatureDeps(deps); got.GraphNeighborhoods != nil || got.GraphRawCypher != nil || got.GraphCatalog != nil || got.GraphExposure != nil {
 		t.Fatalf("newGraphQueryFeatureDeps() = %#v, want nil graph query store", got)
 	}
 	if got := newGraphIngestFeatureDeps(deps, nil); got.Sources != nil || got.Runtimes != nil || got.Projector != nil || got.GraphStore != nil || got.RuntimeConfigStore != nil {
@@ -39,7 +39,7 @@ func TestFeatureDependencyBundlesAreNilSafe(t *testing.T) {
 	if got := newRuntimeResponseFeatureDeps(deps); got.Blocklist != nil {
 		t.Fatalf("newRuntimeResponseFeatureDeps() = %#v, want nil runtime response store", got)
 	}
-	if got := newGraphReasoningFeatureDeps(deps); got.GraphQueries != nil || got.GraphAgentLLM != nil || got.TrajectoryStore != nil {
+	if got := newGraphReasoningFeatureDeps(deps); got.GraphNeighborhoods != nil || got.GraphRawCypher != nil || got.GraphAgentLLM != nil || got.TrajectoryStore != nil {
 		t.Fatalf("newGraphReasoningFeatureDeps() = %#v, want nil dependencies", got)
 	}
 }
@@ -49,20 +49,20 @@ func TestProductReadDependencyBundlesPreferConfiguredAuthority(t *testing.T) {
 	authority := &stubGraphStore{}
 	deps := Dependencies{
 		GraphStore:    legacy,
-		GraphQueries:  authority,
+		GraphReads:    NewGraphReadCapabilities(authority),
 		GraphAgentLLM: graphagent.NewStubLLMClient(),
 	}
 
-	if got := newReportFeatureDeps(deps).GraphQueries; got != authority {
-		t.Fatalf("report graph queries = %#v, want configured authority", got)
+	if got := newReportFeatureDeps(deps).GraphNeighborhoods; got != authority {
+		t.Fatalf("report graph neighborhoods = %#v, want configured authority", got)
 	}
-	if got := newFindingFeatureDeps(deps).GraphQueries; got != authority {
-		t.Fatalf("finding graph queries = %#v, want configured authority", got)
+	if got := newFindingFeatureDeps(deps).GraphRawCypher; got != authority {
+		t.Fatalf("finding raw Cypher graph = %#v, want configured authority", got)
 	}
-	if got := newGraphQueryFeatureDeps(deps).GraphQueries; got != authority {
-		t.Fatalf("graph query service = %#v, want configured authority", got)
+	if got := newGraphQueryFeatureDeps(deps); got.GraphNeighborhoods != authority || got.GraphRawCypher != authority || got.GraphCatalog != authority || got.GraphExposure != authority {
+		t.Fatalf("graph query service = %#v, want configured authority for all capabilities", got)
 	}
-	if got := newGraphReasoningFeatureDeps(deps).GraphQueries; got != authority {
+	if got := newGraphReasoningFeatureDeps(deps); got.GraphNeighborhoods != authority || got.GraphRawCypher != authority {
 		t.Fatalf("graph reasoning queries = %#v, want configured authority", got)
 	}
 }
@@ -73,16 +73,16 @@ func TestProductReadDependencyBundlesDoNotFallbackToLegacyGraphStore(t *testing.
 		GraphAgentLLM: graphagent.NewStubLLMClient(),
 	}
 
-	if got := newReportFeatureDeps(deps).GraphQueries; got != nil {
+	if got := newReportFeatureDeps(deps).GraphNeighborhoods; got != nil {
 		t.Fatalf("report graph queries = %#v, want nil without configured authority", got)
 	}
-	if got := newFindingFeatureDeps(deps).GraphQueries; got != nil {
+	if got := newFindingFeatureDeps(deps).GraphRawCypher; got != nil {
 		t.Fatalf("finding graph queries = %#v, want nil without configured authority", got)
 	}
-	if got := newGraphQueryFeatureDeps(deps).GraphQueries; got != nil {
+	if got := newGraphQueryFeatureDeps(deps); got.GraphNeighborhoods != nil || got.GraphRawCypher != nil || got.GraphCatalog != nil || got.GraphExposure != nil {
 		t.Fatalf("graph query service = %#v, want nil without configured authority", got)
 	}
-	if got := newGraphReasoningFeatureDeps(deps).GraphQueries; got != nil {
+	if got := newGraphReasoningFeatureDeps(deps); got.GraphNeighborhoods != nil || got.GraphRawCypher != nil {
 		t.Fatalf("graph reasoning queries = %#v, want nil without configured authority", got)
 	}
 }

--- a/internal/bootstrap/graph_provenance.go
+++ b/internal/bootstrap/graph_provenance.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/writer/cerebro/internal/graphprovenance"
-	"github.com/writer/cerebro/internal/ports"
 )
 
 func (a *App) handleGetGraphProvenance(w http.ResponseWriter, r *http.Request) {
@@ -14,12 +13,7 @@ func (a *App) handleGetGraphProvenance(w http.ResponseWriter, r *http.Request) {
 		writeGraphQueryError(w, err)
 		return
 	}
-	graphStore := dependencyGraphQueryStore(a.deps)
-	var catalogStore ports.EntityCatalogStore
-	if graphStore != nil {
-		catalogStore, _ = graphStore.(ports.EntityCatalogStore)
-	}
-	response, err := graphprovenance.New(catalogStore).Get(r.Context(), graphprovenance.Request{URN: urn})
+	response, err := graphprovenance.New(a.deps.GraphReads.Catalog).Get(r.Context(), graphprovenance.Request{URN: urn})
 	if err != nil {
 		writeGraphQueryError(w, err)
 		return

--- a/internal/bootstrap/graph_provenance_test.go
+++ b/internal/bootstrap/graph_provenance_test.go
@@ -22,7 +22,7 @@ func TestHandleGetGraphProvenance(t *testing.T) {
 			"attributes_json": `{"event_id":"evt-1","observed_at":"2026-06-15T12:00:00Z","projection_class":"durable_state","projection_reason":"projected_current_state"}`,
 		}},
 	}}}
-	app := New(graphReasoningAuthConfig(), Dependencies{GraphStore: graphStore, GraphQueries: graphStore}, nil)
+	app := New(graphReasoningAuthConfig(), Dependencies{GraphStore: graphStore, GraphReads: NewGraphReadCapabilities(graphStore)}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -565,7 +565,7 @@ func (a *App) handleGRCEntityImpact(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	graphStore := dependencyGraphQueryStore(a.deps)
+	graphStore := a.deps.GraphReads.Neighborhoods
 	if graphStore == nil {
 		writeGRCError(w, graphquery.ErrRuntimeUnavailable)
 		return
@@ -668,7 +668,7 @@ func (a *App) buildGRCAuditPreview(r *http.Request, findingID string) (grcAuditP
 	}
 	var graph *ports.EntityNeighborhood
 	if len(finding.ResourceURNs) > 0 {
-		if graphStore := dependencyGraphQueryStore(a.deps); graphStore != nil {
+		if graphStore := a.deps.GraphReads.Neighborhoods; graphStore != nil {
 			var graphErr error
 			graph, graphErr = graphStore.GetEntityNeighborhood(r.Context(), finding.ResourceURNs[0], int(limit))
 			if graphErr != nil {

--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -58,8 +58,9 @@ func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	graphStore := dependencyGraphQueryStore(a.deps)
-	if graphStore == nil {
+	rawCypher := a.deps.GraphReads.RawCypher
+	neighborhoods := a.deps.GraphReads.Neighborhoods
+	if rawCypher == nil || neighborhoods == nil {
 		evt.failureStage = "graph_store_nil"
 		evt.finish(r, started, http.StatusServiceUnavailable, graphquery.ErrRuntimeUnavailable)
 		writeGRCError(w, graphquery.ErrRuntimeUnavailable)
@@ -81,7 +82,7 @@ func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
 
 	clearLongRunningWriteDeadline(w)
 	flusher, _ := w.(http.Flusher)
-	service := graphagent.NewServiceWithOptions(graphStore, llm, graphagent.ValidatorOptions{Explain: true}, graphagent.ServiceOptions{
+	service := graphagent.NewServiceWithCapabilities(rawCypher, neighborhoods, llm, graphagent.ValidatorOptions{Explain: true}, graphagent.ServiceOptions{
 		TrajectoryStore:             askTrajectoryStore(a.deps.StateStore),
 		EnableGraphProbes:           true,
 		EnableDeterministicFastPath: true,

--- a/internal/bootstrap/grc_ask_test.go
+++ b/internal/bootstrap/grc_ask_test.go
@@ -38,7 +38,7 @@ LIMIT 25`,
 		},
 		Summary: "Review `urn:cerebro:example:asset:alpha` first.",
 	}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphQueries: graphStore, GraphAgentLLM: llm}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphReads: NewGraphReadCapabilities(graphStore), GraphAgentLLM: llm}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -91,7 +91,7 @@ LIMIT 25`,
 		},
 		Summary: "Review `urn:cerebro:example:asset:alpha` first.",
 	}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphQueries: graphStore, GraphAgentLLM: llm}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graphStore, GraphReads: NewGraphReadCapabilities(graphStore), GraphAgentLLM: llm}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -110,8 +110,8 @@ LIMIT 25`,
 func TestGRCAskTelemetryIncludesQueryPlanDiagnostics(t *testing.T) {
 	graphStore := &stubGraphStore{}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		GraphStore:   graphStore,
-		GraphQueries: graphStore,
+		GraphStore: graphStore,
+		GraphReads: NewGraphReadCapabilities(graphStore),
 		GraphAgentLLM: &graphagent.StubLLMClient{DraftResponse: &graphagent.DraftResponse{
 			Rationale: "Planning filtered high-risk findings.",
 			Plan:      &graphagent.AskQueryPlan{Intent: graphagent.IntentTopRiskFindings, Filters: map[string]string{"owner": "security"}},
@@ -223,7 +223,7 @@ func TestGRCAskDraftFailureReturnsServiceUnavailable(t *testing.T) {
 	graphStore := &stubGraphStore{}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
 		GraphStore:    graphStore,
-		GraphQueries:  graphStore,
+		GraphReads:    NewGraphReadCapabilities(graphStore),
 		GraphAgentLLM: &graphagent.StubLLMClient{DraftErr: errors.New("bedrock unavailable")},
 	}, nil)
 	server := httptest.NewServer(app.Handler())
@@ -273,8 +273,8 @@ func TestGRCAskDraftFailureReturnsServiceUnavailable(t *testing.T) {
 func TestGRCAskLLMAuthenticationFailureUsesSpecificErrorCode(t *testing.T) {
 	graphStore := &stubGraphStore{}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		GraphStore:   graphStore,
-		GraphQueries: graphStore,
+		GraphStore: graphStore,
+		GraphReads: NewGraphReadCapabilities(graphStore),
 		GraphAgentLLM: &graphagent.StubLLMClient{DraftErr: errors.Join(
 			graphagent.ErrLLMAuthenticationFailed,
 			errors.New("openrouter authentication failed; check CEREBRO_OPENROUTER_API_KEY"),
@@ -318,8 +318,8 @@ func TestGRCAskLLMAuthenticationFailureUsesSpecificErrorCode(t *testing.T) {
 func TestGRCAskLLMAccessDeniedUsesSpecificErrorCode(t *testing.T) {
 	graphStore := &stubGraphStore{}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
-		GraphStore:   graphStore,
-		GraphQueries: graphStore,
+		GraphStore: graphStore,
+		GraphReads: NewGraphReadCapabilities(graphStore),
 		GraphAgentLLM: &graphagent.StubLLMClient{DraftErr: errors.Join(
 			graphagent.ErrLLMAccessDenied,
 			errors.New("bedrock access denied; grant bedrock:InvokeModel"),
@@ -364,7 +364,7 @@ func TestGRCAskExplainFailureReturnsServiceUnavailable(t *testing.T) {
 	graphStore := &stubGraphStore{err: errors.New("neo4j unavailable")}
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{
 		GraphStore:    graphStore,
-		GraphQueries:  graphStore,
+		GraphReads:    NewGraphReadCapabilities(graphStore),
 		GraphAgentLLM: graphagent.NewStubLLMClient(),
 	}, nil)
 	server := httptest.NewServer(app.Handler())

--- a/internal/bootstrap/grc_policy_lifecycle.go
+++ b/internal/bootstrap/grc_policy_lifecycle.go
@@ -17,7 +17,7 @@ func (a *App) handleGRCPolicyLifecycle(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	store := dependencyGraphQueryStore(a.deps)
+	store := a.deps.GraphReads.RawCypher
 	if store == nil {
 		writeGRCError(w, graphquery.ErrRuntimeUnavailable)
 		return
@@ -94,7 +94,7 @@ func (a *App) handleGRCPolicyLifecycleExport(w http.ResponseWriter, r *http.Requ
 		writeGRCError(w, err)
 		return
 	}
-	store := dependencyGraphQueryStore(a.deps)
+	store := a.deps.GraphReads.RawCypher
 	if store == nil {
 		writeGRCError(w, graphquery.ErrRuntimeUnavailable)
 		return

--- a/internal/bootstrap/grc_policy_lifecycle_test.go
+++ b/internal/bootstrap/grc_policy_lifecycle_test.go
@@ -124,7 +124,7 @@ func TestGRCPolicyLifecycleEndpointReturnsOperationalObjects(t *testing.T) {
 			grcPolicyLifecycleTestRelation(reminder, fabriccontract.RelationAssignedTo, nil, group),
 		},
 	}}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graph, GraphQueries: graph}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph)}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -1179,7 +1179,7 @@ func TestGRCEntityImpactAndAuditPacket(t *testing.T) {
 		},
 	}
 	appendLog := &recordingAppendLog{}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store, GraphStore: graphStore, GraphQueries: graphStore, AppendLog: appendLog}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store, GraphStore: graphStore, GraphReads: NewGraphReadCapabilities(graphStore), AppendLog: appendLog}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 
@@ -1495,7 +1495,7 @@ func TestGRCEntityImpactResolvesLegacyGitHubRepoURN(t *testing.T) {
 			},
 		},
 	}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store, GraphStore: graphStore, GraphQueries: graphStore}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: store, GraphStore: graphStore, GraphReads: NewGraphReadCapabilities(graphStore)}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
 

--- a/internal/bootstrap/grc_vendor.go
+++ b/internal/bootstrap/grc_vendor.go
@@ -70,7 +70,7 @@ func (a *App) handleGRCVendors(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	vendors, err := grcvendor.New(dependencyGRCVendorGraphStore(a.deps)).ListVendors(r.Context(), grcvendor.ListVendorsRequest{
+	vendors, err := grcvendor.NewWithCapabilities(a.deps.GraphReads.Catalog, a.deps.GraphReads.Neighborhoods).ListVendors(r.Context(), grcvendor.ListVendorsRequest{
 		TenantID:    scope.TenantID,
 		RuntimeID:   scope.RuntimeID,
 		RuntimeIDs:  scope.RuntimeIDs,
@@ -102,15 +102,6 @@ func (a *App) handleGRCVendors(w http.ResponseWriter, r *http.Request) {
 		Vendors:     vendors,
 		GeneratedAt: time.Now().UTC(),
 	})
-}
-
-func dependencyGRCVendorGraphStore(deps Dependencies) grcvendor.GraphStore {
-	graphStore := dependencyGraphQueryStore(deps)
-	if graphStore == nil {
-		return nil
-	}
-	store, _ := graphStore.(grcvendor.GraphStore)
-	return store
 }
 
 func (a *App) handleGRCVendorDetail(w http.ResponseWriter, r *http.Request) {
@@ -150,7 +141,7 @@ func (a *App) grcVendorDetailResponse(r *http.Request) (grcVendorDetailResponse,
 	if err != nil {
 		return grcVendorDetailResponse{}, err
 	}
-	detail, err := grcvendor.New(dependencyGRCVendorGraphStore(a.deps)).GetVendor(r.Context(), grcvendor.VendorDetailRequest{
+	detail, err := grcvendor.NewWithCapabilities(a.deps.GraphReads.Catalog, a.deps.GraphReads.Neighborhoods).GetVendor(r.Context(), grcvendor.VendorDetailRequest{
 		URN:        urn,
 		VendorID:   vendorID,
 		TenantID:   scope.TenantID,
@@ -222,7 +213,7 @@ func (a *App) handleGRCVendorDiscoveries(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	decisionState := strings.TrimSpace(r.URL.Query().Get("decision_state"))
-	discoveries, err := grcvendor.New(dependencyGRCVendorGraphStore(a.deps)).ListDiscoveries(r.Context(), grcvendor.ListDiscoveriesRequest{
+	discoveries, err := grcvendor.NewWithCapabilities(a.deps.GraphReads.Catalog, a.deps.GraphReads.Neighborhoods).ListDiscoveries(r.Context(), grcvendor.ListDiscoveriesRequest{
 		TenantID:      scope.TenantID,
 		RuntimeID:     scope.RuntimeID,
 		RuntimeIDs:    scope.RuntimeIDs,

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -381,7 +381,7 @@ func (a *App) runtimeOrchestrationService() (*runtimeorchestration.SecurityPathS
 		return nil, fmt.Errorf("%w: runtime orchestration storage is unavailable", platformjobs.ErrRuntimeUnavailable)
 	}
 	return runtimeorchestration.NewSecurityPathService(runtimeorchestration.SecurityPathDependencies{
-		GraphQueries: dependencyGraphQueryStore(a.deps), GraphIngest: a.graphIngestService(), Checkpoints: checkpoints,
+		GraphQueries: a.deps.GraphReads.RawCypher, GraphIngest: a.graphIngestService(), Checkpoints: checkpoints,
 		RuntimeStore: runtimeStore, LeaseStore: sourceRuntimeLeaseStore(a.deps.StateStore), RuntimeSync: a.runtimeService(),
 	}), nil
 }

--- a/internal/bootstrap/mcp.go
+++ b/internal/bootstrap/mcp.go
@@ -1224,13 +1224,9 @@ func (app *App) mcpAssetSearchResults(r *http.Request, args map[string]any) ([]m
 	if err := authorizeTenantID(r.Context(), tenantID); err != nil {
 		return nil, err
 	}
-	store := dependencyGraphQueryStore(app.deps)
+	store := app.deps.GraphReads.Catalog
 	if store == nil {
 		return nil, graphquery.ErrRuntimeUnavailable
-	}
-	typed, ok := store.(ports.EntityCatalogStore)
-	if !ok {
-		return nil, ports.ErrGraphTypedOperationRequired
 	}
 	filter := ports.EntityCatalogFilter{TenantID: tenantID, ExactAgentKey: urn, Query: query}
 	if runtimeID != "" {
@@ -1239,7 +1235,7 @@ func (app *App) mcpAssetSearchResults(r *http.Request, args map[string]any) ([]m
 	if entityType != "" {
 		filter.IncludeKinds = []string{entityType}
 	}
-	page, err := typed.ListEntities(r.Context(), ports.EntityCatalogPageRequest{Filter: filter, Limit: limit})
+	page, err := store.ListEntities(r.Context(), ports.EntityCatalogPageRequest{Filter: filter, Limit: limit})
 	if err != nil {
 		return nil, err
 	}
@@ -1469,7 +1465,7 @@ func (app *App) mcpBuildRiskActionPlan(r *http.Request, args map[string]any) (mc
 		}
 		riskConfig = &config
 	}
-	if graphStore := dependencyGraphQueryStore(app.deps); graphStore != nil {
+	if graphStore := app.deps.GraphReads.Neighborhoods; graphStore != nil {
 		graphEvidenceStatus = mcpGraphEvidenceIncluded
 		targetURNs := riskplan.TargetURNs(findings, riskplan.Options{
 			TenantID:          tenantID,

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -3232,7 +3232,7 @@ func newMCPTestServerWithGraphReasoningAndSources(t *testing.T, store *stubRunti
 				TenantID:  "writer",
 			}},
 		},
-	}, Dependencies{StateStore: store, GraphStore: graph, GraphQueries: graph, GraphAgentLLM: llm}, sources)
+	}, Dependencies{StateStore: store, GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph), GraphAgentLLM: llm}, sources)
 	return httptest.NewServer(app.Handler())
 }
 

--- a/internal/bootstrap/policy_candidates.go
+++ b/internal/bootstrap/policy_candidates.go
@@ -181,7 +181,7 @@ func (a *App) policyCandidateService() policycandidate.Service {
 	store, _ := a.deps.StateStore.(policycandidate.Store)
 	experiments, _ := a.deps.StateStore.(policycandidate.ExperimentStore)
 	datasets, _ := a.deps.StateStore.(policycandidate.PolicyEvaluationDatasetStore)
-	graph := dependencyGraphQueryStore(a.deps)
+	graph := a.deps.GraphReads.RawCypher
 	var author *agentauthoring.Service
 	if a.deps.PolicyAuthoring != nil {
 		copy := *a.deps.PolicyAuthoring

--- a/internal/bootstrap/policy_candidates_test.go
+++ b/internal/bootstrap/policy_candidates_test.go
@@ -18,7 +18,7 @@ func TestPolicyCandidateReadsUseConfiguredAuthority(t *testing.T) {
 	authority := &stubGraphStore{}
 	app := &App{deps: Dependencies{
 		GraphStore:      legacy,
-		GraphQueries:    authority,
+		GraphReads:      NewGraphReadCapabilities(authority),
 		PolicyAuthoring: &agentauthoring.Service{},
 	}}
 

--- a/internal/bootstrap/policy_experiment_jobs_test.go
+++ b/internal/bootstrap/policy_experiment_jobs_test.go
@@ -130,7 +130,7 @@ func TestPolicyExperimentJobRunsCurrentGraphCanaryAndPersistsReceipt(t *testing.
 	statusReader := policyExperimentStatusReader{status: policycandidate.ExperimentCheckpointStatus{
 		RuntimeID: "runtime-canary", TenantID: "tenant-a", CheckpointID: checkpoint.ID, Found: true, Completed: true, CheckpointCurrent: true,
 	}}
-	app := New(config.Config{HTTPAddr: "127.0.0.1:0"}, Dependencies{StateStore: store, GraphStore: graph, GraphQueries: graph, PolicyExperimentCheckpoints: statusReader}, nil)
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0"}, Dependencies{StateStore: store, GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph), PolicyExperimentCheckpoints: statusReader}, nil)
 	result, _, err := app.runPolicyCandidateExperimentJob(context.Background(), &ports.Job{
 		ID: "job-canary", TenantID: "tenant-a", SubjectID: experiment.ID, Payload: map[string]any{"experiment_id": experiment.ID},
 	}, nil)

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -62,11 +62,18 @@ func NewService(store Store, llm LLMClient, options ValidatorOptions) *Service {
 }
 
 func NewServiceWithOptions(store Store, llm LLMClient, validatorOptions ValidatorOptions, serviceOptions ServiceOptions) *Service {
+	if store == nil {
+		return NewServiceWithCapabilities(nil, nil, llm, validatorOptions, serviceOptions)
+	}
+	return NewServiceWithCapabilities(store, store, llm, validatorOptions, serviceOptions)
+}
+
+func NewServiceWithCapabilities(rawCypher ports.RawCypherQueryStore, neighborhoods ports.GraphNeighborhoodStore, llm LLMClient, validatorOptions ValidatorOptions, serviceOptions ServiceOptions) *Service {
 	return &Service{
-		rawCypher:     store,
-		neighborhoods: store,
+		rawCypher:     rawCypher,
+		neighborhoods: neighborhoods,
 		llm:           llm,
-		validator:     NewValidator(store, validatorOptions),
+		validator:     NewValidator(rawCypher, validatorOptions),
 		options:       normalizeServiceOptions(serviceOptions),
 	}
 }

--- a/internal/graphquery/service.go
+++ b/internal/graphquery/service.go
@@ -38,17 +38,42 @@ type NeighborhoodRequest struct {
 
 // New constructs a bounded graph neighborhood service.
 func New(store ports.GraphNeighborhoodStore) *Service {
-	service := &Service{neighborhoods: store}
+	return NewWithCapabilities(
+		store,
+		graphRawCypherCapability(store),
+		graphCatalogCapability(store),
+		graphExposureCapability(store),
+	)
+}
+
+func NewWithCapabilities(neighborhoods ports.GraphNeighborhoodStore, rawCypher ports.RawCypherQueryStore, catalog ports.EntityCatalogStore, exposure ports.ExposureCoverageStore) *Service {
+	return &Service{
+		neighborhoods: neighborhoods,
+		rawCypher:     rawCypher,
+		catalog:       catalog,
+		exposure:      exposure,
+	}
+}
+
+func graphRawCypherCapability(store ports.GraphNeighborhoodStore) ports.RawCypherQueryStore {
 	if rawCypher, ok := store.(ports.RawCypherQueryStore); ok {
-		service.rawCypher = rawCypher
+		return rawCypher
 	}
+	return nil
+}
+
+func graphCatalogCapability(store ports.GraphNeighborhoodStore) ports.EntityCatalogStore {
 	if catalog, ok := store.(ports.EntityCatalogStore); ok {
-		service.catalog = catalog
+		return catalog
 	}
+	return nil
+}
+
+func graphExposureCapability(store ports.GraphNeighborhoodStore) ports.ExposureCoverageStore {
 	if exposure, ok := store.(ports.ExposureCoverageStore); ok {
-		service.exposure = exposure
+		return exposure
 	}
-	return service
+	return nil
 }
 
 // GetEntityNeighborhood loads one bounded root-centered graph neighborhood.

--- a/internal/grcvendor/service.go
+++ b/internal/grcvendor/service.go
@@ -466,6 +466,38 @@ func New(store GraphStore) *Service {
 	return &Service{store: store, now: time.Now}
 }
 
+func NewWithCapabilities(catalog ports.EntityCatalogStore, neighborhoods ports.GraphNeighborhoodStore) *Service {
+	if catalog == nil || neighborhoods == nil {
+		return New(nil)
+	}
+	return New(graphStoreCapabilities{catalog: catalog, neighborhoods: neighborhoods})
+}
+
+type graphStoreCapabilities struct {
+	catalog       ports.EntityCatalogStore
+	neighborhoods ports.GraphNeighborhoodStore
+}
+
+func (s graphStoreCapabilities) Ping(ctx context.Context) error {
+	return s.neighborhoods.Ping(ctx)
+}
+
+func (s graphStoreCapabilities) GetEntityNeighborhood(ctx context.Context, rootURN string, limit int) (*ports.EntityNeighborhood, error) {
+	return s.neighborhoods.GetEntityNeighborhood(ctx, rootURN, limit)
+}
+
+func (s graphStoreCapabilities) ListEntities(ctx context.Context, request ports.EntityCatalogPageRequest) (*ports.EntityCatalogPage, error) {
+	return s.catalog.ListEntities(ctx, request)
+}
+
+func (s graphStoreCapabilities) CountEntityKinds(ctx context.Context, request ports.EntityKindCountRequest) (*ports.EntityKindCountPage, error) {
+	return s.catalog.CountEntityKinds(ctx, request)
+}
+
+func (s graphStoreCapabilities) ListEntityRelations(ctx context.Context, request ports.EntityRelationPageRequest) (*ports.EntityRelationPage, error) {
+	return s.catalog.ListEntityRelations(ctx, request)
+}
+
 func (s *Service) ListVendors(ctx context.Context, request ListVendorsRequest) ([]Vendor, error) {
 	if s == nil || s.store == nil {
 		return nil, ErrRuntimeUnavailable

--- a/internal/ports/graphquery.go
+++ b/internal/ports/graphquery.go
@@ -3,6 +3,7 @@ package ports
 import (
 	"context"
 	"errors"
+	"reflect"
 )
 
 // ErrGraphEntityNotFound indicates that the requested graph root entity does not exist.
@@ -79,16 +80,54 @@ type RawCypherQueryStore interface {
 	ExecuteReadCypher(context.Context, CypherQueryRequest) ([]CypherRow, error)
 }
 
-// GraphReadStore is the top-level graph read handle wired by bootstrap: Rust
-// authority typed reads (neighborhoods, batched neighborhoods, entity catalog,
-// exposure coverage) plus the retained raw-Cypher compatibility surface.
-// Consumers narrow it to the capability interfaces they need.
-type GraphReadStore interface {
-	GraphNeighborhoodStore
-	GraphNeighborhoodBatchStore
-	EntityCatalogStore
-	ExposureCoverageStore
-	RawCypherQueryStore
+type GraphReadCapabilities struct {
+	Neighborhoods GraphNeighborhoodStore
+	RawCypher     RawCypherQueryStore
+	Catalog       EntityCatalogStore
+	Exposure      ExposureCoverageStore
+}
+
+func NewGraphReadCapabilities(store GraphStore) GraphReadCapabilities {
+	if isNilGraphReadCapability(store) {
+		return GraphReadCapabilities{}
+	}
+	var capabilities GraphReadCapabilities
+	if neighborhoods, ok := store.(GraphNeighborhoodStore); ok && !isNilGraphReadCapability(neighborhoods) {
+		capabilities.Neighborhoods = neighborhoods
+	}
+	if rawCypher, ok := store.(RawCypherQueryStore); ok && !isNilGraphReadCapability(rawCypher) {
+		capabilities.RawCypher = rawCypher
+	}
+	if catalog, ok := store.(EntityCatalogStore); ok && !isNilGraphReadCapability(catalog) {
+		capabilities.Catalog = catalog
+	}
+	if exposure, ok := store.(ExposureCoverageStore); ok && !isNilGraphReadCapability(exposure) {
+		capabilities.Exposure = exposure
+	}
+	return capabilities
+}
+
+func (c GraphReadCapabilities) ReadinessStore() GraphStore {
+	if !isNilGraphReadCapability(c.Neighborhoods) {
+		return c.Neighborhoods
+	}
+	if !isNilGraphReadCapability(c.RawCypher) {
+		return c.RawCypher
+	}
+	return nil
+}
+
+func isNilGraphReadCapability(value any) bool {
+	if value == nil {
+		return true
+	}
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
 }
 
 // GraphNeighborhoodBatchStore exposes batched bounded graph neighborhood reads.

--- a/tools/archtests/rust_organizational_platform_test.go
+++ b/tools/archtests/rust_organizational_platform_test.go
@@ -174,7 +174,7 @@ func TestRustOrganizationalPlatformBoundary(t *testing.T) {
 		"cmd/cerebro/finding_rule_graph_evaluate.go",
 	} {
 		source := readText(t, filepath.Join(root, filepath.FromSlash(productionPath)))
-		if !strings.Contains(source, "dependencyGraphQueryStore(") {
+		if !strings.Contains(source, ".GraphReads.RawCypher") {
 			t.Errorf("%s bypasses configured Rust graph authority", productionPath)
 		}
 	}
@@ -271,6 +271,13 @@ func TestRustOrganizationalPlatformBoundary(t *testing.T) {
 	cerebroMain := readText(t, filepath.Join(root, "cmd/cerebro/main.go"))
 	if strings.Contains(cerebroMain, "ports.GraphQueryStore") {
 		t.Error("cerebro main restored transitional composite graph query dependency")
+	}
+	portsGraphQuery := readText(t, filepath.Join(root, "internal/ports/graphquery.go"))
+	if strings.Contains(portsGraphQuery, "type GraphReadStore interface") {
+		t.Error("ports restored aggregate graph read store interface")
+	}
+	if strings.Contains(bootstrapApp, "GraphQueries") || strings.Contains(bootstrapApp, "ports.GraphReadStore") {
+		t.Error("bootstrap app restored aggregate graph read handle")
 	}
 
 	goNeo4jStore := readText(t, filepath.Join(root, "internal/graphstore/neo4j/store.go"))


### PR DESCRIPTION
## Summary
- replace the remaining aggregate graph read handle with explicit graph read capabilities
- wire bootstrap callers to raw-Cypher, neighborhood, catalog, and exposure capabilities directly
- keep raw-Cypher behavior unchanged while adding guards against restoring aggregate graph read interfaces

## Tests
- go test ./internal/bootstrap ./internal/graphquery ./internal/graphagent ./internal/grcvendor ./cmd/cerebro ./tools/archtests -count=1
- make lint-shard LINT_PACKAGES="./internal/bootstrap ./internal/graphquery ./internal/graphagent ./internal/grcvendor ./internal/ports ./cmd/cerebro" LINT_SHARD_TOTAL=1 LINT_SHARD_INDEX=0
- make check-structural check-structural-test check-arch
- git diff --check
