### PR TITLE
Add Google Workspace users provider adapter

### DIFF
--- a/crates/source-runtime-next/src/google_workspace.rs
+++ b/crates/source-runtime-next/src/google_workspace.rs
@@ -8,16 +8,22 @@
 //! This fails closed for fallback-only records that Go Read can emit but Go
 //! Discover cannot turn into a canonical source URN.
 
-use std::{collections::BTreeMap, error::Error, fmt, str::FromStr};
+use std::{collections::BTreeMap, str::FromStr};
 
 use reqwest::Url;
 use serde_json::Value;
 
+mod error;
 mod materialization;
 mod normalization;
+mod user_adapter;
+
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod user_adapter_tests;
 
+pub use error::GoogleWorkspaceError;
 use normalization::*;
 
 const SOURCE_ID: &str = "google_workspace";
@@ -427,55 +433,3 @@ impl GoogleWorkspaceKernel {
         Ok(url)
     }
 }
-
-/// Safe Google Workspace kernel failures. Messages never include credentials.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum GoogleWorkspaceError {
-    /// Family identifier is not one of the five supported contracts.
-    InvalidFamily,
-    /// Base URL is not a secure provider origin.
-    InvalidBaseUrl,
-    /// Tenant domain is blank.
-    MissingDomain,
-    /// Group-member collection omitted its group key.
-    MissingGroupKey,
-    /// Page size is outside the provider's 1 through 200 bound.
-    InvalidPageSize,
-    /// Response JSON does not match the family page contract.
-    InvalidResponse,
-    /// A provider record is not an object.
-    InvalidRecord,
-    /// A provider record omitted its stable identity.
-    MissingRecordIdentity,
-    /// Role-assignee response decoding lost its request-bound state.
-    MissingRoleState,
-    /// A request was decoded by a kernel configured for another family or origin.
-    RequestScopeMismatch,
-    /// Caller-supplied page observation time is not RFC 3339.
-    InvalidObservedAt,
-    /// A normalized record cannot produce the Go discovery identity.
-    MissingDiscoveryIdentity,
-}
-
-impl fmt::Display for GoogleWorkspaceError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(match self {
-            Self::InvalidFamily => "google_workspace family is invalid",
-            Self::InvalidBaseUrl => "google_workspace base URL must be a secure origin",
-            Self::MissingDomain => "google_workspace domain is required",
-            Self::MissingGroupKey => "google_workspace group key is required for group members",
-            Self::InvalidPageSize => "google_workspace page size must be between 1 and 200",
-            Self::InvalidResponse => "google_workspace response does not match the page contract",
-            Self::InvalidRecord => "google_workspace record must be an object",
-            Self::MissingRecordIdentity => "google_workspace record identity is missing",
-            Self::MissingRoleState => "google_workspace role lookup state is missing",
-            Self::RequestScopeMismatch => {
-                "google_workspace request family or origin does not match the kernel"
-            }
-            Self::InvalidObservedAt => "google_workspace observed_at must be RFC 3339",
-            Self::MissingDiscoveryIdentity => "google_workspace discovery identity is missing",
-        })
-    }
-}
-
-impl Error for GoogleWorkspaceError {}

--- a/crates/source-runtime-next/src/google_workspace/error.rs
+++ b/crates/source-runtime-next/src/google_workspace/error.rs
@@ -1,0 +1,119 @@
+//! Stable, body-redacted Google Workspace provider failures.
+
+use std::{error::Error, fmt};
+
+/// Safe Google Workspace kernel failures. Messages never include credentials.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GoogleWorkspaceError {
+    /// Family identifier is not one of the five supported contracts.
+    InvalidFamily,
+    /// Base URL is not a secure provider origin.
+    InvalidBaseUrl,
+    /// Tenant domain is blank.
+    MissingDomain,
+    /// Group-member collection omitted its group key.
+    MissingGroupKey,
+    /// Page size is outside the provider's 1 through 200 bound.
+    InvalidPageSize,
+    /// Response JSON does not match the family page contract.
+    InvalidResponse,
+    /// A provider record is not an object.
+    InvalidRecord,
+    /// A provider record omitted its stable identity.
+    MissingRecordIdentity,
+    /// Role-assignee response decoding lost its request-bound state.
+    MissingRoleState,
+    /// A request was decoded by a kernel configured for another family or origin.
+    RequestScopeMismatch,
+    /// Caller-supplied page observation time is not RFC 3339.
+    InvalidObservedAt,
+    /// A normalized record cannot produce the Go discovery identity.
+    MissingDiscoveryIdentity,
+    /// The users adapter was invoked on a kernel configured for another family.
+    UserFamilyRequired,
+    /// Tenant domain cannot safely scope a stable user identity.
+    InvalidTenantIdentity,
+    /// Customer selector is oversized, control-bearing, or malformed.
+    InvalidCustomerId,
+    /// Provider continuation is oversized, control-bearing, or malformed.
+    InvalidCursor,
+    /// Provider response exceeds the shared eight-mebibyte host bound.
+    ResponseTooLarge,
+    /// Provider returned more user records than the requested page bound.
+    TooManyUserRecords,
+    /// One page contains different user records with the same provider identity.
+    ConflictingUserIdentity,
+    /// Provider rejected the operation-scoped bearer credential.
+    AuthenticationRejected,
+    /// Provider credential lacks the required Directory user read scope.
+    RequiredUserScopeMissing,
+    /// Provider credential is valid but cannot read the requested customer.
+    PermissionDenied,
+    /// Provider rate limit requires retrying the same cursor later.
+    RateLimited,
+    /// Provider is temporarily unavailable; progress must not advance.
+    ProviderUnavailable(u16),
+    /// Provider returned an unrecognized non-success status.
+    UnexpectedProviderStatus(u16),
+}
+
+impl fmt::Display for GoogleWorkspaceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::InvalidFamily => "google_workspace family is invalid",
+            Self::InvalidBaseUrl => "google_workspace base URL must be a secure origin",
+            Self::MissingDomain => "google_workspace domain is required",
+            Self::MissingGroupKey => "google_workspace group key is required for group members",
+            Self::InvalidPageSize => "google_workspace page size must be between 1 and 200",
+            Self::InvalidResponse => "google_workspace response does not match the page contract",
+            Self::InvalidRecord => "google_workspace record must be an object",
+            Self::MissingRecordIdentity => "google_workspace record identity is missing",
+            Self::MissingRoleState => "google_workspace role lookup state is missing",
+            Self::RequestScopeMismatch => {
+                "google_workspace request family or origin does not match the kernel"
+            }
+            Self::InvalidObservedAt => "google_workspace observed_at must be RFC 3339",
+            Self::MissingDiscoveryIdentity => "google_workspace discovery identity is missing",
+            Self::UserFamilyRequired => "google_workspace users adapter requires family=user",
+            Self::InvalidTenantIdentity => {
+                "google_workspace tenant domain is not a stable identity scope"
+            }
+            Self::InvalidCustomerId => "google_workspace customer identifier is invalid",
+            Self::InvalidCursor => "google_workspace user page cursor is invalid",
+            Self::ResponseTooLarge => "google_workspace user response exceeds 8388608 bytes",
+            Self::TooManyUserRecords => {
+                "google_workspace user response exceeds the requested page bound"
+            }
+            Self::ConflictingUserIdentity => {
+                "google_workspace user page contains conflicting provider identities"
+            }
+            Self::AuthenticationRejected => {
+                "google_workspace authentication was rejected; repair the credential binding"
+            }
+            Self::RequiredUserScopeMissing => {
+                "google_workspace credential is missing the Directory user read scope"
+            }
+            Self::PermissionDenied => {
+                "google_workspace credential cannot read the configured customer"
+            }
+            Self::RateLimited => {
+                "google_workspace rate limit requires retrying the same cursor later"
+            }
+            Self::ProviderUnavailable(status) => {
+                return write!(
+                    formatter,
+                    "google_workspace provider is unavailable with HTTP {status}; retry later"
+                );
+            }
+            Self::UnexpectedProviderStatus(status) => {
+                return write!(
+                    formatter,
+                    "google_workspace provider returned unexpected HTTP {status}"
+                );
+            }
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl Error for GoogleWorkspaceError {}

