### PR TITLE
feat(source-runtime): add credential-free Okta kernel

### DIFF
--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -26,6 +26,7 @@ mod google_workspace;
 mod grc;
 mod http;
 mod mapper;
+mod okta;
 mod panopticon;
 mod protocol;
 mod provider_failure;
@@ -119,6 +120,9 @@ pub use google_workspace::{
 pub use grc::{GrcError, GrcFamily, GrcKernel, GrcPage, GrcRecord, GrcRequest};
 pub use http::{HttpConnectorError, HttpProviderAccess, HttpSourceConnector, ResolvedAuth};
 pub use mapper::{CatalogGraphMapper, CatalogMapperError, IdentityResolutionSnapshot};
+pub use okta::{
+    OktaError, OktaFamily, OktaFilters, OktaKernel, OktaPage, OktaRecord, OktaRequest, OktaResponse,
+};
 pub use panopticon::{
     PanopticonError, PanopticonFamily, PanopticonKernel, PanopticonOutcome, PanopticonPage,
     PanopticonRecord, PanopticonRequest,

--- a/crates/source-runtime-next/src/okta.rs
+++ b/crates/source-runtime-next/src/okta.rs
@@ -1,0 +1,21 @@
+//! Credential-free Okta request planning and response normalization kernel.
+//!
+//! The trusted runtime host owns SSWS credential resolution and network I/O.
+//! This module accepts only a public Okta origin, tenant identity, bounded
+//! selectors, response bytes, and response metadata.
+
+mod cursor;
+mod error;
+mod family;
+mod normalize;
+mod origin;
+mod request;
+mod response;
+mod types;
+
+pub use error::OktaError;
+pub use family::OktaFamily;
+pub use types::{OktaFilters, OktaKernel, OktaPage, OktaRecord, OktaRequest, OktaResponse};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/okta/cursor.rs
+++ b/crates/source-runtime-next/src/okta/cursor.rs
@@ -1,0 +1,93 @@
+//! Go-compatible Okta continuation validation.
+
+use reqwest::Url;
+
+use super::{OktaError, OktaFamily, OktaRequest};
+
+const MAX_CURSOR_BYTES: usize = 4_096;
+
+pub(super) fn bounded_cursor(cursor: Option<&str>) -> Result<Option<String>, OktaError> {
+    let cursor = cursor.map(str::trim).filter(|value| !value.is_empty());
+    if cursor.is_some_and(|value| {
+        value.len() > MAX_CURSOR_BYTES
+            || value.chars().any(char::is_control)
+            || value.starts_with("http://")
+            || value.starts_with("https://")
+    }) {
+        return Err(OktaError::InvalidCursor);
+    }
+    Ok(cursor.map(str::to_owned))
+}
+
+pub(super) fn assignment_cursor(cursor: Option<&str>) -> Result<(&str, Option<String>), OktaError> {
+    let cursor = bounded_cursor(cursor)?;
+    let Some(cursor) = cursor.as_deref() else {
+        return Ok(("users", None));
+    };
+    if let Some((phase, value)) = cursor.split_once(':')
+        && matches!(phase.trim(), "users" | "groups")
+    {
+        return Ok((phase.trim(), bounded_cursor(Some(value))?));
+    }
+    Ok(("users", Some(cursor.to_owned())))
+}
+
+pub(super) fn next_cursor(
+    request: &OktaRequest,
+    base_origin: &str,
+    link_header: Option<&str>,
+) -> Result<Option<String>, OktaError> {
+    let Some(header) = link_header.map(str::trim).filter(|value| !value.is_empty()) else {
+        if request.family == OktaFamily::AppAssignment
+            && request.assignment_phase.as_deref() == Some("users")
+        {
+            return Ok(Some("groups:".to_owned()));
+        }
+        return Ok(None);
+    };
+    if header.len() > MAX_CURSOR_BYTES * 2 || header.chars().any(char::is_control) {
+        return Err(OktaError::InvalidCursor);
+    }
+    for part in header.split(',') {
+        let part = part.trim();
+        let Some(close) = part.find('>') else {
+            continue;
+        };
+        let Some(raw_url) = part.get(1..close).filter(|_| part.starts_with('<')) else {
+            continue;
+        };
+        if !part.get(close + 1..).is_some_and(|params| {
+            params.split(';').any(|param| {
+                let param = param.trim().replace('"', "");
+                param == "rel=next"
+            })
+        }) {
+            continue;
+        }
+        let url = Url::parse(raw_url)
+            .or_else(|_| request.url.join(raw_url))
+            .map_err(|_| OktaError::InvalidCursor)?;
+        if url.origin().unicode_serialization() != base_origin
+            || url.path() != request.url.path()
+            || url.fragment().is_some()
+        {
+            return Err(OktaError::InvalidCursor);
+        }
+        let after = url
+            .query_pairs()
+            .find_map(|(name, value)| (name == "after").then(|| value.into_owned()))
+            .ok_or(OktaError::InvalidCursor)?;
+        let after = bounded_cursor(Some(&after))?.ok_or(OktaError::InvalidCursor)?;
+        if request.family == OktaFamily::AppAssignment {
+            let phase = request.assignment_phase.as_deref().unwrap_or("users");
+            return Ok(Some(format!("{phase}:{after}")));
+        }
+        return Ok(Some(after));
+    }
+    if request.family == OktaFamily::AppAssignment
+        && request.assignment_phase.as_deref() == Some("users")
+    {
+        return Ok(Some("groups:".to_owned()));
+    }
+    Ok(None)
+}

--- a/crates/source-runtime-next/src/okta/cursor.rs
+++ b/crates/source-runtime-next/src/okta/cursor.rs
@@ -19,15 +19,22 @@ pub(super) fn bounded_cursor(cursor: Option<&str>) -> Result<Option<String>, Okt
     Ok(cursor.map(str::to_owned))
 }
 
-pub(super) fn assignment_cursor(cursor: Option<&str>) -> Result<(&str, Option<String>), OktaError> {
+pub(super) fn assignment_cursor(
+    cursor: Option<&str>,
+) -> Result<(&'static str, Option<String>), OktaError> {
     let cursor = bounded_cursor(cursor)?;
     let Some(cursor) = cursor.as_deref() else {
         return Ok(("users", None));
     };
-    if let Some((phase, value)) = cursor.split_once(':')
-        && matches!(phase.trim(), "users" | "groups")
-    {
-        return Ok((phase.trim(), bounded_cursor(Some(value))?));
+    if let Some((phase, value)) = cursor.split_once(':') {
+        let phase = match phase.trim() {
+            "users" => Some("users"),
+            "groups" => Some("groups"),
+            _ => None,
+        };
+        if let Some(phase) = phase {
+            return Ok((phase, bounded_cursor(Some(value))?));
+        }
     }
     Ok(("users", Some(cursor.to_owned())))
 }

--- a/crates/source-runtime-next/src/okta/error.rs
+++ b/crates/source-runtime-next/src/okta/error.rs
@@ -1,0 +1,97 @@
+//! Stable fail-closed Okta kernel errors.
+
+use std::{error::Error, fmt};
+
+/// Stable Okta request, response, and provider failure states.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OktaError {
+    /// The configured API base URL is not an allowed secure origin.
+    InvalidBaseUrl,
+    /// The selected family is not in the closed Okta family set.
+    InvalidFamily,
+    /// Source tenant identity is required.
+    MissingTenantId,
+    /// A family-specific parent selector is absent.
+    MissingScope(&'static str),
+    /// Page size is outside the Go source's inclusive 1 through 200 range.
+    InvalidPageSize,
+    /// A selector is not valid for the selected family.
+    InvalidConfiguration(&'static str),
+    /// Provider continuation is oversized, control-bearing, or malformed.
+    InvalidCursor,
+    /// A planned request does not belong to this kernel.
+    RequestScopeMismatch,
+    /// Provider rejected the credential.
+    AuthenticationRejected,
+    /// Provider credential lacks the required family scope.
+    PermissionDenied,
+    /// Provider asked the runtime to retry later.
+    RateLimited,
+    /// Provider or network is temporarily unavailable.
+    ProviderUnavailable,
+    /// Provider returned a status outside the family contract.
+    UnexpectedProviderStatus,
+    /// Provider response exceeds the four-mebibyte Go compatibility bound.
+    ResponseTooLarge,
+    /// Provider response exceeds the requested page cardinality.
+    TooManyRecords,
+    /// Response JSON does not match the selected provider family.
+    InvalidResponse,
+    /// A provider record has no stable identity.
+    MissingProviderIdentity,
+    /// Tenant or provider identity is not collision-safe.
+    InvalidEventIdentity,
+    /// One page contains different records with the same provider identity.
+    ConflictingProviderIdentity,
+    /// A required event contract field is absent.
+    EventContractRejected(&'static str),
+}
+
+impl fmt::Display for OktaError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidBaseUrl => formatter.write_str("okta base URL must be a secure origin"),
+            Self::InvalidFamily => formatter.write_str("okta family is not registered"),
+            Self::MissingTenantId => formatter.write_str("okta tenant_id is required"),
+            Self::MissingScope(name) => write!(formatter, "okta family requires {name}"),
+            Self::InvalidPageSize => formatter.write_str("okta per_page must be between 1 and 200"),
+            Self::InvalidConfiguration(name) => {
+                write!(formatter, "okta configuration is invalid for {name}")
+            }
+            Self::InvalidCursor => formatter.write_str("okta continuation cursor is invalid"),
+            Self::RequestScopeMismatch => {
+                formatter.write_str("okta request does not match the kernel")
+            }
+            Self::AuthenticationRejected => formatter.write_str("okta rejected the credential"),
+            Self::PermissionDenied => {
+                formatter.write_str("okta credential lacks the required scope")
+            }
+            Self::RateLimited => formatter.write_str("okta rate limit requires a bounded retry"),
+            Self::ProviderUnavailable => formatter.write_str("okta provider is unavailable"),
+            Self::UnexpectedProviderStatus => {
+                formatter.write_str("okta returned an unexpected status")
+            }
+            Self::ResponseTooLarge => formatter.write_str("okta response exceeds 4194304 bytes"),
+            Self::TooManyRecords => {
+                formatter.write_str("okta response exceeds the requested page size")
+            }
+            Self::InvalidResponse => {
+                formatter.write_str("okta response does not match the selected family")
+            }
+            Self::MissingProviderIdentity => {
+                formatter.write_str("okta record has no stable provider identity")
+            }
+            Self::InvalidEventIdentity => {
+                formatter.write_str("okta tenant or provider identity is not event-ID safe")
+            }
+            Self::ConflictingProviderIdentity => {
+                formatter.write_str("okta page contains conflicting provider identities")
+            }
+            Self::EventContractRejected(field) => {
+                write!(formatter, "okta event contract rejected {field}")
+            }
+        }
+    }
+}
+
+impl Error for OktaError {}

--- a/crates/source-runtime-next/src/okta/family.rs
+++ b/crates/source-runtime-next/src/okta/family.rs
@@ -1,0 +1,149 @@
+//! Closed Okta source-family catalog.
+
+use std::str::FromStr;
+
+use super::OktaError;
+
+/// Okta families preserved by the Go compatibility runtime.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum OktaFamily {
+    /// System Log audit events.
+    Audit,
+    /// User inventory.
+    User,
+    /// Group inventory.
+    Group,
+    /// Group membership inventory.
+    GroupMembership,
+    /// Application inventory.
+    Application,
+    /// User and group application assignments.
+    AppAssignment,
+    /// User administrator roles.
+    AdminRole,
+    /// Policy rules.
+    PolicyRule,
+    /// API token metadata.
+    ApiToken,
+    /// Authorization servers.
+    AuthorizationServer,
+    /// Authenticators.
+    Authenticator,
+    /// Brands.
+    Brand,
+    /// Device assurance policies.
+    DeviceAssurance,
+    /// Event hooks.
+    EventHook,
+    /// Identity providers.
+    IdentityProvider,
+    /// Inline hooks.
+    InlineHook,
+    /// Log streams.
+    LogStream,
+    /// Network zones.
+    NetworkZone,
+    /// ThreatInsight configuration.
+    ThreatInsight,
+    /// Trusted origins.
+    TrustedOrigin,
+}
+
+impl OktaFamily {
+    /// Every family in the public Okta runtime catalog.
+    pub const ALL: [Self; 20] = [
+        Self::Audit,
+        Self::AdminRole,
+        Self::AppAssignment,
+        Self::Application,
+        Self::ApiToken,
+        Self::AuthorizationServer,
+        Self::Authenticator,
+        Self::Brand,
+        Self::DeviceAssurance,
+        Self::EventHook,
+        Self::Group,
+        Self::GroupMembership,
+        Self::IdentityProvider,
+        Self::InlineHook,
+        Self::LogStream,
+        Self::NetworkZone,
+        Self::PolicyRule,
+        Self::ThreatInsight,
+        Self::TrustedOrigin,
+        Self::User,
+    ];
+
+    /// Return the exact runtime family identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Audit => "audit",
+            Self::User => "user",
+            Self::Group => "group",
+            Self::GroupMembership => "group_membership",
+            Self::Application => "application",
+            Self::AppAssignment => "app_assignment",
+            Self::AdminRole => "admin_role",
+            Self::PolicyRule => "policy_rule",
+            Self::ApiToken => "api_token",
+            Self::AuthorizationServer => "authorization_server",
+            Self::Authenticator => "authenticator",
+            Self::Brand => "brand",
+            Self::DeviceAssurance => "device_assurance",
+            Self::EventHook => "event_hook",
+            Self::IdentityProvider => "identity_provider",
+            Self::InlineHook => "inline_hook",
+            Self::LogStream => "log_stream",
+            Self::NetworkZone => "network_zone",
+            Self::ThreatInsight => "threat_insight",
+            Self::TrustedOrigin => "trusted_origin",
+        }
+    }
+
+    /// Return the exact event kind emitted by Go.
+    pub fn provider_kind(self) -> String {
+        format!("okta.{}", self.as_str())
+    }
+
+    /// Return the exact event schema reference emitted by Go.
+    pub fn schema_ref(self) -> String {
+        format!("okta/{}/v1", self.as_str())
+    }
+
+    pub(super) const fn endpoint(self) -> &'static str {
+        match self {
+            Self::Audit => "/api/v1/logs",
+            Self::User => "/api/v1/users",
+            Self::Group => "/api/v1/groups",
+            Self::Application => "/api/v1/apps",
+            Self::ApiToken => "/api/v1/api-tokens",
+            Self::AuthorizationServer => "/api/v1/authorizationServers",
+            Self::Authenticator => "/api/v1/authenticators",
+            Self::Brand => "/api/v1/brands",
+            Self::DeviceAssurance => "/api/v1/device-assurances",
+            Self::EventHook => "/api/v1/eventHooks",
+            Self::IdentityProvider => "/api/v1/idps",
+            Self::InlineHook => "/api/v1/inlineHooks",
+            Self::LogStream => "/api/v1/logStreams",
+            Self::NetworkZone => "/api/v1/zones",
+            Self::ThreatInsight => "/api/v1/threats/configuration",
+            Self::TrustedOrigin => "/api/v1/trustedOrigins",
+            Self::GroupMembership | Self::AppAssignment | Self::AdminRole | Self::PolicyRule => "",
+        }
+    }
+
+    pub(super) const fn singleton(self) -> bool {
+        matches!(self, Self::ThreatInsight)
+    }
+}
+
+impl FromStr for OktaFamily {
+    type Err = OktaError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|family| family.as_str() == value.trim())
+            .ok_or(OktaError::InvalidFamily)
+    }
+}

