### PR TITLE
perf(web): start Home queries in parallel

### DIFF
--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -3,11 +3,28 @@
  */
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { GRCProgramReadiness } from "@/lib/grc";
+import { defaultUserPreferences } from "@/lib/user-preferences";
 
-import { buildHomeQueue, ReviewNowPanel } from "./page";
+const mocks = vi.hoisted(() => ({
+  reload: vi.fn(),
+  useGRCQuery: vi.fn(),
+  useUserPreferences: vi.fn(),
+}));
+
+vi.mock("@/components/providers", () => ({
+  useUserPreferences: mocks.useUserPreferences,
+}));
+vi.mock("@/lib/grc-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/grc-client")>();
+  return { ...actual, useGRCQuery: mocks.useGRCQuery };
+});
+
+import { grcDashboardPath, grcPath, grcProgramReadinessPath } from "@/lib/grc-client";
+
+import Home, { buildHomeQueue, ReviewNowPanel } from "./page";
 
 const reactActEnvironment = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
@@ -18,6 +35,17 @@ describe("Home review links", () => {
   let root: Root;
 
   beforeEach(() => {
+    mocks.reload.mockReset().mockResolvedValue(undefined);
+    mocks.useUserPreferences.mockReset().mockReturnValue({ preferences: defaultUserPreferences });
+    mocks.useGRCQuery.mockReset().mockImplementation((path: string | null) => ({
+      data: null,
+      durationMs: null,
+      error: null,
+      lastSuccessfulAt: null,
+      loading: Boolean(path),
+      reload: mocks.reload,
+      state: path ? "loading" : "empty",
+    }));
     reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -54,5 +82,22 @@ describe("Home review links", () => {
 
     const links = [...container.querySelectorAll<HTMLAnchorElement>("a")];
     expect(links.map((link) => link.getAttribute("href"))).toContain("/controls?framework=SOC%202&control=CC6.6");
+  });
+
+  it("starts independent Home queries on the initial render", async () => {
+    await act(async () => {
+      root.render(<Home />);
+    });
+
+    expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([
+      grcDashboardPath({ limit: 12 }),
+      grcProgramReadinessPath(),
+      grcPath("/connectors/coverage", {
+        coverage_scope: "configured",
+        coverage_view: "page",
+        blind_spots_only: "true",
+        page_size: 3,
+      }),
+    ]);
   });
 });

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -439,9 +439,9 @@ export default function Home() {
   const compactHome = preferences.display.density === "compact";
   const dashboard = useGRCQuery<GRCDashboard>(grcDashboardPath({ limit: HOME_DASHBOARD_FINDING_LIMIT }));
   const data = dashboard.data;
-  const readinessQuery = useGRCQuery<GRCProgramReadiness>(data ? grcProgramReadinessPath() : null);
+  const readinessQuery = useGRCQuery<GRCProgramReadiness>(grcProgramReadinessPath());
   const coverageQuery = useGRCQuery<{ blind_spots?: GRCSourceCoverageRecord[]; records?: GRCSourceCoverageRecord[] }>(
-    data ? grcPath("/connectors/coverage", { coverage_scope: "configured", coverage_view: "page", blind_spots_only: "true", page_size: 3 }) : null,
+    grcPath("/connectors/coverage", { coverage_scope: "configured", coverage_view: "page", blind_spots_only: "true", page_size: 3 }),
   );
   const readiness = readinessQuery.data?.summary;
   const priorityFindings = useMemo(() => (data?.findings ?? []).slice().sort(riskSort), [data?.findings]);


### PR DESCRIPTION
## Baseline

Home enabled the program-readiness and connector-coverage queries only after the dashboard query returned. The focused regression test records the initial hook inputs as the dashboard path followed by two disabled queries.

## Change

Start the three independent Home queries on the initial render. Existing authentication, cache freshness, fallback data, error handling, and rendering gates are unchanged.

## Validation

- Web lint and full test suite: 105 files, 633 tests passed under Node 22
- Focused Home test verifies all three paths are enabled on the initial render
- Production Next.js build passed under Node 22

## Expected live verification

In an authenticated browser, confirm the dashboard, program-readiness, and connector-coverage requests begin together on initial Home load and that the existing Home content and fallback states remain unchanged.