### PR TITLE
feat(linode): add issue request-response kernel

### DIFF
--- a/crates/source-runtime-next/src/linode.rs
+++ b/crates/source-runtime-next/src/linode.rs
@@ -1,0 +1,26 @@
+//! Credential-free Linode managed-issue kernel facade.
+
+#[path = "linode/cursor.rs"]
+mod cursor;
+#[path = "linode/error.rs"]
+mod error;
+#[path = "linode/identity.rs"]
+mod identity;
+#[path = "linode/model.rs"]
+mod model;
+#[path = "linode/normalize.rs"]
+mod normalize;
+#[path = "linode/origin.rs"]
+mod origin;
+#[path = "linode/request.rs"]
+mod request;
+#[path = "linode/response.rs"]
+mod response;
+#[path = "linode/time.rs"]
+mod time;
+#[path = "linode/wire.rs"]
+mod wire;
+
+pub use error::LinodeError;
+pub use model::{LinodePage, LinodeRecord};
+pub use request::{LinodeKernel, LinodeRequest};

--- a/crates/source-runtime-next/src/linode/cursor.rs
+++ b/crates/source-runtime-next/src/linode/cursor.rs
@@ -1,0 +1,42 @@
+//! Bounded, round-trippable Linode page cursors.
+
+use super::LinodeError;
+
+const MAX_PAGE: u32 = 1_000_000;
+
+pub(super) fn request_page(cursor: Option<&str>) -> Result<u32, LinodeError> {
+    let Some(value) = cursor else {
+        return Ok(1);
+    };
+    let raw = value.trim();
+    if raw.is_empty() {
+        return Ok(1);
+    }
+    if raw.len() > 7
+        || raw != value
+        || raw.chars().any(char::is_control)
+        || !raw.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return Err(LinodeError::InvalidCursor);
+    }
+    let page = raw.parse::<u32>().map_err(|_| LinodeError::InvalidCursor)?;
+    if page == 0 || page > MAX_PAGE || page.to_string() != raw {
+        return Err(LinodeError::InvalidCursor);
+    }
+    Ok(page)
+}
+
+pub(super) fn next_cursor(page: u32, pages: u32) -> Result<Option<String>, LinodeError> {
+    if page == 0 || pages == 0 || page > pages || pages > MAX_PAGE {
+        return Err(LinodeError::InvalidResponse);
+    }
+    if page == pages {
+        return Ok(None);
+    }
+    let next = page
+        .checked_add(1)
+        .ok_or(LinodeError::InvalidCursor)?
+        .to_string();
+    request_page(Some(&next))?;
+    Ok(Some(next))
+}

--- a/crates/source-runtime-next/src/linode/error.rs
+++ b/crates/source-runtime-next/src/linode/error.rs
@@ -1,0 +1,87 @@
+//! Stable fail-closed Linode kernel errors.
+
+use std::{error::Error, fmt};
+
+/// Stable Linode request and response failures.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LinodeError {
+    /// The configured API base URL is not an allowed secure v4 origin.
+    InvalidBaseUrl,
+    /// Source tenant identity is required.
+    MissingTenantId,
+    /// Page size is outside Linode's inclusive 25 through 500 range.
+    InvalidPageSize,
+    /// Provider page continuation is oversized, non-canonical, or out of range.
+    InvalidCursor,
+    /// A planned request does not belong to this kernel.
+    RequestScopeMismatch,
+    /// Provider response exceeds the eight-mebibyte host bound.
+    ResponseTooLarge,
+    /// Provider response exceeds the requested page cardinality.
+    TooManyRecords,
+    /// Response JSON does not match the managed-issues wire contract.
+    InvalidResponse,
+    /// Response pagination does not match the requested page.
+    ResponsePageMismatch,
+    /// A provider record has no stable identity under the Go selector order.
+    MissingProviderIdentity,
+    /// Tenant, provider, or discriminator identity is not collision-safe.
+    InvalidEventIdentity,
+    /// One page contains different records with the same provider identity.
+    ConflictingProviderIdentity,
+    /// A catalog-required raw provider field is missing or empty.
+    MissingRequiredPayloadField(&'static str),
+    /// A catalog-required normalized attribute is missing.
+    MissingRequiredAttribute(&'static str),
+}
+
+impl fmt::Display for LinodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidBaseUrl => {
+                formatter.write_str("linode base URL must be a secure v4 origin")
+            }
+            Self::MissingTenantId => formatter.write_str("linode tenant_id is required"),
+            Self::InvalidPageSize => {
+                formatter.write_str("linode page_size must be between 25 and 500")
+            }
+            Self::InvalidCursor => formatter.write_str("linode page cursor is invalid"),
+            Self::RequestScopeMismatch => {
+                formatter.write_str("linode request does not match the kernel")
+            }
+            Self::ResponseTooLarge => formatter.write_str("linode response exceeds 8388608 bytes"),
+            Self::TooManyRecords => {
+                formatter.write_str("linode response exceeds the requested page size")
+            }
+            Self::InvalidResponse => {
+                formatter.write_str("linode response does not match managed issues")
+            }
+            Self::ResponsePageMismatch => {
+                formatter.write_str("linode response page does not match the request")
+            }
+            Self::MissingProviderIdentity => {
+                formatter.write_str("linode issue has no stable provider identity")
+            }
+            Self::InvalidEventIdentity => {
+                formatter.write_str("linode tenant or issue identity is not event-ID safe")
+            }
+            Self::ConflictingProviderIdentity => {
+                formatter.write_str("linode page contains conflicting provider identities")
+            }
+            Self::MissingRequiredPayloadField(name) => {
+                write!(
+                    formatter,
+                    "linode issue is missing required payload field {name}"
+                )
+            }
+            Self::MissingRequiredAttribute(name) => {
+                write!(
+                    formatter,
+                    "linode issue is missing required attribute {name}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for LinodeError {}

--- a/crates/source-runtime-next/src/linode/identity.rs
+++ b/crates/source-runtime-next/src/linode/identity.rs
@@ -1,0 +1,106 @@
+//! Collision-safe Go-compatible Linode identities.
+
+use sha2::{Digest, Sha256};
+
+use super::{LinodeError, wire::IdentityDiscriminatorsWire};
+
+pub(super) fn require_event_identity(value: &str) -> Result<(), LinodeError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || trimmed != value
+        || trimmed.chars().any(char::is_control)
+        || normalize_id(trimmed) != trimmed
+    {
+        return Err(LinodeError::InvalidEventIdentity);
+    }
+    Ok(())
+}
+
+pub(super) fn provider_identity<const N: usize>(
+    values: [String; N],
+) -> Result<String, LinodeError> {
+    let value = values
+        .into_iter()
+        .find(|value| !value.trim().is_empty())
+        .unwrap_or_default();
+    if value.is_empty() {
+        Err(LinodeError::MissingProviderIdentity)
+    } else {
+        Ok(value)
+    }
+}
+
+pub(super) fn record_identity(
+    record_id: &str,
+    identity: &IdentityDiscriminatorsWire,
+) -> Result<String, LinodeError> {
+    require_event_identity(record_id)?;
+    let device = identity.device.as_ref();
+    let agent = identity.agent.as_ref();
+    let values = [
+        ("device_id", identity.device_id.as_ref()),
+        ("device.id", device.and_then(|value| value.id.as_ref())),
+        ("serial_number", identity.serial_number.as_ref()),
+        ("agent_id", identity.agent_id.as_ref()),
+        ("agent.uuid", agent.and_then(|value| value.uuid.as_ref())),
+        ("device_uuid", identity.device_uuid.as_ref()),
+        ("installed_version", identity.installed_version.as_ref()),
+        ("version", identity.version.as_ref()),
+    ];
+    let mut parts = vec![record_id.to_owned()];
+    for (name, value) in values {
+        let Some(value) = value else {
+            continue;
+        };
+        if !value.canonical_identity() {
+            return Err(LinodeError::InvalidEventIdentity);
+        }
+        let value = value.text();
+        if !value.is_empty() {
+            parts.push(format!("{name}={value}"));
+        }
+    }
+    if parts.len() == 1 {
+        return Ok(record_id.to_owned());
+    }
+    let material = parts.join("\0");
+    Ok(format!(
+        "{}-{}",
+        record_id,
+        hex_prefix(&Sha256::digest(material.as_bytes()), 24)
+    ))
+}
+
+pub(super) fn event_id(tenant_id: &str, base_url: &str, path: &str, provider_id: &str) -> String {
+    let scope = Sha256::digest(format!("{base_url}\0{path}").as_bytes());
+    format!(
+        "linode-{}-{}-issue-{}",
+        normalize_id(tenant_id),
+        hex_prefix(&scope, 12),
+        normalize_id(provider_id)
+    )
+}
+
+fn normalize_id(value: &str) -> String {
+    let value = value.trim();
+    if value.is_empty() {
+        return "unknown".to_owned();
+    }
+    value.replace([' ', '/', ':', '\t', '\n'], "-")
+}
+
+fn hex_prefix(bytes: &[u8], length: usize) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(length);
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        if encoded.len() == length {
+            break;
+        }
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+        if encoded.len() == length {
+            break;
+        }
+    }
+    encoded
+}

