### PR TITLE
feat(rust): refresh OAuth authorization-code sources

### DIFF
--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -75,8 +75,8 @@ use cerebro_security_lifecycle::{
     project_observation, query_records_with_source,
 };
 use cerebro_source_catalog::{
-    AuthModel, CatalogSummary, CompiledOauthClientCredentials, CompiledSource, ProjectionClass,
-    SourceCatalog,
+    AuthModel, CatalogSummary, CompiledOauthAuthorizationCode, CompiledOauthClientCredentials,
+    CompiledSource, ProjectionClass, SourceCatalog,
 };
 use cerebro_source_runtime_next::{
     AwsSecretReadError, AwsSecretReader, AwsSecretValue, CatalogGraphMapper, CollectionRequest,
@@ -1847,6 +1847,7 @@ struct CatalogAuthSettings {
     header_parameters: BTreeMap<String, String>,
     query_parameters: BTreeMap<String, String>,
     json_body_parameters: BTreeMap<String, String>,
+    oauth_authorization_code: Option<CompiledOauthAuthorizationCode>,
     oauth_client_credentials: Option<CompiledOauthClientCredentials>,
 }
 
@@ -1858,6 +1859,7 @@ impl CatalogAuthSettings {
             header_parameters: source.auth_header_parameters().clone(),
             query_parameters: source.auth_query_parameters().clone(),
             json_body_parameters: source.auth_json_body_parameters().clone(),
+            oauth_authorization_code: source.oauth_authorization_code().cloned(),
             oauth_client_credentials: source.oauth_client_credentials().cloned(),
         }
     }
