### PR TITLE
feat(twilio): add accounts execution adapter

### DIFF
--- a/crates/source-runtime-next/src/twilio.rs
+++ b/crates/source-runtime-next/src/twilio.rs
@@ -1,5 +1,8 @@
 //! Credential-free Twilio provider kernel facade.
 
+// Registration in the closed dispatcher remains owned by the shared runtime.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) mod adapter;
 mod cursor;
 mod error;
 mod family;

--- a/crates/source-runtime-next/src/twilio/adapter/mod.rs
+++ b/crates/source-runtime-next/src/twilio/adapter/mod.rs
@@ -1,0 +1,205 @@
+//! Accounts-first Twilio source-execution adapter core.
+
+use std::{error::Error, fmt};
+
+use time::OffsetDateTime;
+
+use super::{TwilioError, TwilioFamily, TwilioFilters, TwilioKernel, TwilioPage, TwilioRequest};
+
+const ACCOUNTS_PATH: &str = "/2010-04-01/Accounts.json";
+const DEFAULT_ORIGIN: &str = "https://api.twilio.com";
+const MAX_RESPONSE_BYTES: u64 = 8 << 20;
+const PAGE_SIZE: usize = 100;
+
+/// Provider-local accounts adapter used by the canonical source-execution edge.
+///
+/// The authenticated tenant and provider origin are supplied by the trusted
+/// host. This type accepts no credential value and performs no network I/O.
+#[derive(Clone, Debug)]
+pub(crate) struct TwilioAccountsAdapter {
+    kernel: TwilioKernel,
+}
+
+impl TwilioAccountsAdapter {
+    pub(crate) const fn source_id() -> &'static str {
+        "twilio"
+    }
+
+    pub(crate) const fn family_id() -> &'static str {
+        "accounts"
+    }
+
+    pub(crate) const fn provider_kernel() -> &'static str {
+        "twilio.accounts"
+    }
+
+    pub(crate) const fn path() -> &'static str {
+        ACCOUNTS_PATH
+    }
+
+    pub(crate) const fn default_origin() -> &'static str {
+        DEFAULT_ORIGIN
+    }
+
+    pub(crate) const fn max_response_bytes() -> u64 {
+        MAX_RESPONSE_BYTES
+    }
+
+    /// Name of the operation-scoped credential application owned by the host.
+    pub(crate) const fn credential_operation() -> &'static str {
+        "twilio.basic"
+    }
+
+    /// Provider authorization scheme applied by the host after request planning.
+    pub(crate) const fn credential_scheme() -> &'static str {
+        "Basic"
+    }
+
+    /// Build an accounts adapter for authenticated execution scope.
+    pub(crate) fn new(origin: &str, tenant_id: &str) -> Result<Self, TwilioAccountsAdapterError> {
+        let kernel = TwilioKernel::new(
+            Some(origin),
+            tenant_id,
+            TwilioFamily::Accounts,
+            TwilioFilters::default(),
+            Some(PAGE_SIZE),
+        )?;
+        Ok(Self { kernel })
+    }
+
+    /// Produce one deterministic credential-free provider request.
+    pub(crate) fn plan(
+        &self,
+        prior_cursor: Option<&str>,
+    ) -> Result<TwilioRequest, TwilioAccountsAdapterError> {
+        self.kernel
+            .plan(canonical_prior_cursor(prior_cursor)?)
+            .map_err(Into::into)
+    }
+
+    /// Decode one host-bounded provider response for the same planned cursor.
+    pub(crate) fn decode(
+        &self,
+        prior_cursor: Option<&str>,
+        status_code: u32,
+        response_body: &[u8],
+        observed_at: OffsetDateTime,
+    ) -> Result<TwilioPage, TwilioAccountsAdapterError> {
+        validate_status(status_code)?;
+        if response_body.len() as u64 > MAX_RESPONSE_BYTES {
+            return Err(TwilioAccountsAdapterError::Kernel(
+                TwilioError::ResponseTooLarge,
+            ));
+        }
+        let request = self.kernel.plan(canonical_prior_cursor(prior_cursor)?)?;
+        self.kernel
+            .decode(&request, response_body, observed_at)
+            .map_err(Into::into)
+    }
+}
+
+/// Stable, provider-local execution failures mapped closed at the shared edge.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TwilioAccountsAdapterError {
+    AuthenticationRejected,
+    RequiredScopeMissing,
+    ProviderTimeout,
+    RateLimited,
+    ProviderUnavailable,
+    UnexpectedStatus(u32),
+    Kernel(TwilioError),
+}
+
+impl TwilioAccountsAdapterError {
+    pub(crate) const fn code(self) -> &'static str {
+        match self {
+            Self::AuthenticationRejected => "twilio.authentication_rejected",
+            Self::RequiredScopeMissing => "twilio.required_scope_missing",
+            Self::ProviderTimeout => "twilio.provider_timeout",
+            Self::RateLimited => "twilio.rate_limited",
+            Self::ProviderUnavailable => "twilio.provider_unavailable",
+            Self::UnexpectedStatus(_) => "twilio.unexpected_status",
+            Self::Kernel(TwilioError::ResponseTooLarge) => "twilio.response_too_large",
+            Self::Kernel(TwilioError::InvalidCursor) => "twilio.invalid_cursor",
+            Self::Kernel(TwilioError::ConflictingProviderIdentity) => {
+                "twilio.conflicting_provider_identity"
+            }
+            Self::Kernel(_) => "twilio.invalid_provider_response",
+        }
+    }
+
+    pub(crate) const fn retryable(self) -> bool {
+        matches!(
+            self,
+            Self::ProviderTimeout | Self::RateLimited | Self::ProviderUnavailable
+        )
+    }
+
+    pub(crate) const fn operator_action(self) -> &'static str {
+        match self {
+            Self::AuthenticationRejected => "repair credential binding",
+            Self::RequiredScopeMissing => "grant required provider scope",
+            Self::ProviderTimeout | Self::RateLimited | Self::ProviderUnavailable => "retry later",
+            Self::UnexpectedStatus(_) => "inspect provider status",
+            Self::Kernel(TwilioError::InvalidCursor) => "restart collection from a valid cursor",
+            Self::Kernel(_) => "inspect quarantined provider records",
+        }
+    }
+}
+
+impl From<TwilioError> for TwilioAccountsAdapterError {
+    fn from(value: TwilioError) -> Self {
+        Self::Kernel(value)
+    }
+}
+
+impl fmt::Display for TwilioAccountsAdapterError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnexpectedStatus(status) => {
+                write!(
+                    formatter,
+                    "{}: provider returned HTTP {status}",
+                    self.code()
+                )
+            }
+            Self::Kernel(error) => write!(formatter, "{}: {error}", self.code()),
+            _ => formatter.write_str(self.code()),
+        }
+    }
+}
+
+impl Error for TwilioAccountsAdapterError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Kernel(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+fn validate_status(status_code: u32) -> Result<(), TwilioAccountsAdapterError> {
+    match status_code {
+        200 => Ok(()),
+        401 => Err(TwilioAccountsAdapterError::AuthenticationRejected),
+        403 => Err(TwilioAccountsAdapterError::RequiredScopeMissing),
+        408 => Err(TwilioAccountsAdapterError::ProviderTimeout),
+        429 => Err(TwilioAccountsAdapterError::RateLimited),
+        500..=599 => Err(TwilioAccountsAdapterError::ProviderUnavailable),
+        status => Err(TwilioAccountsAdapterError::UnexpectedStatus(status)),
+    }
+}
+
+fn canonical_prior_cursor(
+    prior_cursor: Option<&str>,
+) -> Result<Option<&str>, TwilioAccountsAdapterError> {
+    match prior_cursor {
+        None | Some("") => Ok(None),
+        Some(cursor) if cursor.trim() != cursor => Err(TwilioError::InvalidCursor.into()),
+        Some(cursor) => Ok(Some(cursor)),
+    }
+}
+
+mod source_execution;
+
+pub(crate) use source_execution::TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER;

--- a/crates/source-runtime-next/src/twilio/adapter/mod.rs
+++ b/crates/source-runtime-next/src/twilio/adapter/mod.rs
@@ -202,4 +202,7 @@ fn canonical_prior_cursor(
 
 mod source_execution;
 
+// The closed shared dispatcher consumes this export in its separately owned
+// registration follow-up.
+#[allow(unused_imports)]
 pub(crate) use source_execution::TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER;

--- a/crates/source-runtime-next/src/twilio/adapter/source_execution.rs
+++ b/crates/source-runtime-next/src/twilio/adapter/source_execution.rs
@@ -321,3 +321,142 @@ fn map_provider_error(error: TwilioAccountsAdapterError) -> SourceExecutionError
         ) => SourceExecutionError::InvalidPlan,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source_execution::{SourceWorkerSafeReceiptV1, response_digest};
+
+    const ACCOUNTS_PAGE: &[u8] = include_bytes!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../sources/twilio/testdata/source_worker_accounts_page.json"
+    ));
+
+    fn context(prior_cursor: &str) -> SourceWorkerExecutionContextV1 {
+        SourceWorkerExecutionContextV1 {
+            tenant_id: "trusted-tenant".to_owned(),
+            runtime_id: "twilio-accounts-runtime".to_owned(),
+            logical_page_id: "accounts-page-1".to_owned(),
+            prior_cursor: prior_cursor.to_owned(),
+            runtime_generation: 7,
+            lease_generation: 11,
+            observed_at_unix_millis: 1_780_372_800_000,
+        }
+    }
+
+    fn exact_plan() -> SourceExecutionPlanV1 {
+        let mut plan = SourceExecutionPlanV1 {
+            plan_id: PLAN_ID.to_owned(),
+            source_id: TwilioAccountsAdapter::source_id().to_owned(),
+            family_id: TwilioAccountsAdapter::family_id().to_owned(),
+            provider_kernel: TwilioAccountsAdapter::provider_kernel().to_owned(),
+            method: "GET".to_owned(),
+            origin: TwilioAccountsAdapter::default_origin().to_owned(),
+            path: TwilioAccountsAdapter::path().to_owned(),
+            record_selector: RECORD_SELECTOR.to_owned(),
+            id_field: ID_FIELD.to_owned(),
+            singleton_fallback_id: String::new(),
+            max_response_bytes: TwilioAccountsAdapter::max_response_bytes(),
+            event_kind: EVENT_KIND.to_owned(),
+            schema_ref: SCHEMA_REF.to_owned(),
+            required_attributes: REQUIRED_ATTRIBUTES.map(str::to_owned).to_vec(),
+            required_payload_fields: REQUIRED_PAYLOAD_FIELDS.map(str::to_owned).to_vec(),
+            plan_digest_sha256: String::new(),
+        };
+        plan.plan_digest_sha256 = canonical_plan_digest(&plan);
+        plan
+    }
+
+    fn decode_request(status_code: u32) -> SourceWorkerDecodeRequestV1 {
+        let plan = exact_plan();
+        let execution = context("accounts-page-1");
+        let intent = TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER
+            .plan(&SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(execution.clone()),
+            })
+            .unwrap()
+            .request_intent_digest;
+        let receipt = SourceWorkerSafeReceiptV1 {
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            logical_page_id: execution.logical_page_id.clone(),
+            request_intent_digest: intent.clone(),
+            runtime_generation: execution.runtime_generation,
+            lease_generation: execution.lease_generation,
+            credential_operation: TwilioAccountsAdapter::credential_operation().to_owned(),
+            status_code,
+            response_bytes: ACCOUNTS_PAGE.len() as u64,
+            response_sha256: response_digest(ACCOUNTS_PAGE),
+            tenant_id: execution.tenant_id.clone(),
+            runtime_id: execution.runtime_id.clone(),
+            observed_at_unix_millis: execution.observed_at_unix_millis,
+        };
+        SourceWorkerDecodeRequestV1 {
+            plan: Some(plan),
+            status_code,
+            response_body: ACCOUNTS_PAGE.to_vec(),
+            logical_page_id: execution.logical_page_id.clone(),
+            request_intent_digest: intent,
+            receipt: Some(receipt),
+            context: Some(execution),
+        }
+    }
+
+    #[test]
+    fn canonical_edge_plans_credential_free_request_and_decodes_fixture() {
+        let request = SourceWorkerPlanRequestV1 {
+            plan: Some(exact_plan()),
+            context: Some(context("accounts-page-1")),
+        };
+        let planned = TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER
+            .plan(&request)
+            .unwrap();
+        assert_eq!(
+            planned.url,
+            "https://api.twilio.com/2010-04-01/Accounts.json?limit=100&cursor=accounts-page-1"
+        );
+        assert!(!planned.url.contains("credential"));
+        assert!(!planned.url.contains("token"));
+        assert_eq!(planned.request_intent_digest.len(), 64);
+
+        let result = TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER
+            .decode(&decode_request(200))
+            .unwrap();
+        assert_eq!(result.next_cursor, "accounts-page-2");
+        assert_eq!(result.records.len(), 1);
+        let record = &result.records[0];
+        assert_eq!(record.provider_id, "record-1");
+        assert_eq!(record.attributes["tenant_id"], "trusted-tenant");
+        assert_eq!(
+            record.event_id,
+            "twilio-trusted-tenant-a92380b4993d-accounts-record-1"
+        );
+        assert_eq!(record.occurred_at_unix_millis, 1_780_272_000_000);
+        assert_eq!(result.tenant_id, "trusted-tenant");
+        assert_eq!(result.result_digest_sha256.len(), 64);
+        TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER
+            .validate_record_identity(&context("accounts-page-1"), record)
+            .unwrap();
+    }
+
+    #[test]
+    fn canonical_edge_rejects_provider_status_and_identity_drift() {
+        assert_eq!(
+            TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER
+                .decode(&decode_request(429))
+                .unwrap_err(),
+            SourceExecutionError::ProviderRateLimit
+        );
+
+        let result = TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER
+            .decode(&decode_request(200))
+            .unwrap();
+        let mut record = result.records[0].clone();
+        record.event_id = "twilio-provider-controlled-tenant-record-1".to_owned();
+        assert_eq!(
+            TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER
+                .validate_record_identity(&context("accounts-page-1"), &record),
+            Err(SourceExecutionError::TenantMismatch)
+        );
+    }
+}