--- a/crates/source-runtime-next/src/linode/model.rs
+++ b/crates/source-runtime-next/src/linode/model.rs
@@ -1,0 +1,39 @@
+//! Public Linode page and normalized issue contracts.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+/// One normalized Linode managed issue.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LinodeRecord {
+    /// Source-catalog family identifier.
+    pub family: String,
+    /// Exact provider kind.
+    pub provider_kind: String,
+    /// Exact source schema reference.
+    pub schema_ref: String,
+    /// Configured source tenant bound to this normalization.
+    pub tenant_id: String,
+    /// Stable provider identity selected in Go order.
+    pub provider_id: String,
+    /// Go-compatible tenant, scope, family, and provider event identity.
+    pub event_id: String,
+    /// Portable normalized attributes.
+    pub fields: BTreeMap<String, String>,
+    /// UTC provider occurrence time or observation fallback.
+    pub occurred_at: String,
+    /// Exact raw provider object.
+    pub payload: Value,
+}
+
+/// One bounded Linode managed-issue page.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LinodePage {
+    /// Deduplicated issues in provider order.
+    pub records: Vec<LinodeRecord>,
+    /// Validated next provider page.
+    pub next_cursor: Option<String>,
+    /// Provider total result count.
+    pub total_results: u64,
+}

