### PR TITLE
fix(ci): align Rust candidate catalog totals

### DIFF
--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -177,8 +177,8 @@ jobs:
             test -x /usr/local/bin/cerebro-event-admission-worker
           '
           summary="$(docker run --rm "${CANDIDATE_IMAGE}" catalog-summary)"
-          test "$(jq -r .sources <<<"${summary}")" -eq 798
-          test "$(jq -r .families <<<"${summary}")" -eq 3925
+          test "$(jq -r .sources <<<"${summary}")" -eq 799
+          test "$(jq -r .families <<<"${summary}")" -eq 3926
       - name: Start disposable PostgreSQL, Neo4j, and JetStream
         run: |
           set -euo pipefail
@@ -246,7 +246,7 @@ jobs:
             | .checks += [
                 {name:"rust_entrypoint",status:"passed",evidence:"image starts cerebro-platform directly"},
                 {name:"go_binary_absent",status:"passed",evidence:"/usr/local/bin/cerebro is absent"},
-                {name:"source_catalog",status:"passed",evidence:"798 sources and 3925 families loaded"}
+                {name:"source_catalog",status:"passed",evidence:"799 sources and 3926 families loaded"}
               ]
           ' .dist/rust-only-e2e/rust-only-e2e-receipt.json \
             > .dist/rust-only-e2e/receipt.tmp

--- a/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
+++ b/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
@@ -107,9 +107,9 @@ fn rust_candidate_build_never_invokes_go_or_emulation() {
         "Run the candidate through its declared Rust entrypoint",
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- seed",
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- verify",
-        r#"test "$(jq -r .sources <<<"${summary}")" -eq 798"#,
-        r#"test "$(jq -r .families <<<"${summary}")" -eq 3925"#,
-        r#"evidence:"798 sources and 3925 families loaded""#,
+        r#"test "$(jq -r .sources <<<"${summary}")" -eq 799"#,
+        r#"test "$(jq -r .families <<<"${summary}")" -eq 3926"#,
+        r#"evidence:"799 sources and 3926 families loaded""#,
         "cerebro.rust-only-e2e/v1",
         "cerebro.rust-only-candidate/v1",
     ] {


### PR DESCRIPTION
## What changed

- update the Rust-only candidate image gate to require the current authoritative catalog totals: 799 sources and 3,926 families
- keep the candidate receipt evidence and structural workflow contract test bound to the same totals

## Failure reproduced

Rust-only Candidate run 32460316726 on public main b8ea1b326a03ac03d67c6bbef0815c519d0247e5 failed only the catalog-summary assertion. The catalog totals were updated by #2421, while the candidate workflow and structural test retained the previous 798 / 3,925 values.

## Validation

- git diff --check: passed
- rustfmt --edition 2024 --check crates/cerebro-platform/tests/rust_only_runtime_contract.rs: passed
- mechanical stale-value scan across the two contract paths: passed
- focused Cargo test: not started; DDESK client 1.12.12 is behind deployed 1.12.13 and the managed Cargo cache gate is short by 16,592,394,854 bytes

Hosted checks must provide the Rust compile and test receipt before this leaves draft.