--- a/crates/source-runtime-next/src/okta/normalize.rs
+++ b/crates/source-runtime-next/src/okta/normalize.rs
@@ -1,0 +1,682 @@
+//! Go-compatible Okta record normalization helpers.
+
+use std::collections::BTreeMap;
+
+use reqwest::Url;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, UtcOffset, format_description::well_known::Rfc3339};
+
+use super::{OktaError, OktaFamily, OktaKernel, OktaRecord, OktaRequest};
+
+pub(super) fn normalize_record(
+    kernel: &OktaKernel,
+    request: &OktaRequest,
+    mut payload: Value,
+    observed_at: OffsetDateTime,
+) -> Result<OktaRecord, OktaError> {
+    let object = payload.as_object().ok_or(OktaError::InvalidResponse)?;
+    if object.contains_key("tenant_id") {
+        return Err(OktaError::InvalidResponse);
+    }
+    let provider_id = provider_id(kernel.family, object, &kernel.tenant_id)?;
+    require_identity_component(&provider_id)?;
+    let occurred_at = occurred_at(kernel.family, object, observed_at)?;
+    let fields = normalized_fields(kernel, request, object, &provider_id)?;
+    if fields
+        .get("family")
+        .is_none_or(|value| value != kernel.family.as_str())
+    {
+        return Err(OktaError::EventContractRejected("attributes.family"));
+    }
+    scrub_sensitive_values(&mut payload);
+    let event_id = event_id(&kernel.tenant_id, kernel.family, &provider_id, &occurred_at);
+    Ok(OktaRecord {
+        family: kernel.family.as_str().to_owned(),
+        provider_kind: kernel.family.provider_kind(),
+        schema_ref: kernel.family.schema_ref(),
+        tenant_id: kernel.tenant_id.clone(),
+        provider_id,
+        event_id,
+        fields,
+        occurred_at,
+        payload,
+    })
+}
+
+pub(super) fn require_identity_component(value: &str) -> Result<(), OktaError> {
+    let value = value.trim();
+    if value.is_empty()
+        || value.len() > 512
+        || value
+            .chars()
+            .any(|character| character.is_control() || matches!(character, '/' | '\\' | '?' | '#'))
+    {
+        return Err(OktaError::InvalidEventIdentity);
+    }
+    Ok(())
+}
+
+fn provider_id(
+    family: OktaFamily,
+    object: &serde_json::Map<String, Value>,
+    tenant_id: &str,
+) -> Result<String, OktaError> {
+    let value = match family {
+        OktaFamily::Audit => text(object.get("uuid")),
+        OktaFamily::ThreatInsight => first([text(object.get("id")), tenant_id.to_owned()]),
+        _ => text(object.get("id")),
+    };
+    if value.is_empty() {
+        return Err(OktaError::MissingProviderIdentity);
+    }
+    Ok(value)
+}
+
+fn normalized_fields(
+    kernel: &OktaKernel,
+    request: &OktaRequest,
+    object: &serde_json::Map<String, Value>,
+    provider_id: &str,
+) -> Result<BTreeMap<String, String>, OktaError> {
+    let mut fields = BTreeMap::from([
+        ("domain".to_owned(), kernel.tenant_id.clone()),
+        ("family".to_owned(), kernel.family.as_str().to_owned()),
+    ]);
+    match kernel.family {
+        OktaFamily::Audit => audit_fields(&mut fields, object, &kernel.tenant_id),
+        OktaFamily::User => user_fields(&mut fields, object, provider_id),
+        OktaFamily::Group => group_fields(&mut fields, object, provider_id),
+        OktaFamily::GroupMembership => {
+            let group_id = required_filter(&kernel.filters.group_id, "group_id")?;
+            user_fields(&mut fields, object, provider_id);
+            insert(&mut fields, "group_id", group_id);
+            insert(&mut fields, "member_id", provider_id);
+            insert(&mut fields, "member_user_id", provider_id);
+            insert(&mut fields, "member_type", "user");
+            if let Some(profile) = nested(object, "profile") {
+                insert(
+                    &mut fields,
+                    "member_email",
+                    first([path_text(profile, "email"), path_text(profile, "login")]),
+                );
+                insert(&mut fields, "member_name", display_name(profile));
+                insert(&mut fields, "member_status", text(object.get("status")));
+            }
+        }
+        OktaFamily::Application => application_fields(&mut fields, object, provider_id),
+        OktaFamily::AppAssignment => {
+            assignment_fields(kernel, request, &mut fields, object, provider_id)?
+        }
+        OktaFamily::AdminRole => admin_role_fields(kernel, &mut fields, object, provider_id)?,
+        OktaFamily::PolicyRule => policy_rule_fields(kernel, &mut fields, object, provider_id)?,
+        family => asset_fields(family, &mut fields, object, provider_id),
+    }
+    Ok(fields)
+}
+
+fn audit_fields(
+    fields: &mut BTreeMap<String, String>,
+    object: &serde_json::Map<String, Value>,
+    tenant_id: &str,
+) {
+    let event_type = text(object.get("eventType"));
+    insert(fields, "event_type", event_type.clone());
+    insert(fields, "severity", text(object.get("severity")));
+    if let Some(actor) = nested(object, "actor") {
+        insert(fields, "actor_id", path_text(actor, "id"));
+        insert(fields, "actor_type", path_text(actor, "type"));
+        insert(fields, "actor_email", path_text(actor, "alternateId"));
+        insert(
+            fields,
+            "actor_display_name",
+            path_text(actor, "displayName"),
+        );
+    }
+    let target = object
+        .get("target")
+        .and_then(Value::as_array)
+        .and_then(|targets| targets.first())
+        .and_then(Value::as_object);
+    let actor = nested(object, "actor");
+    let resource_id = target
+        .map(|value| {
+            first([
+                path_text(value, "id"),
+                path_text(value, "alternateId"),
+                path_text(value, "displayName"),
+            ])
+        })
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            actor.map(|value| first([path_text(value, "alternateId"), path_text(value, "id")]))
+        })
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| tenant_id.to_owned());
+    let resource_type = target
+        .map(|value| path_text(value, "type"))
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| event_type.split('.').next().unwrap_or("audit").to_owned());
+    insert(fields, "resource_id", resource_id);
+    insert(fields, "resource_type", resource_type);
+}
+
+fn user_fields(
+    fields: &mut BTreeMap<String, String>,
+    object: &serde_json::Map<String, Value>,
+    provider_id: &str,
+) {
+    insert(fields, "user_id", provider_id);
+    insert(fields, "status", text(object.get("status")));
+    insert(fields, "realm_id", text(object.get("realmId")));
+    if let Some(profile) = nested(object, "profile") {
+        for (target, source) in [
+            ("email", "email"),
+            ("login", "login"),
+            ("department", "department"),
+            ("job_title", "title"),
+            ("title", "title"),
+            ("organization", "organization"),
+            ("manager", "manager"),
+            ("manager_id", "managerId"),
+            ("employee_number", "employeeNumber"),
+            ("user_type", "userType"),
+        ] {
+            insert(fields, target, path_text(profile, source));
+        }
+    }
+    if let Some(kind) = nested(object, "type") {
+        insert(fields, "type_id", path_text(kind, "id"));
+        insert(fields, "type_name", path_text(kind, "name"));
+    }
+    if let Some(factors) = object.get("factors").and_then(Value::as_array) {
+        let mut kinds: Vec<_> = factors
+            .iter()
+            .filter(|factor| factor.get("status").and_then(Value::as_str) == Some("ACTIVE"))
+            .filter_map(|factor| factor.get("factorType").and_then(Value::as_str))
+            .map(str::to_owned)
+            .collect();
+        kinds.sort();
+        kinds.dedup();
+        insert(fields, "mfa_enrolled", (!kinds.is_empty()).to_string());
+        insert(fields, "mfa_factor_count", kinds.len().to_string());
+        insert(fields, "mfa_factor_types", kinds.join(","));
+        let resistant = kinds
+            .iter()
+            .any(|kind| matches!(kind.as_str(), "signed_nonce" | "u2f" | "webauthn"));
+        insert(fields, "mfa_phishing_resistant", resistant.to_string());
+    }
+}
+
+fn group_fields(
+    fields: &mut BTreeMap<String, String>,
+    object: &serde_json::Map<String, Value>,
+    provider_id: &str,
+) {
+    insert(fields, "group_id", provider_id);
+    insert(fields, "type", text(object.get("type")));
+    if let Some(profile) = nested(object, "profile") {
+        let name = path_text(profile, "name");
+        insert(fields, "group_name", name.clone());
+        insert(fields, "name", name);
+        insert(fields, "description", path_text(profile, "description"));
+        insert(
+            fields,
+            "group_email",
+            first([path_text(profile, "email"), path_text(profile, "login")]),
+        );
+    }
+}
+
+fn application_fields(
+    fields: &mut BTreeMap<String, String>,
+    object: &serde_json::Map<String, Value>,
+    provider_id: &str,
+) {
+    insert(fields, "app_id", provider_id);
+    insert(fields, "app_label", text(object.get("label")));
+    insert(
+        fields,
+        "app_name",
+        first([text(object.get("label")), text(object.get("name"))]),
+    );
+    insert(fields, "name", text(object.get("name")));
+    insert(fields, "status", text(object.get("status")));
+    let sign_on_mode = text(object.get("signOnMode"));
+    insert(fields, "sign_on_mode", sign_on_mode.clone());
+    let oauth = nested(object, "settings").and_then(|value| nested(value, "oauthClient"));
+    let credentials = nested(object, "credentials").and_then(|value| nested(value, "oauthClient"));
+    let application_type = oauth
+        .map(|value| path_text(value, "application_type"))
+        .unwrap_or_default();
+    let auth_method = credentials
+        .map(|value| path_text(value, "token_endpoint_auth_method"))
+        .unwrap_or_default();
+    let grants = oauth
+        .map(|value| string_list(value.get("grant_types")))
+        .unwrap_or_default();
+    let responses = oauth
+        .map(|value| string_list(value.get("response_types")))
+        .unwrap_or_default();
+    insert(fields, "application_type", application_type.clone());
+    insert(fields, "token_endpoint_auth_method", auth_method.clone());
+    insert(
+        fields,
+        "client_id",
+        credentials
+            .map(|value| path_text(value, "client_id"))
+            .unwrap_or_default(),
+    );
+    insert(fields, "grant_types", grants.join(","));
+    insert(fields, "response_types", responses.join(","));
+    let public = matches!(
+        application_type.to_ascii_lowercase().as_str(),
+        "browser" | "native" | "spa"
+    ) || auth_method.eq_ignore_ascii_case("none");
+    insert(fields, "oauth_public_client", public.to_string());
+    let mode = format!("{} {}", text(object.get("name")), sign_on_mode).to_ascii_lowercase();
+    insert(
+        fields,
+        "oauth2",
+        (mode.contains("oidc")
+            || mode.contains("oauth")
+            || !grants.is_empty()
+            || !responses.is_empty()
+            || !application_type.is_empty())
+        .to_string(),
+    );
+    insert(fields, "saml", mode.contains("saml").to_string());
+}
+
+fn assignment_fields(
+    kernel: &OktaKernel,
+    request: &OktaRequest,
+    fields: &mut BTreeMap<String, String>,
+    object: &serde_json::Map<String, Value>,
+    provider_id: &str,
+) -> Result<(), OktaError> {
+    let app_id = required_filter(&kernel.filters.app_id, "app_id")?;
+    let subject_type = request
+        .assignment_phase
+        .as_deref()
+        .unwrap_or("users")
+        .trim_end_matches('s');
+    insert(fields, "app_id", app_id);
+    for name in ["assignee_id", "subject_id"] {
+        insert(fields, name, provider_id);
+    }
+    for name in ["assignee_type", "principal_type", "subject_type"] {
+        insert(fields, name, subject_type);
+    }
+    insert(fields, "status", text(object.get("status")));
+    insert(fields, "scope", text(object.get("scope")));
+    if let Some(profile) = nested(object, "profile") {
+        let email = first([
+            path_text(profile, "email"),
+            path_text(profile, "login"),
+            path_text(profile, "userName"),
+        ]);
+        insert(fields, "subject_email", email.clone());
+        insert(fields, "email", email.clone());
+        insert(
+            fields,
+            "subject_name",
+            first([
+                path_text(profile, "displayName"),
+                path_text(profile, "name"),
+                email,
+                provider_id.to_owned(),
+            ]),
+        );
+    }
+    if subject_type == "group" {
+        insert(fields, "group_id", provider_id);
+    }
+    Ok(())
+}
+
+fn admin_role_fields(
+    kernel: &OktaKernel,
+    fields: &mut BTreeMap<String, String>,
+    object: &serde_json::Map<String, Value>,
+    provider_id: &str,
+) -> Result<(), OktaError> {
+    let user_id = required_filter(&kernel.filters.user_id, "user_id")?;
+    insert(fields, "role_id", provider_id);
+    insert(
+        fields,
+        "role_name",
+        first([
+            text(object.get("label")),
+            text(object.get("type")),
+            provider_id.to_owned(),
+        ]),
+    );
+    insert(fields, "role_type", text(object.get("type")));
+    insert(fields, "subject_id", user_id);
+    insert(fields, "subject_type", "user");
+    insert(fields, "event_type", "admin.role.assignment");
+    insert(fields, "action", "admin.role.assignment");
+    insert(fields, "is_admin", "true");
+    insert(fields, "actor_privileged", "true");
+    insert(fields, "assigned_to", user_id);
+    insert(fields, "status", text(object.get("status")));
+    insert(
+        fields,
+        "assignment_type",
+        text(object.get("assignmentType")),
+    );
+    if let Some(email) = kernel.filters.user_email.as_deref() {
+        insert(fields, "subject_email", email);
+    }
+    Ok(())
+}
+
+fn policy_rule_fields(
+    kernel: &OktaKernel,
+    fields: &mut BTreeMap<String, String>,
+    object: &serde_json::Map<String, Value>,
+    provider_id: &str,
+) -> Result<(), OktaError> {
+    let policy_id = required_filter(&kernel.filters.policy_id, "policy_id")?;
+    insert(fields, "policy_id", policy_id);
+    insert(fields, "policy_rule_id", provider_id);
+    insert(fields, "resource_id", provider_id);
+    insert(fields, "resource_type", "PolicyRule");
+    insert(fields, "name", text(object.get("name")));
+    insert(fields, "status", text(object.get("status")));
+    insert(fields, "policy_rule_status", text(object.get("status")));
+    insert(fields, "priority", text(object.get("priority")));
+    insert(fields, "system", text(object.get("system")));
+    if let Some(signon) = nested(object, "actions").and_then(|value| nested(value, "signon")) {
+        insert(
+            fields,
+            "access",
+            path_text(signon, "access").to_ascii_uppercase(),
+        );
+        insert(fields, "requires_mfa", text(signon.get("requireFactor")));
+        if let Some(session) = nested(signon, "session") {
+            insert(
+                fields,
+                "session_idle_minutes",
+                text(session.get("maxSessionIdleMinutes")),
+            );
+            insert(
+                fields,
+                "session_persistent",
+                text(session.get("usePersistentCookie")),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn asset_fields(
+    family: OktaFamily,
+    fields: &mut BTreeMap<String, String>,
+    object: &serde_json::Map<String, Value>,
+    provider_id: &str,
+) {
+    insert(fields, "resource_id", provider_id);
+    insert(fields, "resource_type", title_family(family.as_str()));
+    let id_name = format!("{}_id", family.as_str());
+    insert(fields, &id_name, provider_id);
+    for key in [
+        "name",
+        "status",
+        "type",
+        "key",
+        "origin",
+        "usage",
+        "system",
+        "createdBy",
+        "lastUpdatedBy",
+    ] {
+        insert(fields, snake_case(key), text(object.get(key)));
+    }
+    if family == OktaFamily::NetworkZone {
+        insert(fields, "zone_id", provider_id);
+        insert(fields, "zone_type", text(object.get("type")));
+    }
+    if family == OktaFamily::TrustedOrigin {
+        if let Some(origin) = object.get("origin").and_then(Value::as_str) {
+            insert(
+                fields,
+                "origin_host",
+                Url::parse(origin)
+                    .ok()
+                    .and_then(|url| url.host_str().map(str::to_owned))
+                    .unwrap_or_default(),
+            );
+            insert(fields, "wildcard_origin", origin.contains('*').to_string());
+        }
+        let scopes = object
+            .get("scopes")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let mut types: Vec<_> = scopes
+            .iter()
+            .filter_map(|value| value.get("type").and_then(Value::as_str))
+            .map(str::to_owned)
+            .collect();
+        types.sort();
+        insert(fields, "scope_count", types.len().to_string());
+        insert(fields, "scope_types", types.join(","));
+        insert(
+            fields,
+            "cors",
+            types.iter().any(|value| value == "CORS").to_string(),
+        );
+        insert(
+            fields,
+            "redirect",
+            types.iter().any(|value| value == "REDIRECT").to_string(),
+        );
+    }
+    for (container, uri_key, field_name) in [
+        ("channel", "uri", "uri_host"),
+        ("settings", "issuer", "issuer_host"),
+    ] {
+        if let Some(uri) = nested(object, container)
+            .map(|value| path_text(value, uri_key))
+            .filter(|value| !value.is_empty())
+        {
+            insert(
+                fields,
+                field_name,
+                Url::parse(&uri)
+                    .ok()
+                    .and_then(|url| url.host_str().map(str::to_owned))
+                    .unwrap_or_default(),
+            );
+        }
+    }
+}
+
+fn occurred_at(
+    family: OktaFamily,
+    object: &serde_json::Map<String, Value>,
+    observed_at: OffsetDateTime,
+) -> Result<String, OktaError> {
+    let keys: &[&str] = if family == OktaFamily::Audit {
+        &["published"]
+    } else {
+        &[
+            "lastUpdated",
+            "created",
+            "statusChanged",
+            "lastLogin",
+            "passwordChanged",
+        ]
+    };
+    for key in keys {
+        let raw = text(object.get(*key));
+        if raw.is_empty() {
+            continue;
+        }
+        let parsed =
+            OffsetDateTime::parse(&raw, &Rfc3339).map_err(|_| OktaError::InvalidResponse)?;
+        if parsed.unix_timestamp_nanos() <= 0 {
+            return Err(OktaError::InvalidResponse);
+        }
+        return parsed
+            .to_offset(UtcOffset::UTC)
+            .format(&Rfc3339)
+            .map_err(|_| OktaError::InvalidResponse);
+    }
+    if family == OktaFamily::Audit || observed_at.unix_timestamp_nanos() <= 0 {
+        return Err(OktaError::InvalidResponse);
+    }
+    observed_at
+        .to_offset(UtcOffset::UTC)
+        .format(&Rfc3339)
+        .map_err(|_| OktaError::InvalidResponse)
+}
+
+fn event_id(tenant_id: &str, family: OktaFamily, provider_id: &str, occurred_at: &str) -> String {
+    let digest = Sha256::digest(
+        format!(
+            "cerebro.okta.event.v1\0{tenant_id}\0{}\0{provider_id}\0{occurred_at}",
+            family.as_str()
+        )
+        .as_bytes(),
+    );
+    let encoded = digest
+        .iter()
+        .fold(String::with_capacity(64), |mut output, byte| {
+            use std::fmt::Write as _;
+            write!(&mut output, "{byte:02x}").expect("writing to String cannot fail");
+            output
+        });
+    format!("okta-{}-{encoded}", family.as_str().replace('_', "-"))
+}
+
+fn scrub_sensitive_values(value: &mut Value) {
+    match value {
+        Value::Array(values) => values.iter_mut().for_each(scrub_sensitive_values),
+        Value::Object(values) => {
+            values.retain(|key, _| {
+                !matches!(
+                    key.to_ascii_lowercase().as_str(),
+                    "token"
+                        | "apitoken"
+                        | "api_token"
+                        | "access_token"
+                        | "refreshtoken"
+                        | "refresh_token"
+                        | "sessiontoken"
+                        | "session_token"
+                        | "clientsecret"
+                        | "client_secret"
+                        | "privatekey"
+                        | "private_key"
+                        | "password"
+                        | "passcode"
+                        | "authorization"
+                        | "cookie"
+                )
+            });
+            values.values_mut().for_each(scrub_sensitive_values);
+        }
+        _ => {}
+    }
+}
+
+fn required_filter<'a>(
+    value: &'a Option<String>,
+    name: &'static str,
+) -> Result<&'a str, OktaError> {
+    value
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or(OktaError::MissingScope(name))
+}
+
+fn nested<'a>(
+    object: &'a serde_json::Map<String, Value>,
+    key: &str,
+) -> Option<&'a serde_json::Map<String, Value>> {
+    object.get(key).and_then(Value::as_object)
+}
+
+fn path_text(object: &serde_json::Map<String, Value>, key: &str) -> String {
+    text(object.get(key))
+}
+
+fn text(value: Option<&Value>) -> String {
+    match value {
+        Some(Value::String(value)) => value.trim().to_owned(),
+        Some(Value::Number(value)) => value.to_string(),
+        Some(Value::Bool(value)) => value.to_string(),
+        _ => String::new(),
+    }
+}
+
+fn first<const N: usize>(values: [String; N]) -> String {
+    values
+        .into_iter()
+        .find(|value| !value.trim().is_empty())
+        .unwrap_or_default()
+}
+
+fn insert(fields: &mut BTreeMap<String, String>, name: impl AsRef<str>, value: impl AsRef<str>) {
+    let value = value.as_ref().trim();
+    if !value.is_empty() {
+        fields.insert(name.as_ref().to_owned(), value.to_owned());
+    }
+}
+
+fn display_name(profile: &serde_json::Map<String, Value>) -> String {
+    first([
+        path_text(profile, "displayName"),
+        format!(
+            "{} {}",
+            path_text(profile, "firstName"),
+            path_text(profile, "lastName")
+        )
+        .trim()
+        .to_owned(),
+        path_text(profile, "login"),
+    ])
+}
+
+fn string_list(value: Option<&Value>) -> Vec<String> {
+    let mut values: Vec<_> = value
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect();
+    values.sort();
+    values
+}
+
+fn snake_case(value: &str) -> String {
+    value.chars().fold(String::new(), |mut output, character| {
+        if character.is_ascii_uppercase() {
+            output.push('_');
+            output.push(character.to_ascii_lowercase());
+        } else {
+            output.push(character);
+        }
+        output
+    })
+}
+
+fn title_family(value: &str) -> String {
+    value
+        .split('_')
+        .map(|part| {
+            let mut chars = part.chars();
+            chars
+                .next()
+                .map(|first| first.to_ascii_uppercase().to_string() + chars.as_str())
+                .unwrap_or_default()
+        })
+        .collect::<String>()
+}

