### PR TITLE
test(backstage): prove component and system provider replay

### DIFF
--- a/crates/source-runtime-next/testdata/go_fixture_oracle.json
+++ b/crates/source-runtime-next/testdata/go_fixture_oracle.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "cerebro.source-fixture-parity.v2",
-  "corpus_revision": "14682C4C785808497184A3B052ABCA748E61CFC2D36D913EDDFA253FBE6A187E",
+  "corpus_revision": "DB97396F2D48308498BB2FBD83668EDDD9A0874D0188A123FF38BED50DAC5A9D",
   "cases": [
     {
       "source_id": "appwrite",
@@ -853,6 +853,186 @@
       },
       "go_page_digest_sha256": "CB4D88B05C18D0740111B03293728EF42D840440D940EBE9774DBDC93C32DB44",
       "oracle_digest_sha256": "8C43FD83931B433F34FB44D8ACFD69FC4C119E9F57AC255BE66028900D5A2E90",
+      "offline_proof": "fixture_only_no_provider_network",
+      "provider_network_egress": false
+    },
+    {
+      "source_id": "backstage",
+      "family_id": "component",
+      "case_id": "public_first_page",
+      "operation": "check",
+      "payload_sha256": "bc6d7f50b574894d7d20c0a747928d42126e91eb07d20568e9e55b4bed3cce3a",
+      "go_page": {
+        "source_id": "backstage",
+        "family_id": "component",
+        "case_id": "public_first_page",
+        "operation": "check",
+        "accepted_events": [],
+        "quarantines": [],
+        "duplicates": [],
+        "scanned_count": 0,
+        "accepted_count": 0,
+        "rejected_count": 0,
+        "short_circuit_reasons": [
+          "check_only"
+        ]
+      },
+      "go_page_digest_sha256": "3AEF44E778820CFA2E55789ACA6223C1D06C374AA5D513B735D1DE863DC37605",
+      "oracle_digest_sha256": "B8EC0BFBD1D15FE0B1ABF8D9156FB38ABC904CB8ED72782D3AFE88B05F0BF8FC",
+      "offline_proof": "fixture_only_no_provider_network",
+      "provider_network_egress": false
+    },
+    {
+      "source_id": "backstage",
+      "family_id": "component",
+      "case_id": "public_first_page",
+      "operation": "discover",
+      "payload_sha256": "bc6d7f50b574894d7d20c0a747928d42126e91eb07d20568e9e55b4bed3cce3a",
+      "go_page": {
+        "source_id": "backstage",
+        "family_id": "component",
+        "case_id": "public_first_page",
+        "operation": "discover",
+        "accepted_events": [
+          {
+            "event_id": "EB3F3A901751B6CF73BDD91E3782152B364AD97BC10F008FAA38370017C05536",
+            "kind": "backstage.component",
+            "input_index": 0,
+            "payload_sha256": "D88F624D45AB7DBF1B2FCA27EE071CFE722611EE7333F42FD444BF72543FF785"
+          }
+        ],
+        "quarantines": [],
+        "duplicates": [],
+        "scanned_count": 1,
+        "accepted_count": 1,
+        "rejected_count": 0,
+        "proposed_checkpoint": "0A7ABE40D0F989F1E63F9388D80D6EE0573A8A4088F5E49265F0ADF6AB1B807A"
+      },
+      "go_page_digest_sha256": "2C22B0050F8204D41A5D0B3FBBF93B90416AE7A478DB9BE461712A9DA76E905B",
+      "oracle_digest_sha256": "F032CDACB7E35BEF94894331F627613E9606034CCB7AD9C97CFB2532106A5520",
+      "offline_proof": "fixture_only_no_provider_network",
+      "provider_network_egress": false
+    },
+    {
+      "source_id": "backstage",
+      "family_id": "component",
+      "case_id": "public_first_page",
+      "operation": "read-page",
+      "payload_sha256": "bc6d7f50b574894d7d20c0a747928d42126e91eb07d20568e9e55b4bed3cce3a",
+      "go_page": {
+        "source_id": "backstage",
+        "family_id": "component",
+        "case_id": "public_first_page",
+        "operation": "read-page",
+        "accepted_events": [],
+        "quarantines": [
+          {
+            "category": "missing_identity",
+            "field_path": "$.id",
+            "input_index": 0
+          }
+        ],
+        "duplicates": [],
+        "scanned_count": 1,
+        "accepted_count": 0,
+        "rejected_count": 1,
+        "proposed_checkpoint": "AF2A6572CE4008E6A98AEB7A5D4827825C0BBD18B8359C3A7F3BBB77E37D80E5",
+        "short_circuit_reasons": [
+          "final_page"
+        ]
+      },
+      "go_page_digest_sha256": "EA7C36EA93A80F92DEF0F25170A2FA69CD9BC909F71A08D5296D56246A8D89FB",
+      "oracle_digest_sha256": "9B2294FC6370134B068ADCBBE01904D8418E4EB4066AEE7F66437E6B103EBC18",
+      "offline_proof": "fixture_only_no_provider_network",
+      "provider_network_egress": false
+    },
+    {
+      "source_id": "backstage",
+      "family_id": "system",
+      "case_id": "public_first_page",
+      "operation": "check",
+      "payload_sha256": "3b7ec8d61a467bd30a0da2bf9e3a86ae9039a1446b98ff550d8de65780751d8b",
+      "go_page": {
+        "source_id": "backstage",
+        "family_id": "system",
+        "case_id": "public_first_page",
+        "operation": "check",
+        "accepted_events": [],
+        "quarantines": [],
+        "duplicates": [],
+        "scanned_count": 0,
+        "accepted_count": 0,
+        "rejected_count": 0,
+        "short_circuit_reasons": [
+          "check_only"
+        ]
+      },
+      "go_page_digest_sha256": "EB9237F2BB3E9810ADBC3BF9BAF68AEB0EFD9620FFB6C1A84296424AE0FF4783",
+      "oracle_digest_sha256": "8E6590320ED201CB0A1432C5E5B934C8CD1BD025BEDD07D6ED89D94C13CEE70D",
+      "offline_proof": "fixture_only_no_provider_network",
+      "provider_network_egress": false
+    },
+    {
+      "source_id": "backstage",
+      "family_id": "system",
+      "case_id": "public_first_page",
+      "operation": "discover",
+      "payload_sha256": "3b7ec8d61a467bd30a0da2bf9e3a86ae9039a1446b98ff550d8de65780751d8b",
+      "go_page": {
+        "source_id": "backstage",
+        "family_id": "system",
+        "case_id": "public_first_page",
+        "operation": "discover",
+        "accepted_events": [
+          {
+            "event_id": "1EFB6C7415A420D839FA82AA4AE99D4E9ED436328545602A732539DEAEFCEDF1",
+            "kind": "backstage.system",
+            "input_index": 0,
+            "payload_sha256": "9FA07E8BB1BAE98E4F19AC97C61C2F41657E7D7E053F6D32CAA5C30C5317914D"
+          }
+        ],
+        "quarantines": [],
+        "duplicates": [],
+        "scanned_count": 1,
+        "accepted_count": 1,
+        "rejected_count": 0,
+        "proposed_checkpoint": "23EF336020F4FE5E1414977EE6D72E69112BF8F22DB6E435887E19897313055C"
+      },
+      "go_page_digest_sha256": "1A2DA1E4C18A38032004195A316E085743B08308FD85C802197C3E02B6674877",
+      "oracle_digest_sha256": "5EB00EE35B0EDC5D027F2521CD99117705BA6C74B38552E55CAC50281EE8B1C9",
+      "offline_proof": "fixture_only_no_provider_network",
+      "provider_network_egress": false
+    },
+    {
+      "source_id": "backstage",
+      "family_id": "system",
+      "case_id": "public_first_page",
+      "operation": "read-page",
+      "payload_sha256": "3b7ec8d61a467bd30a0da2bf9e3a86ae9039a1446b98ff550d8de65780751d8b",
+      "go_page": {
+        "source_id": "backstage",
+        "family_id": "system",
+        "case_id": "public_first_page",
+        "operation": "read-page",
+        "accepted_events": [],
+        "quarantines": [
+          {
+            "category": "missing_identity",
+            "field_path": "$.id",
+            "input_index": 0
+          }
+        ],
+        "duplicates": [],
+        "scanned_count": 1,
+        "accepted_count": 0,
+        "rejected_count": 1,
+        "proposed_checkpoint": "1E0FEA34016CB437DA3FA1466DDD3A75A9D73D86290F10D36F6E2D3DC2E1FD49",
+        "short_circuit_reasons": [
+          "final_page"
+        ]
+      },
+      "go_page_digest_sha256": "8C569CCE458983C96FD88DC735FE899EF5B351CAF18725805B4E2D4673577A1F",
+      "oracle_digest_sha256": "DAC3FB618D587533B5ED77BB07B3D526E2AF6FE6BE1C25485DC3EE1A2C58B2AA",
       "offline_proof": "fixture_only_no_provider_network",
       "provider_network_egress": false
     },