--- a/crates/source-runtime-next/src/linode/normalize.rs
+++ b/crates/source-runtime-next/src/linode/normalize.rs
@@ -1,0 +1,239 @@
+//! Go-compatible Linode issue normalization helpers.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use time::OffsetDateTime;
+
+use super::{
+    LinodeError, LinodeRecord,
+    identity::{event_id, provider_identity, record_identity, require_event_identity},
+    time::occurred_at,
+    wire::{IssueWire, WireScalar},
+};
+
+pub(super) fn normalize_issue(
+    payload: Value,
+    tenant_id: &str,
+    scope_base: &str,
+    observed_at: OffsetDateTime,
+) -> Result<LinodeRecord, LinodeError> {
+    let issue: IssueWire =
+        serde_json::from_value(payload.clone()).map_err(|_| LinodeError::InvalidResponse)?;
+    let metadata = issue.metadata.as_ref();
+    let evidence = issue.evidence_cas.as_ref();
+    let record_id = provider_identity([
+        scalar(&issue.id),
+        scalar(&issue.created),
+        scalar(&issue.finding_id),
+        scalar(&issue.resource_urn),
+    ])?;
+    require_payload_id(&issue.id)?;
+    let provider_id = record_identity(&record_id, &issue.identity)?;
+    let mut fields = base_fields(tenant_id, &record_id);
+    let entity = issue.entity.as_ref().map(value_text).unwrap_or_default();
+    for (name, value) in [
+        (
+            "description",
+            first([scalar(&issue.description), scalar(&issue.summary)]),
+        ),
+        (
+            "evidence_cas_digest",
+            first([
+                scalar(&evidence.and_then(|value| value.digest.clone())),
+                scalar(&issue.evidence_cas_digest),
+            ]),
+        ),
+        (
+            "evidence_cas_uri",
+            first([
+                scalar(&evidence.and_then(|value| value.uri.clone())),
+                scalar(&issue.evidence_cas_uri),
+            ]),
+        ),
+        ("finding_id", scalar(&issue.id)),
+        ("id", scalar(&issue.id)),
+        (
+            "name",
+            first([
+                entity.clone(),
+                scalar(&issue.summary),
+                scalar(&issue.description),
+            ]),
+        ),
+        (
+            "observed_at",
+            first([
+                scalar(&issue.observed_at),
+                scalar(&issue.updated_at),
+                scalar(&issue.last_seen_at),
+            ]),
+        ),
+        (
+            "resource_id",
+            first([
+                scalar(&issue.resource_id),
+                scalar(&issue.id),
+                scalar(&metadata.and_then(|value| value.resource_id.clone())),
+            ]),
+        ),
+        (
+            "resource_name",
+            first([
+                scalar(&issue.name),
+                scalar(&issue.display_name),
+                scalar(&issue.hostname),
+                scalar(&metadata.and_then(|value| value.resource_name.clone())),
+            ]),
+        ),
+        (
+            "resource_type",
+            first([
+                scalar(&issue.resource_type),
+                scalar(&metadata.and_then(|value| value.resource_type.clone())),
+            ]),
+        ),
+        (
+            "resource_urn",
+            first([
+                scalar(&issue.resource_urn),
+                scalar(&issue.urn),
+                scalar(&metadata.and_then(|value| value.resource_urn.clone())),
+            ]),
+        ),
+        (
+            "severity",
+            first([
+                scalar(&issue.severity),
+                scalar(&issue.risk),
+                scalar(&issue.priority),
+            ]),
+        ),
+        (
+            "source_event_id",
+            first([
+                scalar(&issue.event_id),
+                scalar(&issue.id),
+                scalar(&metadata.and_then(|value| value.event_id.clone())),
+            ]),
+        ),
+        (
+            "status",
+            first([scalar(&issue.status), scalar(&issue.state)]),
+        ),
+        (
+            "title",
+            first([entity, scalar(&issue.summary), scalar(&issue.description)]),
+        ),
+    ] {
+        insert(&mut fields, name, value);
+    }
+    // Provider tenant fields are deliberately ignored; authenticated context owns tenancy.
+    let _untrusted_tenant = (
+        &issue.tenant_id,
+        metadata.and_then(|value| value.tenant_id.as_ref()),
+    );
+    for required in [
+        "tenant_id",
+        "source_event_id",
+        "finding_id",
+        "resource_urn",
+        "severity",
+        "status",
+    ] {
+        require_field(&fields, required)?;
+    }
+    let occurred_at = occurred_at(
+        [
+            scalar(&issue.observed_at),
+            scalar(&issue.updated_at),
+            scalar(&issue.last_seen_at),
+            scalar(&issue.created_at),
+        ],
+        observed_at,
+    );
+    Ok(LinodeRecord {
+        family: "issue".to_owned(),
+        provider_kind: "linode.issue".to_owned(),
+        schema_ref: "linode/issue/v1".to_owned(),
+        tenant_id: tenant_id.to_owned(),
+        event_id: event_id(tenant_id, scope_base, "/managed/issues", &provider_id),
+        provider_id,
+        fields,
+        occurred_at,
+        payload,
+    })
+}
+
+fn require_payload_id(value: &Option<WireScalar>) -> Result<(), LinodeError> {
+    let value = value
+        .as_ref()
+        .ok_or(LinodeError::MissingRequiredPayloadField("id"))?;
+    let text = value.text();
+    if text.is_empty() {
+        return Err(LinodeError::MissingRequiredPayloadField("id"));
+    }
+    if !value.canonical_identity() {
+        return Err(LinodeError::InvalidEventIdentity);
+    }
+    require_event_identity(&text)
+}
+
+fn base_fields(tenant_id: &str, record_id: &str) -> BTreeMap<String, String> {
+    let mut fields = BTreeMap::new();
+    for (name, value) in [
+        ("external_id", record_id),
+        ("family", "issue"),
+        ("provider", "linode"),
+        ("record_class", "finding"),
+        ("schema", "issue"),
+        ("source_provider", "linode"),
+        ("source_system", "linode"),
+        ("tenant_id", tenant_id),
+    ] {
+        insert(&mut fields, name, value.to_owned());
+    }
+    fields
+}
+
+fn require_field(fields: &BTreeMap<String, String>, name: &'static str) -> Result<(), LinodeError> {
+    fields
+        .get(name)
+        .filter(|value| !value.trim().is_empty())
+        .map(|_| ())
+        .ok_or(LinodeError::MissingRequiredAttribute(name))
+}
+
+fn insert(fields: &mut BTreeMap<String, String>, name: &str, value: String) {
+    let value = value.trim();
+    if !value.is_empty() {
+        fields.insert(name.to_owned(), value.to_owned());
+    }
+}
+
+fn scalar(value: &Option<WireScalar>) -> String {
+    value.as_ref().map(WireScalar::text).unwrap_or_default()
+}
+
+fn first<const N: usize>(values: [String; N]) -> String {
+    values
+        .into_iter()
+        .find(|value| !value.trim().is_empty())
+        .unwrap_or_default()
+}
+
+fn value_text(value: &Value) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::String(value) => value.trim().to_owned(),
+        Value::Number(value) => value.to_string(),
+        Value::Bool(value) => value.to_string(),
+        Value::Array(values) => values
+            .iter()
+            .map(value_text)
+            .filter(|value| !value.is_empty())
+            .collect::<Vec<_>>()
+            .join(","),
+        Value::Object(_) => serde_json::to_string(value).unwrap_or_default(),
+    }
+}