--- a/crates/source-runtime-next/src/google_workspace/fixtures/missing_scope.json
+++ b/crates/source-runtime-next/src/google_workspace/fixtures/missing_scope.json
@@ -1,0 +1,12 @@
+{
+  "error": {
+    "code": 403,
+    "status": "PERMISSION_DENIED",
+    "errors": [
+      {
+        "domain": "global",
+        "reason": "insufficientPermissions"
+      }
+    ]
+  }
+}

--- a/crates/source-runtime-next/src/google_workspace/fixtures/users_page_1.json
+++ b/crates/source-runtime-next/src/google_workspace/fixtures/users_page_1.json
@@ -1,0 +1,33 @@
+{
+  "users": [
+    {
+      "id": "1001",
+      "primaryEmail": "admin@writer.com",
+      "name": { "fullName": "Admin Writer" },
+      "isAdmin": true,
+      "isDelegatedAdmin": true,
+      "isEnrolledIn2Sv": false,
+      "isEnforcedIn2Sv": false,
+      "suspended": false,
+      "archived": false,
+      "creationTime": "2025-01-01T00:00:00.000Z",
+      "lastLoginTime": "2025-01-15T00:00:00.000Z",
+      "orgUnitPath": "/"
+    },
+    {
+      "id": "1001",
+      "primaryEmail": "admin@writer.com",
+      "name": { "fullName": "Admin Writer" },
+      "isAdmin": true,
+      "isDelegatedAdmin": true,
+      "isEnrolledIn2Sv": false,
+      "isEnforcedIn2Sv": false,
+      "suspended": false,
+      "archived": false,
+      "creationTime": "2025-01-01T00:00:00.000Z",
+      "lastLoginTime": "2025-01-15T00:00:00.000Z",
+      "orgUnitPath": "/"
+    }
+  ],
+  "nextPageToken": "page-2"
+}

--- a/crates/source-runtime-next/src/google_workspace/fixtures/users_page_2.json
+++ b/crates/source-runtime-next/src/google_workspace/fixtures/users_page_2.json
@@ -1,0 +1,18 @@
+{
+  "users": [
+    {
+      "id": "1002",
+      "primaryEmail": "alice@writer.com",
+      "name": { "fullName": "Alice Writer" },
+      "isAdmin": false,
+      "isDelegatedAdmin": false,
+      "isEnrolledIn2Sv": true,
+      "isEnforcedIn2Sv": true,
+      "suspended": false,
+      "archived": false,
+      "creationTime": "2026-04-20T00:00:00.000Z",
+      "lastLoginTime": "2026-04-23T00:00:00.000Z",
+      "orgUnitPath": "/Engineering"
+    }
+  ]
+}

