### PR TITLE
feat(rust): add Cloudflare source runtime kernel

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -2666,7 +2666,7 @@ mod tests {
         .unwrap();
         let summary = catalog.summary();
         assert_eq!(summary.sources, 799);
-        assert_eq!(summary.families, 3_926);
+        assert_eq!(summary.families, 3_938);
         assert_eq!(summary.push_sources, 1);
         assert_eq!(summary.push_families, 10);
         assert_eq!(
@@ -3546,7 +3546,7 @@ mod tests {
         .unwrap();
         let report = catalog.unsupported_feature_report();
         assert_eq!(report.total_sources, 799);
-        assert_eq!(report.total_families, 3_926);
+        assert_eq!(report.total_families, 3_938);
         assert_eq!(report.families.len(), report.total_families);
         assert!(report.missing_family_reports.is_empty());
         assert_eq!(
@@ -3595,7 +3595,7 @@ mod tests {
         )
         .unwrap();
         let report = catalog.authority_readiness_report();
-        assert_eq!(report.total_families, 3_926);
+        assert_eq!(report.total_families, 3_938);
         assert_eq!(report.rust_authoritative_families, 0);
         assert_eq!(report.shadow_or_go_families, report.total_families);
         let aws_bedrock = report

--- a/crates/source-runtime-next/src/cloudflare.rs
+++ b/crates/source-runtime-next/src/cloudflare.rs
@@ -1,0 +1,21 @@
+//! Credential-free Cloudflare request, response, cursor, and normalization kernel.
+//!
+//! The kernel covers the `cloudflare` source catalog. It never receives an API
+//! token: the trusted host applies the declared bearer credential after the
+//! request has passed the origin and scope checks in this module.
+
+mod cursor;
+mod error;
+mod family;
+mod kernel;
+mod normalize;
+mod origin;
+
+pub use error::CloudflareError;
+pub use family::{CloudflareFamily, CloudflareScope};
+pub use kernel::{
+    CloudflareKernel, CloudflarePage, CloudflareRecord, CloudflareRequest, CloudflareRequestKind,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/cloudflare/cursor.rs
+++ b/crates/source-runtime-next/src/cloudflare/cursor.rs
@@ -1,0 +1,47 @@
+use serde_json::{Map, Value};
+
+use super::CloudflareError;
+
+const MAX_PAGES: u32 = 10_000;
+
+pub(super) fn parse_cursor(cursor: Option<&str>) -> Result<u32, CloudflareError> {
+    let Some(value) = cursor.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(1);
+    };
+    value
+        .parse::<u32>()
+        .ok()
+        .filter(|page| (1..=MAX_PAGES).contains(page))
+        .ok_or(CloudflareError::InvalidCursor)
+}
+
+pub(super) fn next_cursor(
+    result_info: Option<&Value>,
+    request_page: u32,
+    request_page_size: usize,
+    record_count: usize,
+) -> Result<Option<String>, CloudflareError> {
+    let Some(info) = result_info else {
+        return Ok(
+            (record_count == request_page_size && request_page < MAX_PAGES)
+                .then(|| (request_page + 1).to_string()),
+        );
+    };
+    if info.is_null() {
+        return Ok(None);
+    }
+    let info = info.as_object().ok_or(CloudflareError::InvalidResponse)?;
+    let page = u32_at(info, "page").ok_or(CloudflareError::InvalidResponse)?;
+    let total_pages = u32_at(info, "total_pages").ok_or(CloudflareError::InvalidResponse)?;
+    if page != request_page || total_pages == 0 || total_pages > MAX_PAGES || page > total_pages {
+        return Err(CloudflareError::InvalidCursor);
+    }
+    Ok((page < total_pages).then(|| (page + 1).to_string()))
+}
+
+fn u32_at(object: &Map<String, Value>, key: &str) -> Option<u32> {
+    object
+        .get(key)
+        .and_then(|value| value.as_u64().or_else(|| value.as_str()?.parse().ok()))
+        .and_then(|value| u32::try_from(value).ok())
+}

--- a/crates/source-runtime-next/src/cloudflare/error.rs
+++ b/crates/source-runtime-next/src/cloudflare/error.rs
@@ -1,0 +1,126 @@
+use std::{error::Error, fmt};
+
+/// Bounded Cloudflare provider and contract failures.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CloudflareError {
+    /// Family identifier is outside the checked-in Cloudflare catalog.
+    InvalidFamily,
+    /// Base URL is not a public credential-free HTTPS origin.
+    InvalidBaseUrl,
+    /// Authenticated tenant identifier is missing or unsafe.
+    InvalidTenantId,
+    /// A family-scoped account or zone identifier is missing or unsafe.
+    InvalidScopeId,
+    /// Page size is outside the Cloudflare API bound.
+    InvalidPageSize,
+    /// Continuation is not a bounded positive page number.
+    InvalidCursor,
+    /// Request was decoded by another family, scope, origin, or kernel instance.
+    RequestScopeMismatch,
+    /// Response exceeded the byte bound before decoding.
+    ResponseTooLarge,
+    /// Cloudflare returned a malformed success envelope.
+    InvalidResponse,
+    /// Response contains more records or pages than the kernel admits.
+    BudgetExceeded,
+    /// A provider record is missing its stable `id`.
+    MissingProviderIdentity,
+    /// A provider record carries a scope that conflicts with the request.
+    ProviderScopeMismatch,
+    /// The same scoped provider identity appeared with different content.
+    ConflictingDuplicate,
+    /// Provider payload contains credential-bearing field names.
+    CredentialMaterial,
+    /// Cloudflare rejected the externally applied bearer credential.
+    AuthenticationRejected,
+    /// The credential is valid but cannot read the selected family or scope.
+    RequiredScopeMissing,
+    /// Cloudflare asked the trusted host to retry later.
+    RateLimited {
+        /// Bounded retry delay admitted from `Retry-After`.
+        retry_after_seconds: Option<u64>,
+    },
+    /// Cloudflare returned a retryable server status.
+    ProviderUnavailable {
+        /// Status in the inclusive 500-599 range.
+        status: u16,
+    },
+    /// Provider returned another non-success status.
+    UnexpectedStatus {
+        /// Status outside the typed cases.
+        status: u16,
+    },
+    /// Retry-After exceeded the one-hour persistence bound.
+    InvalidRetryAfter,
+    /// A success-status envelope explicitly reported failure.
+    ProviderRejected,
+}
+
+impl CloudflareError {
+    /// Next bounded operator action for this typed failure.
+    pub const fn operator_action(&self) -> &'static str {
+        match self {
+            Self::InvalidFamily
+            | Self::InvalidBaseUrl
+            | Self::InvalidTenantId
+            | Self::InvalidScopeId
+            | Self::InvalidPageSize
+            | Self::RequestScopeMismatch => "repair source configuration",
+            Self::AuthenticationRejected => "repair credential binding",
+            Self::RequiredScopeMissing => "grant required Cloudflare read scope",
+            Self::RateLimited { .. } | Self::ProviderUnavailable { .. } => "retry later",
+            Self::InvalidCursor => "restart collection from the last committed checkpoint",
+            Self::ResponseTooLarge
+            | Self::InvalidResponse
+            | Self::BudgetExceeded
+            | Self::MissingProviderIdentity
+            | Self::ProviderScopeMismatch
+            | Self::ConflictingDuplicate
+            | Self::CredentialMaterial
+            | Self::ProviderRejected => "inspect quarantined provider records",
+            Self::UnexpectedStatus { .. } | Self::InvalidRetryAfter => {
+                "inspect provider response and repair forward"
+            }
+        }
+    }
+}
+
+impl fmt::Display for CloudflareError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidFamily => "cloudflare family is invalid",
+            Self::InvalidBaseUrl => {
+                "cloudflare base URL must be a public credential-free HTTPS origin"
+            }
+            Self::InvalidTenantId => "cloudflare tenant ID is required and must be bounded",
+            Self::InvalidScopeId => {
+                "cloudflare account or zone scope is required and must be bounded"
+            }
+            Self::InvalidPageSize => "cloudflare page size is outside the provider bound",
+            Self::InvalidCursor => "cloudflare cursor must be a bounded positive page number",
+            Self::RequestScopeMismatch => "cloudflare request does not match the configured kernel",
+            Self::ResponseTooLarge => "cloudflare response exceeds the kernel byte bound",
+            Self::InvalidResponse => "cloudflare response JSON does not match the selected family",
+            Self::BudgetExceeded => "cloudflare response exceeds a page, record, or nesting bound",
+            Self::MissingProviderIdentity => "cloudflare record is missing a stable provider ID",
+            Self::ProviderScopeMismatch => {
+                "cloudflare record scope conflicts with the requested account or zone"
+            }
+            Self::ConflictingDuplicate => {
+                "cloudflare scoped provider identity has conflicting content"
+            }
+            Self::CredentialMaterial => "cloudflare response contains credential-bearing material",
+            Self::AuthenticationRejected => "cloudflare rejected the bearer credential",
+            Self::RequiredScopeMissing => {
+                "cloudflare bearer credential lacks the selected family scope"
+            }
+            Self::RateLimited { .. } => "cloudflare rate limited the bounded request",
+            Self::ProviderUnavailable { .. } => "cloudflare provider is temporarily unavailable",
+            Self::UnexpectedStatus { .. } => "cloudflare returned an unexpected HTTP status",
+            Self::InvalidRetryAfter => "cloudflare Retry-After exceeds the one-hour bound",
+            Self::ProviderRejected => "cloudflare success envelope reported a provider failure",
+        })
+    }
+}
+
+impl Error for CloudflareError {}

--- a/crates/source-runtime-next/src/cloudflare/family.rs
+++ b/crates/source-runtime-next/src/cloudflare/family.rs
@@ -1,0 +1,187 @@
+use std::str::FromStr;
+
+use super::CloudflareError;
+
+/// Scope required to build one Cloudflare family request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CloudflareScope {
+    /// Family is global to the credential-visible Cloudflare account set.
+    None,
+    /// Family requires one Cloudflare account identifier.
+    Account,
+    /// Family requires one Cloudflare zone identifier.
+    Zone,
+}
+
+/// Closed Cloudflare source-catalog family vocabulary.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum CloudflareFamily {
+    /// Cloudflare accounts.
+    Account,
+    /// Account members.
+    Member,
+    /// Account roles.
+    Role,
+    /// Account rulesets.
+    AccountRuleset,
+    /// Workers script metadata.
+    WorkerScript,
+    /// Account audit entries.
+    AuditLog,
+    /// Account-scoped Access applications.
+    AccessApplication,
+    /// Zone-scoped Access applications.
+    ZoneAccessApplication,
+    /// Account-scoped Access groups.
+    AccessGroup,
+    /// Zone-scoped Access groups.
+    ZoneAccessGroup,
+    /// Gateway rules.
+    GatewayRule,
+    /// Zones.
+    Zone,
+    /// DNS records.
+    DnsRecord,
+    /// Zone rulesets.
+    ZoneRuleset,
+    /// Zone load balancers.
+    LoadBalancer,
+    /// Account load-balancer pools.
+    LoadBalancerPool,
+}
+
+impl CloudflareFamily {
+    /// Every family in stable catalog order.
+    pub const ALL: [Self; 16] = [
+        Self::AccessApplication,
+        Self::AccessGroup,
+        Self::Account,
+        Self::AccountRuleset,
+        Self::AuditLog,
+        Self::Member,
+        Self::GatewayRule,
+        Self::LoadBalancer,
+        Self::LoadBalancerPool,
+        Self::Role,
+        Self::WorkerScript,
+        Self::Zone,
+        Self::ZoneAccessApplication,
+        Self::ZoneAccessGroup,
+        Self::ZoneRuleset,
+        Self::DnsRecord,
+    ];
+
+    /// Catalog family identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Account => "account",
+            Self::Member => "member",
+            Self::Role => "role",
+            Self::AccountRuleset => "account_ruleset",
+            Self::WorkerScript => "worker_script",
+            Self::AuditLog => "audit_log",
+            Self::AccessApplication => "access_application",
+            Self::ZoneAccessApplication => "zone_access_application",
+            Self::AccessGroup => "access_group",
+            Self::ZoneAccessGroup => "zone_access_group",
+            Self::GatewayRule => "gateway_rule",
+            Self::Zone => "zone",
+            Self::DnsRecord => "dns_record",
+            Self::ZoneRuleset => "zone_ruleset",
+            Self::LoadBalancer => "load_balancer",
+            Self::LoadBalancerPool => "load_balancer_pool",
+        }
+    }
+
+    /// Exact emitted event kind.
+    pub fn event_kind(self) -> String {
+        format!("cloudflare.{}", self.as_str())
+    }
+
+    /// Exact checked-in event schema.
+    pub fn schema_ref(self) -> String {
+        format!("cloudflare/{}/v1", self.as_str())
+    }
+
+    /// Scope required by the provider endpoint.
+    pub const fn scope(self) -> CloudflareScope {
+        match self {
+            Self::Account | Self::Zone => CloudflareScope::None,
+            Self::ZoneAccessApplication
+            | Self::ZoneAccessGroup
+            | Self::ZoneRuleset
+            | Self::DnsRecord
+            | Self::LoadBalancer => CloudflareScope::Zone,
+            Self::Member
+            | Self::Role
+            | Self::AccountRuleset
+            | Self::WorkerScript
+            | Self::AuditLog
+            | Self::AccessApplication
+            | Self::AccessGroup
+            | Self::GatewayRule
+            | Self::LoadBalancerPool => CloudflareScope::Account,
+        }
+    }
+
+    /// Provider list path, with the validated scope substituted by the kernel.
+    pub(crate) const fn path_template(self) -> &'static str {
+        match self {
+            Self::Account => "/accounts",
+            Self::Member => "/accounts/{scope}/members",
+            Self::Role => "/accounts/{scope}/roles",
+            Self::AccountRuleset => "/accounts/{scope}/rulesets",
+            Self::WorkerScript => "/accounts/{scope}/workers/scripts",
+            Self::AuditLog => "/accounts/{scope}/audit_logs",
+            Self::AccessApplication => "/accounts/{scope}/access/apps",
+            Self::ZoneAccessApplication => "/zones/{scope}/access/apps",
+            Self::AccessGroup => "/accounts/{scope}/access/groups",
+            Self::ZoneAccessGroup => "/zones/{scope}/access/groups",
+            Self::GatewayRule => "/accounts/{scope}/gateway/rules",
+            Self::Zone => "/zones",
+            Self::DnsRecord => "/zones/{scope}/dns_records",
+            Self::ZoneRuleset => "/zones/{scope}/rulesets",
+            Self::LoadBalancer => "/zones/{scope}/load_balancers",
+            Self::LoadBalancerPool => "/accounts/{scope}/load_balancers/pools",
+        }
+    }
+
+    /// Optional provider detail path used to enrich list records.
+    pub const fn detail_path_template(self) -> Option<&'static str> {
+        match self {
+            Self::Role => Some("/accounts/{scope}/roles/{id}"),
+            Self::AccountRuleset => Some("/accounts/{scope}/rulesets/{id}"),
+            Self::ZoneRuleset => Some("/zones/{scope}/rulesets/{id}"),
+            _ => None,
+        }
+    }
+
+    pub(crate) const fn id_attribute(self) -> &'static str {
+        match self {
+            Self::Account => "account_id",
+            Self::Member => "member_id",
+            Self::Role => "role_id",
+            Self::AccountRuleset | Self::ZoneRuleset => "ruleset_id",
+            Self::WorkerScript => "script_id",
+            Self::AuditLog => "audit_id",
+            Self::AccessApplication | Self::ZoneAccessApplication => "application_id",
+            Self::AccessGroup | Self::ZoneAccessGroup => "group_id",
+            Self::GatewayRule => "rule_id",
+            Self::Zone => "zone_id",
+            Self::DnsRecord => "record_id",
+            Self::LoadBalancer => "load_balancer_id",
+            Self::LoadBalancerPool => "pool_id",
+        }
+    }
+}
+
+impl FromStr for CloudflareFamily {
+    type Err = CloudflareError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|family| family.as_str() == value.trim())
+            .ok_or(CloudflareError::InvalidFamily)
+    }
+}

