### PR TITLE
Close nested wire metadata contracts

### DIFF
--- a/crates/platform-sdk/src/lib.rs
+++ b/crates/platform-sdk/src/lib.rs
@@ -71,14 +71,14 @@ pub use view::{MaterializedViewDefinition, MaterializedViewSnapshot, ViewRefresh
 pub use wire::{
     AGENT_ACTIVITY_SCHEMA_V1, AGENT_CAPABILITY_SCHEMA_V1, AgentActionStage, AgentActivity,
     AgentCapability, CONNECTOR_MANIFEST_SCHEMA_V1, ConnectorManifest, DecodedWirePayload,
-    ENDPOINT_SESSION_LEASE_SCHEMA_V1, ENDPOINT_TELEMETRY_SCHEMA_V1, EXTERNAL_EVENT_SCHEMA_V1,
-    EndpointNetworkProfile, EndpointOwnership, EndpointSessionLease, EndpointTelemetry,
-    EvidenceCompleteness, EvidenceFreshness, ExternalEventEnvelope, METRIC_SNAPSHOT_SCHEMA_V1,
-    MetricSnapshot, REMEDIATION_OUTCOME_SCHEMA_V1, RemediationOutcome, SCANNER_FINDING_SCHEMA_V1,
-    ScannerFinding, ScannerSeverity, ScannerValidationState, THREAT_INTELLIGENCE_SCHEMA_V1,
-    ThreatIndicatorKind, ThreatIntelligenceObservation, ThreatPromotionReason, ThreatVerdict,
-    WireContractFamily, WireEvidenceState, WireIngestOutcome, WireIngestReason, WireIngestReceipt,
-    WireSignature,
+    ENDPOINT_SESSION_LEASE_SCHEMA_V1, ENDPOINT_TELEMETRY_SCHEMA_V1, EXTERNAL_EVENT_ATTRIBUTE_KEYS,
+    EXTERNAL_EVENT_SCHEMA_V1, EndpointNetworkProfile, EndpointOwnership, EndpointSessionLease,
+    EndpointTelemetry, EvidenceCompleteness, EvidenceFreshness, ExternalEventEnvelope,
+    MAX_EXTERNAL_EVENT_ATTRIBUTE_VALUE_BYTES, METRIC_SNAPSHOT_SCHEMA_V1, MetricSnapshot,
+    REMEDIATION_OUTCOME_SCHEMA_V1, RemediationOutcome, SCANNER_FINDING_SCHEMA_V1, ScannerFinding,
+    ScannerSeverity, ScannerValidationState, THREAT_INTELLIGENCE_SCHEMA_V1, ThreatIndicatorKind,
+    ThreatIntelligenceObservation, ThreatPromotionReason, ThreatVerdict, WireContractFamily,
+    WireEvidenceState, WireIngestOutcome, WireIngestReason, WireIngestReceipt, WireSignature,
 };
 
 /// Stable schema revision for the reusable SDK contracts.

--- a/crates/platform-sdk/src/wire/envelope.rs
+++ b/crates/platform-sdk/src/wire/envelope.rs
@@ -9,7 +9,9 @@ use super::payload::{
     AgentActivity, AgentCapability, ConnectorManifest, EndpointSessionLease, EndpointTelemetry,
     MetricSnapshot, RemediationOutcome, ScannerFinding, ThreatIntelligenceObservation,
 };
-use super::validation::{validate_digest, validate_id, validate_json_bounds, validate_text};
+use super::validation::{
+    validate_attribute, validate_digest, validate_id, validate_json_bounds, validate_text,
+};
 use super::{
     EXTERNAL_EVENT_SCHEMA_V1, MAX_PAYLOAD_BYTES, SIGNING_DOMAIN_V1, WireContractFamily,
     WireEvidenceState,
@@ -17,6 +19,7 @@ use super::{
 
 /// Detached signature metadata. Key material and trust roots remain host-owned.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WireSignature {
     pub algorithm: String,
     pub key_id: String,
@@ -82,12 +85,11 @@ impl ExternalEventEnvelope {
         if self.occurred_at_unix_ms == 0 || self.observed_at_unix_ms < self.occurred_at_unix_ms {
             return Err(SdkError::OutOfRange("external event observation time"));
         }
-        if self.attributes.len() > 64 {
+        if self.attributes.len() > super::EXTERNAL_EVENT_ATTRIBUTE_KEYS.len() {
             return Err(SdkError::OutOfRange("external event attributes"));
         }
         for (key, value) in &self.attributes {
-            validate_id(key, "external event attribute key")?;
-            validate_text(value, "external event attribute value")?;
+            validate_attribute(key, value)?;
         }
         if let Some(digest) = self.previous_event_digest.as_deref() {
             validate_digest(digest, "external previous event digest")?;

--- a/crates/platform-sdk/src/wire/evidence.rs
+++ b/crates/platform-sdk/src/wire/evidence.rs
@@ -20,6 +20,7 @@ pub enum EvidenceFreshness {
 
 /// Fail-closed evidence quality carried by every external producer.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WireEvidenceState {
     pub completeness: EvidenceCompleteness,
     pub freshness: EvidenceFreshness,

--- a/crates/platform-sdk/src/wire/mod.rs
+++ b/crates/platform-sdk/src/wire/mod.rs
@@ -36,6 +36,17 @@ pub const SCANNER_FINDING_SCHEMA_V1: &str = "cerebro/scanner/finding/v1";
 pub const CONNECTOR_MANIFEST_SCHEMA_V1: &str = "cerebro/connector/manifest/v1";
 /// Agent capability payload schema.
 pub const AGENT_CAPABILITY_SCHEMA_V1: &str = "cerebro/agent/capability/v1";
+/// Closed non-secret operational metadata keys accepted on an external event.
+pub const EXTERNAL_EVENT_ATTRIBUTE_KEYS: &[&str] = &[
+    "correlation_id",
+    "environment",
+    "producer_version",
+    "region",
+    "source_kind",
+    "trace_id",
+];
+/// Maximum bytes accepted in one external-event operational metadata value.
+pub const MAX_EXTERNAL_EVENT_ATTRIBUTE_VALUE_BYTES: usize = 256;
 
 const SIGNING_DOMAIN_V1: &str = "cerebro.external-event-signature/v1";
 const MAX_ID_BYTES: usize = 256;

--- a/crates/platform-sdk/src/wire/tests.rs
+++ b/crates/platform-sdk/src/wire/tests.rs
@@ -260,6 +260,26 @@ fn attributes_accept_only_bounded_non_secret_operational_metadata() {
         );
     }
 
+    for value in [
+        "api_key",
+        "token-value",
+        "password:value",
+        "secret/value",
+        "private_key",
+        "session_cookie",
+        "authorization",
+        "bearer:credential",
+    ] {
+        let mut event = envelope(family, payload.clone());
+        event
+            .attributes
+            .insert("correlation_id".into(), value.into());
+        assert!(
+            event.validate().is_err(),
+            "credential-like attribute value {value} was accepted"
+        );
+    }
+
     let mut event = envelope(family, payload);
     event.attributes.insert(
         "correlation_id".into(),

--- a/crates/platform-sdk/src/wire/tests.rs
+++ b/crates/platform-sdk/src/wire/tests.rs
@@ -212,6 +212,68 @@ fn remediation_fixture_preserves_its_serialized_idempotency_key() {
 }
 
 #[test]
+fn nested_evidence_and_signature_reject_unknown_members() {
+    let (family, payload) = sample_payloads().remove(0);
+    let mut evidence_value = serde_json::to_value(envelope(family, payload.clone())).unwrap();
+    evidence_value["evidence"]["authoritative"] = Value::Bool(false);
+    assert!(serde_json::from_value::<ExternalEventEnvelope>(evidence_value).is_err());
+
+    let mut signed = envelope(family, payload);
+    signed.signature = Some(WireSignature {
+        algorithm: "ed25519".into(),
+        key_id: "key-1".into(),
+        value: "signature-a".into(),
+    });
+    let mut signature_value = serde_json::to_value(signed).unwrap();
+    signature_value["signature"]["trust_override"] = Value::Bool(true);
+    assert!(serde_json::from_value::<ExternalEventEnvelope>(signature_value).is_err());
+}
+
+#[test]
+fn attributes_accept_only_bounded_non_secret_operational_metadata() {
+    let (family, payload) = sample_payloads().remove(0);
+    for key in EXTERNAL_EVENT_ATTRIBUTE_KEYS {
+        let mut event = envelope(family, payload.clone());
+        event.attributes.insert((*key).into(), "value-1".into());
+        event.validate().unwrap();
+    }
+
+    for key in [
+        "api_key",
+        "api-key",
+        "apiKey",
+        "token",
+        "access_token",
+        "password",
+        "secret",
+        "client_secret",
+        "private_key",
+        "session_cookie",
+        "authorization",
+        "proxy_authorization",
+    ] {
+        let mut event = envelope(family, payload.clone());
+        event.attributes.insert(key.into(), "redacted".into());
+        assert!(
+            event.validate().is_err(),
+            "attribute key {key} was accepted"
+        );
+    }
+
+    let mut event = envelope(family, payload);
+    event.attributes.insert(
+        "correlation_id".into(),
+        "a".repeat(MAX_EXTERNAL_EVENT_ATTRIBUTE_VALUE_BYTES),
+    );
+    event.validate().unwrap();
+    event.attributes.insert(
+        "correlation_id".into(),
+        "a".repeat(MAX_EXTERNAL_EVENT_ATTRIBUTE_VALUE_BYTES + 1),
+    );
+    assert!(event.validate().is_err());
+}
+
+#[test]
 fn family_schema_and_payload_must_match() {
     let (_, payload) = sample_payloads().remove(0);
     let mut event = envelope(WireContractFamily::AgentActivity, payload);

--- a/crates/platform-sdk/src/wire/validation.rs
+++ b/crates/platform-sdk/src/wire/validation.rs
@@ -14,6 +14,26 @@ pub(super) fn validate_attribute(key: &str, value: &str) -> Result<(), SdkError>
     if value.len() > MAX_EXTERNAL_EVENT_ATTRIBUTE_VALUE_BYTES {
         return Err(SdkError::TooLong("external event attribute value"));
     }
+    let normalized = value
+        .to_ascii_lowercase()
+        .replace(['-', '.', '/', ':', '@', '%'], "_");
+    let compact = normalized.replace('_', "");
+    if [
+        "apikey",
+        "authorization",
+        "bearer",
+        "credential",
+        "password",
+        "privatekey",
+        "secret",
+        "sessioncookie",
+        "token",
+    ]
+    .iter()
+    .any(|marker| compact.contains(marker))
+    {
+        return Err(SdkError::Invalid("external event attribute value"));
+    }
     validate_id(value, "external event attribute value")
 }
 

--- a/crates/platform-sdk/src/wire/validation.rs
+++ b/crates/platform-sdk/src/wire/validation.rs
@@ -3,8 +3,19 @@ use serde_json::Value;
 use crate::SdkError;
 
 use super::{
-    MAX_ID_BYTES, MAX_PAYLOAD_BYTES, MAX_PAYLOAD_DEPTH, MAX_PAYLOAD_NODES, MAX_REFS, MAX_TEXT_BYTES,
+    EXTERNAL_EVENT_ATTRIBUTE_KEYS, MAX_EXTERNAL_EVENT_ATTRIBUTE_VALUE_BYTES, MAX_ID_BYTES,
+    MAX_PAYLOAD_BYTES, MAX_PAYLOAD_DEPTH, MAX_PAYLOAD_NODES, MAX_REFS, MAX_TEXT_BYTES,
 };
+
+pub(super) fn validate_attribute(key: &str, value: &str) -> Result<(), SdkError> {
+    if !EXTERNAL_EVENT_ATTRIBUTE_KEYS.contains(&key) {
+        return Err(SdkError::Invalid("external event attribute key"));
+    }
+    if value.len() > MAX_EXTERNAL_EVENT_ATTRIBUTE_VALUE_BYTES {
+        return Err(SdkError::TooLong("external event attribute value"));
+    }
+    validate_id(value, "external event attribute value")
+}
 
 pub(super) fn validate_id(value: &str, field: &'static str) -> Result<(), SdkError> {
     if value.is_empty() {

--- a/docs/contracts/external-evidence-wire.md
+++ b/docs/contracts/external-evidence-wire.md
@@ -38,7 +38,8 @@ authorities rather than redefining them.
 - Envelope attributes accept only `correlation_id`, `environment`,
   `producer_version`, `region`, `source_kind`, and `trace_id`. Values are
   identifier-like operational metadata capped at 256 bytes; credentials,
-  authorization data, cookies, secrets, and content are not attribute fields.
+  authorization data, cookies, secrets, tokens, credential markers, and content
+  are rejected as attribute keys or values.
 - Event sequences start at one; zero cannot enter the admission path.
 - Observation time cannot precede occurrence time.
 - Omitted evidence quality means `partial` and `unknown`; it cannot authorize a

--- a/docs/contracts/external-evidence-wire.md
+++ b/docs/contracts/external-evidence-wire.md
@@ -35,6 +35,10 @@ authorities rather than redefining them.
 - Each family accepts exactly one payload schema in v1.
 - IDs, references, collections, payload depth, payload nodes, and serialized
   payload bytes are bounded before persistence.
+- Envelope attributes accept only `correlation_id`, `environment`,
+  `producer_version`, `region`, `source_kind`, and `trace_id`. Values are
+  identifier-like operational metadata capped at 256 bytes; credentials,
+  authorization data, cookies, secrets, and content are not attribute fields.
 - Event sequences start at one; zero cannot enter the admission path.
 - Observation time cannot precede occurrence time.
 - Omitted evidence quality means `partial` and `unknown`; it cannot authorize a


### PR DESCRIPTION
## What changed

- Close nested unknown-field acceptance for evidence state and signatures so canonical security and decision input is not silently discarded.
- Replace the generic operational metadata escape hatch with a strict six-key allowlist: `correlation_id`, `environment`, `producer_version`, `region`, `source_kind`, and `trace_id`.
- Bound operational metadata values to 256 identifier-like bytes and reject credential- or content-bearing keys and values.
- Preserve the public attributes map API, modular wire layout, serialized contract bytes, and the ingest receipt outcome/reason/digest matrix.

## Validation

Validated on head `8c92ec9cd0d3a5cc5773b8f84c4ef59515d22979`, tree `4bdbaaf3a5d57ed5c8983e8ed5ef7a5401a760fd`, based on `2c79cb4bc18536afa17c2e8a74662f43dba7eb95`:

- `cargo fmt --all -- --check`
- focused nested-field, metadata, and receipt-matrix tests
- `cargo test -p cerebro-platform-sdk --all-targets --locked` (18 unit and 15 contract tests passed)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `make docs-drift-check`
- `git diff --check 2c79cb4bc18536afa17c2e8a74662f43dba7eb95...HEAD`
- committed-tree Gitleaks v8.30.1: 410,494,121 bytes scanned in 12m55s, no leaks found

## Boundary

This is public SDK foundation work. It does not implement producer adapters, transport, credentials, trust roots, provider execution, persistence, deployment, graph projection, or prove that any source family is live.
