### PR TITLE
fix: preserve SentinelOne application identity parity

### DIFF
--- a/crates/source-runtime-next/src/append_log.rs
+++ b/crates/source-runtime-next/src/append_log.rs
@@ -742,7 +742,7 @@ fn sentinelone_optional_attribute_component<'a>(
     }
 }
 
-fn sentinelone_component_value<'a>(value: Option<&'a str>) -> Option<Option<&'a str>> {
+fn sentinelone_component_value(value: Option<&str>) -> Option<Option<&str>> {
     let value = value?.trim();
     if value.is_empty() {
         return Some(None);

--- a/crates/source-runtime-next/src/append_log.rs
+++ b/crates/source-runtime-next/src/append_log.rs
@@ -30,6 +30,13 @@ const OKTA_THREAT_INSIGHT_SCHEMA_REF: &str = "okta/threat_insight/v1";
 const LEGACY_OKTA_THREAT_INSIGHT_PREFIX: &str = "okta-threat-insight-";
 const CURRENT_OKTA_THREAT_INSIGHT_PREFIX: &str = "okta-threat-insight-sha256-";
 const COMPATIBILITY_OBSERVATION_ID_PREFIX: &str = "compat:v1:";
+const SENTINELONE_APPLICATION_KIND: &str = "sentinelone.application_inventory";
+const SENTINELONE_APPLICATION_SCHEMA_REF: &str = "sentinelone/application_inventory/v1";
+const SENTINELONE_APPLICATION_EVENT_ID_PREFIX: &str = "sentinelone-application-";
+const SENTINELONE_APPLICATION_COMPATIBILITY_DOMAIN: &str =
+    "cerebro.compat-observation-id.sentinelone-application/v1";
+const MAX_SENTINELONE_APPLICATION_EVENT_ID_BYTES: usize = 256;
+const MAX_SENTINELONE_APPLICATION_COMPONENT_BYTES: usize = 256;
 
 #[derive(Clone, PartialEq, Message)]
 struct CommittedSourceWire {
@@ -476,13 +483,26 @@ fn decode_observation_id(
     match ObservationId::parse(event_id) {
         Ok(observation_id) => Ok(observation_id),
         Err(error) => match compatible_legacy_invalid_identity(
-            event_id, source_id, event_kind, schema_ref, attributes, payload,
+            event_id, tenant_id, source_id, event_kind, schema_ref, attributes, payload,
         ) {
             Some(LegacyInvalidIdentity::PreservedEventId) => {
                 let mut hasher = Sha256::new();
                 hash_field(
                     &mut hasher,
                     b"cerebro.compat-observation-id.invalid-character/v1",
+                );
+                hash_field(&mut hasher, tenant_id.as_str().as_bytes());
+                hash_field(&mut hasher, source_id.as_bytes());
+                hash_field(&mut hasher, event_kind.as_bytes());
+                hash_field(&mut hasher, schema_ref.as_bytes());
+                hash_field(&mut hasher, event_id.as_bytes());
+                compatibility_observation_id(hasher)
+            }
+            Some(LegacyInvalidIdentity::SentinelOneApplication) => {
+                let mut hasher = Sha256::new();
+                hash_field(
+                    &mut hasher,
+                    SENTINELONE_APPLICATION_COMPATIBILITY_DOMAIN.as_bytes(),
                 );
                 hash_field(&mut hasher, tenant_id.as_str().as_bytes());
                 hash_field(&mut hasher, source_id.as_bytes());
@@ -553,11 +573,13 @@ fn is_bounded_provider_domain(value: &str) -> bool {
 
 enum LegacyInvalidIdentity<'a> {
     PreservedEventId,
+    SentinelOneApplication,
     AwsPublicEndpoint(&'a str),
 }
 
 fn compatible_legacy_invalid_identity<'a>(
     event_id: &str,
+    tenant_id: &TenantId,
     source_id: &str,
     event_kind: &str,
     schema_ref: &str,
@@ -566,6 +588,11 @@ fn compatible_legacy_invalid_identity<'a>(
 ) -> Option<LegacyInvalidIdentity<'a>> {
     if event_id.is_empty() {
         return None;
+    }
+    if sentinelone_application_legacy_identity_is_safe(
+        event_id, tenant_id, source_id, event_kind, schema_ref, attributes, payload,
+    ) {
+        return Some(LegacyInvalidIdentity::SentinelOneApplication);
     }
     match (source_id, event_kind, schema_ref) {
         ("gcp", "gcp.iam_role_assignment", "gcp/iam_role_assignment/v1")
@@ -589,6 +616,140 @@ fn compatible_legacy_invalid_identity<'a>(
         }
         _ => None,
     }
+}
+
+fn sentinelone_application_legacy_identity_is_safe(
+    event_id: &str,
+    tenant_id: &TenantId,
+    source_id: &str,
+    event_kind: &str,
+    schema_ref: &str,
+    attributes: &HashMap<String, String>,
+    payload: &serde_json::Value,
+) -> bool {
+    if source_id != "sentinelone"
+        || event_kind != SENTINELONE_APPLICATION_KIND
+        || schema_ref != SENTINELONE_APPLICATION_SCHEMA_REF
+    {
+        return false;
+    }
+    let Some(tail) = event_id.strip_prefix(SENTINELONE_APPLICATION_EVENT_ID_PREFIX) else {
+        return false;
+    };
+    if event_id.len() > MAX_SENTINELONE_APPLICATION_EVENT_ID_BYTES
+        || tail.is_empty()
+        || tail.chars().any(char::is_control)
+        || attributes.get("family").map(String::as_str) != Some("application")
+    {
+        return false;
+    }
+
+    let Some(payload_agent_id) = sentinelone_payload_component(payload, "agent_id") else {
+        return false;
+    };
+    let Some(payload_tenant_host) = sentinelone_payload_component(payload, "tenant_host") else {
+        return false;
+    };
+    let Some(payload_name) = sentinelone_optional_payload_component(payload, "name") else {
+        return false;
+    };
+    let Some(payload_publisher) = sentinelone_optional_payload_component(payload, "publisher")
+    else {
+        return false;
+    };
+    let Some(payload_version) = sentinelone_optional_payload_component(payload, "version") else {
+        return false;
+    };
+    let Some(attribute_agent_id) = sentinelone_attribute_component(attributes, "agent_id") else {
+        return false;
+    };
+    let Some(attribute_tenant_host) = sentinelone_attribute_component(attributes, "tenant_host")
+    else {
+        return false;
+    };
+    let Some(attribute_name) =
+        sentinelone_optional_attribute_component(attributes, "application_name")
+    else {
+        return false;
+    };
+    let Some(attribute_publisher) =
+        sentinelone_optional_attribute_component(attributes, "publisher")
+    else {
+        return false;
+    };
+    let Some(attribute_version) = sentinelone_optional_attribute_component(attributes, "version")
+    else {
+        return false;
+    };
+    if payload_agent_id != attribute_agent_id
+        || payload_tenant_host != attribute_tenant_host
+        || payload_name != attribute_name
+        || payload_publisher != attribute_publisher
+        || payload_version != attribute_version
+        || payload_tenant_host != tenant_id.as_str()
+    {
+        return false;
+    }
+
+    let application_parts = [payload_publisher, payload_name, payload_version]
+        .into_iter()
+        .flatten()
+        .map(|value| value.replace(' ', "_"))
+        .collect::<Vec<_>>();
+    let application_id = if application_parts.is_empty() {
+        "unknown".to_owned()
+    } else {
+        application_parts.join("::")
+    };
+    let expected = format!(
+        "{SENTINELONE_APPLICATION_EVENT_ID_PREFIX}{payload_tenant_host}-{payload_agent_id}-{application_id}"
+    );
+    expected == event_id
+}
+
+fn sentinelone_payload_component<'a>(payload: &'a serde_json::Value, key: &str) -> Option<&'a str> {
+    sentinelone_optional_payload_component(payload, key)?
+        .as_ref()
+        .copied()
+}
+
+fn sentinelone_attribute_component<'a>(
+    attributes: &'a HashMap<String, String>,
+    key: &str,
+) -> Option<&'a str> {
+    sentinelone_optional_attribute_component(attributes, key)?
+        .as_ref()
+        .copied()
+}
+
+fn sentinelone_optional_payload_component<'a>(
+    payload: &'a serde_json::Value,
+    key: &str,
+) -> Option<Option<&'a str>> {
+    match payload.get(key) {
+        None => Some(None),
+        Some(value) => sentinelone_component_value(Some(value.as_str()?)),
+    }
+}
+
+fn sentinelone_optional_attribute_component<'a>(
+    attributes: &'a HashMap<String, String>,
+    key: &str,
+) -> Option<Option<&'a str>> {
+    match attributes.get(key) {
+        None => Some(None),
+        Some(value) => sentinelone_component_value(Some(value.as_str())),
+    }
+}
+
+fn sentinelone_component_value<'a>(value: Option<&'a str>) -> Option<Option<&'a str>> {
+    let value = value?.trim();
+    if value.is_empty() {
+        return Some(None);
+    }
+    (value.len() <= MAX_SENTINELONE_APPLICATION_COMPONENT_BYTES
+        && !value.chars().any(char::is_control))
+    .then_some(Some(value))
 }
 
 /// The Go producer derives these identities as
