### PR TITLE
Fix Trivy package URL normalization parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,6 +1141,7 @@ dependencies = [
  "cerebro-source-catalog",
  "futures-util",
  "hmac",
+ "packageurl",
  "prost",
  "prost-types",
  "reqwest",
@@ -2690,6 +2691,16 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "packageurl"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d33fa1a190c3c9024f21b82e6b30f94137d9c1bf25071e2ab2ba13020135fbaf"
+dependencies = [
+ "percent-encoding",
+ "thiserror 2.0.19",
+]
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ hmac = "0.13.0"
 jsonwebtoken = { version = "11.0.0", default-features = false, features = ["aws_lc_rs"] }
 prost = "0.14.4"
 prost-types = "0.14.4"
+packageurl = "0.7.0"
 regex = { version = "1.12.3", default-features = false, features = ["perf", "std"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde-saphyr = { version = "1.0.0", default-features = false, features = ["deserialize"] }

--- a/crates/source-runtime-next/Cargo.toml
+++ b/crates/source-runtime-next/Cargo.toml
@@ -20,6 +20,7 @@ cerebro-organizational-model.workspace = true
 cerebro-source-catalog.workspace = true
 futures-util.workspace = true
 hmac.workspace = true
+packageurl.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 reqwest = { workspace = true, features = ["form", "stream"] }

--- a/crates/source-runtime-next/src/trivy.rs
+++ b/crates/source-runtime-next/src/trivy.rs
@@ -11,6 +11,7 @@ use std::{
     str::FromStr,
 };
 
+use packageurl::PackageUrl;
 use serde::Deserialize;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -483,30 +484,24 @@ fn normalize_vulnerability_status(status: &str) -> String {
 }
 
 fn normalized_package_id(purl: &str, ecosystem: &str, name: &str, version: &str) -> Option<String> {
-    if let Some(body) = purl.trim().strip_prefix("pkg:") {
-        let body = body.split(['?', '#']).next().unwrap_or_default();
-        if let Some((package_type, package_path)) = body.split_once('/') {
-            let (package_name, purl_version) = package_path
-                .rsplit_once('@')
-                .map_or((package_path, ""), |(name, version)| (name, version));
-            if !package_type.trim().is_empty()
-                && !package_name.trim_matches('/').trim().is_empty()
-                && !package_type.chars().any(char::is_whitespace)
-                && !package_name.chars().any(char::is_whitespace)
-            {
-                let resolved_version = nonblank(purl_version).or_else(|| nonblank(version))?;
-                return Some(
-                    format!(
-                        "{}|{}|{}",
-                        package_type.trim(),
-                        package_name.trim_matches('/').trim(),
-                        resolved_version
-                    )
-                    .to_lowercase(),
-                );
-            }
+    if valid_percent_encoding(purl)
+        && let Ok(parsed) = PackageUrl::from_str(purl.trim())
+    {
+        let package_name = parsed.namespace().map_or_else(
+            || parsed.name().to_owned(),
+            |namespace| format!("{namespace}/{}", parsed.name()),
+        );
+        if !package_name.is_empty() {
+            let resolved_version = parsed
+                .version()
+                .and_then(nonblank)
+                .or_else(|| nonblank(version))?;
+            return Some(
+                format!("{}|{package_name}|{resolved_version}", parsed.ty()).to_lowercase(),
+            );
         }
     }
+
     let name = nonblank(name)?;
     let version = nonblank(version)?;
     Some(
@@ -516,6 +511,25 @@ fn normalized_package_id(purl: &str, ecosystem: &str, name: &str, version: &str)
         )
         .to_lowercase(),
     )
+}
+
+fn valid_percent_encoding(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            if index + 2 >= bytes.len()
+                || !bytes[index + 1].is_ascii_hexdigit()
+                || !bytes[index + 2].is_ascii_hexdigit()
+            {
+                return false;
+            }
+            index += 3;
+        } else {
+            index += 1;
+        }
+    }
+    true
 }
 
 fn compact<'a>(values: impl IntoIterator<Item = (&'a str, &'a str)>) -> BTreeMap<String, String> {
@@ -666,6 +680,48 @@ mod tests {
             fields.get("normalized_id").map(String::as_str),
             Some("deb|debian/openssl|1.0.0")
         );
+    }
+
+    #[test]
+    fn normalized_package_ids_match_packageurl_go_parity() {
+        let cases = [
+            (
+                "pkg:npm/%40opentelemetry/sdk-trace-node@2.2.0",
+                "npm",
+                "sdk-trace-node",
+                "2.2.0",
+                "npm|@opentelemetry/sdk-trace-node|2.2.0",
+            ),
+            (
+                "pkg:deb/debian/libstdc%2B%2B6@12.2.0-14",
+                "debian",
+                "libstdc++6",
+                "12.2.0-14",
+                "deb|debian/libstdc++6|12.2.0-14",
+            ),
+            (
+                "pkg:pypi/My_Package@1.0.0",
+                "python-pkg",
+                "My_Package",
+                "1.0.0",
+                "pypi|my-package|1.0.0",
+            ),
+            (
+                "pkg:npm/%4Gbroken@1.0.0",
+                "node-pkg",
+                "Fallback_Name",
+                "9.9.9",
+                "node-pkg|fallback_name|9.9.9",
+            ),
+        ];
+
+        for (purl, ecosystem, name, version, expected) in cases {
+            assert_eq!(
+                normalized_package_id(purl, ecosystem, name, version).as_deref(),
+                Some(expected),
+                "PURL parity mismatch for {purl}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- parse valid Trivy PURLs with `packageurl` before emitting `fields.normalized_id`
- match packageurl-go normalization for encoded npm scopes, Debian `+`, and PyPI names
- reject malformed percent escapes so normalization falls back to Trivy ecosystem/name/version fields

## Validation

- `cargo test -p cerebro-source-runtime-next trivy::tests::normalized_package_ids_match_packageurl_go_parity -- --exact`
- `cargo test --locked -p cerebro-source-runtime-next` (152 passed)
- `cargo clippy --locked -p cerebro-source-runtime-next --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `make rust-workspace-policy`
- `make rust-deny`