--- a/crates/source-runtime-next/src/linode/origin.rs
+++ b/crates/source-runtime-next/src/linode/origin.rs
@@ -1,0 +1,59 @@
+//! Secure Linode API-origin and v4 base-path validation.
+
+use std::{net::IpAddr, str::FromStr};
+
+use reqwest::Url;
+
+use super::LinodeError;
+
+pub(super) fn validate_base_url(raw: &str) -> Result<Url, LinodeError> {
+    let mut url = Url::parse(raw.trim()).map_err(|_| LinodeError::InvalidBaseUrl)?;
+    let host = url.host_str().ok_or(LinodeError::InvalidBaseUrl)?;
+    let loopback =
+        host == "localhost" || IpAddr::from_str(host).is_ok_and(|address| address.is_loopback());
+    if url.scheme() != "https" && !(url.scheme() == "http" && loopback) {
+        return Err(LinodeError::InvalidBaseUrl);
+    }
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || !matches!(url.path(), "/v4" | "/v4/")
+    {
+        return Err(LinodeError::InvalidBaseUrl);
+    }
+    if IpAddr::from_str(host).is_ok_and(|address| unsafe_ip_literal(address, loopback)) {
+        return Err(LinodeError::InvalidBaseUrl);
+    }
+    if url.port().is_some_and(|port| port != 443) && !loopback {
+        return Err(LinodeError::InvalidBaseUrl);
+    }
+    url.set_path("/v4/");
+    Ok(url)
+}
+
+pub(super) fn scope_base(url: &Url) -> String {
+    format!("{}/v4", url.origin().unicode_serialization())
+}
+
+fn unsafe_ip_literal(address: IpAddr, loopback: bool) -> bool {
+    if loopback {
+        return false;
+    }
+    match address {
+        IpAddr::V4(address) => {
+            address.is_private()
+                || address.is_link_local()
+                || address.is_broadcast()
+                || address.is_documentation()
+                || address.is_unspecified()
+                || address.is_multicast()
+        }
+        IpAddr::V6(address) => {
+            address.is_unique_local()
+                || address.is_unicast_link_local()
+                || address.is_unspecified()
+                || address.is_multicast()
+        }
+    }
+}

--- a/crates/source-runtime-next/src/linode/request.rs
+++ b/crates/source-runtime-next/src/linode/request.rs
@@ -1,0 +1,117 @@
+//! Credential-free Linode request planning and scope validation.
+
+use reqwest::Url;
+
+use super::{
+    LinodeError,
+    cursor::request_page,
+    identity::require_event_identity,
+    origin::{scope_base, validate_base_url},
+};
+
+const DEFAULT_BASE_URL: &str = "https://api.linode.com/v4";
+const DEFAULT_PAGE_SIZE: usize = 100;
+const MIN_PAGE_SIZE: usize = 25;
+const MAX_PAGE_SIZE: usize = 500;
+const ISSUE_PATH: &str = "/v4/managed/issues";
+
+/// One credential-free Linode managed-issues request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LinodeRequest {
+    pub(super) url: Url,
+    pub(super) page: u32,
+}
+
+impl LinodeRequest {
+    /// Return the exact provider URL. The caller must authorize it before I/O.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Return the provider authorization scheme without credential material.
+    pub const fn authorization_scheme(&self) -> &'static str {
+        "Bearer"
+    }
+
+    /// Return the required response media type.
+    pub const fn accept(&self) -> &'static str {
+        "application/json"
+    }
+}
+
+/// Bounded request and response kernel for Linode managed issues.
+#[derive(Clone, Debug)]
+pub struct LinodeKernel {
+    pub(super) base_url: Url,
+    pub(super) scope_base: String,
+    pub(super) tenant_id: String,
+    pub(super) page_size: usize,
+}
+
+impl LinodeKernel {
+    /// Build a kernel for one Linode v4 origin and authenticated tenant.
+    ///
+    /// Planned requests still require the trusted host's egress decision and
+    /// an operation-scoped Bearer credential. This type never accepts or
+    /// stores credential material.
+    pub fn new(
+        base_url: Option<&str>,
+        tenant_id: &str,
+        page_size: Option<usize>,
+    ) -> Result<Self, LinodeError> {
+        let base_url = validate_base_url(base_url.unwrap_or(DEFAULT_BASE_URL))?;
+        let normalized_tenant_id = tenant_id.trim();
+        if normalized_tenant_id.is_empty() {
+            return Err(LinodeError::MissingTenantId);
+        }
+        require_event_identity(tenant_id)?;
+        let page_size = page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+        if !(MIN_PAGE_SIZE..=MAX_PAGE_SIZE).contains(&page_size) {
+            return Err(LinodeError::InvalidPageSize);
+        }
+        Ok(Self {
+            scope_base: scope_base(&base_url),
+            base_url,
+            tenant_id: normalized_tenant_id.to_owned(),
+            page_size,
+        })
+    }
+
+    /// Return whether this planning and decoding kernel accepts credentials.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+
+    /// Plan one bounded provider page without performing I/O.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<LinodeRequest, LinodeError> {
+        let page = request_page(cursor)?;
+        let mut url = self.endpoint()?;
+        {
+            let mut query = url.query_pairs_mut();
+            query.append_pair("page", &page.to_string());
+            query.append_pair("page_size", &self.page_size.to_string());
+        }
+        Ok(LinodeRequest { url, page })
+    }
+
+    pub(super) fn validate_request(&self, request: &LinodeRequest) -> Result<(), LinodeError> {
+        let expected = self.plan(Some(&request.page.to_string()))?;
+        if request.url != expected.url {
+            return Err(LinodeError::RequestScopeMismatch);
+        }
+        Ok(())
+    }
+
+    fn endpoint(&self) -> Result<Url, LinodeError> {
+        let mut url = self.base_url.clone();
+        let mut segments = url
+            .path_segments_mut()
+            .map_err(|_| LinodeError::InvalidBaseUrl)?;
+        segments.pop_if_empty().push("managed").push("issues");
+        drop(segments);
+        if url.path() != ISSUE_PATH {
+            return Err(LinodeError::InvalidBaseUrl);
+        }
+        Ok(url)
+    }
+}

