### PR TITLE
Rename security path raw Cypher dependency

### DIFF
--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -487,7 +487,7 @@ func runGraphInspect(args []string) error {
 		if err != nil {
 			return err
 		}
-		store := dependencyGraphQueryStore(deps)
+		store := deps.GraphReads.Neighborhoods
 		if store == nil {
 			return fmt.Errorf("graph read store is required for neighborhoods")
 		}
@@ -811,11 +811,11 @@ func runGraphImpact(args []string) error {
 		return err
 	}
 	defer logClose(closeDeps)
-	store := dependencyGraphQueryStore(deps)
+	store := deps.GraphReads.Neighborhoods
 	if store == nil {
 		return fmt.Errorf("graph read store is required for impact traversals")
 	}
-	result, err := graphquery.New(store).GetImpact(ctx, request)
+	result, err := graphquery.NewWithCapabilities(store, deps.GraphReads.RawCypher, deps.GraphReads.Catalog, deps.GraphReads.Exposure).GetImpact(ctx, request)
 	if err != nil {
 		return err
 	}

--- a/internal/bootstrap/jobs.go
+++ b/internal/bootstrap/jobs.go
@@ -381,7 +381,7 @@ func (a *App) runtimeOrchestrationService() (*runtimeorchestration.SecurityPathS
 		return nil, fmt.Errorf("%w: runtime orchestration storage is unavailable", platformjobs.ErrRuntimeUnavailable)
 	}
 	return runtimeorchestration.NewSecurityPathService(runtimeorchestration.SecurityPathDependencies{
-		GraphQueries: a.deps.GraphReads.RawCypher, GraphIngest: a.graphIngestService(), Checkpoints: checkpoints,
+		RawCypher: a.deps.GraphReads.RawCypher, GraphIngest: a.graphIngestService(), Checkpoints: checkpoints,
 		RuntimeStore: runtimeStore, LeaseStore: sourceRuntimeLeaseStore(a.deps.StateStore), RuntimeSync: a.runtimeService(),
 	}), nil
 }

