### PR TITLE
Allow Rust candidate attestation to index artifact metadata

### DIFF
--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -84,6 +84,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [resolve, image]
     permissions:
+      artifact-metadata: write
       attestations: write
       contents: read
       id-token: write

--- a/scripts/tests/test_release_workflow_serialization.py
+++ b/scripts/tests/test_release_workflow_serialization.py
@@ -7,6 +7,9 @@ import unittest
 ROOT = Path(__file__).resolve().parents[2]
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 CUT_RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "cut-release.yml"
+RUST_ONLY_CANDIDATE_WORKFLOW = (
+    ROOT / ".github" / "workflows" / "rust-only-candidate.yml"
+)
 
 
 class ReleaseWorkflowSerializationTest(unittest.TestCase):
@@ -54,6 +57,12 @@ class ReleaseWorkflowSerializationTest(unittest.TestCase):
 
         for job in (manifest, web_manifest):
             self.assertIn("artifact-metadata: write", job)
+
+    def test_rust_only_candidate_attestation_can_index_artifact_metadata(self) -> None:
+        workflow = RUST_ONLY_CANDIDATE_WORKFLOW.read_text(encoding="utf-8")
+        manifest = workflow.split("  manifest:\n", 1)[1].split("\n  e2e:", 1)[0]
+
+        self.assertIn("artifact-metadata: write", manifest)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds the missing job-scoped artifact metadata permission to the Rust-only candidate manifest attestation.

The workflow contract test now guards this permission on the exact manifest job.

Validation:
- 6 focused workflow contract tests passed
- 174 script tests passed on browser-build DDESK
- actionlint v1.7.12 passed
- git diff --check passed