### PR TITLE
Allow candidate attestations to index artifact metadata

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -278,6 +278,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [resolve, image]
     permissions:
+      artifact-metadata: write
       attestations: write
       contents: read
       id-token: write
@@ -546,6 +547,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [resolve, web-image]
     permissions:
+      artifact-metadata: write
       attestations: write
       contents: read
       id-token: write

--- a/scripts/tests/test_release_workflow_serialization.py
+++ b/scripts/tests/test_release_workflow_serialization.py
@@ -43,6 +43,18 @@ class ReleaseWorkflowSerializationTest(unittest.TestCase):
         self.assertIn("runner: ubuntu-24.04-arm", web_image)
         self.assertNotIn("docker/setup-qemu-action", web_image)
 
+    def test_candidate_image_attestations_can_index_artifact_metadata(self) -> None:
+        workflow = CUT_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        manifest = workflow.split("  manifest:\n", 1)[1].split(
+            "\n  rust-organizational-e2e:", 1
+        )[0]
+        web_manifest = workflow.split("  web-manifest:\n", 1)[1].split(
+            "\n  scan-images:", 1
+        )[0]
+
+        for job in (manifest, web_manifest):
+            self.assertIn("artifact-metadata: write", job)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary
- grant job-scoped artifact metadata write access to the candidate runtime and web manifest attestation jobs
- add a workflow contract test covering both jobs

Validation
- python3 -m unittest discover -s scripts/tests
- actionlint v1.7.12 .github/workflows/cut-release.yml
- zizmor .github/workflows/cut-release.yml (no new findings versus main)
- git diff --check