### PR TITLE
fix(rust): harden Twilio provider identity admission

### DIFF
--- a/crates/source-runtime-next/src/twilio/error.rs
+++ b/crates/source-runtime-next/src/twilio/error.rs
@@ -27,6 +27,10 @@ pub enum TwilioError {
     InvalidResponse,
     /// A provider record has no stable identity under the Go selector order.
     MissingProviderIdentity,
+    /// Tenant, provider, or discriminator identity is not collision-safe.
+    InvalidEventIdentity,
+    /// One page contains different records with the same provider identity.
+    ConflictingProviderIdentity,
     /// A catalog-required raw provider field is missing or empty.
     MissingRequiredPayloadField(&'static str),
     /// A catalog-required normalized attribute is missing.
@@ -58,6 +62,12 @@ impl fmt::Display for TwilioError {
             }
             Self::MissingProviderIdentity => {
                 formatter.write_str("twilio record has no stable provider identity")
+            }
+            Self::InvalidEventIdentity => {
+                formatter.write_str("twilio tenant or provider identity is not event-ID safe")
+            }
+            Self::ConflictingProviderIdentity => {
+                formatter.write_str("twilio page contains conflicting provider identities")
             }
             Self::MissingRequiredPayloadField(name) => {
                 write!(

--- a/crates/source-runtime-next/src/twilio/family/accounts/mod.rs
+++ b/crates/source-runtime-next/src/twilio/family/accounts/mod.rs
@@ -34,7 +34,7 @@ pub(in crate::twilio) fn normalize(
         scalar(&record.primary_email),
         scalar(&record.login),
     ])?;
-    let provider_id = record_identity(&record_id, &record.identity);
+    let provider_id = record_identity(&record_id, &record.identity)?;
     let mut fields = base_fields(
         TwilioFamily::Accounts,
         tenant_id,

--- a/crates/source-runtime-next/src/twilio/family/audit_events/mod.rs
+++ b/crates/source-runtime-next/src/twilio/family/audit_events/mod.rs
@@ -36,7 +36,7 @@ pub(in crate::twilio) fn normalize(
         scalar(&record.uuid),
         scalar(&record.request_id),
     ])?;
-    let provider_id = record_identity(&record_id, &record.identity);
+    let provider_id = record_identity(&record_id, &record.identity)?;
     let mut fields = base_fields(
         TwilioFamily::AuditEvents,
         tenant_id,

--- a/crates/source-runtime-next/src/twilio/family/keys/mod.rs
+++ b/crates/source-runtime-next/src/twilio/family/keys/mod.rs
@@ -33,7 +33,7 @@ pub(in crate::twilio) fn normalize(
         scalar(&record.key),
         scalar(&record.sid),
     ])?;
-    let provider_id = record_identity(&record_id, &record.identity);
+    let provider_id = record_identity(&record_id, &record.identity)?;
     let mut fields = base_fields(TwilioFamily::Keys, tenant_id, &record_id, "secret");
     let mappings = [
         (

--- a/crates/source-runtime-next/src/twilio/family/wire.rs
+++ b/crates/source-runtime-next/src/twilio/family/wire.rs
@@ -32,6 +32,26 @@ pub(in crate::twilio) struct IdentityObjectWire {
     pub(in crate::twilio) uuid: Option<WireScalar>,
 }
 
+impl IdentityDiscriminatorsWire {
+    pub(in crate::twilio) fn contains_control(&self) -> bool {
+        let device = self.device.as_ref();
+        let agent = self.agent.as_ref();
+        [
+            self.device_id.as_ref(),
+            device.and_then(|value| value.id.as_ref()),
+            self.serial_number.as_ref(),
+            self.agent_id.as_ref(),
+            agent.and_then(|value| value.uuid.as_ref()),
+            self.device_uuid.as_ref(),
+            self.installed_version.as_ref(),
+            self.version.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        .any(WireScalar::contains_control)
+    }
+}
+
 impl WireScalar {
     pub(in crate::twilio) fn text(&self) -> String {
         match self {
@@ -39,6 +59,10 @@ impl WireScalar {
             Self::Number(value) => value.to_string(),
             Self::Bool(value) => value.to_string(),
         }
+    }
+
+    pub(in crate::twilio) fn contains_control(&self) -> bool {
+        matches!(self, Self::String(value) if value.chars().any(char::is_control))
     }
 }
 

--- a/crates/source-runtime-next/src/twilio/normalize.rs
+++ b/crates/source-runtime-next/src/twilio/normalize.rs
@@ -40,14 +40,27 @@ pub(super) fn provider_identity<const N: usize>(
 }
 
 pub(super) fn require_payload_id(value: &Option<WireScalar>) -> Result<(), TwilioError> {
-    if scalar(value).is_empty() {
-        Err(TwilioError::MissingRequiredPayloadField("id"))
-    } else {
-        Ok(())
+    let value = value
+        .as_ref()
+        .ok_or(TwilioError::MissingRequiredPayloadField("id"))?;
+    let text = value.text();
+    if text.is_empty() {
+        return Err(TwilioError::MissingRequiredPayloadField("id"));
+    }
+    match value {
+        WireScalar::String(raw) => require_event_identity(raw),
+        WireScalar::Number(_) | WireScalar::Bool(_) => require_event_identity(&text),
     }
 }
 
-pub(super) fn record_identity(record_id: &str, identity: &IdentityDiscriminatorsWire) -> String {
+pub(super) fn record_identity(
+    record_id: &str,
+    identity: &IdentityDiscriminatorsWire,
+) -> Result<String, TwilioError> {
+    require_event_identity(record_id)?;
+    if identity.contains_control() {
+        return Err(TwilioError::InvalidEventIdentity);
+    }
     let device = identity.device.as_ref();
     let agent = identity.agent.as_ref();
     let mut parts = vec![record_id.trim().to_owned()];
@@ -72,14 +85,27 @@ pub(super) fn record_identity(record_id: &str, identity: &IdentityDiscriminators
         }
     }
     if parts.len() == 1 {
-        return parts.remove(0);
+        return Ok(parts.remove(0));
     }
     let material = parts.join("\0");
-    format!(
+    Ok(format!(
         "{}-{}",
         record_id.trim(),
         hex_prefix(&Sha256::digest(material.as_bytes()), 24)
-    )
+    ))
+}
+
+pub(super) fn require_event_identity(value: &str) -> Result<(), TwilioError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || trimmed != value
+        || trimmed.chars().any(char::is_control)
+        || normalize_id(trimmed) != trimmed
+    {
+        Err(TwilioError::InvalidEventIdentity)
+    } else {
+        Ok(())
+    }
 }
 
 pub(super) fn require_field(
@@ -155,7 +181,8 @@ fn normalized_time(value: &str) -> Option<String> {
         return None;
     }
     let parsed = if numeric > 1_000_000_000_000.0 {
-        OffsetDateTime::from_unix_timestamp_nanos((numeric.trunc() as i128) * 1_000_000).ok()?
+        let nanos = (numeric.trunc() as i128).checked_mul(1_000_000)?;
+        OffsetDateTime::from_unix_timestamp_nanos(nanos).ok()?
     } else {
         let whole = numeric.trunc();
         let fraction = numeric - whole;

--- a/crates/source-runtime-next/src/twilio/request.rs
+++ b/crates/source-runtime-next/src/twilio/request.rs
@@ -5,6 +5,7 @@ use reqwest::Url;
 use super::{
     TwilioError, TwilioFamily, TwilioFilters,
     cursor::bounded_cursor,
+    normalize::require_event_identity,
     origin::{origin_string, validate_origin},
 };
 
@@ -61,7 +62,9 @@ impl TwilioKernel {
         page_size: Option<usize>,
     ) -> Result<Self, TwilioError> {
         let base_url = validate_origin(base_url.unwrap_or(DEFAULT_BASE_URL))?;
-        let tenant_id = required(tenant_id, TwilioError::MissingTenantId)?;
+        let normalized_tenant_id = required(tenant_id, TwilioError::MissingTenantId)?;
+        require_event_identity(tenant_id)?;
+        let tenant_id = normalized_tenant_id;
         let account_sid = filters
             .account_sid
             .map(|value| value.trim().to_owned())

--- a/crates/source-runtime-next/src/twilio/response.rs
+++ b/crates/source-runtime-next/src/twilio/response.rs
@@ -1,6 +1,6 @@
 //! Bounded Twilio response decoding and family dispatch.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use serde_json::Value;
 use time::OffsetDateTime;
@@ -41,16 +41,21 @@ impl TwilioKernel {
             return Err(TwilioError::TooManyRecords);
         }
         let path = request.url.path();
-        let mut seen = HashSet::new();
+        let mut seen = HashMap::new();
         let mut records = Vec::with_capacity(raw_records.len());
         for payload in raw_records {
             if !payload.is_object() {
                 return Err(TwilioError::InvalidResponse);
             }
             let record = self.normalize_record(payload, path, observed_at)?;
-            if seen.insert(record.provider_id.clone()) {
-                records.push(record);
+            if let Some(index) = seen.get(&record.provider_id).copied() {
+                if records.get(index) != Some(&record) {
+                    return Err(TwilioError::ConflictingProviderIdentity);
+                }
+                continue;
             }
+            seen.insert(record.provider_id.clone(), records.len());
+            records.push(record);
         }
         Ok(TwilioPage {
             records,

--- a/crates/source-runtime-next/src/twilio/tests/failure.rs
+++ b/crates/source-runtime-next/src/twilio/tests/failure.rs
@@ -162,7 +162,7 @@ fn response_shape_wire_types_identity_cursor_and_bounds_fail_closed() {
 #[test]
 fn invalid_or_missing_provider_time_falls_back_to_observation_utc() {
     let kernel = kernel(TwilioFamily::Accounts);
-    for updated_at in [Value::Null, json!("not-rfc3339")] {
+    for updated_at in [Value::Null, json!("not-rfc3339"), json!(1e308)] {
         let body = serde_json::to_vec(&json!({
             "items": [{"id": "record-1", "updated_at": updated_at}]
         }))
@@ -194,6 +194,108 @@ fn invalid_or_missing_provider_time_falls_back_to_observation_utc() {
             .unwrap();
         assert_eq!(page.records[0].occurred_at, expected, "field {field}");
     }
+}
+
+#[test]
+fn event_identity_aliases_and_discriminator_controls_fail_closed() {
+    for tenant_id in [
+        "tenant/id",
+        "tenant:id",
+        "tenant id",
+        "tenant\tid",
+        "tenant\nid",
+        "tenant\0id",
+        " tenant",
+    ] {
+        assert_eq!(
+            TwilioKernel::new(
+                None,
+                tenant_id,
+                TwilioFamily::Accounts,
+                TwilioFilters::default(),
+                None,
+            )
+            .unwrap_err(),
+            TwilioError::InvalidEventIdentity,
+            "tenant {tenant_id:?}"
+        );
+    }
+
+    let accounts_kernel = kernel(TwilioFamily::Accounts);
+    let request = accounts_kernel.plan(None).unwrap();
+    for record_id in ["a/b", "a:b", "a b", "a\tb", "a\nb", "a\0b", " a-b"] {
+        let body = serde_json::to_vec(&json!({"items": [{"id": record_id}]})).unwrap();
+        assert_eq!(
+            accounts_kernel
+                .decode(&request, &body, observed_at())
+                .unwrap_err(),
+            TwilioError::InvalidEventIdentity,
+            "record id {record_id:?}"
+        );
+    }
+    let canonical = accounts_kernel
+        .decode(&request, br#"{"items":[{"id":"a-b"}]}"#, observed_at())
+        .unwrap();
+    assert!(canonical.records[0].event_id.ends_with("-a-b"));
+
+    for family in [
+        TwilioFamily::Accounts,
+        TwilioFamily::Keys,
+        TwilioFamily::AuditEvents,
+    ] {
+        let family_kernel = kernel(family);
+        assert_eq!(
+            family_kernel
+                .decode(
+                    &family_kernel.plan(None).unwrap(),
+                    br#"{"items":[{"id":"a/b"}]}"#,
+                    observed_at(),
+                )
+                .unwrap_err(),
+            TwilioError::InvalidEventIdentity,
+            "family {family:?}"
+        );
+    }
+
+    let collision_pair = br#"{"items":[
+        {"id":"record-1","device_id":"alpha\u0000serial_number=beta"},
+        {"id":"record-1","device_id":"alpha","serial_number":"beta"}
+    ]}"#;
+    assert_eq!(
+        accounts_kernel
+            .decode(&request, collision_pair, observed_at())
+            .unwrap_err(),
+        TwilioError::InvalidEventIdentity
+    );
+    for body in [
+        br#"{"items":[{"id":"record-1","device":{"id":"bad\u0000id"}}]}"#.as_slice(),
+        br#"{"items":[{"id":"record-1","agent":{"uuid":"bad\u001fuuid"}}]}"#.as_slice(),
+    ] {
+        assert_eq!(
+            accounts_kernel
+                .decode(&request, body, observed_at())
+                .unwrap_err(),
+            TwilioError::InvalidEventIdentity
+        );
+    }
+}
+
+#[test]
+fn conflicting_duplicate_provider_identities_fail_closed() {
+    let kernel = kernel(TwilioFamily::Accounts);
+    assert_eq!(
+        kernel
+            .decode(
+                &kernel.plan(None).unwrap(),
+                br#"{"items":[
+                    {"id":"record-1","name":"First"},
+                    {"id":"record-1","name":"Different"}
+                ]}"#,
+                observed_at(),
+            )
+            .unwrap_err(),
+        TwilioError::ConflictingProviderIdentity
+    );
 }
 
 #[test]

--- a/crates/source-runtime-next/src/twilio/tests/request.rs
+++ b/crates/source-runtime-next/src/twilio/tests/request.rs
@@ -31,7 +31,7 @@ fn plans_exact_go_paths_pagination_and_credential_free_basic_auth() {
 }
 
 #[test]
-fn decodes_bounded_provider_cursor_and_deduplicates_in_provider_order() {
+fn decodes_bounded_provider_cursor_and_deduplicates_identical_records_in_provider_order() {
     let kernel = kernel(TwilioFamily::Accounts);
     let page = kernel
         .decode(
@@ -39,7 +39,7 @@ fn decodes_bounded_provider_cursor_and_deduplicates_in_provider_order() {
             br#"{
                 "data":[
                     {"id":"record-1","name":"First","updated_at":"2026-06-01T00:00:00Z"},
-                    {"id":"record-1","name":"Duplicate","updated_at":"2026-06-01T00:00:00Z"}
+                    {"id":"record-1","name":"First","updated_at":"2026-06-01T00:00:00Z"}
                 ],
                 "pagination":{"next_cursor":"accounts-2"}
             }"#,


### PR DESCRIPTION
## Summary

- bound numeric provider timestamps before nanosecond conversion so extreme finite values fall back to the observation time
- reject tenant and provider identity components that would alias under the existing event-ID format
- reject control-bearing top-level and nested discriminator values before NUL-delimited identity hashing
- deduplicate only identical normalized records and fail closed on conflicting records with the same provider identity

## Scope

This is a 10-path provider-local follow-up to the Twilio kernel merged in #2424. It repairs the four confirmed findings from the exact-head independent audit of that foundation. It does not add private credential hosting, shared runtime or ledger integration, deployment, or live-provider proof.

## Validation

- `cargo test -p cerebro-source-runtime-next twilio::tests -- --nocapture` — 15 passed
- `cargo test -p cerebro-source-runtime-next` — 328 library tests and 4 source-worker tests passed; doctests passed
- `go test ./sources/twilio -count=1` — passed
- `go test ./internal/sourceprojection -run Twilio -count=1` — passed
- `cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check 8cde221f243c42c8feff81ba5d2846573d714aa7...HEAD` — passed
- Gitleaks v8.30.1 committed-tree equivalent — 640.36 MB scanned, no leaks

## Audit

The predecessor audit was bound to #2424 head `62dd8846abfa4a6af87daa1cc09d065ee6e136ef`, scan `6ded51a8-c06e-4771-9c93-9679e6831ca4`, report SHA-256 `5ee9712862d9621024a4896c6538af1f394e4d947cf928208193b0e6cb87a58d`. This successor requires a new independent audit bound to its exact head before it is readied.
