### PR TITLE
Add Archetype provider-local event adapter

### DIFF
--- a/crates/source-runtime-next/src/archetype.rs
+++ b/crates/source-runtime-next/src/archetype.rs
@@ -4,9 +4,11 @@
 //! provider requests and decodes responses without performing network I/O,
 //! accepting credential material, or owning durable checkpoint advancement.
 
+mod adapter;
 mod cursor;
 mod error;
 mod family;
+mod knowledge;
 mod normalization;
 mod request;
 mod types;

--- a/crates/source-runtime-next/src/archetype/adapter.rs
+++ b/crates/source-runtime-next/src/archetype/adapter.rs
@@ -1,0 +1,99 @@
+//! Provider-local event materialization for Archetype records.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use super::{
+    ArchetypeError, ArchetypeKernel, ArchetypeRecord, ArchetypeRequest, types::normalized_timestamp,
+};
+
+pub(super) const MAX_RESPONSE_BYTES: usize = 8 << 20;
+pub(super) const MAX_ENRICHMENT_RECORDS: usize = 500;
+const MAX_TENANT_ID_BYTES: usize = 256;
+
+pub(super) struct RecordParts {
+    pub(super) provider_kind: &'static str,
+    pub(super) provider_id: String,
+    pub(super) provider_occurred_at: Option<String>,
+    pub(super) fields: BTreeMap<String, String>,
+    pub(super) payload: Value,
+}
+
+impl ArchetypeKernel {
+    /// Bind the tenant identity supplied by the trusted runtime context.
+    ///
+    /// Provider responses cannot override this identity. The kernel still does
+    /// not accept credentials or perform network I/O.
+    pub fn bind_tenant(mut self, tenant_id: &str) -> Result<Self, ArchetypeError> {
+        let tenant_id = tenant_id.trim();
+        if tenant_id.is_empty()
+            || tenant_id.len() > MAX_TENANT_ID_BYTES
+            || tenant_id.chars().any(char::is_control)
+        {
+            return Err(ArchetypeError::MissingTenantId);
+        }
+        self.tenant_id = Some(tenant_id.to_owned());
+        Ok(self)
+    }
+
+    /// Return whether this credential-free planning and decoding kernel accepts secrets.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+
+    pub(super) fn adapt_record(
+        &self,
+        request: &ArchetypeRequest,
+        observed_at: &str,
+        parts: RecordParts,
+    ) -> Result<ArchetypeRecord, ArchetypeError> {
+        let RecordParts {
+            provider_kind,
+            provider_id,
+            provider_occurred_at,
+            fields,
+            payload,
+        } = parts;
+        let tenant_id = self
+            .tenant_id
+            .as_deref()
+            .ok_or(ArchetypeError::MissingTenantId)?;
+        let observed_at =
+            normalized_timestamp(observed_at).ok_or(ArchetypeError::InvalidObservedAt)?;
+        let schema_ref = match provider_kind {
+            "archetype.scan" => "archetype/scan/v1",
+            "archetype.vulnerability" => "archetype/vulnerability/v1",
+            "archetype.library_note" => "archetype/library-note/v1",
+            _ => return Err(ArchetypeError::InvalidResponse),
+        };
+        Ok(ArchetypeRecord {
+            family: self.family.as_str().to_owned(),
+            source_id: "archetype".to_owned(),
+            provider_kind: provider_kind.to_owned(),
+            schema_ref: schema_ref.to_owned(),
+            tenant_id: tenant_id.to_owned(),
+            event_id: provider_id.clone(),
+            provider_id,
+            request_kind: request.kind.as_str().to_owned(),
+            request_path: request.provenance(),
+            occurred_at: provider_occurred_at.unwrap_or(observed_at),
+            fields,
+            payload,
+        })
+    }
+}
+
+pub(super) fn validate_response_size(body: &[u8]) -> Result<(), ArchetypeError> {
+    if body.len() > MAX_RESPONSE_BYTES {
+        return Err(ArchetypeError::ResponseTooLarge);
+    }
+    Ok(())
+}
+
+pub(super) fn validate_enrichment_count(record_count: usize) -> Result<(), ArchetypeError> {
+    if record_count > MAX_ENRICHMENT_RECORDS {
+        return Err(ArchetypeError::TooManyRecords);
+    }
+    Ok(())
+}

--- a/crates/source-runtime-next/src/archetype/cursor.rs
+++ b/crates/source-runtime-next/src/archetype/cursor.rs
@@ -1,6 +1,7 @@
 use super::{
     ArchetypeError, ArchetypeKernel, ArchetypeRequest, ArchetypeRequestKind, ArchetypeScan,
-    request::SCAN_PAGE_LIMIT, types::normalized_timestamp, wire::ScanResponse,
+    adapter::validate_response_size, request::SCAN_PAGE_LIMIT, types::normalized_timestamp,
+    wire::ScanResponse,
 };
 
 /// One decoded descending scan page and its provider pagination hint.
@@ -20,42 +21,58 @@ impl ArchetypeKernel {
         body: &[u8],
     ) -> Result<ArchetypePage, ArchetypeError> {
         self.validate_request(request, ArchetypeRequestKind::Scans, None)?;
+        validate_response_size(body)?;
         let raw: Vec<ScanResponse> =
             serde_json::from_slice(body).map_err(|_| ArchetypeError::InvalidResponse)?;
         let page_is_full = raw.len() == SCAN_PAGE_LIMIT;
         if raw.len() > SCAN_PAGE_LIMIT {
             return Err(ArchetypeError::ResponseLimitExceeded);
         }
+        let request_path = request.provenance();
         let mut scans = raw
             .into_iter()
-            .map(scan_from_response)
+            .map(|scan| scan_from_response(scan, &request_path))
             .collect::<Result<Vec<_>, _>>()?;
         scans.sort_by_key(|scan| scan.id);
-        if scans.windows(2).any(|pair| pair[0].id == pair[1].id) {
-            return Err(ArchetypeError::DuplicateRecordIdentity);
+        let mut deduplicated: Vec<ArchetypeScan> = Vec::with_capacity(scans.len());
+        for scan in scans {
+            if let Some(previous) = deduplicated.last()
+                && previous.id == scan.id
+            {
+                if previous != &scan {
+                    return Err(ArchetypeError::DuplicateRecordIdentity);
+                }
+                continue;
+            }
+            deduplicated.push(scan);
         }
-        let next_before_id = page_is_full && !scans.is_empty();
+        let next_before_id = page_is_full && !deduplicated.is_empty();
         Ok(ArchetypePage {
-            next_before_id: next_before_id.then(|| scans[0].id),
-            scans,
+            next_before_id: next_before_id.then(|| deduplicated[0].id),
+            scans: deduplicated,
         })
     }
 }
 