--- a/internal/runtimeorchestration/security_path_capture.go
+++ b/internal/runtimeorchestration/security_path_capture.go
@@ -42,7 +42,7 @@ type runtimeSyncService interface {
 }
 
 type SecurityPathDependencies struct {
-	GraphQueries ports.RawCypherQueryStore
+	RawCypher    ports.RawCypherQueryStore
 	GraphIngest  graphIngestService
 	Checkpoints  CheckpointStore
 	RuntimeStore ports.SourceRuntimeStore
@@ -104,7 +104,7 @@ func (s *SecurityPathService) captureSnapshot(ctx context.Context, request snaps
 	if tenantID == "" || runtimeID == "" {
 		return securitypathdelta.Snapshot{}, errors.New("source runtime tenant and id are required for security path capture")
 	}
-	if s == nil || s.deps.GraphQueries == nil {
+	if s == nil || s.deps.RawCypher == nil {
 		return securitypathdelta.Snapshot{}, attackpath.ErrRuntimeUnavailable
 	}
 	migrationLimitations, err := s.migrateLegacyAssertions(ctx, tenantID)
@@ -112,7 +112,7 @@ func (s *SecurityPathService) captureSnapshot(ctx context.Context, request snaps
 		return securitypathdelta.Snapshot{}, err
 	}
 	observedAt := time.Now().UTC()
-	result, err := attackpath.New(s.deps.GraphQueries).Traverse(ctx, attackpath.Request{
+	result, err := attackpath.New(s.deps.RawCypher).Traverse(ctx, attackpath.Request{
 		TenantID:              tenantID,
 		AccountID:             strings.TrimSpace(request.AccountID),
 		RequireAssertionProof: true,
@@ -129,7 +129,7 @@ func (s *SecurityPathService) captureSnapshot(ctx context.Context, request snaps
 	limitations := append([]string(nil), request.GraphReceipt.limitations...)
 	limitations = append(limitations, migrationLimitations...)
 	limitations = append(limitations, sourceruntime.CollectionIncompletenessReasons(runtime)...)
-	coverageStore, ok := s.deps.GraphQueries.(ports.ProjectionAssertionCoverageStore)
+	coverageStore, ok := s.deps.RawCypher.(ports.ProjectionAssertionCoverageStore)
 	if !ok || coverageStore == nil {
 		limitations = append(limitations, "material_link_assertion_coverage_unavailable")
 	} else {
@@ -199,7 +199,7 @@ func (s *SecurityPathService) captureSnapshot(ctx context.Context, request snaps
 }
 
 func (s *SecurityPathService) migrateLegacyAssertions(ctx context.Context, tenantID string) ([]string, error) {
-	migrator, ok := s.deps.GraphQueries.(ports.ProjectionAssertionMigrator)
+	migrator, ok := s.deps.RawCypher.(ports.ProjectionAssertionMigrator)
 	if !ok || migrator == nil {
 		return []string{"material_link_assertion_migration_unavailable"}, nil
 	}

--- a/internal/runtimeorchestration/security_path_orchestrator.go
+++ b/internal/runtimeorchestration/security_path_orchestrator.go
@@ -44,7 +44,7 @@ func (s *SecurityPathService) Capture(ctx context.Context, request SecurityPathR
 	if runtimeID == "" {
 		return result, errors.New("source runtime id is required for security path capture")
 	}
-	if s == nil || s.deps.GraphQueries == nil || s.deps.GraphIngest == nil || s.deps.Checkpoints == nil || s.deps.RuntimeStore == nil || s.deps.RuntimeSync == nil || s.deps.LeaseStore == nil {
+	if s == nil || s.deps.RawCypher == nil || s.deps.GraphIngest == nil || s.deps.Checkpoints == nil || s.deps.RuntimeStore == nil || s.deps.RuntimeSync == nil || s.deps.LeaseStore == nil {
 		return result, errors.New("security path capture dependencies are unavailable")
 	}
 	owner := strings.TrimSpace(request.LeaseOwner)

--- a/internal/runtimeorchestration/security_path_orchestrator_test.go
+++ b/internal/runtimeorchestration/security_path_orchestrator_test.go
@@ -25,7 +25,7 @@ func TestCollectVerificationRefreshesEveryContributingRuntime(t *testing.T) {
 	graph := &verificationGraph{now: now, checkpoints: map[string]graphstore.IngestCheckpoint{}}
 	leases := &verificationLeaseStore{}
 	service := NewSecurityPathService(SecurityPathDependencies{
-		GraphQueries: graph, GraphIngest: graph, Checkpoints: graph, RuntimeStore: runtimes, LeaseStore: leases,
+		RawCypher: graph, GraphIngest: graph, Checkpoints: graph, RuntimeStore: runtimes, LeaseStore: leases,
 	})
 	reference := verificationReferenceSnapshot(t, now)
 	current := verificationCurrentSnapshot(now, map[string]string{"runtime-a": "current-a", "runtime-b": "current-b"})
@@ -72,7 +72,7 @@ func TestCollectVerificationStopsBeforeReadsWhenContributorLeaseIsHeld(t *testin
 	now := time.Now().UTC().Add(-2 * time.Minute)
 	graph := &verificationGraph{now: now, checkpoints: map[string]graphstore.IngestCheckpoint{}}
 	leases := &verificationLeaseStore{blockedRuntime: "runtime-b"}
-	service := NewSecurityPathService(SecurityPathDependencies{GraphQueries: graph, GraphIngest: graph, Checkpoints: graph, RuntimeStore: verificationRuntimeStore(now), LeaseStore: leases})
+	service := NewSecurityPathService(SecurityPathDependencies{RawCypher: graph, GraphIngest: graph, Checkpoints: graph, RuntimeStore: verificationRuntimeStore(now), LeaseStore: leases})
 
 	_, err := service.collectVerification(context.Background(), verificationRequest{
 		PrimaryRuntimeID: "runtime-a", LeaseOwner: "owner-a", Current: verificationCurrentSnapshot(now, nil),

--- a/tools/archtests/rust_organizational_platform_test.go
+++ b/tools/archtests/rust_organizational_platform_test.go
@@ -237,6 +237,9 @@ func TestRustOrganizationalPlatformBoundary(t *testing.T) {
 	if strings.Contains(securityPathCapture, "GraphQueries ports.GraphQueryStore") {
 		t.Error("security path capture restored full graph query dependency")
 	}
+	if strings.Contains(securityPathCapture, "GraphQueries ports.RawCypherQueryStore") {
+		t.Error("security path capture restored graph query naming for raw-Cypher dependency")
+	}
 	graphAgentValidator := readText(t, filepath.Join(root, "internal/graphagent/validator.go"))
 	if strings.Contains(graphAgentValidator, "store   ports.GraphQueryStore") || strings.Contains(graphAgentValidator, "func NewValidator(store ports.GraphQueryStore") {
 		t.Error("graph agent validator restored full graph query dependency")


### PR DESCRIPTION
## Summary
- rename runtime orchestration security path graph dependency from `GraphQueries` to `RawCypher`
- wire bootstrap job composition through the explicit raw-Cypher read capability
- fix graph CLI authority read calls to use the explicit graph read capabilities after the bootstrap split
- add an architecture guard preventing security path raw-Cypher wiring from reverting to graph-query naming

## Tests
- go test ./internal/runtimeorchestration ./internal/bootstrap ./cmd/cerebro ./tools/archtests -count=1
- make lint-shard LINT_PACKAGES="./internal/runtimeorchestration ./internal/bootstrap ./cmd/cerebro" LINT_SHARD_TOTAL=1 LINT_SHARD_INDEX=0
- make check-structural check-structural-test check-arch
- git diff --check
