### PR TITLE
feat(rust): add modular Twilio provider kernel

### DIFF
--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -33,6 +33,7 @@ mod sdk;
 mod security_tooling_map;
 mod sentinelone;
 mod trivy;
+mod twilio;
 mod vulnview;
 
 pub use amplitude::{
@@ -145,6 +146,9 @@ pub use sentinelone::{
     SentinelOnePage, SentinelOneRecord, SentinelOneRequest,
 };
 pub use trivy::{TrivyError, TrivyFamily, TrivyKernel, TrivyPage, TrivyRecord};
+pub use twilio::{
+    TwilioError, TwilioFamily, TwilioFilters, TwilioKernel, TwilioPage, TwilioRecord, TwilioRequest,
+};
 pub use vulnview::{
     VulnViewError, VulnViewFamily, VulnViewFilters, VulnViewKernel, VulnViewPage, VulnViewRecord,
     VulnViewRequest,

--- a/crates/source-runtime-next/src/twilio.rs
+++ b/crates/source-runtime-next/src/twilio.rs
@@ -1,0 +1,17 @@
+//! Credential-free Twilio provider kernel facade.
+
+mod cursor;
+mod error;
+mod family;
+mod model;
+mod normalize;
+mod origin;
+mod request;
+mod response;
+
+#[cfg(test)]
+mod tests;
+
+pub use error::TwilioError;
+pub use model::{TwilioFamily, TwilioFilters, TwilioPage, TwilioRecord};
+pub use request::{TwilioKernel, TwilioRequest};

--- a/crates/source-runtime-next/src/twilio/cursor.rs
+++ b/crates/source-runtime-next/src/twilio/cursor.rs
@@ -1,0 +1,124 @@
+//! Opaque Twilio provider continuation validation and decoding.
+
+use reqwest::Url;
+use serde_json::{Map, Value};
+
+use super::TwilioError;
+
+const MAX_CURSOR_BYTES: usize = 4_096;
+
+pub(super) fn bounded_cursor(cursor: Option<&str>) -> Result<Option<String>, TwilioError> {
+    let cursor = cursor.map(str::trim).filter(|value| !value.is_empty());
+    if cursor.is_some_and(|value| {
+        value.len() > MAX_CURSOR_BYTES
+            || value.chars().any(char::is_control)
+            || value.starts_with("http://")
+            || value.starts_with("https://")
+    }) {
+        return Err(TwilioError::InvalidCursor);
+    }
+    Ok(cursor.map(str::to_owned))
+}
+
+pub(super) fn response_cursor(object: &Map<String, Value>) -> Result<Option<String>, TwilioError> {
+    const KEYS: [&str; 7] = [
+        "nextCursor",
+        "next_cursor",
+        "cursor",
+        "next",
+        "nextPageToken",
+        "next_page_token",
+        "next_page",
+    ];
+    for key in KEYS {
+        if let Some(value) = object.get(key) {
+            let cursor = bounded_cursor(response_cursor_value(value)?.as_deref())?;
+            if cursor.is_some() {
+                return Ok(cursor);
+            }
+        }
+    }
+    for container in [
+        "pagination",
+        "page",
+        "pageInfo",
+        "meta",
+        "result_info",
+        "resultInfo",
+    ] {
+        let Some(Value::Object(nested)) = object.get(container) else {
+            continue;
+        };
+        for key in KEYS {
+            if let Some(value) = nested.get(key) {
+                let cursor = bounded_cursor(response_cursor_value(value)?.as_deref())?;
+                if cursor.is_some() {
+                    return Ok(cursor);
+                }
+            }
+        }
+        if let Some(next) = next_page_cursor(nested)? {
+            return bounded_cursor(Some(&next));
+        }
+    }
+    Ok(None)
+}
+
+fn response_cursor_value(value: &Value) -> Result<Option<String>, TwilioError> {
+    let Some(value) = cursor_scalar(value)? else {
+        return Ok(None);
+    };
+    let value = value.trim();
+    if value.is_empty() || value.starts_with("http://") || value.starts_with("https://") {
+        return Ok((!value.is_empty()).then(|| value.to_owned()));
+    }
+    let base = Url::parse("https://twilio.invalid/").map_err(|_| TwilioError::InvalidResponse)?;
+    let parsed = base.join(value).map_err(|_| TwilioError::InvalidCursor)?;
+    if let Some((_, cursor)) = parsed
+        .query_pairs()
+        .find(|(name, value)| name == "cursor" && !value.trim().is_empty())
+    {
+        return Ok(Some(cursor.into_owned()));
+    }
+    Ok(Some(value.to_owned()))
+}
+
+fn cursor_scalar(value: &Value) -> Result<Option<String>, TwilioError> {
+    match value {
+        Value::Null => Ok(None),
+        Value::String(value) => Ok(Some(value.clone())),
+        Value::Number(value) => Ok(Some(value.to_string())),
+        _ => Err(TwilioError::InvalidResponse),
+    }
+}
+
+fn next_page_cursor(object: &Map<String, Value>) -> Result<Option<String>, TwilioError> {
+    let Some(page) = object.get("page") else {
+        return Ok(None);
+    };
+    let total = object
+        .get("total_pages")
+        .or_else(|| object.get("totalPages"))
+        .or_else(|| object.get("page_count"))
+        .or_else(|| object.get("pageCount"));
+    let Some(total) = total else {
+        return Ok(None);
+    };
+    let page = positive_integer(page)?;
+    let total = positive_integer(total)?;
+    if page >= total {
+        return Ok(None);
+    }
+    Ok(Some((page + 1).to_string()))
+}
+
+fn positive_integer(value: &Value) -> Result<u64, TwilioError> {
+    let parsed = match value {
+        Value::Number(value) => value.as_u64(),
+        Value::String(value) => value.trim().parse().ok(),
+        _ => None,
+    };
+    parsed
+        .filter(|value| *value > 0)
+        .ok_or(TwilioError::InvalidResponse)
+}

--- a/crates/source-runtime-next/src/twilio/error.rs
+++ b/crates/source-runtime-next/src/twilio/error.rs
@@ -1,0 +1,78 @@
+//! Stable fail-closed Twilio kernel errors.
+
+use std::{error::Error, fmt};
+
+/// Stable Twilio request and response failures.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TwilioError {
+    /// The configured API base URL is not an allowed secure origin.
+    InvalidBaseUrl,
+    /// The selected family is not in the Twilio source catalog.
+    InvalidFamily,
+    /// Source tenant identity is required.
+    MissingTenantId,
+    /// Account SID is required for the keys family.
+    MissingAccountSid,
+    /// Page size is outside the Go source's inclusive 1 through 500 range.
+    InvalidPageSize,
+    /// Provider continuation is oversized, control-bearing, or malformed.
+    InvalidCursor,
+    /// A planned request does not belong to this kernel.
+    RequestScopeMismatch,
+    /// Provider response exceeds the eight-mebibyte host bound.
+    ResponseTooLarge,
+    /// Provider response exceeds the requested maximum page cardinality.
+    TooManyRecords,
+    /// Response JSON does not match the selected provider family.
+    InvalidResponse,
+    /// A provider record has no stable identity under the Go selector order.
+    MissingProviderIdentity,
+    /// A catalog-required raw provider field is missing or empty.
+    MissingRequiredPayloadField(&'static str),
+    /// A catalog-required normalized attribute is missing.
+    MissingRequiredAttribute(&'static str),
+}
+
+impl fmt::Display for TwilioError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidBaseUrl => formatter.write_str("twilio base URL must be a secure origin"),
+            Self::InvalidFamily => {
+                formatter.write_str("twilio family must be accounts, keys, or audit_events")
+            }
+            Self::MissingTenantId => formatter.write_str("twilio tenant_id is required"),
+            Self::MissingAccountSid => {
+                formatter.write_str("twilio account_sid is required for keys")
+            }
+            Self::InvalidPageSize => {
+                formatter.write_str("twilio per_page must be between 1 and 500")
+            }
+            Self::InvalidCursor => formatter.write_str("twilio page cursor is invalid"),
+            Self::RequestScopeMismatch => {
+                formatter.write_str("twilio request does not match the kernel")
+            }
+            Self::ResponseTooLarge => formatter.write_str("twilio response exceeds 8388608 bytes"),
+            Self::TooManyRecords => formatter.write_str("twilio response exceeds 500 records"),
+            Self::InvalidResponse => {
+                formatter.write_str("twilio response does not match the selected family")
+            }
+            Self::MissingProviderIdentity => {
+                formatter.write_str("twilio record has no stable provider identity")
+            }
+            Self::MissingRequiredPayloadField(name) => {
+                write!(
+                    formatter,
+                    "twilio record is missing required payload field {name}"
+                )
+            }
+            Self::MissingRequiredAttribute(name) => {
+                write!(
+                    formatter,
+                    "twilio record is missing required attribute {name}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for TwilioError {}

--- a/crates/source-runtime-next/src/twilio/family/accounts/mod.rs
+++ b/crates/source-runtime-next/src/twilio/family/accounts/mod.rs
@@ -1,0 +1,268 @@
+//! Go-compatible Twilio accounts normalization.
+
+mod wire;
+
+use serde_json::Value;
+use time::OffsetDateTime;
+
+use super::super::{
+    TwilioError, TwilioFamily, TwilioRecord,
+    normalize::{
+        base_fields, event_id, first, insert, occurred_at, provider_identity, record_identity,
+        require_field, require_payload_id, scalar,
+    },
+};
+use wire::AccountWire;
+
+pub(in crate::twilio) fn normalize(
+    payload: Value,
+    tenant_id: &str,
+    base_origin: &str,
+    path: &str,
+    observed_at: OffsetDateTime,
+) -> Result<TwilioRecord, TwilioError> {
+    let record: AccountWire =
+        serde_json::from_value(payload.clone()).map_err(|_| TwilioError::InvalidResponse)?;
+    require_payload_id(&record.id)?;
+    let profile = record.profile.as_ref();
+    let metadata = record.metadata.as_ref();
+    let evidence = record.evidence_cas.as_ref();
+    let record_id = provider_identity([
+        scalar(&record.id),
+        scalar(&record.user_id),
+        scalar(&record.email),
+        scalar(&record.primary_email),
+        scalar(&record.login),
+    ])?;
+    let provider_id = record_identity(&record_id, &record.identity);
+    let mut fields = base_fields(
+        TwilioFamily::Accounts,
+        tenant_id,
+        &record_id,
+        "identity_user",
+    );
+    let mappings = [
+        (
+            "created_at",
+            first([
+                scalar(&record.created_at),
+                scalar(&record.created),
+                scalar(&profile.and_then(|value| value.created_at.clone())),
+            ]),
+        ),
+        (
+            "department",
+            first([
+                scalar(&record.department),
+                scalar(&profile.and_then(|value| value.department.clone())),
+            ]),
+        ),
+        (
+            "display_name",
+            first([
+                scalar(&record.display_name),
+                scalar(&record.name),
+                scalar(&profile.and_then(|value| value.display_name.clone())),
+                scalar(&profile.and_then(|value| value.name.clone())),
+            ]),
+        ),
+        (
+            "domain",
+            first([
+                scalar(&record.domain),
+                scalar(&record.tenant_domain),
+                scalar(&record.organization_domain),
+            ]),
+        ),
+        (
+            "email",
+            first([
+                scalar(&record.email),
+                scalar(&record.primary_email),
+                scalar(&profile.and_then(|value| value.email.clone())),
+            ]),
+        ),
+        (
+            "evidence_cas_commit_id",
+            first([
+                scalar(&evidence.and_then(|value| value.commit_id.clone())),
+                scalar(&record.evidence_cas_commit_id),
+                scalar(&record.commit_id),
+            ]),
+        ),
+        (
+            "evidence_cas_digest",
+            first([
+                scalar(&evidence.and_then(|value| value.digest.clone())),
+                scalar(&record.evidence_cas_digest),
+                scalar(&record.digest),
+            ]),
+        ),
+        (
+            "evidence_cas_merkle_root",
+            first([
+                scalar(&evidence.and_then(|value| value.merkle_root.clone())),
+                scalar(&record.evidence_cas_merkle_root),
+                scalar(&record.merkle_root),
+            ]),
+        ),
+        (
+            "evidence_cas_ref_type",
+            first([
+                scalar(&evidence.and_then(|value| value.ref_type.clone())),
+                scalar(&record.evidence_cas_ref_type),
+                scalar(&record.ref_type),
+            ]),
+        ),
+        (
+            "evidence_cas_uri",
+            first([
+                scalar(&evidence.and_then(|value| value.uri.clone())),
+                scalar(&record.evidence_cas_uri),
+                scalar(&record.uri),
+            ]),
+        ),
+        (
+            "job_title",
+            first([
+                scalar(&record.job_title),
+                scalar(&record.title),
+                scalar(&profile.and_then(|value| value.title.clone())),
+            ]),
+        ),
+        (
+            "last_login_at",
+            first([
+                scalar(&record.last_login_at),
+                scalar(&record.last_login),
+                scalar(&record.last_seen_at),
+            ]),
+        ),
+        (
+            "login",
+            first([
+                scalar(&record.login),
+                scalar(&record.username),
+                scalar(&record.email),
+                scalar(&profile.and_then(|value| value.login.clone())),
+            ]),
+        ),
+        (
+            "manager",
+            first([
+                scalar(&record.manager),
+                scalar(&profile.and_then(|value| value.manager.clone())),
+            ]),
+        ),
+        (
+            "observed_at",
+            first([
+                scalar(&record.observed_at),
+                scalar(&record.updated_at),
+                scalar(&record.last_seen_at),
+            ]),
+        ),
+        (
+            "primary_email",
+            first([
+                scalar(&record.primary_email),
+                scalar(&record.email),
+                scalar(&profile.and_then(|value| value.email.clone())),
+            ]),
+        ),
+        (
+            "resource_id",
+            first([
+                scalar(&record.resource_id),
+                scalar(&record.id),
+                scalar(&metadata.and_then(|value| value.resource_id.clone())),
+            ]),
+        ),
+        (
+            "resource_name",
+            first([
+                scalar(&record.name),
+                scalar(&record.display_name),
+                scalar(&record.hostname),
+                scalar(&metadata.and_then(|value| value.resource_name.clone())),
+            ]),
+        ),
+        (
+            "resource_type",
+            first([
+                scalar(&record.resource_type),
+                scalar(&record.kind),
+                scalar(&metadata.and_then(|value| value.resource_type.clone())),
+            ]),
+        ),
+        (
+            "resource_urn",
+            first([
+                scalar(&record.resource_urn),
+                scalar(&record.urn),
+                scalar(&metadata.and_then(|value| value.resource_urn.clone())),
+            ]),
+        ),
+        (
+            "source_event_id",
+            first([
+                scalar(&record.event_id),
+                scalar(&record.id),
+                scalar(&metadata.and_then(|value| value.event_id.clone())),
+            ]),
+        ),
+        (
+            "status",
+            first([
+                scalar(&record.status),
+                scalar(&record.state),
+                scalar(&record.lifecycle_state),
+            ]),
+        ),
+        (
+            "user_id",
+            first([
+                scalar(&record.user_id),
+                scalar(&record.id),
+                scalar(&record.uid),
+            ]),
+        ),
+    ];
+    for (name, value) in mappings {
+        insert(&mut fields, name, value);
+    }
+    require_field(&fields, "source_event_id")?;
+    require_field(&fields, "user_id")?;
+    let occurred_at = occurred_at(
+        [
+            scalar(&record.observed_at),
+            scalar(&record.updated_at),
+            scalar(&record.last_seen_at),
+            scalar(&record.created_at),
+            scalar(&record.updated_at_camel),
+            scalar(&record.last_seen_at_camel),
+            scalar(&record.last_check_in),
+            scalar(&record.last_check_in_camel),
+            scalar(&record.created_at_camel),
+            scalar(&record.timestamp),
+        ],
+        observed_at,
+    );
+    Ok(TwilioRecord {
+        family: TwilioFamily::Accounts.as_str().to_owned(),
+        provider_kind: TwilioFamily::Accounts.provider_kind().to_owned(),
+        schema_ref: TwilioFamily::Accounts.schema_ref().to_owned(),
+        tenant_id: tenant_id.to_owned(),
+        provider_id: provider_id.clone(),
+        event_id: event_id(
+            tenant_id,
+            base_origin,
+            path,
+            TwilioFamily::Accounts,
+            &provider_id,
+        ),
+        fields,
+        occurred_at,
+        payload,
+    })
+}

--- a/crates/source-runtime-next/src/twilio/family/accounts/wire.rs
+++ b/crates/source-runtime-next/src/twilio/family/accounts/wire.rs
@@ -1,0 +1,82 @@
+//! Typed Twilio accounts provider object.
+
+use serde::Deserialize;
+
+use super::super::wire::{EvidenceCasWire, IdentityDiscriminatorsWire, MetadataWire, WireScalar};
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub(super) struct AccountWire {
+    #[serde(flatten)]
+    pub(super) identity: IdentityDiscriminatorsWire,
+    pub(super) id: Option<WireScalar>,
+    pub(super) user_id: Option<WireScalar>,
+    pub(super) uid: Option<WireScalar>,
+    pub(super) email: Option<WireScalar>,
+    pub(super) primary_email: Option<WireScalar>,
+    pub(super) login: Option<WireScalar>,
+    pub(super) username: Option<WireScalar>,
+    pub(super) name: Option<WireScalar>,
+    pub(super) display_name: Option<WireScalar>,
+    pub(super) hostname: Option<WireScalar>,
+    pub(super) created_at: Option<WireScalar>,
+    pub(super) created: Option<WireScalar>,
+    pub(super) updated_at: Option<WireScalar>,
+    #[serde(rename = "updatedAt")]
+    pub(super) updated_at_camel: Option<WireScalar>,
+    pub(super) last_seen_at: Option<WireScalar>,
+    #[serde(rename = "lastSeenAt")]
+    pub(super) last_seen_at_camel: Option<WireScalar>,
+    pub(super) last_check_in: Option<WireScalar>,
+    #[serde(rename = "lastCheckIn")]
+    pub(super) last_check_in_camel: Option<WireScalar>,
+    #[serde(rename = "createdAt")]
+    pub(super) created_at_camel: Option<WireScalar>,
+    pub(super) timestamp: Option<WireScalar>,
+    pub(super) department: Option<WireScalar>,
+    pub(super) domain: Option<WireScalar>,
+    pub(super) tenant_domain: Option<WireScalar>,
+    pub(super) organization_domain: Option<WireScalar>,
+    pub(super) job_title: Option<WireScalar>,
+    pub(super) title: Option<WireScalar>,
+    pub(super) last_login_at: Option<WireScalar>,
+    pub(super) last_login: Option<WireScalar>,
+    pub(super) manager: Option<WireScalar>,
+    pub(super) observed_at: Option<WireScalar>,
+    pub(super) resource_id: Option<WireScalar>,
+    #[serde(rename = "type")]
+    pub(super) kind: Option<WireScalar>,
+    pub(super) resource_type: Option<WireScalar>,
+    pub(super) resource_urn: Option<WireScalar>,
+    pub(super) urn: Option<WireScalar>,
+    pub(super) event_id: Option<WireScalar>,
+    pub(super) status: Option<WireScalar>,
+    pub(super) state: Option<WireScalar>,
+    pub(super) lifecycle_state: Option<WireScalar>,
+    pub(super) evidence_cas_commit_id: Option<WireScalar>,
+    pub(super) commit_id: Option<WireScalar>,
+    pub(super) evidence_cas_digest: Option<WireScalar>,
+    pub(super) digest: Option<WireScalar>,
+    pub(super) evidence_cas_merkle_root: Option<WireScalar>,
+    pub(super) merkle_root: Option<WireScalar>,
+    pub(super) evidence_cas_ref_type: Option<WireScalar>,
+    pub(super) ref_type: Option<WireScalar>,
+    pub(super) evidence_cas_uri: Option<WireScalar>,
+    pub(super) uri: Option<WireScalar>,
+    pub(super) profile: Option<ProfileWire>,
+    pub(super) metadata: Option<MetadataWire>,
+    pub(super) evidence_cas: Option<EvidenceCasWire>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub(super) struct ProfileWire {
+    pub(super) created_at: Option<WireScalar>,
+    pub(super) department: Option<WireScalar>,
+    pub(super) display_name: Option<WireScalar>,
+    pub(super) name: Option<WireScalar>,
+    pub(super) email: Option<WireScalar>,
+    pub(super) title: Option<WireScalar>,
+    pub(super) login: Option<WireScalar>,
+    pub(super) manager: Option<WireScalar>,
+}

--- a/crates/source-runtime-next/src/twilio/family/audit_events/mod.rs
+++ b/crates/source-runtime-next/src/twilio/family/audit_events/mod.rs
@@ -1,0 +1,223 @@
+//! Go-compatible Twilio audit-events normalization.
+
+mod wire;
+
+use serde_json::Value;
+use time::OffsetDateTime;
+
+use super::super::{
+    TwilioError, TwilioFamily, TwilioRecord,
+    normalize::{
+        base_fields, event_id, first, insert, occurred_at, provider_identity, record_identity,
+        require_field, require_payload_id, scalar,
+    },
+};
+use wire::AuditEventWire;
+
+pub(in crate::twilio) fn normalize(
+    payload: Value,
+    tenant_id: &str,
+    base_origin: &str,
+    path: &str,
+    observed_at: OffsetDateTime,
+) -> Result<TwilioRecord, TwilioError> {
+    let record: AuditEventWire =
+        serde_json::from_value(payload.clone()).map_err(|_| TwilioError::InvalidResponse)?;
+    require_payload_id(&record.id)?;
+    let actor = record.actor.as_ref();
+    let user = record.user.as_ref();
+    let target = record.target.as_ref();
+    let resource = record.resource.as_ref();
+    let metadata = record.metadata.as_ref();
+    let evidence = record.evidence_cas.as_ref();
+    let record_id = provider_identity([
+        scalar(&record.id),
+        scalar(&record.event_id),
+        scalar(&record.uuid),
+        scalar(&record.request_id),
+    ])?;
+    let provider_id = record_identity(&record_id, &record.identity);
+    let mut fields = base_fields(
+        TwilioFamily::AuditEvents,
+        tenant_id,
+        &record_id,
+        "audit_event",
+    );
+    let mappings = [
+        (
+            "actor_email",
+            first([
+                scalar(&record.actor_email),
+                scalar(&actor.and_then(|value| value.email.clone())),
+                scalar(&record.email),
+                scalar(&user.and_then(|value| value.email.clone())),
+            ]),
+        ),
+        (
+            "actor_id",
+            first([
+                scalar(&record.actor_id),
+                scalar(&actor.and_then(|value| value.id.clone())),
+                scalar(&record.actor_id_camel),
+                scalar(&record.user_id),
+                scalar(&user.and_then(|value| value.id.clone())),
+            ]),
+        ),
+        (
+            "actor_name",
+            first([
+                scalar(&record.actor_name),
+                scalar(&actor.and_then(|value| value.name.clone())),
+                scalar(&user.and_then(|value| value.name.clone())),
+            ]),
+        ),
+        (
+            "event_type",
+            first([
+                scalar(&record.event_type),
+                scalar(&record.event_name),
+                scalar(&record.action),
+                scalar(&record.kind),
+            ]),
+        ),
+        (
+            "evidence_cas_commit_id",
+            first([
+                scalar(&evidence.and_then(|value| value.commit_id.clone())),
+                scalar(&record.evidence_cas_commit_id),
+                scalar(&record.commit_id),
+            ]),
+        ),
+        (
+            "evidence_cas_digest",
+            first([
+                scalar(&evidence.and_then(|value| value.digest.clone())),
+                scalar(&record.evidence_cas_digest),
+                scalar(&record.digest),
+            ]),
+        ),
+        (
+            "evidence_cas_merkle_root",
+            first([
+                scalar(&evidence.and_then(|value| value.merkle_root.clone())),
+                scalar(&record.evidence_cas_merkle_root),
+                scalar(&record.merkle_root),
+            ]),
+        ),
+        (
+            "evidence_cas_ref_type",
+            first([
+                scalar(&evidence.and_then(|value| value.ref_type.clone())),
+                scalar(&record.evidence_cas_ref_type),
+                scalar(&record.ref_type),
+            ]),
+        ),
+        (
+            "evidence_cas_uri",
+            first([
+                scalar(&evidence.and_then(|value| value.uri.clone())),
+                scalar(&record.evidence_cas_uri),
+                scalar(&record.uri),
+            ]),
+        ),
+        (
+            "observed_at",
+            first([
+                scalar(&record.observed_at),
+                scalar(&record.updated_at),
+                scalar(&record.last_seen_at),
+            ]),
+        ),
+        (
+            "resource_email",
+            first([
+                scalar(&record.resource_email),
+                scalar(&record.target_email),
+                scalar(&target.and_then(|value| value.email.clone())),
+            ]),
+        ),
+        (
+            "resource_id",
+            first([
+                scalar(&record.resource_id),
+                scalar(&record.target_id),
+                scalar(&target.and_then(|value| value.id.clone())),
+                scalar(&resource.and_then(|value| value.id.clone())),
+                scalar(&record.object_id),
+            ]),
+        ),
+        (
+            "resource_name",
+            first([
+                scalar(&record.resource_name),
+                scalar(&record.target_name),
+                scalar(&target.and_then(|value| value.name.clone())),
+                scalar(&resource.and_then(|value| value.name.clone())),
+                scalar(&record.object_name),
+            ]),
+        ),
+        (
+            "resource_type",
+            first([
+                scalar(&record.resource_type),
+                scalar(&record.target_type),
+                scalar(&target.and_then(|value| value.kind.clone())),
+                scalar(&record.object_type),
+            ]),
+        ),
+        (
+            "resource_urn",
+            first([
+                scalar(&record.resource_urn),
+                scalar(&record.urn),
+                scalar(&metadata.and_then(|value| value.resource_urn.clone())),
+            ]),
+        ),
+        (
+            "source_event_id",
+            first([
+                scalar(&record.event_id),
+                scalar(&record.id),
+                scalar(&metadata.and_then(|value| value.event_id.clone())),
+            ]),
+        ),
+    ];
+    for (name, value) in mappings {
+        insert(&mut fields, name, value);
+    }
+    for name in ["source_event_id", "event_type", "actor_id"] {
+        require_field(&fields, name)?;
+    }
+    let occurred_at = occurred_at(
+        [
+            scalar(&record.observed_at),
+            scalar(&record.updated_at),
+            scalar(&record.last_seen_at),
+            scalar(&record.created_at),
+            scalar(&record.updated_at_camel),
+            scalar(&record.last_seen_at_camel),
+            scalar(&record.last_check_in),
+            scalar(&record.last_check_in_camel),
+            scalar(&record.created_at_camel),
+            scalar(&record.timestamp),
+        ],
+        observed_at,
+    );
+    Ok(TwilioRecord {
+        family: TwilioFamily::AuditEvents.as_str().to_owned(),
+        provider_kind: TwilioFamily::AuditEvents.provider_kind().to_owned(),
+        schema_ref: TwilioFamily::AuditEvents.schema_ref().to_owned(),
+        tenant_id: tenant_id.to_owned(),
+        provider_id: provider_id.clone(),
+        event_id: event_id(
+            tenant_id,
+            base_origin,
+            path,
+            TwilioFamily::AuditEvents,
+            &provider_id,
+        ),
+        fields,
+        occurred_at,
+        payload,
+    })
+}

--- a/crates/source-runtime-next/src/twilio/family/audit_events/wire.rs
+++ b/crates/source-runtime-next/src/twilio/family/audit_events/wire.rs
@@ -1,0 +1,89 @@
+//! Typed Twilio audit-events provider object.
+
+use serde::Deserialize;
+
+use super::super::wire::{EvidenceCasWire, IdentityDiscriminatorsWire, MetadataWire, WireScalar};
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub(super) struct AuditEventWire {
+    #[serde(flatten)]
+    pub(super) identity: IdentityDiscriminatorsWire,
+    pub(super) id: Option<WireScalar>,
+    pub(super) event_id: Option<WireScalar>,
+    pub(super) uuid: Option<WireScalar>,
+    pub(super) request_id: Option<WireScalar>,
+    pub(super) actor_email: Option<WireScalar>,
+    pub(super) email: Option<WireScalar>,
+    pub(super) user_id: Option<WireScalar>,
+    pub(super) actor_id: Option<WireScalar>,
+    #[serde(rename = "actorId")]
+    pub(super) actor_id_camel: Option<WireScalar>,
+    pub(super) actor_name: Option<WireScalar>,
+    pub(super) event_type: Option<WireScalar>,
+    pub(super) event_name: Option<WireScalar>,
+    pub(super) action: Option<WireScalar>,
+    #[serde(rename = "type")]
+    pub(super) kind: Option<WireScalar>,
+    pub(super) observed_at: Option<WireScalar>,
+    pub(super) updated_at: Option<WireScalar>,
+    #[serde(rename = "updatedAt")]
+    pub(super) updated_at_camel: Option<WireScalar>,
+    pub(super) last_seen_at: Option<WireScalar>,
+    #[serde(rename = "lastSeenAt")]
+    pub(super) last_seen_at_camel: Option<WireScalar>,
+    pub(super) last_check_in: Option<WireScalar>,
+    #[serde(rename = "lastCheckIn")]
+    pub(super) last_check_in_camel: Option<WireScalar>,
+    pub(super) created_at: Option<WireScalar>,
+    #[serde(rename = "createdAt")]
+    pub(super) created_at_camel: Option<WireScalar>,
+    pub(super) timestamp: Option<WireScalar>,
+    pub(super) resource_email: Option<WireScalar>,
+    pub(super) target_email: Option<WireScalar>,
+    pub(super) target_id: Option<WireScalar>,
+    pub(super) object_id: Option<WireScalar>,
+    pub(super) resource_id: Option<WireScalar>,
+    pub(super) target_name: Option<WireScalar>,
+    pub(super) object_name: Option<WireScalar>,
+    pub(super) resource_name: Option<WireScalar>,
+    pub(super) target_type: Option<WireScalar>,
+    pub(super) object_type: Option<WireScalar>,
+    pub(super) resource_type: Option<WireScalar>,
+    pub(super) resource_urn: Option<WireScalar>,
+    pub(super) urn: Option<WireScalar>,
+    pub(super) evidence_cas_commit_id: Option<WireScalar>,
+    pub(super) commit_id: Option<WireScalar>,
+    pub(super) evidence_cas_digest: Option<WireScalar>,
+    pub(super) digest: Option<WireScalar>,
+    pub(super) evidence_cas_merkle_root: Option<WireScalar>,
+    pub(super) merkle_root: Option<WireScalar>,
+    pub(super) evidence_cas_ref_type: Option<WireScalar>,
+    pub(super) ref_type: Option<WireScalar>,
+    pub(super) evidence_cas_uri: Option<WireScalar>,
+    pub(super) uri: Option<WireScalar>,
+    pub(super) actor: Option<ActorWire>,
+    pub(super) user: Option<ActorWire>,
+    pub(super) target: Option<ResourceWire>,
+    pub(super) resource: Option<ResourceWire>,
+    pub(super) metadata: Option<MetadataWire>,
+    pub(super) evidence_cas: Option<EvidenceCasWire>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub(super) struct ActorWire {
+    pub(super) id: Option<WireScalar>,
+    pub(super) email: Option<WireScalar>,
+    pub(super) name: Option<WireScalar>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub(super) struct ResourceWire {
+    pub(super) id: Option<WireScalar>,
+    pub(super) email: Option<WireScalar>,
+    pub(super) name: Option<WireScalar>,
+    #[serde(rename = "type")]
+    pub(super) kind: Option<WireScalar>,
+}

--- a/crates/source-runtime-next/src/twilio/family/keys/mod.rs
+++ b/crates/source-runtime-next/src/twilio/family/keys/mod.rs
@@ -1,0 +1,228 @@
+//! Go-compatible Twilio keys normalization.
+
+mod wire;
+
+use serde_json::Value;
+use time::OffsetDateTime;
+
+use super::super::{
+    TwilioError, TwilioFamily, TwilioRecord,
+    normalize::{
+        base_fields, event_id, first, insert, occurred_at, provider_identity, record_identity,
+        require_field, require_payload_id, scalar,
+    },
+};
+use wire::KeyWire;
+
+pub(in crate::twilio) fn normalize(
+    payload: Value,
+    tenant_id: &str,
+    base_origin: &str,
+    path: &str,
+    observed_at: OffsetDateTime,
+) -> Result<TwilioRecord, TwilioError> {
+    let record: KeyWire =
+        serde_json::from_value(payload.clone()).map_err(|_| TwilioError::InvalidResponse)?;
+    require_payload_id(&record.id)?;
+    let metadata = record.metadata.as_ref();
+    let evidence = record.evidence_cas.as_ref();
+    let record_id = provider_identity([
+        scalar(&record.id),
+        scalar(&record.secret_id),
+        scalar(&record.name),
+        scalar(&record.key),
+        scalar(&record.sid),
+    ])?;
+    let provider_id = record_identity(&record_id, &record.identity);
+    let mut fields = base_fields(TwilioFamily::Keys, tenant_id, &record_id, "secret");
+    let mappings = [
+        (
+            "evidence_cas_commit_id",
+            first([
+                scalar(&evidence.and_then(|value| value.commit_id.clone())),
+                scalar(&record.evidence_cas_commit_id),
+                scalar(&record.commit_id),
+            ]),
+        ),
+        (
+            "evidence_cas_digest",
+            first([
+                scalar(&evidence.and_then(|value| value.digest.clone())),
+                scalar(&record.evidence_cas_digest),
+                scalar(&record.digest),
+            ]),
+        ),
+        (
+            "evidence_cas_merkle_root",
+            first([
+                scalar(&evidence.and_then(|value| value.merkle_root.clone())),
+                scalar(&record.evidence_cas_merkle_root),
+                scalar(&record.merkle_root),
+            ]),
+        ),
+        (
+            "evidence_cas_ref_type",
+            first([
+                scalar(&evidence.and_then(|value| value.ref_type.clone())),
+                scalar(&record.evidence_cas_ref_type),
+                scalar(&record.ref_type),
+            ]),
+        ),
+        (
+            "evidence_cas_uri",
+            first([
+                scalar(&evidence.and_then(|value| value.uri.clone())),
+                scalar(&record.evidence_cas_uri),
+                scalar(&record.uri),
+            ]),
+        ),
+        (
+            "observed_at",
+            first([
+                scalar(&record.observed_at),
+                scalar(&record.updated_at),
+                scalar(&record.last_seen_at),
+            ]),
+        ),
+        (
+            "resource_id",
+            first([
+                scalar(&record.resource_id),
+                scalar(&record.id),
+                scalar(&metadata.and_then(|value| value.resource_id.clone())),
+            ]),
+        ),
+        (
+            "resource_name",
+            first([
+                scalar(&record.name),
+                scalar(&record.display_name),
+                scalar(&record.hostname),
+                scalar(&metadata.and_then(|value| value.resource_name.clone())),
+            ]),
+        ),
+        (
+            "resource_type",
+            first([
+                scalar(&record.resource_type),
+                scalar(&record.provider_type),
+                scalar(&metadata.and_then(|value| value.resource_type.clone())),
+            ]),
+        ),
+        (
+            "resource_urn",
+            first([
+                scalar(&record.resource_urn),
+                scalar(&record.urn),
+                scalar(&metadata.and_then(|value| value.resource_urn.clone())),
+            ]),
+        ),
+        (
+            "secret_created_at",
+            first([
+                scalar(&record.created_at),
+                scalar(&record.created),
+                scalar(&record.date_created),
+            ]),
+        ),
+        (
+            "secret_id",
+            first([
+                scalar(&record.secret_id),
+                scalar(&record.id),
+                scalar(&record.key),
+                scalar(&record.sid),
+                scalar(&record.name),
+            ]),
+        ),
+        (
+            "secret_last_rotated_at",
+            first([
+                scalar(&record.secret_last_rotated_at),
+                scalar(&record.last_rotated_at),
+                scalar(&record.last_rotated),
+                scalar(&record.rotated_at),
+            ]),
+        ),
+        (
+            "secret_name",
+            first([
+                scalar(&record.secret_name),
+                scalar(&record.name),
+                scalar(&record.display_name),
+                scalar(&record.label),
+                scalar(&record.title),
+            ]),
+        ),
+        (
+            "secret_rotation_enabled",
+            first([
+                scalar(&record.secret_rotation_enabled),
+                scalar(&record.rotation_enabled),
+                scalar(&record.auto_rotate),
+            ]),
+        ),
+        (
+            "secret_status",
+            first([
+                scalar(&record.secret_status),
+                scalar(&record.status),
+                scalar(&record.state),
+            ]),
+        ),
+        (
+            "secret_type",
+            first([
+                scalar(&record.secret_type),
+                scalar(&record.provider_type),
+                scalar(&record.kind),
+            ]),
+        ),
+        (
+            "source_event_id",
+            first([
+                scalar(&record.event_id),
+                scalar(&record.id),
+                scalar(&metadata.and_then(|value| value.event_id.clone())),
+            ]),
+        ),
+    ];
+    for (name, value) in mappings {
+        insert(&mut fields, name, value);
+    }
+    for name in ["source_event_id", "secret_id", "secret_name"] {
+        require_field(&fields, name)?;
+    }
+    let occurred_at = occurred_at(
+        [
+            scalar(&record.observed_at),
+            scalar(&record.updated_at),
+            scalar(&record.last_seen_at),
+            scalar(&record.created_at),
+            scalar(&record.updated_at_camel),
+            scalar(&record.last_seen_at_camel),
+            scalar(&record.last_check_in),
+            scalar(&record.last_check_in_camel),
+            scalar(&record.created_at_camel),
+            scalar(&record.timestamp),
+        ],
+        observed_at,
+    );
+    Ok(TwilioRecord {
+        family: TwilioFamily::Keys.as_str().to_owned(),
+        provider_kind: TwilioFamily::Keys.provider_kind().to_owned(),
+        schema_ref: TwilioFamily::Keys.schema_ref().to_owned(),
+        tenant_id: tenant_id.to_owned(),
+        provider_id: provider_id.clone(),
+        event_id: event_id(
+            tenant_id,
+            base_origin,
+            path,
+            TwilioFamily::Keys,
+            &provider_id,
+        ),
+        fields,
+        occurred_at,
+        payload,
+    })
+}

--- a/crates/source-runtime-next/src/twilio/family/keys/wire.rs
+++ b/crates/source-runtime-next/src/twilio/family/keys/wire.rs
@@ -1,0 +1,69 @@
+//! Typed Twilio keys provider object.
+
+use serde::Deserialize;
+
+use super::super::wire::{EvidenceCasWire, IdentityDiscriminatorsWire, MetadataWire, WireScalar};
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub(super) struct KeyWire {
+    #[serde(flatten)]
+    pub(super) identity: IdentityDiscriminatorsWire,
+    pub(super) id: Option<WireScalar>,
+    pub(super) secret_id: Option<WireScalar>,
+    pub(super) name: Option<WireScalar>,
+    pub(super) hostname: Option<WireScalar>,
+    pub(super) key: Option<WireScalar>,
+    pub(super) sid: Option<WireScalar>,
+    pub(super) created_at: Option<WireScalar>,
+    pub(super) created: Option<WireScalar>,
+    pub(super) date_created: Option<WireScalar>,
+    pub(super) updated_at: Option<WireScalar>,
+    #[serde(rename = "updatedAt")]
+    pub(super) updated_at_camel: Option<WireScalar>,
+    pub(super) last_seen_at: Option<WireScalar>,
+    #[serde(rename = "lastSeenAt")]
+    pub(super) last_seen_at_camel: Option<WireScalar>,
+    pub(super) last_check_in: Option<WireScalar>,
+    #[serde(rename = "lastCheckIn")]
+    pub(super) last_check_in_camel: Option<WireScalar>,
+    #[serde(rename = "createdAt")]
+    pub(super) created_at_camel: Option<WireScalar>,
+    pub(super) timestamp: Option<WireScalar>,
+    pub(super) observed_at: Option<WireScalar>,
+    pub(super) secret_last_rotated_at: Option<WireScalar>,
+    pub(super) last_rotated_at: Option<WireScalar>,
+    pub(super) last_rotated: Option<WireScalar>,
+    pub(super) rotated_at: Option<WireScalar>,
+    pub(super) secret_name: Option<WireScalar>,
+    pub(super) display_name: Option<WireScalar>,
+    pub(super) label: Option<WireScalar>,
+    pub(super) title: Option<WireScalar>,
+    pub(super) secret_rotation_enabled: Option<WireScalar>,
+    pub(super) rotation_enabled: Option<WireScalar>,
+    pub(super) auto_rotate: Option<WireScalar>,
+    pub(super) secret_status: Option<WireScalar>,
+    pub(super) status: Option<WireScalar>,
+    pub(super) state: Option<WireScalar>,
+    pub(super) secret_type: Option<WireScalar>,
+    #[serde(rename = "type")]
+    pub(super) provider_type: Option<WireScalar>,
+    pub(super) kind: Option<WireScalar>,
+    pub(super) resource_id: Option<WireScalar>,
+    pub(super) resource_type: Option<WireScalar>,
+    pub(super) resource_urn: Option<WireScalar>,
+    pub(super) urn: Option<WireScalar>,
+    pub(super) event_id: Option<WireScalar>,
+    pub(super) evidence_cas_commit_id: Option<WireScalar>,
+    pub(super) commit_id: Option<WireScalar>,
+    pub(super) evidence_cas_digest: Option<WireScalar>,
+    pub(super) digest: Option<WireScalar>,
+    pub(super) evidence_cas_merkle_root: Option<WireScalar>,
+    pub(super) merkle_root: Option<WireScalar>,
+    pub(super) evidence_cas_ref_type: Option<WireScalar>,
+    pub(super) ref_type: Option<WireScalar>,
+    pub(super) evidence_cas_uri: Option<WireScalar>,
+    pub(super) uri: Option<WireScalar>,
+    pub(super) metadata: Option<MetadataWire>,
+    pub(super) evidence_cas: Option<EvidenceCasWire>,
+}

--- a/crates/source-runtime-next/src/twilio/family/mod.rs
+++ b/crates/source-runtime-next/src/twilio/family/mod.rs
@@ -1,0 +1,6 @@
+//! Focused Twilio family wire and normalization modules.
+
+pub(super) mod accounts;
+pub(super) mod audit_events;
+pub(super) mod keys;
+pub(super) mod wire;

--- a/crates/source-runtime-next/src/twilio/family/wire.rs
+++ b/crates/source-runtime-next/src/twilio/family/wire.rs
@@ -1,0 +1,64 @@
+//! Shared typed provider scalar and nested evidence objects.
+
+use serde::Deserialize;
+use serde_json::Number;
+
+/// Provider scalar accepted by the Go JSON adapter.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub(in crate::twilio) enum WireScalar {
+    String(String),
+    Number(Number),
+    Bool(bool),
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub(in crate::twilio) struct IdentityDiscriminatorsWire {
+    pub(in crate::twilio) device_id: Option<WireScalar>,
+    pub(in crate::twilio) serial_number: Option<WireScalar>,
+    pub(in crate::twilio) agent_id: Option<WireScalar>,
+    pub(in crate::twilio) device_uuid: Option<WireScalar>,
+    pub(in crate::twilio) installed_version: Option<WireScalar>,
+    pub(in crate::twilio) version: Option<WireScalar>,
+    pub(in crate::twilio) device: Option<IdentityObjectWire>,
+    pub(in crate::twilio) agent: Option<IdentityObjectWire>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub(in crate::twilio) struct IdentityObjectWire {
+    pub(in crate::twilio) id: Option<WireScalar>,
+    pub(in crate::twilio) uuid: Option<WireScalar>,
+}
+
+impl WireScalar {
+    pub(in crate::twilio) fn text(&self) -> String {
+        match self {
+            Self::String(value) => value.trim().to_owned(),
+            Self::Number(value) => value.to_string(),
+            Self::Bool(value) => value.to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub(super) struct EvidenceCasWire {
+    pub(super) commit_id: Option<WireScalar>,
+    pub(super) digest: Option<WireScalar>,
+    pub(super) merkle_root: Option<WireScalar>,
+    pub(super) ref_type: Option<WireScalar>,
+    pub(super) uri: Option<WireScalar>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub(super) struct MetadataWire {
+    pub(super) event_id: Option<WireScalar>,
+    pub(super) resource_id: Option<WireScalar>,
+    pub(super) resource_name: Option<WireScalar>,
+    pub(super) resource_type: Option<WireScalar>,
+    pub(super) resource_urn: Option<WireScalar>,
+    pub(super) tenant_id: Option<WireScalar>,
+}

--- a/crates/source-runtime-next/src/twilio/model.rs
+++ b/crates/source-runtime-next/src/twilio/model.rs
@@ -1,0 +1,123 @@
+//! Public Twilio family, page, and record contracts.
+
+use std::{collections::BTreeMap, str::FromStr};
+
+use serde_json::Value;
+
+use super::TwilioError;
+
+/// Twilio inventory families owned by the Go source catalog.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TwilioFamily {
+    /// Twilio accounts.
+    Accounts,
+    /// Twilio account API keys.
+    Keys,
+    /// Twilio monitor audit events.
+    AuditEvents,
+}
+
+impl TwilioFamily {
+    /// Return the exact source-catalog family identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Accounts => "accounts",
+            Self::Keys => "keys",
+            Self::AuditEvents => "audit_events",
+        }
+    }
+
+    /// Return the exact provider kind emitted by the Go source.
+    pub const fn provider_kind(self) -> &'static str {
+        match self {
+            Self::Accounts => "twilio.accounts",
+            Self::Keys => "twilio.keys",
+            Self::AuditEvents => "twilio.audit_events",
+        }
+    }
+
+    /// Return the exact schema reference emitted by the Go source.
+    pub const fn schema_ref(self) -> &'static str {
+        match self {
+            Self::Accounts => "twilio/accounts/v1",
+            Self::Keys => concat!("twilio/", "keys", "/v1"),
+            Self::AuditEvents => "twilio/audit_events/v1",
+        }
+    }
+
+    pub(super) const fn response_keys(self) -> &'static [&'static str] {
+        match self {
+            Self::Accounts => &[
+                "data",
+                "items",
+                "results",
+                "records",
+                "accounts",
+                "accountss",
+            ],
+            Self::Keys => &["data", "items", "results", "records", "keys", "keyss"],
+            Self::AuditEvents => &[
+                "data",
+                "items",
+                "results",
+                "records",
+                "audit_events",
+                "audit_eventss",
+                "auditevents",
+                "auditeventss",
+            ],
+        }
+    }
+}
+
+impl FromStr for TwilioFamily {
+    type Err = TwilioError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim() {
+            "accounts" => Ok(Self::Accounts),
+            "keys" => Ok(Self::Keys),
+            "audit_events" => Ok(Self::AuditEvents),
+            _ => Err(TwilioError::InvalidFamily),
+        }
+    }
+}
+
+/// Provider-local Twilio selectors.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct TwilioFilters {
+    /// Config-bound account parent required by the keys family.
+    pub account_sid: Option<String>,
+}
+
+/// One normalized Twilio provider record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TwilioRecord {
+    /// Source-catalog family identifier.
+    pub family: String,
+    /// Exact provider kind.
+    pub provider_kind: String,
+    /// Exact source schema reference.
+    pub schema_ref: String,
+    /// Configured source tenant bound to this normalization.
+    pub tenant_id: String,
+    /// Stable provider identity selected in Go order.
+    pub provider_id: String,
+    /// Go-compatible tenant, scope, family, and provider event identity.
+    pub event_id: String,
+    /// Portable normalized attributes.
+    pub fields: BTreeMap<String, String>,
+    /// UTC provider occurrence time or observation fallback.
+    pub occurred_at: String,
+    /// Exact raw provider object.
+    pub payload: Value,
+}
+
+/// One bounded Twilio page and its opaque continuation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TwilioPage {
+    /// Deduplicated records in provider order.
+    pub records: Vec<TwilioRecord>,
+    /// Exact bounded provider continuation.
+    pub next_cursor: Option<String>,
+}

--- a/crates/source-runtime-next/src/twilio/normalize.rs
+++ b/crates/source-runtime-next/src/twilio/normalize.rs
@@ -1,0 +1,228 @@
+//! Shared Go-compatible Twilio normalization helpers.
+
+use std::collections::BTreeMap;
+
+use sha2::{Digest, Sha256};
+use time::{Date, Duration, OffsetDateTime, UtcOffset, format_description::well_known::Rfc3339};
+
+use super::{
+    TwilioError, TwilioFamily,
+    family::wire::{IdentityDiscriminatorsWire, WireScalar},
+};
+
+pub(super) fn insert(fields: &mut BTreeMap<String, String>, name: &str, value: String) {
+    let value = value.trim();
+    if !value.is_empty() {
+        fields.insert(name.to_owned(), value.to_owned());
+    }
+}
+
+pub(super) fn first<const N: usize>(values: [String; N]) -> String {
+    values
+        .into_iter()
+        .find(|value| !value.trim().is_empty())
+        .unwrap_or_default()
+}
+
+pub(super) fn scalar(value: &Option<WireScalar>) -> String {
+    value.as_ref().map(WireScalar::text).unwrap_or_default()
+}
+
+pub(super) fn provider_identity<const N: usize>(
+    values: [String; N],
+) -> Result<String, TwilioError> {
+    let value = first(values);
+    if value.is_empty() {
+        Err(TwilioError::MissingProviderIdentity)
+    } else {
+        Ok(value)
+    }
+}
+
+pub(super) fn require_payload_id(value: &Option<WireScalar>) -> Result<(), TwilioError> {
+    if scalar(value).is_empty() {
+        Err(TwilioError::MissingRequiredPayloadField("id"))
+    } else {
+        Ok(())
+    }
+}
+
+pub(super) fn record_identity(record_id: &str, identity: &IdentityDiscriminatorsWire) -> String {
+    let device = identity.device.as_ref();
+    let agent = identity.agent.as_ref();
+    let mut parts = vec![record_id.trim().to_owned()];
+    for (key, value) in [
+        ("device_id", scalar(&identity.device_id)),
+        (
+            "device.id",
+            scalar(&device.and_then(|value| value.id.clone())),
+        ),
+        ("serial_number", scalar(&identity.serial_number)),
+        ("agent_id", scalar(&identity.agent_id)),
+        (
+            "agent.uuid",
+            scalar(&agent.and_then(|value| value.uuid.clone())),
+        ),
+        ("device_uuid", scalar(&identity.device_uuid)),
+        ("installed_version", scalar(&identity.installed_version)),
+        ("version", scalar(&identity.version)),
+    ] {
+        if !value.is_empty() {
+            parts.push(format!("{key}={value}"));
+        }
+    }
+    if parts.len() == 1 {
+        return parts.remove(0);
+    }
+    let material = parts.join("\0");
+    format!(
+        "{}-{}",
+        record_id.trim(),
+        hex_prefix(&Sha256::digest(material.as_bytes()), 24)
+    )
+}
+
+pub(super) fn require_field(
+    fields: &BTreeMap<String, String>,
+    name: &'static str,
+) -> Result<(), TwilioError> {
+    fields
+        .get(name)
+        .filter(|value| !value.trim().is_empty())
+        .map(|_| ())
+        .ok_or(TwilioError::MissingRequiredAttribute(name))
+}
+
+pub(super) fn base_fields(
+    family: TwilioFamily,
+    tenant_id: &str,
+    record_id: &str,
+    record_class: &str,
+) -> BTreeMap<String, String> {
+    let mut fields = BTreeMap::new();
+    for (name, value) in [
+        ("external_id", record_id),
+        ("family", family.as_str()),
+        ("provider", "twilio"),
+        ("record_class", record_class),
+        ("schema", family.as_str()),
+        ("source_provider", "twilio"),
+        ("source_system", "twilio"),
+        ("tenant_id", tenant_id),
+    ] {
+        insert(&mut fields, name, value.to_owned());
+    }
+    fields
+}
+
+pub(super) fn event_id(
+    tenant_id: &str,
+    base_origin: &str,
+    path: &str,
+    family: TwilioFamily,
+    provider_id: &str,
+) -> String {
+    let scope = Sha256::digest(format!("{base_origin}\0{path}").as_bytes());
+    format!(
+        "twilio-{}-{}-{}-{}",
+        normalize_id(tenant_id),
+        hex_prefix(&scope, 12),
+        normalize_id(family.as_str()),
+        normalize_id(provider_id)
+    )
+}
+
+pub(super) fn occurred_at<const N: usize>(
+    values: [String; N],
+    observed_at: OffsetDateTime,
+) -> String {
+    values
+        .iter()
+        .find_map(|value| normalized_time(value))
+        .unwrap_or_else(|| normalized_observed_at(observed_at))
+}
+
+fn normalized_time(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    if let Some(parsed) = parse_provider_time(value) {
+        return parsed.to_offset(UtcOffset::UTC).format(&Rfc3339).ok();
+    }
+    let numeric = value.parse::<f64>().ok()?;
+    if !numeric.is_finite() || numeric <= 0.0 {
+        return None;
+    }
+    let parsed = if numeric > 1_000_000_000_000.0 {
+        OffsetDateTime::from_unix_timestamp_nanos((numeric.trunc() as i128) * 1_000_000).ok()?
+    } else {
+        let whole = numeric.trunc();
+        let fraction = numeric - whole;
+        OffsetDateTime::from_unix_timestamp(whole as i64)
+            .ok()?
+            .checked_add(Duration::nanoseconds((fraction * 1_000_000_000.0) as i64))?
+    };
+    parsed.to_offset(UtcOffset::UTC).format(&Rfc3339).ok()
+}
+
+fn parse_provider_time(value: &str) -> Option<OffsetDateTime> {
+    if let Ok(parsed) = OffsetDateTime::parse(value, &Rfc3339) {
+        return Some(parsed);
+    }
+    if let Some(normalized) = compact_offset_time(value)
+        && let Ok(parsed) = OffsetDateTime::parse(&normalized, &Rfc3339)
+    {
+        return Some(parsed);
+    }
+    let date_format = time::format_description::parse_borrowed::<2>("[year]-[month]-[day]").ok()?;
+    Date::parse(value, &date_format)
+        .ok()
+        .map(|date| date.midnight().assume_utc())
+}
+
+fn compact_offset_time(value: &str) -> Option<String> {
+    let split = value.len().checked_sub(5)?;
+    let bytes = value.as_bytes();
+    if !matches!(bytes.get(split), Some(b'+' | b'-'))
+        || !bytes.get(split + 1..)?.iter().all(u8::is_ascii_digit)
+    {
+        return None;
+    }
+    let mut normalized = String::with_capacity(value.len() + 1);
+    normalized.push_str(value.get(..split + 3)?);
+    normalized.push(':');
+    normalized.push_str(value.get(split + 3..)?);
+    Some(normalized)
+}
+
+fn normalized_observed_at(value: OffsetDateTime) -> String {
+    value
+        .to_offset(UtcOffset::UTC)
+        .format(&Rfc3339)
+        .expect("RFC3339 formats OffsetDateTime")
+}
+
+fn normalize_id(value: &str) -> String {
+    let value = value.trim();
+    if value.is_empty() {
+        return "unknown".to_owned();
+    }
+    value.replace([' ', '/', ':', '\t', '\n'], "-")
+}
+
+fn hex_prefix(bytes: &[u8], length: usize) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(length);
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        if encoded.len() == length {
+            break;
+        }
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+        if encoded.len() == length {
+            break;
+        }
+    }
+    encoded
+}

--- a/crates/source-runtime-next/src/twilio/origin.rs
+++ b/crates/source-runtime-next/src/twilio/origin.rs
@@ -1,0 +1,59 @@
+//! Secure Twilio API-origin validation.
+
+use std::{net::IpAddr, str::FromStr};
+
+use reqwest::Url;
+
+use super::TwilioError;
+
+pub(super) fn validate_origin(raw: &str) -> Result<Url, TwilioError> {
+    let mut url = Url::parse(raw.trim()).map_err(|_| TwilioError::InvalidBaseUrl)?;
+    let host = url.host_str().ok_or(TwilioError::InvalidBaseUrl)?;
+    let loopback =
+        host == "localhost" || IpAddr::from_str(host).is_ok_and(|address| address.is_loopback());
+    if url.scheme() != "https" && !(url.scheme() == "http" && loopback) {
+        return Err(TwilioError::InvalidBaseUrl);
+    }
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || !matches!(url.path(), "" | "/")
+    {
+        return Err(TwilioError::InvalidBaseUrl);
+    }
+    if IpAddr::from_str(host).is_ok_and(|address| unsafe_ip_literal(address, loopback)) {
+        return Err(TwilioError::InvalidBaseUrl);
+    }
+    if url.port().is_some_and(|port| port != 443) && !loopback {
+        return Err(TwilioError::InvalidBaseUrl);
+    }
+    url.set_path("/");
+    Ok(url)
+}
+
+pub(super) fn origin_string(url: &Url) -> String {
+    url.origin().unicode_serialization()
+}
+
+fn unsafe_ip_literal(address: IpAddr, loopback: bool) -> bool {
+    if loopback {
+        return false;
+    }
+    match address {
+        IpAddr::V4(address) => {
+            address.is_private()
+                || address.is_link_local()
+                || address.is_broadcast()
+                || address.is_documentation()
+                || address.is_unspecified()
+                || address.is_multicast()
+        }
+        IpAddr::V6(address) => {
+            address.is_unique_local()
+                || address.is_unicast_link_local()
+                || address.is_unspecified()
+                || address.is_multicast()
+        }
+    }
+}

--- a/crates/source-runtime-next/src/twilio/request.rs
+++ b/crates/source-runtime-next/src/twilio/request.rs
@@ -1,0 +1,157 @@
+//! Credential-free Twilio request planning and scope validation.
+
+use reqwest::Url;
+
+use super::{
+    TwilioError, TwilioFamily, TwilioFilters,
+    cursor::bounded_cursor,
+    origin::{origin_string, validate_origin},
+};
+
+const DEFAULT_BASE_URL: &str = "https://api.twilio.com";
+const DEFAULT_PAGE_SIZE: usize = 100;
+const MAX_PAGE_SIZE: usize = 500;
+
+/// One credential-free Twilio API request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TwilioRequest {
+    pub(super) url: Url,
+    pub(super) family: TwilioFamily,
+}
+
+impl TwilioRequest {
+    /// Return the exact provider URL. The caller must authorize it before I/O.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Return the provider authorization scheme without credential material.
+    pub const fn authorization_scheme(&self) -> &'static str {
+        "Basic"
+    }
+
+    /// Return the required response media type.
+    pub const fn accept(&self) -> &'static str {
+        "application/json"
+    }
+}
+
+/// Bounded request and response kernel for Twilio inventory.
+#[derive(Clone, Debug)]
+pub struct TwilioKernel {
+    pub(super) base_url: Url,
+    pub(super) base_origin: String,
+    pub(super) tenant_id: String,
+    pub(super) family: TwilioFamily,
+    pub(super) account_sid: Option<String>,
+    pub(super) page_size: usize,
+}
+
+impl TwilioKernel {
+    /// Build a kernel for one Twilio origin, tenant, and family.
+    ///
+    /// Planned requests still require the shared live-egress decision and an
+    /// operation-scoped Basic credential. This type never accepts or stores a
+    /// credential value.
+    pub fn new(
+        base_url: Option<&str>,
+        tenant_id: &str,
+        family: TwilioFamily,
+        filters: TwilioFilters,
+        page_size: Option<usize>,
+    ) -> Result<Self, TwilioError> {
+        let base_url = validate_origin(base_url.unwrap_or(DEFAULT_BASE_URL))?;
+        let tenant_id = required(tenant_id, TwilioError::MissingTenantId)?;
+        let account_sid = filters
+            .account_sid
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty());
+        if family == TwilioFamily::Keys && account_sid.is_none() {
+            return Err(TwilioError::MissingAccountSid);
+        }
+        let page_size = page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+        if !(1..=MAX_PAGE_SIZE).contains(&page_size) {
+            return Err(TwilioError::InvalidPageSize);
+        }
+        Ok(Self {
+            base_origin: origin_string(&base_url),
+            base_url,
+            tenant_id,
+            family,
+            account_sid,
+            page_size,
+        })
+    }
+
+    /// Return whether this planning and decoding kernel accepts credentials.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+
+    /// Plan one bounded provider page without performing I/O.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<TwilioRequest, TwilioError> {
+        let cursor = bounded_cursor(cursor)?;
+        let mut url = self.endpoint()?;
+        {
+            let mut query = url.query_pairs_mut();
+            query.append_pair("limit", &self.page_size.to_string());
+            if let Some(cursor) = cursor.as_deref() {
+                query.append_pair("cursor", cursor);
+            }
+        }
+        Ok(TwilioRequest {
+            url,
+            family: self.family,
+        })
+    }
+
+    pub(super) fn endpoint(&self) -> Result<Url, TwilioError> {
+        let mut url = self.base_url.clone();
+        let segments: Vec<&str> = match self.family {
+            TwilioFamily::Accounts => vec!["2010-04-01", "Accounts.json"],
+            TwilioFamily::Keys => vec![
+                "2010-04-01",
+                "Accounts",
+                self.account_sid
+                    .as_deref()
+                    .ok_or(TwilioError::MissingAccountSid)?,
+                "Keys.json",
+            ],
+            TwilioFamily::AuditEvents => vec!["v1", "Events"],
+        };
+        url.path_segments_mut()
+            .map_err(|_| TwilioError::InvalidBaseUrl)?
+            .extend(segments);
+        Ok(url)
+    }
+
+    pub(super) fn validate_request(&self, request: &TwilioRequest) -> Result<(), TwilioError> {
+        let endpoint = self.endpoint()?;
+        if request.family != self.family
+            || request.url.origin() != self.base_url.origin()
+            || request.url.path() != endpoint.path()
+            || request.url.fragment().is_some()
+        {
+            return Err(TwilioError::RequestScopeMismatch);
+        }
+        let mut limit = None;
+        let mut cursor_seen = false;
+        for (name, value) in request.url.query_pairs() {
+            match name.as_ref() {
+                "limit" if limit.is_none() => limit = Some(value.into_owned()),
+                "cursor" if !cursor_seen => cursor_seen = true,
+                _ => return Err(TwilioError::RequestScopeMismatch),
+            }
+        }
+        let expected = self.page_size.to_string();
+        if limit.as_deref() != Some(expected.as_str()) {
+            return Err(TwilioError::RequestScopeMismatch);
+        }
+        Ok(())
+    }
+}
+
+fn required(value: &str, error: TwilioError) -> Result<String, TwilioError> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_owned()).ok_or(error)
+}

