### PR TITLE
Add Trusted Endpoint Rust push projection

### DIFF
--- a/crates/cerebro-platform/src/append_log_consumer.rs
+++ b/crates/cerebro-platform/src/append_log_consumer.rs
@@ -540,7 +540,9 @@ pub(crate) async fn run(runtime: Arc<ProjectionRuntime>) -> Result<(), Box<dyn E
             subject_source,
             &subject,
             &config.subject_prefix,
-            runtime.catalog.get(subject_source).is_some(),
+            runtime
+                .catalog
+                .admits_event_family(subject_source, subject_family),
         ) {
             Ok(Some(event)) => event,
             Ok(None) => {
@@ -1477,6 +1479,7 @@ fn consumer_io(error: impl std::fmt::Display) -> io::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cerebro_source_catalog::SourceCatalog;
     use prost::Message;
     use prost_types::Timestamp;
     use std::collections::HashMap;
@@ -1933,6 +1936,42 @@ mod tests {
             .unwrap()
             .is_none()
         );
+    }
+
+    #[test]
+    fn trusted_endpoint_push_contract_prevents_catalog_absence_skip() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()
+            .unwrap();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        assert!(catalog.get("trusted_endpoint").is_none());
+
+        let payload = encoded_event(
+            "trusted_endpoint",
+            "trusted_endpoint.host_posture",
+            "trusted_endpoint/host_posture/v1",
+            br#"{"agent_id":"device-1","observation_table":"host_posture"}"#.to_vec(),
+        );
+        let admitted = catalog.admits_event_family("trusted_endpoint", "host_posture");
+        assert!(admitted);
+        assert!(
+            decode_event(
+                &payload,
+                "trusted_endpoint",
+                "events.trusted_endpoint.host_posture",
+                "events",
+                admitted,
+            )
+            .unwrap()
+            .is_some()
+        );
+
+        assert!(!catalog.admits_event_family("trusted_endpoint", "unknown"));
     }
 
     #[test]

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -13,6 +13,7 @@ mod slack_agent_session;
 mod slack_authority;
 mod slack_mrkdwn;
 mod threat_insight_projection;