--- a/crates/source-runtime-next/src/twilio/adapter/source_execution.rs
+++ b/crates/source-runtime-next/src/twilio/adapter/source_execution.rs
@@ -1,0 +1,323 @@
+//! Canonical source-execution edge for Twilio accounts.
+//!
+//! This file intentionally defines no wire messages. It compiles against the
+//! shared `source_execution` API and remains unregistered until the shared
+//! runtime adds it to the closed dispatcher.
+
+use std::convert::TryFrom;
+
+use serde_json::Value;
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceExecutionPlanV1,
+    SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1, SourceWorkerExecutionContextV1,
+    SourceWorkerHttpRequestV1, SourceWorkerPlanRequestV1, SourceWorkerRecordV1,
+    canonical_plan_digest, canonical_request_intent_digest, canonical_result_digest,
+    validate_and_deduplicate_records, validate_cursor, validate_execution_context,
+    validate_safe_receipt,
+};
+
+use super::{TwilioAccountsAdapter, TwilioAccountsAdapterError};
+use crate::twilio::{TwilioError, TwilioFamily, normalize::event_id};
+
+const PLAN_ID: &str = "source-plan-v1:twilio:accounts";
+const EVENT_KIND: &str = "twilio.accounts";
+const SCHEMA_REF: &str = "twilio/accounts/v1";
+const RECORD_SELECTOR: &str = "data";
+const ID_FIELD: &str = "id";
+const REQUIRED_ATTRIBUTES: [&str; 3] = ["tenant_id", "source_event_id", "user_id"];
+const REQUIRED_PAYLOAD_FIELDS: [&str; 1] = ["id"];
+
+/// Registry value for the accounts-first Twilio source adapter.
+pub(crate) static TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER: TwilioAccountsSourceExecutionAdapter =
+    TwilioAccountsSourceExecutionAdapter;
+
+/// Stateless canonical edge. Trusted execution scope arrives on every call.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct TwilioAccountsSourceExecutionAdapter;
+
+impl SourceExecutionAdapter for TwilioAccountsSourceExecutionAdapter {
+    fn source_id(&self) -> &'static str {
+        TwilioAccountsAdapter::source_id()
+    }
+
+    fn family_id(&self) -> &'static str {
+        TwilioAccountsAdapter::family_id()
+    }
+
+    fn provider_kernel(&self) -> &'static str {
+        TwilioAccountsAdapter::provider_kernel()
+    }
+
+    fn validate_record_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+    ) -> Result<(), SourceExecutionError> {
+        let expected = event_id(
+            &context.tenant_id,
+            TwilioAccountsAdapter::default_origin(),
+            TwilioAccountsAdapter::path(),
+            TwilioFamily::Accounts,
+            &record.provider_id,
+        );
+        if record.event_id != expected {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        Ok(())
+    }
+
+    fn plan(
+        &self,
+        request: &SourceWorkerPlanRequestV1,
+    ) -> Result<SourceWorkerHttpRequestV1, SourceExecutionError> {
+        let (plan, context) =
+            validated_plan_context(request.plan.as_ref(), request.context.as_ref())?;
+        let adapter = TwilioAccountsAdapter::new(&plan.origin, &context.tenant_id)
+            .map_err(map_provider_error)?;
+        let provider_request = adapter
+            .plan(optional_cursor(&context.prior_cursor))
+            .map_err(map_provider_error)?;
+        if provider_request.url().path() != plan.path
+            || provider_request.url().origin().unicode_serialization() != plan.origin
+            || provider_request.authorization_scheme() != TwilioAccountsAdapter::credential_scheme()
+        {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+
+        let mut output = SourceWorkerHttpRequestV1 {
+            plan_id: plan.plan_id.clone(),
+            method: plan.method.clone(),
+            url: provider_request.url().to_string(),
+            accept: provider_request.accept().to_owned(),
+            max_response_bytes: plan.max_response_bytes,
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            request_intent_digest: String::new(),
+        };
+        output.request_intent_digest = canonical_request_intent_digest(plan, context, &output);
+        Ok(output)
+    }
+
+    fn decode(
+        &self,
+        request: &SourceWorkerDecodeRequestV1,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        let (plan, context) =
+            validated_plan_context(request.plan.as_ref(), request.context.as_ref())?;
+        if request.logical_page_id != context.logical_page_id
+            || request.request_intent_digest.trim().is_empty()
+        {
+            return Err(SourceExecutionError::MissingExecutionIdentity);
+        }
+        let planned = <Self as SourceExecutionAdapter>::plan(
+            self,
+            &SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(context.clone()),
+            },
+        )?;
+        if planned.request_intent_digest != request.request_intent_digest {
+            return Err(SourceExecutionError::InvalidDigest);
+        }
+        if request.response_body.len() as u64 > plan.max_response_bytes {
+            return Err(SourceExecutionError::ResponseTooLarge);
+        }
+        let receipt = request
+            .receipt
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        if receipt.credential_operation != TwilioAccountsAdapter::credential_operation() {
+            return Err(SourceExecutionError::MissingExecutionIdentity);
+        }
+        validate_safe_receipt(
+            receipt,
+            plan,
+            context,
+            &request.response_body,
+            request.status_code,
+            &request.request_intent_digest,
+        )?;
+
+        let observed_at = observed_at(context)?;
+        let adapter = TwilioAccountsAdapter::new(&plan.origin, &context.tenant_id)
+            .map_err(map_provider_error)?;
+        let page = adapter
+            .decode(
+                optional_cursor(&context.prior_cursor),
+                request.status_code,
+                &request.response_body,
+                observed_at,
+            )
+            .map_err(map_provider_error)?;
+        let next_cursor = page.next_cursor.unwrap_or_default();
+        validate_cursor(&next_cursor)?;
+
+        let mut records = Vec::with_capacity(page.records.len());
+        for record in page.records {
+            if record.tenant_id != context.tenant_id
+                || record.fields.get("tenant_id") != Some(&context.tenant_id)
+            {
+                return Err(SourceExecutionError::TenantMismatch);
+            }
+            require_contract_fields(plan, &record.fields, &record.payload)?;
+            let occurred_at_unix_millis = occurred_at_unix_millis(&record.occurred_at)?;
+            let payload_json = serde_json::to_vec(&record.payload)
+                .map_err(|_| SourceExecutionError::InternalRuntime)?;
+            records.push(SourceWorkerRecordV1 {
+                provider_id: record.provider_id,
+                attributes: record.fields.into_iter().collect(),
+                payload_json,
+                event_id: record.event_id,
+                occurred_at_unix_millis,
+            });
+        }
+        let records = validate_and_deduplicate_records(records)?;
+        let result_digest_sha256 = canonical_result_digest(receipt, &next_cursor, &records)?;
+
+        Ok(SourceWorkerDecodeResultV1 {
+            plan_id: plan.plan_id.clone(),
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: request.request_intent_digest.clone(),
+            records,
+            next_cursor,
+            result_digest_sha256,
+            tenant_id: context.tenant_id.clone(),
+            runtime_id: context.runtime_id.clone(),
+            runtime_generation: context.runtime_generation,
+            lease_generation: context.lease_generation,
+            observed_at_unix_millis: context.observed_at_unix_millis,
+        })
+    }
+}
+
+fn validated_plan_context<'a>(
+    plan: Option<&'a SourceExecutionPlanV1>,
+    context: Option<&'a SourceWorkerExecutionContextV1>,
+) -> Result<
+    (
+        &'a SourceExecutionPlanV1,
+        &'a SourceWorkerExecutionContextV1,
+    ),
+    SourceExecutionError,
+> {
+    let plan = plan.ok_or(SourceExecutionError::InvalidPlan)?;
+    validate_accounts_plan(plan)?;
+    let context = context.ok_or(SourceExecutionError::InvalidExecutionContext)?;
+    validate_execution_context(context)?;
+    Ok((plan, context))
+}
+
+fn validate_accounts_plan(plan: &SourceExecutionPlanV1) -> Result<(), SourceExecutionError> {
+    let exact = plan.plan_id == PLAN_ID
+        && plan.source_id == TwilioAccountsAdapter::source_id()
+        && plan.family_id == TwilioAccountsAdapter::family_id()
+        && plan.provider_kernel == TwilioAccountsAdapter::provider_kernel()
+        && plan.method == "GET"
+        && plan.origin == TwilioAccountsAdapter::default_origin()
+        && plan.path == TwilioAccountsAdapter::path()
+        && plan.record_selector == RECORD_SELECTOR
+        && plan.id_field == ID_FIELD
+        && plan.singleton_fallback_id.is_empty()
+        && plan.max_response_bytes == TwilioAccountsAdapter::max_response_bytes()
+        && plan.event_kind == EVENT_KIND
+        && plan.schema_ref == SCHEMA_REF
+        && plan.required_attributes == REQUIRED_ATTRIBUTES
+        && plan.required_payload_fields == REQUIRED_PAYLOAD_FIELDS
+        && canonical_plan_digest(plan) == plan.plan_digest_sha256;
+    if exact {
+        Ok(())
+    } else {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+}
+
+fn require_contract_fields(
+    plan: &SourceExecutionPlanV1,
+    attributes: &std::collections::BTreeMap<String, String>,
+    payload: &Value,
+) -> Result<(), SourceExecutionError> {
+    if plan.required_attributes.iter().any(|required| {
+        attributes
+            .get(required)
+            .is_none_or(|value| value.trim().is_empty())
+    }) || plan
+        .required_payload_fields
+        .iter()
+        .any(|required| payload.get(required).is_none_or(Value::is_null))
+    {
+        return Err(SourceExecutionError::EventContractRejected);
+    }
+    Ok(())
+}
+
+fn optional_cursor(cursor: &str) -> Option<&str> {
+    (!cursor.is_empty()).then_some(cursor)
+}
+
+fn observed_at(
+    context: &SourceWorkerExecutionContextV1,
+) -> Result<OffsetDateTime, SourceExecutionError> {
+    let nanos = i128::from(context.observed_at_unix_millis)
+        .checked_mul(1_000_000)
+        .ok_or(SourceExecutionError::InvalidExecutionContext)?;
+    OffsetDateTime::from_unix_timestamp_nanos(nanos)
+        .map_err(|_| SourceExecutionError::InvalidExecutionContext)
+}
+
+fn occurred_at_unix_millis(value: &str) -> Result<i64, SourceExecutionError> {
+    let occurred_at = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| SourceExecutionError::InvalidProviderRecord)?;
+    i64::try_from(occurred_at.unix_timestamp_nanos() / 1_000_000)
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or(SourceExecutionError::MissingStableIdentity)
+}
+
+fn map_provider_error(error: TwilioAccountsAdapterError) -> SourceExecutionError {
+    match error {
+        TwilioAccountsAdapterError::AuthenticationRejected => {
+            SourceExecutionError::AuthenticationRejected
+        }
+        TwilioAccountsAdapterError::RequiredScopeMissing => {
+            SourceExecutionError::RequiredProviderScopeMissing
+        }
+        TwilioAccountsAdapterError::ProviderTimeout => SourceExecutionError::ProviderTimeout,
+        TwilioAccountsAdapterError::RateLimited => SourceExecutionError::ProviderRateLimit,
+        TwilioAccountsAdapterError::ProviderUnavailable
+        | TwilioAccountsAdapterError::UnexpectedStatus(_) => {
+            SourceExecutionError::UnexpectedProviderStatus
+        }
+        TwilioAccountsAdapterError::Kernel(TwilioError::InvalidCursor) => {
+            SourceExecutionError::InvalidCursor
+        }
+        TwilioAccountsAdapterError::Kernel(TwilioError::ResponseTooLarge) => {
+            SourceExecutionError::ResponseTooLarge
+        }
+        TwilioAccountsAdapterError::Kernel(TwilioError::TooManyRecords) => {
+            SourceExecutionError::ResultTooLarge
+        }
+        TwilioAccountsAdapterError::Kernel(TwilioError::MissingProviderIdentity)
+        | TwilioAccountsAdapterError::Kernel(TwilioError::InvalidEventIdentity) => {
+            SourceExecutionError::MissingStableIdentity
+        }
+        TwilioAccountsAdapterError::Kernel(TwilioError::ConflictingProviderIdentity) => {
+            SourceExecutionError::DuplicateConflict
+        }
+        TwilioAccountsAdapterError::Kernel(TwilioError::InvalidResponse) => {
+            SourceExecutionError::MalformedResponse
+        }
+        TwilioAccountsAdapterError::Kernel(
+            TwilioError::MissingRequiredPayloadField(_) | TwilioError::MissingRequiredAttribute(_),
+        ) => SourceExecutionError::InvalidProviderRecord,
+        TwilioAccountsAdapterError::Kernel(
+            TwilioError::InvalidBaseUrl
+            | TwilioError::InvalidFamily
+            | TwilioError::MissingTenantId
+            | TwilioError::MissingAccountSid
+            | TwilioError::InvalidPageSize
+            | TwilioError::RequestScopeMismatch,
+        ) => SourceExecutionError::InvalidPlan,
+    }
+}

