### PR TITLE
fix(rust): reject ambiguous Twilio discriminators

### DIFF
--- a/crates/source-runtime-next/src/twilio/family/wire.rs
+++ b/crates/source-runtime-next/src/twilio/family/wire.rs
@@ -33,7 +33,7 @@ pub(in crate::twilio) struct IdentityObjectWire {
 }
 
 impl IdentityDiscriminatorsWire {
-    pub(in crate::twilio) fn contains_control(&self) -> bool {
+    pub(in crate::twilio) fn has_noncanonical_value(&self) -> bool {
         let device = self.device.as_ref();
         let agent = self.agent.as_ref();
         [
@@ -48,7 +48,7 @@ impl IdentityDiscriminatorsWire {
         ]
         .into_iter()
         .flatten()
-        .any(WireScalar::contains_control)
+        .any(WireScalar::is_noncanonical_identity)
     }
 }
 
@@ -61,8 +61,11 @@ impl WireScalar {
         }
     }
 
-    pub(in crate::twilio) fn contains_control(&self) -> bool {
-        matches!(self, Self::String(value) if value.chars().any(char::is_control))
+    pub(in crate::twilio) fn is_noncanonical_identity(&self) -> bool {
+        match self {
+            Self::String(value) => value != value.trim() || value.chars().any(char::is_control),
+            Self::Number(_) | Self::Bool(_) => true,
+        }
     }
 }
 

--- a/crates/source-runtime-next/src/twilio/normalize.rs
+++ b/crates/source-runtime-next/src/twilio/normalize.rs
@@ -58,7 +58,7 @@ pub(super) fn record_identity(
     identity: &IdentityDiscriminatorsWire,
 ) -> Result<String, TwilioError> {
     require_event_identity(record_id)?;
-    if identity.contains_control() {
+    if identity.has_noncanonical_value() {
         return Err(TwilioError::InvalidEventIdentity);
     }
     let device = identity.device.as_ref();

--- a/crates/source-runtime-next/src/twilio/tests/failure.rs
+++ b/crates/source-runtime-next/src/twilio/tests/failure.rs
@@ -299,6 +299,68 @@ fn conflicting_duplicate_provider_identities_fail_closed() {
 }
 
 #[test]
+fn discriminator_text_and_type_aliases_fail_closed_across_pages() {
+    let kernel = kernel(TwilioFamily::Accounts);
+    let request = kernel.plan(None).unwrap();
+    for field in [
+        "device_id",
+        "serial_number",
+        "agent_id",
+        "device_uuid",
+        "installed_version",
+        "version",
+    ] {
+        let canonical = serde_json::to_vec(&json!({
+            "items": [{"id": "record-1", (field): "value-1"}]
+        }))
+        .unwrap();
+        kernel.decode(&request, &canonical, observed_at()).unwrap();
+        let alias = serde_json::to_vec(&json!({
+            "items": [{"id": "record-1", (field): " value-1 "}]
+        }))
+        .unwrap();
+        assert_eq!(
+            kernel.decode(&request, &alias, observed_at()).unwrap_err(),
+            TwilioError::InvalidEventIdentity,
+            "top-level discriminator {field}"
+        );
+    }
+
+    for (object, field) in [("device", "id"), ("agent", "uuid")] {
+        let canonical = serde_json::to_vec(&json!({
+            "items": [{"id": "record-1", (object): {(field): "value-1"}}]
+        }))
+        .unwrap();
+        kernel.decode(&request, &canonical, observed_at()).unwrap();
+        let alias = serde_json::to_vec(&json!({
+            "items": [{"id": "record-1", (object): {(field): " value-1 "}}]
+        }))
+        .unwrap();
+        assert_eq!(
+            kernel.decode(&request, &alias, observed_at()).unwrap_err(),
+            TwilioError::InvalidEventIdentity,
+            "nested discriminator {object}.{field}"
+        );
+    }
+
+    for (canonical, alias) in [(json!("1"), json!(1)), (json!("true"), json!(true))] {
+        let canonical = serde_json::to_vec(&json!({
+            "items": [{"id": "record-1", "device_id": canonical}]
+        }))
+        .unwrap();
+        kernel.decode(&request, &canonical, observed_at()).unwrap();
+        let alias = serde_json::to_vec(&json!({
+            "items": [{"id": "record-1", "device_id": alias}]
+        }))
+        .unwrap();
+        assert_eq!(
+            kernel.decode(&request, &alias, observed_at()).unwrap_err(),
+            TwilioError::InvalidEventIdentity
+        );
+    }
+}
+
+#[test]
 fn go_identity_discriminators_prevent_version_aliases_before_dedupe() {
     let kernel = kernel(TwilioFamily::Accounts);
     let page = kernel


### PR DESCRIPTION
## Summary

- admit only canonical, control-free String values as Twilio identity discriminators
- reject numeric and Boolean discriminator values before string conversion can erase their scalar type
- cover every top-level discriminator plus nested `device.id` and `agent.uuid` with separate-page whitespace and scalar-type alias regressions

## Scope

This is a three-path provider-local follow-up to the Twilio identity hardening merged in #2427. It closes the sole residual finding from that exact-head audit. It does not add private credential hosting, shared runtime or ledger integration, deployment, or live-provider proof.

## Validation

- `cargo test -p cerebro-source-runtime-next twilio::tests -- --nocapture` — 16 passed
- `cargo test -p cerebro-source-runtime-next` — 329 library tests and 4 source-worker tests passed; doctests passed
- `go test ./sources/twilio -count=1` — passed
- `go test ./internal/sourceprojection -run Twilio -count=1` — passed
- `cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- Gitleaks v8.30.1 committed-tree equivalent — 640.49 MB scanned, no leaks

## Audit

The predecessor audit was bound to #2427 head `f950a323b695d613a98f691cb7ee755c18a91d2d`, scan `179c9f21-b959-4d01-a608-4234078f9418`, report SHA-256 `e3b2b4525d87222fcc6f89666e19b551be0c923386e13fd2892799c0da81e8a5`. Its sole finding was `twilio.lossy-discriminator-canonicalization`. This successor requires a fresh independent audit bound to its exact head before it is readied.
