### PR TITLE
Fix Rust candidate catalog count

### DIFF
--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -176,8 +176,8 @@ jobs:
             test -x /usr/local/bin/cerebro-event-admission-worker
           '
           summary="$(docker run --rm "${CANDIDATE_IMAGE}" catalog-summary)"
-          test "$(jq -r .sources <<<"${summary}")" -eq 794
-          test "$(jq -r .families <<<"${summary}")" -eq 3894
+          test "$(jq -r .sources <<<"${summary}")" -eq 795
+          test "$(jq -r .families <<<"${summary}")" -eq 3896
       - name: Start disposable PostgreSQL, Neo4j, and JetStream
         run: |
           set -euo pipefail
@@ -245,7 +245,7 @@ jobs:
             | .checks += [
                 {name:"rust_entrypoint",status:"passed",evidence:"image starts cerebro-platform directly"},
                 {name:"go_binary_absent",status:"passed",evidence:"/usr/local/bin/cerebro is absent"},
-                {name:"source_catalog",status:"passed",evidence:"794 sources and 3894 families loaded"}
+                {name:"source_catalog",status:"passed",evidence:"795 sources and 3896 families loaded"}
               ]
           ' .dist/rust-only-e2e/rust-only-e2e-receipt.json \
             > .dist/rust-only-e2e/receipt.tmp

--- a/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
+++ b/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
@@ -107,6 +107,9 @@ fn rust_candidate_build_never_invokes_go_or_emulation() {
         "Run the candidate through its declared Rust entrypoint",
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- seed",
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- verify",
+        r#"test "$(jq -r .sources <<<"${summary}")" -eq 795"#,
+        r#"test "$(jq -r .families <<<"${summary}")" -eq 3896"#,
+        r#"evidence:"795 sources and 3896 families loaded""#,
         "cerebro.rust-only-e2e/v1",
         "cerebro.rust-only-candidate/v1",
     ] {


### PR DESCRIPTION
Fix the Rust-only candidate gate after the Backstage runtime migration expanded the compiled catalog.

The exact failed image reports 795 sources and 3896 families. Keep the executable assertions and signed receipt evidence on those same values, and bind both strings in the existing Rust runtime-contract test.

Validation:
- cargo fmt --all -- --check
- cargo test --locked -p cerebro-platform --test rust_only_runtime_contract (6 passed)
- exact candidate image catalog-summary: 795 sources, 3896 families
- checkout catalog-summary: 795 sources, 3896 families
- git diff --check