--- a/sources/backstage/source_test.go
+++ b/sources/backstage/source_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcefixture"
 )
 
 func TestSourceSpec(t *testing.T) {
@@ -42,6 +44,99 @@ func TestRuntimeFixturesSatisfyCatalogContracts(t *testing.T) {
 		if _, err := sourcecdk.LoadFixtureEventsWithContracts(os.DirFS("."), "testdata/read_"+family+".json", catalog.EventContracts); err != nil {
 			t.Fatalf("load %s read fixture: %v", family, err)
 		}
+	}
+}
+
+func TestGenuineProviderResponsesReplayEveryRuntimeFamily(t *testing.T) {
+	tests := []struct {
+		family   string
+		wantKind string
+	}{
+		{family: familyComponent, wantKind: "backstage.component"},
+		{family: familySystem, wantKind: "backstage.system"},
+	}
+	for _, test := range tests {
+		t.Run(test.family, func(t *testing.T) {
+			bundle, err := sourcefixture.FindBundle("../..", sourceID, test.family, "public_first_page")
+			if err != nil {
+				t.Fatalf("FindBundle() error = %v", err)
+			}
+			capturedURL, err := url.Parse(bundle.Manifest.Request.URL)
+			if err != nil {
+				t.Fatalf("parse captured URL: %v", err)
+			}
+			if capturedURL.Path != "/api/catalog/entities/by-query" {
+				t.Fatalf("capture path = %q, want /api/catalog/entities/by-query", capturedURL.Path)
+			}
+			if got, want := capturedURL.Query().Get("filter"), "kind="+test.family; got != want {
+				t.Fatalf("capture filter = %q, want %q", got, want)
+			}
+			if got := capturedURL.Query().Get("limit"); got != "1" {
+				t.Fatalf("capture limit = %q, want 1", got)
+			}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Fatalf("method = %q, want GET", r.Method)
+				}
+				if r.URL.Path != capturedURL.Path {
+					t.Fatalf("path = %q, want %q", r.URL.Path, capturedURL.Path)
+				}
+				if got, want := r.URL.Query().Get("filter"), "kind="+test.family; got != want {
+					t.Fatalf("filter = %q, want %q", got, want)
+				}
+				if got := r.URL.Query().Get("limit"); got != "100" {
+					t.Fatalf("limit = %q, want 100", got)
+				}
+				if got := r.Header.Get("Authorization"); got != "Bearer replay-token" {
+					t.Fatalf("Authorization = %q, want Bearer replay-token", got)
+				}
+				w.Header().Set("Content-Type", bundle.Manifest.Response.ContentType)
+				for name, value := range bundle.Manifest.Response.Headers {
+					w.Header().Set(name, value)
+				}
+				w.WriteHeader(bundle.Manifest.Response.Status)
+				_, _ = w.Write(bundle.Payload)
+			}))
+			defer server.Close()
+
+			source, err := New()
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			source.allowLoopbackForTest()
+			cfg := sourcecdk.NewConfig(map[string]string{
+				"tenant_id": "tenant",
+				"base_url":  server.URL,
+				"token":     "replay-token",
+				"family":    test.family,
+			})
+			pull, err := source.Read(context.Background(), cfg, nil)
+			if err != nil {
+				t.Fatalf("Read() error = %v", err)
+			}
+			if len(pull.Events) != 1 {
+				t.Fatalf("events = %d, want 1", len(pull.Events))
+			}
+			if got := pull.Events[0].Kind; got != test.wantKind {
+				t.Fatalf("event kind = %q, want %q", got, test.wantKind)
+			}
+			for _, attribute := range []string{"name", "kind"} {
+				if strings.TrimSpace(pull.Events[0].Attributes[attribute]) == "" {
+					t.Fatalf("required attribute %q missing", attribute)
+				}
+			}
+			urns, err := source.Discover(context.Background(), cfg)
+			if err != nil {
+				t.Fatalf("Discover() error = %v", err)
+			}
+			if err := sourcefixture.StabilizeEvents(bundle, pull.Events, true); err != nil {
+				t.Fatalf("StabilizeEvents() error = %v", err)
+			}
+			if err := sourcefixture.CompareOrUpdateSourceOutputs(".", test.family, pull.Events, urns, os.Getenv("CEREBRO_UPDATE_SOURCE_FIXTURES") == "1"); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 