--- a/crates/source-runtime-next/src/twilio/response.rs
+++ b/crates/source-runtime-next/src/twilio/response.rs
@@ -1,0 +1,113 @@
+//! Bounded Twilio response decoding and family dispatch.
+
+use std::collections::HashSet;
+
+use serde_json::Value;
+use time::OffsetDateTime;
+
+use super::{
+    TwilioError, TwilioFamily, TwilioKernel, TwilioPage, TwilioRecord, TwilioRequest,
+    cursor::{bounded_cursor, response_cursor},
+    family::{accounts, audit_events, keys},
+};
+
+const MAX_RESPONSE_BYTES: usize = 8 << 20;
+const MAX_RECORDS_PER_PAGE: usize = 500;
+
+impl TwilioKernel {
+    /// Decode one provider response for a request produced by this kernel.
+    pub fn decode(
+        &self,
+        request: &TwilioRequest,
+        body: &[u8],
+        observed_at: OffsetDateTime,
+    ) -> Result<TwilioPage, TwilioError> {
+        self.validate_request(request)?;
+        if body.len() > MAX_RESPONSE_BYTES {
+            return Err(TwilioError::ResponseTooLarge);
+        }
+        let payload: Value =
+            serde_json::from_slice(body).map_err(|_| TwilioError::InvalidResponse)?;
+        let (raw_records, next_cursor) = match payload {
+            Value::Array(records) => (records, None),
+            Value::Object(object) => {
+                let records = self.records_from_object(&object)?;
+                let cursor = response_cursor(&object)?;
+                (records, cursor)
+            }
+            _ => return Err(TwilioError::InvalidResponse),
+        };
+        if raw_records.len() > MAX_RECORDS_PER_PAGE {
+            return Err(TwilioError::TooManyRecords);
+        }
+        let path = request.url.path();
+        let mut seen = HashSet::new();
+        let mut records = Vec::with_capacity(raw_records.len());
+        for payload in raw_records {
+            if !payload.is_object() {
+                return Err(TwilioError::InvalidResponse);
+            }
+            let record = self.normalize_record(payload, path, observed_at)?;
+            if seen.insert(record.provider_id.clone()) {
+                records.push(record);
+            }
+        }
+        Ok(TwilioPage {
+            records,
+            next_cursor: bounded_cursor(next_cursor.as_deref())?,
+        })
+    }
+
+    fn records_from_object(
+        &self,
+        object: &serde_json::Map<String, Value>,
+    ) -> Result<Vec<Value>, TwilioError> {
+        for key in self.family.response_keys() {
+            let Some(value) = object.get(*key) else {
+                continue;
+            };
+            return match value {
+                Value::Array(records) => Ok(records.clone()),
+                _ => Err(TwilioError::InvalidResponse),
+            };
+        }
+        Err(TwilioError::InvalidResponse)
+    }
+
+    fn normalize_record(
+        &self,
+        payload: Value,
+        path: &str,
+        observed_at: OffsetDateTime,
+    ) -> Result<TwilioRecord, TwilioError> {
+        match self.family {
+            TwilioFamily::Accounts => accounts::normalize(
+                payload,
+                &self.tenant_id,
+                &self.base_origin,
+                path,
+                observed_at,
+            ),
+            TwilioFamily::Keys => keys::normalize(
+                payload,
+                &self.tenant_id,
+                &self.base_origin,
+                path,
+                observed_at,
+            ),
+            TwilioFamily::AuditEvents => audit_events::normalize(
+                payload,
+                &self.tenant_id,
+                &self.base_origin,
+                path,
+                observed_at,
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+pub(super) const TEST_MAX_RESPONSE_BYTES: usize = MAX_RESPONSE_BYTES;
+
+#[cfg(test)]
+pub(super) const TEST_MAX_RECORDS_PER_PAGE: usize = MAX_RECORDS_PER_PAGE;

--- a/crates/source-runtime-next/src/twilio/tests/accounts.rs
+++ b/crates/source-runtime-next/src/twilio/tests/accounts.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+#[test]
+fn checked_in_accounts_fixture_binds_catalog_fields_payload_identity_and_time() {
+    let kernel = kernel(TwilioFamily::Accounts);
+    let page = kernel
+        .decode(&kernel.plan(None).unwrap(), ACCOUNTS_FIXTURE, observed_at())
+        .unwrap();
+    assert_eq!(page.next_cursor, None);
+    assert_eq!(page.records.len(), 1);
+    let record = &page.records[0];
+    assert_eq!(record.family, "accounts");
+    assert_eq!(record.provider_kind, "twilio.accounts");
+    assert_eq!(record.schema_ref, "twilio/accounts/v1");
+    assert_eq!(record.tenant_id, TENANT_ID);
+    assert_eq!(record.provider_id, "record-1");
+    assert_eq!(
+        record.event_id,
+        "twilio-tenant-a92380b4993d-accounts-record-1"
+    );
+    assert_eq!(record.occurred_at, "2026-06-01T00:00:00Z");
+    for (name, value) in [
+        ("external_id", "record-1"),
+        ("family", "accounts"),
+        ("provider", "twilio"),
+        ("record_class", "identity_user"),
+        ("schema", "accounts"),
+        ("source_event_id", "record-1"),
+        ("source_system", "twilio"),
+        ("tenant_id", TENANT_ID),
+        ("user_id", "record-1"),
+    ] {
+        assert_eq!(record.fields.get(name).map(String::as_str), Some(value));
+    }
+    assert_eq!(record.fields["evidence_cas_digest"], "sha256:test");
+    assert_eq!(record.payload["id"], "record-1");
+    assert_eq!(record.payload["name"], "Record One");
+    assert_eq!(record.payload.as_object().unwrap().len(), 8);
+}
+
+#[test]
+fn accounts_follow_go_selector_and_nested_attribute_precedence() {
+    let kernel = kernel(TwilioFamily::Accounts);
+    let page = kernel
+        .decode(
+            &kernel.plan(None).unwrap(),
+            br#"{"accounts":[{
+                "id":"record-2",
+                "event_id":"provider-event-2",
+                "email":"user@example.test",
+                "user_id":"user-1",
+                "uid":"user-1",
+                "profile":{"display_name":"Profile Name","department":"Security"},
+                "metadata":{"resource_id":"resource-1","resource_name":"Metadata Resource"}
+            }]}"#,
+            observed_at(),
+        )
+        .unwrap();
+    let record = &page.records[0];
+    assert_eq!(record.provider_id, "record-2");
+    assert_eq!(record.fields["display_name"], "Profile Name");
+    assert_eq!(record.fields["department"], "Security");
+    assert_eq!(record.fields["resource_id"], "record-2");
+    assert_eq!(record.fields["resource_name"], "Metadata Resource");
+    assert_eq!(record.fields["source_event_id"], "provider-event-2");
+    assert_eq!(record.fields["user_id"], "user-1");
+}

--- a/crates/source-runtime-next/src/twilio/tests/audit_events.rs
+++ b/crates/source-runtime-next/src/twilio/tests/audit_events.rs
@@ -1,0 +1,65 @@
+use super::*;
+
+#[test]
+fn audit_events_bind_nested_actor_resource_catalog_fields_and_timestamp() {
+    let kernel = kernel(TwilioFamily::AuditEvents);
+    let page = kernel
+        .decode(
+            &kernel.plan(None).unwrap(),
+            br#"{"audit_events":[{
+                "id":"evt-1",
+                "action":"user.login",
+                "actor":{"id":"user-1","email":"user@example.test","name":"User One"},
+                "target":{"id":"app-1","name":"Application One","type":"application"},
+                "created_at":"2026-06-01T00:00:00Z"
+            }]}"#,
+            observed_at(),
+        )
+        .unwrap();
+    let record = &page.records[0];
+    assert_eq!(record.provider_kind, "twilio.audit_events");
+    assert_eq!(record.schema_ref, "twilio/audit_events/v1");
+    assert_eq!(record.provider_id, "evt-1");
+    assert_eq!(
+        record.event_id,
+        "twilio-tenant-8a1703761e9e-audit_events-evt-1"
+    );
+    assert_eq!(record.occurred_at, "2026-06-01T00:00:00Z");
+    for (name, value) in [
+        ("actor_email", "user@example.test"),
+        ("actor_id", "user-1"),
+        ("actor_name", "User One"),
+        ("event_type", "user.login"),
+        ("record_class", "audit_event"),
+        ("resource_id", "app-1"),
+        ("resource_name", "Application One"),
+        ("resource_type", "application"),
+        ("source_event_id", "evt-1"),
+        ("tenant_id", TENANT_ID),
+    ] {
+        assert_eq!(record.fields.get(name).map(String::as_str), Some(value));
+    }
+    assert_eq!(record.payload["actor"]["id"], "user-1");
+}
+
+#[test]
+fn audit_events_fail_closed_without_catalog_actor_or_event_type() {
+    let kernel = kernel(TwilioFamily::AuditEvents);
+    for (body, error) in [
+        (
+            br#"{"audit_events":[{"id":"evt-1","action":"login"}]}"#.as_slice(),
+            TwilioError::MissingRequiredAttribute("actor_id"),
+        ),
+        (
+            br#"{"audit_events":[{"id":"evt-1","actor_id":"user-1"}]}"#.as_slice(),
+            TwilioError::MissingRequiredAttribute("event_type"),
+        ),
+    ] {
+        assert_eq!(
+            kernel
+                .decode(&kernel.plan(None).unwrap(), body, observed_at())
+                .unwrap_err(),
+            error
+        );
+    }
+}