--- a/crates/source-runtime-next/src/cloudflare/kernel.rs
+++ b/crates/source-runtime-next/src/cloudflare/kernel.rs
@@ -1,0 +1,432 @@
+use std::collections::BTreeMap;
+
+use reqwest::Url;
+use serde_json::{Map, Value};
+
+use super::{
+    CloudflareError, CloudflareFamily, CloudflareScope,
+    cursor::{next_cursor, parse_cursor},
+    normalize::{
+        attribute_contract, bounded_component, common_attributes, kernel_fingerprint,
+        reject_credential_material, string_at, string_path, tenant_event_id, value_string_at,
+    },
+    origin::validate_origin,
+};
+
+const MAX_RESPONSE_BYTES: usize = 8 << 20;
+const DEFAULT_PAGE_SIZE: usize = 100;
+const MAX_PAGE_SIZE: usize = 1_000;
+const MAX_IDENTIFIER_BYTES: usize = 512;
+const MAX_TENANT_BYTES: usize = 255;
+
+/// One credential-free Cloudflare request stage.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CloudflareRequestKind {
+    /// List one bounded page for the selected family.
+    List,
+    /// Fetch one provider object after a list result requested enrichment.
+    Detail {
+        /// Stable provider ID substituted into the checked-in detail path.
+        provider_id: String,
+    },
+}
+
+/// A bounded Cloudflare request plan without credential bytes.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CloudflareRequest {
+    url: Url,
+    family: CloudflareFamily,
+    scope_id: Option<String>,
+    page: u32,
+    page_size: usize,
+    kind: CloudflareRequestKind,
+    kernel_fingerprint: [u8; 32],
+}
+
+impl CloudflareRequest {
+    /// Fully planned provider URL.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Selected catalog family.
+    pub const fn family(&self) -> CloudflareFamily {
+        self.family
+    }
+
+    /// Request stage.
+    pub fn kind(&self) -> &CloudflareRequestKind {
+        &self.kind
+    }
+
+    /// Header populated by the trusted credential host.
+    pub const fn authorization_header(&self) -> &'static str {
+        "Authorization"
+    }
+
+    /// Scheme applied outside this kernel.
+    pub const fn authorization_scheme(&self) -> &'static str {
+        "Bearer"
+    }
+
+    /// Portable request plans never contain provider credential bytes.
+    pub const fn contains_credentials(&self) -> bool {
+        false
+    }
+
+    /// Redirects remain disabled at the trusted host.
+    pub const fn allows_redirects(&self) -> bool {
+        false
+    }
+
+    /// Maximum response body admitted before decoding.
+    pub const fn max_response_bytes(&self) -> usize {
+        MAX_RESPONSE_BYTES
+    }
+
+    /// Required provider response media type.
+    pub const fn accept(&self) -> &'static str {
+        "application/json"
+    }
+
+    /// Page represented by a list request.
+    pub const fn page(&self) -> u32 {
+        self.page
+    }
+}
+
+/// One normalized, tenant-bound Cloudflare provider record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CloudflareRecord {
+    /// Raw provider object ID retained for investigation.
+    pub provider_id: String,
+    /// Account- or zone-qualified provider identity used for dedupe.
+    pub scoped_provider_id: String,
+    /// Stable tenant-scoped event identity.
+    pub event_id: String,
+    /// Exact source-catalog family.
+    pub family: String,
+    /// Exact source-catalog event kind.
+    pub event_kind: String,
+    /// Exact source-catalog schema reference.
+    pub schema_ref: String,
+    /// Go-compatible scalar attributes in deterministic key order.
+    pub attributes: BTreeMap<String, String>,
+    /// Credential-free provider payload.
+    pub payload: Value,
+}
+
+/// One normalized Cloudflare provider page.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CloudflarePage {
+    /// Records in provider order after idempotent duplicate collapse.
+    pub records: Vec<CloudflareRecord>,
+    /// Go-compatible page continuation.
+    pub next_cursor: Option<String>,
+    /// Provider records examined before duplicate collapse.
+    pub scanned_count: usize,
+}
+
+/// Closed Cloudflare provider kernel for one tenant, family, and scope.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CloudflareKernel {
+    base_url: Url,
+    tenant_id: String,
+    family: CloudflareFamily,
+    scope_id: Option<String>,
+    page_size: usize,
+    fingerprint: [u8; 32],
+}
+
+impl CloudflareKernel {
+    /// Compile one family into an origin- and scope-bound provider kernel.
+    ///
+    /// `scope_id` is an account ID for account-scoped families and a zone ID
+    /// for zone-scoped families. Global `account` and `zone` families reject it.
+    pub fn new(
+        base_url: &str,
+        tenant_id: &str,
+        family: CloudflareFamily,
+        scope_id: Option<&str>,
+        page_size: Option<usize>,
+    ) -> Result<Self, CloudflareError> {
+        let base_url = validate_origin(base_url)?;
+        let tenant_id = bounded_component(tenant_id, MAX_TENANT_BYTES)
+            .ok_or(CloudflareError::InvalidTenantId)?;
+        let scope_id = match (family.scope(), scope_id) {
+            (CloudflareScope::None, None) => None,
+            (CloudflareScope::None, Some(value)) if value.trim().is_empty() => None,
+            (CloudflareScope::None, Some(_)) => return Err(CloudflareError::InvalidScopeId),
+            (_, Some(value)) => Some(
+                bounded_component(value, MAX_IDENTIFIER_BYTES)
+                    .ok_or(CloudflareError::InvalidScopeId)?,
+            ),
+            (_, None) => return Err(CloudflareError::InvalidScopeId),
+        };
+        let page_size = page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+        if !(1..=MAX_PAGE_SIZE).contains(&page_size) {
+            return Err(CloudflareError::InvalidPageSize);
+        }
+        let fingerprint = kernel_fingerprint(
+            base_url.as_str(),
+            &tenant_id,
+            family,
+            scope_id.as_deref(),
+            page_size,
+        );
+        Ok(Self {
+            base_url,
+            tenant_id,
+            family,
+            scope_id,
+            page_size,
+            fingerprint,
+        })
+    }
+
+    /// Plan one credential-free list request from an optional Go page cursor.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<CloudflareRequest, CloudflareError> {
+        let page = parse_cursor(cursor)?;
+        self.request(CloudflareRequestKind::List, page)
+    }
+
+    /// Plan a bounded detail request for families that declare one.
+    pub fn plan_detail(&self, provider_id: &str) -> Result<CloudflareRequest, CloudflareError> {
+        if self.family.detail_path_template().is_none() {
+            return Err(CloudflareError::RequestScopeMismatch);
+        }
+        let provider_id = bounded_component(provider_id, MAX_IDENTIFIER_BYTES)
+            .ok_or(CloudflareError::MissingProviderIdentity)?;
+        self.request(CloudflareRequestKind::Detail { provider_id }, 1)
+    }
+
+    /// Classify status, validate a success envelope, and normalize one page.
+    pub fn decode_http(
+        &self,
+        request: &CloudflareRequest,
+        status: u16,
+        retry_after_seconds: Option<u64>,
+        body: &[u8],
+    ) -> Result<CloudflarePage, CloudflareError> {
+        self.validate_request(request)?;
+        if body.len() > MAX_RESPONSE_BYTES {
+            return Err(CloudflareError::ResponseTooLarge);
+        }
+        if retry_after_seconds.is_some_and(|seconds| seconds > 3_600) {
+            return Err(CloudflareError::InvalidRetryAfter);
+        }
+        match status {
+            200 => {}
+            401 => return Err(CloudflareError::AuthenticationRejected),
+            403 => return Err(CloudflareError::RequiredScopeMissing),
+            429 => {
+                return Err(CloudflareError::RateLimited {
+                    retry_after_seconds,
+                });
+            }
+            500..=599 => return Err(CloudflareError::ProviderUnavailable { status }),
+            _ => return Err(CloudflareError::UnexpectedStatus { status }),
+        }
+        let body: Value =
+            serde_json::from_slice(body).map_err(|_| CloudflareError::InvalidResponse)?;
+        reject_credential_material(&body, 0)?;
+        let envelope = body.as_object().ok_or(CloudflareError::InvalidResponse)?;
+        if envelope.get("success").and_then(Value::as_bool) == Some(false) {
+            return Err(CloudflareError::ProviderRejected);
+        }
+        match &request.kind {
+            CloudflareRequestKind::List => self.decode_list(request, envelope),
+            CloudflareRequestKind::Detail { provider_id } => {
+                self.decode_detail(request, envelope, provider_id)
+            }
+        }
+    }
+
+    /// Decode a normal HTTP 200 response.
+    pub fn decode(
+        &self,
+        request: &CloudflareRequest,
+        body: &[u8],
+    ) -> Result<CloudflarePage, CloudflareError> {
+        self.decode_http(request, 200, None, body)
+    }
+
+    fn request(
+        &self,
+        kind: CloudflareRequestKind,
+        page: u32,
+    ) -> Result<CloudflareRequest, CloudflareError> {
+        let template = match &kind {
+            CloudflareRequestKind::List => self.family.path_template(),
+            CloudflareRequestKind::Detail { .. } => self
+                .family
+                .detail_path_template()
+                .ok_or(CloudflareError::RequestScopeMismatch)?,
+        };
+        let mut path = template.replace("{scope}", self.scope_id.as_deref().unwrap_or_default());
+        if let CloudflareRequestKind::Detail { provider_id } = &kind {
+            path = path.replace("{id}", provider_id);
+        }
+        if path.contains('{') || path.contains('}') {
+            return Err(CloudflareError::RequestScopeMismatch);
+        }
+        let mut url = self.base_url.clone();
+        let base_path = self.base_url.path().trim_end_matches('/');
+        url.set_path(&format!("{base_path}{path}"));
+        url.set_query(None);
+        url.set_fragment(None);
+        if matches!(kind, CloudflareRequestKind::List) {
+            url.query_pairs_mut()
+                .append_pair("page", &page.to_string())
+                .append_pair("per_page", &self.page_size.to_string());
+        }
+        Ok(CloudflareRequest {
+            url,
+            family: self.family,
+            scope_id: self.scope_id.clone(),
+            page,
+            page_size: self.page_size,
+            kind,
+            kernel_fingerprint: self.fingerprint,
+        })
+    }
+
+    fn validate_request(&self, request: &CloudflareRequest) -> Result<(), CloudflareError> {
+        if request.family != self.family
+            || request.scope_id != self.scope_id
+            || request.page_size != self.page_size
+            || request.kernel_fingerprint != self.fingerprint
+            || request.url.origin() != self.base_url.origin()
+        {
+            return Err(CloudflareError::RequestScopeMismatch);
+        }
+        Ok(())
+    }
+
+    fn decode_list(
+        &self,
+        request: &CloudflareRequest,
+        envelope: &Map<String, Value>,
+    ) -> Result<CloudflarePage, CloudflareError> {
+        let values = envelope
+            .get("result")
+            .and_then(Value::as_array)
+            .ok_or(CloudflareError::InvalidResponse)?;
+        if values.len() > MAX_PAGE_SIZE {
+            return Err(CloudflareError::BudgetExceeded);
+        }
+        let records = self.normalize_records(values)?;
+        let next_cursor = next_cursor(
+            envelope.get("result_info"),
+            request.page,
+            request.page_size,
+            values.len(),
+        )?;
+        Ok(CloudflarePage {
+            records,
+            next_cursor,
+            scanned_count: values.len(),
+        })
+    }
+
+    fn decode_detail(
+        &self,
+        _request: &CloudflareRequest,
+        envelope: &Map<String, Value>,
+        provider_id: &str,
+    ) -> Result<CloudflarePage, CloudflareError> {
+        let value = envelope
+            .get("result")
+            .and_then(Value::as_object)
+            .ok_or(CloudflareError::InvalidResponse)?;
+        let record = self.normalize_record(&Value::Object(value.clone()))?;
+        if record.provider_id != provider_id {
+            return Err(CloudflareError::ProviderScopeMismatch);
+        }
+        Ok(CloudflarePage {
+            records: vec![record],
+            next_cursor: None,
+            scanned_count: 1,
+        })
+    }
+
+    fn normalize_records(
+        &self,
+        values: &[Value],
+    ) -> Result<Vec<CloudflareRecord>, CloudflareError> {
+        let mut seen = BTreeMap::<String, Value>::new();
+        let mut records = Vec::with_capacity(values.len());
+        for value in values {
+            let record = self.normalize_record(value)?;
+            match seen.get(&record.scoped_provider_id) {
+                Some(payload) if payload == &record.payload => continue,
+                Some(_) => return Err(CloudflareError::ConflictingDuplicate),
+                None => {
+                    seen.insert(record.scoped_provider_id.clone(), record.payload.clone());
+                    records.push(record);
+                }
+            }
+        }
+        Ok(records)
+    }
+
+    fn normalize_record(&self, value: &Value) -> Result<CloudflareRecord, CloudflareError> {
+        let object = value.as_object().ok_or(CloudflareError::InvalidResponse)?;
+        let provider_id = string_at(object, "id")
+            .filter(|value| bounded_component(value, MAX_IDENTIFIER_BYTES).is_some())
+            .ok_or(CloudflareError::MissingProviderIdentity)?;
+        self.validate_provider_scope(object)?;
+        let scoped_provider_id = match self.scope_id.as_deref() {
+            Some(scope) => format!("{scope}|{provider_id}"),
+            None => provider_id.clone(),
+        };
+        let event_id = tenant_event_id(&self.tenant_id, self.family, &scoped_provider_id);
+        let mut attributes = common_attributes(self.family, &provider_id, &self.tenant_id);
+        if let Some(scope) = self.scope_id.as_deref() {
+            let key = match self.family.scope() {
+                CloudflareScope::Account => "account_id",
+                CloudflareScope::Zone => "zone_id",
+                CloudflareScope::None => return Err(CloudflareError::RequestScopeMismatch),
+            };
+            attributes.insert(key.to_owned(), scope.to_owned());
+        }
+        for (key, paths) in attribute_contract(self.family) {
+            if let Some(value) = paths.iter().find_map(|path| value_string_at(object, path)) {
+                attributes.insert((*key).to_owned(), value);
+            }
+        }
+        if attributes
+            .get(self.family.id_attribute())
+            .is_none_or(|value| value.trim().is_empty())
+        {
+            return Err(CloudflareError::MissingProviderIdentity);
+        }
+        Ok(CloudflareRecord {
+            provider_id,
+            scoped_provider_id,
+            event_id,
+            family: self.family.as_str().to_owned(),
+            event_kind: self.family.event_kind(),
+            schema_ref: self.family.schema_ref(),
+            attributes,
+            payload: value.clone(),
+        })
+    }
+
+    fn validate_provider_scope(&self, object: &Map<String, Value>) -> Result<(), CloudflareError> {
+        let Some(expected) = self.scope_id.as_deref() else {
+            return Ok(());
+        };
+        let candidates: &[&str] = match self.family.scope() {
+            CloudflareScope::Account => &["account_id", "account.id"],
+            CloudflareScope::Zone => &["zone_id", "zone.id"],
+            CloudflareScope::None => return Err(CloudflareError::RequestScopeMismatch),
+        };
+        if let Some(actual) = candidates.iter().find_map(|path| string_path(object, path))
+            && actual != expected
+        {
+            return Err(CloudflareError::ProviderScopeMismatch);
+        }
+        Ok(())
+    }
+}