--- a/sources/backstage/testdata/api/component/public_first_page/provenance.yaml
+++ b/sources/backstage/testdata/api/component/public_first_page/provenance.yaml
@@ -1,0 +1,18 @@
+schema_version: cerebro.source-api-fixture.v1
+source_id: backstage
+family: component
+case: public_first_page
+replay_test: source_test.go#TestGenuineProviderResponsesReplayEveryRuntimeFamily
+request:
+    method: GET
+    url: https://demo.backstage.io/api/catalog/entities/by-query?filter=kind%3Dcomponent&limit=1
+response:
+    status: 200
+    content_type: application/json; charset=utf-8
+    captured_at: "2026-08-20T18:03:41Z"
+    sha256: bc6d7f50b574894d7d20c0a747928d42126e91eb07d20568e9e55b4bed3cce3a
+sanitization:
+    tool: sourcefixture
+    version: 1
+origin:
+    type: operator_request

--- a/sources/backstage/testdata/api/component/public_first_page/response.json
+++ b/sources/backstage/testdata/api/component/public_first_page/response.json
@@ -1,0 +1,42 @@
+{
+  "items": [
+    {
+      "apiVersion": "backstage.io/v1alpha1",
+      "kind": "Component",
+      "metadata": {
+        "annotations": {
+          "backstage.io/edit-url": "https://github.com/backstage/backstage/edit/master/packages/catalog-model/examples/components/wayback-archive-storage-component.yaml",
+          "backstage.io/managed-by-location": "url:https://github.com/backstage/backstage/tree/master/packages/catalog-model/examples/components/wayback-archive-storage-component.yaml",
+          "backstage.io/managed-by-origin-location": "url:https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-components.yaml",
+          "backstage.io/source-location": "url:https://github.com/backstage/backstage/tree/master/packages/catalog-model/examples/components/",
+          "backstage.io/view-url": "https://github.com/backstage/backstage/tree/master/packages/catalog-model/examples/components/wayback-archive-storage-component.yaml"
+        },
+        "description": "Storage subsystem of the Wayback Archive",
+        "etag": "2bea3967fe39609c23d254944b69adaef8681c37",
+        "name": "wayback-archive-storage",
+        "namespace": "default",
+        "uid": "03c09ec0-833b-4100-89a6-7702bd6c5e01"
+      },
+      "relations": [
+        {
+          "targetRef": "group:default/team-a",
+          "type": "ownedBy"
+        },
+        {
+          "targetRef": "component:default/wayback-archive",
+          "type": "partOf"
+        }
+      ],
+      "spec": {
+        "lifecycle": "production",
+        "owner": "team-a",
+        "subcomponentOf": "wayback-archive",
+        "type": "service"
+      }
+    }
+  ],
+  "pageInfo": {
+    "nextCursor": "eyJvcmRlckZpZWxkcyI6W10sImlzUHJldmlvdXMiOmZhbHNlLCJxdWVyeSI6eyJraW5kIjoiY29tcG9uZW50In0sImZ1bGxUZXh0RmlsdGVyIjp7InRlcm0iOiIifSwib3JkZXJGaWVsZFZhbHVlcyI6WyIwM2MwOWVjMC04MzNiLTQxMDAtODlhNi03NzAyYmQ2YzVlMDEiXSwiZmlyc3RTb3J0RmllbGRWYWx1ZXMiOlsiMDNjMDllYzAtODMzYi00MTAwLTg5YTYtNzcwMmJkNmM1ZTAxIl0sInRvdGFsSXRlbXMiOjE2fQ=="
+  },
+  "totalItems": 16
+}