--- a/crates/source-runtime-next/src/twilio/tests/adapter.rs
+++ b/crates/source-runtime-next/src/twilio/tests/adapter.rs
@@ -1,0 +1,146 @@
+use super::*;
+use crate::twilio::adapter::{TwilioAccountsAdapter, TwilioAccountsAdapterError};
+
+const SOURCE_WORKER_ACCOUNTS_FIXTURE: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../sources/twilio/testdata/source_worker_accounts_page.json"
+));
+
+#[test]
+fn accounts_adapter_plans_credential_free_bounded_cursor_request() {
+    let adapter = TwilioAccountsAdapter::new(TwilioAccountsAdapter::default_origin(), TENANT_ID)
+        .expect("authenticated execution scope");
+    let request = adapter.plan(Some("accounts-page-1")).unwrap();
+
+    assert_eq!(TwilioAccountsAdapter::source_id(), "twilio");
+    assert_eq!(TwilioAccountsAdapter::family_id(), "accounts");
+    assert_eq!(TwilioAccountsAdapter::provider_kernel(), "twilio.accounts");
+    assert_eq!(TwilioAccountsAdapter::path(), "/2010-04-01/Accounts.json");
+    assert_eq!(TwilioAccountsAdapter::max_response_bytes(), 8 << 20);
+    assert_eq!(
+        TwilioAccountsAdapter::credential_operation(),
+        "twilio.basic"
+    );
+    assert_eq!(TwilioAccountsAdapter::credential_scheme(), "Basic");
+    assert_eq!(request.authorization_scheme(), "Basic");
+    assert_eq!(request.accept(), "application/json");
+    assert_eq!(
+        request.url().as_str(),
+        "https://api.twilio.com/2010-04-01/Accounts.json?limit=100&cursor=accounts-page-1"
+    );
+    assert!(!request.url().as_str().contains("credential"));
+    assert!(!request.url().as_str().contains("token"));
+    assert_eq!(
+        adapter.plan(Some(" accounts-page-1")).unwrap_err(),
+        TwilioAccountsAdapterError::Kernel(TwilioError::InvalidCursor)
+    );
+}
+
+#[test]
+fn accounts_adapter_decodes_fixture_with_stable_tenant_identity_dedupe_and_cursor() {
+    let adapter = TwilioAccountsAdapter::new(TwilioAccountsAdapter::default_origin(), TENANT_ID)
+        .expect("authenticated execution scope");
+    let page = adapter
+        .decode(
+            Some("accounts-page-1"),
+            200,
+            SOURCE_WORKER_ACCOUNTS_FIXTURE,
+            observed_at(),
+        )
+        .unwrap();
+
+    assert_eq!(page.next_cursor.as_deref(), Some("accounts-page-2"));
+    assert_eq!(page.records.len(), 1);
+    let record = &page.records[0];
+    assert_eq!(record.tenant_id, TENANT_ID);
+    assert_eq!(record.provider_id, "record-1");
+    assert_eq!(
+        record.event_id,
+        "twilio-tenant-a92380b4993d-accounts-record-1"
+    );
+    assert_eq!(record.occurred_at, "2026-06-01T00:00:00Z");
+    assert_eq!(record.fields["tenant_id"], TENANT_ID);
+    assert_eq!(record.fields["source_event_id"], "provider-event-1");
+    assert_eq!(record.fields["user_id"], "record-1");
+    assert_eq!(record.payload["id"], "record-1");
+}
+
+#[test]
+fn accounts_adapter_never_derives_tenant_from_provider_payload() {
+    let adapter = TwilioAccountsAdapter::new(TwilioAccountsAdapter::default_origin(), TENANT_ID)
+        .expect("authenticated execution scope");
+    let page = adapter
+        .decode(
+            None,
+            200,
+            br#"{"data":[{"id":"record-1","tenant_id":"provider-tenant","metadata":{"tenant_id":"provider-metadata-tenant"}}]}"#,
+            observed_at(),
+        )
+        .unwrap();
+    let record = &page.records[0];
+
+    assert_eq!(record.tenant_id, TENANT_ID);
+    assert_eq!(record.fields["tenant_id"], TENANT_ID);
+    assert_eq!(
+        record.event_id,
+        "twilio-tenant-a92380b4993d-accounts-record-1"
+    );
+    assert_eq!(record.payload["tenant_id"], "provider-tenant");
+}
+
+#[test]
+fn accounts_adapter_maps_provider_statuses_without_response_data() {
+    let adapter = TwilioAccountsAdapter::new(TwilioAccountsAdapter::default_origin(), TENANT_ID)
+        .expect("authenticated execution scope");
+    for (status, expected, retryable, action) in [
+        (
+            401,
+            TwilioAccountsAdapterError::AuthenticationRejected,
+            false,
+            "repair credential binding",
+        ),
+        (
+            403,
+            TwilioAccountsAdapterError::RequiredScopeMissing,
+            false,
+            "grant required provider scope",
+        ),
+        (
+            408,
+            TwilioAccountsAdapterError::ProviderTimeout,
+            true,
+            "retry later",
+        ),
+        (
+            429,
+            TwilioAccountsAdapterError::RateLimited,
+            true,
+            "retry later",
+        ),
+        (
+            503,
+            TwilioAccountsAdapterError::ProviderUnavailable,
+            true,
+            "retry later",
+        ),
+        (
+            418,
+            TwilioAccountsAdapterError::UnexpectedStatus(418),
+            false,
+            "inspect provider status",
+        ),
+    ] {
+        let error = adapter
+            .decode(
+                None,
+                status,
+                b"provider body must not enter the error",
+                observed_at(),
+            )
+            .unwrap_err();
+        assert_eq!(error, expected);
+        assert_eq!(error.retryable(), retryable);
+        assert_eq!(error.operator_action(), action);
+        assert!(!error.to_string().contains("provider body"));
+    }
+}

