### PR TITLE
Use typed graph counts for agent probes

### DIFF
--- a/internal/bootstrap/feature_dependencies.go
+++ b/internal/bootstrap/feature_dependencies.go
@@ -265,33 +265,27 @@ func newRuntimeResponseFeatureService(deps runtimeResponseFeatureDeps) *runtimer
 }
 
 type graphReasoningFeatureDeps struct {
-	GraphNeighborhoods    ports.GraphNeighborhoodStore
-	GraphRawCypher        ports.RawCypherQueryStore
-	GraphEntityKindCounts ports.EntityKindCountStore
-	GraphRelationCounts   ports.RelationCountStore
-	GraphAgentLLM         graphagent.LLMClient
-	TrajectoryStore       ports.AskTrajectoryStore
+	GraphReads      ports.GraphReadCapabilities
+	GraphAgentLLM   graphagent.LLMClient
+	TrajectoryStore ports.AskTrajectoryStore
 }
 
 func newGraphReasoningFeatureDeps(deps Dependencies) graphReasoningFeatureDeps {
 	return graphReasoningFeatureDeps{
-		GraphNeighborhoods:    deps.GraphReads.Neighborhoods,
-		GraphRawCypher:        deps.GraphReads.RawCypher,
-		GraphEntityKindCounts: deps.GraphReads.EntityKindCounts,
-		GraphRelationCounts:   deps.GraphReads.RelationCounts,
-		GraphAgentLLM:         deps.GraphAgentLLM,
-		TrajectoryStore:       askTrajectoryStore(deps.StateStore),
+		GraphReads:      deps.GraphReads,
+		GraphAgentLLM:   deps.GraphAgentLLM,
+		TrajectoryStore: askTrajectoryStore(deps.StateStore),
 	}
 }
 
 func newGraphReasoningFeatureService(deps graphReasoningFeatureDeps) (*graphagent.Service, error) {
-	if deps.GraphRawCypher == nil || deps.GraphNeighborhoods == nil {
+	if deps.GraphReads.RawCypher == nil || deps.GraphReads.Neighborhoods == nil {
 		return nil, graphquery.ErrRuntimeUnavailable
 	}
 	if deps.GraphAgentLLM == nil {
 		return nil, errors.Join(graphagent.ErrRuntimeUnavailable, errors.New("graph agent llm is not configured"))
 	}
-	return graphagent.NewServiceWithGraphCapabilities(deps.GraphRawCypher, deps.GraphNeighborhoods, deps.GraphEntityKindCounts, deps.GraphRelationCounts, deps.GraphAgentLLM, graphagent.ValidatorOptions{Explain: true}, graphagent.ServiceOptions{
+	return graphagent.NewServiceWithGraphCapabilities(deps.GraphReads.RawCypher, deps.GraphReads.Neighborhoods, deps.GraphReads.EntityKindCounts, deps.GraphReads.RelationCounts, deps.GraphAgentLLM, graphagent.ValidatorOptions{Explain: true}, graphagent.ServiceOptions{
 		TrajectoryStore:             deps.TrajectoryStore,
 		EnableGraphProbes:           true,
 		EnableDeterministicFastPath: true,

--- a/internal/bootstrap/feature_dependencies.go
+++ b/internal/bootstrap/feature_dependencies.go
@@ -265,18 +265,22 @@ func newRuntimeResponseFeatureService(deps runtimeResponseFeatureDeps) *runtimer
 }
 
 type graphReasoningFeatureDeps struct {
-	GraphNeighborhoods ports.GraphNeighborhoodStore
-	GraphRawCypher     ports.RawCypherQueryStore
-	GraphAgentLLM      graphagent.LLMClient
-	TrajectoryStore    ports.AskTrajectoryStore
+	GraphNeighborhoods    ports.GraphNeighborhoodStore
+	GraphRawCypher        ports.RawCypherQueryStore
+	GraphEntityKindCounts ports.EntityKindCountStore
+	GraphRelationCounts   ports.RelationCountStore
+	GraphAgentLLM         graphagent.LLMClient
+	TrajectoryStore       ports.AskTrajectoryStore
 }
 
 func newGraphReasoningFeatureDeps(deps Dependencies) graphReasoningFeatureDeps {
 	return graphReasoningFeatureDeps{
-		GraphNeighborhoods: deps.GraphReads.Neighborhoods,
-		GraphRawCypher:     deps.GraphReads.RawCypher,
-		GraphAgentLLM:      deps.GraphAgentLLM,
-		TrajectoryStore:    askTrajectoryStore(deps.StateStore),
+		GraphNeighborhoods:    deps.GraphReads.Neighborhoods,
+		GraphRawCypher:        deps.GraphReads.RawCypher,
+		GraphEntityKindCounts: deps.GraphReads.EntityKindCounts,
+		GraphRelationCounts:   deps.GraphReads.RelationCounts,
+		GraphAgentLLM:         deps.GraphAgentLLM,
+		TrajectoryStore:       askTrajectoryStore(deps.StateStore),
 	}
 }
 
@@ -287,7 +291,7 @@ func newGraphReasoningFeatureService(deps graphReasoningFeatureDeps) (*graphagen
 	if deps.GraphAgentLLM == nil {
 		return nil, errors.Join(graphagent.ErrRuntimeUnavailable, errors.New("graph agent llm is not configured"))
 	}
-	return graphagent.NewServiceWithCapabilities(deps.GraphRawCypher, deps.GraphNeighborhoods, deps.GraphAgentLLM, graphagent.ValidatorOptions{Explain: true}, graphagent.ServiceOptions{
+	return graphagent.NewServiceWithGraphCapabilities(deps.GraphRawCypher, deps.GraphNeighborhoods, deps.GraphEntityKindCounts, deps.GraphRelationCounts, deps.GraphAgentLLM, graphagent.ValidatorOptions{Explain: true}, graphagent.ServiceOptions{
 		TrajectoryStore:             deps.TrajectoryStore,
 		EnableGraphProbes:           true,
 		EnableDeterministicFastPath: true,

--- a/internal/bootstrap/feature_dependencies_test.go
+++ b/internal/bootstrap/feature_dependencies_test.go
@@ -62,7 +62,7 @@ func TestProductReadDependencyBundlesPreferConfiguredAuthority(t *testing.T) {
 	if got := newGraphQueryFeatureDeps(deps); got.GraphNeighborhoods != authority || got.GraphRawCypher != authority || got.GraphCatalog != authority || got.GraphExposure != authority {
 		t.Fatalf("graph query service = %#v, want configured authority for all capabilities", got)
 	}
-	if got := newGraphReasoningFeatureDeps(deps); got.GraphNeighborhoods != authority || got.GraphRawCypher != authority {
+	if got := newGraphReasoningFeatureDeps(deps); got.GraphNeighborhoods != authority || got.GraphRawCypher != authority || got.GraphEntityKindCounts != authority || got.GraphRelationCounts != authority {
 		t.Fatalf("graph reasoning queries = %#v, want configured authority", got)
 	}
 }

--- a/internal/bootstrap/feature_dependencies_test.go
+++ b/internal/bootstrap/feature_dependencies_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/writer/cerebro/internal/graphagent"
+	"github.com/writer/cerebro/internal/ports"
 )
 
 func TestFeatureDependencyBundlesAreNilSafe(t *testing.T) {
@@ -39,7 +40,7 @@ func TestFeatureDependencyBundlesAreNilSafe(t *testing.T) {
 	if got := newRuntimeResponseFeatureDeps(deps); got.Blocklist != nil {
 		t.Fatalf("newRuntimeResponseFeatureDeps() = %#v, want nil runtime response store", got)
 	}
-	if got := newGraphReasoningFeatureDeps(deps); got.GraphNeighborhoods != nil || got.GraphRawCypher != nil || got.GraphAgentLLM != nil || got.TrajectoryStore != nil {
+	if got := newGraphReasoningFeatureDeps(deps); got.GraphReads != (ports.GraphReadCapabilities{}) || got.GraphAgentLLM != nil || got.TrajectoryStore != nil {
 		t.Fatalf("newGraphReasoningFeatureDeps() = %#v, want nil dependencies", got)
 	}
 }
@@ -62,7 +63,7 @@ func TestProductReadDependencyBundlesPreferConfiguredAuthority(t *testing.T) {
 	if got := newGraphQueryFeatureDeps(deps); got.GraphNeighborhoods != authority || got.GraphRawCypher != authority || got.GraphCatalog != authority || got.GraphExposure != authority {
 		t.Fatalf("graph query service = %#v, want configured authority for all capabilities", got)
 	}
-	if got := newGraphReasoningFeatureDeps(deps); got.GraphNeighborhoods != authority || got.GraphRawCypher != authority || got.GraphEntityKindCounts != authority || got.GraphRelationCounts != authority {
+	if got := newGraphReasoningFeatureDeps(deps); got.GraphReads.Neighborhoods != authority || got.GraphReads.RawCypher != authority || got.GraphReads.EntityKindCounts != authority || got.GraphReads.RelationCounts != authority {
 		t.Fatalf("graph reasoning queries = %#v, want configured authority", got)
 	}
 }
@@ -82,7 +83,7 @@ func TestProductReadDependencyBundlesDoNotFallbackToLegacyGraphStore(t *testing.
 	if got := newGraphQueryFeatureDeps(deps); got.GraphNeighborhoods != nil || got.GraphRawCypher != nil || got.GraphCatalog != nil || got.GraphExposure != nil {
 		t.Fatalf("graph query service = %#v, want nil without configured authority", got)
 	}
-	if got := newGraphReasoningFeatureDeps(deps); got.GraphNeighborhoods != nil || got.GraphRawCypher != nil {
+	if got := newGraphReasoningFeatureDeps(deps); got.GraphReads != (ports.GraphReadCapabilities{}) {
 		t.Fatalf("graph reasoning queries = %#v, want nil without configured authority", got)
 	}
 }

--- a/internal/bootstrap/grc_ask.go
+++ b/internal/bootstrap/grc_ask.go
@@ -82,7 +82,7 @@ func (a *App) handleGRCAsk(w http.ResponseWriter, r *http.Request) {
 
 	clearLongRunningWriteDeadline(w)
 	flusher, _ := w.(http.Flusher)
-	service := graphagent.NewServiceWithCapabilities(rawCypher, neighborhoods, llm, graphagent.ValidatorOptions{Explain: true}, graphagent.ServiceOptions{
+	service := graphagent.NewServiceWithGraphCapabilities(rawCypher, neighborhoods, a.deps.GraphReads.EntityKindCounts, a.deps.GraphReads.RelationCounts, llm, graphagent.ValidatorOptions{Explain: true}, graphagent.ServiceOptions{
 		TrajectoryStore:             askTrajectoryStore(a.deps.StateStore),
 		EnableGraphProbes:           true,
 		EnableDeterministicFastPath: true,

--- a/internal/graphagent/ask.go
+++ b/internal/graphagent/ask.go
@@ -50,11 +50,13 @@ type Store interface {
 }
 
 type Service struct {
-	rawCypher     ports.RawCypherQueryStore
-	neighborhoods ports.GraphNeighborhoodStore
-	llm           LLMClient
-	validator     *Validator
-	options       ServiceOptions
+	rawCypher        ports.RawCypherQueryStore
+	neighborhoods    ports.GraphNeighborhoodStore
+	entityKindCounts ports.EntityKindCountStore
+	relationCounts   ports.RelationCountStore
+	llm              LLMClient
+	validator        *Validator
+	options          ServiceOptions
 }
 
 func NewService(store Store, llm LLMClient, options ValidatorOptions) *Service {
@@ -63,19 +65,42 @@ func NewService(store Store, llm LLMClient, options ValidatorOptions) *Service {
 
 func NewServiceWithOptions(store Store, llm LLMClient, validatorOptions ValidatorOptions, serviceOptions ServiceOptions) *Service {
 	if store == nil {
-		return NewServiceWithCapabilities(nil, nil, llm, validatorOptions, serviceOptions)
+		return NewServiceWithGraphCapabilities(nil, nil, nil, nil, llm, validatorOptions, serviceOptions)
 	}
-	return NewServiceWithCapabilities(store, store, llm, validatorOptions, serviceOptions)
+	return NewServiceWithGraphCapabilities(store, store, entityKindCountCapability(store), relationCountCapability(store), llm, validatorOptions, serviceOptions)
 }
 
 func NewServiceWithCapabilities(rawCypher ports.RawCypherQueryStore, neighborhoods ports.GraphNeighborhoodStore, llm LLMClient, validatorOptions ValidatorOptions, serviceOptions ServiceOptions) *Service {
+	return NewServiceWithGraphCapabilities(rawCypher, neighborhoods, entityKindCountCapability(rawCypher), relationCountCapability(rawCypher), llm, validatorOptions, serviceOptions)
+}
+
+// NewServiceWithGraphCapabilities wires the graphagent's separate read
+// capabilities. Raw Cypher remains required for runtime-authored Ask queries,
+// while graph probes use the typed count operations directly.
+func NewServiceWithGraphCapabilities(rawCypher ports.RawCypherQueryStore, neighborhoods ports.GraphNeighborhoodStore, entityKindCounts ports.EntityKindCountStore, relationCounts ports.RelationCountStore, llm LLMClient, validatorOptions ValidatorOptions, serviceOptions ServiceOptions) *Service {
 	return &Service{
-		rawCypher:     rawCypher,
-		neighborhoods: neighborhoods,
-		llm:           llm,
-		validator:     NewValidator(rawCypher, validatorOptions),
-		options:       normalizeServiceOptions(serviceOptions),
+		rawCypher:        rawCypher,
+		neighborhoods:    neighborhoods,
+		entityKindCounts: entityKindCounts,
+		relationCounts:   relationCounts,
+		llm:              llm,
+		validator:        NewValidator(rawCypher, validatorOptions),
+		options:          normalizeServiceOptions(serviceOptions),
 	}
+}
+
+func entityKindCountCapability(store any) ports.EntityKindCountStore {
+	if counts, ok := store.(ports.EntityKindCountStore); ok {
+		return counts
+	}
+	return nil
+}
+
+func relationCountCapability(store any) ports.RelationCountStore {
+	if counts, ok := store.(ports.RelationCountStore); ok {
+		return counts
+	}
+	return nil
 }
 
 func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) error {
@@ -109,7 +134,7 @@ func (s *Service) Stream(ctx context.Context, request AskRequest, emit Emitter) 
 			return err
 		}
 		probeStarted := time.Now()
-		collected := collectGraphProbe(ctx, s.rawCypher, s.neighborhoods, request)
+		collected := collectGraphProbe(ctx, s.entityKindCounts, s.relationCounts, s.neighborhoods, request)
 		timings.ProbeMS = time.Since(probeStarted).Milliseconds()
 		probe = &collected
 		if err := emit(Event{Name: EventGraphProbe, Data: GraphProbeEvent{Probe: collected}}); err != nil {

--- a/internal/graphagent/ask_test.go
+++ b/internal/graphagent/ask_test.go
@@ -419,19 +419,37 @@ func TestCollectGraphProbeCachesTenantCounts(t *testing.T) {
 	}
 	request := AskRequest{TenantID: "writer", Question: "What is risky?"}
 
-	first := collectGraphProbe(context.Background(), store, store, request)
+	first := collectGraphProbe(context.Background(), store, store, store, request)
 	if first.SourceCount != 3 {
 		t.Fatalf("first probe source count = %d, want 3", first.SourceCount)
 	}
 	if store.countRequests != 2 {
 		t.Fatalf("store count requests after first probe = %d, want 2", store.countRequests)
 	}
-	second := collectGraphProbe(context.Background(), store, store, request)
+	second := collectGraphProbe(context.Background(), store, store, store, request)
 	if second.SourceCount != 3 {
 		t.Fatalf("second probe source count = %d, want cached 3", second.SourceCount)
 	}
 	if store.countRequests != 2 {
 		t.Fatalf("store count requests after second probe = %d, want tenant count cache hit", store.countRequests)
+	}
+}
+
+func TestCollectGraphProbeUsesTypedCountStoresWithoutRawCypher(t *testing.T) {
+	resetGraphProbeCountsCacheForTest()
+	defer resetGraphProbeCountsCacheForTest()
+	store := &askStore{
+		rows: []ports.CypherRow{{Values: map[string]any{"unexpected": "raw query"}}},
+	}
+	probe := collectGraphProbe(context.Background(), store, store, nil, AskRequest{TenantID: "writer", Question: "What is risky?"})
+	if probe.SourceCount != 3 || probe.FindingCount != 0 {
+		t.Fatalf("probe counts = %#v, want typed source count 3 and no finding count", probe)
+	}
+	if len(probe.Warnings) != 0 {
+		t.Fatalf("probe warnings = %#v, want none", probe.Warnings)
+	}
+	if len(store.requests) != 0 {
+		t.Fatalf("raw Cypher requests = %#v, want none", store.requests)
 	}
 }
 

--- a/internal/graphagent/probe.go
+++ b/internal/graphagent/probe.go
@@ -44,9 +44,9 @@ type GraphProbeCount struct {
 	Count int64  `json:"count"`
 }
 
-func collectGraphProbe(ctx context.Context, rawCypher ports.RawCypherQueryStore, neighborhoods ports.GraphNeighborhoodStore, request AskRequest) GraphProbe {
+func collectGraphProbe(ctx context.Context, entityKindCounts ports.EntityKindCountStore, relationCounts ports.RelationCountStore, neighborhoods ports.GraphNeighborhoodStore, request AskRequest) GraphProbe {
 	probe := GraphProbe{ScopeURN: strings.TrimSpace(request.ScopeURN)}
-	if rawCypher == nil && neighborhoods == nil {
+	if entityKindCounts == nil && relationCounts == nil && neighborhoods == nil {
 		probe.Warnings = append(probe.Warnings, "graph_store_unavailable")
 		return probe
 	}
@@ -61,10 +61,6 @@ func collectGraphProbe(ctx context.Context, rawCypher ports.RawCypherQueryStore,
 			probe.ScopeLabel = neighborhood.Root.Label
 		}
 	}
-	if rawCypher == nil {
-		probe.Warnings = append(probe.Warnings, "graph_store_unavailable")
-		return probe
-	}
 	if cached, ok := cachedGraphProbeCounts(request.TenantID); ok {
 		probe.EntityTypes = cached.EntityTypes
 		probe.Relations = cached.Relations
@@ -73,9 +69,7 @@ func collectGraphProbe(ctx context.Context, rawCypher ports.RawCypherQueryStore,
 		return probe
 	}
 	warningsBeforeCounts := len(probe.Warnings)
-	entityKindCounts, entityKindOK := rawCypher.(ports.EntityKindCountStore)
-	relationCounts, relationOK := rawCypher.(ports.RelationCountStore)
-	if !entityKindOK || !relationOK {
+	if entityKindCounts == nil || relationCounts == nil {
 		probe.Warnings = append(probe.Warnings, "graph_count_store_unavailable")
 		return probe
 	}

--- a/internal/ports/graphquery.go
+++ b/internal/ports/graphquery.go
@@ -81,10 +81,12 @@ type RawCypherQueryStore interface {
 }
 
 type GraphReadCapabilities struct {
-	Neighborhoods GraphNeighborhoodStore
-	RawCypher     RawCypherQueryStore
-	Catalog       EntityCatalogStore
-	Exposure      ExposureCoverageStore
+	Neighborhoods    GraphNeighborhoodStore
+	RawCypher        RawCypherQueryStore
+	Catalog          EntityCatalogStore
+	Exposure         ExposureCoverageStore
+	EntityKindCounts EntityKindCountStore
+	RelationCounts   RelationCountStore
 }
 
 func NewGraphReadCapabilities(store GraphStore) GraphReadCapabilities {
@@ -103,6 +105,12 @@ func NewGraphReadCapabilities(store GraphStore) GraphReadCapabilities {
 	}
 	if exposure, ok := store.(ExposureCoverageStore); ok && !isNilGraphReadCapability(exposure) {
 		capabilities.Exposure = exposure
+	}
+	if entityKindCounts, ok := store.(EntityKindCountStore); ok && !isNilGraphReadCapability(entityKindCounts) {
+		capabilities.EntityKindCounts = entityKindCounts
+	}
+	if relationCounts, ok := store.(RelationCountStore); ok && !isNilGraphReadCapability(relationCounts) {
+		capabilities.RelationCounts = relationCounts
 	}
 	return capabilities
 }


### PR DESCRIPTION
## Summary

- pass graphagent probe counts through explicit typed graph-read capabilities
- keep runtime-authored Ask Cypher on the compatibility port
- preserve probe output with a no-Cypher compatibility test

## Validation

- `go test ./internal/graphagent ./internal/bootstrap ./internal/ports`
- `make lint-bootstrap`
- `go test -race ./internal/graphagent ./internal/bootstrap ./internal/ports` was blocked by the local filesystem exhausting available space before tests ran