-pub(super) fn scan_from_response(scan: ScanResponse) -> Result<ArchetypeScan, ArchetypeError> {
-    let occurred_at = [
+pub(super) fn scan_from_response(
+    scan: ScanResponse,
+    request_path: &str,
+) -> Result<ArchetypeScan, ArchetypeError> {
+    let selected_time = [
         scan.completed_at.as_str(),
         scan.started_at.as_str(),
         scan.created_at.as_str(),
     ]
     .into_iter()
-    .find_map(normalized_timestamp);
+    .find(|value| !value.trim().is_empty());
+    let occurred_at = selected_time.and_then(normalized_timestamp);
     let payload = serde_json::to_value(&scan).map_err(|_| ArchetypeError::InvalidResponse)?;
     let scan = ArchetypeScan {
         id: scan.id,
         repository_id: scan.repository_id,
         status: scan.status,
         occurred_at,
+        request_path: request_path.to_owned(),
         payload,
     };
     scan.validate_invariant()?;

--- a/crates/source-runtime-next/src/archetype/error.rs
+++ b/crates/source-runtime-next/src/archetype/error.rs
@@ -11,15 +11,25 @@ pub enum ArchetypeError {
     InvalidApiPrefix,
     /// Fanout concurrency is outside the Go-compatible 1 through 16 bound.
     InvalidFanoutConcurrency,
+    /// The trusted runtime context did not bind a tenant identity.
+    MissingTenantId,
+    /// The explicit observation timestamp is not RFC 3339.
+    InvalidObservedAt,
     /// A scan or repository scope ID is zero.
     InvalidScopedId,
     /// Response JSON does not match the selected Archetype contract.
     InvalidResponse,
     /// The provider returned more scans than the fixed page limit.
     ResponseLimitExceeded,
-    /// A provider record omitted its stable positive identity.
+    /// A provider response exceeded the byte limit before decoding.
+    ResponseTooLarge,
+    /// A provider enrichment response exceeded its record-count limit.
+    TooManyRecords,
+    /// Provider metadata contained a credential-shaped field name.
+    SecretFieldRejected,
+    /// A provider identity is missing or outside the Go-compatible positive range.
     MissingRecordIdentity,
-    /// One response contains colliding stable provider identities.
+    /// One response contains the same identity with conflicting content.
     DuplicateRecordIdentity,
     /// A response record belongs to a different request-bound scan.
     ResponseScopeMismatch,
@@ -40,10 +50,19 @@ impl fmt::Display for ArchetypeError {
             Self::InvalidFanoutConcurrency => {
                 "archetype fanout concurrency must be between 1 and 16"
             }
+            Self::MissingTenantId => "archetype tenant_id is required for event materialization",
+            Self::InvalidObservedAt => "archetype observed_at must be an RFC 3339 timestamp",
             Self::InvalidScopedId => "archetype request scope ID must be positive",
             Self::InvalidResponse => "archetype response does not match the selected contract",
             Self::ResponseLimitExceeded => "archetype scan response exceeds the page limit",
-            Self::MissingRecordIdentity => "archetype record identity is missing",
+            Self::ResponseTooLarge => "archetype response exceeds 8388608 bytes",
+            Self::TooManyRecords => "archetype enrichment response exceeds the record limit",
+            Self::SecretFieldRejected => {
+                "archetype provider metadata contains a credential-shaped field"
+            }
+            Self::MissingRecordIdentity => {
+                "archetype record identity is missing or outside the supported range"
+            }
             Self::DuplicateRecordIdentity => "archetype record identity is duplicated",
             Self::ResponseScopeMismatch => {
                 "archetype response record does not match the requested scan"

--- a/crates/source-runtime-next/src/archetype/knowledge.rs
+++ b/crates/source-runtime-next/src/archetype/knowledge.rs
@@ -1,0 +1,186 @@
+//! Repository-knowledge decoding and `archetype.library_note` normalization.
+
+use std::collections::{BTreeMap, HashMap};
+
+use serde_json::Value;
+
+use super::{
+    ArchetypeError, ArchetypeKernel, ArchetypeRecord, ArchetypeRepository, ArchetypeRequest,
+    ArchetypeRequestKind, ArchetypeScan,
+    adapter::{RecordParts, validate_enrichment_count, validate_response_size},
+    normalization::{compact, require_repository_scope},
+    wire::KnowledgeResponse,
+};
+
+impl ArchetypeKernel {
+    /// Decode repository knowledge into catalog-valid library-note records.
+    pub fn decode_knowledge(
+        &self,
+        request: &ArchetypeRequest,
+        body: &[u8],
+        scan: &ArchetypeScan,
+        repository: Option<&ArchetypeRepository>,
+        observed_at: &str,
+    ) -> Result<Vec<ArchetypeRecord>, ArchetypeError> {
+        scan.validate_invariant()?;
+        self.require_vulnerability_family()?;
+        self.validate_request(
+            request,
+            ArchetypeRequestKind::Knowledge,
+            Some(scan.repository_id),
+        )?;
+        require_repository_scope(scan, repository)?;
+        validate_response_size(body)?;
+        let response: KnowledgeResponse =
+            serde_json::from_slice(body).map_err(|_| ArchetypeError::InvalidResponse)?;
+        validate_enrichment_count(response.entries.len())?;
+        let mut identities = HashMap::new();
+        let mut records = Vec::new();
+        for mut entry in response.entries {
+            entry.slug = entry.slug.trim().to_owned();
+            if entry.repository_id == 0 {
+                entry.repository_id = scan.repository_id;
+            } else if entry.repository_id != scan.repository_id {
+                return Err(ArchetypeError::ResponseScopeMismatch);
+            }
+            if entry.owner.trim().is_empty() {
+                entry.owner = repository
+                    .map_or("", |value| value.owner.as_str())
+                    .to_owned();
+            }
+            if entry.repository_name.trim().is_empty() {
+                entry.repository_name = repository
+                    .map_or("", |value| value.name.as_str())
+                    .to_owned();
+            }
+            entry.owner = entry.owner.trim().to_owned();
+            entry.repository_name = entry.repository_name.trim().to_owned();
+            if entry.slug.is_empty() || entry.owner.is_empty() || entry.repository_name.is_empty() {
+                continue;
+            }
+            if entry.title.trim().is_empty() || entry.summary.trim().is_empty() {
+                return Err(ArchetypeError::InvalidResponse);
+            }
+            if metadata_contains_secret_field(&entry.metadata) {
+                return Err(ArchetypeError::SecretFieldRejected);
+            }
+            let identity = format!(
+                "archetype-library-{}-{}",
+                entry.repository_id,
+                query_escape(&entry.slug)
+            );
+            let payload =
+                serde_json::to_value(&entry).map_err(|_| ArchetypeError::InvalidResponse)?;
+            let mut fields = compact([
+                ("knowledge_slug", entry.slug.clone()),
+                ("title", entry.title.clone()),
+                ("scan_id", scan.id.to_string()),
+                ("repository_id", entry.repository_id.to_string()),
+                ("dominant_severity", entry.dominant_severity.clone()),
+                ("topics", entry.topics.join(",")),
+                ("generated_at", entry.generated_at.clone()),
+                ("source_files", entry.source_files.join(",")),
+                ("owner", entry.owner.clone()),
+                ("repo", entry.repository_name.clone()),
+            ]);
+            for key in [
+                "context_pack",
+                "context_kind",
+                "health_score",
+                "freshness_state",
+                "recommended_depth",
+                "evidence_plane",
+                "state_store",
+                "context_stale",
+                "needs_learning",
+            ] {
+                if let Some(value) = metadata_string(&entry.metadata, key) {
+                    fields.insert(key.to_owned(), value);
+                }
+            }
+            let record = self.adapt_record(
+                request,
+                observed_at,
+                RecordParts {
+                    provider_kind: "archetype.library_note",
+                    provider_id: identity.clone(),
+                    provider_occurred_at: scan.occurred_at.clone(),
+                    fields,
+                    payload,
+                },
+            )?;
+            if let Some(index) = identities.get(&identity).copied() {
+                if records.get(index) != Some(&record) {
+                    return Err(ArchetypeError::DuplicateRecordIdentity);
+                }
+                continue;
+            }
+            identities.insert(identity, records.len());
+            records.push(record);
+        }
+        Ok(records)
+    }
+}
+
+fn metadata_string(metadata: &BTreeMap<String, Value>, key: &str) -> Option<String> {
+    match metadata.get(key)? {
+        Value::String(value) => nonblank(value).map(str::to_owned),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn metadata_contains_secret_field(metadata: &BTreeMap<String, Value>) -> bool {
+    metadata
+        .iter()
+        .any(|(key, value)| secret_field_name(key) || value_contains_secret_field(value))
+}
+
+fn value_contains_secret_field(value: &Value) -> bool {
+    match value {
+        Value::Object(values) => values
+            .iter()
+            .any(|(key, value)| secret_field_name(key) || value_contains_secret_field(value)),
+        Value::Array(values) => values.iter().any(value_contains_secret_field),
+        _ => false,
+    }
+}
+
+fn secret_field_name(name: &str) -> bool {
+    let normalized = name
+        .trim()
+        .to_ascii_lowercase()
+        .replace(['-', ' ', '.', '/'], "_");
+    [
+        "api_key",
+        "authorization",
+        "cookie",
+        "credential",
+        "password",
+        "private_key",
+        "secret",
+        "token",
+    ]
+    .iter()
+    .any(|marker| normalized.contains(marker))
+}
+
+fn query_escape(value: &str) -> String {
+    let mut escaped = String::new();
+    for byte in value.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                escaped.push(char::from(*byte));
+            }
+            b' ' => escaped.push('+'),
+            _ => escaped.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    escaped
+}
+
+fn nonblank(value: &str) -> Option<&str> {
+    let value = value.trim();
+    (!value.is_empty()).then_some(value)
+}

--- a/crates/source-runtime-next/src/archetype/normalization.rs
+++ b/crates/source-runtime-next/src/archetype/normalization.rs
@@ -1,12 +1,11 @@
-use std::collections::{BTreeMap, HashSet};
-
-use serde_json::Value;
+use std::collections::BTreeMap;
 
 use super::{
     ArchetypeError, ArchetypeFamily, ArchetypeKernel, ArchetypeRecord, ArchetypeRepository,
     ArchetypeRequest, ArchetypeRequestKind, ArchetypeScan, VulnerabilityCollectionState,
-    types::normalized_timestamp,
-    wire::{KnowledgeResponse, RepositoryResponse, VulnerabilityResponse},
+    adapter::{RecordParts, validate_enrichment_count, validate_response_size},
+    types::{normalized_timestamp, valid_provider_id},
+    wire::{RepositoryResponse, VulnerabilityResponse},
 };
 
 impl ArchetypeKernel {
@@ -17,11 +16,13 @@ impl ArchetypeKernel {
         body: &[u8],
     ) -> Result<BTreeMap<u64, ArchetypeRepository>, ArchetypeError> {
         self.validate_request(request, ArchetypeRequestKind::Repositories, None)?;
+        validate_response_size(body)?;
         let raw: Vec<RepositoryResponse> =
             serde_json::from_slice(body).map_err(|_| ArchetypeError::InvalidResponse)?;
+        validate_enrichment_count(raw.len())?;
         let mut repositories = BTreeMap::new();
         for repository in raw {
-            if repository.id == 0 {
+            if !valid_provider_id(repository.id) {
                 return Err(ArchetypeError::MissingRecordIdentity);
             }
             let repository = ArchetypeRepository {
@@ -29,9 +30,13 @@ impl ArchetypeKernel {
                 owner: repository.owner,
                 name: repository.name,
             };
-            if repositories.insert(repository.id, repository).is_some() {
-                return Err(ArchetypeError::DuplicateRecordIdentity);
+            if let Some(previous) = repositories.get(&repository.id) {
+                if previous != &repository {
+                    return Err(ArchetypeError::DuplicateRecordIdentity);
+                }
+                continue;
             }
+            repositories.insert(repository.id, repository);
         }
         Ok(repositories)
     }
@@ -39,11 +44,17 @@ impl ArchetypeKernel {
     /// Normalize a scan after its vulnerability collection state is known.
     pub fn scan_record(
         &self,
+        request: &ArchetypeRequest,
         scan: &ArchetypeScan,
         repository: Option<&ArchetypeRepository>,
         collection_state: VulnerabilityCollectionState,
+        observed_at: &str,
     ) -> Result<ArchetypeRecord, ArchetypeError> {
         scan.validate_invariant()?;
+        self.validate_request(request, ArchetypeRequestKind::Scans, None)?;
+        if scan.request_path != request.provenance() {
+            return Err(ArchetypeError::RequestScopeMismatch);
+        }
         require_repository_scope(scan, repository)?;
         match (self.family, collection_state) {
             (ArchetypeFamily::Scan, VulnerabilityCollectionState::NotRequested)
@@ -62,14 +73,17 @@ impl ArchetypeKernel {
             ),
         ]);
         add_repository_fields(&mut fields, repository);
-        Ok(ArchetypeRecord {
-            family: self.family.as_str().to_owned(),
-            provider_kind: "archetype.scan".to_owned(),
-            provider_id: format!("archetype-scan-{}", scan.id),
-            occurred_at: scan.occurred_at.clone(),
-            fields,
-            payload: scan.payload.clone(),
-        })
+        self.adapt_record(
+            request,
+            observed_at,
+            RecordParts {
+                provider_kind: "archetype.scan",
+                provider_id: format!("archetype-scan-{}", scan.id),
+                provider_occurred_at: scan.occurred_at.clone(),
+                fields,
+                payload: scan.payload.clone(),
+            },
+        )
     }
 
     /// Decode and normalize vulnerabilities for the exact request-bound scan.
@@ -79,6 +93,7 @@ impl ArchetypeKernel {
         body: &[u8],
         scan: &ArchetypeScan,
         repository: Option<&ArchetypeRepository>,
+        observed_at: &str,
     ) -> Result<Vec<ArchetypeRecord>, ArchetypeError> {
         scan.validate_invariant()?;
         self.require_vulnerability_family()?;
@@ -88,148 +103,67 @@ impl ArchetypeKernel {
             Some(scan.id),
         )?;
         require_repository_scope(scan, repository)?;
+        validate_response_size(body)?;
         let raw: Vec<VulnerabilityResponse> =
             serde_json::from_slice(body).map_err(|_| ArchetypeError::InvalidResponse)?;
-        let mut identities = HashSet::new();
-        raw.into_iter()
-            .map(|vulnerability| {
-                if vulnerability.id == 0 || vulnerability.scan_id == 0 {
-                    return Err(ArchetypeError::MissingRecordIdentity);
-                }
-                if vulnerability.scan_id != scan.id {
-                    return Err(ArchetypeError::ResponseScopeMismatch);
-                }
-                if vulnerability.severity.trim().is_empty()
-                    || vulnerability.category.trim().is_empty()
-                    || vulnerability.file_path.trim().is_empty()
-                {
-                    return Err(ArchetypeError::InvalidResponse);
-                }
-                if !identities.insert(vulnerability.id) {
-                    return Err(ArchetypeError::DuplicateRecordIdentity);
-                }
-                let payload = serde_json::to_value(&vulnerability)
-                    .map_err(|_| ArchetypeError::InvalidResponse)?;
-                let mut fields = compact([
-                    ("vulnerability_id", vulnerability.id.to_string()),
-                    ("scan_id", vulnerability.scan_id.to_string()),
-                    ("repository_id", scan.repository_id.to_string()),
-                    ("severity", vulnerability.severity.clone()),
-                    ("category", vulnerability.category.clone()),
-                    ("file_path", vulnerability.file_path.clone()),
-                    ("line_number", vulnerability.line_number.to_string()),
-                    ("source_product", "archetype".to_owned()),
-                ]);
-                add_repository_fields(&mut fields, repository);
-                Ok(ArchetypeRecord {
-                    family: self.family.as_str().to_owned(),
-                    provider_kind: "archetype.vulnerability".to_owned(),
+        validate_enrichment_count(raw.len())?;
+        let mut identities = BTreeMap::new();
+        let mut records = Vec::with_capacity(raw.len());
+        for vulnerability in raw {
+            if !valid_provider_id(vulnerability.id) || !valid_provider_id(vulnerability.scan_id) {
+                return Err(ArchetypeError::MissingRecordIdentity);
+            }
+            if vulnerability.scan_id != scan.id {
+                return Err(ArchetypeError::ResponseScopeMismatch);
+            }
+            if vulnerability.severity.trim().is_empty()
+                || vulnerability.category.trim().is_empty()
+                || vulnerability.file_path.trim().is_empty()
+            {
+                return Err(ArchetypeError::InvalidResponse);
+            }
+            let payload = serde_json::to_value(&vulnerability)
+                .map_err(|_| ArchetypeError::InvalidResponse)?;
+            let mut fields = compact([
+                ("vulnerability_id", vulnerability.id.to_string()),
+                ("scan_id", vulnerability.scan_id.to_string()),
+                ("repository_id", scan.repository_id.to_string()),
+                ("severity", vulnerability.severity.clone()),
+                ("category", vulnerability.category.clone()),
+                ("file_path", vulnerability.file_path.clone()),
+                ("line_number", vulnerability.line_number.to_string()),
+                ("source_product", "archetype".to_owned()),
+            ]);
+            add_repository_fields(&mut fields, repository);
+            let record = self.adapt_record(
+                request,
+                observed_at,
+                RecordParts {
+                    provider_kind: "archetype.vulnerability",
                     provider_id: format!(
                         "archetype-vulnerability-{}-{}",
                         scan.id, vulnerability.id
                     ),
-                    occurred_at: normalized_timestamp(&vulnerability.created_at)
+                    provider_occurred_at: normalized_timestamp(&vulnerability.created_at)
                         .or_else(|| scan.occurred_at.clone()),
                     fields,
                     payload,
-                })
-            })
-            .collect()
-    }
-
-    /// Decode and normalize repository knowledge for the request-bound scan.
-    pub fn decode_knowledge(
-        &self,
-        request: &ArchetypeRequest,
-        body: &[u8],
-        scan: &ArchetypeScan,
-        repository: Option<&ArchetypeRepository>,
-    ) -> Result<Vec<ArchetypeRecord>, ArchetypeError> {
-        scan.validate_invariant()?;
-        self.require_vulnerability_family()?;
-        self.validate_request(
-            request,
-            ArchetypeRequestKind::Knowledge,
-            Some(scan.repository_id),
-        )?;
-        require_repository_scope(scan, repository)?;
-        let response: KnowledgeResponse =
-            serde_json::from_slice(body).map_err(|_| ArchetypeError::InvalidResponse)?;
-        let mut identities = HashSet::new();
-        let mut records = Vec::new();
-        for mut entry in response.entries {
-            entry.slug = entry.slug.trim().to_owned();
-            if entry.repository_id == 0 {
-                entry.repository_id = scan.repository_id;
-            } else if entry.repository_id != scan.repository_id {
-                return Err(ArchetypeError::ResponseScopeMismatch);
-            }
-            if entry.owner.trim().is_empty() {
-                entry.owner = repository
-                    .map_or("", |value| value.owner.as_str())
-                    .to_owned();
-            }
-            if entry.repository_name.trim().is_empty() {
-                entry.repository_name = repository
-                    .map_or("", |value| value.name.as_str())
-                    .to_owned();
-            }
-            entry.owner = entry.owner.trim().to_owned();
-            entry.repository_name = entry.repository_name.trim().to_owned();
-            if entry.slug.is_empty() || entry.owner.is_empty() || entry.repository_name.is_empty() {
+                },
+            )?;
+            if let Some(index) = identities.get(&record.provider_id).copied() {
+                if records.get(index) != Some(&record) {
+                    return Err(ArchetypeError::DuplicateRecordIdentity);
+                }
                 continue;
             }
-            let identity = format!(
-                "archetype-library-{}-{}",
-                entry.repository_id,
-                query_escape(&entry.slug)
-            );
-            if !identities.insert(identity.clone()) {
-                return Err(ArchetypeError::DuplicateRecordIdentity);
-            }
-            let payload =
-                serde_json::to_value(&entry).map_err(|_| ArchetypeError::InvalidResponse)?;
-            let mut fields = compact([
-                ("knowledge_slug", entry.slug.clone()),
-                ("title", entry.title.clone()),
-                ("scan_id", scan.id.to_string()),
-                ("repository_id", entry.repository_id.to_string()),
-                ("dominant_severity", entry.dominant_severity.clone()),
-                ("topics", entry.topics.join(",")),
-                ("generated_at", entry.generated_at.clone()),
-                ("source_files", entry.source_files.join(",")),
-                ("owner", entry.owner.clone()),
-                ("repo", entry.repository_name.clone()),
-            ]);
-            for key in [
-                "context_pack",
-                "context_kind",
-                "health_score",
-                "freshness_state",
-                "recommended_depth",
-                "evidence_plane",
-                "state_store",
-                "context_stale",
-                "needs_learning",
-            ] {
-                if let Some(value) = metadata_string(&entry.metadata, key) {
-                    fields.insert(key.to_owned(), value);
-                }
-            }
-            records.push(ArchetypeRecord {
-                family: self.family.as_str().to_owned(),
-                provider_kind: "archetype.library_note".to_owned(),
-                provider_id: identity,
-                occurred_at: scan.occurred_at.clone(),
-                fields,
-                payload,
-            });
+            identities.insert(record.provider_id.clone(), records.len());
+            records.push(record);
         }
         Ok(records)
     }
 }
 
-fn require_repository_scope(
+pub(super) fn require_repository_scope(
     scan: &ArchetypeScan,
     repository: Option<&ArchetypeRepository>,
 ) -> Result<(), ArchetypeError> {
@@ -239,14 +173,14 @@ fn require_repository_scope(
     Ok(())
 }
 
-fn compact<const N: usize>(values: [(&str, String); N]) -> BTreeMap<String, String> {
+pub(super) fn compact<const N: usize>(values: [(&str, String); N]) -> BTreeMap<String, String> {
     values
         .into_iter()
         .filter_map(|(key, value)| (!value.trim().is_empty()).then(|| (key.to_owned(), value)))
         .collect()
 }
 
-fn add_repository_fields(
+pub(super) fn add_repository_fields(
     fields: &mut BTreeMap<String, String>,
     repository: Option<&ArchetypeRepository>,
 ) {
@@ -258,32 +192,4 @@ fn add_repository_fields(
             fields.insert("repo".to_owned(), repository.name.clone());
         }
     }
-}
-
-fn metadata_string(metadata: &BTreeMap<String, Value>, key: &str) -> Option<String> {
-    match metadata.get(key)? {
-        Value::String(value) => nonblank(value).map(str::to_owned),
-        Value::Number(value) => Some(value.to_string()),
-        Value::Bool(value) => Some(value.to_string()),
-        _ => None,
-    }
-}
-
-fn query_escape(value: &str) -> String {
-    let mut escaped = String::new();
-    for byte in value.as_bytes() {
-        match byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                escaped.push(char::from(*byte));
-            }
-            b' ' => escaped.push('+'),
-            _ => escaped.push_str(&format!("%{byte:02X}")),
-        }
-    }
-    escaped
-}
-
-fn nonblank(value: &str) -> Option<&str> {
-    let value = value.trim();
-    (!value.is_empty()).then_some(value)
 }

--- a/crates/source-runtime-next/src/archetype/request.rs
+++ b/crates/source-runtime-next/src/archetype/request.rs
@@ -2,7 +2,7 @@ use std::{net::IpAddr, str::FromStr};
 
 use reqwest::Url;
 
-use super::{ArchetypeError, ArchetypeFamily};
+use super::{ArchetypeError, ArchetypeFamily, types::valid_provider_id};
 
 const DEFAULT_API_PREFIX: &str = "/api/v1";
 pub(super) const SCAN_PAGE_LIMIT: usize = 100;
@@ -22,12 +22,25 @@ pub enum ArchetypeRequestKind {
     Knowledge,
 }
 
+impl ArchetypeRequestKind {
+    /// Return the stable provider operation name used in request provenance.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Scans => "scans",
+            Self::Repositories => "repositories",
+            Self::Vulnerabilities => "vulnerabilities",
+            Self::Knowledge => "knowledge",
+        }
+    }
+}
+
 /// One credential-free HTTP request planned by the Archetype kernel.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ArchetypeRequest {
-    url: Url,
-    kind: ArchetypeRequestKind,
-    scoped_id: Option<u64>,
+    pub(super) url: Url,
+    pub(super) family: ArchetypeFamily,
+    pub(super) kind: ArchetypeRequestKind,
+    pub(super) scoped_id: Option<u64>,
 }
 
 impl ArchetypeRequest {
@@ -55,6 +68,13 @@ impl ArchetypeRequest {
     pub const fn accept(&self) -> &'static str {
         "application/json"
     }
+
+    pub(super) fn provenance(&self) -> String {
+        self.url.query().map_or_else(
+            || self.url.path().to_owned(),
+            |query| format!("{}?{query}", self.url.path()),
+        )
+    }
 }
 /// Provider-specific Archetype request and response kernel.
 #[derive(Clone, Debug)]
@@ -63,6 +83,7 @@ pub struct ArchetypeKernel {
     pub(super) api_prefix: String,
     pub(super) family: ArchetypeFamily,
     pub(super) fanout_concurrency: usize,
+    pub(super) tenant_id: Option<String>,
 }
 
 impl ArchetypeKernel {
@@ -87,6 +108,7 @@ impl ArchetypeKernel {
             api_prefix,
             family,
             fanout_concurrency,
+            tenant_id: None,
         })
     }
 
@@ -97,7 +119,7 @@ impl ArchetypeKernel {
 
     /// Plan one descending scan-page request.
     pub fn plan_scans(&self, before_id: Option<u64>) -> Result<ArchetypeRequest, ArchetypeError> {
-        if before_id == Some(0) {
+        if before_id.is_some_and(|value| !valid_provider_id(value)) {
             return Err(ArchetypeError::InvalidScopedId);
         }
         let mut request = self.request("/scans", ArchetypeRequestKind::Scans, None)?;
@@ -119,7 +141,7 @@ impl ArchetypeKernel {
     /// Plan vulnerability enrichment for one positive scan ID.
     pub fn plan_vulnerabilities(&self, scan_id: u64) -> Result<ArchetypeRequest, ArchetypeError> {
         self.require_vulnerability_family()?;
-        if scan_id == 0 {
+        if !valid_provider_id(scan_id) {
             return Err(ArchetypeError::InvalidScopedId);
         }
         self.request(
@@ -132,7 +154,7 @@ impl ArchetypeKernel {
     /// Plan knowledge enrichment for one positive repository ID.
     pub fn plan_knowledge(&self, repository_id: u64) -> Result<ArchetypeRequest, ArchetypeError> {
         self.require_vulnerability_family()?;
-        if repository_id == 0 {
+        if !valid_provider_id(repository_id) {
             return Err(ArchetypeError::InvalidScopedId);
         }
         self.request(
@@ -154,6 +176,7 @@ impl ArchetypeKernel {
             .map_err(|_| ArchetypeError::InvalidApiPrefix)?;
         Ok(ArchetypeRequest {
             url,
+            family: self.family,
             kind,
             scoped_id,
         })
@@ -165,14 +188,33 @@ impl ArchetypeKernel {
         kind: ArchetypeRequestKind,
         scoped_id: Option<u64>,
     ) -> Result<(), ArchetypeError> {
-        if request.kind != kind
+        if request.family != self.family
+            || request.kind != kind
             || request.scoped_id != scoped_id
             || request.url.origin() != self.base_url.origin()
-            || !request
-                .url
-                .path()
-                .starts_with(&format!("{}/", self.api_prefix))
+            || request.url.fragment().is_some()
         {
+            return Err(ArchetypeError::RequestScopeMismatch);
+        }
+        let expected_path = match (kind, scoped_id) {
+            (ArchetypeRequestKind::Scans, None) => format!("{}/scans", self.api_prefix),
+            (ArchetypeRequestKind::Repositories, None) => {
+                format!("{}/repositories", self.api_prefix)
+            }
+            (ArchetypeRequestKind::Vulnerabilities, Some(scan_id)) => {
+                format!("{}/scans/{scan_id}/vulnerabilities", self.api_prefix)
+            }
+            (ArchetypeRequestKind::Knowledge, Some(repository_id)) => {
+                format!("{}/repositories/{repository_id}/knowledge", self.api_prefix)
+            }
+            _ => return Err(ArchetypeError::RequestScopeMismatch),
+        };
+        if request.url.path() != expected_path {
+            return Err(ArchetypeError::RequestScopeMismatch);
+        }
+        if kind == ArchetypeRequestKind::Scans {
+            validate_scan_query(&request.url)?;
+        } else if request.url.query().is_some() {
             return Err(ArchetypeError::RequestScopeMismatch);
         }
         Ok(())
@@ -184,6 +226,30 @@ impl ArchetypeKernel {
         }
         Ok(())
     }
+}
+
+fn validate_scan_query(url: &Url) -> Result<(), ArchetypeError> {
+    let mut limit = None;
+    let mut before_id = None;
+    for (name, value) in url.query_pairs() {
+        match name.as_ref() {
+            "limit" if limit.is_none() => limit = Some(value.into_owned()),
+            "before_id" if before_id.is_none() => {
+                let value = value
+                    .parse::<u64>()
+                    .ok()
+                    .filter(|value| valid_provider_id(*value))
+                    .ok_or(ArchetypeError::RequestScopeMismatch)?;
+                before_id = Some(value);
+            }
+            _ => return Err(ArchetypeError::RequestScopeMismatch),
+        }
+    }
+    let expected_limit = SCAN_PAGE_LIMIT.to_string();
+    if limit.as_deref() != Some(expected_limit.as_str()) {
+        return Err(ArchetypeError::RequestScopeMismatch);
+    }
+    Ok(())
 }
 fn validate_origin(raw: &str) -> Result<Url, ArchetypeError> {
     let mut url = Url::parse(raw.trim()).map_err(|_| ArchetypeError::InvalidBaseUrl)?;

--- a/crates/source-runtime-next/src/archetype/tests/failure.rs
+++ b/crates/source-runtime-next/src/archetype/tests/failure.rs
@@ -1,0 +1,337 @@
+use super::*;
+use crate::archetype::adapter::{MAX_ENRICHMENT_RECORDS, MAX_RESPONSE_BYTES};
+
+#[test]
+fn observation_fallback_is_deterministic_and_tenant_is_context_bound() {
+    let kernel = kernel(ArchetypeFamily::Scan);
+    let request = kernel.plan_scans(None).unwrap();
+    let page = kernel
+        .decode_scans(
+            &request,
+            br#"[{"id":1,"repository_id":7,"status":"completed","tenant_id":"provider-tenant","api_token":"must-not-flow"}]"#,
+        )
+        .unwrap();
+    let first = kernel
+        .scan_record(
+            &request,
+            &page.scans[0],
+            None,
+            VulnerabilityCollectionState::NotRequested,
+            "2026-08-19T19:00:00-07:00",
+        )
+        .unwrap();
+    let second = kernel
+        .scan_record(
+            &request,
+            &page.scans[0],
+            None,
+            VulnerabilityCollectionState::NotRequested,
+            OBSERVED_AT,
+        )
+        .unwrap();
+    assert_eq!(first.occurred_at, OBSERVED_AT);
+    assert_eq!(first.occurred_at, second.occurred_at);
+    assert_eq!(first.tenant_id, TENANT_ID);
+    assert!(first.payload.get("tenant_id").is_none());
+    assert!(first.payload.get("api_token").is_none());
+    assert!(!request.url().as_str().contains("must-not-flow"));
+    assert!(!ArchetypeKernel::requires_credentials());
+}
+
+#[test]
+fn invalid_first_provider_timestamp_uses_observation_in_go_precedence_order() {
+    let kernel = kernel(ArchetypeFamily::Scan);
+    let request = kernel.plan_scans(None).unwrap();
+    let page = kernel
+        .decode_scans(
+            &request,
+            br#"[{"id":1,"repository_id":7,"status":"completed","completed_at":"invalid","started_at":"2026-08-20T01:00:00Z"}]"#,
+        )
+        .unwrap();
+    assert_eq!(page.scans[0].occurred_at, None);
+    let record = kernel
+        .scan_record(
+            &request,
+            &page.scans[0],
+            None,
+            VulnerabilityCollectionState::NotRequested,
+            OBSERVED_AT,
+        )
+        .unwrap();
+    assert_eq!(record.occurred_at, OBSERVED_AT);
+}
+
+#[test]
+fn enrichment_timestamps_use_scan_then_explicit_observation_fallback() {
+    let kernel = kernel(ArchetypeFamily::Vulnerability);
+    let scans = kernel.plan_scans(None).unwrap();
+    let scan = kernel
+        .decode_scans(
+            &scans,
+            br#"[{"id":9,"repository_id":7,"status":"completed"}]"#,
+        )
+        .unwrap()
+        .scans
+        .remove(0);
+
+    let vulnerabilities = kernel.plan_vulnerabilities(scan.id).unwrap();
+    let vulnerability = kernel
+        .decode_vulnerabilities(
+            &vulnerabilities,
+            br#"[{"id":1,"scan_id":9,"file_path":"app.py","category":"ssrf","severity":"high","created_at":"invalid"}]"#,
+            &scan,
+            None,
+            OBSERVED_AT,
+        )
+        .unwrap()
+        .remove(0);
+    assert_eq!(vulnerability.occurred_at, OBSERVED_AT);
+
+    let knowledge = kernel.plan_knowledge(scan.repository_id).unwrap();
+    let library_note = kernel
+        .decode_knowledge(
+            &knowledge,
+            br#"{"entries":[{"slug":"fallback","title":"title","summary":"summary","owner":"WriterInternal","repository_name":"Archetype"}]}"#,
+            &scan,
+            None,
+            OBSERVED_AT,
+        )
+        .unwrap()
+        .remove(0);
+    assert_eq!(library_note.occurred_at, OBSERVED_AT);
+}
+
+#[test]
+fn materialization_requires_trusted_tenant_and_valid_observation_time() {
+    let unbound = ArchetypeKernel::new(
+        "https://archetype.example.test",
+        None,
+        ArchetypeFamily::Scan,
+        None,
+    )
+    .unwrap();
+    let request = unbound.plan_scans(None).unwrap();
+    let page = unbound
+        .decode_scans(
+            &request,
+            br#"[{"id":1,"repository_id":7,"status":"completed"}]"#,
+        )
+        .unwrap();
+    assert_eq!(
+        unbound
+            .scan_record(
+                &request,
+                &page.scans[0],
+                None,
+                VulnerabilityCollectionState::NotRequested,
+                OBSERVED_AT,
+            )
+            .unwrap_err(),
+        ArchetypeError::MissingTenantId
+    );
+
+    let bound = unbound.bind_tenant(TENANT_ID).unwrap();
+    assert_eq!(
+        bound
+            .scan_record(
+                &request,
+                &page.scans[0],
+                None,
+                VulnerabilityCollectionState::NotRequested,
+                "not-a-time",
+            )
+            .unwrap_err(),
+        ArchetypeError::InvalidObservedAt
+    );
+}
+
+#[test]
+fn response_and_record_rejections_are_bounded_and_body_free() {
+    let kernel = kernel(ArchetypeFamily::Vulnerability);
+    let scans = kernel.plan_scans(None).unwrap();
+    assert_eq!(
+        kernel
+            .decode_scans(&scans, &vec![b' '; MAX_RESPONSE_BYTES + 1])
+            .unwrap_err(),
+        ArchetypeError::ResponseTooLarge
+    );
+
+    let scan = scan(&kernel);
+    let knowledge = kernel.plan_knowledge(scan.repository_id).unwrap();
+    let entries = (0..=MAX_ENRICHMENT_RECORDS)
+        .map(|index| {
+            serde_json::json!({
+                "slug": format!("note-{index}"),
+                "title": "title",
+                "summary": "summary",
+                "owner": "WriterInternal",
+                "repository_name": "Archetype"
+            })
+        })
+        .collect::<Vec<_>>();
+    let body = serde_json::to_vec(&serde_json::json!({"entries": entries})).unwrap();
+    assert_eq!(
+        kernel
+            .decode_knowledge(&knowledge, &body, &scan, None, OBSERVED_AT)
+            .unwrap_err(),
+        ArchetypeError::TooManyRecords
+    );
+
+    let marker = "must-not-appear-in-error";
+    let error = kernel.decode_scans(&scans, marker.as_bytes()).unwrap_err();
+    assert_eq!(error, ArchetypeError::InvalidResponse);
+    assert!(!error.to_string().contains(marker));
+}
+
+#[test]
+fn identical_duplicates_collapse_and_conflicts_fail_closed() {
+    let kernel = kernel(ArchetypeFamily::Vulnerability);
+    let scans = kernel.plan_scans(None).unwrap();
+    let identical = br#"[
+        {"id":9,"repository_id":7,"status":"completed"},
+        {"id":9,"repository_id":7,"status":"completed"}
+    ]"#;
+    assert_eq!(
+        kernel.decode_scans(&scans, identical).unwrap().scans.len(),
+        1
+    );
+    let conflicting = br#"[
+        {"id":9,"repository_id":7,"status":"completed"},
+        {"id":9,"repository_id":7,"status":"running"}
+    ]"#;
+    assert_eq!(
+        kernel.decode_scans(&scans, conflicting).unwrap_err(),
+        ArchetypeError::DuplicateRecordIdentity
+    );
+
+    let scan = scan(&kernel);
+    let vulnerabilities = kernel.plan_vulnerabilities(scan.id).unwrap();
+    let duplicate_vulnerability = br#"[
+        {"id":1,"scan_id":9,"file_path":"app.py","category":"ssrf","severity":"high"},
+        {"id":1,"scan_id":9,"file_path":"app.py","category":"ssrf","severity":"high"}
+    ]"#;
+    assert_eq!(
+        kernel
+            .decode_vulnerabilities(
+                &vulnerabilities,
+                duplicate_vulnerability,
+                &scan,
+                None,
+                OBSERVED_AT,
+            )
+            .unwrap()
+            .len(),
+        1
+    );
+    let conflicting_vulnerability = br#"[
+        {"id":1,"scan_id":9,"file_path":"app.py","category":"ssrf","severity":"high"},
+        {"id":1,"scan_id":9,"file_path":"app.py","category":"ssrf","severity":"critical"}
+    ]"#;
+    assert_eq!(
+        kernel
+            .decode_vulnerabilities(
+                &vulnerabilities,
+                conflicting_vulnerability,
+                &scan,
+                None,
+                OBSERVED_AT,
+            )
+            .unwrap_err(),
+        ArchetypeError::DuplicateRecordIdentity
+    );
+
+    let repositories = kernel.plan_repositories().unwrap();
+    let duplicate_repository = br#"[
+        {"id":7,"owner":"WriterInternal","name":"Archetype"},
+        {"id":7,"owner":"WriterInternal","name":"Archetype"}
+    ]"#;
+    assert_eq!(
+        kernel
+            .decode_repositories(&repositories, duplicate_repository)
+            .unwrap()
+            .len(),
+        1
+    );
+    let conflicting_repository = br#"[
+        {"id":7,"owner":"WriterInternal","name":"Archetype"},
+        {"id":7,"owner":"Other","name":"Archetype"}
+    ]"#;
+    assert_eq!(
+        kernel
+            .decode_repositories(&repositories, conflicting_repository)
+            .unwrap_err(),
+        ArchetypeError::DuplicateRecordIdentity
+    );
+
+    let knowledge = kernel.plan_knowledge(scan.repository_id).unwrap();
+    let duplicate_note = br#"{"entries":[
+        {"slug":"one","title":"title","summary":"summary","owner":"WriterInternal","repository_name":"Archetype"},
+        {"slug":"one","title":"title","summary":"summary","owner":"WriterInternal","repository_name":"Archetype"}
+    ]}"#;
+    assert_eq!(
+        kernel
+            .decode_knowledge(&knowledge, duplicate_note, &scan, None, OBSERVED_AT)
+            .unwrap()
+            .len(),
+        1
+    );
+    let conflicting_note = br#"{"entries":[
+        {"slug":"one","title":"title","summary":"summary","owner":"WriterInternal","repository_name":"Archetype"},
+        {"slug":"one","title":"different","summary":"summary","owner":"WriterInternal","repository_name":"Archetype"}
+    ]}"#;
+    assert_eq!(
+        kernel
+            .decode_knowledge(&knowledge, conflicting_note, &scan, None, OBSERVED_AT)
+            .unwrap_err(),
+        ArchetypeError::DuplicateRecordIdentity
+    );
+}
+
+#[test]
+fn library_note_required_payload_fields_fail_closed() {
+    let kernel = kernel(ArchetypeFamily::Vulnerability);
+    let scan = scan(&kernel);
+    let request = kernel.plan_knowledge(scan.repository_id).unwrap();
+    for missing in ["title", "summary"] {
+        let mut entry = serde_json::json!({
+            "slug": "required-fields",
+            "title": "title",
+            "summary": "summary",
+            "owner": "WriterInternal",
+            "repository_name": "Archetype"
+        });
+        entry[missing] = serde_json::Value::String(" ".to_owned());
+        let body = serde_json::to_vec(&serde_json::json!({"entries": [entry]})).unwrap();
+        assert_eq!(
+            kernel
+                .decode_knowledge(&request, &body, &scan, None, OBSERVED_AT)
+                .unwrap_err(),
+            ArchetypeError::InvalidResponse,
+            "required payload field {missing}"
+        );
+    }
+}
+
+#[test]
+fn library_note_metadata_rejects_credential_shaped_fields_without_echoing_values() {
+    let kernel = kernel(ArchetypeFamily::Vulnerability);
+    let scan = scan(&kernel);
+    let request = kernel.plan_knowledge(scan.repository_id).unwrap();
+    let marker = "must-not-flow-through-library-note";
+    let body = serde_json::to_vec(&serde_json::json!({
+        "entries": [{
+            "slug": "credential-shaped-metadata",
+            "title": "title",
+            "summary": "summary",
+            "owner": "WriterInternal",
+            "repository_name": "Archetype",
+            "metadata": {"nested": {"apiToken": marker}}
+        }]
+    }))
+    .unwrap();
+    let error = kernel
+        .decode_knowledge(&request, &body, &scan, None, OBSERVED_AT)
+        .unwrap_err();
+    assert_eq!(error, ArchetypeError::SecretFieldRejected);
+    assert!(!error.to_string().contains(marker));
+}

--- a/crates/source-runtime-next/src/archetype/tests/fixtures/go_parity.json
+++ b/crates/source-runtime-next/src/archetype/tests/fixtures/go_parity.json
@@ -1,0 +1,140 @@
+{
+  "tenant_id": "tenant-archetype",
+  "observed_at": "2026-08-20T02:00:00Z",
+  "scans": [
+    {
+      "id": 9,
+      "repository_id": 7,
+      "status": "completed",
+      "completed_at": "2026-08-20T01:02:03Z"
+    }
+  ],
+  "repositories": [
+    {
+      "id": 7,
+      "owner": "WriterInternal",
+      "name": "Archetype"
+    }
+  ],
+  "vulnerabilities": [
+    {
+      "id": 1,
+      "scan_id": 9,
+      "line_number": 42,
+      "file_path": "app/main.py",
+      "category": "ssrf",
+      "severity": "high"
+    }
+  ],
+  "knowledge": {
+    "entries": [
+      {
+        "slug": "security:sql/injection",
+        "title": "SQL injection context",
+        "summary": "Repository query handling context.",
+        "topics": ["security", "sql"],
+        "metadata": {
+          "context_pack": "repository_context_pack_v2",
+          "health_score": 72,
+          "context_stale": true
+        }
+      }
+    ]
+  },
+  "expected": {
+    "scan": {
+      "family": "vulnerability",
+      "provider_kind": "archetype.scan",
+      "schema_ref": "archetype/scan/v1",
+      "event_id": "archetype-scan-9",
+      "request_kind": "scans",
+      "request_path": "/api/v1/scans?limit=100",
+      "occurred_at": "2026-08-20T01:02:03Z",
+      "fields": {
+        "owner": "WriterInternal",
+        "repo": "Archetype",
+        "repository_id": "7",
+        "scan_id": "9",
+        "source_product": "archetype",
+        "status": "completed",
+        "vulnerability_collection_state": "complete"
+      },
+      "payload": {
+        "id": 9,
+        "repository_id": 7,
+        "status": "completed",
+        "started_at": "",
+        "completed_at": "2026-08-20T01:02:03Z",
+        "created_at": ""
+      }
+    },
+    "vulnerability": {
+      "family": "vulnerability",
+      "provider_kind": "archetype.vulnerability",
+      "schema_ref": "archetype/vulnerability/v1",
+      "event_id": "archetype-vulnerability-9-1",
+      "request_kind": "vulnerabilities",
+      "request_path": "/api/v1/scans/9/vulnerabilities",
+      "occurred_at": "2026-08-20T01:02:03Z",
+      "fields": {
+        "category": "ssrf",
+        "file_path": "app/main.py",
+        "line_number": "42",
+        "owner": "WriterInternal",
+        "repo": "Archetype",
+        "repository_id": "7",
+        "scan_id": "9",
+        "severity": "high",
+        "source_product": "archetype",
+        "vulnerability_id": "1"
+      },
+      "payload": {
+        "id": 1,
+        "scan_id": 9,
+        "line_number": 42,
+        "file_path": "app/main.py",
+        "category": "ssrf",
+        "severity": "high",
+        "description": "",
+        "analyzer_score": 0.0,
+        "analyzer_label": "",
+        "created_at": ""
+      }
+    },
+    "library_note": {
+      "family": "vulnerability",
+      "provider_kind": "archetype.library_note",
+      "schema_ref": "archetype/library-note/v1",
+      "event_id": "archetype-library-7-security%3Asql%2Finjection",
+      "request_kind": "knowledge",
+      "request_path": "/api/v1/repositories/7/knowledge",
+      "occurred_at": "2026-08-20T01:02:03Z",
+      "fields": {
+        "context_pack": "repository_context_pack_v2",
+        "context_stale": "true",
+        "health_score": "72",
+        "knowledge_slug": "security:sql/injection",
+        "owner": "WriterInternal",
+        "repo": "Archetype",
+        "repository_id": "7",
+        "scan_id": "9",
+        "title": "SQL injection context",
+        "topics": "security,sql"
+      },
+      "payload": {
+        "slug": "security:sql/injection",
+        "title": "SQL injection context",
+        "summary": "Repository query handling context.",
+        "topics": ["security", "sql"],
+        "metadata": {
+          "context_pack": "repository_context_pack_v2",
+          "health_score": 72,
+          "context_stale": true
+        },
+        "repository_id": 7,
+        "repository_name": "Archetype",
+        "owner": "WriterInternal"
+      }
+    }
+  }
+}

--- a/crates/source-runtime-next/src/archetype/tests/knowledge.rs
+++ b/crates/source-runtime-next/src/archetype/tests/knowledge.rs
@@ -16,6 +16,7 @@ fn knowledge_uses_repository_fallbacks_and_go_query_escape_identity() {
                 br#"{"entries":[{"slug":"security:sql/injection","title":"SQL injection","summary":"context","topics":[" security ","sql"],"source_files":["state.json"],"metadata":{"context_pack":"repository_context_pack_v2","health_score":72,"context_stale":true}}]}"#,
                 &scan,
                 Some(&repository),
+                OBSERVED_AT,
             )
             .unwrap();
     assert_eq!(
@@ -66,7 +67,8 @@ fn knowledge_rejects_repository_and_entry_scope_mismatches() {
                 &request,
                 br#"{"entries":[]}"#,
                 &scan,
-                Some(&wrong_repository)
+                Some(&wrong_repository),
+                OBSERVED_AT,
             )
             .unwrap_err(),
         ArchetypeError::ResponseScopeMismatch
@@ -79,6 +81,7 @@ fn knowledge_rejects_repository_and_entry_scope_mismatches() {
                 br#"{"entries":[{"slug":"scope-mismatch","repository_id":999,"owner":"Other","repository_name":"Repository"}]}"#,
                 &scan,
                 None,
+                OBSERVED_AT,
             )
             .unwrap_err(),
         ArchetypeError::ResponseScopeMismatch

--- a/crates/source-runtime-next/src/archetype/tests/mod.rs
+++ b/crates/source-runtime-next/src/archetype/tests/mod.rs
@@ -1,12 +1,20 @@
 use super::*;
 
+mod failure;
 mod knowledge;
+mod parity;
 mod request;
 mod scan_page;
 mod vulnerability;
 
+pub(super) const TENANT_ID: &str = "tenant-archetype";
+pub(super) const OBSERVED_AT: &str = "2026-08-20T02:00:00Z";
+
 pub(super) fn kernel(family: ArchetypeFamily) -> ArchetypeKernel {
-    ArchetypeKernel::new("https://archetype.example.test", None, family, None).unwrap()
+    ArchetypeKernel::new("https://archetype.example.test", None, family, None)
+        .unwrap()
+        .bind_tenant(TENANT_ID)
+        .unwrap()
 }
 
 pub(super) fn scan(kernel: &ArchetypeKernel) -> ArchetypeScan {

--- a/crates/source-runtime-next/src/archetype/tests/parity.rs
+++ b/crates/source-runtime-next/src/archetype/tests/parity.rs
@@ -1,0 +1,99 @@
+use super::*;
+
+#[test]
+fn provider_local_adapter_matches_go_event_semantics() {
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/go_parity.json")).unwrap();
+    let kernel = ArchetypeKernel::new(
+        "https://archetype.example.test",
+        None,
+        ArchetypeFamily::Vulnerability,
+        None,
+    )
+    .unwrap()
+    .bind_tenant(fixture["tenant_id"].as_str().unwrap())
+    .unwrap();
+    let observed_at = fixture["observed_at"].as_str().unwrap();
+
+    let scan_request = kernel.plan_scans(None).unwrap();
+    let scan_body = serde_json::to_vec(&fixture["scans"]).unwrap();
+    let page = kernel.decode_scans(&scan_request, &scan_body).unwrap();
+    let repository_request = kernel.plan_repositories().unwrap();
+    let repository_body = serde_json::to_vec(&fixture["repositories"]).unwrap();
+    let repositories = kernel
+        .decode_repositories(&repository_request, &repository_body)
+        .unwrap();
+    let scan = &page.scans[0];
+    let repository = repositories.get(&scan.repository_id).unwrap();
+
+    let scan_record = kernel
+        .scan_record(
+            &scan_request,
+            scan,
+            Some(repository),
+            VulnerabilityCollectionState::Complete,
+            observed_at,
+        )
+        .unwrap();
+    assert_record(&scan_record, &fixture["expected"]["scan"]);
+
+    let vulnerability_request = kernel.plan_vulnerabilities(scan.id).unwrap();
+    let vulnerability_body = serde_json::to_vec(&fixture["vulnerabilities"]).unwrap();
+    let vulnerability_records = kernel
+        .decode_vulnerabilities(
+            &vulnerability_request,
+            &vulnerability_body,
+            scan,
+            Some(repository),
+            observed_at,
+        )
+        .unwrap();
+    assert_record(
+        &vulnerability_records[0],
+        &fixture["expected"]["vulnerability"],
+    );
+
+    let knowledge_request = kernel.plan_knowledge(scan.repository_id).unwrap();
+    let knowledge_body = serde_json::to_vec(&fixture["knowledge"]).unwrap();
+    let library_records = kernel
+        .decode_knowledge(
+            &knowledge_request,
+            &knowledge_body,
+            scan,
+            Some(repository),
+            observed_at,
+        )
+        .unwrap();
+    assert_record(&library_records[0], &fixture["expected"]["library_note"]);
+}
+
+fn assert_record(record: &ArchetypeRecord, expected: &serde_json::Value) {
+    assert_eq!(record.tenant_id, TENANT_ID);
+    assert_eq!(record.source_id, "archetype");
+    assert_eq!(record.family, expected_string(expected, "family"));
+    assert_eq!(
+        record.provider_kind,
+        expected_string(expected, "provider_kind")
+    );
+    assert_eq!(record.schema_ref, expected_string(expected, "schema_ref"));
+    assert_eq!(record.provider_id, expected_string(expected, "event_id"));
+    assert_eq!(record.event_id, expected_string(expected, "event_id"));
+    assert_eq!(
+        record.request_kind,
+        expected_string(expected, "request_kind")
+    );
+    assert_eq!(
+        record.request_path,
+        expected_string(expected, "request_path")
+    );
+    assert_eq!(record.occurred_at, expected_string(expected, "occurred_at"));
+    assert_eq!(
+        serde_json::to_value(&record.fields).unwrap(),
+        expected["fields"]
+    );
+    assert_eq!(record.payload, expected["payload"]);
+}
+
+fn expected_string<'a>(expected: &'a serde_json::Value, field: &str) -> &'a str {
+    expected[field].as_str().unwrap()
+}

--- a/crates/source-runtime-next/src/archetype/tests/request.rs
+++ b/crates/source-runtime-next/src/archetype/tests/request.rs
@@ -14,6 +14,7 @@ fn plans_the_go_pull_routes_without_credentials() {
     assert_eq!(scans.url().query(), Some("limit=100&before_id=106"));
     assert_eq!(scans.authorization_scheme(), "Bearer");
     assert_eq!(scans.accept(), "application/json");
+    assert!(!ArchetypeKernel::requires_credentials());
     assert_eq!(kernel.fanout_concurrency(), 16);
     assert_eq!(
         kernel.plan_repositories().unwrap().url().path(),
@@ -26,6 +27,78 @@ fn plans_the_go_pull_routes_without_credentials() {
     assert_eq!(
         kernel.plan_knowledge(7).unwrap().url().path(),
         "/api/v1/repositories/7/knowledge"
+    );
+}
+
+#[test]
+fn request_provenance_rejects_family_path_and_query_drift() {
+    let kernel = kernel(ArchetypeFamily::Vulnerability);
+    let scan = scan(&kernel);
+
+    let mut wrong_family = kernel.plan_scans(None).unwrap();
+    wrong_family.family = ArchetypeFamily::Scan;
+    assert_eq!(
+        kernel.decode_scans(&wrong_family, b"[]").unwrap_err(),
+        ArchetypeError::RequestScopeMismatch
+    );
+
+    let mut wrong_query = kernel.plan_scans(None).unwrap();
+    wrong_query.url.set_query(Some("limit=99"));
+    assert_eq!(
+        kernel.decode_scans(&wrong_query, b"[]").unwrap_err(),
+        ArchetypeError::RequestScopeMismatch
+    );
+
+    let mut extra_query = kernel.plan_vulnerabilities(scan.id).unwrap();
+    extra_query.url.set_query(Some("token=not-a-credential"));
+    assert_eq!(
+        kernel
+            .decode_vulnerabilities(&extra_query, b"[]", &scan, None, OBSERVED_AT)
+            .unwrap_err(),
+        ArchetypeError::RequestScopeMismatch
+    );
+}
+
+#[test]
+fn cursor_inputs_are_positive_and_go_int64_round_trippable() {
+    let kernel = kernel(ArchetypeFamily::Scan);
+    for invalid in [0, (i64::MAX as u64) + 1] {
+        assert_eq!(
+            kernel.plan_scans(Some(invalid)).unwrap_err(),
+            ArchetypeError::InvalidScopedId
+        );
+    }
+    let request = kernel.plan_scans(Some(i64::MAX as u64)).unwrap();
+    assert_eq!(
+        request.url().query(),
+        Some("limit=100&before_id=9223372036854775807")
+    );
+}
+
+#[test]
+fn scan_materialization_is_bound_to_the_exact_collection_request() {
+    let kernel = kernel(ArchetypeFamily::Scan);
+    let first_request = kernel.plan_scans(None).unwrap();
+    let scan = kernel
+        .decode_scans(
+            &first_request,
+            br#"[{"id":1,"repository_id":7,"status":"completed"}]"#,
+        )
+        .unwrap()
+        .scans
+        .remove(0);
+    let continuation_request = kernel.plan_scans(Some(2)).unwrap();
+    assert_eq!(
+        kernel
+            .scan_record(
+                &continuation_request,
+                &scan,
+                None,
+                VulnerabilityCollectionState::NotRequested,
+                OBSERVED_AT,
+            )
+            .unwrap_err(),
+        ArchetypeError::RequestScopeMismatch
     );
 }
 

--- a/crates/source-runtime-next/src/archetype/tests/scan_page.rs
+++ b/crates/source-runtime-next/src/archetype/tests/scan_page.rs
@@ -26,15 +26,17 @@ fn scan_page_is_ascending_and_emits_go_compatible_record() {
     };
     let record = kernel
         .scan_record(
+            &request,
             &page.scans[1],
             Some(&repository),
             VulnerabilityCollectionState::Complete,
+            OBSERVED_AT,
         )
         .unwrap();
     assert_eq!(record.family, "vulnerability");
     assert_eq!(record.provider_kind, "archetype.scan");
     assert_eq!(record.provider_id, "archetype-scan-9");
-    assert_eq!(record.occurred_at.as_deref(), Some("2026-08-20T01:02:03Z"));
+    assert_eq!(record.occurred_at, "2026-08-20T01:02:03Z");
     assert_eq!(
         record.fields.get("owner").map(String::as_str),
         Some("WriterInternal")
@@ -70,6 +72,8 @@ fn full_scan_page_exposes_the_oldest_id_without_owning_the_checkpoint() {
     assert_eq!(page.scans.first().map(|scan| scan.id), Some(1));
     assert_eq!(page.scans.last().map(|scan| scan.id), Some(100));
     assert_eq!(page.next_before_id, Some(1));
+    let continuation = kernel.plan_scans(page.next_before_id).unwrap();
+    assert_eq!(continuation.url().query(), Some("limit=100&before_id=1"));
 }
 
 #[test]
@@ -92,9 +96,11 @@ fn scan_status_and_repository_scope_fail_closed() {
     assert_eq!(
         kernel
             .scan_record(
+                &request,
                 &scan,
                 Some(&wrong_repository),
                 VulnerabilityCollectionState::Complete,
+                OBSERVED_AT,
             )
             .unwrap_err(),
         ArchetypeError::ResponseScopeMismatch
@@ -104,13 +110,20 @@ fn scan_status_and_repository_scope_fail_closed() {
 #[test]
 fn scan_record_revalidates_mutable_fields_against_the_decoded_payload() {
     let kernel = kernel(ArchetypeFamily::Vulnerability);
+    let request = kernel.plan_scans(None).unwrap();
     let valid = scan(&kernel);
 
     let mut missing_id = valid.clone();
     missing_id.id = 0;
     assert_eq!(
         kernel
-            .scan_record(&missing_id, None, VulnerabilityCollectionState::Complete,)
+            .scan_record(
+                &request,
+                &missing_id,
+                None,
+                VulnerabilityCollectionState::Complete,
+                OBSERVED_AT,
+            )
             .unwrap_err(),
         ArchetypeError::MissingRecordIdentity
     );
@@ -120,9 +133,11 @@ fn scan_record_revalidates_mutable_fields_against_the_decoded_payload() {
     assert_eq!(
         kernel
             .scan_record(
+                &request,
                 &missing_repository_id,
                 None,
                 VulnerabilityCollectionState::Complete,
+                OBSERVED_AT,
             )
             .unwrap_err(),
         ArchetypeError::MissingRecordIdentity
@@ -147,7 +162,13 @@ fn scan_record_revalidates_mutable_fields_against_the_decoded_payload() {
     ] {
         assert_eq!(
             kernel
-                .scan_record(&inconsistent, None, VulnerabilityCollectionState::Complete,)
+                .scan_record(
+                    &request,
+                    &inconsistent,
+                    None,
+                    VulnerabilityCollectionState::Complete,
+                    OBSERVED_AT,
+                )
                 .unwrap_err(),
             ArchetypeError::InvalidResponse
         );
@@ -157,12 +178,17 @@ fn scan_record_revalidates_mutable_fields_against_the_decoded_payload() {
     blank_status.status = " ".to_owned();
     assert_eq!(
         kernel
-            .scan_record(&blank_status, None, VulnerabilityCollectionState::Complete,)
+            .scan_record(
+                &request,
+                &blank_status,
+                None,
+                VulnerabilityCollectionState::Complete,
+                OBSERVED_AT,
+            )
             .unwrap_err(),
         ArchetypeError::InvalidResponse
     );
 
-    let request = kernel.plan_scans(None).unwrap();
     let mut no_provider_timestamp = kernel
         .decode_scans(
             &request,
@@ -176,9 +202,11 @@ fn scan_record_revalidates_mutable_fields_against_the_decoded_payload() {
     assert_eq!(
         kernel
             .scan_record(
+                &request,
                 &no_provider_timestamp,
                 None,
                 VulnerabilityCollectionState::Complete,
+                OBSERVED_AT,
             )
             .unwrap_err(),
         ArchetypeError::InvalidResponse

--- a/crates/source-runtime-next/src/archetype/tests/vulnerability.rs
+++ b/crates/source-runtime-next/src/archetype/tests/vulnerability.rs
@@ -11,6 +11,7 @@ fn vulnerability_identity_is_scoped_to_the_request_scan() {
                 br#"[{"id":1,"scan_id":9,"line_number":42,"file_path":"app/main.py","category":"ssrf","severity":"high","created_at":"2026-08-19T18:03:00-07:00"}]"#,
                 &scan,
                 None,
+                OBSERVED_AT,
             )
             .unwrap();
     assert_eq!(records[0].provider_id, "archetype-vulnerability-9-1");
@@ -18,13 +19,16 @@ fn vulnerability_identity_is_scoped_to_the_request_scan() {
         records[0].fields.get("line_number").map(String::as_str),
         Some("42")
     );
-    assert_eq!(
-        records[0].occurred_at.as_deref(),
-        Some("2026-08-20T01:03:00Z")
-    );
+    assert_eq!(records[0].occurred_at, "2026-08-20T01:03:00Z");
 
     let error = kernel
-        .decode_vulnerabilities(&request, br#"[{"id":1,"scan_id":10}]"#, &scan, None)
+        .decode_vulnerabilities(
+            &request,
+            br#"[{"id":1,"scan_id":10}]"#,
+            &scan,
+            None,
+            OBSERVED_AT,
+        )
         .unwrap_err();
     assert_eq!(error, ArchetypeError::ResponseScopeMismatch);
 }
@@ -46,7 +50,7 @@ fn vulnerability_required_fields_and_repository_scope_fail_closed() {
         let body = serde_json::to_vec(&[vulnerability]).unwrap();
         assert_eq!(
             kernel
-                .decode_vulnerabilities(&request, &body, &scan, None)
+                .decode_vulnerabilities(&request, &body, &scan, None, OBSERVED_AT)
                 .unwrap_err(),
             ArchetypeError::InvalidResponse,
             "required field {missing_field}"
@@ -60,7 +64,7 @@ fn vulnerability_required_fields_and_repository_scope_fail_closed() {
     };
     assert_eq!(
         kernel
-            .decode_vulnerabilities(&request, b"[]", &scan, Some(&wrong_repository))
+            .decode_vulnerabilities(&request, b"[]", &scan, Some(&wrong_repository), OBSERVED_AT,)
             .unwrap_err(),
         ArchetypeError::ResponseScopeMismatch
     );

--- a/crates/source-runtime-next/src/archetype/types.rs
+++ b/crates/source-runtime-next/src/archetype/types.rs
@@ -5,6 +5,12 @@ use time::{OffsetDateTime, UtcOffset, format_description::well_known::Rfc3339};
 
 use super::ArchetypeError;
 
+pub(super) const MAX_PROVIDER_ID: u64 = i64::MAX as u64;
+
+pub(super) const fn valid_provider_id(value: u64) -> bool {
+    value > 0 && value <= MAX_PROVIDER_ID
+}
+
 /// One decoded Archetype scan used to drive bounded enrichment fanout.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ArchetypeScan {
@@ -16,15 +22,17 @@ pub struct ArchetypeScan {
     pub status: String,
     /// Go-compatible occurrence time precedence: completed, started, created.
     pub occurred_at: Option<String>,
+    pub(super) request_path: String,
     pub(super) payload: Value,
 }
 
 impl ArchetypeScan {
     pub(super) fn validate_invariant(&self) -> Result<(), ArchetypeError> {
-        if self.id == 0 || self.repository_id == 0 {
+        if !valid_provider_id(self.id) || !valid_provider_id(self.repository_id) {
             return Err(ArchetypeError::MissingRecordIdentity);
         }
-        if self.status.trim().is_empty()
+        if self.request_path.trim().is_empty()
+            || self.status.trim().is_empty()
             || self.payload.get("id").and_then(Value::as_u64) != Some(self.id)
             || self.payload.get("repository_id").and_then(Value::as_u64) != Some(self.repository_id)
             || self.payload.get("status").and_then(Value::as_str) != Some(self.status.as_str())
@@ -37,9 +45,13 @@ impl ArchetypeScan {
 }
 
 fn scan_occurrence_time(payload: &Value) -> Option<String> {
-    ["completed_at", "started_at", "created_at"]
+    let selected = ["completed_at", "started_at", "created_at"]
         .into_iter()
-        .find_map(|field| payload.get(field)?.as_str().and_then(normalized_timestamp))
+        .find_map(|field| {
+            let value = payload.get(field)?.as_str()?;
+            (!value.trim().is_empty()).then_some(value)
+        });
+    selected.and_then(normalized_timestamp)
 }
 
 pub(super) fn normalized_timestamp(value: &str) -> Option<String> {
@@ -62,12 +74,24 @@ pub struct ArchetypeRepository {
 pub struct ArchetypeRecord {
     /// Source-catalog family that requested the record.
     pub family: String,
+    /// Portable source identifier.
+    pub source_id: String,
     /// Go-compatible emitted event kind.
     pub provider_kind: String,
+    /// Exact source schema reference selected for the emitted kind.
+    pub schema_ref: String,
+    /// Tenant identity supplied by the trusted runtime context.
+    pub tenant_id: String,
     /// Go-compatible stable event identity.
     pub provider_id: String,
-    /// Selected provider occurrence timestamp, when present.
-    pub occurred_at: Option<String>,
+    /// Go-compatible event identity, scoped separately by `tenant_id`.
+    pub event_id: String,
+    /// Stable credential-free operation that produced the record.
+    pub request_kind: String,
+    /// Exact credential-free provider path and query that produced the record.
+    pub request_path: String,
+    /// Selected provider occurrence timestamp or explicit observation fallback.
+    pub occurred_at: String,
     /// Portable scalar attributes used by source projection.
     pub fields: BTreeMap<String, String>,
     /// Provider payload with Go-compatible fallback enrichment applied.

--- a/crates/source-runtime-next/src/archetype/wire.rs
+++ b/crates/source-runtime-next/src/archetype/wire.rs
@@ -43,12 +43,19 @@ pub(super) struct KnowledgeEntryResponse {
     pub(super) slug: String,
     pub(super) title: String,
     pub(super) summary: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(super) topics: Vec<String>,
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub(super) generated_at: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(super) source_files: Vec<String>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub(super) metadata: BTreeMap<String, Value>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(super) severity_tags: Vec<String>,
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub(super) dominant_severity: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(super) severity_breakdown: Vec<Value>,
     pub(super) repository_id: u64,
     pub(super) repository_name: String,


### PR DESCRIPTION
## Scope

- Materialize Archetype scan and vulnerability records with trusted tenant binding, exact request provenance, deterministic timestamps, bounded responses, and conflict-aware deduplication.
- Add the first provider-local library_note decoder with the catalog schema, required payload fields, Go-compatible identity, and repository fallback semantics.
- Keep the existing four-field ArchetypeScan public contract intact and reject credential-shaped provider metadata without echoing values.

## Validation

- cargo fmt --all -- --check
- cargo test --locked -p cerebro-source-runtime-next archetype: 22 passed
- cargo test --locked -p cerebro-source-runtime-next: 341 library and 4 worker tests passed
- cargo clippy --locked -p cerebro-source-runtime-next --all-targets -- -D warnings
- go test ./sources/archetype ./internal/sourceprojection ./internal/findings ./internal/sourcecdk -count=1
- make source-fixture-check fixture-oracle-check sourcegen-check
- make check-structural check-structural-test check-arch
- scripts/leak_check.sh range origin/main..HEAD

## Integration boundary

This pull request owns provider-local planning, decoding, normalization, and tests only. Shared source-runtime admission, append, checkpoint, and projection wiring is intentionally unchanged and remains the integration boundary before this draft is ready to merge.