### PR TITLE
Fix leak check commit metadata scanning

### DIFF
--- a/scripts/leak_check.sh
+++ b/scripts/leak_check.sh
@@ -31,6 +31,7 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 patterns_file="${repo_root}/scripts/leak_patterns.txt"
 user_patterns_file="${CEREBRO_LEAK_USER_PATTERNS:-$HOME/.config/cerebro/leak_patterns.txt}"
+commit_metadata_format='Author: %an <%ae>%nCommitter: %cn <%ce>%n%s%n%b%n---'
 
 if [ "${CEREBRO_LEAK_CHECK_BYPASS:-}" = "1" ]; then
   echo "leak-check: BYPASS via CEREBRO_LEAK_CHECK_BYPASS=1 (mode=${1:-?})" >&2
@@ -218,7 +219,7 @@ EOF
     if [[ "$range" == *...* ]]; then
       commits_range="${base_part}..${head_part}"
     fi
-    commits_meta="$(git log --format='%H%nAuthor: %an <%ae>%nCommitter: %cn <%ce>%n%s%n%b%n---' "$commits_range" 2>/dev/null || true)"
+    commits_meta="$(git log --format="$commit_metadata_format" "$commits_range" 2>/dev/null || true)"
     commits_diff="$(added_diff_for_changed_files "$range")"
     combined="${commits_meta}
 ${commits_diff}"
@@ -257,7 +258,7 @@ ${commits_diff}"
       else
         range="${remote_sha}..${local_sha}"
       fi
-      commits_meta="$(git log --format='%H%nAuthor: %an <%ae>%nCommitter: %cn <%ce>%n%s%n%b%n---' "$range" 2>/dev/null || true)"
+      commits_meta="$(git log --format="$commit_metadata_format" "$range" 2>/dev/null || true)"
       commits_diff="$(added_diff_for_changed_files "$range")"
       combined="${commits_meta}
 ${commits_diff}"

--- a/tools/archtests/leak_patterns_test.go
+++ b/tools/archtests/leak_patterns_test.go
@@ -58,6 +58,31 @@ func TestLeakCheckExcludesRootCertificateFiles(t *testing.T) {
 	}
 }
 
+func TestLeakCheckCommitMetadataExcludesRawCommitHashes(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(repoRoot(t), "scripts", "leak_check.sh"))
+	if err != nil {
+		t.Fatalf("read leak_check.sh: %v", err)
+	}
+	script := string(data)
+	const metadataFormat = "commit_metadata_format='Author: %an <%ae>%nCommitter: %cn <%ce>%n%s%n%b%n---'"
+	if strings.Count(script, metadataFormat) != 1 {
+		t.Fatalf("leak_check.sh must define one hash-free commit metadata format")
+	}
+	const metadataScan = `git log --format="$commit_metadata_format"`
+	if strings.Count(script, metadataScan) != 2 {
+		t.Fatalf("range and pushed modes must share the hash-free commit metadata format")
+	}
+	for _, forbidden := range []string{
+		"commit_metadata_format='%H",
+		"git log --format='%H",
+		`git log --format="%H`,
+	} {
+		if strings.Contains(script, forbidden) {
+			t.Fatalf("leak_check.sh scan metadata includes raw commit hashes")
+		}
+	}
+}
+
 func TestLeakCheckRejectsConcretePRMetadata(t *testing.T) {
 	cases := []string{
 		"Overlay test: alert `123` linked to `internet.ip:198.51.100.24` and `aws.ec2.instance:i-0123456789abcdef0`.",


### PR DESCRIPTION
## Summary

- exclude raw commit hashes from metadata scanned in range and pushed modes
- retain author, committer, subject, body, changed-line scanning, and the existing leak patterns
- add a regression that binds both metadata scan paths to the shared hash-free format

## Root cause

The merge commit for #2393 began with a substring accepted by the broad Okta pattern. Changed files had no pattern hits; only the raw commit hash injected into scan metadata matched.

## DDESK validation

- focused leak checker architecture tests
- full architecture tests before the final additive-main rebase
- historical failing range scan
- pushed-mode simulation for the historical range
- repair commit range scan
- shell syntax and Go formatting checks
- exact two-path scope and diff checks
- leak pattern catalog unchanged