--- a/sources/backstage/testdata/api/system/public_first_page/provenance.yaml
+++ b/sources/backstage/testdata/api/system/public_first_page/provenance.yaml
@@ -1,0 +1,18 @@
+schema_version: cerebro.source-api-fixture.v1
+source_id: backstage
+family: system
+case: public_first_page
+replay_test: source_test.go#TestGenuineProviderResponsesReplayEveryRuntimeFamily
+request:
+    method: GET
+    url: https://demo.backstage.io/api/catalog/entities/by-query?filter=kind%3Dsystem&limit=1
+response:
+    status: 200
+    content_type: application/json; charset=utf-8
+    captured_at: "2026-08-20T18:03:41Z"
+    sha256: 3b7ec8d61a467bd30a0da2bf9e3a86ae9039a1446b98ff550d8de65780751d8b
+sanitization:
+    tool: sourcefixture
+    version: 1
+origin:
+    type: operator_request

--- a/sources/backstage/testdata/api/system/public_first_page/response.json
+++ b/sources/backstage/testdata/api/system/public_first_page/response.json
@@ -1,0 +1,56 @@
+{
+  "items": [
+    {
+      "apiVersion": "backstage.io/v1alpha1",
+      "kind": "System",
+      "metadata": {
+        "annotations": {
+          "backstage.io/edit-url": "https://github.com/backstage/backstage/edit/master/packages/catalog-model/examples/systems/artist-engagement-portal-system.yaml",
+          "backstage.io/managed-by-location": "url:https://github.com/backstage/backstage/tree/master/packages/catalog-model/examples/systems/artist-engagement-portal-system.yaml",
+          "backstage.io/managed-by-origin-location": "url:https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-systems.yaml",
+          "backstage.io/source-location": "url:https://github.com/backstage/backstage/tree/master/packages/catalog-model/examples/systems/",
+          "backstage.io/view-url": "https://github.com/backstage/backstage/tree/master/packages/catalog-model/examples/systems/artist-engagement-portal-system.yaml"
+        },
+        "description": "Everything related to artists",
+        "etag": "590edf0fe97c745c2c496d7bc2a052a051cbebbe",
+        "name": "artist-engagement-portal",
+        "namespace": "default",
+        "tags": [
+          "portal"
+        ],
+        "uid": "a3f33ec1-e3c8-44aa-a392-1c37e6da8d70"
+      },
+      "relations": [
+        {
+          "targetRef": "component:default/artist-lookup",
+          "type": "hasPart"
+        },
+        {
+          "targetRef": "component:default/www-artist",
+          "type": "hasPart"
+        },
+        {
+          "targetRef": "resource:default/artists-db",
+          "type": "hasPart"
+        },
+        {
+          "targetRef": "group:default/team-a",
+          "type": "ownedBy"
+        },
+        {
+          "targetRef": "domain:default/artists",
+          "type": "partOf"
+        }
+      ],
+      "spec": {
+        "domain": "artists",
+        "owner": "team-a",
+        "type": "service"
+      }
+    }
+  ],
+  "pageInfo": {
+    "nextCursor": "eyJvcmRlckZpZWxkcyI6W10sImlzUHJldmlvdXMiOmZhbHNlLCJxdWVyeSI6eyJraW5kIjoic3lzdGVtIn0sImZ1bGxUZXh0RmlsdGVyIjp7InRlcm0iOiIifSwib3JkZXJGaWVsZFZhbHVlcyI6WyJhM2YzM2VjMS1lM2M4LTQ0YWEtYTM5Mi0xYzM3ZTZkYThkNzAiXSwiZmlyc3RTb3J0RmllbGRWYWx1ZXMiOlsiYTNmMzNlYzEtZTNjOC00NGFhLWEzOTItMWMzN2U2ZGE4ZDcwIl0sInRvdGFsSXRlbXMiOjN9"
+  },
+  "totalItems": 3
+}