--- a/crates/source-runtime-next/src/linode/response.rs
+++ b/crates/source-runtime-next/src/linode/response.rs
@@ -1,0 +1,61 @@
+//! Bounded Linode managed-issue response decoding.
+
+use std::collections::HashMap;
+
+use time::OffsetDateTime;
+
+use super::{
+    LinodeError, LinodeKernel, LinodePage, LinodeRecord, LinodeRequest, cursor::next_cursor,
+    normalize::normalize_issue, wire::IssuePageWire,
+};
+
+const MAX_RESPONSE_BYTES: usize = 8 << 20;
+const MAX_RECORDS_PER_PAGE: usize = 500;
+
+impl LinodeKernel {
+    /// Decode one provider response for a request produced by this kernel.
+    pub fn decode(
+        &self,
+        request: &LinodeRequest,
+        body: &[u8],
+        observed_at: OffsetDateTime,
+    ) -> Result<LinodePage, LinodeError> {
+        self.validate_request(request)?;
+        if body.len() > MAX_RESPONSE_BYTES {
+            return Err(LinodeError::ResponseTooLarge);
+        }
+        let response: IssuePageWire =
+            serde_json::from_slice(body).map_err(|_| LinodeError::InvalidResponse)?;
+        if response.page != request.page {
+            return Err(LinodeError::ResponsePageMismatch);
+        }
+        if response.data.len() > MAX_RECORDS_PER_PAGE || response.data.len() > self.page_size {
+            return Err(LinodeError::TooManyRecords);
+        }
+        if response.results < response.data.len() as u64 {
+            return Err(LinodeError::InvalidResponse);
+        }
+        let continuation = next_cursor(response.page, response.pages)?;
+        let mut seen = HashMap::new();
+        let mut records: Vec<LinodeRecord> = Vec::with_capacity(response.data.len());
+        for payload in response.data {
+            if !payload.is_object() {
+                return Err(LinodeError::InvalidResponse);
+            }
+            let record = normalize_issue(payload, &self.tenant_id, &self.scope_base, observed_at)?;
+            if let Some(index) = seen.get(&record.provider_id).copied() {
+                if records.get(index) != Some(&record) {
+                    return Err(LinodeError::ConflictingProviderIdentity);
+                }
+                continue;
+            }
+            seen.insert(record.provider_id.clone(), records.len());
+            records.push(record);
+        }
+        Ok(LinodePage {
+            records,
+            next_cursor: continuation,
+            total_results: response.results,
+        })
+    }
+}

--- a/crates/source-runtime-next/src/linode/time.rs
+++ b/crates/source-runtime-next/src/linode/time.rs
@@ -1,0 +1,34 @@
+//! Go-compatible Linode occurrence-time normalization.
+
+use time::{Date, OffsetDateTime, UtcOffset, format_description::well_known::Rfc3339};
+
+pub(super) fn occurred_at<const N: usize>(
+    values: [String; N],
+    observed_at: OffsetDateTime,
+) -> String {
+    values
+        .iter()
+        .find_map(|value| normalized_time(value))
+        .unwrap_or_else(|| format_time(observed_at))
+}
+
+fn normalized_time(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    if let Ok(parsed) = OffsetDateTime::parse(value, &Rfc3339) {
+        return Some(format_time(parsed));
+    }
+    let date_format = time::format_description::parse_borrowed::<2>("[year]-[month]-[day]").ok()?;
+    Date::parse(value, &date_format)
+        .ok()
+        .map(|date| format_time(date.midnight().assume_utc()))
+}
+
+fn format_time(value: OffsetDateTime) -> String {
+    value
+        .to_offset(UtcOffset::UTC)
+        .format(&Rfc3339)
+        .expect("RFC3339 formats OffsetDateTime")
+}