--- a/crates/source-runtime-next/src/twilio/tests/failure.rs
+++ b/crates/source-runtime-next/src/twilio/tests/failure.rs
@@ -1,0 +1,231 @@
+use std::str::FromStr;
+
+use super::*;
+use crate::twilio::response::{TEST_MAX_RECORDS_PER_PAGE, TEST_MAX_RESPONSE_BYTES};
+
+#[test]
+fn configuration_origin_cursor_and_request_scope_fail_closed() {
+    assert_eq!(
+        TwilioFamily::from_str("unknown").unwrap_err(),
+        TwilioError::InvalidFamily
+    );
+    assert_eq!(
+        TwilioKernel::new(
+            None,
+            "  ",
+            TwilioFamily::Accounts,
+            TwilioFilters::default(),
+            None,
+        )
+        .unwrap_err(),
+        TwilioError::MissingTenantId
+    );
+    assert_eq!(
+        TwilioKernel::new(
+            None,
+            TENANT_ID,
+            TwilioFamily::Keys,
+            TwilioFilters::default(),
+            None,
+        )
+        .unwrap_err(),
+        TwilioError::MissingAccountSid
+    );
+    assert_eq!(
+        TwilioKernel::new(
+            None,
+            TENANT_ID,
+            TwilioFamily::Accounts,
+            TwilioFilters::default(),
+            Some(501),
+        )
+        .unwrap_err(),
+        TwilioError::InvalidPageSize
+    );
+    for base_url in [
+        "http://api.twilio.com",
+        "https://user@api.twilio.com",
+        "https://api.twilio.com/v1",
+        "https://10.0.0.1",
+    ] {
+        assert_eq!(
+            TwilioKernel::new(
+                Some(base_url),
+                TENANT_ID,
+                TwilioFamily::Accounts,
+                TwilioFilters::default(),
+                None,
+            )
+            .unwrap_err(),
+            TwilioError::InvalidBaseUrl,
+            "base URL {base_url}"
+        );
+    }
+    let accounts = kernel(TwilioFamily::Accounts);
+    for cursor in ["bad\ncursor".to_owned(), "x".repeat(4_097)] {
+        assert_eq!(
+            accounts.plan(Some(&cursor)).unwrap_err(),
+            TwilioError::InvalidCursor
+        );
+    }
+    assert_eq!(
+        accounts
+            .plan(Some("https://api.twilio.com/next"))
+            .unwrap_err(),
+        TwilioError::InvalidCursor
+    );
+    let keys_request = kernel(TwilioFamily::Keys).plan(None).unwrap();
+    assert_eq!(
+        accounts
+            .decode(&keys_request, ACCOUNTS_FIXTURE, observed_at())
+            .unwrap_err(),
+        TwilioError::RequestScopeMismatch
+    );
+}
+
+#[test]
+fn response_shape_wire_types_identity_cursor_and_bounds_fail_closed() {
+    let accounts_kernel = kernel(TwilioFamily::Accounts);
+    let request = accounts_kernel.plan(None).unwrap();
+    for body in [
+        br#"{}"#.as_slice(),
+        br#"{"items":{}}"#.as_slice(),
+        br#"{"items":[false]}"#.as_slice(),
+        br#"{"items":[{"id":{"nested":true}}]}"#.as_slice(),
+        br#"{"items":[{"id":"record-1"}],"next_cursor":{}}"#.as_slice(),
+    ] {
+        assert_eq!(
+            accounts_kernel
+                .decode(&request, body, observed_at())
+                .unwrap_err(),
+            TwilioError::InvalidResponse
+        );
+    }
+    assert_eq!(
+        accounts_kernel
+            .decode(
+                &request,
+                br#"{"items":[{"name":"display-only"}]}"#,
+                observed_at(),
+            )
+            .unwrap_err(),
+        TwilioError::MissingRequiredPayloadField("id")
+    );
+    for (family, body) in [
+        (
+            TwilioFamily::Accounts,
+            br#"{"items":[{"email":"user@example.test","uid":"user-1"}]}"#.as_slice(),
+        ),
+        (
+            TwilioFamily::Keys,
+            br#"{"items":[{"secret_id":"key-1","secret_name":"Key One"}]}"#.as_slice(),
+        ),
+        (
+            TwilioFamily::AuditEvents,
+            br#"{"items":[{"event_id":"event-1","event_type":"login","actor_id":"user-1"}]}"#
+                .as_slice(),
+        ),
+    ] {
+        let family_kernel = kernel(family);
+        assert_eq!(
+            family_kernel
+                .decode(&family_kernel.plan(None).unwrap(), body, observed_at())
+                .unwrap_err(),
+            TwilioError::MissingRequiredPayloadField("id"),
+            "family {family:?} must fail before catalog admission"
+        );
+    }
+    assert_eq!(
+        accounts_kernel
+            .decode(
+                &request,
+                &vec![b' '; TEST_MAX_RESPONSE_BYTES + 1],
+                observed_at(),
+            )
+            .unwrap_err(),
+        TwilioError::ResponseTooLarge
+    );
+    let too_many = serde_json::to_vec(&json!({
+        "items": (0..=TEST_MAX_RECORDS_PER_PAGE)
+            .map(|index| json!({"id": index.to_string()}))
+            .collect::<Vec<_>>()
+    }))
+    .unwrap();
+    assert_eq!(
+        accounts_kernel
+            .decode(&request, &too_many, observed_at())
+            .unwrap_err(),
+        TwilioError::TooManyRecords
+    );
+}
+
+#[test]
+fn invalid_or_missing_provider_time_falls_back_to_observation_utc() {
+    let kernel = kernel(TwilioFamily::Accounts);
+    for updated_at in [Value::Null, json!("not-rfc3339")] {
+        let body = serde_json::to_vec(&json!({
+            "items": [{"id": "record-1", "updated_at": updated_at}]
+        }))
+        .unwrap();
+        let page = kernel
+            .decode(&kernel.plan(None).unwrap(), &body, observed_at())
+            .unwrap();
+        assert_eq!(
+            page.records[0].occurred_at,
+            "2026-06-02T02:04:05.123456789Z"
+        );
+    }
+
+    for (field, value, expected) in [
+        (
+            "updatedAt",
+            "2026-06-02T03:04:05.123+0100",
+            "2026-06-02T02:04:05.123Z",
+        ),
+        ("timestamp", "2026-06-01", "2026-06-01T00:00:00Z"),
+        ("lastCheckIn", "1760000000.25", "2025-10-09T08:53:20.25Z"),
+    ] {
+        let body = serde_json::to_vec(&json!({
+            "items": [{"id": "record-1", (field): value}]
+        }))
+        .unwrap();
+        let page = kernel
+            .decode(&kernel.plan(None).unwrap(), &body, observed_at())
+            .unwrap();
+        assert_eq!(page.records[0].occurred_at, expected, "field {field}");
+    }
+}
+
+#[test]
+fn go_identity_discriminators_prevent_version_aliases_before_dedupe() {
+    let kernel = kernel(TwilioFamily::Accounts);
+    let page = kernel
+        .decode(
+            &kernel.plan(None).unwrap(),
+            br#"{"items":[
+                {"id":"record-1","version":"v1"},
+                {"id":"record-1","version":"v2"},
+                {"id":"record-1","version":"v1"},
+                {"id":"record-1","device":{"id":"device-1"}}
+            ]}"#,
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(page.records.len(), 3);
+    assert_eq!(
+        page.records
+            .iter()
+            .map(|record| record.provider_id.as_str())
+            .collect::<Vec<_>>(),
+        [
+            "record-1-806dcf595db8eaaf80f8a39a",
+            "record-1-60eacac4769c93003b2fdb27",
+            "record-1-690d2beaf4627ca31ca6d500",
+        ]
+    );
+    for record in &page.records {
+        assert_eq!(record.fields["external_id"], "record-1");
+        assert_eq!(record.fields["source_event_id"], "record-1");
+        assert!(record.event_id.ends_with(&record.provider_id));
+    }
+}