--- a/sources/backstage/testdata/discover_component.json
+++ b/sources/backstage/testdata/discover_component.json
@@ -1,3 +1,3 @@
 [
-  "urn:cerebro:tenant:backstage_component:component-1"
+  "urn:cerebro:tenant:backstage_component:03c09ec0-833b-4100-89a6-7702bd6c5e01"
 ]

--- a/sources/backstage/testdata/discover_system.json
+++ b/sources/backstage/testdata/discover_system.json
@@ -1,3 +1,3 @@
 [
-  "urn:cerebro:tenant:backstage_system:system-1"
+  "urn:cerebro:tenant:backstage_system:a3f33ec1-e3c8-44aa-a392-1c37e6da8d70"
 ]

--- a/sources/backstage/testdata/read_component.json
+++ b/sources/backstage/testdata/read_component.json
@@ -1,41 +1,59 @@
 [
   {
-    "attributes": {
-      "external_id": "component-1",
-      "family": "component",
-      "kind": "Component",
-      "lifecycle": "production",
-      "name": "cerebro",
-      "namespace": "default",
-      "owner": "group:platform/security",
-      "provider": "backstage",
-      "resource_id": "component-1",
-      "resource_name": "cerebro",
-      "resource_type": "service",
-      "source_product": "backstage",
-      "source_provider": "backstage",
-      "system": "security",
-      "uid": "component-1"
-    },
-    "id": "backstage-component-event-1",
+    "id": "backstage-tenant-component-0f617935da1b3c41",
+    "tenant_id": "tenant",
+    "source_id": "backstage",
     "kind": "backstage.component",
-    "occurred_at": "2026-08-20T00:00:00Z",
+    "occurred_at": "2026-08-20T18:03:41Z",
+    "schema_ref": "backstage/component/v1",
     "payload": {
+      "apiVersion": "backstage.io/v1alpha1",
       "kind": "Component",
       "metadata": {
-        "name": "cerebro",
+        "annotations": {
+          "backstage.io/edit-url": "https://github.com/backstage/backstage/edit/master/packages/catalog-model/examples/components/wayback-archive-storage-component.yaml",
+          "backstage.io/managed-by-location": "url:https://github.com/backstage/backstage/tree/master/packages/catalog-model/examples/components/wayback-archive-storage-component.yaml",
+          "backstage.io/managed-by-origin-location": "url:https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-components.yaml",
+          "backstage.io/source-location": "url:https://github.com/backstage/backstage/tree/master/packages/catalog-model/examples/components/",
+          "backstage.io/view-url": "https://github.com/backstage/backstage/tree/master/packages/catalog-model/examples/components/wayback-archive-storage-component.yaml"
+        },
+        "description": "Storage subsystem of the Wayback Archive",
+        "etag": "2bea3967fe39609c23d254944b69adaef8681c37",
+        "name": "wayback-archive-storage",
         "namespace": "default",
-        "uid": "component-1"
+        "uid": "03c09ec0-833b-4100-89a6-7702bd6c5e01"
       },
+      "relations": [
+        {
+          "targetRef": "group:default/team-a",
+          "type": "ownedBy"
+        },
+        {
+          "targetRef": "component:default/wayback-archive",
+          "type": "partOf"
+        }
+      ],
       "spec": {
         "lifecycle": "production",
-        "owner": "group:platform/security",
-        "system": "security",
+        "owner": "team-a",
+        "subcomponentOf": "wayback-archive",
         "type": "service"
       }
     },
-    "schema_ref": "backstage/component/v1",
-    "source_id": "backstage",
-    "tenant_id": "tenant"
+    "attributes": {
+      "description": "Storage subsystem of the Wayback Archive",
+      "external_id": "03c09ec0-833b-4100-89a6-7702bd6c5e01",
+      "family": "component",
+      "kind": "Component",
+      "lifecycle": "production",
+      "name": "wayback-archive-storage",
+      "namespace": "default",
+      "owner": "team-a",
+      "provider": "backstage",
+      "source_product": "backstage",
+      "source_provider": "backstage",
+      "type": "service",
+      "uid": "03c09ec0-833b-4100-89a6-7702bd6c5e01"
+    }
   }
 ]