--- a/crates/source-runtime-next/src/okta/origin.rs
+++ b/crates/source-runtime-next/src/okta/origin.rs
@@ -1,0 +1,56 @@
+//! Secure Okta origin validation.
+
+use std::{net::IpAddr, str::FromStr};
+
+use reqwest::Url;
+
+use super::OktaError;
+
+pub(super) fn validate_origin(raw: &str) -> Result<Url, OktaError> {
+    let mut url = Url::parse(raw.trim()).map_err(|_| OktaError::InvalidBaseUrl)?;
+    let host = url.host_str().ok_or(OktaError::InvalidBaseUrl)?;
+    if url.scheme() != "https" {
+        return Err(OktaError::InvalidBaseUrl);
+    }
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || !matches!(url.path(), "" | "/")
+    {
+        return Err(OktaError::InvalidBaseUrl);
+    }
+    if host == "localhost" || IpAddr::from_str(host).is_ok_and(unsafe_ip_literal) {
+        return Err(OktaError::InvalidBaseUrl);
+    }
+    if url.port().is_some_and(|port| port != 443) {
+        return Err(OktaError::InvalidBaseUrl);
+    }
+    url.set_path("/");
+    Ok(url)
+}
+
+pub(super) fn origin_string(url: &Url) -> String {
+    url.origin().unicode_serialization()
+}
+
+fn unsafe_ip_literal(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => {
+            address.is_loopback()
+                || address.is_private()
+                || address.is_link_local()
+                || address.is_broadcast()
+                || address.is_documentation()
+                || address.is_unspecified()
+                || address.is_multicast()
+        }
+        IpAddr::V6(address) => {
+            address.is_loopback()
+                || address.is_unique_local()
+                || address.is_unicast_link_local()
+                || address.is_unspecified()
+                || address.is_multicast()
+        }
+    }
+}