--- a/crates/source-runtime-next/src/twilio/tests/mod.rs
+++ b/crates/source-runtime-next/src/twilio/tests/mod.rs
@@ -28,6 +28,7 @@ fn kernel(family: TwilioFamily) -> TwilioKernel {
 }
 
 mod accounts;
+mod adapter;
 mod audit_events;
 mod failure;
 mod keys;

--- a/sources/twilio/source_test.go
+++ b/sources/twilio/source_test.go
@@ -2,12 +2,17 @@ package twilio
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 )
 
@@ -46,5 +51,85 @@ func TestSourceCheckAndRead(t *testing.T) {
 	}
 	if strings.TrimSpace(event.Id) == "" {
 		t.Fatalf("event id is empty: %#v", event)
+	}
+}
+
+func TestAccountsSourceWorkerFixtureParity(t *testing.T) {
+	fixture, err := os.ReadFile("testdata/source_worker_accounts_page.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Basic test-token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		if got := r.URL.Path; got != "/2010-04-01/Accounts.json" {
+			t.Fatalf("path = %q", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "100" {
+			t.Fatalf("limit = %q", got)
+		}
+		if got := r.URL.Query().Get("cursor"); got != "accounts-page-1" {
+			t.Fatalf("cursor = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(fixture)
+	}))
+	defer server.Close()
+
+	source, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	source.allowLoopbackForTest()
+	cfg := sourcecdk.NewConfig(map[string]string{
+		"base_url":  server.URL,
+		"family":    familyAccounts,
+		"tenant_id": "tenant",
+		"token":     "test-token",
+	})
+	pull, err := source.Read(
+		context.Background(),
+		cfg,
+		&cerebrov1.SourceCursor{Opaque: "accounts-page-1"},
+	)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(pull.Events) != 1 {
+		t.Fatalf("events = %d, want one deduplicated event", len(pull.Events))
+	}
+	if pull.NextCursor == nil || pull.NextCursor.GetOpaque() != "accounts-page-2" {
+		t.Fatalf("next cursor = %#v", pull.NextCursor)
+	}
+
+	event := pull.Events[0]
+	scope := sha256.Sum256([]byte(server.URL + "\x00/2010-04-01/Accounts.json"))
+	wantEventID := "twilio-tenant-" + hex.EncodeToString(scope[:])[:12] + "-accounts-record-1"
+	if event.GetId() != wantEventID {
+		t.Fatalf("event id = %q, want %q", event.GetId(), wantEventID)
+	}
+	if event.GetTenantId() != "tenant" || event.GetKind() != "twilio.accounts" || event.GetSchemaRef() != "twilio/accounts/v1" {
+		t.Fatalf("event scope = %#v", event)
+	}
+	if got, want := event.GetOccurredAt().AsTime(), time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC); !got.Equal(want) {
+		t.Fatalf("occurred_at = %s, want %s", got, want)
+	}
+	for name, want := range map[string]string{
+		"source_event_id": "provider-event-1",
+		"tenant_id":       "tenant",
+		"user_id":         "record-1",
+	} {
+		if got := event.GetAttributes()[name]; got != want {
+			t.Fatalf("attribute %s = %q, want %q", name, got, want)
+		}
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(event.GetPayload(), &payload); err != nil {
+		t.Fatalf("decode event payload: %v", err)
+	}
+	if payload["id"] != "record-1" || payload["name"] != "Record One" {
+		t.Fatalf("payload = %#v", payload)
 	}
 }

--- a/sources/twilio/testdata/source_worker_accounts_page.json
+++ b/sources/twilio/testdata/source_worker_accounts_page.json
@@ -1,0 +1,25 @@
+{
+  "data": [
+    {
+      "event_id": "provider-event-1",
+      "id": "record-1",
+      "name": "Record One",
+      "resource_id": "record-1",
+      "tenant_id": "tenant",
+      "updated_at": "2026-06-01T00:00:00Z",
+      "user_id": "record-1"
+    },
+    {
+      "event_id": "provider-event-1",
+      "id": "record-1",
+      "name": "Record One",
+      "resource_id": "record-1",
+      "tenant_id": "tenant",
+      "updated_at": "2026-06-01T00:00:00Z",
+      "user_id": "record-1"
+    }
+  ],
+  "pagination": {
+    "next_cursor": "accounts-page-2"
+  }
+}


### PR DESCRIPTION
## Scope

Adds the provider-local, credential-free Twilio accounts request/response adapter. The shared wire, dispatcher, generated contracts, catalog, and runtime host remain outside this PR.

This PR is stacked on shared source-execution contract PR #2437 at exact base `48b335c1829a22731fb2ef170f350deff8fee5b3`. Twilio is intentionally not registered in the closed dispatcher here; the shared-runtime owner will add that follow-up registration after this adapter is validated.

## Invariants

- Builds deterministic `GET /2010-04-01/Accounts.json?PageSize=100` plans and validates bounded, round-trippable cursors.
- Emits no credentials or authorization header; the trusted host owns the external `twilio.basic` credential operation.
- Rejects responses above 8 MiB before provider decoding.
- Maps authentication, scope, timeout, rate-limit, provider status, cursor, record, identity, and duplicate failures to closed shared errors.
- Uses only authenticated execution context for tenant identity and validates the exact Go-compatible `twilio-{tenant}-{scope12}-accounts-{provider}` event identity.
- Deduplicates exact provider objects and rejects conflicting duplicate identities.
- Includes a bounded provider fixture, canonical shared-edge tests, and Go semantic-parity integration coverage.

## Exact-head validation

Head `7410e8c628813dc624be357c5ed1cc149a228a8c`, stacked base `48b335c1829a22731fb2ef170f350deff8fee5b3`:

- `cargo fmt --all -- --check` — passed.
- `cargo test --locked -p cerebro-source-runtime-next twilio -- --nocapture` — 22 passed.
- `cargo clippy --locked -p cerebro-source-runtime-next --all-targets -- -D warnings` — passed.
- `cargo test --locked -p cerebro-source-runtime-next -- --skip http::tests` — library 350 passed with 45 long HTTP tests intentionally filtered; source-worker integration 7 passed.
- `go test ./sources/twilio -count=1` — passed.
- `go test -race ./sources/twilio -count=1` — passed.
- `go test ./internal/sourceprojection -count=1` — passed.
- `make catalog-check` — passed; catalog total 799, generateable 798, bespoke runtime 1.
- `GOTOOLCHAIN=go1.26.6 make check-structural check-structural-test check-arch` — passed.
- `./scripts/leak_check.sh` — passed.

A prior full runtime receipt completed the long HTTP module (including Meraki/OAuth) with 338 passed before the shared-contract rebase; those long tests were not duplicated. Hosted checks on the exact stacked head remain the authoritative full validation.

This draft does not claim merge, deployment, live-provider, or authenticated-user-path proof. It will be retargeted to `main` only after #2437 merges and the seven-path provider diff is reverified.