--- a/sources/backstage/testdata/read_system.json
+++ b/sources/backstage/testdata/read_system.json
@@ -1,39 +1,73 @@
 [
   {
-    "attributes": {
-      "domain": "security",
-      "external_id": "system-1",
-      "family": "system",
-      "kind": "System",
-      "name": "security-platform",
-      "namespace": "default",
-      "owner": "group:platform/security",
-      "provider": "backstage",
-      "resource_id": "system-1",
-      "resource_name": "security-platform",
-      "resource_type": "product",
-      "source_product": "backstage",
-      "source_provider": "backstage",
-      "uid": "system-1"
-    },
-    "id": "backstage-system-event-1",
+    "id": "backstage-tenant-system-40c54c4b132db237",
+    "tenant_id": "tenant",
+    "source_id": "backstage",
     "kind": "backstage.system",
-    "occurred_at": "2026-08-20T00:00:00Z",
+    "occurred_at": "2026-08-20T18:03:41Z",
+    "schema_ref": "backstage/system/v1",
     "payload": {
+      "apiVersion": "backstage.io/v1alpha1",
       "kind": "System",
       "metadata": {
-        "name": "security-platform",
+        "annotations": {
+          "backstage.io/edit-url": "https://github.com/backstage/backstage/edit/master/packages/catalog-model/examples/systems/artist-engagement-portal-system.yaml",
+          "backstage.io/managed-by-location": "url:https://github.com/backstage/backstage/tree/master/packages/catalog-model/examples/systems/artist-engagement-portal-system.yaml",
+          "backstage.io/managed-by-origin-location": "url:https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-systems.yaml",
+          "backstage.io/source-location": "url:https://github.com/backstage/backstage/tree/master/packages/catalog-model/examples/systems/",
+          "backstage.io/view-url": "https://github.com/backstage/backstage/tree/master/packages/catalog-model/examples/systems/artist-engagement-portal-system.yaml"
+        },
+        "description": "Everything related to artists",
+        "etag": "590edf0fe97c745c2c496d7bc2a052a051cbebbe",
+        "name": "artist-engagement-portal",
         "namespace": "default",
-        "uid": "system-1"
+        "tags": [
+          "portal"
+        ],
+        "uid": "a3f33ec1-e3c8-44aa-a392-1c37e6da8d70"
       },
+      "relations": [
+        {
+          "targetRef": "component:default/artist-lookup",
+          "type": "hasPart"
+        },
+        {
+          "targetRef": "component:default/www-artist",
+          "type": "hasPart"
+        },
+        {
+          "targetRef": "resource:default/artists-db",
+          "type": "hasPart"
+        },
+        {
+          "targetRef": "group:default/team-a",
+          "type": "ownedBy"
+        },
+        {
+          "targetRef": "domain:default/artists",
+          "type": "partOf"
+        }
+      ],
       "spec": {
-        "domain": "security",
-        "owner": "group:platform/security",
-        "type": "product"
+        "domain": "artists",
+        "owner": "team-a",
+        "type": "service"
       }
     },
-    "schema_ref": "backstage/system/v1",
-    "source_id": "backstage",
-    "tenant_id": "tenant"
+    "attributes": {
+      "description": "Everything related to artists",
+      "domain": "artists",
+      "external_id": "a3f33ec1-e3c8-44aa-a392-1c37e6da8d70",
+      "family": "system",
+      "kind": "System",
+      "name": "artist-engagement-portal",
+      "namespace": "default",
+      "owner": "team-a",
+      "provider": "backstage",
+      "source_product": "backstage",
+      "source_provider": "backstage",
+      "type": "service",
+      "uid": "a3f33ec1-e3c8-44aa-a392-1c37e6da8d70"
+    }
   }
 ]

