### PR TITLE
Rename findings raw Cypher dependency

### DIFF
--- a/cmd/cerebro/finding_rule_graph_evaluate.go
+++ b/cmd/cerebro/finding_rule_graph_evaluate.go
@@ -73,7 +73,7 @@ func runFindingRuleGraphEvaluate(args []string) error {
 		findingEvaluationRunStore(deps.StateStore),
 		findingEvidenceStore(deps.StateStore),
 		claimStore(deps.StateStore),
-	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithGraphQueryStore(dependencyGraphQueryStore(deps)).WithTrustedSourceResolution().WithAppendLog(deps.AppendLog)
+	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithRawCypherQueryStore(dependencyGraphQueryStore(deps)).WithTrustedSourceResolution().WithAppendLog(deps.AppendLog)
 	evaluation, err := service.EvaluateSourceRuntimeGraphRules(ctx, findings.EvaluateGraphRulesRequest{
 		RuntimeID: options.RuntimeID,
 		RuleIDs:   []string{options.RuleID},

--- a/cmd/cerebro/github_findings_live_e2e_test.go
+++ b/cmd/cerebro/github_findings_live_e2e_test.go
@@ -87,7 +87,7 @@ func TestGitHubDependabotFindingsEndToEndWithGHCLI(t *testing.T) {
 		state,
 		state,
 		state,
-	).WithGraphStore(graphStore).WithGraphQueryStore(graphStore)
+	).WithGraphStore(graphStore).WithRawCypherQueryStore(graphStore)
 	result, err := findingService.EvaluateSourceRuntime(ctx, findings.EvaluateRequest{
 		RuntimeID: runtimeID,
 		RuleID:    githubDependabotOpenAlertRuleID,
@@ -237,7 +237,7 @@ func TestGitHubAuditFindingsGraphPreviewWithGHCLI(t *testing.T) {
 		state,
 		state,
 		state,
-	).WithGraphStore(graphStore).WithGraphQueryStore(graphStore)
+	).WithGraphStore(graphStore).WithRawCypherQueryStore(graphStore)
 	result, err := findingService.EvaluateSourceRuntimeRules(ctx, findings.EvaluateRulesRequest{
 		RuntimeID:  runtimeID,
 		RuleIDs:    githubAuditSOTARuleIDs(),

--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -392,7 +392,7 @@ func runOrchestratorLoop(ctx context.Context, options orchestratorOptions) (resu
 		findingEvaluationRunStore(deps.StateStore),
 		findingEvidenceStore(deps.StateStore),
 		claimStore(deps.StateStore),
-	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithGraphQueryStore(dependencyGraphQueryStore(deps)).WithTrustedSourceResolution().WithAppendLog(deps.AppendLog).WithGraphRuleQueryTimeout(graphRuleQueryBudgetForPhase(options.PhaseTimeout)).WithRuntimeIndexReplayPreparer(cfg.AppendLog.JetStreamRuntimeIndexEnabled, deps.AppendLog, deps.StateStore)
+	).WithGraphStore(sourceProjectionGraphStore(deps.GraphStore)).WithRawCypherQueryStore(dependencyGraphQueryStore(deps)).WithTrustedSourceResolution().WithAppendLog(deps.AppendLog).WithGraphRuleQueryTimeout(graphRuleQueryBudgetForPhase(options.PhaseTimeout)).WithRuntimeIndexReplayPreparer(cfg.AppendLog.JetStreamRuntimeIndexEnabled, deps.AppendLog, deps.StateStore)
 	graphService := graphingest.New(
 		registry,
 		lister,

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -616,7 +616,7 @@ func TestRunOrchestratorIterationRunsGraphRulesAfterIngest(t *testing.T) {
 	graphStore.cypherRows = []ports.CypherRow{
 		{Values: map[string]any{"label": "alice@writer.com"}},
 	}
-	findingService := findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry).WithGraphQueryStore(graphStore)
+	findingService := findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry).WithRawCypherQueryStore(graphStore)
 	graphService := graphingest.New(registry, store, sourceprojection.New(nil, graphStore), graphStore)
 	result, err := runOrchestratorIteration(
 		context.Background(),
@@ -792,7 +792,7 @@ func TestRunOrchestratorIterationSkipsGraphRulesUntilGraphIngestCatchesSyncCurso
 	eventLog := &orchestratorEventLog{}
 	findingStore := &orchestratorFindingStore{}
 	graphStore := newGraphTestStore()
-	findingService := findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry).WithGraphQueryStore(graphStore)
+	findingService := findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry).WithRawCypherQueryStore(graphStore)
 	graphService := graphingest.New(registry, store, sourceprojection.New(nil, graphStore), graphStore)
 
 	result, err := runOrchestratorIteration(
@@ -966,7 +966,7 @@ func TestRunOrchestratorIterationRunsGraphRulesWhenOnlyRunRecordWriteFails(t *te
 	eventLog := &orchestratorEventLog{}
 	findingStore := &orchestratorFindingStore{}
 	graphStore := &failingCompletedIngestGraphStore{graphTestStore: newGraphTestStore()}
-	findingService := findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry).WithGraphQueryStore(graphStore)
+	findingService := findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry).WithRawCypherQueryStore(graphStore)
 	graphService := graphingest.New(registry, store, sourceprojection.New(nil, graphStore), graphStore)
 	result, err := runOrchestratorIteration(
 		context.Background(),
@@ -1038,7 +1038,7 @@ func TestRunOrchestratorIterationRecordsGraphIngestWhenSourceAndGraphAreCurrent(
 	}); err != nil {
 		t.Fatalf("PutIngestCheckpoint() error = %v", err)
 	}
-	findingService := findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry).WithGraphQueryStore(graphStore)
+	findingService := findings.NewWithRegistry(store, eventLog, findingStore, findingStore, findingStore, findingStore, ruleRegistry).WithRawCypherQueryStore(graphStore)
 
 	result, err := runOrchestratorIteration(
 		context.Background(),

--- a/internal/bootstrap/feature_dependencies.go
+++ b/internal/bootstrap/feature_dependencies.go
@@ -144,7 +144,7 @@ func newFindingCandidateFeatureService(deps findingFeatureDeps) *findings.Servic
 func newFindingWorkflowFeatureService(deps findingFeatureDeps) *findings.Service {
 	return newFindingCandidateFeatureService(deps).
 		WithGraphStore(deps.ProjectionGraph).
-		WithGraphQueryStore(deps.GraphQueries).WithTrustedSourceResolution().
+		WithRawCypherQueryStore(deps.GraphQueries).WithTrustedSourceResolution().
 		WithAppendLog(deps.AppendLog)
 }
 

--- a/internal/findings/graph.go
+++ b/internal/findings/graph.go
@@ -265,7 +265,7 @@ func (s *Service) recordFindingStatusWorkflow(ctx context.Context, finding *port
 	if pruneGraph {
 		return nil
 	}
-	if s.graph == nil || s.graphQuery == nil {
+	if s.graph == nil || s.rawCypher == nil {
 		return nil
 	}
 	workflowMetadata := map[string]any{

--- a/internal/findings/graph_rule_performance_test.go
+++ b/internal/findings/graph_rule_performance_test.go
@@ -83,7 +83,7 @@ func TestEvaluateSourceRuntimeGraphRulesReadsConcurrentlyAndReturnsInRuleOrder(t
 	if err != nil {
 		t.Fatal(err)
 	}
-	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithRawCypherQueryStore(graphStore)
 
 	type evaluationResult struct {
 		result *EvaluateGraphRulesResult
@@ -142,7 +142,7 @@ func TestEvaluateSourceRuntimeGraphRulesEnforcesPerRuleQueryTimeout(t *testing.T
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
 	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).
-		WithGraphQueryStore(graphStore).
+		WithRawCypherQueryStore(graphStore).
 		WithGraphRuleQueryTimeout(25 * time.Millisecond)
 
 	started := time.Now()

--- a/internal/findings/graph_rule_service.go
+++ b/internal/findings/graph_rule_service.go
@@ -80,7 +80,7 @@ func (s *Service) EvaluateSourceRuntimeGraphRules(ctx context.Context, request E
 	if s == nil || s.runtimeStore == nil || s.store == nil || s.runStore == nil || s.evidenceStore == nil || s.rules == nil {
 		return nil, ErrRuntimeUnavailable
 	}
-	if s.graphQuery == nil {
+	if s.rawCypher == nil {
 		return nil, ErrGraphRuntimeUnavailable
 	}
 	runtimeID := strings.TrimSpace(request.RuntimeID)
@@ -242,7 +242,7 @@ func (s *Service) evaluateGraphRule(ctx context.Context, runtime *cerebrov1.Sour
 		queryCtx, cancelQuery = context.WithTimeout(ctx, budget)
 		defer cancelQuery()
 	}
-	rows, err := s.graphQuery.ExecuteReadCypher(queryCtx, queryRequest)
+	rows, err := s.rawCypher.ExecuteReadCypher(queryCtx, queryRequest)
 	if err != nil {
 		evaluationErr := fmt.Errorf("execute graph rule %q cypher: %w", spec.GetId(), err)
 		return result, s.finishFailedGraphRun(ctx, run, 0, nil, evaluationErr)

--- a/internal/findings/graph_rule_test.go
+++ b/internal/findings/graph_rule_test.go
@@ -82,7 +82,7 @@ func TestEvaluateSourceRuntimeGraphRulesExcludesNamedRules(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
-	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithRawCypherQueryStore(graphStore)
 
 	// Excluding rule-a leaves only rule-b (coverage for the other rule is kept).
 	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta", ExcludeRuleIDs: []string{"rule-a"}})
@@ -186,7 +186,7 @@ func TestEvaluateSourceRuntimeGraphRulesEmitsAndPersistsFindings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
-	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithRawCypherQueryStore(graphStore)
 	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta"})
 	if err != nil {
 		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
@@ -273,7 +273,7 @@ func TestEvaluateSourceRuntimeGraphRulesTruncatedSkipsStaleResolution(t *testing
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
-	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithRawCypherQueryStore(graphStore)
 	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta"})
 	if err != nil {
 		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
@@ -341,7 +341,7 @@ func TestEvaluateSourceRuntimeGraphRulesCapSignalSkipsStaleResolution(t *testing
 			if err != nil {
 				t.Fatalf("NewRegistry() error = %v", err)
 			}
-			service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+			service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithRawCypherQueryStore(graphStore)
 			result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta"})
 			if err != nil {
 				t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
@@ -421,7 +421,7 @@ func TestEvaluateSourceRuntimeGraphRulesCapAwareStaleResolutionResolvesCompleteS
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
-	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithRawCypherQueryStore(graphStore)
 	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-aws"})
 	if err != nil {
 		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
@@ -494,7 +494,7 @@ func TestEvaluateSourceRuntimeGraphRulesCapAwareResolutionSkippedOnRowLimit(t *t
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
-	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithRawCypherQueryStore(graphStore)
 	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-aws"})
 	if err != nil {
 		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
@@ -533,7 +533,7 @@ func TestEvaluateSourceRuntimeGraphRulesPropagatesCypherFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
-	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithRawCypherQueryStore(graphStore)
 	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta"})
 	if err == nil {
 		t.Fatalf("EvaluateSourceRuntimeGraphRules() expected error")
@@ -570,7 +570,7 @@ func TestEvaluateSourceRuntimeGraphRulesContinuesAfterRuleFailure(t *testing.T) 
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
-	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithRawCypherQueryStore(graphStore)
 	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta"})
 	if err == nil {
 		t.Fatalf("EvaluateSourceRuntimeGraphRules() expected error from failing rule")
@@ -616,7 +616,7 @@ func TestEvaluateSourceRuntimeGraphRulesSelectsByRuleID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
-	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithRawCypherQueryStore(graphStore)
 	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: "runtime-okta", RuleIDs: []string{"selected"}})
 	if err != nil {
 		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
@@ -767,7 +767,7 @@ func TestEvaluateSourceRuntimeGraphRulesPinsFindingButRecordsEvidencePerRuntime(
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
-	service := NewWithRegistry(runtimeStore, &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	service := NewWithRegistry(runtimeStore, &stubReplayer{}, store, store, store, store, registry).WithRawCypherQueryStore(graphStore)
 
 	oktaResult, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: oktaRuntime.GetId()})
 	if err != nil {
@@ -844,7 +844,7 @@ func TestEvaluateSourceRuntimeGraphRulesPersistsRunWithoutEventLimit(t *testing.
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
-	service := NewWithRegistry(runtimeStore, &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	service := NewWithRegistry(runtimeStore, &stubReplayer{}, store, store, store, store, registry).WithRawCypherQueryStore(graphStore)
 	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: runtime.GetId()})
 	if err != nil {
 		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
@@ -882,7 +882,7 @@ func TestEvaluateSourceRuntimeGraphRulesRecordsGraphTelemetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
-	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithRawCypherQueryStore(graphStore)
 	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: runtime.GetId()})
 	if err != nil {
 		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
@@ -922,7 +922,7 @@ func TestEvaluateSourceRuntimeGraphRulesEmptyQueryPersistsGraphRuleFlag(t *testi
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
-	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithRawCypherQueryStore(graphStore)
 	if _, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: runtime.GetId()}); err != nil {
 		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
 	}
@@ -958,7 +958,7 @@ func TestEvaluateSourceRuntimeGraphRulesRetiredEmptyQueryResolvesOpenFindings(t 
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
-	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(&stubGraphStore{})
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithRawCypherQueryStore(&stubGraphStore{})
 	result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: runtime.GetId()})
 	if err != nil {
 		t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)
@@ -994,7 +994,7 @@ func TestEvaluateSourceRuntimeGraphRulesFailedRunPreservesGraphTelemetry(t *test
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
-	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+	service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithRawCypherQueryStore(graphStore)
 	if _, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: runtime.GetId()}); err == nil {
 		t.Fatal("EvaluateSourceRuntimeGraphRules() error = nil, want failure")
 	}

--- a/internal/findings/identity_privileged_no_mfa_sensitive_access_rule_test.go
+++ b/internal/findings/identity_privileged_no_mfa_sensitive_access_rule_test.go
@@ -299,7 +299,7 @@ func TestIdentityPrivilegedNoMfaPlusSensitiveAccessGraphRuleRemediationMatrix(t 
 			if err != nil {
 				t.Fatalf("NewRegistry() error = %v", err)
 			}
-			service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithGraphQueryStore(graphStore)
+			service := NewWithRegistry(newGraphRuleStubRuntimeStore(runtime), &stubReplayer{}, store, store, store, store, registry).WithRawCypherQueryStore(graphStore)
 			result, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{RuntimeID: runtime.GetId()})
 			if err != nil {
 				t.Fatalf("EvaluateSourceRuntimeGraphRules() error = %v", err)

--- a/internal/findings/rulepack_audit_test.go
+++ b/internal/findings/rulepack_audit_test.go
@@ -732,7 +732,7 @@ func assertRulepackConvertGraphReplaySingleOpenRow(t *testing.T, rule Rule, defi
 		store,
 		store,
 		registry,
-	).WithGraphQueryStore(graphStore)
+	).WithRawCypherQueryStore(graphStore)
 
 	firstResult, err := service.EvaluateSourceRuntimeGraphRules(context.Background(), EvaluateGraphRulesRequest{
 		RuntimeID: fixture.runtime.GetId(),

--- a/internal/findings/service.go
+++ b/internal/findings/service.go
@@ -74,7 +74,7 @@ type Service struct {
 	evidenceStore             ports.FindingEvidenceStore
 	candidateStore            ports.FindingCandidateStore
 	claimStore                ports.ClaimStore
-	graphQuery                ports.RawCypherQueryStore
+	rawCypher                 ports.RawCypherQueryStore
 	graphRunStore             GraphIngestRunStore
 	requireTrustedResolution  bool
 	graph                     ports.ProjectionGraphStore
@@ -250,13 +250,13 @@ func (s *Service) WithGraphStore(graph ports.ProjectionGraphStore) *Service {
 	return s
 }
 
-// WithGraphQueryStore wires one optional graph query boundary used by workflow bridges.
-func (s *Service) WithGraphQueryStore(graphQuery ports.RawCypherQueryStore) *Service {
+// WithRawCypherQueryStore wires one optional raw-Cypher compatibility boundary used by workflow bridges.
+func (s *Service) WithRawCypherQueryStore(rawCypher ports.RawCypherQueryStore) *Service {
 	if s == nil {
 		return nil
 	}
-	s.graphQuery = graphQuery
-	if graphRuns, ok := graphQuery.(GraphIngestRunStore); ok {
+	s.rawCypher = rawCypher
+	if graphRuns, ok := rawCypher.(GraphIngestRunStore); ok {
 		s.graphRunStore = graphRuns
 	}
 	return s

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -1601,7 +1601,7 @@ func TestEvaluateSourceRuntimeResolvesAndPrunesStaleFindings(t *testing.T) {
 		store,
 		store,
 		registry,
-	).WithGraphStore(graph).WithGraphQueryStore(graph)
+	).WithGraphStore(graph).WithRawCypherQueryStore(graph)
 
 	result, err := service.EvaluateSourceRuntime(context.Background(), EvaluateRequest{
 		RuntimeID: "writer-okta-audit",
@@ -5034,7 +5034,7 @@ func TestResolveFindingBridgesDecisionAndOutcomeWhenGraphConfigured(t *testing.T
 		},
 	}
 	appendLog := &recordingAppendLog{}
-	service := New(nil, nil, store, store, store, store).WithGraphStore(graphStore).WithGraphQueryStore(graphStore).WithAppendLog(appendLog)
+	service := New(nil, nil, store, store, store, store).WithGraphStore(graphStore).WithRawCypherQueryStore(graphStore).WithAppendLog(appendLog)
 	finding, err := service.ResolveFinding(context.Background(), "finding-1", workflowevents.FindingStatusReasonNoLongerEmitted)
 	if err != nil {
 		t.Fatalf("ResolveFinding() error = %v", err)

--- a/internal/findings/trusted_evaluation_test.go
+++ b/internal/findings/trusted_evaluation_test.go
@@ -255,7 +255,7 @@ func TestTrustedGraphEvaluationReportsSharedProjectionAsUnfenced(t *testing.T) {
 		runtime.GetId(): completedGraphRun("graph-okta", runtime.GetId(), "checkpoint-okta", sourceAt.Add(time.Minute)),
 	}}
 	service := NewWithRegistry(runtimeStore, &stubReplayer{}, store, store, store, store, registry).
-		WithGraphQueryStore(&stubGraphStore{}).
+		WithRawCypherQueryStore(&stubGraphStore{}).
 		WithGraphIngestRunStore(runStore).
 		WithTrustedSourceResolution()
 

--- a/tools/archtests/rust_organizational_platform_test.go
+++ b/tools/archtests/rust_organizational_platform_test.go
@@ -225,6 +225,10 @@ func TestRustOrganizationalPlatformBoundary(t *testing.T) {
 	if strings.Contains(policyCandidateGrounding, "graph ports.GraphQueryStore") {
 		t.Error("policy candidate grounding restored full graph query dependency")
 	}
+	findingsService := readText(t, filepath.Join(root, "internal/findings/service.go"))
+	if strings.Contains(findingsService, "WithGraphQueryStore") || strings.Contains(findingsService, "graphQuery                ports.RawCypherQueryStore") {
+		t.Error("findings service restored graph query naming for raw-Cypher dependency")
+	}
 	grcVendorService := readText(t, filepath.Join(root, "internal/grcvendor/service.go"))
 	if strings.Contains(grcVendorService, "store ports.GraphQueryStore") {
 		t.Error("GRC vendor service restored full graph query dependency")


### PR DESCRIPTION
## Summary
- rename findings service graph-rule wiring from graph-query-store terminology to raw-Cypher terminology
- update bootstrap/cmd callers and tests to use `WithRawCypherQueryStore`
- add an architecture guard preventing the stale findings graph-query setter name from returning

## Tests
- go test ./internal/findings ./internal/bootstrap ./cmd/cerebro ./tools/archtests -count=1
- make lint-shard LINT_PACKAGES="./internal/findings ./internal/bootstrap ./cmd/cerebro" LINT_SHARD_TOTAL=1 LINT_SHARD_INDEX=0
- make check-structural check-structural-test check-arch
- git diff --check
