### PR TITLE
Keep GRC dashboard available when runtime health is slow

### DIFF
--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -32,12 +32,13 @@ import (
 )
 
 const (
-	grcDefaultLimit           = uint32(100)
-	grcMaxLimit               = uint32(500)
-	grcMaxRuntimeScope        = uint32(500)
-	grcRuntimeScopeFetchLimit = grcMaxRuntimeScope + 1
-	grcDashboardPreviewLimit  = uint32(25)
-	grcAuditPacketSchema      = grcauditpacket.SchemaVersion
+	grcDefaultLimit                  = uint32(100)
+	grcMaxLimit                      = uint32(500)
+	grcMaxRuntimeScope               = uint32(500)
+	grcRuntimeScopeFetchLimit        = grcMaxRuntimeScope + 1
+	grcDashboardPreviewLimit         = uint32(25)
+	grcDashboardRuntimeHealthTimeout = 5 * time.Second
+	grcAuditPacketSchema             = grcauditpacket.SchemaVersion
 )
 
 type grcScope struct {
@@ -156,12 +157,13 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	findingIDs := grcFindingIDs(findings)
 	generatedAt := time.Now().UTC()
 	var (
-		evidence        []*cerebrov1.FindingEvidence
-		findingSummary  *ports.FindingSummary
-		evidenceCount   *int
-		aggregate       *ports.GRCDashboardAggregate
-		sourceSummaries []sourceRuntimeHealthSummary
-		coverage        []sourcecoverage.Record
+		evidence         []*cerebrov1.FindingEvidence
+		findingSummary   *ports.FindingSummary
+		evidenceCount    *int
+		aggregate        *ports.GRCDashboardAggregate
+		sourceSummaries  []sourceRuntimeHealthSummary
+		coverage         []sourcecoverage.Record
+		runtimeHealthErr error
 	)
 	group, groupCtx := errgroup.WithContext(r.Context())
 	group.Go(func() error {
@@ -191,11 +193,17 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		})
 	})
 	group.Go(func() error {
-		var err error
-		return operationtelemetry.RunMainPhase(groupCtx, "grc.dashboard.runtime_health", telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: len(runtimes)}), func(ctx context.Context) (telemetry.Attributes, error) {
+		runtimeHealthCtx, cancel := context.WithTimeout(groupCtx, grcDashboardRuntimeHealthTimeout)
+		defer cancel()
+		runtimeHealthErr = operationtelemetry.RunMainPhase(runtimeHealthCtx, "grc.dashboard.runtime_health", telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: len(runtimes)}), func(ctx context.Context) (telemetry.Attributes, error) {
+			var err error
 			sourceSummaries, err = a.grcSourceRuntimeHealthSummaries(ctx, runtimes, generatedAt)
 			return telemetry.Attrs(telemetry.Field{Key: "source_summary_count", Value: len(sourceSummaries)}), err
 		})
+		if runtimeHealthErr != nil {
+			sourceSummaries = nil
+		}
+		return nil
 	})
 	group.Go(func() error {
 		var err error
@@ -213,6 +221,12 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
+	endAttrs = endAttrs.With(
+		telemetry.Attrs(
+			telemetry.Field{Key: "source_summaries_status", Value: grcTelemetryStatus(runtimeHealthErr)},
+			telemetry.Field{Key: "source_summary_count", Value: len(sourceSummaries)},
+		),
+	)
 	if aggregate != nil {
 		findingSummary = &aggregate.FindingSummary
 		evidenceCount = &aggregate.EvidenceCount

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -365,6 +365,60 @@ func TestGRCDashboardEmitsLatencyTelemetry(t *testing.T) {
 	}
 }
 
+func TestGRCDashboardReturnsCoreDataWhenRuntimeHealthUnavailable(t *testing.T) {
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-grc": {
+				Id:       "writer-grc",
+				SourceId: "grc",
+				TenantId: "writer",
+			},
+		},
+		findings:        map[string]*ports.FindingRecord{},
+		findingEvidence: map[string]*cerebrov1.FindingEvidence{},
+	}
+	app := New(
+		config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second},
+		Dependencies{
+			StateStore: store,
+			GraphStore: &stubGraphStore{err: errors.New("runtime health graph read unavailable")},
+		},
+		nil,
+	)
+	server := httptest.NewServer(app.Handler())
+
+	stderr := captureBootstrapStderr(t, func() {
+		defer server.Close()
+		resp, err := server.Client().Get(server.URL + "/grc/dashboard?tenant_id=writer&limit=1")
+		if err != nil {
+			t.Fatalf("GET /grc/dashboard error = %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET /grc/dashboard status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		var payload grcDashboardResponse
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode /grc/dashboard: %v", err)
+		}
+		if len(payload.SourceSummaries) != 0 {
+			t.Fatalf("source summaries = %#v, want omitted degraded enrichment", payload.SourceSummaries)
+		}
+	})
+
+	phasePayload := decodeBootstrapTelemetryPayload(t, stderr, "grc.dashboard.runtime_health")
+	if got := phasePayload["status"]; got != "failed" {
+		t.Fatalf("runtime health status = %#v, want failed; payload=%#v", got, phasePayload)
+	}
+	dashboardPayload := decodeBootstrapTelemetryPayload(t, stderr, "grc.dashboard")
+	if got := dashboardPayload["status"]; got != "completed" {
+		t.Fatalf("dashboard status = %#v, want completed; payload=%#v", got, dashboardPayload)
+	}
+	if got := dashboardPayload["source_summaries_status"]; got != "failed" {
+		t.Fatalf("source summaries status = %#v, want failed; payload=%#v", got, dashboardPayload)
+	}
+}
+
 func TestGRCDashboardTelemetryRecordsHTTPErrorStatus(t *testing.T) {
 	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: &stubRuntimeStore{}}, nil)
 	server := httptest.NewServer(app.Handler())


### PR DESCRIPTION
Live sec-dev evidence:
- authenticated Home requests to `/grc/dashboard?limit=12&view=summary` return 500 after about 12 seconds
- runtimes, findings, evidence, coverage, and aggregate phases complete
- `grc.dashboard.runtime_health` is canceled while reading latest Neo4j ingest runs, which currently blanks the whole Home dashboard

This change:
- bounds the optional runtime-health enrichment to five seconds
- keeps its failed phase and degraded source-summary status in telemetry
- returns the core risks, controls, evidence, and coverage dashboard when that enrichment is unavailable

Validation:
- `go test ./internal/bootstrap -count=1`
- `go test -race ./internal/bootstrap -run TestGRCDashboardReturnsCoreDataWhenRuntimeHealthUnavailable -count=1`
- `git diff --check`

DDESK readiness passed, but a new checkout stream requested an additional project disk. No billable disk was provisioned; focused local validation used the managed Go cache and hosted checks are the full-suite gate.