--- a/crates/source-runtime-next/src/twilio/tests/keys.rs
+++ b/crates/source-runtime-next/src/twilio/tests/keys.rs
@@ -1,0 +1,80 @@
+use super::*;
+
+#[test]
+fn keys_bind_config_parent_catalog_fields_scalar_values_and_raw_object() {
+    let kernel = kernel(TwilioFamily::Keys);
+    let page = kernel
+        .decode(
+            &kernel.plan(None).unwrap(),
+            br#"{
+                "keys":[{
+                    "id":"key-1",
+                    "name":"Primary key",
+                    "type":"api_key",
+                    "status":"active",
+                    "rotation_enabled":true,
+                    "updated_at":"2026-06-01T01:02:03.123456789+01:00"
+                }],
+                "nextCursor":"keys-2"
+            }"#,
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(page.next_cursor.as_deref(), Some("keys-2"));
+    let record = &page.records[0];
+    assert_eq!(record.provider_kind, "twilio.keys");
+    assert_eq!(record.schema_ref, "twilio/keys/v1");
+    assert_eq!(record.provider_id, "key-1");
+    assert_eq!(record.event_id, "twilio-tenant-ada263abb3a3-keys-key-1");
+    assert_eq!(record.occurred_at, "2026-06-01T00:02:03.123456789Z");
+    for (name, value) in [
+        ("record_class", "secret"),
+        ("secret_id", "key-1"),
+        ("secret_name", "Primary key"),
+        ("secret_rotation_enabled", "true"),
+        ("secret_status", "active"),
+        ("secret_type", "api_key"),
+        ("source_event_id", "key-1"),
+        ("tenant_id", TENANT_ID),
+    ] {
+        assert_eq!(record.fields.get(name).map(String::as_str), Some(value));
+    }
+    assert_eq!(record.payload["rotation_enabled"], true);
+}
+
+#[test]
+fn keys_reject_records_that_cannot_meet_catalog_secret_name() {
+    let kernel = kernel(TwilioFamily::Keys);
+    assert_eq!(
+        kernel
+            .decode(
+                &kernel.plan(None).unwrap(),
+                br#"{"keys":[{"id":"SK123"}]}"#,
+                observed_at(),
+            )
+            .unwrap_err(),
+        TwilioError::MissingRequiredAttribute("secret_name")
+    );
+}
+
+#[test]
+fn keys_match_go_hostname_and_distinct_type_kind_precedence() {
+    let kernel = kernel(TwilioFamily::Keys);
+    let page = kernel
+        .decode(
+            &kernel.plan(None).unwrap(),
+            br#"{"keys":[{
+                "id":"key-2",
+                "secret_name":"Key Two",
+                "hostname":"keys.example.test",
+                "type":"provider-type",
+                "kind":"provider-kind"
+            }]}"#,
+            observed_at(),
+        )
+        .unwrap();
+    let fields = &page.records[0].fields;
+    assert_eq!(fields["resource_name"], "keys.example.test");
+    assert_eq!(fields["resource_type"], "provider-type");
+    assert_eq!(fields["secret_type"], "provider-type");
+}