--- a/crates/source-runtime-next/src/google_workspace/user_adapter.rs
+++ b/crates/source-runtime-next/src/google_workspace/user_adapter.rs
@@ -1,0 +1,396 @@
+//! Users-family host adapter contract.
+//!
+//! The shared host owns credentials, egress, redirects, deadlines, retries,
+//! and response collection. This adapter accepts only a provider status and
+//! already-bounded response bytes, then returns deterministic user events.
+
+use std::collections::BTreeMap;
+
+use reqwest::StatusCode;
+use serde_json::Value;
+
+use super::{
+    GoogleWorkspaceError, GoogleWorkspaceFamily, GoogleWorkspaceFilters, GoogleWorkspaceKernel,
+    GoogleWorkspaceOutcome, GoogleWorkspacePage, GoogleWorkspaceRecord, GoogleWorkspaceRequest,
+    RequestStage, materialization::GoogleWorkspaceEventPage,
+};
+
+const DIRECTORY_USER_READ_SCOPE: &str =
+    "https://www.googleapis.com/auth/admin.directory.user.readonly";
+const MAX_CURSOR_BYTES: usize = 4 << 10;
+const MAX_RESPONSE_BYTES: usize = 8 << 20;
+
+impl GoogleWorkspaceRequest {
+    /// Return the exact HTTP method for a users-list request.
+    pub const fn method(&self) -> &'static str {
+        "GET"
+    }
+}
+
+impl GoogleWorkspaceKernel {
+    /// Build the provider-local users adapter without accepting credentials.
+    pub fn new_user_adapter(
+        base_url: &str,
+        tenant_domain: &str,
+        customer_id: Option<String>,
+        page_size: Option<usize>,
+    ) -> Result<Self, GoogleWorkspaceError> {
+        if !valid_tenant_domain(tenant_domain) {
+            return Err(GoogleWorkspaceError::InvalidTenantIdentity);
+        }
+        if customer_id
+            .as_deref()
+            .is_some_and(|value| !valid_customer_id(value))
+        {
+            return Err(GoogleWorkspaceError::InvalidCustomerId);
+        }
+        Self::new(
+            base_url,
+            tenant_domain,
+            GoogleWorkspaceFamily::User,
+            GoogleWorkspaceFilters {
+                customer_id,
+                group_key: None,
+                application: None,
+            },
+            page_size,
+        )
+    }
+
+    /// Return whether this adapter accepts or stores credential values.
+    pub const fn user_adapter_accepts_credential_values() -> bool {
+        false
+    }
+
+    /// Return the least-privilege OAuth scope required by the users operation.
+    pub const fn user_adapter_required_oauth_scope() -> &'static str {
+        DIRECTORY_USER_READ_SCOPE
+    }
+
+    /// Plan one exact users-list request with a fixed provider origin.
+    pub fn plan_user_page(
+        &self,
+        cursor: Option<&str>,
+    ) -> Result<GoogleWorkspaceRequest, GoogleWorkspaceError> {
+        self.require_user_adapter()?;
+        let cursor = bounded_cursor(cursor)?;
+        let mut url = self.endpoint(&["admin", "directory", "v1", "users"])?;
+        {
+            let mut query = url.query_pairs_mut();
+            query.append_pair("customer", &self.customer_id);
+            query.append_pair("maxResults", &self.page_size.to_string());
+            if let Some(cursor) = cursor.as_deref() {
+                query.append_pair("pageToken", cursor);
+            }
+        }
+        Ok(GoogleWorkspaceRequest {
+            url,
+            family: GoogleWorkspaceFamily::User,
+            stage: RequestStage::Direct,
+            role_state: None,
+        })
+    }
+
+    /// Decode one users-list response supplied by the trusted HTTP host.
+    ///
+    /// Non-success responses return typed, body-redacted failures. Successful
+    /// pages are byte- and record-bounded, deduplicated by stable provider ID,
+    /// materialized with Go-compatible event fields, and scoped to the tenant
+    /// domain before the caller can admit them.
+    pub fn decode_user_response(
+        &self,
+        request: &GoogleWorkspaceRequest,
+        status: StatusCode,
+        body: &[u8],
+        observed_at: &str,
+    ) -> Result<GoogleWorkspaceEventPage, GoogleWorkspaceError> {
+        self.require_user_adapter()?;
+        self.validate_user_request(request)?;
+        if body.len() > MAX_RESPONSE_BYTES {
+            return Err(GoogleWorkspaceError::ResponseTooLarge);
+        }
+        validate_provider_status(status, body)?;
+        let GoogleWorkspaceOutcome::Page(page) = self.decode(request, body)? else {
+            return Err(GoogleWorkspaceError::RequestScopeMismatch);
+        };
+        let page = self.validate_and_deduplicate_users(page)?;
+        let mut materialized = page.materialize(observed_at)?;
+        if materialized.events.is_empty() {
+            materialized.next_cursor.clone_from(&page.next_cursor);
+            materialized.checkpoint_cursor.clone_from(&page.next_cursor);
+        }
+        self.validate_materialized_users(&materialized)?;
+        Ok(materialized)
+    }
+
+    fn require_user_adapter(&self) -> Result<(), GoogleWorkspaceError> {
+        if self.family != GoogleWorkspaceFamily::User {
+            return Err(GoogleWorkspaceError::UserFamilyRequired);
+        }
+        if !valid_tenant_domain(&self.domain) {
+            return Err(GoogleWorkspaceError::InvalidTenantIdentity);
+        }
+        Ok(())
+    }
+
+    fn validate_user_request(
+        &self,
+        request: &GoogleWorkspaceRequest,
+    ) -> Result<(), GoogleWorkspaceError> {
+        let mut cursor = None;
+        for (name, value) in request.url.query_pairs() {
+            if name == "pageToken" && cursor.is_none() {
+                cursor = Some(value.into_owned());
+            }
+        }
+        let expected = self.plan_user_page(cursor.as_deref())?;
+        if request != &expected {
+            return Err(GoogleWorkspaceError::RequestScopeMismatch);
+        }
+        Ok(())
+    }
+
+    fn validate_and_deduplicate_users(
+        &self,
+        mut page: GoogleWorkspacePage,
+    ) -> Result<GoogleWorkspacePage, GoogleWorkspaceError> {
+        if page.records.len() > self.page_size {
+            return Err(GoogleWorkspaceError::TooManyUserRecords);
+        }
+        page.next_cursor = bounded_cursor(page.next_cursor.as_deref())?;
+        let mut seen = BTreeMap::<String, usize>::new();
+        let mut records = Vec::<GoogleWorkspaceRecord>::with_capacity(page.records.len());
+        for mut record in page.records {
+            enforce_go_user_wire_semantics(&mut record)?;
+            let user_id = record
+                .fields
+                .get("user_id")
+                .map(String::as_str)
+                .filter(|value| valid_provider_identity(value))
+                .ok_or(GoogleWorkspaceError::MissingRecordIdentity)?;
+            if record.provider_id != user_id
+                || record.family != GoogleWorkspaceFamily::User.as_str()
+                || record.provider_kind != GoogleWorkspaceFamily::User.provider_kind()
+            {
+                return Err(GoogleWorkspaceError::MissingRecordIdentity);
+            }
+            if let Some(index) = seen.get(user_id).copied() {
+                if records.get(index) != Some(&record) {
+                    return Err(GoogleWorkspaceError::ConflictingUserIdentity);
+                }
+                continue;
+            }
+            seen.insert(user_id.to_owned(), records.len());
+            records.push(record);
+        }
+        page.records = records;
+        Ok(page)
+    }
+
+    fn validate_materialized_users(
+        &self,
+        page: &GoogleWorkspaceEventPage,
+    ) -> Result<(), GoogleWorkspaceError> {
+        let urn_prefix = format!("urn:cerebro:{}:google_workspace_user:", self.domain);
+        for event in &page.events {
+            let user_id = event
+                .attributes
+                .get("user_id")
+                .map(String::as_str)
+                .filter(|value| valid_provider_identity(value))
+                .ok_or(GoogleWorkspaceError::MissingRecordIdentity)?;
+            if event.tenant_id != self.domain
+                || event.source_id != "google_workspace"
+                || event.provider_kind != GoogleWorkspaceFamily::User.provider_kind()
+                || event.schema_ref != GoogleWorkspaceFamily::User.schema_ref()
+                || event.event_id != format!("google-workspace-user-{user_id}")
+                || event.discovery_urn != format!("{urn_prefix}{user_id}")
+                || event.attributes.get("domain") != Some(&self.domain)
+                || event.attributes.get("family").map(String::as_str) != Some("user")
+                || event.payload.get("id").and_then(Value::as_str) != Some(user_id)
+                || event.payload.get("domain").and_then(Value::as_str) != Some(self.domain.as_str())
+            {
+                return Err(GoogleWorkspaceError::InvalidTenantIdentity);
+            }
+        }
+        let expected_checkpoint = page
+            .next_cursor
+            .as_deref()
+            .or_else(|| page.events.last().map(|event| event.event_id.as_str()));
+        let expected_watermark = page.events.last().map(|event| event.occurred_at.as_str());
+        if page.checkpoint_cursor.as_deref() != expected_checkpoint
+            || page.watermark.as_deref() != expected_watermark
+        {
+            return Err(GoogleWorkspaceError::InvalidResponse);
+        }
+        Ok(())
+    }
+}
+
+fn enforce_go_user_wire_semantics(
+    record: &mut GoogleWorkspaceRecord,
+) -> Result<(), GoogleWorkspaceError> {
+    let object = record
+        .payload
+        .as_object()
+        .ok_or(GoogleWorkspaceError::InvalidRecord)?;
+    for field in [
+        "id",
+        "primaryEmail",
+        "creationTime",
+        "lastLoginTime",
+        "orgUnitPath",
+    ] {
+        if object
+            .get(field)
+            .is_some_and(|value| !value.is_null() && !value.is_string())
+        {
+            return Err(GoogleWorkspaceError::InvalidRecord);
+        }
+    }
+    if let Some(name) = object.get("name")
+        && !name.is_null()
+        && (!name.is_object()
+            || name
+                .get("fullName")
+                .is_some_and(|value| !value.is_null() && !value.is_string()))
+    {
+        return Err(GoogleWorkspaceError::InvalidRecord);
+    }
+    for (provider_field, attribute) in [
+        ("isAdmin", "is_admin"),
+        ("isDelegatedAdmin", "is_delegated_admin"),
+        ("isEnrolledIn2Sv", "mfa_enrolled"),
+        ("isEnforcedIn2Sv", "mfa_enforced"),
+        ("suspended", "suspended"),
+        ("archived", "archived"),
+    ] {
+        match object.get(provider_field) {
+            None | Some(Value::Null) => {
+                record
+                    .fields
+                    .insert(attribute.to_owned(), "false".to_owned());
+            }
+            Some(Value::Bool(value)) => {
+                record
+                    .fields
+                    .insert(attribute.to_owned(), value.to_string());
+            }
+            Some(_) => return Err(GoogleWorkspaceError::InvalidRecord),
+        }
+    }
+    Ok(())
+}
+
+fn bounded_cursor(raw: Option<&str>) -> Result<Option<String>, GoogleWorkspaceError> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let cursor = raw.trim();
+    if cursor.is_empty() {
+        return Ok(None);
+    }
+    if cursor.len() > MAX_CURSOR_BYTES || cursor.chars().any(char::is_control) {
+        return Err(GoogleWorkspaceError::InvalidCursor);
+    }
+    Ok(Some(cursor.to_owned()))
+}
+
+fn valid_tenant_domain(raw: &str) -> bool {
+    let domain = raw.trim();
+    !domain.is_empty()
+        && domain.len() <= 253
+        && domain == raw
+        && domain.split('.').all(|label| {
+            !label.is_empty()
+                && label.len() <= 63
+                && label
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+                && label
+                    .as_bytes()
+                    .first()
+                    .is_some_and(|byte| byte.is_ascii_alphanumeric())
+                && label
+                    .as_bytes()
+                    .last()
+                    .is_some_and(|byte| byte.is_ascii_alphanumeric())
+        })
+}
+
+fn valid_provider_identity(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 256
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'@'))
+}
+
+fn valid_customer_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 256
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+}
+
+fn validate_provider_status(status: StatusCode, body: &[u8]) -> Result<(), GoogleWorkspaceError> {
+    if status.is_success() {
+        return Ok(());
+    }
+    match status {
+        StatusCode::UNAUTHORIZED => Err(GoogleWorkspaceError::AuthenticationRejected),
+        StatusCode::FORBIDDEN => Err(classify_forbidden(body)),
+        StatusCode::TOO_MANY_REQUESTS => Err(GoogleWorkspaceError::RateLimited),
+        status if status.is_server_error() => {
+            Err(GoogleWorkspaceError::ProviderUnavailable(status.as_u16()))
+        }
+        status => Err(GoogleWorkspaceError::UnexpectedProviderStatus(
+            status.as_u16(),
+        )),
+    }
+}
+
+fn classify_forbidden(body: &[u8]) -> GoogleWorkspaceError {
+    let Ok(Value::Object(root)) = serde_json::from_slice::<Value>(body) else {
+        return GoogleWorkspaceError::PermissionDenied;
+    };
+    let Some(Value::Object(error)) = root.get("error") else {
+        return GoogleWorkspaceError::PermissionDenied;
+    };
+    if error.get("status").and_then(Value::as_str) == Some("RESOURCE_EXHAUSTED") {
+        return GoogleWorkspaceError::RateLimited;
+    }
+    let legacy_reason = error
+        .get("errors")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_object)
+        .filter_map(|entry| entry.get("reason").and_then(Value::as_str));
+    let detail_reason = error
+        .get("details")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_object)
+        .filter_map(|entry| entry.get("reason").and_then(Value::as_str));
+    let reasons = legacy_reason.chain(detail_reason).collect::<Vec<_>>();
+    if reasons.iter().any(|reason| {
+        matches!(
+            *reason,
+            "dailyLimitExceeded" | "quotaExceeded" | "rateLimitExceeded" | "userRateLimitExceeded"
+        )
+    }) {
+        return GoogleWorkspaceError::RateLimited;
+    }
+    if reasons.iter().any(|reason| {
+        matches!(
+            *reason,
+            "insufficientPermissions" | "ACCESS_TOKEN_SCOPE_INSUFFICIENT" | "insufficient_scope"
+        )
+    }) {
+        return GoogleWorkspaceError::RequiredUserScopeMissing;
+    }
+    GoogleWorkspaceError::PermissionDenied
+}