@@ -1874,6 +1876,7 @@ fn resolved_auth(
         header_parameters,
         query_parameters,
         json_body_parameters,
+        oauth_authorization_code,
         oauth_client_credentials,
     } = settings;
     Ok(match model {
@@ -1938,6 +1941,46 @@ fn resolved_auth(
                 scope_separator: oauth.scope_separator().to_owned(),
                 token_request_auth_method: oauth.token_request_auth_method().to_owned(),
                 token_params,
+            }
+        }
+        AuthModel::OauthAuthorizationCode => {
+            if let Some(token) = take_first_config(
+                config,
+                &["token", "access_token", "api_token", "bearer_token"],
+            ) {
+                for key in [
+                    "token",
+                    "access_token",
+                    "api_token",
+                    "bearer_token",
+                    "client_id",
+                    "client_secret",
+                    "refresh_token",
+                    "oauth_client_reference",
+                ] {
+                    discard_config_secret(config, key);
+                }
+                ResolvedAuth::Bearer { token }
+            } else {
+                let oauth = oauth_authorization_code
+                    .as_ref()
+                    .ok_or("source catalog OAuth authorization-code settings are missing")?;
+                let token_url = resolve_oauth_token_url(oauth.token_url(), config)?;
+                let mut token_params = BTreeMap::new();
+                for (key, value) in oauth.token_params() {
+                    token_params.insert(key.clone(), render_source_config_template(value, config)?);
+                }
+                discard_config_secret(config, "oauth_client_reference");
+                ResolvedAuth::OauthAuthorizationCode {
+                    client_id: take_required_config(config, "client_id")?,
+                    client_secret: take_required_config(config, "client_secret")?,
+                    refresh_token: take_required_config(config, "refresh_token")?,
+                    token_url,
+                    scopes: oauth.scopes().to_vec(),
+                    scope_separator: oauth.scope_separator().to_owned(),
+                    token_request_auth_method: oauth.token_request_auth_method().to_owned(),
+                    token_params,
+                }
             }
         }
         AuthModel::DuoHmac | AuthModel::Signature => {
@@ -2066,6 +2109,21 @@ fn take_first_required_config(
             .join(", ")
     )
     .into())
+}
+
+fn take_first_config(config: &mut BTreeMap<String, String>, keys: &[&str]) -> Option<String> {
+    for key in keys {
+        if let Some(value) = remove_nonempty(config, key) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn discard_config_secret(config: &mut BTreeMap<String, String>, key: &str) {
+    if let Some(mut value) = config.remove(key) {
+        value.zeroize();
+    }
 }
 
 fn remove_nonempty(config: &mut BTreeMap<String, String>, key: &str) -> Option<String> {
@@ -4525,6 +4583,64 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn oauth_authorization_code_resolution_refreshes_or_uses_a_resolved_bearer() {
+        let catalog = load_catalog().unwrap();
+        let source = catalog.get("hubspot").unwrap();
+        let mut refresh = BTreeMap::from([
+            ("client_id".to_owned(), "client-example".to_owned()),
+            ("client_secret".to_owned(), "credential-example".to_owned()),
+            ("refresh_token".to_owned(), "refresh-example".to_owned()),
+            ("base_url".to_owned(), "https://api.hubapi.com".to_owned()),
+            ("family".to_owned(), "users".to_owned()),
+        ]);
+        let auth = resolved_auth(
+            source.auth(),
+            CatalogAuthSettings::from_source(source),
+            &mut refresh,
+        )
+        .unwrap();
+        assert!(matches!(
+            auth,
+            ResolvedAuth::OauthAuthorizationCode {
+                ref client_id,
+                ref client_secret,
+                ref refresh_token,
+                ref token_url,
+                ..
+            } if client_id == "client-example"
+                && client_secret == "credential-example"
+                && refresh_token == "refresh-example"
+                && token_url == "https://api.hubapi.com/oauth/token"
+        ));
+        for secret_key in ["client_id", "client_secret", "refresh_token"] {
+            assert!(!refresh.contains_key(secret_key));
+        }
+        assert_eq!(refresh.get("family").map(String::as_str), Some("users"));
+
+        let referenced = catalog.get("drchrono").unwrap();
+        let mut bearer = BTreeMap::from([
+            ("access_token".to_owned(), "access-example".to_owned()),
+            (
+                "oauth_client_reference".to_owned(),
+                "managed-client-example".to_owned(),
+            ),
+            ("base_url".to_owned(), "https://drchrono.com".to_owned()),
+            ("family".to_owned(), "patients".to_owned()),
+        ]);
+        assert!(matches!(
+            resolved_auth(
+                referenced.auth(),
+                CatalogAuthSettings::from_source(referenced),
+                &mut bearer,
+            )
+            .unwrap(),
+            ResolvedAuth::Bearer { ref token } if token == "access-example"
+        ));
+        assert!(!bearer.contains_key("access_token"));
+        assert!(!bearer.contains_key("oauth_client_reference"));
     }
 
     #[test]

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -341,9 +341,41 @@ pub struct CompiledSource {
     auth_header_parameters: BTreeMap<String, String>,
     auth_query_parameters: BTreeMap<String, String>,
     auth_json_body_parameters: BTreeMap<String, String>,
+    oauth_authorization_code: Option<CompiledOauthAuthorizationCode>,
     oauth_client_credentials: Option<CompiledOauthClientCredentials>,
     authority: CollectionAuthority,
     families: Vec<CompiledFamily>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompiledOauthAuthorizationCode {
+    token_url: String,
+    scopes: Vec<String>,
+    scope_separator: String,
+    token_request_auth_method: String,
+    token_params: BTreeMap<String, String>,
+}
+
+impl CompiledOauthAuthorizationCode {
+    pub fn token_url(&self) -> &str {
+        &self.token_url
+    }
+
+    pub fn scopes(&self) -> &[String] {
+        &self.scopes
+    }
+
+    pub fn scope_separator(&self) -> &str {
+        &self.scope_separator
+    }
+
+    pub fn token_request_auth_method(&self) -> &str {
+        &self.token_request_auth_method
+    }
+
+    pub fn token_params(&self) -> &BTreeMap<String, String> {
+        &self.token_params
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -412,6 +444,10 @@ impl CompiledSource {
 
     pub fn oauth_client_credentials(&self) -> Option<&CompiledOauthClientCredentials> {
         self.oauth_client_credentials.as_ref()
+    }
+
+    pub fn oauth_authorization_code(&self) -> Option<&CompiledOauthAuthorizationCode> {
+        self.oauth_authorization_code.as_ref()
     }
 
     pub fn authority(&self) -> CollectionAuthority {
@@ -748,6 +784,8 @@ struct AuthWire {
     #[serde(default)]
     token_url: String,
     #[serde(default)]
+    refresh_url: String,
+    #[serde(default)]
     scopes: Vec<String>,
     #[serde(default)]
     scope_separator: String,
@@ -908,6 +946,7 @@ fn compile_source(
         .iter()
         .map(|field| field.key.trim())
         .collect::<BTreeSet<_>>();
+    let oauth_authorization_code = compile_oauth_authorization_code(path, &entry.definition.auth)?;
     let oauth_client_credentials =
         compile_oauth_client_credentials(path, &entry.definition.auth, &credential_fields)?;
     let mut auth_header_parameters = BTreeMap::new();
@@ -1093,10 +1132,83 @@ fn compile_source(
         auth_header_parameters,
         auth_query_parameters,
         auth_json_body_parameters,
+        oauth_authorization_code,
         oauth_client_credentials,
         authority,
         families,
     })
+}
+
+fn compile_oauth_authorization_code(
+    path: &Path,
+    auth: &AuthWire,
+) -> Result<Option<CompiledOauthAuthorizationCode>, CatalogError> {
+    if auth.model.trim() != "oauth_authorization_code" {
+        return Ok(None);
+    }
+    let token_url = if auth.refresh_url.trim().is_empty() {
+        auth.token_url.trim()
+    } else {
+        auth.refresh_url.trim()
+    };
+    if token_url.is_empty() || token_url.len() > 2_048 || token_url.chars().any(char::is_control) {
+        return invalid(path, "oauth_authorization_code token_url is invalid");
+    }
+    let token_request_auth_method = match auth.token_request_auth_method.trim() {
+        "" | "client_secret_post" => "client_secret_post",
+        "client_secret_basic" | "basic" => "client_secret_basic",
+        _ => {
+            return invalid(
+                path,
+                "oauth_authorization_code token request auth method is invalid",
+            );
+        }
+    };
+    let scope_separator = if auth.scope_separator.is_empty() {
+        " "
+    } else {
+        auth.scope_separator.as_str()
+    };
+    if scope_separator.len() > 16 || scope_separator.chars().any(char::is_control) {
+        return invalid(path, "oauth_authorization_code scope separator is invalid");
+    }
+    let scopes = auth
+        .scopes
+        .iter()
+        .map(|scope| scope.trim())
+        .filter(|scope| !scope.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    if scopes.len() > 128
+        || scopes
+            .iter()
+            .any(|scope| scope.len() > 512 || scope.chars().any(char::is_control))
+    {
+        return invalid(path, "oauth_authorization_code scopes are invalid");
+    }
+    if auth.token_params.len() > 32
+        || auth.token_params.iter().any(|(key, value)| {
+            key.is_empty()
+                || key.len() > 128
+                || !key
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+                || value.len() > 2_048
+                || value.chars().any(char::is_control)
+        })
+    {
+        return invalid(
+            path,
+            "oauth_authorization_code token parameters are invalid",
+        );
+    }
+    Ok(Some(CompiledOauthAuthorizationCode {
+        token_url: token_url.to_owned(),
+        scopes,
+        scope_separator: scope_separator.to_owned(),
+        token_request_auth_method: token_request_auth_method.to_owned(),
+        token_params: auth.token_params.clone(),
+    }))
 }
 
 fn compile_oauth_client_credentials(
@@ -2572,6 +2684,59 @@ mod tests {
             Some("https://${config.domain}/api/v2/")
         );
         assert!(oauth.scopes().contains(&"read:users".to_owned()));
+    }
+
+    #[test]
+    fn oauth_authorization_code_contract_is_compiled_for_every_catalog_source() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let actual = catalog
+            .sources()
+            .filter(|source| source.oauth_authorization_code().is_some())
+            .map(CompiledSource::id)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual,
+            vec![
+                "azure_devops",
+                "bitbucket_cloud",
+                "dracoon",
+                "drchrono",
+                "dropbox_business",
+                "google_drive",
+                "hubspot",
+                "miro",
+                "runscope",
+                "salesforce",
+                "servicenow",
+                "signl4",
+                "slack",
+                "square",
+            ]
+        );
+        let drchrono = catalog
+            .get("drchrono")
+            .unwrap()
+            .oauth_authorization_code()
+            .unwrap();
+        assert_eq!(drchrono.token_url(), "https://drchrono.com/o/token/");
+        assert_eq!(drchrono.token_request_auth_method(), "client_secret_basic");
+        assert!(drchrono.scopes().contains(&"patients:read".to_owned()));
+        assert_eq!(drchrono.scope_separator(), " ");
+        assert!(drchrono.token_params().is_empty());
+        assert_eq!(
+            catalog
+                .get("signl4")
+                .unwrap()
+                .oauth_authorization_code()
+                .unwrap()
+                .token_url(),
+            "https://connect.signl4.com/identity/connect/token"
+        );
     }
 
     #[test]

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -84,6 +84,25 @@ pub enum ResolvedAuth {
         /// Additional provider-declared token form parameters.
         token_params: BTreeMap<String, String>,
     },
+    /// Refresh an OAuth authorization-code grant before provider reads.
+    OauthAuthorizationCode {
+        /// OAuth client identifier.
+        client_id: String,
+        /// OAuth client secret.
+        client_secret: String,
+        /// Provider-issued refresh token.
+        refresh_token: String,
+        /// Fully rendered provider token endpoint.
+        token_url: String,
+        /// Requested OAuth scopes.
+        scopes: Vec<String>,
+        /// Provider scope separator.
+        scope_separator: String,
+        /// Client authentication method for the token request.
+        token_request_auth_method: String,
+        /// Additional provider-declared token form parameters.
+        token_params: BTreeMap<String, String>,
+    },
     /// Send HTTP Basic credentials.
     Basic {
         /// Basic-auth username.
@@ -160,6 +179,27 @@ impl fmt::Debug for ResolvedAuth {
                     &token_params.keys().collect::<Vec<_>>(),
                 )
                 .finish(),
+            Self::OauthAuthorizationCode {
+                token_url,
+                scopes,
+                scope_separator,
+                token_request_auth_method,
+                token_params,
+                ..
+            } => formatter
+                .debug_struct("OauthAuthorizationCode")
+                .field("client_id", &"[REDACTED]")
+                .field("client_secret", &"[REDACTED]")
+                .field("refresh_token", &"[REDACTED]")
+                .field("token_url", token_url)
+                .field("scopes", scopes)
+                .field("scope_separator", scope_separator)
+                .field("token_request_auth_method", token_request_auth_method)
+                .field(
+                    "token_param_names",
+                    &token_params.keys().collect::<Vec<_>>(),
+                )
+                .finish(),
             Self::Basic { .. } => {
                 formatter.write_str("Basic { username: [REDACTED], password: [REDACTED] }")
             }
@@ -220,6 +260,20 @@ impl Drop for ResolvedAuth {
                     value.zeroize();
                 }
             }
+            Self::OauthAuthorizationCode {
+                client_id,
+                client_secret,
+                refresh_token,
+                token_params,
+                ..
+            } => {
+                client_id.zeroize();
+                client_secret.zeroize();
+                refresh_token.zeroize();
+                for value in token_params.values_mut() {
+                    value.zeroize();
+                }
+            }
             Self::Basic { username, password } => {
                 username.zeroize();
                 password.zeroize();
@@ -265,7 +319,8 @@ impl ResolvedAuth {
     /// Token endpoint that must be included in the exact provider egress allowlist.
     pub fn oauth_token_url(&self) -> Option<&str> {
         match self {
-            Self::OauthClientCredentials { token_url, .. } => Some(token_url),
+            Self::OauthClientCredentials { token_url, .. }
+            | Self::OauthAuthorizationCode { token_url, .. } => Some(token_url),
             _ => None,
         }
     }
@@ -744,7 +799,7 @@ impl SourceConnector for HttpSourceConnector {
     async fn collect(&mut self, request: CollectionRequest) -> Result<CollectedBatch, Self::Error> {
         let observed_at = unix_millis()?;
         let _lease_scope = self.validate_provider_access(&request)?;
-        let oauth_access_token = self.exchange_oauth_client_credentials().await?;
+        let oauth_access_token = self.exchange_oauth_token().await?;
         let request_scopes = self.request_scopes()?;
         let initial_cursor = effective_cursor(self.family.pagination(), request.cursor.as_deref());
         if request.cursor.is_some() && request_scopes.len() > 1 {
@@ -793,6 +848,13 @@ impl SourceConnector for HttpSourceConnector {
                         builder.bearer_auth(oauth_access_token.as_deref().ok_or_else(|| {
                             HttpConnectorError::InvalidConfiguration(
                                 "OAuth client-credentials token is unavailable".to_owned(),
+                            )
+                        })?)
+                    }
+                    ResolvedAuth::OauthAuthorizationCode { .. } => {
+                        builder.bearer_auth(oauth_access_token.as_deref().ok_or_else(|| {
+                            HttpConnectorError::InvalidConfiguration(
+                                "OAuth authorization-code token is unavailable".to_owned(),
                             )
                         })?)
                     }
@@ -1000,11 +1062,12 @@ impl Drop for OauthTokenResponse {
 }
 
 impl HttpSourceConnector {
-    async fn exchange_oauth_client_credentials(
+    async fn exchange_oauth_token(
         &mut self,
     ) -> Result<Option<Zeroizing<String>>, HttpConnectorError> {
         let token_url = match &self.auth {
-            ResolvedAuth::OauthClientCredentials { token_url, .. } => Url::parse(token_url)
+            ResolvedAuth::OauthClientCredentials { token_url, .. }
+            | ResolvedAuth::OauthAuthorizationCode { token_url, .. } => Url::parse(token_url)
                 .map_err(|_| {
                     HttpConnectorError::InvalidConfiguration(
                         "OAuth token URL is invalid".to_owned(),
@@ -1013,20 +1076,59 @@ impl HttpSourceConnector {
             _ => return Ok(None),
         };
         self.authorize_provider_url(&token_url)?;
-        let ResolvedAuth::OauthClientCredentials {
+        let (
             client_id,
             client_secret,
+            refresh_token,
             scopes,
             scope_separator,
             token_request_auth_method,
             token_params,
-            ..
-        } = &self.auth
-        else {
-            return Ok(None);
+        ) = match &self.auth {
+            ResolvedAuth::OauthClientCredentials {
+                client_id,
+                client_secret,
+                scopes,
+                scope_separator,
+                token_request_auth_method,
+                token_params,
+                ..
+            } => (
+                client_id,
+                client_secret,
+                None,
+                scopes,
+                scope_separator,
+                token_request_auth_method,
+                token_params,
+            ),
+            ResolvedAuth::OauthAuthorizationCode {
+                client_id,
+                client_secret,
+                refresh_token,
+                scopes,
+                scope_separator,
+                token_request_auth_method,
+                token_params,
+                ..
+            } => (
+                client_id,
+                client_secret,
+                Some(refresh_token),
+                scopes,
+                scope_separator,
+                token_request_auth_method,
+                token_params,
+            ),
+            _ => return Ok(None),
         };
         let mut form = token_params.clone();
-        form.insert("grant_type".to_owned(), "client_credentials".to_owned());
+        if let Some(refresh_token) = refresh_token {
+            form.insert("grant_type".to_owned(), "refresh_token".to_owned());
+            form.insert("refresh_token".to_owned(), refresh_token.clone());
+        } else {
+            form.insert("grant_type".to_owned(), "client_credentials".to_owned());
+        }
         let scope = scopes.join(scope_separator);
         if !scope.trim().is_empty() {
             form.insert("scope".to_owned(), scope);
@@ -1182,10 +1284,7 @@ fn validate_auth(source: &CompiledSource, actual: &ResolvedAuth) -> Result<(), H
             }
             _ => false,
         },
-        AuthModel::BearerToken
-        | AuthModel::OauthAuthorizationCode
-        | AuthModel::TwoStep
-        | AuthModel::Jwt => matches!(
+        AuthModel::BearerToken | AuthModel::TwoStep | AuthModel::Jwt => matches!(
             actual,
             ResolvedAuth::Bearer { .. } | ResolvedAuth::Header { .. }
         ),
@@ -1193,6 +1292,12 @@ fn validate_auth(source: &CompiledSource, actual: &ResolvedAuth) -> Result<(), H
             matches!(
                 actual,
                 ResolvedAuth::OauthClientCredentials { .. } | ResolvedAuth::Bearer { .. }
+            )
+        }
+        AuthModel::OauthAuthorizationCode => {
+            matches!(
+                actual,
+                ResolvedAuth::OauthAuthorizationCode { .. } | ResolvedAuth::Bearer { .. }
             )
         }
         AuthModel::AwsSigV4 => matches!(actual, ResolvedAuth::AwsSigV4 { .. }),
@@ -2297,13 +2402,94 @@ mod tests {
             "box-prod",
             &base_url,
         );
-        let token = connector
-            .exchange_oauth_client_credentials()
-            .await
-            .unwrap()
-            .unwrap();
+        let token = connector.exchange_oauth_token().await.unwrap().unwrap();
         assert_eq!(token.as_str(), "oauth-token-example");
         server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn oauth_authorization_code_refresh_is_egress_scoped_and_redacted() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let count = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..count]);
+            assert!(request.starts_with("POST /oauth/token HTTP/1.1"));
+            assert!(
+                request
+                    .contains("authorization: Basic Y2xpZW50LWV4YW1wbGU6Y3JlZGVudGlhbC1leGFtcGxl")
+            );
+            assert!(request.contains("grant_type=refresh_token"));
+            assert!(request.contains("refresh_token=refresh-example"));
+            assert!(request.contains("client_id=client-example"));
+            assert!(!request.contains("client_secret=credential-example"));
+            assert!(request.contains("scope=read%3Ausers+read%3Agroups"));
+            let body = r#"{"access_token":"oauth-token-example","token_type":"Bearer"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let base_url = format!("http://{address}");
+        let root = repository_root();
+        let source = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap()
+        .get("hubspot")
+        .unwrap()
+        .clone();
+        let auth = ResolvedAuth::OauthAuthorizationCode {
+            client_id: "client-example".to_owned(),
+            client_secret: "credential-example".to_owned(),
+            refresh_token: "refresh-example".to_owned(),
+            token_url: format!("{base_url}/oauth/token"),
+            scopes: vec!["read:users".to_owned(), "read:groups".to_owned()],
+            scope_separator: " ".to_owned(),
+            token_request_auth_method: "client_secret_basic".to_owned(),
+            token_params: BTreeMap::new(),
+        };
+        let debug = format!("{auth:?}");
+        for secret in ["client-example", "credential-example", "refresh-example"] {
+            assert!(!debug.contains(secret));
+        }
+        let mut connector = with_test_provider_access(
+            HttpSourceConnector::new(source.clone(), "users", &base_url, BTreeMap::new(), auth)
+                .unwrap(),
+            "tenant-a",
+            "hubspot-prod",
+            &base_url,
+        );
+        let token = connector.exchange_oauth_token().await.unwrap().unwrap();
+        assert_eq!(token.as_str(), "oauth-token-example");
+        server.await.unwrap();
+
+        let denied_auth = ResolvedAuth::OauthAuthorizationCode {
+            client_id: "client-example".to_owned(),
+            client_secret: "credential-example".to_owned(),
+            refresh_token: "refresh-example".to_owned(),
+            token_url: "http://127.0.0.1:1/oauth/token".to_owned(),
+            scopes: Vec::new(),
+            scope_separator: " ".to_owned(),
+            token_request_auth_method: "client_secret_post".to_owned(),
+            token_params: BTreeMap::new(),
+        };
+        let mut denied = with_test_provider_access(
+            HttpSourceConnector::new(source, "users", &base_url, BTreeMap::new(), denied_auth)
+                .unwrap(),
+            "tenant-a",
+            "hubspot-prod",
+            &base_url,
+        );
+        assert!(matches!(
+            denied.exchange_oauth_token().await,
+            Err(HttpConnectorError::EgressDenied(_))
+        ));
     }
 
     #[test]

--- a/scripts/changed_checks.py
+++ b/scripts/changed_checks.py
@@ -92,6 +92,50 @@ def select_commands(files: list[str], repo: Path) -> list[CommandPlan]:
     if packages:
         add_command(commands, seen, "go-test-changed-packages", ["go", "test", *packages, "-count=1"], "Go package files changed.")
 
+    source_runtime_crates = (
+        "crates/cerebro-platform/",
+        "crates/source-catalog/",
+        "crates/source-runtime-next/",
+    )
+    if any(path.startswith(source_runtime_crates) for path in files):
+        rust_packages = (
+            "cerebro-platform",
+            "cerebro-source-catalog",
+            "cerebro-source-runtime-next",
+        )
+        package_args = [argument for package in rust_packages for argument in ("-p", package)]
+        add_command(
+            commands,
+            seen,
+            "rust-source-runtime-fmt",
+            ["cargo", "fmt", "--all", "--", "--check"],
+            "Rust source catalog, runtime, or platform code changed.",
+        )
+        add_command(
+            commands,
+            seen,
+            "rust-source-runtime-test",
+            ["cargo", "test", "--locked", *package_args],
+            "Rust source catalog, runtime, or platform code changed.",
+        )
+        add_command(
+            commands,
+            seen,
+            "rust-source-runtime-clippy",
+            [
+                "cargo",
+                "clippy",
+                "--locked",
+                *package_args,
+                "--all-targets",
+                "--all-features",
+                "--",
+                "-D",
+                "warnings",
+            ],
+            "Rust source catalog, runtime, or platform code changed.",
+        )
+
     if any(path_matches(path, prefixes=("internal/connectorcatalog/catalog/", "internal/connectordefinitions/", "internal/sourcegen/"), exact=("cmd/cerebro/source_runtime_sdk.go",)) for path in files):
         add_command(commands, seen, "sourcegen-check", ["make", "sourcegen-check"], "Connector definition or sourcegen contract changed.")
 

--- a/scripts/tests/test_changed_checks.py
+++ b/scripts/tests/test_changed_checks.py
@@ -68,6 +68,46 @@ class ChangedChecksTests(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertIn("rust-deny", self.command_names([path]))
 
+    def test_source_runtime_crates_select_focused_rust_validation(self):
+        packages = [
+            "-p",
+            "cerebro-platform",
+            "-p",
+            "cerebro-source-catalog",
+            "-p",
+            "cerebro-source-runtime-next",
+        ]
+        for path in (
+            "crates/cerebro-platform/src/main.rs",
+            "crates/source-catalog/src/lib.rs",
+            "crates/source-runtime-next/src/http.rs",
+        ):
+            with self.subTest(path=path):
+                selected = changed.select_commands([path], Path("."))
+                commands = {plan.name: plan.argv for plan in selected}
+                self.assertEqual(
+                    commands["rust-source-runtime-fmt"],
+                    ["cargo", "fmt", "--all", "--", "--check"],
+                )
+                self.assertEqual(
+                    commands["rust-source-runtime-test"],
+                    ["cargo", "test", "--locked", *packages],
+                )
+                self.assertEqual(
+                    commands["rust-source-runtime-clippy"],
+                    [
+                        "cargo",
+                        "clippy",
+                        "--locked",
+                        *packages,
+                        "--all-targets",
+                        "--all-features",
+                        "--",
+                        "-D",
+                        "warnings",
+                    ],
+                )
+
     def test_workspace_manifests_and_policy_select_workspace_check(self):
         for path in (
             "Cargo.toml",


### PR DESCRIPTION
## Summary

- compile the provider refresh endpoint, scopes, client-auth method, and token parameters for all 14 oauth_authorization_code sources
- refresh authorization-code credentials in the Rust HTTP runtime with redacted failures, zeroized secrets, and exact token-origin egress authorization
- accept an already resolved bearer token for reference-backed OAuth clients and scrub all credential aliases before provider configuration is retained
- make changed-check select exact format, test, and clippy commands whenever the Rust source catalog, runtime, or platform changes

## Test Plan

- PASS: rustfmt --edition 2024 --check crates/cerebro-platform/src/main.rs crates/source-catalog/src/lib.rs crates/source-runtime-next/src/http.rs
- PASS: git diff --check origin/main...HEAD
- PASS: python3 scripts/readme_check.py
- PASS: python3 -m unittest scripts.tests.test_changed_checks (18 tests)
- PENDING exact-head hosted Linux via deterministic-review changed-check: cargo test --locked -p cerebro-platform -p cerebro-source-catalog -p cerebro-source-runtime-next
- PENDING exact-head hosted Linux via deterministic-review changed-check: cargo clippy --locked -p cerebro-platform -p cerebro-source-catalog -p cerebro-source-runtime-next --all-targets --all-features -- -D warnings

DDESK project cb-src-rust-oauth is waiting-for-disk with critical shared capacity, sync/bootstrap blocked, and no registered disk. No project storage was provisioned and no Cargo or Go build was run on the Mac.

## Known Invariants

- Provider API requests still require an operation-scoped credential lease and exact egress policy.
- OAuth token requests are authorized before network access and provider request errors remain redacted.
- Client IDs, client secrets, refresh tokens, and token parameter values are zeroized or removed from retained connector configuration.
- Existing bearer-token execution remains available for externally managed OAuth clients.