--- a/crates/source-runtime-next/src/twilio/tests/mod.rs
+++ b/crates/source-runtime-next/src/twilio/tests/mod.rs
@@ -1,0 +1,34 @@
+use super::*;
+use serde_json::{Value, json};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+const TENANT_ID: &str = "tenant";
+const ACCOUNT_SID: &str = "AC123";
+const OBSERVED_AT: &str = "2026-06-02T03:04:05.123456789+01:00";
+const ACCOUNTS_FIXTURE: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../sources/twilio/testdata/read_accounts.json"
+));
+
+fn observed_at() -> OffsetDateTime {
+    OffsetDateTime::parse(OBSERVED_AT, &Rfc3339).unwrap()
+}
+
+fn kernel(family: TwilioFamily) -> TwilioKernel {
+    TwilioKernel::new(
+        None,
+        TENANT_ID,
+        family,
+        TwilioFilters {
+            account_sid: (family == TwilioFamily::Keys).then(|| ACCOUNT_SID.to_owned()),
+        },
+        None,
+    )
+    .unwrap()
+}
+
+mod accounts;
+mod audit_events;
+mod failure;
+mod keys;
+mod request;

--- a/crates/source-runtime-next/src/twilio/tests/request.rs
+++ b/crates/source-runtime-next/src/twilio/tests/request.rs
@@ -1,0 +1,70 @@
+use super::*;
+
+#[test]
+fn plans_exact_go_paths_pagination_and_credential_free_basic_auth() {
+    let accounts = kernel(TwilioFamily::Accounts);
+    let request = accounts.plan(Some("accounts-2")).unwrap();
+    assert_eq!(
+        request.url().as_str(),
+        "https://api.twilio.com/2010-04-01/Accounts.json?limit=100&cursor=accounts-2"
+    );
+    assert_eq!(request.authorization_scheme(), "Basic");
+    assert_eq!(request.accept(), "application/json");
+    assert!(!TwilioKernel::requires_credentials());
+
+    let keys = kernel(TwilioFamily::Keys).plan(Some("keys-2")).unwrap();
+    assert_eq!(
+        keys.url().as_str(),
+        "https://api.twilio.com/2010-04-01/Accounts/AC123/Keys.json?limit=100&cursor=keys-2"
+    );
+    let events = kernel(TwilioFamily::AuditEvents)
+        .plan(Some("events-2"))
+        .unwrap();
+    assert_eq!(
+        events.url().as_str(),
+        "https://api.twilio.com/v1/Events?limit=100&cursor=events-2"
+    );
+    assert_eq!(
+        accounts.plan(Some(" \t ")).unwrap().url().as_str(),
+        "https://api.twilio.com/2010-04-01/Accounts.json?limit=100"
+    );
+}
+
+#[test]
+fn decodes_bounded_provider_cursor_and_deduplicates_in_provider_order() {
+    let kernel = kernel(TwilioFamily::Accounts);
+    let page = kernel
+        .decode(
+            &kernel.plan(None).unwrap(),
+            br#"{
+                "data":[
+                    {"id":"record-1","name":"First","updated_at":"2026-06-01T00:00:00Z"},
+                    {"id":"record-1","name":"Duplicate","updated_at":"2026-06-01T00:00:00Z"}
+                ],
+                "pagination":{"next_cursor":"accounts-2"}
+            }"#,
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(page.records.len(), 1);
+    assert_eq!(page.records[0].fields["display_name"], "First");
+    assert_eq!(page.next_cursor.as_deref(), Some("accounts-2"));
+
+    let later_cursor = kernel
+        .decode(
+            &kernel.plan(None).unwrap(),
+            br#"{"items":[{"id":"record-2"}],"next_cursor":"  ","cursor":"accounts-3"}"#,
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(later_cursor.next_cursor.as_deref(), Some("accounts-3"));
+
+    let relative_cursor = kernel
+        .decode(
+            &kernel.plan(None).unwrap(),
+            br#"{"items":[{"id":"record-3"}],"next":"/v1/Events?cursor=accounts-4&limit=100"}"#,
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(relative_cursor.next_cursor.as_deref(), Some("accounts-4"));
+}


### PR DESCRIPTION
## Summary

- Add a credential-free Twilio request and response kernel for accounts, API keys, and audit events.
- Keep the provider facade small and split family wire types, normalization, cursors, origin validation, request planning, response decoding, errors, and tests into focused modules.
- Preserve provider paths, catalog-required fields, deterministic identities, bounded pagination, raw provider objects, and fail-closed response handling.

## Validation

- `cargo test -p cerebro-source-runtime-next twilio:: -- --nocapture`
- `cargo test -p cerebro-source-runtime-next`
- `cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `go test ./sources/twilio -count=1`
- `go test ./internal/sourceprojection -run Twilio -count=1`
- `git diff --check HEAD^..HEAD`

## Boundary

This is provider-local foundation work. It does not wire private credential hosting, shared runtime collection, append or admission, projection, checkpoint or lease persistence, or a live provider request. Checked-in fixtures prove deterministic compatibility; they are not live-provider capture.