--- a/crates/source-runtime-next/src/google_workspace/user_adapter_tests.rs
+++ b/crates/source-runtime-next/src/google_workspace/user_adapter_tests.rs
@@ -1,0 +1,495 @@
+//! Users-family adapter fixtures and host-boundary tests.
+
+use std::collections::BTreeMap;
+
+use reqwest::StatusCode;
+use serde_json::Value;
+
+use super::*;
+
+const USERS_PAGE_1: &[u8] = include_bytes!("fixtures/users_page_1.json");
+const USERS_PAGE_2: &[u8] = include_bytes!("fixtures/users_page_2.json");
+const MISSING_SCOPE: &[u8] = include_bytes!("fixtures/missing_scope.json");
+const GO_USER_FIXTURE: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../sources/googleworkspace/testdata/read_user.json"
+));
+const OBSERVED_AT: &str = "2026-08-21T03:00:00Z";
+
+fn user_adapter(tenant: &str, page_size: usize) -> GoogleWorkspaceKernel {
+    GoogleWorkspaceKernel::new_user_adapter(
+        "https://admin.googleapis.com",
+        tenant,
+        Some("C01".to_owned()),
+        Some(page_size),
+    )
+    .unwrap()
+}
+
+struct GoUserAttributeFixture<'a> {
+    user_id: &'a str,
+    email: &'a str,
+    display_name: &'a str,
+    created_at: &'a str,
+    last_login_at: &'a str,
+    org_unit_path: &'a str,
+    is_admin: bool,
+    is_delegated_admin: bool,
+    mfa_enabled: bool,
+}
+
+fn go_user_attributes(fixture: GoUserAttributeFixture<'_>) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        ("archived".to_owned(), "false".to_owned()),
+        ("created_at".to_owned(), fixture.created_at.to_owned()),
+        ("display_name".to_owned(), fixture.display_name.to_owned()),
+        ("domain".to_owned(), "writer.com".to_owned()),
+        ("email".to_owned(), fixture.email.to_owned()),
+        ("family".to_owned(), "user".to_owned()),
+        ("is_admin".to_owned(), fixture.is_admin.to_string()),
+        (
+            "is_delegated_admin".to_owned(),
+            fixture.is_delegated_admin.to_string(),
+        ),
+        ("last_login_at".to_owned(), fixture.last_login_at.to_owned()),
+        ("login".to_owned(), fixture.email.to_owned()),
+        ("mfa_enforced".to_owned(), fixture.mfa_enabled.to_string()),
+        ("mfa_enrolled".to_owned(), fixture.mfa_enabled.to_string()),
+        ("org_unit_path".to_owned(), fixture.org_unit_path.to_owned()),
+        ("primary_email".to_owned(), fixture.email.to_owned()),
+        ("suspended".to_owned(), "false".to_owned()),
+        ("user_id".to_owned(), fixture.user_id.to_owned()),
+    ])
+}
+
+#[test]
+fn users_adapter_plans_exact_credential_free_request() {
+    let adapter = user_adapter("writer.com", 2);
+    let request = adapter.plan_user_page(Some("page-2")).unwrap();
+    assert_eq!(request.method(), "GET");
+    assert_eq!(request.authorization_scheme(), "Bearer");
+    assert_eq!(request.accept(), "application/json");
+    assert_eq!(
+        request.url().as_str(),
+        "https://admin.googleapis.com/admin/directory/v1/users?customer=C01&maxResults=2&pageToken=page-2"
+    );
+    assert!(!GoogleWorkspaceKernel::user_adapter_accepts_credential_values());
+    assert_eq!(
+        GoogleWorkspaceKernel::user_adapter_required_oauth_scope(),
+        "https://www.googleapis.com/auth/admin.directory.user.readonly"
+    );
+}
+
+#[test]
+fn users_adapter_keeps_opaque_pagination_on_the_compiled_origin() {
+    let adapter = user_adapter("writer.com", 2);
+    assert_eq!(
+        adapter.plan_user_page(None).unwrap(),
+        adapter.plan_user_page(Some("")).unwrap()
+    );
+    let normalized = adapter.plan_user_page(Some("  page-2  ")).unwrap();
+    assert_eq!(
+        normalized
+            .url()
+            .query_pairs()
+            .find(|(name, _)| name == "pageToken")
+            .map(|(_, value)| value.into_owned()),
+        Some("page-2".to_owned())
+    );
+    let request = adapter
+        .plan_user_page(Some("https://attacker.invalid/next?tenant=other"))
+        .unwrap();
+    assert_eq!(request.url().scheme(), "https");
+    assert_eq!(request.url().host_str(), Some("admin.googleapis.com"));
+    assert_eq!(request.url().path(), "/admin/directory/v1/users");
+    assert_eq!(
+        request
+            .url()
+            .query_pairs()
+            .find(|(name, _)| name == "pageToken")
+            .map(|(_, value)| value.into_owned()),
+        Some("https://attacker.invalid/next?tenant=other".to_owned())
+    );
+
+    let oversized = "x".repeat((4 << 10) + 1);
+    assert_eq!(
+        adapter.plan_user_page(Some(&oversized)),
+        Err(GoogleWorkspaceError::InvalidCursor)
+    );
+    assert_eq!(
+        adapter.plan_user_page(Some("page\n2")),
+        Err(GoogleWorkspaceError::InvalidCursor)
+    );
+}
+
+#[test]
+fn users_adapter_preserves_empty_page_continuation_and_terminal_semantics() {
+    let adapter = user_adapter("writer.com", 2);
+    let request = adapter.plan_user_page(None).unwrap();
+    let continued = adapter
+        .decode_user_response(
+            &request,
+            StatusCode::OK,
+            br#"{"users":[],"nextPageToken":"  page-2  "}"#,
+            OBSERVED_AT,
+        )
+        .unwrap();
+    assert!(continued.events.is_empty());
+    assert_eq!(continued.next_cursor.as_deref(), Some("page-2"));
+    assert_eq!(continued.checkpoint_cursor.as_deref(), Some("page-2"));
+    assert!(continued.watermark.is_none());
+
+    let terminal = adapter
+        .decode_user_response(
+            &request,
+            StatusCode::OK,
+            br#"{"users":[],"nextPageToken":""}"#,
+            OBSERVED_AT,
+        )
+        .unwrap();
+    assert!(terminal.events.is_empty());
+    assert!(terminal.next_cursor.is_none());
+    assert!(terminal.checkpoint_cursor.is_none());
+    assert!(terminal.watermark.is_none());
+}
+
+#[test]
+fn users_adapter_runs_two_pages_with_dedupe_and_restartable_cursor() {
+    let adapter = user_adapter("writer.com", 2);
+    let first_request = adapter.plan_user_page(None).unwrap();
+    let first = adapter
+        .decode_user_response(&first_request, StatusCode::OK, USERS_PAGE_1, OBSERVED_AT)
+        .unwrap();
+    assert_eq!(first.events.len(), 1);
+    assert_eq!(first.next_cursor.as_deref(), Some("page-2"));
+    assert_eq!(first.checkpoint_cursor.as_deref(), Some("page-2"));
+    assert_eq!(first.events[0].event_id, "google-workspace-user-1001");
+    assert_eq!(
+        first.events[0].discovery_urn,
+        "urn:cerebro:writer.com:google_workspace_user:1001"
+    );
+
+    let resumed_request = adapter
+        .plan_user_page(first.next_cursor.as_deref())
+        .unwrap();
+    let resumed = adapter
+        .decode_user_response(&resumed_request, StatusCode::OK, USERS_PAGE_2, OBSERVED_AT)
+        .unwrap();
+    assert_eq!(resumed.events.len(), 1);
+    assert_eq!(resumed.events[0].event_id, "google-workspace-user-1002");
+    assert!(resumed.next_cursor.is_none());
+    assert_eq!(
+        resumed.checkpoint_cursor.as_deref(),
+        Some("google-workspace-user-1002")
+    );
+
+    let replay = adapter
+        .decode_user_response(&first_request, StatusCode::OK, USERS_PAGE_1, OBSERVED_AT)
+        .unwrap();
+    assert_eq!(replay, first);
+}
+
+#[test]
+fn users_adapter_matches_go_user_fixture_semantics() {
+    let adapter = user_adapter("writer.com", 2);
+    let request = adapter.plan_user_page(None).unwrap();
+    let users: Value = serde_json::from_slice(GO_USER_FIXTURE).unwrap();
+    let provider_users = users.as_array().unwrap().clone();
+    let body = serde_json::to_vec(&serde_json::json!({"users": users})).unwrap();
+    let page = adapter
+        .decode_user_response(&request, StatusCode::OK, &body, OBSERVED_AT)
+        .unwrap();
+    assert_eq!(page.events.len(), 2);
+    let expected = [
+        (
+            "google-workspace-user-1001",
+            "2025-01-15T00:00:00Z",
+            "urn:cerebro:writer.com:google_workspace_user:1001",
+            go_user_attributes(GoUserAttributeFixture {
+                user_id: "1001",
+                email: "admin@writer.com",
+                display_name: "Admin Writer",
+                created_at: "2025-01-01T00:00:00.000Z",
+                last_login_at: "2025-01-15T00:00:00.000Z",
+                org_unit_path: "/",
+                is_admin: true,
+                is_delegated_admin: true,
+                mfa_enabled: false,
+            }),
+        ),
+        (
+            "google-workspace-user-1002",
+            "2026-04-23T00:00:00Z",
+            "urn:cerebro:writer.com:google_workspace_user:1002",
+            go_user_attributes(GoUserAttributeFixture {
+                user_id: "1002",
+                email: "alice@writer.com",
+                display_name: "Alice Writer",
+                created_at: "2026-04-20T00:00:00.000Z",
+                last_login_at: "2026-04-23T00:00:00.000Z",
+                org_unit_path: "/Engineering",
+                is_admin: false,
+                is_delegated_admin: false,
+                mfa_enabled: true,
+            }),
+        ),
+    ];
+    for ((event, provider), (event_id, occurred_at, discovery_urn, attributes)) in
+        page.events.iter().zip(provider_users).zip(expected)
+    {
+        assert_eq!(event.event_id, event_id);
+        assert_eq!(event.tenant_id, "writer.com");
+        assert_eq!(event.source_id, "google_workspace");
+        assert_eq!(event.provider_kind, "google_workspace.user");
+        assert_eq!(event.schema_ref, "google_workspace/user/v1");
+        assert_eq!(event.occurred_at, occurred_at);
+        assert_eq!(event.discovery_urn, discovery_urn);
+        assert_eq!(event.attributes, attributes);
+        let mut expected_payload = provider;
+        expected_payload
+            .as_object_mut()
+            .unwrap()
+            .insert("domain".to_owned(), Value::String("writer.com".to_owned()));
+        assert_eq!(event.payload, expected_payload);
+    }
+    assert!(page.next_cursor.is_none());
+    assert_eq!(
+        page.checkpoint_cursor.as_deref(),
+        Some("google-workspace-user-1002")
+    );
+    assert_eq!(page.watermark.as_deref(), Some("2026-04-23T00:00:00Z"));
+}
+
+#[test]
+fn users_adapter_scopes_canonical_identity_by_tenant() {
+    let writer = user_adapter("writer.com", 2);
+    let example = user_adapter("example.com", 2);
+    let writer_request = writer.plan_user_page(None).unwrap();
+    let example_request = example.plan_user_page(None).unwrap();
+    let writer_page = writer
+        .decode_user_response(&writer_request, StatusCode::OK, USERS_PAGE_1, OBSERVED_AT)
+        .unwrap();
+    let example_page = example
+        .decode_user_response(&example_request, StatusCode::OK, USERS_PAGE_1, OBSERVED_AT)
+        .unwrap();
+    assert_eq!(
+        writer_page.events[0].event_id,
+        example_page.events[0].event_id
+    );
+    assert_ne!(
+        (
+            &writer_page.events[0].tenant_id,
+            &writer_page.events[0].event_id,
+        ),
+        (
+            &example_page.events[0].tenant_id,
+            &example_page.events[0].event_id,
+        )
+    );
+    assert_ne!(
+        writer_page.events[0].discovery_urn,
+        example_page.events[0].discovery_urn
+    );
+    assert_eq!(writer_page.events[0].tenant_id, "writer.com");
+    assert_eq!(example_page.events[0].tenant_id, "example.com");
+}
+
+#[test]
+fn users_adapter_classifies_auth_scope_permission_and_retry_failures() {
+    let adapter = user_adapter("writer.com", 2);
+    let request = adapter.plan_user_page(None).unwrap();
+    let cases = [
+        (
+            StatusCode::UNAUTHORIZED,
+            br#"{"error":{"message":"secret-bearing provider text"}}"#.as_slice(),
+            GoogleWorkspaceError::AuthenticationRejected,
+        ),
+        (
+            StatusCode::FORBIDDEN,
+            MISSING_SCOPE,
+            GoogleWorkspaceError::RequiredUserScopeMissing,
+        ),
+        (
+            StatusCode::FORBIDDEN,
+            br#"{"error":{"errors":[{"reason":"forbidden"}]}}"#.as_slice(),
+            GoogleWorkspaceError::PermissionDenied,
+        ),
+        (
+            StatusCode::TOO_MANY_REQUESTS,
+            br#"{"error":{"message":"quota"}}"#.as_slice(),
+            GoogleWorkspaceError::RateLimited,
+        ),
+        (
+            StatusCode::FORBIDDEN,
+            br#"{"error":{"errors":[{"reason":"rateLimitExceeded"}]}}"#.as_slice(),
+            GoogleWorkspaceError::RateLimited,
+        ),
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            br#"{"error":{"message":"unavailable"}}"#.as_slice(),
+            GoogleWorkspaceError::ProviderUnavailable(503),
+        ),
+        (
+            StatusCode::FOUND,
+            br#"{"error":{"message":"redirect refused"}}"#.as_slice(),
+            GoogleWorkspaceError::UnexpectedProviderStatus(302),
+        ),
+    ];
+    for (status, body, expected) in cases {
+        let error = adapter
+            .decode_user_response(&request, status, body, OBSERVED_AT)
+            .unwrap_err();
+        assert_eq!(error, expected);
+        assert!(!error.to_string().contains("secret-bearing provider text"));
+    }
+    let provider_canary = "provider-user@fixture.invalid";
+    let credential_canary = "fixture-only-bearer-canary";
+    let body = format!(
+        r#"{{"error":{{"message":"{provider_canary}","credential":"{credential_canary}"}}}}"#
+    );
+    let error = adapter
+        .decode_user_response(
+            &request,
+            StatusCode::FORBIDDEN,
+            body.as_bytes(),
+            OBSERVED_AT,
+        )
+        .unwrap_err();
+    for rendered in [error.to_string(), format!("{error:?}")] {
+        assert!(!rendered.contains(provider_canary));
+        assert!(!rendered.contains(credential_canary));
+    }
+}
+
+#[test]
+fn users_adapter_rejects_response_record_cursor_and_identity_overflow() {
+    let adapter = user_adapter("writer.com", 1);
+    let request = adapter.plan_user_page(None).unwrap();
+    let oversized_response = vec![b' '; (8 << 20) + 1];
+    assert_eq!(
+        adapter.decode_user_response(&request, StatusCode::OK, &oversized_response, OBSERVED_AT,),
+        Err(GoogleWorkspaceError::ResponseTooLarge)
+    );
+    assert_eq!(
+        adapter.decode_user_response(&request, StatusCode::OK, USERS_PAGE_1, OBSERVED_AT),
+        Err(GoogleWorkspaceError::TooManyUserRecords)
+    );
+
+    let adapter = user_adapter("writer.com", 2);
+    let request = adapter.plan_user_page(None).unwrap();
+    let conflicting = br#"{
+        "users": [
+            {"id":"1001","primaryEmail":"admin@writer.com"},
+            {"id":"1001","primaryEmail":"other@writer.com"}
+        ]
+    }"#;
+    assert_eq!(
+        adapter.decode_user_response(&request, StatusCode::OK, conflicting, OBSERVED_AT),
+        Err(GoogleWorkspaceError::ConflictingUserIdentity)
+    );
+    assert_eq!(
+        adapter.decode_user_response(
+            &request,
+            StatusCode::OK,
+            br#"{"users":[{"primaryEmail":"fallback@writer.com"}]}"#,
+            OBSERVED_AT,
+        ),
+        Err(GoogleWorkspaceError::MissingRecordIdentity)
+    );
+    assert_eq!(
+        adapter.decode_user_response(
+            &request,
+            StatusCode::OK,
+            br#"{"users":[{"id":"1003","isAdmin":"true"}]}"#,
+            OBSERVED_AT,
+        ),
+        Err(GoogleWorkspaceError::InvalidRecord)
+    );
+    let defaults = adapter
+        .decode_user_response(
+            &request,
+            StatusCode::OK,
+            br#"{"users":[{"id":"1003"}]}"#,
+            OBSERVED_AT,
+        )
+        .unwrap();
+    for attribute in [
+        "is_admin",
+        "is_delegated_admin",
+        "mfa_enrolled",
+        "mfa_enforced",
+        "suspended",
+        "archived",
+    ] {
+        assert_eq!(
+            defaults.events[0]
+                .attributes
+                .get(attribute)
+                .map(String::as_str),
+            Some("false")
+        );
+    }
+    let oversized_cursor = serde_json::to_vec(&serde_json::json!({
+        "users": [],
+        "nextPageToken": "x".repeat((4 << 10) + 1)
+    }))
+    .unwrap();
+    assert_eq!(
+        adapter.decode_user_response(&request, StatusCode::OK, &oversized_cursor, OBSERVED_AT),
+        Err(GoogleWorkspaceError::InvalidCursor)
+    );
+}
+
+#[test]
+fn users_adapter_rejects_invalid_tenant_family_and_request_contracts() {
+    assert!(matches!(
+        GoogleWorkspaceKernel::new_user_adapter(
+            "https://admin.googleapis.com",
+            "Writer.COM",
+            None,
+            None,
+        ),
+        Err(GoogleWorkspaceError::InvalidTenantIdentity)
+    ));
+    assert!(matches!(
+        GoogleWorkspaceKernel::new_user_adapter(
+            "https://admin.googleapis.com",
+            "writer.com",
+            Some("customer\nother".to_owned()),
+            None,
+        ),
+        Err(GoogleWorkspaceError::InvalidCustomerId)
+    ));
+    assert!(matches!(
+        GoogleWorkspaceKernel::new_user_adapter(
+            "https://admin.googleapis.com",
+            "writer.com",
+            Some(String::new()),
+            None,
+        ),
+        Err(GoogleWorkspaceError::InvalidCustomerId)
+    ));
+    let group = GoogleWorkspaceKernel::new(
+        "https://admin.googleapis.com",
+        "writer.com",
+        GoogleWorkspaceFamily::Group,
+        GoogleWorkspaceFilters::default(),
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        group.plan_user_page(None),
+        Err(GoogleWorkspaceError::UserFamilyRequired)
+    );
+    let adapter = user_adapter("writer.com", 2);
+    let generic_request = adapter.plan(None).unwrap();
+    assert_eq!(
+        adapter.decode_user_response(
+            &generic_request,
+            StatusCode::OK,
+            br#"{"users":[]}"#,
+            OBSERVED_AT,
+        ),
+        Err(GoogleWorkspaceError::RequestScopeMismatch)
+    );
+}