@@ -867,6 +1028,46 @@ mod tests {
         }
     }
 
+    fn sentinelone_application_wire(event_id: &str) -> CommittedSourceWire {
+        let mut wire = source_wire();
+        wire.id = event_id.to_owned();
+        wire.tenant_id = "sentinelone.example.test".to_owned();
+        wire.source_id = "sentinelone".to_owned();
+        wire.kind = "sentinelone.application_inventory".to_owned();
+        wire.schema_ref = "sentinelone/application_inventory/v1".to_owned();
+        wire.attributes = HashMap::from([
+            (
+                SOURCE_RUNTIME_ID_ATTRIBUTE.to_owned(),
+                "sentinelone-runtime".to_owned(),
+            ),
+            ("family".to_owned(), "application".to_owned()),
+            ("agent_id".to_owned(), "agent-fixture-1".to_owned()),
+            (
+                "tenant_host".to_owned(),
+                "sentinelone.example.test".to_owned(),
+            ),
+            ("application_name".to_owned(), "Example App".to_owned()),
+            ("publisher".to_owned(), "(Example Inc)".to_owned()),
+            ("version".to_owned(), "1.0.0".to_owned()),
+        ]);
+        wire.payload = serde_json::to_vec(&serde_json::json!({
+            "agent_id": "agent-fixture-1",
+            "tenant_host": "sentinelone.example.test",
+            "name": "Example App",
+            "publisher": "(Example Inc)",
+            "version": "1.0.0",
+            "installed_date": "2026-04-20T00:00:00Z",
+            "size_bytes": 12345,
+            "raw": {
+                "name": "Example App",
+                "publisher": "(Example Inc)",
+                "version": "1.0.0"
+            }
+        }))
+        .unwrap();
+        wire
+    }
+
     fn legacy_aws_endpoint_wire(identity: &str) -> CommittedSourceWire {
         let identity = identity.trim();
         let mut wire = source_wire();
@@ -916,6 +1117,174 @@ mod tests {
         assert_eq!(event.observed_at_unix_ms(), 1_720_000_000_123);
         assert_eq!(event.attributes()["provider_id"], "file-1");
         assert_eq!(event.payload()["name"], "board.pdf");
+    }
+
+    #[test]
+    fn sentinelone_legacy_application_identity_is_accepted() {
+        let id = "sentinelone-application-sentinelone.example.test-agent-fixture-1-(Example_Inc)::Example_App::1.0.0";
+        let event = CommittedSourceEvent::decode(&encode(sentinelone_application_wire(id)))
+            .expect("SentinelOne legacy application identity should decode")
+            .expect("source event");
+        assert!(event.observation_id().as_str().starts_with("compat:v1:"));
+    }
+
+    #[test]
+    fn sentinelone_parser_valid_application_identity_is_preserved() {
+        let id = "sentinelone-application-sentinelone.example.test-agent-fixture-1-Example_Inc::Example_App::1.0.0";
+        let event = CommittedSourceEvent::decode(&encode(sentinelone_application_wire(id)))
+            .expect("parser-valid SentinelOne identity should decode")
+            .expect("source event");
+        assert_eq!(event.observation_id().as_str(), id);
+    }
+
+    #[test]
+    fn sentinelone_legacy_application_identity_is_redelivery_stable_without_provenance() {
+        let id = "sentinelone-application-sentinelone.example.test-agent-fixture-1-(Example_Inc)::Example_App::1.0.0";
+        let wire = sentinelone_application_wire(id);
+        let first = CommittedSourceEvent::decode(&encode(wire.clone()))
+            .expect("first SentinelOne identity should decode")
+            .expect("source event");
+        let second = CommittedSourceEvent::decode(&encode(wire.clone()))
+            .expect("redelivery SentinelOne identity should decode")
+            .expect("source event");
+        assert_eq!(first.observation_id(), second.observation_id());
+
+        let mut delivery_variant = wire;
+        delivery_variant.attributes.insert(
+            SOURCE_RUNTIME_ID_ATTRIBUTE.to_owned(),
+            "sentinelone-runtime-retry".to_owned(),
+        );
+        delivery_variant.attributes.insert(
+            SOURCE_COLLECTION_ID_ATTRIBUTE.to_owned(),
+            "collection-retry".to_owned(),
+        );
+        let retry = CommittedSourceEvent::decode(&encode(delivery_variant))
+            .expect("delivery variant should decode")
+            .expect("source event");
+        assert_eq!(first.observation_id(), retry.observation_id());
+    }
+
+    fn assert_sentinelone_application_rejected(label: &str, wire: CommittedSourceWire) {
+        assert!(
+            matches!(
+                CommittedSourceEvent::decode(&encode(wire)),
+                Err(AppendLogDecodeError::InvalidModel(_))
+            ),
+            "{label}"
+        );
+    }
+
+    #[test]
+    fn sentinelone_legacy_application_identity_rejects_adjacent_and_malformed_contracts() {
+        let id = "sentinelone-application-sentinelone.example.test-agent-fixture-1-(Example_Inc)::Example_App::1.0.0";
+
+        let mut wrong_source = sentinelone_application_wire(id);
+        wrong_source.source_id = "other".to_owned();
+        wrong_source.kind = "other.application_inventory".to_owned();
+        wrong_source.schema_ref = "other/application_inventory/v1".to_owned();
+        assert_sentinelone_application_rejected("cross-source identity was accepted", wrong_source);
+
+        let mut wrong_kind = sentinelone_application_wire(id);
+        wrong_kind.kind = "sentinelone.threat".to_owned();
+        wrong_kind.schema_ref = "sentinelone/threat/v1".to_owned();
+        assert_sentinelone_application_rejected("cross-family identity was accepted", wrong_kind);
+
+        let mut wrong_schema = sentinelone_application_wire(id);
+        wrong_schema.schema_ref = "sentinelone/application_inventory/v2".to_owned();
+        assert_sentinelone_application_rejected("cross-schema identity was accepted", wrong_schema);
+
+        let mut bad_prefix = sentinelone_application_wire(id);
+        bad_prefix.id = id.replacen(
+            SENTINELONE_APPLICATION_EVENT_ID_PREFIX,
+            "sentinelone-app-",
+            1,
+        );
+        assert_sentinelone_application_rejected("bad producer prefix was accepted", bad_prefix);
+
+        let mut tenant_mismatch = sentinelone_application_wire(id);
+        tenant_mismatch.tenant_id = "other.example.test".to_owned();
+        assert_sentinelone_application_rejected("tenant mismatch was accepted", tenant_mismatch);
+
+        let mut attribute_mismatch = sentinelone_application_wire(id);
+        attribute_mismatch
+            .attributes
+            .insert("publisher".to_owned(), "Different Inc".to_owned());
+        assert_sentinelone_application_rejected(
+            "attribute/payload disagreement was accepted",
+            attribute_mismatch,
+        );
+
+        let mut agent_mismatch = sentinelone_application_wire(id);
+        agent_mismatch
+            .attributes
+            .insert("agent_id".to_owned(), "other-agent".to_owned());
+        assert_sentinelone_application_rejected(
+            "agent attribute/payload disagreement was accepted",
+            agent_mismatch,
+        );
+
+        let mut reconstructed_id_mismatch = sentinelone_application_wire(id);
+        reconstructed_id_mismatch.id =
+            "sentinelone-application-sentinelone.example.test-agent-fixture-1-(Example_Inc)::Other_App::1.0.0"
+                .to_owned();
+        assert_sentinelone_application_rejected(
+            "identity differing from the reconstructed Go ID was accepted",
+            reconstructed_id_mismatch,
+        );
+
+        let mut control_tail = sentinelone_application_wire(id);
+        control_tail.id =
+            "sentinelone-application-sentinelone.example.test-agent-fixture-1-(Example_\u{1})::Example_App::1.0.0"
+                .to_owned();
+        assert_sentinelone_application_rejected(
+            "control byte in legacy tail was accepted",
+            control_tail,
+        );
+
+        let mut overlong_tail = sentinelone_application_wire(id);
+        overlong_tail.id = format!("{id}{}", "x".repeat(256));
+        assert_sentinelone_application_rejected(
+            "overlong legacy identity was accepted",
+            overlong_tail,
+        );
+    }
+
+    #[test]
+    fn sentinelone_legacy_application_identity_mirrors_optional_go_application_id_parts() {
+        let id = "sentinelone-application-sentinelone.example.test-agent-fixture-1-unknown";
+        let mut wire = sentinelone_application_wire(id);
+        let mut payload: serde_json::Value = serde_json::from_slice(&wire.payload).unwrap();
+        for key in ["name", "publisher", "version"] {
+            payload.as_object_mut().unwrap().remove(key);
+        }
+        wire.payload = serde_json::to_vec(&payload).unwrap();
+        for key in ["application_name", "publisher", "version"] {
+            wire.attributes.remove(key);
+        }
+        let event = CommittedSourceEvent::decode(&encode(wire))
+            .expect("optional Go application ID parts should decode")
+            .expect("source event");
+        assert_eq!(event.observation_id().as_str(), id);
+    }
+
+    #[test]
+    fn sentinelone_legacy_application_identity_mirrors_one_optional_invalid_go_id_part() {
+        let id = "sentinelone-application-sentinelone.example.test-agent-fixture-1-(Example_App)";
+        let mut wire = sentinelone_application_wire(id);
+        wire.payload = serde_json::to_vec(&serde_json::json!({
+            "agent_id": "agent-fixture-1",
+            "tenant_host": "sentinelone.example.test",
+            "name": "(Example App)"
+        }))
+        .unwrap();
+        wire.attributes
+            .insert("application_name".to_owned(), "(Example App)".to_owned());
+        wire.attributes.remove("publisher");
+        wire.attributes.remove("version");
+        let event = CommittedSourceEvent::decode(&encode(wire))
+            .expect("one optional invalid Go ID part should decode")
+            .expect("source event");
+        assert!(event.observation_id().as_str().starts_with("compat:v1:"));
     }
 
     #[test]

--- a/crates/source-runtime-next/testdata/go_fixture_oracle.json
+++ b/crates/source-runtime-next/testdata/go_fixture_oracle.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "cerebro.source-fixture-parity.v2",
-  "corpus_revision": "E084007BD99F43D413587AEB4C28F1AD8D05D05270648B0C82EFA4996ED0EB1F",
+  "corpus_revision": "14682C4C785808497184A3B052ABCA748E61CFC2D36D913EDDFA253FBE6A187E",
   "cases": [
     {
       "source_id": "appwrite",
@@ -17163,6 +17163,97 @@
       },
       "go_page_digest_sha256": "C2B2C152FCAD1FCDDE538C395912D8681F75B8FE399E860B88777B775BD24B42",
       "oracle_digest_sha256": "8B1EFB7F7464B467CB0CD1A649E74BD8568319C5C33C7E5B7611BF8D44A328E1",
+      "offline_proof": "fixture_only_no_provider_network",
+      "provider_network_egress": false
+    },
+    {
+      "source_id": "sentinelone",
+      "family_id": "application",
+      "case_id": "list_applications",
+      "operation": "check",
+      "payload_sha256": "6e3cc6d669e892adc1da21c6189bb02596186e04de918b83e8cb26af2f780c3f",
+      "go_page": {
+        "source_id": "sentinelone",
+        "family_id": "application",
+        "case_id": "list_applications",
+        "operation": "check",
+        "accepted_events": [],
+        "quarantines": [],
+        "duplicates": [],
+        "scanned_count": 0,
+        "accepted_count": 0,
+        "rejected_count": 0,
+        "short_circuit_reasons": [
+          "check_only"
+        ]
+      },
+      "go_page_digest_sha256": "A00FD0ADC43EDADD0A894D7263261B4B394CA6A40E58FAA05E645B54808E7B01",
+      "oracle_digest_sha256": "64C790BACF4F746821788B6FCEABEEA350C7E13D227F7D241DBC199E43768A89",
+      "offline_proof": "fixture_only_no_provider_network",
+      "provider_network_egress": false
+    },
+    {
+      "source_id": "sentinelone",
+      "family_id": "application",
+      "case_id": "list_applications",
+      "operation": "discover",
+      "payload_sha256": "6e3cc6d669e892adc1da21c6189bb02596186e04de918b83e8cb26af2f780c3f",
+      "go_page": {
+        "source_id": "sentinelone",
+        "family_id": "application",
+        "case_id": "list_applications",
+        "operation": "discover",
+        "accepted_events": [
+          {
+            "event_id": "E29DEB53A45F8A9DE1541DB853AC81AEFB8BF2510ACB13C15ACBF7A7443755DB",
+            "kind": "sentinelone.application",
+            "input_index": 0,
+            "payload_sha256": "3430D09AD722DEE057622A75EB359A35B198F766999190B1B53FCCED9309A88E"
+          }
+        ],
+        "quarantines": [],
+        "duplicates": [],
+        "scanned_count": 1,
+        "accepted_count": 1,
+        "rejected_count": 0,
+        "proposed_checkpoint": "606C3B1B1ACBC06248DB6D74F13F9F1A3585BF175608E4B33F58865821310E96"
+      },
+      "go_page_digest_sha256": "47FC02C3440291200C113A7955DBEF3EB342F295AF55040C3598C0BC744A423F",
+      "oracle_digest_sha256": "C13CF3994434F43B03581E7F4102192552C072F926355E5D08AF54705C82BB39",
+      "offline_proof": "fixture_only_no_provider_network",
+      "provider_network_egress": false
+    },
+    {
+      "source_id": "sentinelone",
+      "family_id": "application",
+      "case_id": "list_applications",
+      "operation": "read-page",
+      "payload_sha256": "6e3cc6d669e892adc1da21c6189bb02596186e04de918b83e8cb26af2f780c3f",
+      "go_page": {
+        "source_id": "sentinelone",
+        "family_id": "application",
+        "case_id": "list_applications",
+        "operation": "read-page",
+        "accepted_events": [
+          {
+            "event_id": "C72B338F4B1728440E548DCAFDAD25C888CA55E1F84D2529E5F55A8B8348601C",
+            "kind": "sentinelone.application",
+            "input_index": 0,
+            "payload_sha256": "4BC0164B9F0161752AFDC888928FC1DAEF375366D3446CF3C80B32EDCE81F1E5"
+          }
+        ],
+        "quarantines": [],
+        "duplicates": [],
+        "scanned_count": 1,
+        "accepted_count": 1,
+        "rejected_count": 0,
+        "proposed_checkpoint": "1990AD68EEBB8F1A03A16752871713CF8BB3A2EFEFB0A955355CB53A871614C5",
+        "short_circuit_reasons": [
+          "final_page"
+        ]
+      },
+      "go_page_digest_sha256": "83B8B717AB0670396A1660DFCB4D4BC4782F036FB1B3687CC21F6F90253DEA2F",
+      "oracle_digest_sha256": "49FE763A5FD2A5FCEE8334E79005118251936D119881FCDEBE50ED5E99BF6334",
       "offline_proof": "fixture_only_no_provider_network",
       "provider_network_egress": false
     },

--- a/sources/sentinelone/provider_fixture_test.go
+++ b/sources/sentinelone/provider_fixture_test.go
@@ -1,0 +1,101 @@
+package sentinelone
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcefixture"
+)
+
+func TestSourceReplaysRepositorySentinelOneApplication(t *testing.T) {
+	bundle, err := sourcefixture.FindBundle("../..", "sentinelone", familyApplication, "list_applications")
+	if err != nil {
+		t.Fatalf("FindBundle() error = %v", err)
+	}
+	fixtureRequest, err := url.Parse(bundle.Manifest.Request.URL)
+	if err != nil {
+		t.Fatalf("parse fixture request URL: %v", err)
+	}
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "ApiToken "+fixtureToken {
+			t.Fatalf("Authorization = %q, want replay token", got)
+		}
+		if r.Host != fixtureRequest.Host || r.Method != http.MethodGet || r.URL.EscapedPath() != fixtureRequest.EscapedPath() || r.URL.Query().Get("ids") != fixtureRequest.Query().Get("ids") {
+			t.Fatalf("unexpected SentinelOne replay request %s %s", r.Method, r.URL.RequestURI())
+		}
+		w.Header().Set("Content-Type", bundle.Manifest.Response.ContentType)
+		w.WriteHeader(bundle.Manifest.Response.Status)
+		_, _ = w.Write(bundle.Payload)
+	}))
+	defer server.Close()
+	transport := server.Client().Transport.(*http.Transport).Clone()
+	certificate := server.Certificate()
+	if certificate == nil || len(certificate.DNSNames) == 0 {
+		t.Fatal("TLS test server did not provide a DNS certificate identity")
+	}
+	tlsConfig := transport.TLSClientConfig
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	} else {
+		tlsConfig = tlsConfig.Clone()
+	}
+	tlsConfig.ServerName = certificate.DNSNames[0]
+	transport.TLSClientConfig = tlsConfig
+	dialer := &net.Dialer{}
+	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return dialer.DialContext(ctx, network, server.Listener.Addr().String())
+	}
+	source.client = &http.Client{Transport: transport}
+	source.lookupIPAddrs = func(context.Context, string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("203.0.113.10")}}, nil
+	}
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url": fixtureBaseURL,
+		"family":   familyApplication,
+		"token":    fixtureToken,
+		"agent_id": fixtureRequest.Query().Get("ids"),
+	})
+	pull, err := source.Read(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("Read() returned %d events, want 1", len(pull.Events))
+	}
+	event := pull.Events[0]
+	if event.Kind != "sentinelone.application_inventory" {
+		t.Fatalf("event kind = %q, want sentinelone.application_inventory", event.Kind)
+	}
+	if event.SchemaRef != "sentinelone/application_inventory/v1" {
+		t.Fatalf("event schema = %q, want sentinelone/application_inventory/v1", event.SchemaRef)
+	}
+	if event.Attributes["family"] != familyApplication || event.Attributes["agent_id"] != "agent-fixture-1" {
+		t.Fatalf("event attributes = %#v, want application family and agent identity", event.Attributes)
+	}
+	urns, err := source.Discover(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if len(urns) != 1 {
+		t.Fatalf("Discover() returned %d URNs, want 1 agent scope", len(urns))
+	}
+	if err := sourcefixture.CompareOrUpdateSourceOutputs(".", familyApplication, pull.Events, urns, updateSentinelOneFixtures()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func updateSentinelOneFixtures() bool {
+	return strings.TrimSpace(os.Getenv("CEREBRO_UPDATE_SOURCE_FIXTURES")) == "1"
+}

--- a/sources/sentinelone/testdata/api/application/list_applications/provenance.yaml
+++ b/sources/sentinelone/testdata/api/application/list_applications/provenance.yaml
@@ -1,0 +1,31 @@
+# Schema-derived repository fixture; this is not a provider capture.
+schema_version: cerebro.source-api-fixture.v1
+source_id: sentinelone
+family: application
+case: list_applications
+replay_test: provider_fixture_test.go#TestSourceReplaysRepositorySentinelOneApplication
+request:
+    method: GET
+    url: https://sentinelone.example.test/web/api/v2.1/agents/applications?ids=agent-fixture-1
+response:
+    status: 200
+    content_type: application/json
+    captured_at: "2026-08-20T11:02:58Z"
+    sha256: 6e3cc6d669e892adc1da21c6189bb02596186e04de918b83e8cb26af2f780c3f
+sanitization:
+    tool: sourcefixture
+    version: 1
+    changed_fields:
+        - $request.method
+        - $request.url
+        - $.data
+        - $.data[0].name
+        - $.data[0].publisher
+        - $.data[0].version
+        - $.data[0].installedDate
+        - $.data[0].size
+        - $response.status
+        - $response.content_type
+        - $response.captured_at
+origin:
+    type: operator_request

--- a/sources/sentinelone/testdata/api/application/list_applications/response.json
+++ b/sources/sentinelone/testdata/api/application/list_applications/response.json
@@ -1,0 +1,11 @@
+{
+  "data": [
+    {
+      "installedDate": "2026-04-20T00:00:00Z",
+      "name": "Example App",
+      "publisher": "Example Inc",
+      "size": 12345,
+      "version": "1.0.0"
+    }
+  ]
+}

--- a/sources/sentinelone/testdata/read_application.json
+++ b/sources/sentinelone/testdata/read_application.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "sentinelone-application-sentinelone.example.test-agent-fixture-1-Example_Inc::Example_App",
+    "id": "sentinelone-application-sentinelone.example.test-agent-fixture-1-Example_Inc::Example_App::1.0.0",
     "tenant_id": "sentinelone.example.test",
     "source_id": "sentinelone",
     "kind": "sentinelone.application_inventory",
@@ -14,7 +14,13 @@
       "version": "1.0.0",
       "installed_date": "2026-04-20T00:00:00Z",
       "size_bytes": 12345,
-      "raw": {}
+      "raw": {
+        "installedDate": "2026-04-20T00:00:00Z",
+        "name": "Example App",
+        "publisher": "Example Inc",
+        "size": 12345,
+        "version": "1.0.0"
+      }
     },
     "attributes": {
       "agent_id": "agent-fixture-1",


### PR DESCRIPTION
## Summary

- Add a schema-derived, non-capture SentinelOne application fixture with neutral `operator_request` provenance.
- Regenerate the owning Go fixture oracle for the current SentinelOne application contract.
- Add parse-first, exact contract-gated Rust compatibility for legacy invalid observation IDs, with boundary and negative tests.

## Focused validation

- `go run ./tools/sourcefixture verify -root .`
- `go test ./sources/sentinelone -run TestSourceReplaysRepositorySentinelOneApplication -count=1`
- `go test ./internal/sourceruntime -run TestRustFixtureParityGoOracleArtifactMatchesCurrentOracle -count=1`
- `cargo test -p cerebro-source-runtime-next sentinelone_ -- --nocapture`
- `cargo test -p cerebro-source-runtime-next fixture_parity_matches_checked_in_corpus -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