--- a/crates/source-runtime-next/src/cloudflare/normalize.rs
+++ b/crates/source-runtime-next/src/cloudflare/normalize.rs
@@ -1,0 +1,301 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+
+use super::{CloudflareError, CloudflareFamily};
+
+const MAX_NESTING_DEPTH: usize = 64;
+
+pub(super) fn bounded_component(value: &str, maximum: usize) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()
+        && value.len() <= maximum
+        && !value.chars().any(char::is_control)
+        && !value.contains('/')
+        && !value.contains('?')
+        && !value.contains('#'))
+    .then(|| value.to_owned())
+}
+
+pub(super) fn string_at(object: &Map<String, Value>, key: &str) -> Option<String> {
+    value_string(object.get(key)?)
+}
+
+pub(super) fn string_path(object: &Map<String, Value>, path: &str) -> Option<String> {
+    value_string_at(object, path)
+}
+
+pub(super) fn value_string_at(object: &Map<String, Value>, path: &str) -> Option<String> {
+    let mut value = Value::Object(object.clone());
+    for part in path.split('.') {
+        value = value.get(part)?.clone();
+    }
+    value_string(&value)
+}
+
+fn value_string(value: &Value) -> Option<String> {
+    match value {
+        Value::Null => None,
+        Value::String(value) => nonempty(value),
+        Value::Bool(value) => Some(value.to_string()),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Array(values) => {
+            let values = values.iter().filter_map(value_string).collect::<Vec<_>>();
+            (!values.is_empty()).then(|| values.join(","))
+        }
+        Value::Object(_) => serde_json::to_string(value).ok(),
+    }
+}
+
+fn nonempty(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_owned())
+}
+
+pub(super) fn common_attributes(
+    family: CloudflareFamily,
+    provider_id: &str,
+    tenant_id: &str,
+) -> BTreeMap<String, String> {
+    let resource_type = if family == CloudflareFamily::Member {
+        "identity_user"
+    } else {
+        family.as_str()
+    };
+    BTreeMap::from([
+        ("external_id".to_owned(), provider_id.to_owned()),
+        ("family".to_owned(), family.as_str().to_owned()),
+        ("provider".to_owned(), "cloudflare".to_owned()),
+        ("resource_id".to_owned(), provider_id.to_owned()),
+        ("resource_type".to_owned(), resource_type.to_owned()),
+        ("source_event_id".to_owned(), provider_id.to_owned()),
+        ("source_product".to_owned(), "cloudflare".to_owned()),
+        ("source_provider".to_owned(), "cloudflare".to_owned()),
+        ("source_system".to_owned(), "cloudflare".to_owned()),
+        ("tenant_id".to_owned(), tenant_id.to_owned()),
+    ])
+}
+
+pub(super) fn attribute_contract(
+    family: CloudflareFamily,
+) -> &'static [(&'static str, &'static [&'static str])] {
+    match family {
+        CloudflareFamily::Account => &[
+            ("account_id", &["id"]),
+            ("name", &["name"]),
+            ("type", &["type"]),
+            ("resource_name", &["name", "id"]),
+            ("observed_at", &["modified_on", "created_on"]),
+        ],
+        CloudflareFamily::Member => &[
+            ("member_id", &["id"]),
+            ("account_id", &["account.id", "account_id"]),
+            ("email", &["user.email", "email"]),
+            ("status", &["status"]),
+            ("roles", &["roles"]),
+            ("resource_name", &["user.name", "id"]),
+            ("observed_at", &["modified_on", "created_on"]),
+        ],
+        CloudflareFamily::Role => &[
+            ("role_id", &["id"]),
+            ("name", &["name"]),
+            ("description", &["description"]),
+            ("permissions", &["permissions"]),
+            ("permission_groups", &["permission_groups"]),
+            ("resource_name", &["name", "id"]),
+        ],
+        CloudflareFamily::AccountRuleset | CloudflareFamily::ZoneRuleset => &[
+            ("ruleset_id", &["id"]),
+            ("name", &["name"]),
+            ("kind", &["kind"]),
+            ("phase", &["phase"]),
+            ("version", &["version"]),
+            ("last_updated", &["last_updated"]),
+            ("rules", &["rules"]),
+            ("resource_name", &["name", "id"]),
+            ("observed_at", &["last_updated"]),
+        ],
+        CloudflareFamily::WorkerScript => &[
+            ("script_id", &["id"]),
+            ("created_on", &["created_on"]),
+            ("modified_on", &["modified_on"]),
+            ("compatibility_date", &["compatibility_date"]),
+            ("tags", &["tags"]),
+            ("bindings", &["bindings"]),
+            ("placement", &["placement"]),
+            ("resource_name", &["id", "name"]),
+            ("observed_at", &["modified_on", "created_on"]),
+        ],
+        CloudflareFamily::AuditLog => &[
+            ("audit_id", &["id"]),
+            ("account_id", &["account.id", "account_id"]),
+            ("action", &["action.type", "action"]),
+            ("actor_email", &["actor.email"]),
+            ("actor_ip", &["actor.ip"]),
+            ("resource_id", &["resource.id"]),
+            ("resource_type", &["resource.type"]),
+            ("zone_id", &["zone.id", "zone_id"]),
+            ("resource_name", &["action.type", "id"]),
+            ("observed_at", &["when", "timestamp"]),
+        ],
+        CloudflareFamily::AccessApplication | CloudflareFamily::ZoneAccessApplication => &[
+            ("application_id", &["id"]),
+            ("name", &["name"]),
+            ("domain", &["domain"]),
+            ("type", &["type"]),
+            ("aud", &["aud"]),
+            ("session_duration", &["session_duration"]),
+            ("policies", &["policies"]),
+            ("allowed_idps", &["allowed_idps"]),
+            ("auto_redirect_to_identity", &["auto_redirect_to_identity"]),
+            ("resource_name", &["name", "domain", "id"]),
+            ("observed_at", &["updated_at", "created_at"]),
+        ],
+        CloudflareFamily::AccessGroup | CloudflareFamily::ZoneAccessGroup => &[
+            ("group_id", &["id"]),
+            ("name", &["name"]),
+            ("include", &["include"]),
+            ("exclude", &["exclude"]),
+            ("require", &["require"]),
+            ("resource_name", &["name", "id"]),
+            ("observed_at", &["updated_at", "created_at"]),
+        ],
+        CloudflareFamily::GatewayRule => &[
+            ("rule_id", &["id"]),
+            ("name", &["name"]),
+            ("action", &["action"]),
+            ("traffic", &["traffic"]),
+            ("enabled", &["enabled"]),
+            ("precedence", &["precedence"]),
+            ("filters", &["filters"]),
+            ("rule_settings", &["rule_settings"]),
+            ("resource_name", &["name", "id"]),
+            ("observed_at", &["updated_at", "created_at"]),
+        ],
+        CloudflareFamily::Zone => &[
+            ("zone_id", &["id"]),
+            ("account_id", &["account.id", "account_id"]),
+            ("name", &["name"]),
+            ("status", &["status"]),
+            ("type", &["type"]),
+            ("paused", &["paused"]),
+            ("resource_name", &["name", "id"]),
+            ("observed_at", &["modified_on", "created_on"]),
+        ],
+        CloudflareFamily::DnsRecord => &[
+            ("record_id", &["id"]),
+            ("name", &["name"]),
+            ("type", &["type"]),
+            ("content", &["content"]),
+            ("proxied", &["proxied"]),
+            ("resource_name", &["name", "id"]),
+            ("observed_at", &["modified_on", "created_on"]),
+        ],
+        CloudflareFamily::LoadBalancer => &[
+            ("load_balancer_id", &["id"]),
+            ("name", &["name"]),
+            ("fallback_pool", &["fallback_pool"]),
+            ("default_pools", &["default_pools"]),
+            ("enabled", &["enabled"]),
+            ("proxied", &["proxied"]),
+            ("steering_policy", &["steering_policy"]),
+            ("resource_name", &["name", "id"]),
+            ("observed_at", &["modified_on", "created_on"]),
+        ],
+        CloudflareFamily::LoadBalancerPool => &[
+            ("pool_id", &["id"]),
+            ("name", &["name"]),
+            ("enabled", &["enabled"]),
+            ("origins", &["origins"]),
+            ("check_regions", &["check_regions"]),
+            ("minimum_origins", &["minimum_origins"]),
+            ("resource_name", &["name", "id"]),
+            ("observed_at", &["modified_on", "created_on"]),
+        ],
+    }
+}
+
+pub(super) fn reject_credential_material(
+    value: &Value,
+    depth: usize,
+) -> Result<(), CloudflareError> {
+    if depth > MAX_NESTING_DEPTH {
+        return Err(CloudflareError::BudgetExceeded);
+    }
+    match value {
+        Value::Object(object) => {
+            for (key, value) in object {
+                let key = key.to_ascii_lowercase();
+                if matches!(
+                    key.as_str(),
+                    "authorization"
+                        | "token"
+                        | "password"
+                        | "secret"
+                        | "api_token"
+                        | "access_token"
+                        | "refresh_token"
+                        | "client_secret"
+                        | "session_cookie"
+                ) {
+                    return Err(CloudflareError::CredentialMaterial);
+                }
+                reject_credential_material(value, depth + 1)?;
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                reject_credential_material(value, depth + 1)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+pub(super) fn tenant_event_id(tenant: &str, family: CloudflareFamily, provider_id: &str) -> String {
+    let mut hasher = Sha256::new();
+    for value in [
+        tenant.as_bytes(),
+        family.as_str().as_bytes(),
+        provider_id.as_bytes(),
+    ] {
+        hasher.update((value.len() as u64).to_be_bytes());
+        hasher.update(value);
+    }
+    let digest = hasher.finalize();
+    format!("cloudflare-{}-{}", family.as_str(), hex(&digest[..12]))
+}
+
+pub(super) fn kernel_fingerprint(
+    base_url: &str,
+    tenant: &str,
+    family: CloudflareFamily,
+    scope_id: Option<&str>,
+    page_size: usize,
+) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    let page_size = page_size.to_string();
+    for value in [
+        base_url,
+        tenant,
+        family.as_str(),
+        scope_id.unwrap_or_default(),
+        &page_size,
+    ] {
+        hasher.update((value.len() as u64).to_be_bytes());
+        hasher.update(value.as_bytes());
+    }
+    hasher.finalize().into()
+}
+
+fn hex(value: &[u8]) -> String {
+    use std::fmt::Write as _;
+    value
+        .iter()
+        .fold(String::with_capacity(value.len() * 2), |mut out, byte| {
+            write!(&mut out, "{byte:02x}").expect("writing to String cannot fail");
+            out
+        })
+}

--- a/crates/source-runtime-next/src/cloudflare/origin.rs
+++ b/crates/source-runtime-next/src/cloudflare/origin.rs
@@ -1,0 +1,61 @@
+use std::net::IpAddr;
+
+use reqwest::Url;
+
+use super::CloudflareError;
+
+pub(super) fn validate_origin(value: &str) -> Result<Url, CloudflareError> {
+    let mut url = Url::parse(value.trim()).map_err(|_| CloudflareError::InvalidBaseUrl)?;
+    if url.scheme() != "https"
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port_or_known_default() != Some(443)
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(CloudflareError::InvalidBaseUrl);
+    }
+    let host = url
+        .host_str()
+        .ok_or(CloudflareError::InvalidBaseUrl)?
+        .trim_end_matches('.')
+        .to_ascii_lowercase();
+    if host == "localhost"
+        || host.ends_with(".localhost")
+        || host.ends_with(".local")
+        || !host.contains('.')
+        || host.parse::<IpAddr>().ok().is_some_and(unsafe_address)
+    {
+        return Err(CloudflareError::InvalidBaseUrl);
+    }
+    let path = url.path().trim_end_matches('/').to_owned();
+    url.set_path(if path.is_empty() { "/" } else { &path });
+    Ok(url)
+}
+
+fn unsafe_address(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => {
+            let octets = address.octets();
+            address.is_private()
+                || address.is_loopback()
+                || address.is_link_local()
+                || address.is_multicast()
+                || address.is_unspecified()
+                || (octets[0] == 100 && (64..=127).contains(&octets[1]))
+                || (octets[0] == 192 && octets[1] == 0 && octets[2] == 2)
+                || (octets[0] == 198 && octets[1] == 51 && octets[2] == 100)
+                || (octets[0] == 203 && octets[1] == 0 && octets[2] == 113)
+        }
+        IpAddr::V6(address) => {
+            let segments = address.segments();
+            address.is_loopback()
+                || address.is_multicast()
+                || address.is_unspecified()
+                || address.is_unique_local()
+                || address.is_unicast_link_local()
+                || (segments[0] == 0x2001 && segments[1] == 0x0db8)
+        }
+    }
+}

--- a/crates/source-runtime-next/src/cloudflare/tests.rs
+++ b/crates/source-runtime-next/src/cloudflare/tests.rs
@@ -130,7 +130,7 @@ fn checked_in_catalog_compiles_the_closed_cloudflare_runtime() {
     .unwrap();
     let source = catalog.get("cloudflare").unwrap();
     assert_eq!(source.auth(), &AuthModel::BearerToken);
-    assert_eq!(source.authority(), CollectionAuthority::Authoritative);
+    assert_eq!(source.authority(), CollectionAuthority::ShadowOnly);
     let compiled = source
         .families()
         .iter()
@@ -142,7 +142,7 @@ fn checked_in_catalog_compiles_the_closed_cloudflare_runtime() {
         .collect::<std::collections::BTreeSet<_>>();
     assert_eq!(compiled, expected);
     for family in source.families() {
-        assert!(family.is_authoritative(), "{} collection", family.id());
+        assert!(!family.is_authoritative(), "{} collection", family.id());
         assert!(
             family.is_projection_authoritative(),
             "{} projection",

--- a/crates/source-runtime-next/src/cloudflare/tests.rs
+++ b/crates/source-runtime-next/src/cloudflare/tests.rs
@@ -1,0 +1,508 @@
+use std::{collections::BTreeMap, str::FromStr};
+
+use cerebro_source_catalog::{AuthModel, CollectionAuthority, Pagination, SourceCatalog};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::*;
+
+const BASE_URL: &str = "https://api.cloudflare.com/client/v4";
+
+#[derive(Deserialize)]
+struct OracleEvent {
+    tenant_id: String,
+    kind: String,
+    schema_ref: String,
+    attributes: BTreeMap<String, String>,
+    payload: Value,
+}
+
+fn kernel(family: CloudflareFamily, scope: Option<&str>) -> CloudflareKernel {
+    CloudflareKernel::new(BASE_URL, "tenant", family, scope, Some(100)).unwrap()
+}
+
+fn oracle(family: CloudflareFamily) -> OracleEvent {
+    let payload = match family {
+        CloudflareFamily::AccessApplication => {
+            include_str!("../../../../sources/cloudflare/testdata/read_access_application.json")
+        }
+        CloudflareFamily::AccessGroup => {
+            include_str!("../../../../sources/cloudflare/testdata/read_access_group.json")
+        }
+        CloudflareFamily::Account => {
+            include_str!("../../../../sources/cloudflare/testdata/read_account.json")
+        }
+        CloudflareFamily::AccountRuleset => {
+            include_str!("../../../../sources/cloudflare/testdata/read_account_ruleset.json")
+        }
+        CloudflareFamily::AuditLog => {
+            include_str!("../../../../sources/cloudflare/testdata/read_audit_log.json")
+        }
+        CloudflareFamily::Member => {
+            include_str!("../../../../sources/cloudflare/testdata/read_member.json")
+        }
+        CloudflareFamily::GatewayRule => {
+            include_str!("../../../../sources/cloudflare/testdata/read_gateway_rule.json")
+        }
+        CloudflareFamily::LoadBalancer => {
+            include_str!("../../../../sources/cloudflare/testdata/read_load_balancer.json")
+        }
+        CloudflareFamily::LoadBalancerPool => {
+            include_str!("../../../../sources/cloudflare/testdata/read_load_balancer_pool.json")
+        }
+        CloudflareFamily::Role => {
+            include_str!("../../../../sources/cloudflare/testdata/read_role.json")
+        }
+        CloudflareFamily::WorkerScript => {
+            include_str!("../../../../sources/cloudflare/testdata/read_worker_script.json")
+        }
+        CloudflareFamily::Zone => {
+            include_str!("../../../../sources/cloudflare/testdata/read_zone.json")
+        }
+        CloudflareFamily::ZoneAccessApplication => include_str!(
+            "../../../../sources/cloudflare/testdata/read_zone_access_application.json"
+        ),
+        CloudflareFamily::ZoneAccessGroup => {
+            include_str!("../../../../sources/cloudflare/testdata/read_zone_access_group.json")
+        }
+        CloudflareFamily::ZoneRuleset => {
+            include_str!("../../../../sources/cloudflare/testdata/read_zone_ruleset.json")
+        }
+        CloudflareFamily::DnsRecord => {
+            include_str!("../../../../sources/cloudflare/testdata/read_dns_record.json")
+        }
+    };
+    serde_json::from_str::<Vec<OracleEvent>>(payload)
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap()
+}
+
+fn scope_for(family: CloudflareFamily, event: &OracleEvent) -> Option<String> {
+    match family.scope() {
+        CloudflareScope::None => None,
+        CloudflareScope::Account => Some(
+            event
+                .attributes
+                .get("account_id")
+                .cloned()
+                .unwrap_or_else(|| "account-1".to_owned()),
+        ),
+        CloudflareScope::Zone => Some(
+            event
+                .attributes
+                .get("zone_id")
+                .cloned()
+                .unwrap_or_else(|| "zone-1".to_owned()),
+        ),
+    }
+}
+
+#[test]
+fn family_vocabulary_is_closed_and_contract_bound() {
+    assert_eq!(CloudflareFamily::ALL.len(), 16);
+    for family in CloudflareFamily::ALL {
+        assert_eq!(CloudflareFamily::from_str(family.as_str()).unwrap(), family);
+        assert_eq!(
+            family.event_kind(),
+            format!("cloudflare.{}", family.as_str())
+        );
+        assert_eq!(
+            family.schema_ref(),
+            format!("cloudflare/{}/v1", family.as_str())
+        );
+        assert!(family.path_template().starts_with('/'));
+    }
+    assert_eq!(
+        CloudflareFamily::from_str("unknown"),
+        Err(CloudflareError::InvalidFamily)
+    );
+}
+
+#[test]
+fn checked_in_catalog_compiles_the_closed_cloudflare_runtime() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let catalog = SourceCatalog::load(
+        root.join("internal/connectorcatalog/catalog"),
+        root.join("sources"),
+    )
+    .unwrap();
+    let source = catalog.get("cloudflare").unwrap();
+    assert_eq!(source.auth(), &AuthModel::BearerToken);
+    assert_eq!(source.authority(), CollectionAuthority::Authoritative);
+    let compiled = source
+        .families()
+        .iter()
+        .map(|family| family.id())
+        .collect::<std::collections::BTreeSet<_>>();
+    let expected = CloudflareFamily::ALL
+        .iter()
+        .map(|family| family.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(compiled, expected);
+    for family in source.families() {
+        assert!(family.is_authoritative(), "{} collection", family.id());
+        assert!(
+            family.is_projection_authoritative(),
+            "{} projection",
+            family.id()
+        );
+        assert_eq!(
+            family.pagination(),
+            &Pagination::Page {
+                parameter: "page".to_owned(),
+                start: 1,
+                page_size_parameter: Some("per_page".to_owned()),
+                page_size: 100,
+            },
+            "{} pagination",
+            family.id()
+        );
+    }
+}
+
+#[test]
+fn every_go_oracle_family_normalizes_with_semantic_parity() {
+    for family in CloudflareFamily::ALL {
+        let oracle = oracle(family);
+        let scope = scope_for(family, &oracle);
+        let kernel = kernel(family, scope.as_deref());
+        let request = kernel.plan(None).unwrap();
+        let body = serde_json::to_vec(&json!({
+            "success": true,
+            "errors": [],
+            "messages": [],
+            "result": [oracle.payload],
+            "result_info": {"page": 1, "per_page": 100, "total_pages": 1, "total_count": 1}
+        }))
+        .unwrap();
+        let page = kernel.decode(&request, &body).unwrap();
+        assert_eq!(page.scanned_count, 1, "{}", family.as_str());
+        assert_eq!(page.records.len(), 1, "{}", family.as_str());
+        assert_eq!(page.next_cursor, None, "{}", family.as_str());
+        let record = &page.records[0];
+        assert_eq!(oracle.kind, family.event_kind(), "{}", family.as_str());
+        assert_eq!(
+            oracle.schema_ref,
+            family.schema_ref(),
+            "{}",
+            family.as_str()
+        );
+        assert_eq!(oracle.tenant_id, "tenant");
+        assert_eq!(record.family, family.as_str());
+        assert_eq!(record.event_kind, oracle.kind, "{}", family.as_str());
+        assert_eq!(record.schema_ref, oracle.schema_ref, "{}", family.as_str());
+        assert_eq!(
+            record.attributes.get("tenant_id").map(String::as_str),
+            Some("tenant")
+        );
+        assert_eq!(
+            record.attributes.get("provider").map(String::as_str),
+            Some("cloudflare")
+        );
+        assert_eq!(
+            record.attributes.get(family.id_attribute()),
+            oracle.attributes.get(family.id_attribute()),
+            "{} ID attribute",
+            family.as_str()
+        );
+        for (key, expected) in &oracle.attributes {
+            if matches!(key.as_str(), "resource_urn" | "observed_at") {
+                continue;
+            }
+            let actual = record
+                .attributes
+                .get(key)
+                .unwrap_or_else(|| panic!("{} missing attribute {key}", family.as_str()));
+            assert_eq!(actual, expected, "{} attribute {key}", family.as_str());
+        }
+    }
+}
+
+#[test]
+fn request_plans_are_origin_locked_credential_free_and_paginated() {
+    let kernel = CloudflareKernel::new(
+        BASE_URL,
+        "tenant-a",
+        CloudflareFamily::Member,
+        Some("acct-1"),
+        Some(15),
+    )
+    .unwrap();
+    let first = kernel.plan(None).unwrap();
+    assert_eq!(
+        first.url().as_str(),
+        "https://api.cloudflare.com/client/v4/accounts/acct-1/members?page=1&per_page=15"
+    );
+    assert_eq!(first.authorization_header(), "Authorization");
+    assert_eq!(first.authorization_scheme(), "Bearer");
+    assert!(!first.contains_credentials());
+    assert!(!first.allows_redirects());
+    assert_eq!(first.max_response_bytes(), 8 << 20);
+    assert_eq!(first.accept(), "application/json");
+    let third = kernel.plan(Some("3")).unwrap();
+    assert_eq!(third.page(), 3);
+    assert!(third.url().as_str().ends_with("?page=3&per_page=15"));
+}
+
+#[test]
+fn provider_cursor_round_trips_and_rejects_invalid_progress() {
+    let kernel = kernel(CloudflareFamily::Member, Some("acct-1"));
+    let first = kernel.plan(None).unwrap();
+    let body = br#"{"success":true,"result":[{"id":"m1"}],"result_info":{"page":1,"per_page":100,"total_pages":3,"total_count":201}}"#;
+    let page = kernel.decode(&first, body).unwrap();
+    assert_eq!(page.next_cursor.as_deref(), Some("2"));
+    let second = kernel.plan(page.next_cursor.as_deref()).unwrap();
+    assert_eq!(second.page(), 2);
+    let mismatch = br#"{"success":true,"result":[],"result_info":{"page":3,"total_pages":3}}"#;
+    assert_eq!(
+        kernel.decode(&second, mismatch),
+        Err(CloudflareError::InvalidCursor)
+    );
+    for cursor in ["0", "10001", "-1", "next", "1/2"] {
+        assert_eq!(
+            kernel.plan(Some(cursor)),
+            Err(CloudflareError::InvalidCursor)
+        );
+    }
+}
+
+#[test]
+fn detail_requests_enrich_only_declared_families() {
+    let ruleset_kernel = kernel(CloudflareFamily::AccountRuleset, Some("acct-1"));
+    let request = ruleset_kernel.plan_detail("ruleset-1").unwrap();
+    assert_eq!(
+        request.url().as_str(),
+        "https://api.cloudflare.com/client/v4/accounts/acct-1/rulesets/ruleset-1"
+    );
+    assert!(
+        matches!(request.kind(), CloudflareRequestKind::Detail { provider_id } if provider_id == "ruleset-1")
+    );
+    let page = ruleset_kernel.decode(&request, br#"{"success":true,"result":{"id":"ruleset-1","rules":[{"id":"rule-1","action":"block"}]}}"#).unwrap();
+    assert!(page.records[0].attributes["rules"].contains("rule-1"));
+    assert_eq!(
+        kernel(CloudflareFamily::Member, Some("acct-1")).plan_detail("member-1"),
+        Err(CloudflareError::RequestScopeMismatch)
+    );
+}
+
+#[test]
+fn tenant_and_scope_are_part_of_stable_identity() {
+    let body =
+        br#"{"success":true,"result":[{"id":"app-1"}],"result_info":{"page":1,"total_pages":1}}"#;
+    let a = CloudflareKernel::new(
+        BASE_URL,
+        "tenant-a",
+        CloudflareFamily::AccessApplication,
+        Some("acct-a"),
+        None,
+    )
+    .unwrap();
+    let b = CloudflareKernel::new(
+        BASE_URL,
+        "tenant-b",
+        CloudflareFamily::AccessApplication,
+        Some("acct-a"),
+        None,
+    )
+    .unwrap();
+    let c = CloudflareKernel::new(
+        BASE_URL,
+        "tenant-a",
+        CloudflareFamily::AccessApplication,
+        Some("acct-b"),
+        None,
+    )
+    .unwrap();
+    let a_record = a
+        .decode(&a.plan(None).unwrap(), body)
+        .unwrap()
+        .records
+        .remove(0);
+    let b_record = b
+        .decode(&b.plan(None).unwrap(), body)
+        .unwrap()
+        .records
+        .remove(0);
+    let c_record = c
+        .decode(&c.plan(None).unwrap(), body)
+        .unwrap()
+        .records
+        .remove(0);
+    assert_ne!(a_record.event_id, b_record.event_id);
+    assert_ne!(a_record.event_id, c_record.event_id);
+    assert_ne!(a_record.scoped_provider_id, c_record.scoped_provider_id);
+    assert_eq!(
+        a_record.event_id,
+        a.decode(&a.plan(None).unwrap(), body).unwrap().records[0].event_id
+    );
+}
+
+#[test]
+fn duplicates_are_idempotent_and_conflicts_fail_closed() {
+    let kernel = kernel(CloudflareFamily::Zone, None);
+    let request = kernel.plan(None).unwrap();
+    let duplicate = br#"{"success":true,"result":[{"id":"z1","name":"one"},{"name":"one","id":"z1"}],"result_info":{"page":1,"total_pages":1}}"#;
+    assert_eq!(kernel.decode(&request, duplicate).unwrap().records.len(), 1);
+    let conflicting = br#"{"success":true,"result":[{"id":"z1","name":"one"},{"id":"z1","name":"two"}],"result_info":{"page":1,"total_pages":1}}"#;
+    assert_eq!(
+        kernel.decode(&request, conflicting),
+        Err(CloudflareError::ConflictingDuplicate)
+    );
+}
+
+#[test]
+fn provider_scope_conflicts_fail_closed() {
+    let kernel = kernel(CloudflareFamily::Member, Some("acct-1"));
+    let body = br#"{"success":true,"result":[{"id":"m1","account_id":"acct-2"}],"result_info":{"page":1,"total_pages":1}}"#;
+    assert_eq!(
+        kernel.decode(&kernel.plan(None).unwrap(), body),
+        Err(CloudflareError::ProviderScopeMismatch)
+    );
+}
+
+#[test]
+fn typed_provider_failures_remain_distinct() {
+    let kernel = kernel(CloudflareFamily::Account, None);
+    let request = kernel.plan(None).unwrap();
+    assert_eq!(
+        kernel.decode_http(&request, 401, None, b"{}"),
+        Err(CloudflareError::AuthenticationRejected)
+    );
+    assert_eq!(
+        kernel.decode_http(&request, 403, None, b"{}"),
+        Err(CloudflareError::RequiredScopeMissing)
+    );
+    assert_eq!(
+        kernel.decode_http(&request, 429, Some(12), b"{}"),
+        Err(CloudflareError::RateLimited {
+            retry_after_seconds: Some(12)
+        })
+    );
+    assert_eq!(
+        kernel.decode_http(&request, 503, None, b"{}"),
+        Err(CloudflareError::ProviderUnavailable { status: 503 })
+    );
+    assert_eq!(
+        kernel.decode_http(&request, 400, None, b"{}"),
+        Err(CloudflareError::UnexpectedStatus { status: 400 })
+    );
+    assert_eq!(
+        kernel.decode_http(&request, 429, Some(3_601), b"{}"),
+        Err(CloudflareError::InvalidRetryAfter)
+    );
+    assert_eq!(
+        kernel.decode(&request, br#"{"success":false,"errors":[{"code":10000}]}"#),
+        Err(CloudflareError::ProviderRejected)
+    );
+    assert_eq!(
+        CloudflareError::AuthenticationRejected.operator_action(),
+        "repair credential binding"
+    );
+    assert_eq!(
+        CloudflareError::RateLimited {
+            retry_after_seconds: None
+        }
+        .operator_action(),
+        "retry later"
+    );
+}
+
+#[test]
+fn credential_material_never_enters_request_or_normalized_output() {
+    let marker = "credential-marker-should-not-survive";
+    let kernel = kernel(CloudflareFamily::Account, None);
+    let request = kernel.plan(None).unwrap();
+    assert!(!format!("{request:?}").contains(marker));
+    let body = format!(
+        r#"{{"success":true,"result":[{{"id":"a1","api_token":"{marker}"}}],"result_info":{{"page":1,"total_pages":1}}}}"#
+    );
+    assert_eq!(
+        kernel.decode(&request, body.as_bytes()),
+        Err(CloudflareError::CredentialMaterial)
+    );
+    let clean = kernel.decode(&request, br#"{"success":true,"result":[{"id":"a1","name":"Account"}],"result_info":{"page":1,"total_pages":1}}"#).unwrap();
+    assert!(!format!("{:?}", clean.records[0]).contains(marker));
+}
+
+#[test]
+fn authenticated_tenant_context_cannot_be_replaced_by_provider_data() {
+    let kernel = CloudflareKernel::new(
+        BASE_URL,
+        "tenant-authenticated",
+        CloudflareFamily::Account,
+        None,
+        None,
+    )
+    .unwrap();
+    let request = kernel.plan(None).unwrap();
+    let page = kernel
+        .decode(
+            &request,
+            br#"{"success":true,"result":[{"id":"a1","tenant_id":"tenant-untrusted"}],"result_info":{"page":1,"total_pages":1}}"#,
+        )
+        .unwrap();
+    assert_eq!(
+        page.records[0].attributes["tenant_id"],
+        "tenant-authenticated"
+    );
+    assert!(!page.records[0].event_id.contains("tenant-untrusted"));
+}
+
+#[test]
+fn origin_scope_size_and_record_bounds_are_enforced() {
+    for origin in [
+        "http://api.cloudflare.com/client/v4",
+        "https://127.0.0.1/client/v4",
+        "https://localhost/client/v4",
+        "https://api.cloudflare.com:8443/client/v4",
+        "https://user@api.cloudflare.com/client/v4",
+    ] {
+        assert_eq!(
+            CloudflareKernel::new(origin, "tenant", CloudflareFamily::Account, None, None),
+            Err(CloudflareError::InvalidBaseUrl)
+        );
+    }
+    assert_eq!(
+        CloudflareKernel::new(BASE_URL, "", CloudflareFamily::Account, None, None),
+        Err(CloudflareError::InvalidTenantId)
+    );
+    assert_eq!(
+        CloudflareKernel::new(BASE_URL, "tenant", CloudflareFamily::Member, None, None),
+        Err(CloudflareError::InvalidScopeId)
+    );
+    assert_eq!(
+        CloudflareKernel::new(
+            BASE_URL,
+            "tenant",
+            CloudflareFamily::Account,
+            Some("acct"),
+            None
+        ),
+        Err(CloudflareError::InvalidScopeId)
+    );
+    assert_eq!(
+        CloudflareKernel::new(
+            BASE_URL,
+            "tenant",
+            CloudflareFamily::Account,
+            None,
+            Some(1_001)
+        ),
+        Err(CloudflareError::InvalidPageSize)
+    );
+    let kernel = kernel(CloudflareFamily::Account, None);
+    let request = kernel.plan(None).unwrap();
+    assert_eq!(
+        kernel.decode(&request, &vec![b'x'; (8 << 20) + 1]),
+        Err(CloudflareError::ResponseTooLarge)
+    );
+    assert_eq!(
+        kernel.decode(
+            &request,
+            br#"{"success":true,"result":[{"name":"missing-id"}]}"#
+        ),
+        Err(CloudflareError::MissingProviderIdentity)
+    );
+}

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -14,6 +14,7 @@ mod aws_network_manager;
 mod aws_secret_store;
 mod azure;
 mod cerebro_source;
+mod cloudflare;
 mod cosmo;
 mod credential_lease;
 mod deposit;
@@ -86,6 +87,10 @@ pub use azure::{
 pub use cerebro_source::{
     CerebroSourceError, CerebroSourceFamily, CerebroSourceKernel, CerebroSourcePage,
     CerebroSourceRecord,
+};
+pub use cloudflare::{
+    CloudflareError, CloudflareFamily, CloudflareKernel, CloudflarePage, CloudflareRecord,
+    CloudflareRequest, CloudflareRequestKind, CloudflareScope,
 };
 pub use cosmo::{CosmoError, CosmoFamily, CosmoKernel, CosmoPage, CosmoRecord};
 pub use credential_lease::{

--- a/internal/connectorcatalog/catalog/security-posture-vulnerability/cloudflare.yaml
+++ b/internal/connectorcatalog/catalog/security-posture-vulnerability/cloudflare.yaml
@@ -1,233 +1,520 @@
 entries:
-- classifier_output: supported
-  definition:
-    auth:
-      credential_fields:
-      - key: api_key
-        label: API key
-        reference_only: true
-        required: true
-        secret: true
-      model: api_key
-      requires_references: true
-    categories:
-    - networking
-    - security
-    config_fields:
-    - help: Path parameter inferred from the OpenAPI operation.
-      key: account_id
-      label: Account Id
-      required: true
-    description: "Collects asn, event, account, and organization from Cloudflare and projects them into the Cerebro graph as findings, audit events, users, and groups for asset exposure, vulnerability, finding, and remediation context."
-    display_name: Cloudflare
-    id: builtin_catalog-cloudflare
-    resource_families:
-    - coverage:
-      - families:
-        - asn
-        high_value: true
-        evidence_types:
-        - remediation_state
-        control_domains:
-        - remediation
-        id: findings
-        support: partial
-        title: Asn
-        type: remediation_state
-      default_enabled: true
-      event:
-        kind: cloudflare.asn
-        required_payload_fields:
-        - code
-        schema_ref: cloudflare/asn/v1
-        urn_kind: cloudflare_asn
-      event_kind: asn
-      id: asn
-      id_field: code
-      label: Asn
-      list_key: errors
-      method: GET
-      name_field: code
-      pagination:
-        type: none
-      path: "/accounts/${config.account_id}/botnet_feed/configs/asn"
-      permissions_needed:
-      - api_email
-      - api_key
-      - api_token
-      projection:
-        fields:
-          finding_id: code
-          id: code
-          name: code
-          severity: code
-          status: code
-          title: code
-        template: finding
-      record_selector: "$.errors[*]"
-    - coverage:
-      - families:
-        - event
-        high_value: true
-        evidence_types:
-        - logging_configuration
-        control_domains:
-        - logging_monitoring
-        id: audit_events
-        support: partial
-        title: Event
-        type: audit_event
-      default_enabled: true
-      event:
-        kind: cloudflare.event
-        required_payload_fields:
-        - code
-        schema_ref: cloudflare/event/v1
-        urn_kind: cloudflare_event
-      event_kind: event
-      id: event
-      id_field: code
-      label: Event
-      list_key: errors
-      method: GET
-      name_field: code
-      pagination:
-        type: none
-      path: "/user/load_balancing_analytics/events"
-      permissions_needed:
-      - api_email
-      - api_key
-      - api_token
-      projection:
-        fields:
-          id: code
-          name: code
-          provider_id: code
-        template: audit_event
-      record_selector: "$.errors[*]"
-    - coverage:
-      - families:
-        - account
-        high_value: true
-        evidence_types:
-        - source_snapshot
-        control_domains:
-        - asset_inventory
-        id: account
-        support: partial
-        title: Account
-        type: entity_family
-      default_enabled: true
-      event:
-        kind: cloudflare.account
-        required_payload_fields:
-        - code
-        schema_ref: cloudflare/account/v1
-        urn_kind: cloudflare_account
-      event_kind: account
-      id: account
-      id_field: code
-      label: Account
-      list_key: errors
-      method: GET
-      name_field: code
-      pagination:
-        inject_first_page: true
-        page_param: page
-        page_size: 100
-        page_size_param: per_page
-        start_page: 1
-        type: page
-      path: "/accounts"
-      permissions_needed:
-      - api_email
-      - api_key
-      projection:
-        fields:
-          id: code
-          name: code
-          provider_id: code
-        template: identity_user
-      record_selector: "$.errors[*]"
-    - coverage:
-      - families:
-        - organization
-        high_value: true
-        evidence_types:
-        - source_snapshot
-        control_domains:
-        - asset_inventory
-        id: organization
-        support: partial
-        title: Organization
-        type: entity_family
-      default_enabled: true
-      event:
-        kind: cloudflare.organization
-        required_payload_fields:
-        - id
-        schema_ref: cloudflare/organization/v1
-        urn_kind: cloudflare_organization
-      event_kind: organization
-      id: organization
-      id_field: id
-      label: Organization
-      list_key: errors
-      method: GET
-      pagination:
-        cursor_param: page_token
-        page_size: 100
-        page_size_param: page_size
-        type: cursor
-      path: "/organizations"
-      permissions_needed:
-      - api_email
-      - api_key
-      - api_token
-      projection:
-        fields:
-          id: id
-          provider_id: id
-        template: identity_group
-      record_selector: "$.errors[*]"
-    schema_version: cerebro.integration/v1
-    scope_options:
-    - default_enabled: true
-      families:
-      - asn
-      id: asn
-      label: Asn
-    - default_enabled: true
-      families:
-      - event
-      id: event
-      label: Event
-    - default_enabled: true
-      families:
-      - account
-      id: account
-      label: Account
-    - default_enabled: true
-      families:
-      - organization
-      id: organization
-      label: Organization
-    source_id: cloudflare
-    tenant_id: builtin_catalog
-    transport:
-      base_url: https://api.cloudflare.com/client/v4
-      retry:
-        backoff: exponential
-        max_attempts: 3
-        retry_after_header: Retry-After
-        statuses:
-        - 429
-        - 500
-        - 502
-        - 503
-        - 504
-      verification:
-        expect_status:
-        - 200
-        method: GET
-        path: "/accounts/${config.account_id}/botnet_feed/configs/asn"
+  - classifier_output: supported
+    definition:
+      schema_version: cerebro.integration/v1
+      tenant_id: builtin_catalog
+      source_id: cloudflare
+      id: builtin_catalog-cloudflare
+      display_name: Cloudflare
+      description: Collects Cloudflare accounts, members, roles, Access applications and groups, Gateway rules, rulesets, Workers, load balancers, zones, DNS records, and account audit logs.
+      categories: [networking, security]
+      ingest:
+        mode: pull
+      auth:
+        model: bearer_token
+        requires_references: true
+        credential_fields:
+          - key: token
+            label: Cloudflare API token
+            required: true
+            secret: true
+            reference_only: true
+      config_fields:
+        - key: account_id
+          label: Account ID
+          help: Required for account-scoped families.
+          required: false
+        - key: zone_id
+          label: Zone ID
+          help: Required for zone-scoped families.
+          required: false
+      transport:
+        base_url: https://api.cloudflare.com/client/v4
+        retry:
+          backoff: exponential
+          max_attempts: 3
+          retry_after_header: Retry-After
+          statuses: [429, 500, 502, 503, 504]
+        verification:
+          method: GET
+          path: /accounts
+          expect_status: [200]
+      resource_families:
+        - id: access_application
+          label: Account Access applications
+          method: GET
+          path: /accounts/{account_id}/access/apps
+          record_selector: $.result[*]
+          list_key: result
+          id_field: id
+          name_field: name
+          updated_at_field: updated_at
+          read:
+            path_params: [account_id]
+          config:
+            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+            resource_urn_kind: cloudflare_access_application
+          pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
+          event:
+            kind: cloudflare.access_application
+            schema_ref: cloudflare/access_application/v1
+            urn_kind: cloudflare_access_application
+            required_attributes: [account_id, application_id]
+            required_payload_fields: [id]
+          projection:
+            template: asset
+            fields: {application_id: id, account_id: account_id, name: name, domain: domain, type: type, aud: aud, session_duration: session_duration, policies: policies, allowed_idps: allowed_idps, auto_redirect_to_identity: auto_redirect_to_identity}
+            static_fields: {source_product: cloudflare, resource_type: access_application}
+          coverage:
+            - {id: access_applications, title: Zero Trust Access applications, type: entity_family, families: [access_application], support: supported, high_value: true, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
+          default_enabled: true
+          permissions_needed: ["Access: Apps and Policies Read"]
+
+        - id: zone_access_application
+          label: Zone Access applications
+          method: GET
+          path: /zones/{zone_id}/access/apps
+          record_selector: $.result[*]
+          list_key: result
+          id_field: id
+          name_field: name
+          updated_at_field: updated_at
+          read:
+            path_params: [zone_id]
+          config:
+            config_attributes: {tenant_id: tenant_id, zone_id: zone_id}
+            resource_urn_kind: cloudflare_zone_access_application
+          pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
+          event:
+            kind: cloudflare.zone_access_application
+            schema_ref: cloudflare/zone_access_application/v1
+            urn_kind: cloudflare_zone_access_application
+            required_attributes: [application_id, zone_id]
+            required_payload_fields: [id]
+          projection:
+            template: asset
+            fields: {application_id: id, zone_id: zone_id, name: name, domain: domain, type: type, aud: aud, session_duration: session_duration, policies: policies, allowed_idps: allowed_idps, auto_redirect_to_identity: auto_redirect_to_identity}
+            static_fields: {source_product: cloudflare, resource_type: zone_access_application}
+          coverage:
+            - {id: access_applications, title: Zero Trust Access applications, type: entity_family, families: [zone_access_application], support: supported, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
+          default_enabled: true
+          permissions_needed: ["Access: Apps and Policies Read"]
+
+        - id: access_group
+          label: Account Access groups
+          method: GET
+          path: /accounts/{account_id}/access/groups
+          record_selector: $.result[*]
+          list_key: result
+          id_field: id
+          name_field: name
+          updated_at_field: updated_at
+          read:
+            path_params: [account_id]
+          config:
+            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+            resource_urn_kind: cloudflare_access_group
+          pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
+          event:
+            kind: cloudflare.access_group
+            schema_ref: cloudflare/access_group/v1
+            urn_kind: cloudflare_access_group
+            required_attributes: [account_id, group_id]
+            required_payload_fields: [id]
+          projection:
+            template: policy
+            fields: {group_id: id, name: name, policy_id: id, policy_name: name, policy_type: access_group, account_id: account_id, include: include, exclude: exclude, require: require}
+            static_fields: {source_product: cloudflare, resource_type: access_group}
+          coverage:
+            - {id: access_groups, title: Zero Trust Access groups, type: app_entitlement, families: [access_group], support: supported, high_value: true, evidence_types: [identity_configuration], control_domains: [identity_access]}
+          default_enabled: true
+          permissions_needed: ["Access: Apps and Policies Read"]
+
+        - id: zone_access_group
+          label: Zone Access groups
+          method: GET
+          path: /zones/{zone_id}/access/groups
+          record_selector: $.result[*]
+          list_key: result
+          id_field: id
+          name_field: name
+          updated_at_field: updated_at
+          read:
+            path_params: [zone_id]
+          config:
+            config_attributes: {tenant_id: tenant_id, zone_id: zone_id}
+            resource_urn_kind: cloudflare_zone_access_group
+          pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
+          event:
+            kind: cloudflare.zone_access_group
+            schema_ref: cloudflare/zone_access_group/v1
+            urn_kind: cloudflare_zone_access_group
+            required_attributes: [group_id, zone_id]
+            required_payload_fields: [id]
+          projection:
+            template: policy
+            fields: {group_id: id, name: name, policy_id: id, policy_name: name, policy_type: access_group, zone_id: zone_id, include: include, exclude: exclude, require: require}
+            static_fields: {source_product: cloudflare, resource_type: zone_access_group}
+          coverage:
+            - {id: access_groups, title: Zero Trust Access groups, type: app_entitlement, families: [zone_access_group], support: supported, evidence_types: [identity_configuration], control_domains: [identity_access]}
+          default_enabled: true
+          permissions_needed: ["Access: Apps and Policies Read"]
+
+        - id: account
+          label: Accounts
+          method: GET
+          path: /accounts
+          record_selector: $.result[*]
+          list_key: result
+          id_field: id
+          name_field: name
+          config:
+            config_attributes: {tenant_id: tenant_id}
+            resource_urn_kind: cloudflare_account
+          pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
+          event:
+            kind: cloudflare.account
+            schema_ref: cloudflare/account/v1
+            urn_kind: cloudflare_account
+            required_attributes: [account_id]
+            required_payload_fields: [id]
+          projection:
+            template: asset
+            fields: {account_id: id, name: name, type: type}
+            static_fields: {source_product: cloudflare, resource_type: account}
+          coverage:
+            - {id: accounts, title: Accounts, type: entity_family, families: [account], support: supported, high_value: true, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
+          default_enabled: true
+          permissions_needed: [Account Settings Read]
+
+        - id: account_ruleset
+          label: Account rulesets
+          method: GET
+          path: /accounts/{account_id}/rulesets
+          record_selector: $.result[*]
+          list_key: result
+          id_field: id
+          name_field: name
+          updated_at_field: last_updated
+          read:
+            path_params: [account_id]
+            detail_path: /accounts/{account_id}/rulesets/{id}
+            allow_bare_detail_record: true
+          config:
+            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+            resource_urn_kind: cloudflare_account_ruleset
+          pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
+          event:
+            kind: cloudflare.account_ruleset
+            schema_ref: cloudflare/account_ruleset/v1
+            urn_kind: cloudflare_account_ruleset
+            required_attributes: [account_id, ruleset_id]
+            required_payload_fields: [id]
+          projection:
+            template: policy
+            fields: {ruleset_id: id, name: name, kind: kind, phase: phase, policy_id: id, policy_name: name, policy_type: kind, policy_status: phase, account_id: account_id, version: version, last_updated: last_updated, rules: rules}
+            static_fields: {source_product: cloudflare, resource_type: account_ruleset}
+          coverage:
+            - {id: account_rulesets, title: Account rulesets, type: entity_family, families: [account_ruleset], support: supported, high_value: true, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
+          default_enabled: true
+          permissions_needed: [Account Rulesets Read]
+
+        - id: audit_log
+          label: Account audit logs
+          method: GET
+          path: /accounts/{account_id}/audit_logs
+          record_selector: $.result[*]
+          list_key: result
+          id_field: id
+          updated_at_field: when
+          read:
+            path_params: [account_id]
+          config:
+            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+          pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
+          event:
+            kind: cloudflare.audit_log
+            schema_ref: cloudflare/audit_log/v1
+            urn_kind: cloudflare_audit_log
+            required_attributes: [account_id, audit_id]
+            required_payload_fields: [id]
+          projection:
+            template: audit_event
+            fields: {audit_id: id, event_type: action.type|action, resource_name: action.type|id, account_id: account.id|account_id, action: action.type|action, actor_email: actor.email, actor_ip: actor.ip, resource_id: resource.id, resource_type: resource.type, zone_id: zone.id|zone_id}
+            static_fields: {source_product: cloudflare}
+          coverage:
+            - {id: audit_logs, title: Account audit logs, type: audit_event, families: [audit_log], support: supported, high_value: true, evidence_types: [logging_configuration], control_domains: [logging_monitoring]}
+          default_enabled: true
+          permissions_needed: [Audit Logs Read]
+
+        - id: member
+          label: Account members
+          method: GET
+          path: /accounts/{account_id}/members
+          record_selector: $.result[*]
+          list_key: result
+          id_field: id
+          name_field: id
+          updated_at_field: modified_on
+          read:
+            path_params: [account_id]
+          config:
+            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+            resource_urn_kind: cloudflare_member
+          pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
+          event:
+            kind: cloudflare.member
+            schema_ref: cloudflare/member/v1
+            urn_kind: cloudflare_member
+            required_attributes: [account_id, member_id]
+            required_payload_fields: [id]
+          projection:
+            template: identity_user
+            fields: {member_id: id, user_id: id, account_id: account.id|account_id, email: user.email|email, status: status, roles: roles}
+            static_fields: {source_product: cloudflare, resource_type: identity_user}
+          coverage:
+            - {id: members, title: Account members, type: app_entitlement, families: [member], support: supported, high_value: true, evidence_types: [identity_configuration], control_domains: [identity_access]}
+          default_enabled: true
+          permissions_needed: [Account Memberships Read]
+
+        - id: gateway_rule
+          label: Gateway rules
+          method: GET
+          path: /accounts/{account_id}/gateway/rules
+          record_selector: $.result[*]
+          list_key: result
+          id_field: id
+          name_field: name
+          updated_at_field: updated_at
+          read:
+            path_params: [account_id]
+          config:
+            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+            resource_urn_kind: cloudflare_gateway_rule
+          pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
+          event:
+            kind: cloudflare.gateway_rule
+            schema_ref: cloudflare/gateway_rule/v1
+            urn_kind: cloudflare_gateway_rule
+            required_attributes: [account_id, rule_id]
+            required_payload_fields: [id]
+          projection:
+            template: policy
+            fields: {rule_id: id, name: name, policy_id: id, policy_name: name, policy_type: gateway_rule, policy_status: enabled, account_id: account_id, action: action, traffic: traffic, enabled: enabled, precedence: precedence, filters: filters, rule_settings: rule_settings}
+            static_fields: {source_product: cloudflare, resource_type: gateway_rule}
+          coverage:
+            - {id: gateway_rules, title: Zero Trust Gateway rules, type: entity_family, families: [gateway_rule], support: partial, high_value: true, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
+          default_enabled: true
+          permissions_needed: [Zero Trust Gateway Rules Read]
+
+        - id: load_balancer
+          label: Load balancers
+          method: GET
+          path: /zones/{zone_id}/load_balancers
+          record_selector: $.result[*]
+          list_key: result
+          id_field: id
+          name_field: name
+          updated_at_field: modified_on
+          read:
+            path_params: [zone_id]
+          config:
+            config_attributes: {tenant_id: tenant_id, zone_id: zone_id}
+            resource_urn_kind: cloudflare_load_balancer
+          pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
+          event:
+            kind: cloudflare.load_balancer
+            schema_ref: cloudflare/load_balancer/v1
+            urn_kind: cloudflare_load_balancer
+            required_attributes: [load_balancer_id, zone_id]
+            required_payload_fields: [id]
+          projection:
+            template: asset
+            fields: {load_balancer_id: id, zone_id: zone_id, name: name, fallback_pool: fallback_pool, default_pools: default_pools, enabled: enabled, proxied: proxied, steering_policy: steering_policy}
+            static_fields: {source_product: cloudflare, resource_type: load_balancer}
+          coverage:
+            - {id: load_balancers, title: Load balancers, type: entity_family, families: [load_balancer], support: supported, high_value: true, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
+          default_enabled: true
+          permissions_needed: [Load Balancing Read]
+
+        - id: load_balancer_pool
+          label: Load balancer pools
+          method: GET
+          path: /accounts/{account_id}/load_balancers/pools
+          record_selector: $.result[*]
+          list_key: result
+          id_field: id
+          name_field: name
+          updated_at_field: modified_on
+          read:
+            path_params: [account_id]
+          config:
+            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+            resource_urn_kind: cloudflare_load_balancer_pool
+          pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
+          event:
+            kind: cloudflare.load_balancer_pool
+            schema_ref: cloudflare/load_balancer_pool/v1
+            urn_kind: cloudflare_load_balancer_pool
+            required_attributes: [account_id, pool_id]
+            required_payload_fields: [id]
+          projection:
+            template: asset
+            fields: {pool_id: id, account_id: account_id, name: name, enabled: enabled, origins: origins, check_regions: check_regions, minimum_origins: minimum_origins}
+            static_fields: {source_product: cloudflare, resource_type: load_balancer_pool}
+          coverage:
+            - {id: load_balancer_pools, title: Load balancer pools, type: entity_family, families: [load_balancer_pool], support: supported, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
+          default_enabled: true
+          permissions_needed: [Load Balancing Read]
+
+        - id: role
+          label: Account roles
+          method: GET
+          path: /accounts/{account_id}/roles
+          record_selector: $.result[*]
+          list_key: result
+          id_field: id
+          name_field: name
+          read:
+            path_params: [account_id]
+            detail_path: /accounts/{account_id}/roles/{id}
+            allow_bare_detail_record: true
+          config:
+            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+            resource_urn_kind: cloudflare_role
+          pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
+          event:
+            kind: cloudflare.role
+            schema_ref: cloudflare/role/v1
+            urn_kind: cloudflare_role
+            required_attributes: [account_id, role_id]
+            required_payload_fields: [id]
+          projection:
+            template: policy
+            fields: {role_id: id, name: name, policy_id: id, policy_name: name, policy_type: cloudflare_role, account_id: account_id, description: description, permissions: permissions, permission_groups: permission_groups}
+            static_fields: {source_product: cloudflare, resource_type: role}
+          coverage:
+            - {id: roles, title: Account roles, type: app_entitlement, families: [role], support: supported, high_value: true, evidence_types: [identity_configuration], control_domains: [identity_access]}
+          default_enabled: true
+          permissions_needed: [Account Memberships Read]
+
+        - id: worker_script
+          label: Workers scripts
+          method: GET
+          path: /accounts/{account_id}/workers/scripts
+          record_selector: $.result[*]
+          list_key: result
+          id_field: id
+          name_field: id
+          updated_at_field: modified_on
+          read:
+            path_params: [account_id]
+          config:
+            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+            resource_urn_kind: cloudflare_worker_script
+          pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
+          event:
+            kind: cloudflare.worker_script
+            schema_ref: cloudflare/worker_script/v1
+            urn_kind: cloudflare_worker_script
+            required_attributes: [account_id, script_id]
+            required_payload_fields: [id]
+          projection:
+            template: asset
+            fields: {script_id: id, account_id: account_id, created_on: created_on, modified_on: modified_on, compatibility_date: compatibility_date, tags: tags, bindings: bindings, placement: placement}
+            static_fields: {source_product: cloudflare, resource_type: worker_script}
+          coverage:
+            - {id: worker_scripts, title: Workers scripts, type: entity_family, families: [worker_script], support: partial, high_value: true, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
+          sensitive_payload_paths: [result.bindings.secret_text]
+          default_enabled: true
+          permissions_needed: [Workers Scripts Read]
+
+        - id: zone
+          label: Zones
+          method: GET
+          path: /zones
+          record_selector: $.result[*]
+          list_key: result
+          id_field: id
+          name_field: name
+          updated_at_field: modified_on
+          config:
+            config_attributes: {tenant_id: tenant_id}
+            resource_urn_kind: cloudflare_zone
+          pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
+          event:
+            kind: cloudflare.zone
+            schema_ref: cloudflare/zone/v1
+            urn_kind: cloudflare_zone
+            required_attributes: [zone_id]
+            required_payload_fields: [id]
+          projection:
+            template: asset
+            fields: {zone_id: id, account_id: account.id|account_id, name: name, status: status, type: type, paused: paused}
+            static_fields: {source_product: cloudflare, resource_type: zone}
+          coverage:
+            - {id: zones, title: Zones, type: entity_family, families: [zone], support: supported, high_value: true, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
+          default_enabled: true
+          permissions_needed: [Zone Read]
+
+        - id: zone_ruleset
+          label: Zone rulesets
+          method: GET
+          path: /zones/{zone_id}/rulesets
+          record_selector: $.result[*]
+          list_key: result
+          id_field: id
+          name_field: name
+          updated_at_field: last_updated
+          read:
+            path_params: [zone_id]
+            detail_path: /zones/{zone_id}/rulesets/{id}
+            allow_bare_detail_record: true
+          config:
+            config_attributes: {tenant_id: tenant_id, zone_id: zone_id}
+            resource_urn_kind: cloudflare_zone_ruleset
+          pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
+          event:
+            kind: cloudflare.zone_ruleset
+            schema_ref: cloudflare/zone_ruleset/v1
+            urn_kind: cloudflare_zone_ruleset
+            required_attributes: [ruleset_id, zone_id]
+            required_payload_fields: [id]
+          projection:
+            template: policy
+            fields: {ruleset_id: id, name: name, kind: kind, phase: phase, policy_id: id, policy_name: name, policy_type: kind, policy_status: phase, zone_id: zone_id, version: version, last_updated: last_updated, rules: rules}
+            static_fields: {source_product: cloudflare, resource_type: zone_ruleset}
+          coverage:
+            - {id: zone_rulesets, title: Zone rulesets, type: entity_family, families: [zone_ruleset], support: supported, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
+          default_enabled: true
+          permissions_needed: [Zone Rulesets Read]
+
+        - id: dns_record
+          label: DNS records
+          method: GET
+          path: /zones/{zone_id}/dns_records
+          record_selector: $.result[*]
+          list_key: result
+          id_field: id
+          name_field: name
+          updated_at_field: modified_on
+          read:
+            path_params: [zone_id]
+          config:
+            config_attributes: {tenant_id: tenant_id, zone_id: zone_id}
+            resource_urn_kind: cloudflare_dns_record
+          pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
+          event:
+            kind: cloudflare.dns_record
+            schema_ref: cloudflare/dns_record/v1
+            urn_kind: cloudflare_dns_record
+            required_attributes: [record_id, zone_id]
+            required_payload_fields: [id]
+          projection:
+            template: asset
+            fields: {record_id: id, zone_id: zone_id, name: name, type: type, content: content, proxied: proxied}
+            static_fields: {source_product: cloudflare, resource_type: dns_record}
+          coverage:
+            - {id: dns_records, title: DNS records, type: entity_family, families: [dns_record], support: supported, high_value: true, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
+          default_enabled: true
+          permissions_needed: [DNS Read]

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -478,6 +478,74 @@ func TestBuiltinEntryFindsNormalizedSourceID(t *testing.T) {
 	}
 }
 
+func TestBuiltinCloudflareCatalogClosesTheProviderFamilyAndCredentialContracts(t *testing.T) {
+	entry, ok, err := BuiltinEntry("cloudflare")
+	if err != nil {
+		t.Fatalf("BuiltinEntry(cloudflare) error = %v", err)
+	}
+	if !ok {
+		t.Fatal("BuiltinEntry(cloudflare) ok = false")
+	}
+	definition := entry.Definition
+	if definition.Auth.Model != "bearer_token" || !definition.Auth.RequiresReferences {
+		t.Fatalf("auth = %#v, want reference-only bearer token", definition.Auth)
+	}
+	if len(definition.Auth.CredentialFields) != 1 {
+		t.Fatalf("credential fields = %d, want one token reference", len(definition.Auth.CredentialFields))
+	}
+	credential := definition.Auth.CredentialFields[0]
+	if credential.Key != "token" || !credential.Secret || !credential.ReferenceOnly {
+		t.Fatalf("credential = %#v, want secret reference-only token", credential)
+	}
+
+	want := map[string][]string{
+		"access_application":      {"account_id", "application_id"},
+		"access_group":            {"account_id", "group_id"},
+		"account":                 {"account_id"},
+		"account_ruleset":         {"account_id", "ruleset_id"},
+		"audit_log":               {"account_id", "audit_id"},
+		"member":                  {"account_id", "member_id"},
+		"gateway_rule":            {"account_id", "rule_id"},
+		"load_balancer":           {"load_balancer_id", "zone_id"},
+		"load_balancer_pool":      {"account_id", "pool_id"},
+		"role":                    {"account_id", "role_id"},
+		"worker_script":           {"account_id", "script_id"},
+		"zone":                    {"zone_id"},
+		"zone_access_application": {"application_id", "zone_id"},
+		"zone_access_group":       {"group_id", "zone_id"},
+		"zone_ruleset":            {"ruleset_id", "zone_id"},
+		"dns_record":              {"record_id", "zone_id"},
+	}
+	if len(definition.ResourceFamilies) != len(want) {
+		t.Fatalf("families = %d, want %d", len(definition.ResourceFamilies), len(want))
+	}
+	for _, family := range definition.ResourceFamilies {
+		required, ok := want[family.ID]
+		if !ok {
+			t.Fatalf("unexpected family %q", family.ID)
+		}
+		if family.Event.Kind != "cloudflare."+family.ID || family.Event.SchemaRef != "cloudflare/"+family.ID+"/v1" {
+			t.Fatalf("%s event = %#v", family.ID, family.Event)
+		}
+		if strings.Join(family.Event.RequiredAttributes, ",") != strings.Join(required, ",") {
+			t.Fatalf("%s required attributes = %#v, want %#v", family.ID, family.Event.RequiredAttributes, required)
+		}
+		if family.Pagination == nil || family.Pagination.Type != "page" || family.Pagination.PageParam != "page" || family.Pagination.PageSizeParam != "per_page" {
+			t.Fatalf("%s pagination = %#v", family.ID, family.Pagination)
+		}
+		if family.Config == nil || family.Config.ConfigAttributes["tenant_id"] != "tenant_id" {
+			t.Fatalf("%s config = %#v, want authenticated tenant binding", family.ID, family.Config)
+		}
+		if family.Projection == nil || strings.TrimSpace(family.Projection.Template) == "" {
+			t.Fatalf("%s projection is not compiled", family.ID)
+		}
+		delete(want, family.ID)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing families = %#v", want)
+	}
+}
+
 func TestBuiltinCatalogHashicorpVaultFamiliesMirrorRuntimeConfig(t *testing.T) {
 	entry, ok, err := BuiltinEntry("hashicorp_vault")
 	if err != nil {

--- a/internal/sourceregistry/registry_test.go
+++ b/internal/sourceregistry/registry_test.go
@@ -353,6 +353,15 @@ func TestBuiltinKeepsOnlyCatalogCompatibilityExceptionsAsStaticLoaders(t *testin
 	}
 }
 
+func TestBuiltinKeepsCloudflareConcreteLoaderUntilSeparateRetirementGate(t *testing.T) {
+	for _, loader := range builtinSourceLoaders {
+		if loader.name == "cloudflare" {
+			return
+		}
+	}
+	t.Fatal("cloudflare concrete source loader retired before the separate authority gate")
+}
+
 func TestBuiltinRegistersGenerateableCatalogSources(t *testing.T) {
 	registry, err := Builtin()
 	if err != nil {

--- a/sources/cloudflare/catalog_runtime_parity_test.go
+++ b/sources/cloudflare/catalog_runtime_parity_test.go
@@ -1,0 +1,249 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/connectorcatalog"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourcefixture"
+	"github.com/writer/cerebro/sources/catalogruntime"
+)
+
+type cloudflareOracleEvent struct {
+	TenantID   string            `json:"tenant_id"`
+	SourceID   string            `json:"source_id"`
+	Kind       string            `json:"kind"`
+	SchemaRef  string            `json:"schema_ref"`
+	Payload    json.RawMessage   `json:"payload"`
+	Attributes map[string]string `json:"attributes"`
+}
+
+func TestCatalogRuntimeMatchesAllCloudflareGoOracleFamilies(t *testing.T) {
+	entry, ok, err := connectorcatalog.BuiltinEntry(sourceID)
+	if err != nil {
+		t.Fatalf("BuiltinEntry(cloudflare) error = %v", err)
+	}
+	if !ok {
+		t.Fatal("BuiltinEntry(cloudflare) ok = false")
+	}
+
+	for _, family := range entry.Definition.ResourceFamilies {
+		family := family
+		t.Run(family.ID, func(t *testing.T) {
+			oracle := readCloudflareOracleEvent(t, family.ID)
+			response, err := json.Marshal(map[string]any{
+				"success":     true,
+				"errors":      []any{},
+				"messages":    []any{},
+				"result":      []json.RawMessage{oracle.Payload},
+				"result_info": map[string]any{"page": 1, "per_page": 100, "total_pages": 1, "total_count": 1},
+			})
+			if err != nil {
+				t.Fatalf("marshal provider response: %v", err)
+			}
+			serverFor := func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if got := r.Header.Get("Authorization"); got != "Bearer replay-token" {
+						t.Fatalf("Authorization = %q, want applied outside provider definition", got)
+					}
+					w.Header().Set("Content-Type", "application/json")
+					if family.Read != nil && family.Read.DetailPath != "" && strings.HasSuffix(r.URL.EscapedPath(), "/"+oracle.Attributes[idAttributeForParity(family.ID)]) {
+						detail, err := json.Marshal(map[string]any{"success": true, "result": oracle.Payload})
+						if err != nil {
+							t.Fatalf("marshal detail response: %v", err)
+						}
+						_, _ = w.Write(detail)
+						return
+					}
+					_, _ = w.Write(response)
+				}))
+			}
+
+			goServer := serverFor()
+			defer goServer.Close()
+			goSource := capturedCloudflareSource(t)
+			goPull, err := goSource.Read(context.Background(), cloudflareParityConfig(goServer.URL, family.ID, oracle.Attributes), nil)
+			if err != nil {
+				t.Fatalf("Go Read() error = %v", err)
+			}
+
+			rustServer := serverFor()
+			defer rustServer.Close()
+
+			definition := entry.Definition
+			definition.Transport.BaseURL = rustServer.URL + "/client/v4"
+			source, err := catalogruntime.NewDefinitionWithValidationOptions(definition, catalogruntime.ValidationOptions{AllowLoopbackBaseURL: true})
+			if err != nil {
+				t.Fatalf("NewDefinition() error = %v", err)
+			}
+			pull, err := source.Read(context.Background(), cloudflareParityConfig(rustServer.URL, family.ID, oracle.Attributes), nil)
+			if err != nil {
+				t.Fatalf("Read() error = %v", err)
+			}
+			if len(pull.Events) != 1 || len(goPull.Events) != 1 {
+				t.Fatalf("events = %d, want one Go oracle event", len(pull.Events))
+			}
+			if pull.NextCursor != nil {
+				t.Fatalf("terminal cursor = %#v, want nil", pull.NextCursor)
+			}
+			event := pull.Events[0]
+			goEvent := goPull.Events[0]
+			if event.TenantId != oracle.TenantID || event.SourceId != oracle.SourceID || event.Kind != oracle.Kind || event.SchemaRef != oracle.SchemaRef {
+				t.Fatalf("event contract = tenant %q source %q kind %q schema %q, want %#v", event.TenantId, event.SourceId, event.Kind, event.SchemaRef, oracle)
+			}
+			var gotPayload any
+			if err := json.Unmarshal(event.Payload, &gotPayload); err != nil {
+				t.Fatalf("event payload: %v", err)
+			}
+			var goPayload any
+			if err := json.Unmarshal(goEvent.Payload, &goPayload); err != nil {
+				t.Fatalf("Go payload: %v", err)
+			}
+			if !reflect.DeepEqual(gotPayload, goPayload) {
+				t.Fatalf("payload drift from Go: got %#v want %#v", gotPayload, goPayload)
+			}
+			for key, want := range goEvent.Attributes {
+				if key == "observed_at" {
+					continue
+				}
+				if got := event.Attributes[key]; got != want {
+					t.Errorf("attribute %s = %q, want %q", key, got, want)
+				}
+			}
+			for _, key := range []string{"tenant_id", "source_event_id", idAttributeForParity(family.ID)} {
+				if strings.TrimSpace(event.Attributes[key]) == "" {
+					t.Errorf("required attribute %s is empty", key)
+				}
+			}
+			if strings.Contains(string(event.Payload), "replay-token") {
+				t.Fatal("credential value entered emitted payload")
+			}
+		})
+	}
+}
+
+func TestCatalogRuntimeResumesCloudflareMemberPagesWithGoCursors(t *testing.T) {
+	entry, ok, err := connectorcatalog.BuiltinEntry(sourceID)
+	if err != nil || !ok {
+		t.Fatalf("BuiltinEntry(cloudflare) = ok %v error %v", ok, err)
+	}
+	pages := map[string]sourcefixture.Bundle{
+		"1": capturedCloudflareBundle(t, "member", "list_members"),
+		"2": capturedCloudflareBundle(t, "member", "list_members_page_2"),
+		"3": capturedCloudflareBundle(t, "member", "list_members_page_3"),
+	}
+	requestPath := capturedCloudflareRequestPath(t, pages["1"])
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.EscapedPath() != requestPath {
+			t.Fatalf("path = %q, want %q", r.URL.EscapedPath(), requestPath)
+		}
+		page := r.URL.Query().Get("page")
+		bundle, ok := pages[page]
+		if !ok {
+			t.Fatalf("page = %q, want 1, 2, or 3", page)
+		}
+		writeCapturedCloudflareResponse(w, bundle)
+	}))
+	defer server.Close()
+	definition := entry.Definition
+	definition.Transport.BaseURL = server.URL + "/client/v4"
+	source, err := catalogruntime.NewDefinitionWithValidationOptions(definition, catalogruntime.ValidationOptions{AllowLoopbackBaseURL: true})
+	if err != nil {
+		t.Fatalf("NewDefinition() error = %v", err)
+	}
+	cfg := cloudflareParityConfig(server.URL, "member", map[string]string{
+		"account_id": capturedCloudflarePathSegment(t, requestPath, 3),
+	})
+	var cursor *cerebrov1.SourceCursor
+	for page := 1; page <= 3; page++ {
+		pull, err := source.Read(context.Background(), cfg, cursor)
+		if err != nil {
+			t.Fatalf("Read(page %d) error = %v", page, err)
+		}
+		if len(pull.Events) != 1 {
+			t.Fatalf("Read(page %d) events = %d, want 1", page, len(pull.Events))
+		}
+		if page < 3 {
+			if got, want := pull.NextCursor.GetOpaque(), string(rune('1'+page)); got != want {
+				t.Fatalf("Read(page %d) cursor = %q, want %q", page, got, want)
+			}
+		} else if pull.NextCursor != nil {
+			t.Fatalf("Read(page 3) cursor = %#v, want terminal", pull.NextCursor)
+		}
+		cursor = pull.NextCursor
+	}
+}
+
+func cloudflareParityConfig(baseURL, family string, attributes map[string]string) sourcecdk.Config {
+	return capturedCloudflareConfig(baseURL, family, map[string]string{
+		"account_id": firstNonEmptyForParity(attributes["account_id"], "account-1"),
+		"zone_id":    firstNonEmptyForParity(attributes["zone_id"], "zone-1"),
+		"per_page":   "100",
+	})
+}
+
+func idAttributeForParity(familyID string) string {
+	switch familyID {
+	case "access_application", "zone_access_application":
+		return "application_id"
+	case "access_group", "zone_access_group":
+		return "group_id"
+	case "account":
+		return "account_id"
+	case "account_ruleset", "zone_ruleset":
+		return "ruleset_id"
+	case "audit_log":
+		return "audit_id"
+	case "member":
+		return "member_id"
+	case "gateway_rule":
+		return "rule_id"
+	case "load_balancer":
+		return "load_balancer_id"
+	case "load_balancer_pool":
+		return "pool_id"
+	case "role":
+		return "role_id"
+	case "worker_script":
+		return "script_id"
+	case "zone":
+		return "zone_id"
+	case "dns_record":
+		return "record_id"
+	default:
+		return "id"
+	}
+}
+
+func readCloudflareOracleEvent(t *testing.T, family string) cloudflareOracleEvent {
+	t.Helper()
+	payload, err := os.ReadFile("testdata/read_" + family + ".json") // #nosec G304 -- family is the closed checked-in catalog vocabulary.
+	if err != nil {
+		t.Fatalf("read Go oracle: %v", err)
+	}
+	var events []cloudflareOracleEvent
+	if err := json.Unmarshal(payload, &events); err != nil {
+		t.Fatalf("decode Go oracle: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("Go oracle has no events")
+	}
+	return events[0]
+}
+
+func firstNonEmptyForParity(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Scope

Adds an independently valid, additive credential-free Cloudflare request/response kernel and compiles the declarative Cloudflare catalog for the existing 16-family provider surface: accounts, members, roles, Access applications and groups, Gateway rules, rulesets, Workers metadata, load balancers, zones, DNS records, and audit logs.

The kernel plans bounded origin-pinned requests without credential bytes, validates provider envelopes, preserves typed provider failures and operator actions, derives deterministic tenant/scoped identities, validates page cursors, rejects credential-shaped response fields, and binds normalized records to exact event kind/schema contracts.

The catalog runtime differential test compares all 16 families against the existing Go oracle and exercises three-page member cursor/resume behavior.

## Authority boundary

Go remains the authoritative compatibility execution path for Cloudflare in this PR. The concrete Go loader is intentionally retained and an explicit registry test protects that boundary. Loader retirement will be a separate narrow forward PR only after Rust parity and authority conditions are proven. Go oracle fixtures remain for differential tests.

## Local validation

Passed:

- Direct rustfmt check over the changed Rust files
- git diff --check
- go test ./sources/cloudflare ./internal/connectorcatalog ./internal/connectordefinitions ./internal/sourceprojection ./internal/sourceregistry -count=1
- Explicit Cloudflare concrete-loader authority test
- All-family catalog runtime versus Go-oracle differential parity
- Three-page Cloudflare member cursor/resume parity
- Source fixture provenance verification: 138 bundles, 34 sources, 126 families

Hosted exact-head validation is the completion path for:

- Managed Cargo formatting check
- cerebro-source-runtime-next Rust unit/integration tests
- Clippy with warnings denied
- Projection parity, structural, catalog, security, and full checks

The earlier local broader source-fixture package test stopped during unrelated package linking with no space left on device after provenance verification completed.

No credentials, private routes, deployment configuration, or human reviewers are included.