--- a/crates/source-runtime-next/src/okta/request.rs
+++ b/crates/source-runtime-next/src/okta/request.rs
@@ -1,7 +1,5 @@
 //! Credential-free Okta request planning and scope validation.
 
-use reqwest::Url;
-
 use super::{
     OktaError, OktaFamily, OktaFilters, OktaKernel, OktaRequest,
     cursor::{assignment_cursor, bounded_cursor},

--- a/crates/source-runtime-next/src/okta/request.rs
+++ b/crates/source-runtime-next/src/okta/request.rs
@@ -197,7 +197,7 @@ fn validate_filters(family: OktaFamily, filters: &OktaFilters) -> Result<(), Okt
         _ => None,
     };
     if let Some((value, name)) = required {
-        let value = value.as_deref().ok_or(OktaError::MissingScope(name))?;
+        let value = value.ok_or(OktaError::MissingScope(name))?;
         require_identity_component(value).map_err(|_| OktaError::MissingScope(name))?;
     }
     if family == OktaFamily::Audit {

--- a/crates/source-runtime-next/src/okta/request.rs
+++ b/crates/source-runtime-next/src/okta/request.rs
@@ -1,0 +1,261 @@
+//! Credential-free Okta request planning and scope validation.
+
+use reqwest::Url;
+
+use super::{
+    OktaError, OktaFamily, OktaFilters, OktaKernel, OktaRequest,
+    cursor::{assignment_cursor, bounded_cursor},
+    normalize::require_identity_component,
+    origin::{origin_string, validate_origin},
+};
+
+const DEFAULT_PAGE_SIZE: usize = 10;
+const MAX_PAGE_SIZE: usize = 200;
+
+impl OktaKernel {
+    /// Build a kernel for one tenant, Okta origin, and closed family.
+    pub fn new(
+        base_url: &str,
+        tenant_id: &str,
+        family: OktaFamily,
+        filters: OktaFilters,
+        page_size: Option<usize>,
+    ) -> Result<Self, OktaError> {
+        let base_url = validate_origin(base_url)?;
+        let tenant_id = tenant_id.trim();
+        if tenant_id.is_empty() {
+            return Err(OktaError::MissingTenantId);
+        }
+        require_identity_component(tenant_id)?;
+        let page_size = page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+        if !(1..=MAX_PAGE_SIZE).contains(&page_size) {
+            return Err(OktaError::InvalidPageSize);
+        }
+        validate_filters(family, &filters)?;
+        Ok(Self {
+            base_origin: origin_string(&base_url),
+            base_url,
+            tenant_id: tenant_id.to_owned(),
+            family,
+            filters,
+            page_size,
+        })
+    }
+
+    /// This kernel never accepts or stores credential material.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+
+    /// Plan one bounded, origin-restricted provider page.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<OktaRequest, OktaError> {
+        let (path, assignment_phase, cursor) = self.request_path(cursor)?;
+        let mut url = self.base_url.clone();
+        url.set_path(&path);
+        if !self.family.singleton() {
+            let mut query = url.query_pairs_mut();
+            query.append_pair("limit", &self.page_size.to_string());
+            if let Some(cursor) = cursor.as_deref() {
+                query.append_pair("after", cursor);
+            }
+            for (name, value) in self.query_filters() {
+                query.append_pair(name, &value);
+            }
+        }
+        Ok(OktaRequest {
+            url,
+            family: self.family,
+            assignment_phase,
+        })
+    }
+
+    pub(super) fn validate_request(&self, request: &OktaRequest) -> Result<(), OktaError> {
+        if request.family != self.family
+            || request.url.origin() != self.base_url.origin()
+            || request.url.fragment().is_some()
+        {
+            return Err(OktaError::RequestScopeMismatch);
+        }
+        let expected = self.request_path_from_phase(request.assignment_phase.as_deref())?;
+        if request.url.path() != expected {
+            return Err(OktaError::RequestScopeMismatch);
+        }
+        Ok(())
+    }
+
+    fn request_path(
+        &self,
+        cursor: Option<&str>,
+    ) -> Result<(String, Option<String>, Option<String>), OktaError> {
+        if self.family == OktaFamily::AppAssignment {
+            let (phase, cursor) = assignment_cursor(cursor)?;
+            return Ok((
+                self.request_path_from_phase(Some(phase))?,
+                Some(phase.to_owned()),
+                cursor,
+            ));
+        }
+        let cursor = bounded_cursor(cursor)?;
+        Ok((self.request_path_from_phase(None)?, None, cursor))
+    }
+
+    fn request_path_from_phase(&self, phase: Option<&str>) -> Result<String, OktaError> {
+        match self.family {
+            OktaFamily::GroupMembership => Ok(scoped_path(
+                "/api/v1/groups/",
+                required(&self.filters.group_id, "group_id")?,
+                "/users",
+            )),
+            OktaFamily::AppAssignment => Ok(scoped_path(
+                "/api/v1/apps/",
+                required(&self.filters.app_id, "app_id")?,
+                if phase == Some("groups") {
+                    "/groups"
+                } else {
+                    "/users"
+                },
+            )),
+            OktaFamily::AdminRole => Ok(scoped_path(
+                "/api/v1/users/",
+                required(&self.filters.user_id, "user_id")?,
+                "/roles",
+            )),
+            OktaFamily::PolicyRule => Ok(scoped_path(
+                "/api/v1/policies/",
+                required(&self.filters.policy_id, "policy_id")?,
+                "/rules",
+            )),
+            family => Ok(family.endpoint().to_owned()),
+        }
+    }
+
+    fn query_filters(&self) -> Vec<(&'static str, String)> {
+        let mut values: Vec<(&'static str, String)> = Vec::new();
+        let mut push = |name: &'static str, value: &Option<String>| {
+            if let Some(value) = value
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                values.push((name, value.to_owned()));
+            }
+        };
+        match self.family {
+            OktaFamily::Audit => {
+                push("filter", &self.filters.filter);
+                push("q", &self.filters.q);
+                push("since", &self.filters.since);
+                push("until", &self.filters.until);
+                values.push((
+                    "sortOrder",
+                    normalized_audit_sort(self.filters.sort_order.as_deref())
+                        .expect("filters validated before request planning")
+                        .to_owned(),
+                ));
+            }
+            OktaFamily::User => {
+                push("filter", &self.filters.filter);
+                push("q", &self.filters.q);
+                push("search", &self.filters.search);
+                push("sortBy", &self.filters.sort_by);
+                values.push((
+                    "sortOrder",
+                    normalized_user_sort(self.filters.sort_order.as_deref())
+                        .expect("filters validated before request planning")
+                        .to_owned(),
+                ));
+            }
+            OktaFamily::Group => {
+                push("q", &self.filters.q);
+                push("search", &self.filters.search);
+                push("sortBy", &self.filters.sort_by);
+                push("sortOrder", &self.filters.sort_order);
+            }
+            OktaFamily::Application => {
+                push("filter", &self.filters.filter);
+                push("q", &self.filters.q);
+            }
+            OktaFamily::AuthorizationServer
+            | OktaFamily::Brand
+            | OktaFamily::IdentityProvider
+            | OktaFamily::LogStream
+            | OktaFamily::NetworkZone
+            | OktaFamily::TrustedOrigin => {
+                push("filter", &self.filters.filter);
+                push("q", &self.filters.q);
+            }
+            _ => {}
+        }
+        values
+    }
+}
+
+fn validate_filters(family: OktaFamily, filters: &OktaFilters) -> Result<(), OktaError> {
+    let required = match family {
+        OktaFamily::GroupMembership => Some((filters.group_id.as_ref(), "group_id")),
+        OktaFamily::AppAssignment => Some((filters.app_id.as_ref(), "app_id")),
+        OktaFamily::AdminRole => Some((filters.user_id.as_ref(), "user_id")),
+        OktaFamily::PolicyRule => Some((filters.policy_id.as_ref(), "policy_id")),
+        _ => None,
+    };
+    if let Some((value, name)) = required {
+        let value = value.as_deref().ok_or(OktaError::MissingScope(name))?;
+        require_identity_component(value).map_err(|_| OktaError::MissingScope(name))?;
+    }
+    if family == OktaFamily::Audit {
+        if present(&filters.search) || present(&filters.sort_by) {
+            return Err(OktaError::InvalidConfiguration("audit selectors"));
+        }
+        normalized_audit_sort(filters.sort_order.as_deref())?;
+    } else if present(&filters.since) || present(&filters.until) {
+        return Err(OktaError::InvalidConfiguration("since/until"));
+    }
+    if family == OktaFamily::User {
+        normalized_user_sort(filters.sort_order.as_deref())?;
+    }
+    Ok(())
+}
+
+fn normalized_audit_sort(value: Option<&str>) -> Result<&'static str, OktaError> {
+    match value
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "" | "asc" | "ascending" => Ok("ASCENDING"),
+        "desc" | "descending" => Ok("DESCENDING"),
+        _ => Err(OktaError::InvalidConfiguration("audit sort_order")),
+    }
+}
+
+fn normalized_user_sort(value: Option<&str>) -> Result<&'static str, OktaError> {
+    match value
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "" | "asc" | "ascending" => Ok("asc"),
+        "desc" | "descending" => Ok("desc"),
+        _ => Err(OktaError::InvalidConfiguration("user sort_order")),
+    }
+}
+
+fn present(value: &Option<String>) -> bool {
+    value
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+}
+
+fn required<'a>(value: &'a Option<String>, name: &'static str) -> Result<&'a str, OktaError> {
+    value
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or(OktaError::MissingScope(name))
+}
+
+fn scoped_path(prefix: &str, id: &str, suffix: &str) -> String {
+    format!("{prefix}{}{suffix}", id.trim())
+}