### PR DESCRIPTION
## Scope

- Add a credential-free Google Workspace users request/response adapter in provider-local Rust modules.
- Plan deterministic Admin SDK requests with fixed-origin opaque pagination and externally owned Bearer credentials.
- Bound cursors, response bytes, and page records; emit tenant-scoped stable identities; deduplicate identical users and reject conflicts.
- Classify authentication, missing-scope, permission, rate-limit, provider-status, cursor, and response failures without provider-body or credential leakage.
- Add bounded provider fixtures plus Go semantic-parity, pagination, identity, dedupe, bounds, and redaction tests.

## Invariants

- Credentials, secret references, private routes, redirect policy, retries, deadlines, and deployment topology stay outside the public kernel.
- Query parameter order is deterministic: `customer`, `maxResults`, then optional `pageToken`.
- Pagination tokens remain opaque query values on the compiled Google origin.
- Canonical user identity is scoped by the configured tenant, never a provider-supplied tenant field.
- Empty pages preserve a valid continuation; terminal pages retain the last stable checkpoint.

## Validation

- `cargo fmt --all -- --check`: passed.
- Focused Google Workspace users adapter tests: 9 passed.
- `cargo test --locked -p cerebro-source-runtime-next`: 338 library tests and 4 worker tests passed; doc tests passed.
- Three-package all-targets/all-features Clippy with `-D warnings`: passed.
- Platform tests: 279 passed, 7 environment-dependent tests ignored; Rust-only runtime contract: 6 passed.
- Source catalog tests: 22 passed; doc tests passed.
- Go Google Workspace, source registry, and source projection packages passed.
- Shared event-admission largest-corpus tests reproduced fixed context-deadline failures on the saturated shared desk; no provider-local code participates in those timing bounds.

## Delivery boundary

This draft intentionally stops at the provider-local request/response contract. Shared runtime dispatch has no production caller for this adapter and remains externally owned. Live provider qualification also requires an authorized read-only Google Workspace identity and private host credential binding. No secret or environment route is added here.