--- a/tools/sourcefidelity/main_test.go
+++ b/tools/sourcefidelity/main_test.go
@@ -65,6 +65,25 @@ func TestGeneratedProviderPilotsAreHighFidelity(t *testing.T) {
 	}
 }
 
+func TestBackstageGenuineFixturesCoverEveryRuntimeFamily(t *testing.T) {
+	source, err := analyzeSource(filepath.Join("..", "..", "sources", "backstage"))
+	if err != nil {
+		t.Fatalf("analyzeSource(backstage) error = %v", err)
+	}
+	if source.RuntimeFamilies == 0 {
+		t.Fatal("Backstage runtime families = 0")
+	}
+	if source.GenuineAPIFamilies != source.RuntimeFamilies {
+		t.Fatalf("Backstage genuine API families = %d, want every one of %d runtime families", source.GenuineAPIFamilies, source.RuntimeFamilies)
+	}
+	if source.GenuineAPIBundles < source.RuntimeFamilies {
+		t.Fatalf("Backstage genuine API bundles = %d, want at least %d", source.GenuineAPIBundles, source.RuntimeFamilies)
+	}
+	if !source.HasEveryFamilyTest {
+		t.Fatal("Backstage production-decoder replay does not cover every runtime family")
+	}
+}
+
 func providerPilotDefinition(sourceID string, authModel string, method string, pagination *connectordefinitions.PaginationSpec) connectordefinitions.Definition {
 	credentialFields := []connectordefinitions.Field{{Key: "token", Secret: true, ReferenceOnly: true}}
 	auth := connectordefinitions.AuthSpec{Model: authModel, CredentialFields: credentialFields}


### PR DESCRIPTION
## State

Backstage now has genuine, sanitized response bundles for both active runtime families. The source tests replay those bundles through the production decoder, and sourcefidelity fails closed if genuine-family coverage or every-family replay regresses.

The captures came from credential-free GET requests to the public Backstage demo catalog. Each provenance manifest records the request URL, capture time, and response SHA-256; no credentials were handled or stored.

## Validation

- `make source-fixture-check` (124 bundles, 32 sources, 113 families)
- `make fixture-oracle-check`
- `go test ./sources/backstage ./tools/sourcefidelity -count=1`
- `make catalog-check`
- `make docs-drift-check`
- `cargo test --locked -p cerebro-source-runtime-next fixture_parity_matches_checked_in_corpus -- --nocapture` (372 cases, zero mismatches)
- `cargo test --locked -p cerebro-source-runtime-next backstage_catalog_family_executes_documented_cursor_contract -- --nocapture`
- `cargo test --locked -p cerebro-source-catalog backstage_is_compiled_as_a_verified_authoritative_source -- --nocapture`

## Evidence boundary

This closes the accepted genuine-provider fixture and production-decoder replay contract for Backstage component and system. It does not claim a private deployment or authenticated production tenant.