### PR TITLE
feat(rust): execute precomputed signature sources

### DIFF
--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -1983,7 +1983,36 @@ fn resolved_auth(
                 }
             }
         }
-        AuthModel::DuoHmac | AuthModel::Signature => {
+        AuthModel::Signature => {
+            let aliases = [
+                "token",
+                "signature",
+                "auth_value",
+                "access_token",
+                "api_token",
+                "api_key",
+            ];
+            let value = take_first_required_config(config, &aliases)?;
+            for alias in aliases {
+                discard_config_secret(config, alias);
+            }
+            ResolvedAuth::Header {
+                name: if token_header.trim().is_empty() {
+                    "Authorization".to_owned()
+                } else {
+                    nonempty_catalog_auth_value(&token_header, "token_header")?
+                },
+                value: apply_auth_scheme(
+                    if token_scheme.trim().is_empty() {
+                        "Signature"
+                    } else {
+                        &token_scheme
+                    },
+                    value,
+                ),
+            }
+        }
+        AuthModel::DuoHmac => {
             return Err("source auth requires a bespoke Rust connector".into());
         }
         _ => ResolvedAuth::Bearer {
@@ -4641,6 +4670,49 @@ mod tests {
         ));
         assert!(!bearer.contains_key("access_token"));
         assert!(!bearer.contains_key("oauth_client_reference"));
+    }
+
+    #[test]
+    fn stored_signature_auth_matches_go_aliases_and_scrubs_every_secret() {
+        let catalog = load_catalog().unwrap();
+        for (source_id, selected_alias) in [("netsuite", "token"), ("veracode", "signature")] {
+            let source = catalog.get(source_id).unwrap();
+            let mut config = BTreeMap::from([
+                (
+                    selected_alias.to_owned(),
+                    format!("{source_id}-precomputed-proof"),
+                ),
+                ("access_token".to_owned(), "unused-access-proof".to_owned()),
+                ("api_key".to_owned(), "unused-api-proof".to_owned()),
+                ("family".to_owned(), source.families()[0].id().to_owned()),
+            ]);
+            let auth = resolved_auth(
+                source.auth(),
+                CatalogAuthSettings::from_source(source),
+                &mut config,
+            )
+            .unwrap();
+            assert!(matches!(
+                auth,
+                ResolvedAuth::Header {
+                    ref name,
+                    ref value,
+                } if name == "Authorization"
+                    && value == &format!("Signature {source_id}-precomputed-proof")
+            ));
+            assert!(!format!("{auth:?}").contains("precomputed-proof"));
+            for alias in [
+                "token",
+                "signature",
+                "auth_value",
+                "access_token",
+                "api_token",
+                "api_key",
+            ] {
+                assert!(!config.contains_key(alias));
+            }
+            assert!(config.contains_key("family"));
+        }
     }
 
     #[test]

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -102,6 +102,7 @@ impl AuthModel {
                 | Self::OauthClientCredentials
                 | Self::TwoStep
                 | Self::Jwt
+                | Self::Signature
                 | Self::AwsSigV4
                 | Self::DuoHmacV5
         )
@@ -2737,6 +2738,42 @@ mod tests {
                 .token_url(),
             "https://connect.signl4.com/identity/connect/token"
         );
