### PR TITLE
Preserve versionless Trivy package IDs

### DIFF
--- a/crates/source-runtime-next/src/trivy.rs
+++ b/crates/source-runtime-next/src/trivy.rs
@@ -495,7 +495,8 @@ fn normalized_package_id(purl: &str, ecosystem: &str, name: &str, version: &str)
             let resolved_version = parsed
                 .version()
                 .and_then(nonblank)
-                .or_else(|| nonblank(version))?;
+                .or_else(|| nonblank(version))
+                .unwrap_or_default();
             return Some(
                 format!("{}|{package_name}|{resolved_version}", parsed.ty()).to_lowercase(),
             );
@@ -712,6 +713,13 @@ mod tests {
                 "Fallback_Name",
                 "9.9.9",
                 "node-pkg|fallback_name|9.9.9",
+            ),
+            (
+                "pkg:generic/acme/widget",
+                "generic",
+                "widget",
+                "",
+                "generic|acme/widget|",
             ),
         ];
 


### PR DESCRIPTION
## Summary

- preserve packageurl-go behavior when a valid PURL and the Trivy package record both omit a version
- emit the existing `fields.normalized_id` contract with its trailing version separator, for example `generic|acme/widget|`
- add the versionless vector to the Trivy PURL parity table

This is a forward correction to the Trivy normalization change already merged in #2406.

## Validation

- `cargo test --locked -p cerebro-source-runtime-next trivy::tests::normalized_package_ids_match_packageurl_go_parity -- --exact`
- `cargo check --locked -p cerebro-source-runtime-next`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- full runtime suite on the same correction before additive-main rebase: 195 passed
- `cargo clippy --locked -p cerebro-source-runtime-next --all-targets --all-features -- -D warnings`
- `make rust-workspace-policy`
- `make rust-deny`