--- a/crates/source-runtime-next/src/okta/response.rs
+++ b/crates/source-runtime-next/src/okta/response.rs
@@ -1,0 +1,98 @@
+//! Bounded Okta response decoding and family dispatch.
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+use time::OffsetDateTime;
+
+use super::{
+    OktaError, OktaKernel, OktaPage, OktaRequest, OktaResponse, cursor::next_cursor,
+    normalize::normalize_record,
+};
+
+const MAX_RESPONSE_BYTES: usize = 4 << 20;
+
+impl OktaKernel {
+    /// Decode one provider response for a request produced by this kernel.
+    pub fn decode(
+        &self,
+        request: &OktaRequest,
+        response: OktaResponse<'_>,
+        observed_at: OffsetDateTime,
+    ) -> Result<OktaPage, OktaError> {
+        self.validate_request(request)?;
+        classify_status(response.status)?;
+        if response.body.len() > MAX_RESPONSE_BYTES {
+            return Err(OktaError::ResponseTooLarge);
+        }
+        let payload: Value =
+            serde_json::from_slice(response.body).map_err(|_| OktaError::InvalidResponse)?;
+        let raw_records = if self.family.singleton() {
+            if !payload.is_object() {
+                return Err(OktaError::InvalidResponse);
+            }
+            vec![payload]
+        } else {
+            records(payload)?
+        };
+        if raw_records.len() > self.page_size {
+            return Err(OktaError::TooManyRecords);
+        }
+        let mut seen = HashMap::<String, usize>::new();
+        let mut normalized = Vec::with_capacity(raw_records.len());
+        for payload in raw_records {
+            let record = normalize_record(self, request, payload, observed_at)?;
+            if let Some(index) = seen.get(&record.provider_id).copied() {
+                if normalized.get(index) != Some(&record) {
+                    return Err(OktaError::ConflictingProviderIdentity);
+                }
+                continue;
+            }
+            seen.insert(record.provider_id.clone(), normalized.len());
+            normalized.push(record);
+        }
+        let next_cursor = next_cursor(request, &self.base_origin, response.link_header)?;
+        let input_after = request
+            .url
+            .query_pairs()
+            .find_map(|(name, value)| (name == "after").then(|| value.into_owned()));
+        if next_cursor.as_deref() == input_after.as_deref() {
+            return Err(OktaError::InvalidCursor);
+        }
+        let proposed_checkpoint = normalized.last().map(|record| record.occurred_at.clone());
+        Ok(OktaPage {
+            records: normalized,
+            next_cursor,
+            proposed_checkpoint,
+        })
+    }
+}
+
+fn classify_status(status: u16) -> Result<(), OktaError> {
+    match status {
+        200..=299 => Ok(()),
+        401 => Err(OktaError::AuthenticationRejected),
+        403 => Err(OktaError::PermissionDenied),
+        429 => Err(OktaError::RateLimited),
+        500..=599 => Err(OktaError::ProviderUnavailable),
+        _ => Err(OktaError::UnexpectedProviderStatus),
+    }
+}
+
+fn records(payload: Value) -> Result<Vec<Value>, OktaError> {
+    match payload {
+        Value::Array(records) => Ok(records),
+        Value::Object(mut object) => {
+            for key in ["data", "items", "results", "records"] {
+                if let Some(value) = object.remove(key) {
+                    return value.as_array().cloned().ok_or(OktaError::InvalidResponse);
+                }
+            }
+            Err(OktaError::InvalidResponse)
+        }
+        _ => Err(OktaError::InvalidResponse),
+    }
+}
+
+#[cfg(test)]
+pub(super) const TEST_MAX_RESPONSE_BYTES: usize = MAX_RESPONSE_BYTES;

