### PR TITLE
fix: normalize legacy control links before rendering

### DIFF
--- a/apps/web/src/app/grc/page.test.ts
+++ b/apps/web/src/app/grc/page.test.ts
@@ -94,6 +94,20 @@ describe("GRC page helpers", () => {
     ]);
   });
 
+  it("normalizes legacy control work-item links", () => {
+    const readinessData = {
+      work_items: [{
+        id: "control-cc6.6",
+        kind: "control",
+        status: "failing",
+        title: "SOC 2 CC6.6",
+        href: "/grc/controls?framework=SOC%202&control=CC6.6",
+      }],
+    } as GRCProgramReadiness;
+
+    expect(buildIssueQueue(readinessData, [])[0]?.href).toBe("/controls?framework=SOC%202&control=CC6.6");
+  });
+
   it("builds packet blocker checks instead of roadmap steps", () => {
     const checks = buildReadinessChecks({ summary: summary() });
 

--- a/apps/web/src/app/grc/page.tsx
+++ b/apps/web/src/app/grc/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/grc";
 import { DASHBOARD_FINDING_LIMIT, grcDashboardPath, grcProgramReadinessPath, useGRCQuery } from "@/lib/grc-client";
 import { frameworkRouteSegment } from "@/lib/grc-frameworks";
+import { normalizeLegacyControlHref } from "@/lib/navigation";
 import type { RuntimeState } from "@/lib/runtime-state";
 
 type IssueQueueItem = {
@@ -50,7 +51,7 @@ const controlHref = (control: GRCControl) =>
   `/controls?framework=${encodeURIComponent(control.framework_name)}&control=${encodeURIComponent(control.control_id)}`;
 
 const workItemHref = (item: GRCProgramWorkItem) => {
-  if (item.href) return item.href;
+  if (item.href) return normalizeLegacyControlHref(item.href);
   if (item.framework_name && item.control_id) {
     return `/controls?framework=${encodeURIComponent(item.framework_name)}&control=${encodeURIComponent(item.control_id)}`;
   }
@@ -302,7 +303,7 @@ function IssueQueuePanel({ items }: { items: IssueQueueItem[] }) {
       ) : (
         <div className="divide-y divide-[color:var(--border)]">
           {items.map((item) => (
-            <Link key={item.id} href={item.href} className="grid gap-3 py-3 transition hover:bg-[var(--surface-muted)] md:grid-cols-[minmax(0,1fr)_150px_132px_80px]">
+            <Link key={item.id} href={normalizeLegacyControlHref(item.href)} className="grid gap-3 py-3 transition hover:bg-[var(--surface-muted)] md:grid-cols-[minmax(0,1fr)_150px_132px_80px]">
               <div className="min-w-0">
                 <div className="flex flex-wrap items-center gap-2">
                   <Badge value={item.type} />

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { GRCProgramReadiness } from "@/lib/grc";
+
+import { buildHomeQueue, ReviewNowPanel } from "./page";
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+describe("Home review links", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders a legacy control work item at the current controls route", async () => {
+    const items = buildHomeQueue({
+      connectors: [],
+      controls: [],
+      coverageBlindSpots: [],
+      findings: [],
+      readinessData: {
+        work_items: [{
+          id: "soc2-cc6.6",
+          kind: "control",
+          status: "failing",
+          title: "SOC 2 CC6.6",
+          href: "/grc/controls?framework=SOC%202&control=CC6.6",
+        }],
+      } as GRCProgramReadiness,
+    });
+
+    expect(items[0]?.href).toBe("/controls?framework=SOC%202&control=CC6.6");
+
+    await act(async () => {
+      root.render(<ReviewNowPanel items={items} />);
+    });
+
+    const links = [...container.querySelectorAll<HTMLAnchorElement>("a")];
+    expect(links.map((link) => link.getAttribute("href"))).toContain("/controls?framework=SOC%202&control=CC6.6");
+  });
+});

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -22,6 +22,7 @@ import {
   shortEntity,
 } from "@/lib/grc";
 import { DASHBOARD_FINDING_LIMIT, grcDashboardPath, grcPath, grcProgramReadinessPath, useGRCQuery } from "@/lib/grc-client";
+import { normalizeLegacyControlHref } from "@/lib/navigation";
 
 const HOME_DASHBOARD_FINDING_LIMIT = DASHBOARD_FINDING_LIMIT;
 
@@ -110,7 +111,7 @@ const findingKeyFromHref = (href: string) => {
 };
 
 const workItemReviewItem = (item: GRCProgramWorkItem): HomeQueueItem => {
-  const href = item.href || (item.framework_name && item.control_id ? `/controls?framework=${encodeURIComponent(item.framework_name)}&control=${encodeURIComponent(item.control_id)}` : "/controls");
+  const href = normalizeLegacyControlHref(item.href || (item.framework_name && item.control_id ? `/controls?framework=${encodeURIComponent(item.framework_name)}&control=${encodeURIComponent(item.control_id)}` : "/controls"));
   const evidenceIssue = (item.missing_evidence_items ?? 0) + (item.stale_evidence_items ?? 0);
   const pointsAtRisk = href.startsWith("/findings/");
   return {
@@ -244,7 +245,7 @@ const dedupeQueueItems = (items: HomeQueueItem[]) => {
   });
 };
 
-function buildHomeQueue({
+export function buildHomeQueue({
   connectors,
   controls,
   coverageBlindSpots,
@@ -299,7 +300,7 @@ const pageSummary = (metrics: HomeMetrics) =>
     countLabel(metrics.summary.stale_connectors, "stale source"),
   ].join(", ") + ".";
 
-function ReviewNowPanel({ items }: { items: HomeQueueItem[] }) {
+export function ReviewNowPanel({ items }: { items: HomeQueueItem[] }) {
   return (
     <section className="surface-panel">
       <div className="flex flex-wrap items-start justify-between gap-3 border-b border-[color:var(--border)] px-5 py-4">
@@ -313,7 +314,7 @@ function ReviewNowPanel({ items }: { items: HomeQueueItem[] }) {
         {items.map((item) => (
           <Link
             key={item.id}
-            href={item.href}
+            href={normalizeLegacyControlHref(item.href)}
             className="grid gap-3 px-5 py-4 transition hover:bg-[var(--surface-muted)] lg:grid-cols-[96px_minmax(0,1fr)_180px_128px]"
           >
             <div className="flex items-start gap-2">

--- a/apps/web/src/lib/navigation.test.ts
+++ b/apps/web/src/lib/navigation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { navigationEntries, operatorNavLinks, utilityLinks } from "./navigation";
+import { navigationEntries, normalizeLegacyControlHref, operatorNavLinks, utilityLinks } from "./navigation";
 
 describe("navigation entries", () => {
   it("has unique hrefs across all entries", () => {
@@ -53,5 +53,14 @@ describe("navigation entries", () => {
   it("includes developer tools in utility links", () => {
     const hrefs = utilityLinks.map((e) => e.href);
     expect(hrefs).toContain("/developer");
+  });
+
+  it("normalizes only the legacy internal control route", () => {
+    expect(normalizeLegacyControlHref("/grc/controls?framework=SOC%202&control=CC6.6")).toBe(
+      "/controls?framework=SOC%202&control=CC6.6",
+    );
+    expect(normalizeLegacyControlHref("/grc/controls")).toBe("/controls");
+    expect(normalizeLegacyControlHref("/grc/controls/export?format=csv")).toBe("/grc/controls/export?format=csv");
+    expect(normalizeLegacyControlHref("/api/grc/controls?framework=SOC%202")).toBe("/api/grc/controls?framework=SOC%202");
   });
 });

--- a/apps/web/src/lib/navigation.ts
+++ b/apps/web/src/lib/navigation.ts
@@ -1,2 +1,7 @@
 export type { NavigationEntry } from "@/lib/routes";
 export { navigationEntries, operatorNavLinks, utilityLinks } from "@/lib/routes";
+
+const legacyControlHref = /^\/grc\/controls(?=[?#]|$)/;
+
+export const normalizeLegacyControlHref = (href: string) =>
+  href.replace(legacyControlHref, "/controls");


### PR DESCRIPTION
## Summary

- Normalize the exact legacy `/grc/controls` internal href before Home and GRC queue links render.
- Preserve query strings and leave `/grc/controls/export` and API paths unchanged.
- Add rendered Home-card coverage plus GRC and route-contract tests.

## Validation

- DDESK bounded Vitest: 14 passed across 3 files.
- DDESK targeted ESLint: passed.
- Full no-emit TypeScript check was run; it reports existing unrelated errors in untouched API/audit, fixture, proxy, upload-history, and questionnaire tests. No changed-file TypeScript error was reported.

## Live defect addressed

The promoted v2.1.763 Home SOC 2 CC6.6 card received `/grc/controls?...`, which produced a document 404 and React error #418. This change repairs that link at the rendering boundary; v2.1.763 is not being claimed as fixed.