--- a/crates/source-runtime-next/src/linode/wire.rs
+++ b/crates/source-runtime-next/src/linode/wire.rs
@@ -1,0 +1,111 @@
+//! Typed Linode managed-issue response objects.
+
+use serde::Deserialize;
+use serde_json::{Number, Value};
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct IssuePageWire {
+    pub(super) data: Vec<Value>,
+    pub(super) page: u32,
+    pub(super) pages: u32,
+    pub(super) results: u64,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub(super) struct IssueWire {
+    pub(super) id: Option<WireScalar>,
+    pub(super) created: Option<WireScalar>,
+    pub(super) finding_id: Option<WireScalar>,
+    pub(super) resource_urn: Option<WireScalar>,
+    pub(super) urn: Option<WireScalar>,
+    pub(super) resource_id: Option<WireScalar>,
+    pub(super) resource_type: Option<WireScalar>,
+    pub(super) name: Option<WireScalar>,
+    pub(super) display_name: Option<WireScalar>,
+    pub(super) hostname: Option<WireScalar>,
+    pub(super) entity: Option<Value>,
+    pub(super) summary: Option<WireScalar>,
+    pub(super) description: Option<WireScalar>,
+    pub(super) severity: Option<WireScalar>,
+    pub(super) risk: Option<WireScalar>,
+    pub(super) priority: Option<WireScalar>,
+    pub(super) status: Option<WireScalar>,
+    pub(super) state: Option<WireScalar>,
+    pub(super) event_id: Option<WireScalar>,
+    pub(super) tenant_id: Option<WireScalar>,
+    pub(super) observed_at: Option<WireScalar>,
+    pub(super) updated_at: Option<WireScalar>,
+    pub(super) last_seen_at: Option<WireScalar>,
+    pub(super) created_at: Option<WireScalar>,
+    pub(super) evidence_cas_digest: Option<WireScalar>,
+    pub(super) evidence_cas_uri: Option<WireScalar>,
+    pub(super) metadata: Option<MetadataWire>,
+    pub(super) evidence_cas: Option<EvidenceCasWire>,
+    #[serde(flatten)]
+    pub(super) identity: IdentityDiscriminatorsWire,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub(super) struct MetadataWire {
+    pub(super) event_id: Option<WireScalar>,
+    pub(super) resource_id: Option<WireScalar>,
+    pub(super) resource_name: Option<WireScalar>,
+    pub(super) resource_type: Option<WireScalar>,
+    pub(super) resource_urn: Option<WireScalar>,
+    pub(super) tenant_id: Option<WireScalar>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub(super) struct EvidenceCasWire {
+    pub(super) digest: Option<WireScalar>,
+    pub(super) uri: Option<WireScalar>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub(super) struct IdentityDiscriminatorsWire {
+    pub(super) device_id: Option<WireScalar>,
+    pub(super) serial_number: Option<WireScalar>,
+    pub(super) agent_id: Option<WireScalar>,
+    pub(super) device_uuid: Option<WireScalar>,
+    pub(super) installed_version: Option<WireScalar>,
+    pub(super) version: Option<WireScalar>,
+    pub(super) device: Option<IdentityObjectWire>,
+    pub(super) agent: Option<IdentityObjectWire>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub(super) struct IdentityObjectWire {
+    pub(super) id: Option<WireScalar>,
+    pub(super) uuid: Option<WireScalar>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub(super) enum WireScalar {
+    String(String),
+    Number(Number),
+    Bool(bool),
+}
+
+impl WireScalar {
+    pub(super) fn text(&self) -> String {
+        match self {
+            Self::String(value) => value.trim().to_owned(),
+            Self::Number(value) => value.to_string(),
+            Self::Bool(value) => value.to_string(),
+        }
+    }
+
+    pub(super) fn canonical_identity(&self) -> bool {
+        match self {
+            Self::String(value) => value == value.trim() && !value.chars().any(char::is_control),
+            Self::Number(_) => true,
+            Self::Bool(_) => false,
+        }
+    }
+}

--- a/crates/source-runtime-next/tests/linode_issue.rs
+++ b/crates/source-runtime-next/tests/linode_issue.rs
@@ -1,0 +1,27 @@
+#[path = "../src/linode.rs"]
+mod linode;
+
+use time::OffsetDateTime;
+
+const PARITY_FIXTURE: &[u8] = include_bytes!("../../../sources/linode/testdata/read_issue.json");
+const PROVIDER_FIXTURE: &[u8] =
+    include_bytes!("../../../sources/linode/testdata/managed_issues_page.json");
+
+fn observed_at() -> OffsetDateTime {
+    OffsetDateTime::parse(
+        "2026-06-02T02:04:05.123456789Z",
+        &time::format_description::well_known::Rfc3339,
+    )
+    .unwrap()
+}
+
+fn kernel() -> linode::LinodeKernel {
+    linode::LinodeKernel::new(None, "tenant", None).unwrap()
+}
+
+#[path = "linode_issue/failure.rs"]
+mod failure;
+#[path = "linode_issue/parity.rs"]
+mod parity;
+#[path = "linode_issue/request.rs"]
+mod request;

--- a/crates/source-runtime-next/tests/linode_issue/failure.rs
+++ b/crates/source-runtime-next/tests/linode_issue/failure.rs
@@ -1,0 +1,155 @@
+use serde_json::json;
+
+use super::{kernel, linode, observed_at};
+
+#[test]
+fn origin_response_identity_and_duplicate_bounds_fail_closed() {
+    for base_url in [
+        "http://api.linode.com/v4",
+        "https://user@api.linode.com/v4",
+        "https://api.linode.com/v3",
+        "https://10.0.0.1/v4",
+    ] {
+        assert_eq!(
+            linode::LinodeKernel::new(Some(base_url), "tenant", None).unwrap_err(),
+            linode::LinodeError::InvalidBaseUrl
+        );
+    }
+    for tenant in ["", " tenant", "tenant/id", "tenant:id", "tenant\n"] {
+        let expected = if tenant.is_empty() {
+            linode::LinodeError::MissingTenantId
+        } else {
+            linode::LinodeError::InvalidEventIdentity
+        };
+        assert_eq!(
+            linode::LinodeKernel::new(None, tenant, None).unwrap_err(),
+            expected
+        );
+    }
+    assert_eq!(
+        linode::LinodeKernel::new(None, "tenant", Some(24)).unwrap_err(),
+        linode::LinodeError::InvalidPageSize
+    );
+
+    let kernel = kernel();
+    let request = kernel.plan(None).unwrap();
+    assert_eq!(
+        kernel
+            .decode(&request, &vec![b' '; (8 << 20) + 1], observed_at())
+            .unwrap_err(),
+        linode::LinodeError::ResponseTooLarge
+    );
+    for body in [
+        br#"{}"#.as_slice(),
+        br#"{"data":{},"page":1,"pages":1,"results":0}"#.as_slice(),
+    ] {
+        assert_eq!(
+            kernel.decode(&request, body, observed_at()).unwrap_err(),
+            linode::LinodeError::InvalidResponse
+        );
+    }
+    assert_eq!(
+        kernel
+            .decode(
+                &request,
+                br#"{"data":[{}],"page":1,"pages":1,"results":1}"#,
+                observed_at(),
+            )
+            .unwrap_err(),
+        linode::LinodeError::MissingProviderIdentity
+    );
+    assert_eq!(
+        kernel
+            .decode(
+                &request,
+                br#"{
+                    "data":[{
+                        "created":"2026-06-01T00:00:00Z",
+                        "resource_urn":"urn:cerebro:tenant:linode_issue:823",
+                        "severity":"medium",
+                        "status":"open"
+                    }],
+                    "page":1,
+                    "pages":1,
+                    "results":1
+                }"#,
+                observed_at(),
+            )
+            .unwrap_err(),
+        linode::LinodeError::MissingRequiredPayloadField("id")
+    );
+    let too_many = serde_json::to_vec(&json!({
+        "data": (0..101)
+            .map(|id| json!({
+                "id": id,
+                "resource_urn": format!("urn:cerebro:tenant:linode_issue:{id}"),
+                "severity": "medium",
+                "status": "open"
+            }))
+            .collect::<Vec<_>>(),
+        "page": 1,
+        "pages": 1,
+        "results": 101
+    }))
+    .unwrap();
+    assert_eq!(
+        kernel
+            .decode(&request, &too_many, observed_at())
+            .unwrap_err(),
+        linode::LinodeError::TooManyRecords
+    );
+    let conflicting = serde_json::to_vec(&json!({
+        "data": [
+            {
+                "id": 823,
+                "resource_urn": "urn:cerebro:tenant:linode_issue:823",
+                "severity": "medium",
+                "status": "open"
+            },
+            {
+                "id": 823,
+                "resource_urn": "urn:cerebro:tenant:linode_issue:823",
+                "severity": "high",
+                "status": "open"
+            }
+        ],
+        "page": 1,
+        "pages": 1,
+        "results": 2
+    }))
+    .unwrap();
+    assert_eq!(
+        kernel
+            .decode(&request, &conflicting, observed_at())
+            .unwrap_err(),
+        linode::LinodeError::ConflictingProviderIdentity
+    );
+    let identical = serde_json::to_vec(&json!({
+        "data": [
+            {
+                "id": 823,
+                "resource_urn": "urn:cerebro:tenant:linode_issue:823",
+                "severity": "medium",
+                "status": "open"
+            },
+            {
+                "id": 823,
+                "resource_urn": "urn:cerebro:tenant:linode_issue:823",
+                "severity": "medium",
+                "status": "open"
+            }
+        ],
+        "page": 1,
+        "pages": 1,
+        "results": 2
+    }))
+    .unwrap();
+    assert_eq!(
+        kernel
+            .decode(&request, &identical, observed_at())
+            .unwrap()
+            .records
+            .len(),
+        1
+    );
+}

--- a/crates/source-runtime-next/tests/linode_issue/parity.rs
+++ b/crates/source-runtime-next/tests/linode_issue/parity.rs
@@ -1,0 +1,68 @@
+use super::{PARITY_FIXTURE, PROVIDER_FIXTURE, kernel, linode, observed_at};
+
+#[test]
+fn parity_fixture_matches_go_identity_attributes_payload_and_time() {
+    let kernel = kernel();
+    let page = kernel
+        .decode(&kernel.plan(None).unwrap(), PARITY_FIXTURE, observed_at())
+        .unwrap();
+    assert_eq!(page.next_cursor.as_deref(), Some("2"));
+    assert_eq!(page.total_results, 101);
+    assert_eq!(page.records.len(), 1);
+    let record = &page.records[0];
+    assert_eq!(record.family, "issue");
+    assert_eq!(record.provider_kind, "linode.issue");
+    assert_eq!(record.schema_ref, "linode/issue/v1");
+    assert_eq!(record.tenant_id, "tenant");
+    assert_eq!(record.provider_id, "823");
+    assert_eq!(record.event_id, "linode-tenant-c9ca572ccbf1-issue-823");
+    assert_eq!(record.occurred_at, "2026-06-01T00:00:00Z");
+    for (name, value) in [
+        ("external_id", "823"),
+        ("finding_id", "823"),
+        ("record_class", "finding"),
+        ("resource_urn", "urn:cerebro:tenant:linode_issue:823"),
+        ("severity", "medium"),
+        ("source_event_id", "823"),
+        ("status", "open"),
+        ("tenant_id", "tenant"),
+    ] {
+        assert_eq!(record.fields.get(name).map(String::as_str), Some(value));
+    }
+    assert_eq!(record.payload["id"], 823);
+    assert_eq!(record.payload["tenant_id"], "tenant");
+}
+
+#[test]
+fn official_provider_shape_is_rejected_at_the_catalog_boundary() {
+    let kernel = kernel();
+    assert_eq!(
+        kernel
+            .decode(&kernel.plan(None).unwrap(), PROVIDER_FIXTURE, observed_at())
+            .unwrap_err(),
+        linode::LinodeError::MissingRequiredAttribute("resource_urn")
+    );
+}
+
+#[test]
+fn authenticated_tenant_overrides_untrusted_provider_tenant() {
+    let body = br#"{
+        "data":[{
+            "id":823,
+            "resource_urn":"urn:cerebro:tenant:linode_issue:823",
+            "severity":"medium",
+            "status":"open",
+            "tenant_id":"other-tenant",
+            "metadata":{"tenant_id":"another-tenant"}
+        }],
+        "page":1,
+        "pages":1,
+        "results":1
+    }"#;
+    let kernel = kernel();
+    let page = kernel
+        .decode(&kernel.plan(None).unwrap(), body, observed_at())
+        .unwrap();
+    assert_eq!(page.records[0].tenant_id, "tenant");
+    assert_eq!(page.records[0].fields["tenant_id"], "tenant");
+}

--- a/crates/source-runtime-next/tests/linode_issue/request.rs
+++ b/crates/source-runtime-next/tests/linode_issue/request.rs
@@ -1,0 +1,69 @@
+use super::{PARITY_FIXTURE, kernel, linode, observed_at};
+
+#[test]
+fn plans_exact_request_and_declares_external_bearer_authentication() {
+    let kernel = kernel();
+    let first = kernel.plan(None).unwrap();
+    assert_eq!(
+        first.url().as_str(),
+        "https://api.linode.com/v4/managed/issues?page=1&page_size=100"
+    );
+    assert_eq!(first.authorization_scheme(), "Bearer");
+    assert_eq!(first.accept(), "application/json");
+    assert!(!linode::LinodeKernel::requires_credentials());
+    assert_eq!(
+        kernel.plan(Some("2")).unwrap().url().as_str(),
+        "https://api.linode.com/v4/managed/issues?page=2&page_size=100"
+    );
+}
+
+#[test]
+fn pagination_round_trips_and_rejects_invalid_cursors_and_response_pages() {
+    let kernel = kernel();
+    let page = kernel
+        .decode(&kernel.plan(None).unwrap(), PARITY_FIXTURE, observed_at())
+        .unwrap();
+    let request = kernel.plan(page.next_cursor.as_deref()).unwrap();
+    assert_eq!(request.url().query(), Some("page=2&page_size=100"));
+    let terminal = br#"{"data":[],"page":2,"pages":2,"results":101}"#;
+    assert_eq!(
+        kernel
+            .decode(&request, terminal, observed_at())
+            .unwrap()
+            .next_cursor,
+        None
+    );
+    for cursor in [
+        "0",
+        "02",
+        "1000001",
+        "https://api.linode.com/v4/managed/issues?page=2",
+        "2\n",
+    ] {
+        assert_eq!(
+            kernel.plan(Some(cursor)).unwrap_err(),
+            linode::LinodeError::InvalidCursor
+        );
+    }
+    let wrong_page = br#"{"data":[],"page":2,"pages":2,"results":0}"#;
+    assert_eq!(
+        kernel
+            .decode(&kernel.plan(None).unwrap(), wrong_page, observed_at())
+            .unwrap_err(),
+        linode::LinodeError::ResponsePageMismatch
+    );
+}
+
+#[test]
+fn requests_are_bound_to_the_planning_kernel() {
+    let request = linode::LinodeKernel::new(Some("http://127.0.0.1:8080/v4"), "tenant", None)
+        .unwrap()
+        .plan(None)
+        .unwrap();
+    assert_eq!(
+        kernel()
+            .decode(&request, PARITY_FIXTURE, observed_at())
+            .unwrap_err(),
+        linode::LinodeError::RequestScopeMismatch
+    );
+}

--- a/sources/linode/source_test.go
+++ b/sources/linode/source_test.go
@@ -2,9 +2,12 @@ package linode
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -12,11 +15,16 @@ import (
 )
 
 func TestSourceCheckAndRead(t *testing.T) {
+	fixture, err := os.ReadFile("testdata/read_issue.json")
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
 	source, err := New()
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
 	source.allowLoopbackForTest()
+	readQuerySeen := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer test-token" {
 			t.Fatalf("Authorization = %q", r.Header.Get("Authorization"))
@@ -24,8 +32,15 @@ func TestSourceCheckAndRead(t *testing.T) {
 		if r.URL.Path != "/managed/issues" {
 			t.Fatalf("path = %q", r.URL.Path)
 		}
+		switch pageSize := r.URL.Query().Get("page_size"); pageSize {
+		case "", "1":
+		case "100":
+			readQuerySeen = true
+		default:
+			t.Fatalf("page_size = %q, want empty, 1, or 100", pageSize)
+		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]string{{"id": "record-1", "resource_urn": "urn:cerebro:tenant:runtime_asset:record-1", "resource_type": "asset", "resource_id": "record-1", "name": "Record One", "updated_at": "2026-06-01T00:00:00Z"}}})
+		_, _ = w.Write(fixture)
 	}))
 	defer server.Close()
 	cfgValues := map[string]string{"tenant_id": "tenant", "base_url": server.URL, "family": defaultFamily, "token": "test-token"}
@@ -40,9 +55,42 @@ func TestSourceCheckAndRead(t *testing.T) {
 	if len(pull.Events) != 1 {
 		t.Fatalf("events = %d, want 1", len(pull.Events))
 	}
+	if !readQuerySeen {
+		t.Fatal("read request did not include page_size")
+	}
 	event := pull.Events[0]
 	if event.Kind != "linode.issue" {
 		t.Fatalf("kind = %q", event.Kind)
+	}
+	if event.TenantId != "tenant" {
+		t.Fatalf("tenant_id = %q, want tenant", event.TenantId)
+	}
+	scope := sha256.Sum256([]byte(server.URL + "\x00/managed/issues"))
+	wantID := "linode-tenant-" + hex.EncodeToString(scope[:])[:12] + "-issue-823"
+	if event.Id != wantID {
+		t.Fatalf("event id = %q, want %q", event.Id, wantID)
+	}
+	if event.SchemaRef != "linode/issue/v1" {
+		t.Fatalf("schema_ref = %q", event.SchemaRef)
+	}
+	for key, want := range map[string]string{
+		"finding_id":      "823",
+		"resource_urn":    "urn:cerebro:tenant:linode_issue:823",
+		"severity":        "medium",
+		"source_event_id": "823",
+		"status":          "open",
+		"tenant_id":       "tenant",
+	} {
+		if got := event.Attributes[key]; got != want {
+			t.Fatalf("attribute %s = %q, want %q", key, got, want)
+		}
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("payload decode error = %v", err)
+	}
+	if payload["id"] != float64(823) {
+		t.Fatalf("payload id = %#v", payload["id"])
 	}
 	if strings.TrimSpace(event.Id) == "" {
 		t.Fatalf("event id is empty: %#v", event)

--- a/sources/linode/testdata/managed_issues_page.json
+++ b/sources/linode/testdata/managed_issues_page.json
@@ -1,0 +1,18 @@
+{
+  "data": [
+    {
+      "created": "2018-01-01T00:01:01",
+      "entity": {
+        "id": 98765,
+        "label": "Ticket 98765",
+        "type": "ticket",
+        "url": "/support/tickets/98765"
+      },
+      "id": 823,
+      "services": [654]
+    }
+  ],
+  "page": 1,
+  "pages": 1,
+  "results": 1
+}

--- a/sources/linode/testdata/read_issue.json
+++ b/sources/linode/testdata/read_issue.json
@@ -1,14 +1,20 @@
 {
-  "items": [
+  "data": [
     {
       "evidence_cas_digest": "sha256:test",
-      "evidence_cas_uri": "cas://cases/record-1",
-      "id": "record-1",
-      "name": "Record One",
-      "resource_id": "record-1",
-      "resource_type": "asset",
-      "resource_urn": "urn:cerebro:tenant:runtime_asset:record-1",
+      "evidence_cas_uri": "cas://cases/823",
+      "id": 823,
+      "name": "Managed issue 823",
+      "resource_id": "823",
+      "resource_type": "linode_issue",
+      "resource_urn": "urn:cerebro:tenant:linode_issue:823",
+      "severity": "medium",
+      "status": "open",
+      "tenant_id": "tenant",
       "updated_at": "2026-06-01T00:00:00Z"
     }
-  ]
+  ],
+  "page": 1,
+  "pages": 2,
+  "results": 101
 }


### PR DESCRIPTION
## Scope

- add a credential-free Linode managed-issue request/response kernel
- plan deterministic v4 requests while leaving Bearer credential application and network I/O to the trusted host
- enforce origin, response-size, record-count, cursor, tenant, identity, and duplicate bounds
- add typed provider failures, bounded provider-shaped fixtures, and Go/Rust semantic parity assertions

This draft intentionally does not change shared runtime exports, catalog registration, generated census files, or shared documentation. The provider module therefore has a narrow test compile boundary until the shared runtime owner adds the public module export.

## Local validation

- `cargo test --locked -p cerebro-source-runtime-next --test linode_issue -- --nocapture` — 7 passed
- `cargo test --locked -p cerebro-source-runtime-next` — 329 library, 4 source-worker, and 7 Linode tests passed
- `cargo clippy --locked -p cerebro-source-runtime-next --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `go test ./sources/linode -count=1 -v` — passed
- `go test -race ./sources/linode -count=1` — passed
- `go test -race ./internal/sourceprojection -run Linode -count=1 -v` — 4 passed
- `make source-fixture-check` — 138 bundles, 34 sources, 126 families; passed
- `make projection-parity-test` — passed
- `git diff --check` — passed

The repository-wide structural linter built successfully, but its analysis session lost SSH transport with RC255 before producing a terminal diagnostic. A fresh exact-head structural/architecture rerun remains pending the official DDESK 1.12.16 client readiness receipt. The earlier full `internal/sourceprojection` race run timed out while parsing the complete connector catalog; the focused Linode race projection suite passed.

## Remaining boundaries

- shared `source-runtime-next` export and runtime/catalog wiring are independently owned
- no live credential or provider collection was used
- deployment and authenticated user-path proof depend on the shared runtime path and an authorized read-only provider identity