--- a/crates/source-runtime-next/src/okta/tests.rs
+++ b/crates/source-runtime-next/src/okta/tests.rs
@@ -1,0 +1,576 @@
+use std::str::FromStr;
+
+use serde_json::Value;
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::*;
+
+const ORIGIN: &str = "https://writer.okta.com";
+const TENANT: &str = "writer.okta.com";
+
+#[test]
+fn closed_family_catalog_matches_the_go_runtime_catalog() {
+    let expected = [
+        "audit",
+        "admin_role",
+        "app_assignment",
+        "application",
+        "api_token",
+        "authorization_server",
+        "authenticator",
+        "brand",
+        "device_assurance",
+        "event_hook",
+        "group",
+        "group_membership",
+        "identity_provider",
+        "inline_hook",
+        "log_stream",
+        "network_zone",
+        "policy_rule",
+        "threat_insight",
+        "trusted_origin",
+        "user",
+    ];
+    let actual: Vec<_> = OktaFamily::ALL
+        .into_iter()
+        .map(OktaFamily::as_str)
+        .collect();
+    assert_eq!(actual, expected);
+    let catalog = include_str!("../../../../sources/okta/catalog.yaml");
+    let compiled: Vec<_> = catalog
+        .split_once("runtime_families:\n")
+        .unwrap()
+        .1
+        .split_once("event_contracts:\n")
+        .unwrap()
+        .0
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("- "))
+        .collect();
+    assert_eq!(compiled, expected);
+    for family in expected {
+        assert_eq!(OktaFamily::from_str(family).unwrap().as_str(), family);
+        assert!(catalog.contains(&format!("kind: okta.{family}\n")));
+        assert!(catalog.contains(&format!("schema_ref: okta/{family}/v1\n")));
+    }
+    assert_eq!(
+        OktaFamily::from_str("unknown"),
+        Err(OktaError::InvalidFamily)
+    );
+}
+
+#[test]
+fn plans_every_family_without_credential_material() {
+    for family in OktaFamily::ALL {
+        let filters = filters(family);
+        let kernel = OktaKernel::new(ORIGIN, TENANT, family, filters, Some(200)).unwrap();
+        assert!(!OktaKernel::requires_credentials());
+        let request = kernel.plan(None).unwrap();
+        assert_eq!(request.url().origin().unicode_serialization(), ORIGIN);
+        assert_eq!(request.authorization_scheme(), "SSWS");
+        assert_eq!(request.accept(), "application/json");
+        assert!(!request.url().as_str().contains("credential-secret"));
+        if !family.singleton() {
+            assert_eq!(
+                request
+                    .url()
+                    .query_pairs()
+                    .find(|(name, _)| name == "limit")
+                    .map(|(_, value)| value.into_owned()),
+                Some("200".to_owned())
+            );
+        }
+    }
+}
+
+#[test]
+fn scoped_families_fail_closed_without_their_parent() {
+    for (family, field) in [
+        (OktaFamily::GroupMembership, "group_id"),
+        (OktaFamily::AppAssignment, "app_id"),
+        (OktaFamily::AdminRole, "user_id"),
+        (OktaFamily::PolicyRule, "policy_id"),
+    ] {
+        assert!(matches!(
+            OktaKernel::new(ORIGIN, TENANT, family, OktaFilters::default(), None),
+            Err(OktaError::MissingScope(name)) if name == field
+        ));
+    }
+}
+
+#[test]
+fn selector_validation_and_defaults_match_the_go_runtime() {
+    for value in [None, Some("asc"), Some("ascending")] {
+        let kernel = OktaKernel::new(
+            ORIGIN,
+            TENANT,
+            OktaFamily::User,
+            OktaFilters {
+                sort_order: value.map(str::to_owned),
+                ..OktaFilters::default()
+            },
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            query(&kernel.plan(None).unwrap(), "sortOrder").as_deref(),
+            Some("asc")
+        );
+    }
+    let group = OktaKernel::new(
+        ORIGIN,
+        TENANT,
+        OktaFamily::Group,
+        OktaFilters {
+            search: Some("profile.name sw \"sec\"".to_owned()),
+            sort_by: Some("profile.name".to_owned()),
+            ..OktaFilters::default()
+        },
+        None,
+    )
+    .unwrap()
+    .plan(None)
+    .unwrap();
+    assert_eq!(query(&group, "sortBy").as_deref(), Some("profile.name"));
+    let application = OktaKernel::new(
+        ORIGIN,
+        TENANT,
+        OktaFamily::Application,
+        OktaFilters {
+            q: Some("portal".to_owned()),
+            ..OktaFilters::default()
+        },
+        None,
+    )
+    .unwrap()
+    .plan(None)
+    .unwrap();
+    assert_eq!(query(&application, "q").as_deref(), Some("portal"));
+    assert!(matches!(
+        OktaKernel::new(
+            ORIGIN,
+            TENANT,
+            OktaFamily::Audit,
+            OktaFilters {
+                search: Some("eventType eq x".to_owned()),
+                ..OktaFilters::default()
+            },
+            None,
+        ),
+        Err(OktaError::InvalidConfiguration("audit selectors"))
+    ));
+    assert!(matches!(
+        OktaKernel::new(
+            ORIGIN,
+            TENANT,
+            OktaFamily::Group,
+            OktaFilters {
+                since: Some("2026-08-21T00:00:00Z".to_owned()),
+                ..OktaFilters::default()
+            },
+            None,
+        ),
+        Err(OktaError::InvalidConfiguration("since/until"))
+    ));
+}
+
+#[test]
+fn rejects_unsafe_origins_and_out_of_range_pages() {
+    for origin in [
+        "http://example.okta.com",
+        "http://localhost",
+        "https://127.0.0.1",
+        "https://10.0.0.1",
+        "https://example.okta.com/path",
+        "https://user@example.okta.com",
+    ] {
+        assert!(matches!(
+            OktaKernel::new(
+                origin,
+                TENANT,
+                OktaFamily::User,
+                OktaFilters::default(),
+                None
+            ),
+            Err(OktaError::InvalidBaseUrl)
+        ));
+    }
+    assert!(matches!(
+        OktaKernel::new(
+            ORIGIN,
+            TENANT,
+            OktaFamily::User,
+            OktaFilters::default(),
+            Some(201)
+        ),
+        Err(OktaError::InvalidPageSize)
+    ));
+}
+
+#[test]
+fn response_fixtures_preserve_go_identity_and_projection_contracts() {
+    struct Case {
+        family: OktaFamily,
+        body: &'static [u8],
+        expected: &'static str,
+        required_fields: &'static [&'static str],
+    }
+    let cases = [
+        Case { family: OktaFamily::Audit, body: br#"[{"uuid":"evt-1","published":"2026-04-23T01:00:00Z","eventType":"user.session.start","severity":"INFO","target":[{"id":"00u1","type":"User"}]}]"#, expected: include_str!("../../../../sources/okta/testdata/read_audit.json"), required_fields: &["event_type", "resource_id", "resource_type"] },
+        Case { family: OktaFamily::User, body: include_bytes!("../../../../sources/okta/testdata/api/user/list_users/response.json"), expected: include_str!("../../../../sources/okta/testdata/read_user.json"), required_fields: &["user_id", "status", "email", "login"] },
+        Case { family: OktaFamily::Group, body: include_bytes!("../../../../sources/okta/testdata/api/group/list_groups/response.json"), expected: include_str!("../../../../sources/okta/testdata/read_group.json"), required_fields: &["group_id", "group_name", "type"] },
+        Case { family: OktaFamily::GroupMembership, body: include_bytes!("../../../../sources/okta/testdata/api/group_membership/list_group_members/response.json"), expected: include_str!("../../../../sources/okta/testdata/read_group_membership.json"), required_fields: &["group_id", "member_id", "member_user_id", "member_email"] },
+        Case { family: OktaFamily::Application, body: include_bytes!("../../../../sources/okta/testdata/api/application/list_applications/response.json"), expected: include_str!("../../../../sources/okta/testdata/read_application.json"), required_fields: &["app_id", "app_name", "status", "sign_on_mode"] },
+        Case { family: OktaFamily::AppAssignment, body: include_bytes!("../../../../sources/okta/testdata/api/app_assignment/list_app_assignments/response.json"), expected: include_str!("../../../../sources/okta/testdata/read_app_assignment.json"), required_fields: &["app_id", "subject_id", "subject_type", "status"] },
+        Case { family: OktaFamily::AdminRole, body: include_bytes!("../../../../sources/okta/testdata/api/admin_role/list_admin_roles/response.json"), expected: include_str!("../../../../sources/okta/testdata/read_admin_role.json"), required_fields: &["role_id", "role_name", "subject_id", "is_admin"] },
+        Case { family: OktaFamily::PolicyRule, body: include_bytes!("../../../../sources/okta/testdata/api/policy_rule/list_policy_rules/response.json"), expected: include_str!("../../../../sources/okta/testdata/read_policy_rule.json"), required_fields: &["policy_id", "policy_rule_id", "status", "resource_type"] },
+        Case { family: OktaFamily::EventHook, body: include_bytes!("../../../../sources/okta/testdata/api/event_hook/list_event_hooks/response.json"), expected: include_str!("../../../../sources/okta/testdata/read_event_hook.json"), required_fields: &["event_hook_id", "name", "status"] },
+        Case { family: OktaFamily::InlineHook, body: include_bytes!("../../../../sources/okta/testdata/api/inline_hook/list_inline_hooks/response.json"), expected: include_str!("../../../../sources/okta/testdata/read_inline_hook.json"), required_fields: &["inline_hook_id", "name", "status"] },
+        Case { family: OktaFamily::NetworkZone, body: include_bytes!("../../../../sources/okta/testdata/api/network_zone/list_network_zones/response.json"), expected: include_str!("../../../../sources/okta/testdata/read_network_zone.json"), required_fields: &["network_zone_id", "zone_id", "status", "zone_type"] },
+        Case { family: OktaFamily::TrustedOrigin, body: include_bytes!("../../../../sources/okta/testdata/api/trusted_origin/list_trusted_origins/response.json"), expected: include_str!("../../../../sources/okta/testdata/read_trusted_origin.json"), required_fields: &["trusted_origin_id", "origin", "scope_types"] },
+        Case { family: OktaFamily::Authenticator, body: include_bytes!("../../../../sources/okta/testdata/api/authenticator/list_authenticators/response.json"), expected: include_str!("../../../../sources/okta/testdata/read_authenticator.json"), required_fields: &["authenticator_id", "key", "name", "status"] },
+    ];
+    for case in cases {
+        let kernel =
+            OktaKernel::new(ORIGIN, TENANT, case.family, filters(case.family), Some(200)).unwrap();
+        let request = kernel.plan(None).unwrap();
+        let page = kernel
+            .decode(
+                &request,
+                OktaResponse {
+                    status: 200,
+                    body: case.body,
+                    link_header: None,
+                },
+                observed_at(),
+            )
+            .unwrap();
+        assert!(!page.records.is_empty(), "{}", case.family.as_str());
+        let expected: Vec<Value> = serde_json::from_str(case.expected).unwrap();
+        let expected = expected.first().unwrap();
+        let record = &page.records[0];
+        assert_eq!(record.provider_kind, expected["kind"].as_str().unwrap());
+        assert_eq!(record.schema_ref, expected["schema_ref"].as_str().unwrap());
+        assert_eq!(record.tenant_id, TENANT);
+        assert!(!record.event_id.contains(&record.provider_id));
+        for field in case.required_fields {
+            let actual = record.fields.get(*field).filter(|value| !value.is_empty());
+            assert!(
+                actual.is_some(),
+                "{}/{} missing {field}",
+                case.family.as_str(),
+                record.provider_id
+            );
+            if let Some(expected_value) = expected["attributes"].get(*field).and_then(Value::as_str)
+            {
+                assert_eq!(
+                    actual.map(String::as_str),
+                    Some(expected_value),
+                    "{}/{} {field}",
+                    case.family.as_str(),
+                    record.provider_id
+                );
+            }
+        }
+        assert_eq!(
+            record.fields.get("family").map(String::as_str),
+            Some(case.family.as_str())
+        );
+    }
+}
+
+#[test]
+fn link_cursor_is_origin_locked_and_assignment_phase_round_trips() {
+    let kernel = OktaKernel::new(
+        ORIGIN,
+        TENANT,
+        OktaFamily::User,
+        OktaFilters::default(),
+        None,
+    )
+    .unwrap();
+    let request = kernel.plan(Some("prior")).unwrap();
+    let body = br#"[{"id":"u1","lastUpdated":"2026-08-21T12:00:00Z"}]"#;
+    let page = kernel
+        .decode(
+            &request,
+            OktaResponse {
+                status: 200,
+                body,
+                link_header: Some("</api/v1/users?after=next&limit=10>; rel=\"next\""),
+            },
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(page.next_cursor.as_deref(), Some("next"));
+    assert_eq!(
+        kernel
+            .plan(page.next_cursor.as_deref())
+            .unwrap()
+            .url()
+            .query_pairs()
+            .find_map(|(name, value)| (name == "after").then(|| value.into_owned()))
+            .as_deref(),
+        Some("next")
+    );
+
+    let error = kernel
+        .decode(
+            &request,
+            OktaResponse {
+                status: 200,
+                body,
+                link_header: Some("<https://evil.example/api/v1/users?after=next>; rel=next"),
+            },
+            observed_at(),
+        )
+        .unwrap_err();
+    assert_eq!(error, OktaError::InvalidCursor);
+
+    let assignment = OktaKernel::new(
+        ORIGIN,
+        TENANT,
+        OktaFamily::AppAssignment,
+        filters(OktaFamily::AppAssignment),
+        None,
+    )
+    .unwrap();
+    let users = assignment.plan(None).unwrap();
+    assert!(users.url().path().ends_with("/users"));
+    let page = assignment
+        .decode(
+            &users,
+            OktaResponse {
+                status: 200,
+                body: b"[]",
+                link_header: None,
+            },
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(page.next_cursor.as_deref(), Some("groups:"));
+    assert!(
+        assignment
+            .plan(page.next_cursor.as_deref())
+            .unwrap()
+            .url()
+            .path()
+            .ends_with("/groups")
+    );
+}
+
+#[test]
+fn typed_provider_failures_remain_distinct() {
+    let kernel = OktaKernel::new(
+        ORIGIN,
+        TENANT,
+        OktaFamily::User,
+        OktaFilters::default(),
+        None,
+    )
+    .unwrap();
+    let request = kernel.plan(None).unwrap();
+    for (status, expected) in [
+        (401, OktaError::AuthenticationRejected),
+        (403, OktaError::PermissionDenied),
+        (429, OktaError::RateLimited),
+        (503, OktaError::ProviderUnavailable),
+        (418, OktaError::UnexpectedProviderStatus),
+    ] {
+        assert_eq!(
+            kernel.decode(
+                &request,
+                OktaResponse {
+                    status,
+                    body: b"{}",
+                    link_header: None
+                },
+                observed_at()
+            ),
+            Err(expected)
+        );
+    }
+}
+
+#[test]
+fn secret_shaped_provider_fields_do_not_leave_the_kernel() {
+    let kernel = OktaKernel::new(
+        ORIGIN,
+        TENANT,
+        OktaFamily::ApiToken,
+        OktaFilters::default(),
+        None,
+    )
+    .unwrap();
+    let request = kernel.plan(None).unwrap();
+    let page = kernel.decode(
+        &request,
+        OktaResponse { status: 200, body: br#"[{"id":"tok1","name":"integration","created":"2026-08-21T12:00:00Z","token":"secret","access_token":"secret","clientSecret":"secret","authorization":"secret","nested":{"password":"secret","cookie":"secret"}}]"#, link_header: None },
+        observed_at(),
+    ).unwrap();
+    let encoded = serde_json::to_string(&page.records[0].payload).unwrap();
+    assert!(!encoded.contains("secret"));
+    assert!(!encoded.contains("clientSecret"));
+    assert!(!encoded.contains("access_token"));
+    assert!(!encoded.contains("authorization"));
+    assert!(!encoded.contains("password"));
+    assert!(!encoded.contains("cookie"));
+    assert!(!page.records[0].event_id.contains("secret"));
+    assert!(!page.records[0].occurred_at.contains("secret"));
+    assert!(
+        page.records[0]
+            .fields
+            .values()
+            .all(|value| !value.contains("secret"))
+    );
+    let response = OktaResponse {
+        status: 200,
+        body: b"credential-secret",
+        link_header: Some("credential-secret"),
+    };
+    assert!(!format!("{response:?}").contains("credential-secret"));
+}
+
+#[test]
+fn provider_payload_cannot_supply_tenant_identity() {
+    let kernel = OktaKernel::new(
+        ORIGIN,
+        TENANT,
+        OktaFamily::User,
+        OktaFilters::default(),
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        kernel.decode(
+            &kernel.plan(None).unwrap(),
+            OktaResponse {
+                status: 200,
+                body:
+                    br#"[{"id":"u1","tenant_id":"attacker","lastUpdated":"2026-08-21T12:00:00Z"}]"#,
+                link_header: None,
+            },
+            observed_at(),
+        ),
+        Err(OktaError::InvalidResponse)
+    );
+}
+
+#[test]
+fn tenant_scope_changes_event_identity_and_audit_time_fails_closed() {
+    let first = OktaKernel::new(
+        ORIGIN,
+        "tenant-a",
+        OktaFamily::Audit,
+        OktaFilters::default(),
+        None,
+    )
+    .unwrap();
+    let second = OktaKernel::new(
+        ORIGIN,
+        "tenant-b",
+        OktaFamily::Audit,
+        OktaFilters::default(),
+        None,
+    )
+    .unwrap();
+    let body =
+        br#"[{"uuid":"evt1","published":"2026-08-21T12:00:00Z","eventType":"user.session.start"}]"#;
+    let decode = |kernel: &OktaKernel| {
+        kernel
+            .decode(
+                &kernel.plan(None).unwrap(),
+                OktaResponse {
+                    status: 200,
+                    body,
+                    link_header: None,
+                },
+                observed_at(),
+            )
+            .unwrap()
+            .records[0]
+            .event_id
+            .clone()
+    };
+    assert_ne!(decode(&first), decode(&second));
+    for invalid in [
+        br#"[{"uuid":"evt1"}]"#.as_slice(),
+        br#"[{"uuid":"evt1","published":"1970-01-01T00:00:00Z"}]"#.as_slice(),
+        br#"[{"uuid":"evt1","published":"not-a-time"}]"#.as_slice(),
+    ] {
+        assert_eq!(
+            first.decode(
+                &first.plan(None).unwrap(),
+                OktaResponse {
+                    status: 200,
+                    body: invalid,
+                    link_header: None
+                },
+                observed_at()
+            ),
+            Err(OktaError::InvalidResponse)
+        );
+    }
+}
+
+#[test]
+fn response_and_record_limits_fail_closed() {
+    let kernel = OktaKernel::new(
+        ORIGIN,
+        TENANT,
+        OktaFamily::User,
+        OktaFilters::default(),
+        Some(1),
+    )
+    .unwrap();
+    let request = kernel.plan(None).unwrap();
+    let oversized = vec![b' '; response::TEST_MAX_RESPONSE_BYTES + 1];
+    assert_eq!(
+        kernel.decode(
+            &request,
+            OktaResponse {
+                status: 200,
+                body: &oversized,
+                link_header: None
+            },
+            OffsetDateTime::UNIX_EPOCH
+        ),
+        Err(OktaError::ResponseTooLarge)
+    );
+    assert_eq!(
+        kernel.decode(
+            &request,
+            OktaResponse {
+                status: 200,
+                body: br#"[{"id":"u1"},{"id":"u2"}]"#,
+                link_header: None
+            },
+            observed_at()
+        ),
+        Err(OktaError::TooManyRecords)
+    );
+}
+
+fn observed_at() -> OffsetDateTime {
+    OffsetDateTime::parse("2026-08-21T12:00:00Z", &Rfc3339).unwrap()
+}
+
+fn filters(family: OktaFamily) -> OktaFilters {
+    OktaFilters {
+        group_id: (family == OktaFamily::GroupMembership)
+            .then(|| "example-cb373fbc662034f4".to_owned()),
+        app_id: (family == OktaFamily::AppAssignment)
+            .then(|| "example-f0a6c6d9df5c0037".to_owned()),
+        user_id: (family == OktaFamily::AdminRole).then(|| "example-c90b95af0c0b6fef".to_owned()),
+        policy_id: (family == OktaFamily::PolicyRule).then(|| "00psfar1lATHw2WXj4x6".to_owned()),
+        ..OktaFilters::default()
+    }
+}
+
+fn query(request: &OktaRequest, name: &str) -> Option<String> {
+    request
+        .url()
+        .query_pairs()
+        .find_map(|(candidate, value)| (candidate == name).then(|| value.into_owned()))
+}

--- a/crates/source-runtime-next/src/okta/types.rs
+++ b/crates/source-runtime-next/src/okta/types.rs
@@ -1,0 +1,129 @@
+//! Public Okta kernel contracts.
+
+use std::{collections::BTreeMap, fmt};
+
+use reqwest::Url;
+use serde_json::Value;
+
+use super::OktaFamily;
+
+/// Public, non-secret selectors for one Okta family request.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct OktaFilters {
+    /// Group parent for membership reads.
+    pub group_id: Option<String>,
+    /// Application parent for assignment reads.
+    pub app_id: Option<String>,
+    /// User parent for admin-role reads.
+    pub user_id: Option<String>,
+    /// Optional user label preserved in normalized role attributes.
+    pub user_email: Option<String>,
+    /// Policy parent for policy-rule reads.
+    pub policy_id: Option<String>,
+    /// Provider filter expression.
+    pub filter: Option<String>,
+    /// Provider text query.
+    pub q: Option<String>,
+    /// Provider search expression.
+    pub search: Option<String>,
+    /// User sort field.
+    pub sort_by: Option<String>,
+    /// User or audit sort direction.
+    pub sort_order: Option<String>,
+    /// Audit lower time bound.
+    pub since: Option<String>,
+    /// Audit upper time bound.
+    pub until: Option<String>,
+}
+
+/// One credential-free Okta HTTP request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OktaRequest {
+    pub(super) url: Url,
+    pub(super) family: OktaFamily,
+    pub(super) assignment_phase: Option<String>,
+}
+
+impl OktaRequest {
+    /// Return the exact provider URL. The host must authorize it before I/O.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Return auth metadata without credential bytes.
+    pub const fn authorization_scheme(&self) -> &'static str {
+        "SSWS"
+    }
+
+    /// Return the required response media type.
+    pub const fn accept(&self) -> &'static str {
+        "application/json"
+    }
+}
+
+/// Provider response metadata accepted by the credential-free decoder.
+#[derive(Clone, Eq, PartialEq)]
+pub struct OktaResponse<'a> {
+    /// HTTP response status.
+    pub status: u16,
+    /// Bounded response body.
+    pub body: &'a [u8],
+    /// Optional Link response header used for continuation.
+    pub link_header: Option<&'a str>,
+}
+
+impl fmt::Debug for OktaResponse<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("OktaResponse")
+            .field("status", &self.status)
+            .field("body_len", &self.body.len())
+            .field("has_link_header", &self.link_header.is_some())
+            .finish()
+    }
+}
+
+/// One normalized Okta provider record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OktaRecord {
+    /// Runtime family identifier.
+    pub family: String,
+    /// Exact provider event kind.
+    pub provider_kind: String,
+    /// Exact event schema reference.
+    pub schema_ref: String,
+    /// Trusted runtime tenant identity.
+    pub tenant_id: String,
+    /// Stable provider object identity.
+    pub provider_id: String,
+    /// Deterministic tenant-scoped event identity.
+    pub event_id: String,
+    /// Portable event attributes.
+    pub fields: BTreeMap<String, String>,
+    /// UTC provider occurrence time or observation fallback.
+    pub occurred_at: String,
+    /// Exact provider object, never containing runtime credential material.
+    pub payload: Value,
+}
+
+/// One bounded Okta page.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OktaPage {
+    /// Deduplicated records in provider order.
+    pub records: Vec<OktaRecord>,
+    /// Exact Go-compatible continuation when another page exists.
+    pub next_cursor: Option<String>,
+    /// Proposed high-watermark; the host owns durable checkpoint commit.
+    pub proposed_checkpoint: Option<String>,
+}
+
+/// Bounded request and response kernel for one Okta family.
+#[derive(Clone, Debug)]
+pub struct OktaKernel {
+    pub(super) base_url: Url,
+    pub(super) base_origin: String,
+    pub(super) tenant_id: String,
+    pub(super) family: OktaFamily,
+    pub(super) filters: OktaFilters,
+    pub(super) page_size: usize,
+}