+mod trusted_endpoint_projection;
 
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -836,6 +837,35 @@ impl ProjectionRuntime {
         if threat_insight_projection::matches(&event) {
             let (batch, delta) =
                 threat_insight_projection::project(event).map_err(ProjectionFailure::Invalid)?;
+            let receipt = self
+                .store
+                .lock()
+                .await
+                .apply(&batch, delta)
+                .await
+                .map_err(ProjectionFailure::Store)?;
+            return Ok(ProjectEventResponse {
+                authority: authority.authority,
+                projected: true,
+                graph_revision: Some(receipt.graph_revision),
+                entities_upserted: receipt.entities_upserted,
+                assertions_upserted: receipt.assertions_upserted,
+            });
+        }
+        if trusted_endpoint_projection::matches(&event) {
+            let contract = self
+                .catalog
+                .push_source(event.source_id())
+                .and_then(|source| source.family(event.family_id()))
+                .ok_or_else(|| {
+                    ProjectionFailure::Invalid(format!(
+                        "push family {}.{} is not in the compiled catalog",
+                        event.source_id(),
+                        event.family_id()
+                    ))
+                })?;
+            let (batch, delta) = trusted_endpoint_projection::project(event, contract)
+                .map_err(ProjectionFailure::Invalid)?;
             let receipt = self
                 .store
                 .lock()

--- a/crates/cerebro-platform/src/trusted_endpoint_projection.rs
+++ b/crates/cerebro-platform/src/trusted_endpoint_projection.rs
@@ -1,0 +1,619 @@
+use std::collections::BTreeMap;
+
+use cerebro_organizational_model::{
+    AssertionProvenance, Entity, EntityKind, GraphAssertion, GraphDelta, ObservationRef,
+    ProviderKind, RelationKind, RelationshipAssertion,
+};
+use cerebro_source_catalog::CompiledPushFamily;
+use cerebro_source_runtime_next::{CollectedBatch, CommittedSourceEvent};
+
+const SOURCE_ID: &str = "trusted_endpoint";
+const MAPPER_ID: &str = "cerebro-trusted-endpoint";
+
+pub(crate) fn matches(event: &CommittedSourceEvent) -> bool {
+    event.source_id() == SOURCE_ID
+}
+
+pub(crate) fn project(
+    event: CommittedSourceEvent,
+    contract: &CompiledPushFamily,
+) -> Result<(CollectedBatch, GraphDelta), String> {
+    validate_contract(&event, contract)?;
+    let payload = event
+        .payload()
+        .as_object()
+        .ok_or("Trusted Endpoint payload must be a JSON object")?;
+    let agent_id = first_nonempty([
+        event.attributes().get("agent_id").map(String::as_str),
+        payload_string(payload, "agent_id"),
+        event.attributes().get("device_id").map(String::as_str),
+        payload_string(payload, "device_id"),
+    ])
+    .ok_or("Trusted Endpoint event is missing agent_id")?
+    .to_owned();
+    let hostname = first_nonempty([
+        event.attributes().get("hostname").map(String::as_str),
+        payload_string(payload, "hostname"),
+        Some(agent_id.as_str()),
+    ])
+    .expect("agent ID is non-empty")
+    .to_owned();
+    let tenant_id = event.tenant_id().clone();
+    let runtime_id = event.source_runtime_id().clone();
+    let observation_id = event.observation_id().clone();
+    let observed_at_unix_ms = event.observed_at_unix_ms();
+    let event_kind = event.event_kind().to_owned();
+    let event_label = event_label(&event).to_owned();
+    let event_provider_id = observation_id.as_str().to_owned();
+
+    let batch = event
+        .clone()
+        .into_batch(event_kind.clone(), event_provider_id.clone())
+        .map_err(|error| error.to_string())?;
+    let receipt = batch.scope.receipt().clone();
+    let agent_kind =
+        ProviderKind::parse("trusted_endpoint.agent").map_err(|error| error.to_string())?;
+    let mut agent = Entity::provider(
+        tenant_id.clone(),
+        runtime_id.clone(),
+        agent_kind,
+        agent_id.clone(),
+        EntityKind::Resource,
+        hostname,
+    )
+    .map_err(|error| error.to_string())?;
+    agent = add_properties(
+        agent,
+        event.attributes(),
+        &[
+            "agent_status",
+            "agent_id",
+            "device_id",
+            "hardware_key",
+            "hostname",
+            "managed",
+        ],
+    )?;
+    agent = agent
+        .with_property("source_product", SOURCE_ID)
+        .map_err(|error| error.to_string())?;
+
+    let event_entity_kind =
+        ProviderKind::parse(event_entity_type(&event_kind)).map_err(|error| error.to_string())?;
+    let mut event_entity = Entity::provider(
+        tenant_id.clone(),
+        runtime_id.clone(),
+        event_entity_kind.clone(),
+        event_provider_id.clone(),
+        EntityKind::Provider(event_entity_kind),
+        event_label,
+    )
+    .map_err(|error| error.to_string())?;
+    event_entity = add_properties(
+        event_entity,
+        event.attributes(),
+        &[
+            "action",
+            "control_id",
+            "decision",
+            "finding_id",
+            "agent_status",
+            "managed",
+            "observation_table",
+            "outcome_result",
+            "reason",
+            "severity",
+            "status",
+        ],
+    )?;
+    for (key, value) in normalized_event_properties(&event_kind, event.attributes()) {
+        event_entity = event_entity
+            .with_property(key, value)
+            .map_err(|error| error.to_string())?;
+    }
+    if event_kind == "trusted_endpoint.agent_execution_receipt" {
+        event_entity = add_properties(event_entity, event.attributes(), RECEIPT_ATTRIBUTES)?;
+    }
+    event_entity = event_entity
+        .with_property("event_id", observation_id.as_str())
+        .and_then(|entity| entity.with_property("kind", &event_kind))
+        .and_then(|entity| entity.with_property("source_product", SOURCE_ID))
+        .and_then(|entity| {
+            entity.with_property("observed_at_unix_ms", observed_at_unix_ms.to_string())
+        })
+        .map_err(|error| error.to_string())?;
+
+    let provenance = AssertionProvenance::direct(
+        vec![
+            ObservationRef::new(
+                &receipt,
+                observation_id,
+                format!("{event_kind}:{event_provider_id}"),
+            )
+            .map_err(|error| error.to_string())?,
+        ],
+        MAPPER_ID,
+        env!("CARGO_PKG_VERSION"),
+    )
+    .map_err(|error| error.to_string())?;
+    let mut builder = receipt.begin_delta();
+    builder
+        .add_entity(agent.clone())
+        .map_err(|error| error.to_string())?;
+    builder
+        .add_entity(event_entity.clone())
+        .map_err(|error| error.to_string())?;
+    add_relationship(
+        &mut builder,
+        &agent,
+        RelationKind::TrackedBy,
+        &event_entity,
+        &provenance,
+        observed_at_unix_ms,
+    )?;
+
+    if event_kind == "trusted_endpoint.agent_execution_receipt" {
+        let product = required_attribute(event_entity.properties(), "agent_product")?;
+        let session_id = required_attribute(event_entity.properties(), "session_id")?;
+        let receipt_id = required_attribute(event_entity.properties(), "receipt_id")?;
+        let session = receipt_entity(
+            &tenant_id,
+            &runtime_id,
+            "trusted_endpoint.agent_session",
+            format!("{agent_id}:{product}:{session_id}"),
+            format!("{product} {session_id}"),
+            event.attributes(),
+            &["agent_product", "device_id", "model", "session_id"],
+        )?;
+        let receipt_entity = receipt_entity(
+            &tenant_id,
+            &runtime_id,
+            "trusted_endpoint.agent_execution_receipt",
+            format!("{agent_id}:{receipt_id}"),
+            receipt_id.to_owned(),
+            event.attributes(),
+            &["device_id", "receipt_id", "receipt_key"],
+        )?;
+        builder
+            .add_entity(session.clone())
+            .map_err(|error| error.to_string())?;
+        builder
+            .add_entity(receipt_entity.clone())
+            .map_err(|error| error.to_string())?;
+        add_relationship(
+            &mut builder,
+            &agent,
+            RelationKind::TrackedBy,
+            &session,
+            &provenance,
+            observed_at_unix_ms,
+        )?;
+        add_relationship(
+            &mut builder,
+            &session,
+            RelationKind::DependsOn,
+            &receipt_entity,
+            &provenance,
+            observed_at_unix_ms,
+        )?;
+        add_relationship(
+            &mut builder,
+            &receipt_entity,
+            RelationKind::DependsOn,
+            &event_entity,
+            &provenance,
+            observed_at_unix_ms,
+        )?;
+    }
+    Ok((batch, builder.build()))
+}
+
+const RECEIPT_ATTRIBUTES: &[&str] = &[
+    "agent_product",
+    "captured_at",
+    "claimed_evidence_integrity",
+    "claimed_provider_binding",
+    "claimed_provider_event_id",
+    "evidence_integrity",
+    "local_user_claim",
+    "local_user_claim_source",
+    "model",
+    "permission_mode",
+    "phase",
+    "previous_receipt_digest",
+    "provider_binding",
+    "normalized_receipt_digest",
+    "receipt_digest",
+    "receipt_id",
+    "receipt_key",
+    "sequence",
+    "session_id",
+    "tool_call_id",
+    "tool_name",
+    "turn_id",
+];
+
+fn validate_contract(
+    event: &CommittedSourceEvent,
+    contract: &CompiledPushFamily,
+) -> Result<(), String> {
+    if event.source_id() != SOURCE_ID
+        || event.family_id() != contract.id()
+        || event.event_kind() != contract.event_kind()
+        || event.schema_ref() != contract.schema_ref()
+    {
+        return Err("event does not match the exact Trusted Endpoint push contract".to_owned());
+    }
+    for field in contract.required_attributes() {
+        if event
+            .attributes()
+            .get(field)
+            .is_none_or(|value| value.trim().is_empty())
+        {
+            return Err(format!(
+                "Trusted Endpoint event is missing attribute {field}"
+            ));
+        }
+    }
+    let payload = event
+        .payload()
+        .as_object()
+        .ok_or("Trusted Endpoint payload must be a JSON object")?;
+    for field in contract.required_payload_fields() {
+        if payload.get(field).is_none_or(serde_json::Value::is_null) {
+            return Err(format!("Trusted Endpoint payload is missing field {field}"));
+        }
+    }
+    Ok(())
+}
+
+fn add_properties(
+    mut entity: Entity,
+    attributes: &BTreeMap<String, String>,
+    keys: &[&str],
+) -> Result<Entity, String> {
+    for key in keys {
+        if let Some(value) = attributes.get(*key).map(String::as_str)
+            && !value.trim().is_empty()
+        {
+            entity = entity
+                .with_property(*key, value.trim())
+                .map_err(|error| error.to_string())?;
+        }
+    }
+    Ok(entity)
+}
+
+fn receipt_entity(
+    tenant_id: &cerebro_organizational_model::TenantId,
+    runtime_id: &cerebro_organizational_model::SourceRuntimeId,
+    provider_kind: &str,
+    provider_id: String,
+    label: String,
+    attributes: &BTreeMap<String, String>,
+    keys: &[&str],
+) -> Result<Entity, String> {
+    let kind = ProviderKind::parse(provider_kind).map_err(|error| error.to_string())?;
+    let entity = Entity::provider(
+        tenant_id.clone(),
+        runtime_id.clone(),
+        kind.clone(),
+        provider_id,
+        EntityKind::Provider(kind),
+        label,
+    )
+    .map_err(|error| error.to_string())?;
+    let entity = add_properties(entity, attributes, keys)?;
+    entity
+        .with_property("source_product", SOURCE_ID)
+        .map_err(|error| error.to_string())
+}
+
+fn add_relationship<Mode>(
+    builder: &mut cerebro_organizational_model::GraphDeltaBuilder<Mode>,
+    from: &Entity,
+    relation: RelationKind,
+    to: &Entity,
+    provenance: &AssertionProvenance,
+    observed_at_unix_ms: i64,
+) -> Result<(), String> {
+    builder
+        .add_assertion(GraphAssertion::Relationship(
+            RelationshipAssertion::new(from, relation, to, provenance.clone(), observed_at_unix_ms)
+                .map_err(|error| error.to_string())?,
+        ))
+        .map_err(|error| error.to_string())
+}
+
+fn payload_string<'a>(
+    payload: &'a serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Option<&'a str> {
+    payload.get(key).and_then(serde_json::Value::as_str)
+}
+
+fn first_nonempty<'a>(values: impl IntoIterator<Item = Option<&'a str>>) -> Option<&'a str> {
+    values
+        .into_iter()
+        .flatten()
+        .find(|value| !value.trim().is_empty())
+        .map(str::trim)
+}
+
+fn event_entity_type(kind: &str) -> &str {
+    match kind {
+        "trusted_endpoint.security_finding" => "trusted_endpoint.security_finding",
+        "trusted_endpoint.grc_evidence" => "trusted_endpoint.grc_evidence",
+        "trusted_endpoint.trust_gate_decision" => "trusted_endpoint.trust_gate_decision",
+        "trusted_endpoint.action_outcome" => "trusted_endpoint.action_outcome",
+        "trusted_endpoint.agent_execution_receipt" => {
+            "trusted_endpoint.agent_execution_receipt_observation"
+        }
+        _ => "trusted_endpoint.observation",
+    }
+}
+
+fn event_label(event: &CommittedSourceEvent) -> &str {
+    first_nonempty(
+        [
+            "receipt_id",
+            "finding_id",
+            "control_id",
+            "action",
+            "observation_table",
+        ]
+        .map(|key| event.attributes().get(key).map(String::as_str)),
+    )
+    .unwrap_or_else(|| event.event_kind())
+}
+
+fn normalized_event_properties(
+    kind: &str,
+    attributes: &BTreeMap<String, String>,
+) -> BTreeMap<&'static str, String> {
+    let decision = normalize_decision(attributes.get("decision").map_or("", String::as_str));
+    BTreeMap::from([
+        ("decision_normalized", decision.clone()),
+        (
+            "severity_normalized",
+            normalize_severity(attributes.get("severity").map_or("", String::as_str)),
+        ),
+        (
+            "status_normalized",
+            normalize_status(kind, attributes, &decision),
+        ),
+    ])
+    .into_iter()
+    .filter(|(_, value)| !value.is_empty())
+    .collect()
+}
+
+fn normalize_decision(value: &str) -> String {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "deny" | "denied" | "block" | "blocked" | "fail" | "failed" | "reject" | "rejected" => {
+            "deny".to_owned()
+        }
+        "allow" | "allowed" | "pass" | "passed" | "ok" | "permit" | "permitted" | "approved" => {
+            "allow".to_owned()
+        }
+        "error" | "errored" => "error".to_owned(),
+        value => value.to_owned(),
+    }
+}
+
+fn normalize_severity(value: &str) -> String {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "critical" | "crit" | "p0" | "sev0" => "CRITICAL".to_owned(),
+        "high" | "p1" | "sev1" => "HIGH".to_owned(),
+        "medium" | "med" | "moderate" | "p2" | "sev2" => "MEDIUM".to_owned(),
+        "low" | "p3" | "sev3" => "LOW".to_owned(),
+        "info" | "informational" | "none" | "p4" | "sev4" => "INFO".to_owned(),
+        "" => "UNKNOWN".to_owned(),
+        value => value.to_ascii_uppercase(),
+    }
+}
+
+fn normalize_status(kind: &str, attributes: &BTreeMap<String, String>, decision: &str) -> String {
+    match (kind, decision) {
+        ("trusted_endpoint.trust_gate_decision", "deny" | "error") => {
+            return "failing".to_owned();
+        }
+        ("trusted_endpoint.trust_gate_decision", "allow") => return "passing".to_owned(),
+        _ => {}
+    }
+    if kind == "trusted_endpoint.security_finding" {
+        let status = attributes
+            .get("status")
+            .map_or("", String::as_str)
+            .trim()
+            .to_ascii_lowercase();
+        if matches!(
+            status.as_str(),
+            "resolved" | "closed" | "remediated" | "fixed"
+        ) || attributes
+            .get("resolved_at")
+            .is_some_and(|value| !value.trim().is_empty())
+        {
+            return "passing".to_owned();
+        }
+        return "failing".to_owned();
+    }
+    let status = first_nonempty([
+        attributes.get("status").map(String::as_str),
+        attributes.get("outcome_result").map(String::as_str),
+    ])
+    .unwrap_or("")
+    .to_ascii_lowercase();
+    match status.as_str() {
+        "fail" | "failed" | "failing" | "non_compliant" | "noncompliant" | "violation" | "open" => {
+            "failing".to_owned()
+        }
+        "pass" | "passed" | "passing" | "compliant" | "ok" | "success" | "resolved" | "closed" => {
+            "passing".to_owned()
+        }
+        "" => "unknown".to_owned(),
+        value => value.to_owned(),
+    }
+}
+
+fn required_attribute<'a>(
+    properties: &'a BTreeMap<String, String>,
+    key: &str,
+) -> Result<&'a str, String> {
+    properties
+        .get(key)
+        .map(String::as_str)
+        .ok_or_else(|| format!("Trusted Endpoint receipt is missing {key}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, path::Path};
+
+    use cerebro_organizational_model::{ObservationId, SourceRuntimeId, TenantId};
+    use cerebro_source_catalog::{CompiledPushFamily, SourceCatalog};
+    use cerebro_source_runtime_next::{CommittedSourceEvent, CommittedSourceInput};
+
+    use super::*;
+
+    fn catalog() -> SourceCatalog {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()
+            .unwrap();
+        SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap()
+    }
+
+    fn event(contract: &CompiledPushFamily) -> CommittedSourceEvent {
+        let mut attributes = BTreeMap::from([(
+            "source_runtime_id".to_owned(),
+            "trusted-endpoint-runtime".to_owned(),
+        )]);
+        for field in contract.required_attributes() {
+            attributes.insert(field.clone(), field_value(field).to_owned());
+        }
+        attributes.insert("hostname".to_owned(), "endpoint.example.test".to_owned());
+        attributes.insert("decision".to_owned(), "blocked".to_owned());
+        attributes.insert("severity".to_owned(), "high".to_owned());
+        let mut payload = serde_json::Map::new();
+        for field in contract.required_payload_fields() {
+            payload.insert(
+                field.clone(),
+                serde_json::Value::String(field_value(field).to_owned()),
+            );
+        }
+        CommittedSourceEvent::from_input(CommittedSourceInput {
+            tenant_id: TenantId::parse("tenant-a").unwrap(),
+            source_runtime_id: SourceRuntimeId::parse("trusted-endpoint-runtime").unwrap(),
+            observation_id: ObservationId::parse(format!("compat:v1:{}", contract.id())).unwrap(),
+            source_id: SOURCE_ID.to_owned(),
+            family_id: contract.id().to_owned(),
+            event_kind: contract.event_kind().to_owned(),
+            schema_ref: contract.schema_ref().to_owned(),
+            observed_at_unix_ms: 1_720_000_000_123,
+            attributes,
+            payload: serde_json::Value::Object(payload),
+        })
+        .unwrap()
+    }
+
+    fn field_value(field: &str) -> &str {
+        match field {
+            "agent_id" => "device-1",
+            "device_id" => "device-1",
+            "hostname" => "endpoint.example.test",
+            "hardware_key" => "hardware-key-1",
+            "observation_table" => "host_posture",
+            "repo_path_hash" => {
+                "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+            "session_surface" => "codex",
+            "risk_score" => "75",
+            "finding_id" => "finding-1",
+            "severity" => "high",
+            "control_id" => "control-1",
+            "status" => "open",
+            "action" => "git_push",
+            "decision" => "deny",
+            "outcome" | "outcome_result" => "blocked",
+            "receipt_id" => "receipt-1",
+            "captured_at" => "2026-08-21T00:00:00Z",
+            "agent_product" => "codex",
+            "session_id" => "session-1",
+            "phase" => "completed",
+            "evidence_integrity" => "verified",
+            _ => "value",
+        }
+    }
+
+    #[test]
+    fn all_ten_push_families_project_without_an_http_collector() {
+        let catalog = catalog();
+        let source = catalog.push_source(SOURCE_ID).unwrap();
+        let mut projected = Vec::new();
+        for contract in source.families() {
+            let (batch, delta) = project(event(contract), contract).unwrap();
+            assert_eq!(batch.records.len(), 1, "family={}", contract.id());
+            assert!(delta.entities().len() >= 2, "family={}", contract.id());
+            assert!(!delta.assertions().is_empty(), "family={}", contract.id());
+            assert!(
+                delta.entities().iter().any(|entity| entity
+                    .properties()
+                    .get("source_product")
+                    .map(String::as_str)
+                    == Some(SOURCE_ID)),
+                "family={}",
+                contract.id()
+            );
+            projected.push(contract.id());
+        }
+        assert_eq!(projected.len(), 10);
+    }
+
+    #[test]
+    fn schema_and_required_fields_fail_closed() {
+        let catalog = catalog();
+        let contract = catalog
+            .push_source(SOURCE_ID)
+            .unwrap()
+            .family("host_posture")
+            .unwrap();
+        let mut wrong_schema = event(contract);
+        wrong_schema = CommittedSourceEvent::from_input(CommittedSourceInput {
+            tenant_id: wrong_schema.tenant_id().clone(),
+            source_runtime_id: wrong_schema.source_runtime_id().clone(),
+            observation_id: wrong_schema.observation_id().clone(),
+            source_id: wrong_schema.source_id().to_owned(),
+            family_id: wrong_schema.family_id().to_owned(),
+            event_kind: wrong_schema.event_kind().to_owned(),
+            schema_ref: "trusted_endpoint/host_posture/v2".to_owned(),
+            observed_at_unix_ms: wrong_schema.observed_at_unix_ms(),
+            attributes: wrong_schema.attributes().clone(),
+            payload: wrong_schema.payload().clone(),
+        })
+        .unwrap();
+        assert!(project(wrong_schema, contract).is_err());
+
+        let mut missing = event(contract);
+        let mut attributes = missing.attributes().clone();
+        attributes.remove("agent_id");
+        missing = CommittedSourceEvent::from_input(CommittedSourceInput {
+            tenant_id: missing.tenant_id().clone(),
+            source_runtime_id: missing.source_runtime_id().clone(),
+            observation_id: missing.observation_id().clone(),
+            source_id: missing.source_id().to_owned(),
+            family_id: missing.family_id().to_owned(),
+            event_kind: missing.event_kind().to_owned(),
+            schema_ref: missing.schema_ref().to_owned(),
+            observed_at_unix_ms: missing.observed_at_unix_ms(),
+            attributes,
+            payload: missing.payload().clone(),
+        })
+        .unwrap();
+        assert!(project(missing, contract).is_err());
+    }
+}

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -474,6 +474,8 @@ impl CompiledSource {
 pub struct CatalogSummary {
     pub sources: usize,
     pub families: usize,
+    pub push_sources: usize,
+    pub push_families: usize,
     pub authoritative_sources: usize,
     pub authoritative_families: usize,
     pub shadow_only_sources: usize,
@@ -554,6 +556,63 @@ pub struct AuthorityReadinessReport {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SourceCatalog {
     sources: BTreeMap<String, CompiledSource>,
+    push_sources: BTreeMap<String, CompiledPushSource>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompiledPushSource {
+    id: String,
+    display_name: String,
+    families: BTreeMap<String, CompiledPushFamily>,
+}
+
+impl CompiledPushSource {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn display_name(&self) -> &str {
+        &self.display_name
+    }
+
+    pub fn families(&self) -> impl Iterator<Item = &CompiledPushFamily> {
+        self.families.values()
+    }
+
+    pub fn family(&self, family_id: &str) -> Option<&CompiledPushFamily> {
+        self.families.get(family_id)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompiledPushFamily {
+    id: String,
+    event_kind: String,
+    schema_ref: String,
+    required_attributes: Vec<String>,
+    required_payload_fields: Vec<String>,
+}
+
+impl CompiledPushFamily {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn event_kind(&self) -> &str {
+        &self.event_kind
+    }
+
+    pub fn schema_ref(&self) -> &str {
+        &self.schema_ref
+    }
+
+    pub fn required_attributes(&self) -> &[String] {
+        &self.required_attributes
+    }
+
+    pub fn required_payload_fields(&self) -> &[String] {
+        &self.required_payload_fields
+    }
 }
 
 impl SourceCatalog {
@@ -563,7 +622,7 @@ impl SourceCatalog {
         definition_root: impl AsRef<Path>,
         source_root: impl AsRef<Path>,
     ) -> Result<Self, CatalogError> {
-        let proofs = load_proofs(source_root.as_ref())?;
+        let manifests = load_source_manifests(source_root.as_ref())?;
         let mut definition_paths = yaml_files(definition_root.as_ref())?;
         definition_paths.sort();
         let mut sources = BTreeMap::new();
@@ -575,13 +634,16 @@ impl SourceCatalog {
                     message: error.to_string(),
                 })?;
             for entry in file.entries {
-                let source = compile_source(&path, entry, &proofs)?;
+                let source = compile_source(&path, entry, &manifests.proofs)?;
                 if sources.insert(source.id.clone(), source.clone()).is_some() {
                     return Err(CatalogError::DuplicateSource(source.id));
                 }
             }
         }
-        Ok(Self { sources })
+        Ok(Self {
+            sources,
+            push_sources: manifests.push_sources,
+        })
     }
 
     pub fn get(&self, source_id: &str) -> Option<&CompiledSource> {
@@ -590,6 +652,27 @@ impl SourceCatalog {
 
     pub fn sources(&self) -> impl Iterator<Item = &CompiledSource> {
         self.sources.values()
+    }
+
+    /// Returns a checked-in push-only source contract. Push contracts are
+    /// intentionally separate from HTTP connector definitions so they cannot
+    /// be selected as empty pollers.
+    pub fn push_source(&self, source_id: &str) -> Option<&CompiledPushSource> {
+        self.push_sources.get(source_id)
+    }
+
+    pub fn push_sources(&self) -> impl Iterator<Item = &CompiledPushSource> {
+        self.push_sources.values()
+    }
+
+    /// Returns whether an append-log source/family pair is admitted by either
+    /// the pull connector catalog or an exact push-only event contract.
+    pub fn admits_event_family(&self, source_id: &str, family_id: &str) -> bool {
+        self.sources.contains_key(source_id)
+            || self
+                .push_sources
+                .get(source_id)
+                .is_some_and(|source| source.family(family_id).is_some())
     }
 
     pub fn summary(&self) -> CatalogSummary {
@@ -618,6 +701,12 @@ impl SourceCatalog {
         CatalogSummary {
             sources: self.sources.len(),
             families,
+            push_sources: self.push_sources.len(),
+            push_families: self
+                .push_sources
+                .values()
+                .map(|source| source.families.len())
+                .sum(),
             authoritative_sources,
             authoritative_families,
             shadow_only_sources: self.sources.len() - authoritative_sources,
@@ -902,9 +991,27 @@ struct ProjectionWire {
 #[derive(Clone, Debug, Deserialize)]
 struct ProofManifestWire {
     id: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    collection_mode: String,
+    #[serde(default)]
+    emitted_kinds: Vec<String>,
+    #[serde(default)]
+    event_contracts: Vec<PushEventContractWire>,
     provider_api: Option<ProviderApiWire>,
     #[serde(default)]
     runtime_families: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct PushEventContractWire {
+    kind: String,
+    schema_ref: String,
+    #[serde(default)]
+    required_attributes: Vec<String>,
+    #[serde(default)]
+    required_payload_fields: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -1943,8 +2050,14 @@ fn path_parameter(segment: &str) -> Option<&str> {
     .then_some(parameter)
 }
 
-fn load_proofs(root: &Path) -> Result<BTreeMap<String, ProofManifestWire>, CatalogError> {
+struct SourceManifests {
+    proofs: BTreeMap<String, ProofManifestWire>,
+    push_sources: BTreeMap<String, CompiledPushSource>,
+}
+
+fn load_source_manifests(root: &Path) -> Result<SourceManifests, CatalogError> {
     let mut proofs = BTreeMap::new();
+    let mut push_sources = BTreeMap::new();
     let entries = fs::read_dir(root).map_err(|error| CatalogError::Io {
         path: root.to_path_buf(),
         message: error.to_string(),
@@ -1974,13 +2087,136 @@ fn load_proofs(root: &Path) -> Result<BTreeMap<String, ProofManifestWire>, Catal
                 path: path.clone(),
                 message: error.to_string(),
             })?;
+        if proof.collection_mode.trim() == "push" {
+            let push_source = compile_push_source(&path, &proof)?;
+            if push_sources
+                .insert(push_source.id.clone(), push_source.clone())
+                .is_some()
+            {
+                return Err(CatalogError::DuplicateSource(push_source.id));
+            }
+        } else if !matches!(proof.collection_mode.trim(), "" | "pull") {
+            return invalid(&path, "collection_mode must be pull or push");
+        }
         if proofs.insert(proof.id.clone(), proof).is_some() {
             return Err(CatalogError::DuplicateSource(
                 entry.file_name().to_string_lossy().into(),
             ));
         }
     }
-    Ok(proofs)
+    Ok(SourceManifests {
+        proofs,
+        push_sources,
+    })
+}
+
+fn compile_push_source(
+    path: &Path,
+    manifest: &ProofManifestWire,
+) -> Result<CompiledPushSource, CatalogError> {
+    let source_id = validate_push_identifier(path, "push source id", &manifest.id)?;
+    let display_name = nonempty(path, "name", manifest.name.clone())?;
+    if manifest.emitted_kinds.is_empty() {
+        return invalid(path, "push source must emit at least one event kind");
+    }
+    let emitted_kinds = manifest
+        .emitted_kinds
+        .iter()
+        .map(|kind| kind.trim().to_owned())
+        .collect::<BTreeSet<_>>();
+    if emitted_kinds.len() != manifest.emitted_kinds.len() {
+        return invalid(path, "push source emitted_kinds must be unique");
+    }
+    let mut families = BTreeMap::new();
+    for contract in &manifest.event_contracts {
+        let event_kind = contract.kind.trim();
+        let family_id = event_kind
+            .strip_prefix(&format!("{source_id}."))
+            .ok_or_else(|| CatalogError::Invalid {
+                path: path.to_path_buf(),
+                message: format!("push event kind {event_kind} must use source prefix {source_id}"),
+            })?;
+        let family_id = validate_push_identifier(path, "push family id", family_id)?;
+        if !emitted_kinds.contains(event_kind) {
+            return invalid(
+                path,
+                &format!("push event kind {event_kind} is not listed in emitted_kinds"),
+            );
+        }
+        let schema_ref = contract.schema_ref.trim();
+        let expected_schema = format!("{source_id}/{family_id}/v1");
+        if schema_ref != expected_schema {
+            return invalid(
+                path,
+                &format!("push family {family_id} schema_ref must be {expected_schema}"),
+            );
+        }
+        let required_attributes = compile_push_fields(
+            path,
+            family_id.as_str(),
+            "required attribute",
+            &contract.required_attributes,
+        )?;
+        let required_payload_fields = compile_push_fields(
+            path,
+            family_id.as_str(),
+            "required payload field",
+            &contract.required_payload_fields,
+        )?;
+        let family = CompiledPushFamily {
+            id: family_id.clone(),
+            event_kind: event_kind.to_owned(),
+            schema_ref: schema_ref.to_owned(),
+            required_attributes,
+            required_payload_fields,
+        };
+        if families.insert(family_id.clone(), family).is_some() {
+            return invalid(path, &format!("duplicate push family {family_id}"));
+        }
+    }
+    if families.len() != emitted_kinds.len() {
+        return invalid(
+            path,
+            "every push emitted kind must have exactly one event_contract",
+        );
+    }
+    Ok(CompiledPushSource {
+        id: source_id,
+        display_name,
+        families,
+    })
+}
+
+fn compile_push_fields(
+    path: &Path,
+    family_id: &str,
+    field_kind: &str,
+    fields: &[String],
+) -> Result<Vec<String>, CatalogError> {
+    let mut compiled = BTreeSet::new();
+    for field in fields {
+        let field = validate_push_identifier(path, field_kind, field)?;
+        if !compiled.insert(field) {
+            return invalid(
+                path,
+                &format!("push family {family_id} {field_kind}s must be unique"),
+            );
+        }
+    }
+    Ok(compiled.into_iter().collect())
+}
+
+fn validate_push_identifier(path: &Path, field: &str, value: &str) -> Result<String, CatalogError> {
+    let value = value.trim();
+    if value.is_empty()
+        || value.len() > 128
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return invalid(path, &format!("{field} is invalid"));
+    }
+    Ok(value.to_owned())
 }
 
 fn yaml_files(root: &Path) -> Result<Vec<PathBuf>, CatalogError> {
@@ -2417,6 +2653,8 @@ mod tests {
         let summary = catalog.summary();
         assert_eq!(summary.sources, 798);
         assert_eq!(summary.families, 3_925);
+        assert_eq!(summary.push_sources, 1);
+        assert_eq!(summary.push_families, 10);
         assert_eq!(
             summary.projection_classes.values().sum::<usize>(),
             summary.families
@@ -2849,6 +3087,55 @@ mod tests {
                 family.id()
             );
         }
+    }
+
+    #[test]
+    fn trusted_endpoint_is_a_push_contract_not_an_http_poller() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        assert!(catalog.get("trusted_endpoint").is_none());
+        let source = catalog.push_source("trusted_endpoint").unwrap();
+        assert_eq!(source.id(), "trusted_endpoint");
+        assert_eq!(source.display_name(), "Trusted Endpoint");
+        let families = source
+            .families()
+            .map(|family| family.id())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            families,
+            BTreeSet::from([
+                "action_outcome",
+                "agent_execution_receipt",
+                "agent_identity",
+                "ai_session_summary",
+                "ai_workflow_risk",
+                "grc_evidence",
+                "host_posture",
+                "repo_worktree_context",
+                "security_finding",
+                "trust_gate_decision",
+            ])
+        );
+        for family in source.families() {
+            assert_eq!(
+                family.event_kind(),
+                format!("trusted_endpoint.{}", family.id())
+            );
+            assert_eq!(
+                family.schema_ref(),
+                format!("trusted_endpoint/{}/v1", family.id())
+            );
+            assert!(
+                catalog.admits_event_family("trusted_endpoint", family.id()),
+                "push family {} was not admitted",
+                family.id()
+            );
+        }
+        assert!(!catalog.admits_event_family("trusted_endpoint", "unknown"));
     }
 
     #[test]

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -41,7 +41,7 @@ cerebro-source-catalog --> cerebro-source-runtime-next
 
 `cerebro-organizational-graph` is the only crate that advances current organizational graph state. A commit takes a validated `GraphDelta`; there is no public entity/link mutation method.
 
-`cerebro-source-catalog` compiles all 798 checked-in source definitions and 3,925 resource families into a closed runtime grammar. Every family is assigned one Rust-owned projection class: identity, access, resource, finding, activity, or bespoke. Connector YAML cannot declare another class. It joins those definitions to provider proof manifests. A definition without complete provider proof remains shadow-only even if it can be executed. Bespoke families also remain shadow-only until a native mapper is added.
+`cerebro-source-catalog` compiles all 798 checked-in pull-source definitions and 3,925 resource families into a closed runtime grammar. Every family is assigned one Rust-owned projection class: identity, access, resource, finding, activity, or bespoke. Connector YAML cannot declare another class. It joins those definitions to provider proof manifests. A definition without complete provider proof remains shadow-only even if it can be executed. Bespoke families also remain shadow-only until a native mapper is added. Separately, the catalog admits one push-only Trusted Endpoint source through ten exact event contracts; it does not construct an HTTP collector or change the pull-source totals.
 
 `cerebro-source-runtime-next` owns source collection, pagination, mapping, and graph commit sequencing. Provider redirects are disabled, pagination cannot change origin, pages are bounded, and resolved credentials never enter the graph model. A source cannot obtain a graph store or construct an unvalidated graph write.
 
@@ -257,7 +257,7 @@ Each receipt binds the tenant, runtime, source, family, collection, exact input 
 
 The runtime reads the same authority record before every projection. Legacy authority calls only Go. Rust authority calls only Rust, requires a commit receipt, and fails closed. The compatibility mapper remains available for parity comparison, but it is no longer a write fallback for a promoted family.
 
-The current checked-in catalog compiles to 798 sources and 3,925 families:
+The current checked-in pull catalog compiles to 798 sources and 3,925 families. The push catalog separately compiles one Trusted Endpoint source and ten event families:
 
 | Projection class | Families | Rust meaning |
 | --- | ---: | --- |

--- a/sources/trustedendpoint/catalog.yaml
+++ b/sources/trustedendpoint/catalog.yaml
@@ -1,6 +1,7 @@
 id: trusted_endpoint
 name: Trusted Endpoint
 description: Metadata-only endpoint posture, AI trust, GRC evidence, and trust-gate source for Writer-managed workstations.
+collection_mode: push
 emitted_kinds:
   - trusted_endpoint.agent_identity
   - trusted_endpoint.host_posture


### PR DESCRIPTION
## Summary

- compile the Trusted Endpoint manifest as one push-only source with ten exact event-family contracts
- admit those families in the append-log consumer and project them through a native Rust mapper
- keep Trusted Endpoint outside the HTTP connector catalog so no empty poller is created
- document pull-catalog totals separately from the push contract

## Test Plan

- `cargo test --locked -p cerebro-platform -p cerebro-source-catalog -p cerebro-source-runtime-next`
- `cargo clippy --locked -p cerebro-platform -p cerebro-source-catalog -p cerebro-source-runtime-next --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `go test ./sources/trustedendpoint ./internal/sourceprojection ./internal/sourceregistry`
- `make catalog-check docs-drift-check`
- `make check-structural check-structural-test check-arch`

## Known Invariants

- Push admission requires the exact compiled source and family contract.
- Event kind, schema, required attributes, and required payload fields fail closed.
- Trusted Endpoint remains absent from the pull connector map and cannot construct an HTTP collector.
- Unknown Trusted Endpoint families remain outside the compiled catalog.

## Deterministic Review

- Focus review on push-only catalog separation, exact append-log admission, and native projection coverage.
- The required `deterministic-review` check remains the hosted range gate.