+    }
+
+    #[test]
+    fn precomputed_signature_contract_is_executable_but_remains_shadow_only() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let actual = catalog
+            .sources()
+            .filter(|source| source.auth() == &AuthModel::Signature)
+            .map(CompiledSource::id)
+            .collect::<Vec<_>>();
+        assert_eq!(actual, vec!["netsuite", "veracode"]);
+
+        for source_id in actual {
+            let source = catalog.get(source_id).unwrap();
+            assert!(source.auth().supports_generic_runtime());
+            assert_eq!(source.token_header(), "Authorization");
+            assert_eq!(source.token_scheme(), "Signature");
+            assert_eq!(source.authority(), CollectionAuthority::ShadowOnly);
+            for family in source.families() {
+                assert!(
+                    !family
+                        .unsupported_reasons()
+                        .contains(&UnsupportedReasonCode::UnsupportedAuthModel)
+                );
+                assert!(
+                    family
+                        .unsupported_reasons()
+                        .contains(&UnsupportedReasonCode::MissingProviderProof)
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -1302,7 +1302,27 @@ fn validate_auth(source: &CompiledSource, actual: &ResolvedAuth) -> Result<(), H
         }
         AuthModel::AwsSigV4 => matches!(actual, ResolvedAuth::AwsSigV4 { .. }),
         AuthModel::DuoHmacV5 => matches!(actual, ResolvedAuth::DuoHmacV5 { .. }),
-        AuthModel::Signature | AuthModel::DuoHmac => false,
+        AuthModel::Signature => match actual {
+            ResolvedAuth::Header { name, value } => {
+                let expected_header = if source.token_header().trim().is_empty() {
+                    "Authorization"
+                } else {
+                    source.token_header()
+                };
+                let expected_scheme = if source.token_scheme().trim().is_empty() {
+                    "Signature"
+                } else {
+                    source.token_scheme()
+                };
+                name.eq_ignore_ascii_case(expected_header)
+                    && value
+                        .strip_prefix(expected_scheme)
+                        .and_then(|value| value.strip_prefix(' '))
+                        .is_some_and(|value| !value.trim().is_empty())
+            }
+            _ => false,
+        },
+        AuthModel::DuoHmac => false,
     };
     if valid {
         Ok(())
@@ -4548,6 +4568,76 @@ mod tests {
         assert!(matches!(batch.scope, CollectedScope::Complete(_)));
         assert_eq!(batch.records.len(), 1);
         assert_eq!(batch.records[0].provider_id, "user-1");
+    }
+
+    #[tokio::test]
+    async fn signature_catalog_family_executes_with_a_redacted_precomputed_header() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let read = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            assert!(request.starts_with("GET /v1/assets?"));
+            assert!(request.lines().any(|line| {
+                line.eq_ignore_ascii_case("authorization: Signature precomputed-proof")
+            }));
+            let body = r#"{"data":[{"id":"asset-1","name":"Asset One"}]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("veracode").unwrap().clone();
+        assert_eq!(
+            source.authority(),
+            cerebro_source_catalog::CollectionAuthority::ShadowOnly
+        );
+        let auth = ResolvedAuth::Header {
+            name: "Authorization".to_owned(),
+            value: "Signature precomputed-proof".to_owned(),
+        };
+        assert!(!format!("{auth:?}").contains("precomputed-proof"));
+        assert!(
+            HttpSourceConnector::new(
+                source.clone(),
+                "assets",
+                &format!("http://{address}"),
+                BTreeMap::new(),
+                ResolvedAuth::Bearer {
+                    token: "precomputed-proof".to_owned(),
+                },
+            )
+            .is_err()
+        );
+        let base_url = format!("http://{address}");
+        let mut connector = with_test_provider_access(
+            HttpSourceConnector::new(source, "assets", &base_url, BTreeMap::new(), auth).unwrap(),
+            "tenant-a",
+            "veracode-prod",
+            &base_url,
+        );
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("veracode-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert!(matches!(batch.scope, CollectedScope::NonAuthoritative(_)));
+        assert_eq!(batch.records.len(), 1);
+        assert_eq!(batch.records[0].provider_id, "asset-1");
     }
 
     #[tokio::test]

--- a/internal/connectorcatalog/catalog/business-data-grc/netsuite.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/netsuite.yaml
@@ -8,7 +8,12 @@ entries:
           - key: secret_key
             reference_only: true
             secret: true
+          - key: signature
+            reference_only: true
+            secret: true
         model: signature
+        token_header: Authorization
+        token_scheme: Signature
       categories:
         - business
         - erp

--- a/internal/connectorcatalog/catalog/security-posture-vulnerability/veracode.yaml
+++ b/internal/connectorcatalog/catalog/security-posture-vulnerability/veracode.yaml
@@ -8,7 +8,12 @@ entries:
           - key: secret_key
             reference_only: true
             secret: true
+          - key: signature
+            reference_only: true
+            secret: true
         model: signature
+        token_header: Authorization
+        token_scheme: Signature
       categories:
         - security
         - code_scanning


### PR DESCRIPTION
## Summary

- execute the checked-in precomputed signature authentication contract in the generic Rust source collector
- declare the legacy reference-only signature input and exact authorization placement for NetSuite and Veracode
- wire stored signature aliases into the Rust platform while redacting and scrubbing credential values
- keep both collections non-authoritative until their provider API proofs are verified

## Validation

- `rustfmt --edition 2024 --check crates/source-catalog/src/lib.rs crates/source-runtime-next/src/http.rs crates/cerebro-platform/src/main.rs`
- `git diff --check origin/main...HEAD`
- `python3 scripts/readme_check.py`
- hosted Rust fmt, tests, clippy, sourcegen, and catalog checks pending