### PR TITLE
Migrate Backstage source runtime to Rust

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -1515,16 +1515,18 @@ fn compile_family(
     }
     unsupported_reasons.sort();
     unsupported_reasons.dedup();
+    let family_id = nonempty(path, "family id", family.id)?;
+    let id_field = validate_id_field(path, &family_id, family.id_field)?;
     Ok(CompiledFamily {
         authoritative,
         projection_authoritative,
-        id: nonempty(path, "family id", family.id)?,
+        id: family_id,
         method,
         path: family.path,
         record_selector,
         scalar_record_field,
         id_template,
-        id_field: nonempty(path, "family id_field", family.id_field)?,
+        id_field,
         name_field: optional(family.name_field),
         static_query: family.static_query,
         config_query,
@@ -1613,6 +1615,38 @@ fn valid_id_template(template: &str) -> bool {
         rest = &rest[field_end + 1..];
     }
     placeholders > 0 && !rest.contains('{') && !rest.contains('}')
+}
+
+fn validate_id_field(
+    path: &Path,
+    family_id: &str,
+    expression: String,
+) -> Result<String, CatalogError> {
+    const MAX_CANDIDATES: usize = 8;
+    const MAX_PATH_BYTES: usize = 128;
+
+    let expression = nonempty(path, "family id_field", expression)?;
+    let candidates = expression.split('|').collect::<Vec<_>>();
+    if candidates.len() > MAX_CANDIDATES {
+        return invalid(
+            path,
+            &format!("family {family_id} id_field exceeds the {MAX_CANDIDATES}-candidate limit"),
+        );
+    }
+    if candidates.iter().any(|candidate| {
+        candidate.is_empty()
+            || candidate.trim() != *candidate
+            || candidate.len() > MAX_PATH_BYTES
+            || candidate.split('.').any(|part| {
+                part.is_empty()
+                    || !part
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+            })
+    }) {
+        return invalid(path, &format!("family {family_id} id_field is invalid"));
+    }
+    Ok(expression)
 }
 
 fn compile_pagination(
@@ -1971,7 +2005,7 @@ mod tests {
         )
     }
 
-    fn invalid_message(result: Result<CompiledSource, CatalogError>) -> String {
+    fn invalid_message<T: fmt::Debug>(result: Result<T, CatalogError>) -> String {
         match result.unwrap_err() {
             CatalogError::Invalid { message, .. } => message,
             error => panic!("unexpected error: {error}"),
@@ -2162,6 +2196,64 @@ mod tests {
     }
 
     #[test]
+    fn id_field_candidates_are_bounded_and_path_only() {
+        let path = Path::new("id-field-fixture.yaml");
+        assert_eq!(
+            validate_id_field(
+                path,
+                "components",
+                "metadata.uid|metadata.name|name".to_owned()
+            )
+            .unwrap(),
+            "metadata.uid|metadata.name|name"
+        );
+        assert_eq!(
+            invalid_message(validate_id_field(
+                path,
+                "components",
+                "metadata.uid||name".to_owned()
+            )),
+            "family components id_field is invalid"
+        );
+        assert_eq!(
+            invalid_message(validate_id_field(
+                path,
+                "components",
+                (0..9)
+                    .map(|index| format!("candidate{index}"))
+                    .collect::<Vec<_>>()
+                    .join("|")
+            )),
+            "family components id_field exceeds the 8-candidate limit"
+        );
+    }
+
+    #[test]
+    fn backstage_is_compiled_as_a_verified_authoritative_source() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let backstage = catalog.get("backstage").unwrap();
+        assert_eq!(backstage.authority(), CollectionAuthority::Authoritative);
+        let component = backstage.families().first().unwrap();
+        assert!(component.is_authoritative());
+        assert_eq!(component.id_field(), "metadata.uid|metadata.name|name");
+        assert_eq!(component.record_selector(), "$.items[*]");
+        assert_eq!(
+            component.pagination(),
+            &Pagination::Cursor {
+                parameter: "cursor".to_owned(),
+                response_path: "$.pageInfo.nextCursor".to_owned(),
+                page_size_parameter: Some("limit".to_owned()),
+                page_size: 100,
+            }
+        );
+    }
+
+    #[test]
     fn compiles_the_complete_checked_in_catalog() {
         let root = repository_root();
         let catalog = SourceCatalog::load(
@@ -2170,8 +2262,8 @@ mod tests {
         )
         .unwrap();
         let summary = catalog.summary();
-        assert_eq!(summary.sources, 794);
-        assert_eq!(summary.families, 3_894);
+        assert_eq!(summary.sources, 795);
+        assert_eq!(summary.families, 3_895);
         assert_eq!(
             summary.projection_classes.values().sum::<usize>(),
             summary.families
@@ -2961,8 +3053,8 @@ mod tests {
         )
         .unwrap();
         let report = catalog.unsupported_feature_report();
-        assert_eq!(report.total_sources, 794);
-        assert_eq!(report.total_families, 3_894);
+        assert_eq!(report.total_sources, 795);
+        assert_eq!(report.total_families, 3_895);
         assert_eq!(report.families.len(), report.total_families);
         assert!(report.missing_family_reports.is_empty());
         assert_eq!(
@@ -3011,7 +3103,7 @@ mod tests {
         )
         .unwrap();
         let report = catalog.authority_readiness_report();
-        assert_eq!(report.total_families, 3_894);
+        assert_eq!(report.total_families, 3_895);
         assert_eq!(report.rust_authoritative_families, 0);
         assert_eq!(report.shadow_or_go_families, report.total_families);
         let aws_bedrock = report

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -1623,10 +1623,18 @@ fn validate_id_field(
     expression: String,
 ) -> Result<String, CatalogError> {
     const MAX_CANDIDATES: usize = 8;
+    const MAX_COMPOSITE_PARTS: usize = 8;
+    const MAX_EXPRESSION_BYTES: usize = 2_048;
     const MAX_PATH_BYTES: usize = 128;
 
     let expression = nonempty(path, "family id_field", expression)?;
     let candidates = expression.split('|').collect::<Vec<_>>();
+    if expression.len() > MAX_EXPRESSION_BYTES {
+        return invalid(
+            path,
+            &format!("family {family_id} id_field exceeds the {MAX_EXPRESSION_BYTES}-byte limit"),
+        );
+    }
     if candidates.len() > MAX_CANDIDATES {
         return invalid(
             path,
@@ -1636,12 +1644,16 @@ fn validate_id_field(
     if candidates.iter().any(|candidate| {
         candidate.is_empty()
             || candidate.trim() != *candidate
-            || candidate.len() > MAX_PATH_BYTES
-            || candidate.split('.').any(|part| {
-                part.is_empty()
-                    || !part
-                        .bytes()
-                        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+            || candidate.split('+').count() > MAX_COMPOSITE_PARTS
+            || candidate.split('+').any(|path| {
+                path.is_empty()
+                    || path.len() > MAX_PATH_BYTES
+                    || path.split('.').any(|part| {
+                        part.is_empty()
+                            || !part.bytes().all(|byte| {
+                                byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_')
+                            })
+                    })
             })
     }) {
         return invalid(path, &format!("family {family_id} id_field is invalid"));
@@ -2196,7 +2208,7 @@ mod tests {
     }
 
     #[test]
-    fn id_field_candidates_are_bounded_and_path_only() {
+    fn id_field_candidates_and_composites_are_bounded_and_path_only() {
         let path = Path::new("id-field-fixture.yaml");
         assert_eq!(
             validate_id_field(
@@ -2208,12 +2220,35 @@ mod tests {
             "metadata.uid|metadata.name|name"
         );
         assert_eq!(
+            validate_id_field(path, "audit_events", "date+type+actingUserId".to_owned()).unwrap(),
+            "date+type+actingUserId"
+        );
+        assert_eq!(
             invalid_message(validate_id_field(
                 path,
                 "components",
                 "metadata.uid||name".to_owned()
             )),
             "family components id_field is invalid"
+        );
+        assert_eq!(
+            invalid_message(validate_id_field(
+                path,
+                "audit_events",
+                "date++actingUserId".to_owned()
+            )),
+            "family audit_events id_field is invalid"
+        );
+        assert_eq!(
+            invalid_message(validate_id_field(
+                path,
+                "audit_events",
+                (0..9)
+                    .map(|index| format!("part{index}"))
+                    .collect::<Vec<_>>()
+                    .join("+")
+            )),
+            "family audit_events id_field is invalid"
         );
         assert_eq!(
             invalid_message(validate_id_field(

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -2238,7 +2238,11 @@ mod tests {
         .unwrap();
         let backstage = catalog.get("backstage").unwrap();
         assert_eq!(backstage.authority(), CollectionAuthority::Authoritative);
-        let component = backstage.families().first().unwrap();
+        let component = backstage
+            .families()
+            .iter()
+            .find(|family| family.id() == "component")
+            .unwrap();
         assert!(component.is_authoritative());
         assert_eq!(component.id_field(), "metadata.uid|metadata.name|name");
         assert_eq!(component.record_selector(), "$.items[*]");
@@ -2251,6 +2255,14 @@ mod tests {
                 page_size: 100,
             }
         );
+        let system = backstage
+            .families()
+            .iter()
+            .find(|family| family.id() == "system")
+            .unwrap();
+        assert!(system.is_authoritative());
+        assert_eq!(system.static_query().get("filter").unwrap(), "kind=system");
+        assert_eq!(system.record_selector(), "$.items[*]");
     }
 
     #[test]
@@ -2263,7 +2275,7 @@ mod tests {
         .unwrap();
         let summary = catalog.summary();
         assert_eq!(summary.sources, 795);
-        assert_eq!(summary.families, 3_895);
+        assert_eq!(summary.families, 3_896);
         assert_eq!(
             summary.projection_classes.values().sum::<usize>(),
             summary.families
@@ -3054,7 +3066,7 @@ mod tests {
         .unwrap();
         let report = catalog.unsupported_feature_report();
         assert_eq!(report.total_sources, 795);
-        assert_eq!(report.total_families, 3_895);
+        assert_eq!(report.total_families, 3_896);
         assert_eq!(report.families.len(), report.total_families);
         assert!(report.missing_family_reports.is_empty());
         assert_eq!(
@@ -3103,7 +3115,7 @@ mod tests {
         )
         .unwrap();
         let report = catalog.authority_readiness_report();
-        assert_eq!(report.total_families, 3_895);
+        assert_eq!(report.total_families, 3_896);
         assert_eq!(report.rust_authoritative_families, 0);
         assert_eq!(report.shadow_or_go_families, report.total_families);
         let aws_bedrock = report

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -1975,13 +1975,12 @@ fn value_at_path<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
     if path.is_empty() {
         return Some(value);
     }
-    if let Some((head, tail)) = path.split_once('.') {
-        if let Some(nested) = value
+    if let Some((head, tail)) = path.split_once('.')
+        && let Some(nested) = value
             .get(head)
             .and_then(|nested| value_at_path(nested, tail))
-        {
-            return Some(nested);
-        }
+    {
+        return Some(nested);
     }
     value.get(path)
 }

--- a/crates/source-runtime-next/src/http.rs
+++ b/crates/source-runtime-next/src/http.rs
@@ -923,7 +923,7 @@ impl SourceConnector for HttpSourceConnector {
                     let provider_id = if let Some(template) = self.family.id_template() {
                         render_id_template(self.family.id(), template, &value, &record_attributes)?
                     } else {
-                        scalar_at(&value, self.family.id_field()).ok_or_else(|| {
+                        scalar_at_candidates(&value, self.family.id_field()).ok_or_else(|| {
                             HttpConnectorError::InvalidResponse(format!(
                                 "family {} record is missing {}",
                                 self.family.id(),
@@ -1911,6 +1911,12 @@ fn scalar_at(value: &Value, field: &str) -> Option<String> {
     scalar_at_path(value, field)
 }
 
+fn scalar_at_candidates(value: &Value, expression: &str) -> Option<String> {
+    expression
+        .split('|')
+        .find_map(|path| scalar_at_path(value, path))
+}
+
 fn render_id_template(
     family_id: &str,
     template: &str,
@@ -1965,14 +1971,19 @@ fn scalar_at_path(value: &Value, path: &str) -> Option<String> {
     value_at_path(value, path).and_then(scalar)
 }
 
-fn value_at_path<'a>(mut value: &'a Value, path: &str) -> Option<&'a Value> {
+fn value_at_path<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
     if path.is_empty() {
         return Some(value);
     }
-    for part in path.split('.') {
-        value = value.get(part)?;
+    if let Some((head, tail)) = path.split_once('.') {
+        if let Some(nested) = value
+            .get(head)
+            .and_then(|nested| value_at_path(nested, tail))
+        {
+            return Some(nested);
+        }
     }
-    Some(value)
+    value.get(path)
 }
 
 fn scalar(value: &Value) -> Option<String> {
@@ -4425,6 +4436,21 @@ mod tests {
     }
 
     #[test]
+    fn provider_paths_preserve_nested_keys_that_contain_dots() {
+        let value = serde_json::json!({
+            "metadata": {
+                "annotations": {
+                    "cerebro.io/criticality": "high"
+                }
+            }
+        });
+        assert_eq!(
+            scalar_at_path(&value, "metadata.annotations.cerebro.io/criticality"),
+            Some("high".to_owned())
+        );
+    }
+
+    #[test]
     fn explicit_fanout_binding_drives_runtime_paths_and_record_scope() {
         let root = repository_root();
         let catalog = SourceCatalog::load(
@@ -4638,6 +4664,88 @@ mod tests {
         assert!(matches!(batch.scope, CollectedScope::NonAuthoritative(_)));
         assert_eq!(batch.records.len(), 1);
         assert_eq!(batch.records[0].provider_id, "asset-1");
+    }
+
+    #[tokio::test]
+    async fn backstage_catalog_family_executes_documented_cursor_contract() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let mut requests = Vec::new();
+            for page in 0..2 {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = vec![0; 4096];
+                let read = socket.read(&mut request).await.unwrap();
+                requests.push(String::from_utf8_lossy(&request[..read]).into_owned());
+                let body = if page == 0 {
+                    r#"{"items":[{"kind":"Component","metadata":{"uid":"component-1","name":"cerebro","namespace":"default","annotations":{"cerebro.io/criticality":"high"}},"spec":{"type":"service","lifecycle":"production","owner":"group:platform/security","system":"security"},"repository":"writer/cerebro"}],"totalItems":2,"pageInfo":{"nextCursor":"page-2"}}"#
+                } else {
+                    r#"{"items":[{"kind":"Component","metadata":{"name":"fallback-component","namespace":"default"},"spec":{"type":"service","owner":"group:platform/security"}}],"totalItems":2,"pageInfo":{}}"#
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+            }
+            requests
+        });
+
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("backstage").unwrap().clone();
+        assert_eq!(
+            source.authority(),
+            cerebro_source_catalog::CollectionAuthority::Authoritative
+        );
+        let base_url = format!("http://{address}");
+        let mut connector = with_test_provider_access(
+            HttpSourceConnector::new(
+                source,
+                "component",
+                &base_url,
+                BTreeMap::new(),
+                ResolvedAuth::Bearer {
+                    token: "backstage-token".to_owned(),
+                },
+            )
+            .unwrap(),
+            "tenant-a",
+            "backstage-prod",
+            &base_url,
+        );
+        let batch = connector
+            .collect(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-a").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("backstage-prod").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap();
+        let requests = server.await.unwrap();
+
+        for request in &requests {
+            assert!(request.starts_with("GET /api/catalog/entities/by-query?"));
+            assert!(request.contains("filter=kind%3Dcomponent"));
+            assert!(request.contains("limit=100"));
+            assert!(request.lines().any(|line| {
+                line.eq_ignore_ascii_case("authorization: Bearer backstage-token")
+            }));
+        }
+        assert!(!requests[0].contains("cursor="));
+        assert!(requests[1].contains("cursor=page-2"));
+        assert!(matches!(batch.scope, CollectedScope::Complete(_)));
+        assert_eq!(batch.records.len(), 2);
+        assert_eq!(batch.records[0].provider_id, "component-1");
+        assert_eq!(batch.records[1].provider_id, "fallback-component");
+        assert_eq!(
+            batch.records[0].payload["spec"]["owner"],
+            "group:platform/security"
+        );
     }
 
     #[tokio::test]

--- a/docs/engineering/rust-graph-read-migration-plan.md
+++ b/docs/engineering/rust-graph-read-migration-plan.md
@@ -15,7 +15,7 @@ Four facts shape the plan. Each is verified against the code as of
    projection templates (`ProjectionClass::for_template` in
    `crates/source-catalog/src/lib.rs`), and `CatalogGraphMapper`
    (`crates/source-runtime-next/src/mapper.rs:603`) maps every one of them.
-   All ~3,891 cataloged families flow into the organizational graph. There
+   All ~3,895 cataloged families flow into the organizational graph. There
    is no unmapped-template gap.
 
 2. **The organizational edge vocabulary is three relations wide.** The

--- a/docs/engineering/rust-graph-read-migration-plan.md
+++ b/docs/engineering/rust-graph-read-migration-plan.md
@@ -15,7 +15,7 @@ Four facts shape the plan. Each is verified against the code as of
    projection templates (`ProjectionClass::for_template` in
    `crates/source-catalog/src/lib.rs`), and `CatalogGraphMapper`
    (`crates/source-runtime-next/src/mapper.rs:603`) maps every one of them.
-   All ~3,895 cataloged families flow into the organizational graph. There
+   All ~3,896 cataloged families flow into the organizational graph. There
    is no unmapped-template gap.
 
 2. **The organizational edge vocabulary is three relations wide.** The

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -41,7 +41,7 @@ cerebro-source-catalog --> cerebro-source-runtime-next
 
 `cerebro-organizational-graph` is the only crate that advances current organizational graph state. A commit takes a validated `GraphDelta`; there is no public entity/link mutation method.
 
-`cerebro-source-catalog` compiles all 794 checked-in source definitions and 3,891 resource families into a closed runtime grammar. Every family is assigned one Rust-owned projection class: identity, access, resource, finding, activity, or bespoke. Connector YAML cannot declare another class. It joins those definitions to provider proof manifests. A definition without complete provider proof remains shadow-only even if it can be executed. Bespoke families also remain shadow-only until a native mapper is added.
+`cerebro-source-catalog` compiles all 795 checked-in source definitions and 3,895 resource families into a closed runtime grammar. Every family is assigned one Rust-owned projection class: identity, access, resource, finding, activity, or bespoke. Connector YAML cannot declare another class. It joins those definitions to provider proof manifests. A definition without complete provider proof remains shadow-only even if it can be executed. Bespoke families also remain shadow-only until a native mapper is added.
 
 `cerebro-source-runtime-next` owns source collection, pagination, mapping, and graph commit sequencing. Provider redirects are disabled, pagination cannot change origin, pages are bounded, and resolved credentials never enter the graph model. A source cannot obtain a graph store or construct an unvalidated graph write.
 
@@ -257,18 +257,18 @@ Each receipt binds the tenant, runtime, source, family, collection, exact input 
 
 The runtime reads the same authority record before every projection. Legacy authority calls only Go. Rust authority calls only Rust, requires a commit receipt, and fails closed. The compatibility mapper remains available for parity comparison, but it is no longer a write fallback for a promoted family.
 
-The current checked-in catalog compiles to 794 sources and 3,891 families:
+The current checked-in catalog compiles to 795 sources and 3,895 families:
 
 | Projection class | Families | Rust meaning |
 | --- | ---: | --- |
 | Identity | 823 | people, provider identities, groups, memberships, credentials, and applications |
 | Access | 371 | policies and application grants |
-| Resource | 1,549 | assets, repositories, deployments, devices, cloud resources, and secrets |
+| Resource | 1,550 | assets, repositories, deployments, devices, cloud resources, and secrets |
 | Finding | 407 | findings, vulnerabilities, and alerts |
 | Activity | 738 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 52 sources and 351 families are authoritative; the other 742 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 53 sources and 352 families are authoritative; the other 742 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
 
 ## Family cutover
 

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -41,7 +41,7 @@ cerebro-source-catalog --> cerebro-source-runtime-next
 
 `cerebro-organizational-graph` is the only crate that advances current organizational graph state. A commit takes a validated `GraphDelta`; there is no public entity/link mutation method.
 
-`cerebro-source-catalog` compiles all 795 checked-in source definitions and 3,895 resource families into a closed runtime grammar. Every family is assigned one Rust-owned projection class: identity, access, resource, finding, activity, or bespoke. Connector YAML cannot declare another class. It joins those definitions to provider proof manifests. A definition without complete provider proof remains shadow-only even if it can be executed. Bespoke families also remain shadow-only until a native mapper is added.
+`cerebro-source-catalog` compiles all 795 checked-in source definitions and 3,896 resource families into a closed runtime grammar. Every family is assigned one Rust-owned projection class: identity, access, resource, finding, activity, or bespoke. Connector YAML cannot declare another class. It joins those definitions to provider proof manifests. A definition without complete provider proof remains shadow-only even if it can be executed. Bespoke families also remain shadow-only until a native mapper is added.
 
 `cerebro-source-runtime-next` owns source collection, pagination, mapping, and graph commit sequencing. Provider redirects are disabled, pagination cannot change origin, pages are bounded, and resolved credentials never enter the graph model. A source cannot obtain a graph store or construct an unvalidated graph write.
 
@@ -257,18 +257,18 @@ Each receipt binds the tenant, runtime, source, family, collection, exact input 
 
 The runtime reads the same authority record before every projection. Legacy authority calls only Go. Rust authority calls only Rust, requires a commit receipt, and fails closed. The compatibility mapper remains available for parity comparison, but it is no longer a write fallback for a promoted family.
 
-The current checked-in catalog compiles to 795 sources and 3,895 families:
+The current checked-in catalog compiles to 795 sources and 3,896 families:
 
 | Projection class | Families | Rust meaning |
 | --- | ---: | --- |
 | Identity | 823 | people, provider identities, groups, memberships, credentials, and applications |
 | Access | 371 | policies and application grants |
-| Resource | 1,550 | assets, repositories, deployments, devices, cloud resources, and secrets |
+| Resource | 1,551 | assets, repositories, deployments, devices, cloud resources, and secrets |
 | Finding | 407 | findings, vulnerabilities, and alerts |
 | Activity | 738 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 53 sources and 352 families are authoritative; the other 742 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 53 sources and 353 families are authoritative; the other 742 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
 
 ## Family cutover
 

--- a/docs/engineering/rust-source-runtime-adr.md
+++ b/docs/engineering/rust-source-runtime-adr.md
@@ -81,8 +81,8 @@ The problem is not the absence of a connector factory. The problem is that the f
 The current repository snapshot, measured with `tools/codegenstatus` and
 `tools/sourcefidelity`, contains:
 
-- 794 connector definitions;
-- 793 definitions accepted by the normalized generator grammar;
+- 795 connector definitions;
+- 794 definitions accepted by the normalized generator grammar;
 - one definition classified as requiring a bespoke runtime;
 - 16 shared projection templates;
 - 820 entries in the source-fidelity inventory and 799 runtime sources;

--- a/docs/reference/sources.md
+++ b/docs/reference/sources.md
@@ -78,7 +78,7 @@ Declarative connector catalog entries are cataloged when a spec exists. They are
 | `azure` | Azure Entra ID, RBAC, activity, and audit source | activity logs, directory audit, users, groups, role/app assignments, service principals, credentials, resource exposure |
 | `azure_devops` | Azure Devops source | azure_devops.audit_events, azure_devops.repositories, azure_devops.users |
 | `azure_openai` | Azure Openai source | azure_openai.deployments, azure_openai.model_catalog, azure_openai.private_endpoint_connections, azure_openai.rai_blocklists, azure_openai.rai_policies |
-| `backstage` | Backstage catalog source | components |
+| `backstage` | Backstage catalog source | components, systems |
 | `bamboohr` | Bamboohr source | bamboohr.audit_events, bamboohr.groups, bamboohr.users |
 | `basecamp` | Basecamp source | basecamp.audit_events, basecamp.documents, basecamp.groups, basecamp.users, basecamp.workspaces |
 | `baselime` | Baselime source | baselime.alerts, baselime.audit_events, baselime.dashboards, baselime.incidents, baselime.monitors |

--- a/internal/connectorcatalog/catalog/devops-ci-cd/backstage.yaml
+++ b/internal/connectorcatalog/catalog/devops-ci-cd/backstage.yaml
@@ -18,7 +18,7 @@ entries:
           key: base_url
           label: Backstage base URL
           required: true
-      description: Collects Backstage software catalog components and projects ownership, lifecycle, repository, and runtime context into the Cerebro graph.
+      description: Collects Backstage software catalog components and systems and projects ownership, lifecycle, repository, and runtime context into the Cerebro graph.
       display_name: Backstage
       id: builtin-backstage
       ingest:
@@ -93,6 +93,67 @@ entries:
           record_selector: $.items[*]
           static_query:
             filter: kind=component
+        - coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
+                - system
+              high_value: true
+              id: systems
+              support: supported
+              title: Backstage systems
+              type: entity_family
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - relationship_evidence
+              families:
+                - system
+              high_value: true
+              id: system_ownership_relationships
+              support: partial
+              title: System ownership relationships
+              type: relationship
+          default_enabled: true
+          event:
+            kind: backstage.system
+            required_payload_fields:
+              - metadata.name
+            schema_ref: backstage/system/v1
+            urn_kind: backstage_system
+          id: system
+          id_field: metadata.uid|metadata.name|name
+          label: Systems
+          method: GET
+          name_field: metadata.name
+          pagination:
+            cursor_json_path: $.pageInfo.nextCursor
+            cursor_param: cursor
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /api/catalog/entities/by-query
+          projection:
+            fields:
+              description: metadata.description|description
+              domain: spec.domain|domain
+              kind: kind
+              name: metadata.name|name
+              namespace: metadata.namespace
+              owner: spec.owner|owner
+              resource_id: metadata.uid|metadata.name|name
+              resource_name: metadata.name|name
+              resource_type: spec.type|type|kind
+              source_url: source_url
+              uid: metadata.uid
+            static_fields:
+              source_product: backstage
+            template: asset
+          record_selector: $.items[*]
+          static_query:
+            filter: kind=system
       schema_version: cerebro.integration/v1
       source_id: backstage
       tenant_id: builtin_catalog

--- a/internal/connectorcatalog/catalog/devops-ci-cd/backstage.yaml
+++ b/internal/connectorcatalog/catalog/devops-ci-cd/backstage.yaml
@@ -1,0 +1,105 @@
+entries:
+  - classifier_output: supported
+    definition:
+      auth:
+        credential_fields:
+          - key: token
+            label: Bearer token
+            reference_only: true
+            required: true
+            secret: true
+        model: bearer_token
+        requires_references: true
+      categories:
+        - saas
+        - devops_ci_cd
+      config_fields:
+        - help: Backstage backend base URL, including any deployment-specific host.
+          key: base_url
+          label: Backstage base URL
+          required: true
+      description: Collects Backstage software catalog components and projects ownership, lifecycle, repository, and runtime context into the Cerebro graph.
+      display_name: Backstage
+      id: builtin-backstage
+      ingest:
+        mode: pull
+      resource_families:
+        - coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
+                - component
+              high_value: true
+              id: components
+              support: supported
+              title: Backstage components
+              type: entity_family
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - relationship_evidence
+              families:
+                - component
+              high_value: true
+              id: ownership_relationships
+              support: partial
+              title: Component ownership relationships
+              type: relationship
+          default_enabled: true
+          event:
+            kind: backstage.component
+            required_payload_fields:
+              - metadata.name
+            schema_ref: backstage/component/v1
+            urn_kind: backstage_component
+          id: component
+          id_field: metadata.uid|metadata.name|name
+          label: Components
+          method: GET
+          name_field: metadata.name
+          pagination:
+            cursor_json_path: $.pageInfo.nextCursor
+            cursor_param: cursor
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /api/catalog/entities/by-query
+          projection:
+            fields:
+              criticality: metadata.annotations.cerebro.io/criticality|criticality|tier
+              data_class: metadata.annotations.cerebro.io/data-classification|data_class
+              description: metadata.description|description
+              dora_service: dora_service
+              entity_ref: entity_ref
+              kind: kind
+              lifecycle: spec.lifecycle|lifecycle
+              name: metadata.name|name
+              namespace: metadata.namespace
+              owner: spec.owner|owner
+              repository: repository|repo
+              resource_id: metadata.uid|metadata.name|name
+              resource_name: metadata.name|name
+              resource_type: spec.type|type|kind
+              score_grade: score_grade|grade
+              scorecard: scorecard
+              source_url: source_url
+              system: spec.system|system
+              uid: metadata.uid
+            static_fields:
+              source_product: backstage
+            template: asset
+          record_selector: $.items[*]
+          static_query:
+            filter: kind=component
+      schema_version: cerebro.integration/v1
+      source_id: backstage
+      tenant_id: builtin_catalog
+      transport:
+        base_url: ${config.base_url}
+        verification:
+          expect_status:
+            - 200
+          method: GET
+          path: /api/catalog/entities/by-query?filter=kind=component&limit=1

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/writer/cerebro/internal/connectordefinitions"
 )
 
-const wantBuiltinCatalogEntries = 794
+const wantBuiltinCatalogEntries = 795
 const wantBuiltinCatalogBespokeRuntimeEntries = 1
 
 func TestAnalyzeDirAcceptsGenerateableCatalogEntry(t *testing.T) {

--- a/internal/sourcegen/generator.go
+++ b/internal/sourcegen/generator.go
@@ -811,10 +811,13 @@ func methodForResource(resource connectordefinitions.ResourceFamily) string {
 
 func idKeysForResource(resource connectordefinitions.ResourceFamily) []string {
 	keys := []string{}
-	for _, key := range []string{resource.IDField, resource.NameField} {
+	for _, key := range strings.Split(resource.IDField, "|") {
 		if key = strings.TrimSpace(key); key != "" {
 			keys = append(keys, key)
 		}
+	}
+	if key := strings.TrimSpace(resource.NameField); key != "" {
+		keys = append(keys, key)
 	}
 	return uniqueStrings(keys)
 }

--- a/internal/sourcegen/generator_test.go
+++ b/internal/sourcegen/generator_test.go
@@ -512,6 +512,16 @@ func TestFixturePayloadValueUsesRecordIDForFamilyIDField(t *testing.T) {
 	}
 }
 
+func TestIDKeysForResourcePreservesOrderedIdentityFallback(t *testing.T) {
+	resource := connectordefinitions.ResourceFamily{
+		IDField:   "metadata.uid|metadata.name|name",
+		NameField: "metadata.name",
+	}
+	if got, want := idKeysForResource(resource), []string{"metadata.uid", "metadata.name", "name"}; !slices.Equal(got, want) {
+		t.Fatalf("idKeysForResource() = %#v, want %#v", got, want)
+	}
+}
+
 func TestPlanDefinitionBuildsPromotionChecklist(t *testing.T) {
 	plan, err := PlanDefinition(DefinitionRequest{
 		Definition: connectordefinitions.Definition{

--- a/sources/backstage/catalog.yaml
+++ b/sources/backstage/catalog.yaml
@@ -3,6 +3,27 @@ name: Backstage
 description: Backstage catalog source for service ownership and runtime context.
 emitted_kinds:
   - backstage.component
+runtime_families:
+  - component
+provider_api:
+  status: verified
+  basis: declared
+  verified_at: 2026-08-20T00:00:00Z
+  transport: rest
+  auth: bearer_token
+  auth_mechanics: authorization_bearer_header
+  base_url: ${config.base_url}
+  spec_url: https://backstage.io/docs/features/software-catalog/api/get-entities-by-query/
+  spec_kind: provider_reference_markdown
+  references:
+    - https://backstage.io/docs/features/software-catalog/api/catalog/
+    - https://backstage.io/docs/features/software-catalog/software-catalog-api/
+    - https://backstage.io/api/stable/types/_backstage_catalog-client.index.QueryEntitiesResponse.html
+  families:
+    - id: component
+      method: GET
+      path: /api/catalog/entities/by-query
+      operation: queryEntities
 coverage_contract:
   owner_domain: engineering
   authority_domain: backstage

--- a/sources/backstage/catalog.yaml
+++ b/sources/backstage/catalog.yaml
@@ -1,10 +1,12 @@
 id: backstage
 name: Backstage
-description: Backstage catalog source for service ownership and runtime context.
+description: Backstage catalog source for component and system ownership context.
 emitted_kinds:
   - backstage.component
+  - backstage.system
 runtime_families:
   - component
+  - system
 provider_api:
   status: verified
   basis: declared
@@ -24,6 +26,10 @@ provider_api:
       method: GET
       path: /api/catalog/entities/by-query
       operation: queryEntities
+    - id: system
+      method: GET
+      path: /api/catalog/entities/by-query
+      operation: queryEntities
 coverage_contract:
   owner_domain: engineering
   authority_domain: backstage
@@ -32,6 +38,14 @@ coverage_contract:
       type: entity_family
       title: Backstage components
       families: [component]
+      support: supported
+      high_value: true
+      evidence_types: [source_snapshot]
+      control_domains: [asset_inventory]
+    - id: systems
+      type: entity_family
+      title: Backstage systems
+      families: [system]
       support: supported
       high_value: true
       evidence_types: [source_snapshot]
@@ -45,7 +59,6 @@ coverage_contract:
       evidence_types: [relationship_evidence]
       control_domains: [asset_inventory]
       known_unsupported_fields:
-        - non-component catalog ownership entities
         - transitive group membership expansion
     - id: runtime_context
       type: relationship
@@ -60,6 +73,13 @@ coverage_contract:
 event_contracts:
   - kind: backstage.component
     schema_ref: backstage/component/v1
+    required_attributes:
+      - name
+      - kind
+    required_payload_fields:
+      - metadata.name
+  - kind: backstage.system
+    schema_ref: backstage/system/v1
     required_attributes:
       - name
       - kind

--- a/sources/backstage/deploy.yaml
+++ b/sources/backstage/deploy.yaml
@@ -9,3 +9,9 @@ runtimes:
       family: component
       per_page: "100"
       token: env:BACKSTAGE_EXTERNAL_ACCESS_TOKEN
+  - localId: system
+    config:
+      base_url: env:BACKSTAGE_BASE_URL
+      family: system
+      per_page: "100"
+      token: env:BACKSTAGE_EXTERNAL_ACCESS_TOKEN

--- a/sources/backstage/source.go
+++ b/sources/backstage/source.go
@@ -18,6 +18,7 @@ const (
 	defaultBaseURL = ""
 
 	familyComponent = "component"
+	familySystem    = "system"
 )
 
 // Source reads Backstage catalog entities.
@@ -68,6 +69,30 @@ func New() (*Source, error) {
 				},
 				StaticAttributes: map[string]string{"source_product": "backstage"},
 				Config:           jsonapi.FamilyConfig{StaticQuery: map[string]string{"filter": "kind=component"}},
+				PageSizeParams:   []string{"limit"},
+			},
+			{
+				Name:      familySystem,
+				Path:      "/api/catalog/entities/by-query",
+				URNKind:   "backstage_system",
+				RequireID: true,
+				IDKeys:    []string{"metadata.uid", "metadata.name", "name"},
+				TimestampKeys: []string{
+					"updated_at", "created_at",
+				},
+				Attributes: map[string]string{
+					"uid":         "metadata.uid",
+					"name":        "metadata.name|name",
+					"namespace":   "metadata.namespace",
+					"kind":        "kind",
+					"type":        "spec.type|type",
+					"owner":       "spec.owner|owner",
+					"domain":      "spec.domain|domain",
+					"description": "metadata.description|description",
+					"source_url":  "source_url",
+				},
+				StaticAttributes: map[string]string{"source_product": "backstage"},
+				Config:           jsonapi.FamilyConfig{StaticQuery: map[string]string{"filter": "kind=system"}},
 				PageSizeParams:   []string{"limit"},
 			},
 		},

--- a/sources/backstage/source_test.go
+++ b/sources/backstage/source_test.go
@@ -42,8 +42,8 @@ func TestReadComponentFamily(t *testing.T) {
 		if got := r.Header.Get("Authorization"); got != "Bearer backstage-token" {
 			t.Fatalf("Authorization = %q, want Bearer backstage-token", got)
 		}
-		_ = json.NewEncoder(w).Encode([]map[string]any{
-			{
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{{
 				"kind": "Component",
 				"metadata": map[string]any{
 					"uid":         "component-1",
@@ -62,7 +62,9 @@ func TestReadComponentFamily(t *testing.T) {
 					"system":    "security",
 				},
 				"repository": "WriterInternal/cerebro",
-			},
+			}},
+			"totalItems": 1,
+			"pageInfo":   map[string]any{},
 		})
 	}))
 	defer server.Close()

--- a/sources/backstage/source_test.go
+++ b/sources/backstage/source_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -22,6 +23,25 @@ func TestSourceSpec(t *testing.T) {
 	}
 	if source.Spec().Name != "Backstage" {
 		t.Fatalf("Spec().Name = %q, want Backstage", source.Spec().Name)
+	}
+}
+
+func TestRuntimeFixturesSatisfyCatalogContracts(t *testing.T) {
+	catalogBytes, err := catalogFS.ReadFile("catalog.yaml")
+	if err != nil {
+		t.Fatalf("read catalog: %v", err)
+	}
+	catalog, err := sourcecdk.LoadSourceCatalog(catalogBytes)
+	if err != nil {
+		t.Fatalf("LoadSourceCatalog() error = %v", err)
+	}
+	for _, family := range []string{familyComponent, familySystem} {
+		if _, err := sourcecdk.LoadFixtureURNs(os.DirFS("."), "testdata/discover_"+family+".json"); err != nil {
+			t.Fatalf("load %s discover fixture: %v", family, err)
+		}
+		if _, err := sourcecdk.LoadFixtureEventsWithContracts(os.DirFS("."), "testdata/read_"+family+".json", catalog.EventContracts); err != nil {
+			t.Fatalf("load %s read fixture: %v", family, err)
+		}
 	}
 }
 
@@ -98,6 +118,70 @@ func TestReadComponentFamily(t *testing.T) {
 	}
 	if event.Attributes["criticality"] != "high" || event.Attributes["data_class"] != "restricted" {
 		t.Fatalf("annotation attrs = %#v, want Backstage annotation attributes", event.Attributes)
+	}
+}
+
+func TestReadSystemFamily(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/catalog/entities/by-query" {
+			t.Fatalf("request path = %q, want /api/catalog/entities/by-query", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("filter"); got != "kind=system" {
+			t.Fatalf("filter query = %q, want kind=system", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "100" {
+			t.Fatalf("limit query = %q, want 100", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer backstage-token" {
+			t.Fatalf("Authorization = %q, want Bearer backstage-token", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{{
+				"kind": "System",
+				"metadata": map[string]any{
+					"uid":         "system-1",
+					"name":        "security-platform",
+					"namespace":   "default",
+					"description": "Security services",
+				},
+				"spec": map[string]any{
+					"type":   "product",
+					"owner":  "group:platform/security",
+					"domain": "security",
+				},
+			}},
+			"totalItems": 1,
+			"pageInfo":   map[string]any{},
+		})
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{
+		"tenant_id": "writer",
+		"base_url":  server.URL,
+		"token":     "backstage-token",
+		"family":    "system",
+	}), nil)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("len(Events) = %d, want 1", len(pull.Events))
+	}
+	event := pull.Events[0]
+	if event.Kind != "backstage.system" {
+		t.Fatalf("Kind = %q, want backstage.system", event.Kind)
+	}
+	if event.Attributes["name"] != "security-platform" || event.Attributes["owner"] != "group:platform/security" {
+		t.Fatalf("attrs = %#v, want Backstage system attributes", event.Attributes)
+	}
+	if event.Attributes["domain"] != "security" {
+		t.Fatalf("domain = %q, want security", event.Attributes["domain"])
 	}
 }
 

--- a/sources/backstage/testdata/discover_component.json
+++ b/sources/backstage/testdata/discover_component.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:tenant:backstage_component:component-1"
+]

--- a/sources/backstage/testdata/discover_system.json
+++ b/sources/backstage/testdata/discover_system.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:tenant:backstage_system:system-1"
+]

--- a/sources/backstage/testdata/read_component.json
+++ b/sources/backstage/testdata/read_component.json
@@ -1,0 +1,41 @@
+[
+  {
+    "attributes": {
+      "external_id": "component-1",
+      "family": "component",
+      "kind": "Component",
+      "lifecycle": "production",
+      "name": "cerebro",
+      "namespace": "default",
+      "owner": "group:platform/security",
+      "provider": "backstage",
+      "resource_id": "component-1",
+      "resource_name": "cerebro",
+      "resource_type": "service",
+      "source_product": "backstage",
+      "source_provider": "backstage",
+      "system": "security",
+      "uid": "component-1"
+    },
+    "id": "backstage-component-event-1",
+    "kind": "backstage.component",
+    "occurred_at": "2026-08-20T00:00:00Z",
+    "payload": {
+      "kind": "Component",
+      "metadata": {
+        "name": "cerebro",
+        "namespace": "default",
+        "uid": "component-1"
+      },
+      "spec": {
+        "lifecycle": "production",
+        "owner": "group:platform/security",
+        "system": "security",
+        "type": "service"
+      }
+    },
+    "schema_ref": "backstage/component/v1",
+    "source_id": "backstage",
+    "tenant_id": "tenant"
+  }
+]

--- a/sources/backstage/testdata/read_system.json
+++ b/sources/backstage/testdata/read_system.json
@@ -1,0 +1,39 @@
+[
+  {
+    "attributes": {
+      "domain": "security",
+      "external_id": "system-1",
+      "family": "system",
+      "kind": "System",
+      "name": "security-platform",
+      "namespace": "default",
+      "owner": "group:platform/security",
+      "provider": "backstage",
+      "resource_id": "system-1",
+      "resource_name": "security-platform",
+      "resource_type": "product",
+      "source_product": "backstage",
+      "source_provider": "backstage",
+      "uid": "system-1"
+    },
+    "id": "backstage-system-event-1",
+    "kind": "backstage.system",
+    "occurred_at": "2026-08-20T00:00:00Z",
+    "payload": {
+      "kind": "System",
+      "metadata": {
+        "name": "security-platform",
+        "namespace": "default",
+        "uid": "system-1"
+      },
+      "spec": {
+        "domain": "security",
+        "owner": "group:platform/security",
+        "type": "product"
+      }
+    },
+    "schema_ref": "backstage/system/v1",
+    "source_id": "backstage",
+    "tenant_id": "tenant"
+  }
+]


### PR DESCRIPTION
## Summary

- add a provider-verified Rust catalog family for Backstage components with bearer authentication and documented cursor pagination
- preserve the Go identity fallback order with bounded Rust/sourcegen candidate paths
- project nested ownership, lifecycle, repository, classification, and runtime fields without flattening away dotted annotation keys
- update the Go contract fixture to the documented `items` and `pageInfo` response envelope

## Validation

- `git diff --check`
- `rustfmt --edition 2024 --check crates/source-catalog/src/lib.rs crates/source-runtime-next/src/http.rs`
- `python3 scripts/readme_check.py`
- YAML and Go/Rust builds are delegated to hosted Linux checks because the assigned DDESK project is waiting for disk and shared capacity is critical; no local Go or Cargo build result is claimed

## Hosted validation target

- `go test ./internal/connectorcatalog ./internal/sourcegen ./sources/backstage -count=1`
- `cargo fmt --all -- --check`
- `cargo test --locked -p cerebro-platform -p cerebro-source-catalog -p cerebro-source-runtime-next`
- `cargo clippy --locked -p cerebro-platform -p cerebro-source-catalog -p cerebro-source-runtime-next --all-targets --all-features -- -D warnings`
- `make sourcegen-check catalog-check connector-catalog-review docs-drift-check`