### PR DESCRIPTION
## Scope

- compile all 20 Okta runtime families into a closed Rust family definition
- plan bounded, same-origin requests without credential bytes, including scoped membership, assignment, role, and policy operations
- validate provider status, response size, record count, stable identity, event contracts, and continuation cursors
- normalize tenant-scoped deterministic records for users, groups, memberships, applications, assignments, admin roles, policy rules, hooks, zones, origins, authenticators, and audit events
- compare Rust projection fields with the checked Go Okta fixtures and keep the concrete Go loader as the compatibility oracle
- redact secret-shaped response fields and keep raw credential material outside public kernel types

## Local validation

Passed:
- direct Rust 2024 formatting and format check for the changed Rust paths
- `git diff --check`
- `go test ./sources/okta ./sources/internal/oktaasset ./sources/internal/oktaevent ./internal/sourceregistry`
- `make source-fixture-check catalog-check`
- `make fixture-oracle-check`
- `make check-structural check-structural-test`
- `make check-arch`
- staged and committed leak checks

Blocked before execution by the managed Cargo capacity gate (RC 75):
- `cargo fmt --all -- --check`
- `cargo test --locked -p cerebro-platform -p cerebro-source-catalog -p cerebro-source-runtime-next`
- `cargo clippy --locked -p cerebro-platform -p cerebro-source-catalog -p cerebro-source-runtime-next --all-targets --all-features -- -D warnings`

This PR remains draft until hosted Rust checks provide the missing compile, test, and Clippy evidence. It does not retire the Go Okta loader or change runtime authority.