### PR TITLE
feat(github): add credential-free Rust provider kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,6 +1147,7 @@ dependencies = [
  "prost-types",
  "reqwest",
  "serde",
+ "serde-saphyr",
  "serde_json",
  "sha2 0.11.0",
  "time",

--- a/crates/source-runtime-next/Cargo.toml
+++ b/crates/source-runtime-next/Cargo.toml
@@ -31,6 +31,9 @@ time.workspace = true
 tokio = { workspace = true, features = ["time"] }
 zeroize.workspace = true
 
+[dev-dependencies]
+serde-saphyr.workspace = true
+
 [lints]
 workspace = true
 

--- a/crates/source-runtime-next/src/github.rs
+++ b/crates/source-runtime-next/src/github.rs
@@ -1,0 +1,27 @@
+//! Credential-free GitHub request planning and response normalization.
+//!
+//! This module deliberately retains GitHub's audit, repository, Dependabot,
+//! organization-inventory, pull-request, and secret-scanning contracts. It is
+//! not the narrower generic issue/event/email connector catalog.
+
+mod catalog;
+mod cursor;
+mod error;
+mod normalize;
+mod normalize_audit;
+mod normalize_inventory;
+mod normalize_security;
+mod origin;
+mod request;
+mod response;
+mod types;
+
+pub use catalog::{GitHubEventContract, GitHubRuntimeDefinition};
+pub use error::GitHubError;
+pub use types::{
+    GitHubActorResolution, GitHubCheckpointCandidate, GitHubContinuation, GitHubFamily,
+    GitHubFilters, GitHubKernel, GitHubPage, GitHubRecord, GitHubRequest, GitHubRequestKind,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/github/catalog.rs
+++ b/crates/source-runtime-next/src/github/catalog.rs
@@ -1,0 +1,111 @@
+use super::{GitHubError, GitHubFamily};
+
+/// One closed event contract compiled from `sources/github/catalog.yaml`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GitHubEventContract {
+    /// Exact event kind admitted by the source catalog.
+    pub kind: &'static str,
+    /// Exact schema reference admitted by the source catalog.
+    pub schema_ref: &'static str,
+    /// Required normalized attributes.
+    pub required_attributes: &'static [&'static str],
+    /// Required normalized payload fields.
+    pub required_payload_fields: &'static [&'static str],
+}
+
+/// Closed GitHub runtime definition compiled from the six catalog families.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GitHubRuntimeDefinition {
+    /// Source identifier.
+    pub source_id: &'static str,
+    /// Selected source family.
+    pub family: GitHubFamily,
+    /// Exact events this family may emit.
+    pub event_contracts: &'static [GitHubEventContract],
+    /// Whether this is a bounded pull family.
+    pub pull: bool,
+}
+
+const AUDIT: GitHubEventContract = contract(
+    "github.audit",
+    "github/audit/v1",
+    &["action", "org"],
+    &["action", "org"],
+);
+const REPOSITORY: GitHubEventContract = contract(
+    "github.code.repository",
+    "github/code_repository/v1",
+    &["owner_login", "repository", "resource_id", "resource_type"],
+    &["full_name", "owner_login"],
+);
+const DEPENDABOT: GitHubEventContract = contract(
+    "github.dependabot_alert",
+    "github/dependabot_alert/v1",
+    &["owner", "repo", "repository", "state"],
+    &["number", "repository", "state"],
+);
+const PULL_REQUEST: GitHubEventContract = contract(
+    "github.pull_request",
+    "github/pull_request/v1",
+    &["owner", "repo", "repository"],
+    &["number", "repository"],
+);
+const ORG_MEMBER: GitHubEventContract = contract(
+    "github.org_member",
+    "github/org_member/v1",
+    &["login", "owner", "role"],
+    &["login", "org", "role"],
+);
+const ORG_INSTALLATION: GitHubEventContract = contract(
+    "github.org_installation",
+    "github/org_installation/v1",
+    &["app_slug", "installation_id", "owner"],
+    &["app_slug", "id", "org"],
+);
+const SECRET_SCANNING: GitHubEventContract = contract(
+    "github.secret_scanning_alert",
+    "github/secret_scanning_alert/v1",
+    &["owner", "state"],
+    &["number", "state"],
+);
+
+const fn contract(
+    kind: &'static str,
+    schema_ref: &'static str,
+    required_attributes: &'static [&'static str],
+    required_payload_fields: &'static [&'static str],
+) -> GitHubEventContract {
+    GitHubEventContract {
+        kind,
+        schema_ref,
+        required_attributes,
+        required_payload_fields,
+    }
+}
+
+impl GitHubRuntimeDefinition {
+    /// Compile one catalog family into its closed runtime definition.
+    pub fn compile(family: GitHubFamily) -> Result<Self, GitHubError> {
+        let event_contracts: &'static [GitHubEventContract] = match family {
+            GitHubFamily::Audit => &[AUDIT],
+            GitHubFamily::Repository => &[REPOSITORY],
+            GitHubFamily::DependabotAlert => &[DEPENDABOT],
+            GitHubFamily::OrganizationInventory => &[ORG_MEMBER, ORG_INSTALLATION],
+            GitHubFamily::PullRequest => &[PULL_REQUEST],
+            GitHubFamily::SecretScanningAlert => &[SECRET_SCANNING],
+        };
+        Ok(Self {
+            source_id: "github",
+            family,
+            event_contracts,
+            pull: true,
+        })
+    }
+
+    pub(super) fn contract_for_kind(self, kind: &str) -> Option<GitHubEventContract> {
+        self.event_contracts
+            .iter()
+            .copied()
+            .find(|contract| contract.kind == kind)
+    }
+}

--- a/crates/source-runtime-next/src/github/cursor.rs
+++ b/crates/source-runtime-next/src/github/cursor.rs
@@ -1,0 +1,106 @@
+use super::{GitHubError, GitHubFamily};
+
+const MAX_CURSOR_BYTES: usize = 1_024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum Stage {
+    Primary,
+    Members,
+    Outside,
+    Installations,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) enum CursorToken {
+    After(String),
+    Page(u32),
+}
+
+pub(super) struct CursorState {
+    pub(super) stage: Stage,
+    pub(super) token: Option<CursorToken>,
+}
+
+impl CursorState {
+    pub(super) fn decode(family: GitHubFamily, cursor: Option<&str>) -> Result<Self, GitHubError> {
+        let default_stage = if family == GitHubFamily::OrganizationInventory {
+            Stage::Members
+        } else {
+            Stage::Primary
+        };
+        let Some(cursor) = cursor else {
+            return Ok(Self {
+                stage: default_stage,
+                token: None,
+            });
+        };
+        if cursor.is_empty()
+            || cursor.len() > MAX_CURSOR_BYTES
+            || cursor.chars().any(char::is_control)
+        {
+            return Err(GitHubError::InvalidCursor);
+        }
+        let parts = cursor.split('|').collect::<Vec<_>>();
+        if parts.len() != 4 || parts[0] != "github-v1" {
+            return Err(GitHubError::InvalidCursor);
+        }
+        let stage = match parts[1] {
+            "primary" if family != GitHubFamily::OrganizationInventory => Stage::Primary,
+            "members" if family == GitHubFamily::OrganizationInventory => Stage::Members,
+            "outside" if family == GitHubFamily::OrganizationInventory => Stage::Outside,
+            "installations" if family == GitHubFamily::OrganizationInventory => {
+                Stage::Installations
+            }
+            _ => return Err(GitHubError::InvalidCursor),
+        };
+        let token = match parts[2] {
+            "after" if !parts[3].is_empty() => CursorToken::After(parts[3].to_owned()),
+            "page" => CursorToken::Page(
+                parts[3]
+                    .parse::<u32>()
+                    .ok()
+                    .filter(|value| *value > 0)
+                    .ok_or(GitHubError::InvalidCursor)?,
+            ),
+            _ => return Err(GitHubError::InvalidCursor),
+        };
+        if matches!(token, CursorToken::After(_))
+            && matches!(
+                family,
+                GitHubFamily::Repository
+                    | GitHubFamily::OrganizationInventory
+                    | GitHubFamily::PullRequest
+            )
+        {
+            return Err(GitHubError::InvalidCursor);
+        }
+        Ok(Self {
+            stage,
+            token: Some(token),
+        })
+    }
+}
+
+pub(super) fn encode_cursor(
+    stage: &'static str,
+    after: Option<&str>,
+    page: Option<u32>,
+) -> Result<Option<String>, GitHubError> {
+    if after.is_some() && page.is_some() {
+        return Err(GitHubError::InvalidCursor);
+    }
+    let cursor = match (after, page) {
+        (Some(value), None)
+            if !value.is_empty()
+                && value.len() <= MAX_CURSOR_BYTES / 2
+                && !value.contains('|')
+                && !value.chars().any(char::is_control) =>
+        {
+            Some(format!("github-v1|{stage}|after|{value}"))
+        }
+        (None, Some(value)) if value > 0 => Some(format!("github-v1|{stage}|page|{value}")),
+        (None, None) => None,
+        _ => return Err(GitHubError::InvalidCursor),
+    };
+    Ok(cursor)
+}

--- a/crates/source-runtime-next/src/github/error.rs
+++ b/crates/source-runtime-next/src/github/error.rs
@@ -1,0 +1,179 @@
+use std::{error::Error, fmt};
+
+/// Bounded, credential-free GitHub provider failures.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GitHubError {
+    /// The source family is not one of the six GitHub catalog families.
+    InvalidFamily,
+    /// Required public source configuration is absent or malformed.
+    MissingConfiguration(&'static str),
+    /// A public configuration value is malformed or exceeds its bound.
+    InvalidConfiguration(&'static str),
+    /// The base URL is not a credential-free HTTPS origin.
+    InvalidBaseUrl,
+    /// The base URL names a local, private, or otherwise unsafe IP literal.
+    UnsafeOrigin,
+    /// The authenticated runtime did not supply a valid tenant identifier.
+    InvalidTenantId,
+    /// The trusted host received no credential reference for this source runtime.
+    MissingCredentialReference,
+    /// The trusted host could not redeem the operation-scoped credential lease.
+    CredentialUnavailable,
+    /// A cursor cannot be safely round-tripped for this family and stage.
+    InvalidCursor,
+    /// A request does not belong to the configured kernel.
+    RequestScopeMismatch,
+    /// A response exceeds the byte bound declared to the host.
+    ResponseTooLarge,
+    /// A response contains more records than the planned page permits.
+    TooManyRecords,
+    /// Response JSON does not match the selected GitHub operation.
+    MalformedResponse,
+    /// A provider object violates the selected family contract.
+    InvalidProviderRecord,
+    /// A provider object lacks a stable identity.
+    MissingStableIdentity,
+    /// A provider payload attempted to provide authenticated tenant context.
+    TenantMismatch,
+    /// Credential-shaped material entered the portable response boundary.
+    CredentialMaterial,
+    /// The same provider identity appeared with conflicting content.
+    ConflictingDuplicate,
+    /// An audit actor needs a separately bounded public lookup.
+    ActorResolutionRequired {
+        /// Public GitHub login that must be resolved.
+        actor: String,
+    },
+    /// GitHub rejected the externally applied credential.
+    AuthenticationRejected,
+    /// The credential lacks a permission required by the selected operation.
+    RequiredScopeMissing,
+    /// An organization-scoped repository request may use the declared user fallback.
+    OrganizationNotFound,
+    /// The trusted host denied the public operation's egress.
+    EgressDenied,
+    /// The trusted host could not connect to GitHub.
+    ConnectionFailure,
+    /// The trusted host could not resolve the declared GitHub hostname.
+    DnsFailure,
+    /// The trusted host reached the operation deadline.
+    ProviderTimeout,
+    /// GitHub requested a bounded retry later.
+    RateLimited {
+        /// Bounded provider retry delay, when supplied.
+        retry_after_seconds: Option<u64>,
+    },
+    /// GitHub returned a retryable server response.
+    ProviderUnavailable {
+        /// HTTP status in the 500-599 range.
+        status: u16,
+    },
+    /// GitHub returned a status outside the typed cases.
+    UnexpectedStatus {
+        /// Provider status outside the typed cases.
+        status: u16,
+    },
+    /// Retry-After exceeds the one-hour persistence bound.
+    InvalidRetryAfter,
+    /// A normalized event failed its exact compiled catalog contract.
+    EventContractRejection,
+    /// The durable append operation failed.
+    AppendFailure,
+    /// The graph projection operation failed.
+    ProjectionFailure,
+    /// The runtime lost its source lease before commit.
+    LeaseLoss,
+    /// The runtime lease generation or authority record is stale.
+    StaleAuthority,
+    /// The runtime encountered an internal failure outside provider classification.
+    InternalRuntimeFailure,
+}
+
+impl fmt::Display for GitHubError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::InvalidFamily => "github family is invalid",
+            Self::MissingConfiguration(_) => "github source configuration is missing",
+            Self::InvalidConfiguration(_) => "github source configuration is invalid",
+            Self::InvalidBaseUrl => "github base URL must be a credential-free HTTPS origin",
+            Self::UnsafeOrigin => "github base URL contains an unsafe origin",
+            Self::InvalidTenantId => "github tenant ID is required and must be bounded",
+            Self::MissingCredentialReference => "github credential reference is missing",
+            Self::CredentialUnavailable => "github credential lease is unavailable",
+            Self::InvalidCursor => "github cursor is invalid or not round-trippable",
+            Self::RequestScopeMismatch => "github request does not match the configured kernel",
+            Self::ResponseTooLarge => "github response exceeds the declared byte bound",
+            Self::TooManyRecords => "github response exceeds the planned page bound",
+            Self::MalformedResponse => "github response JSON does not match the operation",
+            Self::InvalidProviderRecord => "github provider record is invalid",
+            Self::MissingStableIdentity => "github provider record has no stable identity",
+            Self::TenantMismatch => "github provider record attempted to supply tenant context",
+            Self::CredentialMaterial => "github response contains credential-shaped material",
+            Self::ConflictingDuplicate => "github provider identity has conflicting content",
+            Self::ActorResolutionRequired { .. } => "github audit actor requires public resolution",
+            Self::AuthenticationRejected => "github rejected the externally applied credential",
+            Self::RequiredScopeMissing => "github credential lacks the required provider scope",
+            Self::OrganizationNotFound => "github organization was not found",
+            Self::EgressDenied => "github operation was denied by trusted-host egress policy",
+            Self::ConnectionFailure => "trusted host could not connect to github",
+            Self::DnsFailure => "trusted host could not resolve the github origin",
+            Self::ProviderTimeout => "github operation timed out",
+            Self::RateLimited { .. } => "github rate limited the operation",
+            Self::ProviderUnavailable { .. } => "github is temporarily unavailable",
+            Self::UnexpectedStatus { .. } => "github returned an unexpected status",
+            Self::InvalidRetryAfter => "github Retry-After exceeds the one-hour bound",
+            Self::EventContractRejection => "github event failed its compiled catalog contract",
+            Self::AppendFailure => "github event append failed",
+            Self::ProjectionFailure => "github event projection failed",
+            Self::LeaseLoss => "github source runtime lost its lease",
+            Self::StaleAuthority => "github source runtime authority is stale",
+            Self::InternalRuntimeFailure => "github source runtime failed internally",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl GitHubError {
+    /// Return the next safe operator action without provider response content.
+    pub const fn operator_action(&self) -> &'static str {
+        match self {
+            Self::InvalidFamily
+            | Self::MissingConfiguration(_)
+            | Self::InvalidConfiguration(_)
+            | Self::InvalidBaseUrl
+            | Self::UnsafeOrigin
+            | Self::InvalidTenantId
+            | Self::MissingCredentialReference => "repair source configuration",
+            Self::CredentialUnavailable | Self::AuthenticationRejected => {
+                "repair credential binding"
+            }
+            Self::RequiredScopeMissing => "grant the required provider scope",
+            Self::RateLimited { .. }
+            | Self::ProviderUnavailable { .. }
+            | Self::ConnectionFailure
+            | Self::DnsFailure
+            | Self::ProviderTimeout => "retry the collection later",
+            Self::EgressDenied => "repair trusted-host egress policy",
+            Self::OrganizationNotFound => "use the declared repository user fallback",
+            Self::InvalidCursor => "restart collection from the last committed checkpoint",
+            Self::MalformedResponse
+            | Self::InvalidProviderRecord
+            | Self::MissingStableIdentity
+            | Self::TenantMismatch
+            | Self::CredentialMaterial
+            | Self::ConflictingDuplicate
+            | Self::ActorResolutionRequired { .. }
+            | Self::EventContractRejection => "inspect quarantined provider records",
+            Self::AppendFailure | Self::ProjectionFailure => "repair the durable commit path",
+            Self::LeaseLoss | Self::StaleAuthority => "restart collection under the current lease",
+            Self::RequestScopeMismatch
+            | Self::ResponseTooLarge
+            | Self::TooManyRecords
+            | Self::UnexpectedStatus { .. }
+            | Self::InvalidRetryAfter
+            | Self::InternalRuntimeFailure => "repair the forward runtime implementation",
+        }
+    }
+}
+
+impl Error for GitHubError {}

--- a/crates/source-runtime-next/src/github/normalize.rs
+++ b/crates/source-runtime-next/src/github/normalize.rs
@@ -1,0 +1,390 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    GitHubActorResolution, GitHubError, GitHubFamily, GitHubKernel, GitHubRecord,
+    normalize_audit::normalize_audit,
+    normalize_inventory::normalize_inventory,
+    normalize_security::{normalize_dependabot, normalize_secret_scanning},
+};
+
+pub(super) fn normalize_record(
+    kernel: &GitHubKernel,
+    stage: &str,
+    raw: Value,
+    observed_at: Option<&str>,
+    actors: &[GitHubActorResolution],
+) -> Result<GitHubRecord, GitHubError> {
+    if contains_key_recursive(&raw, "tenant_id") {
+        return Err(GitHubError::TenantMismatch);
+    }
+    let values = raw.as_object().ok_or(GitHubError::InvalidProviderRecord)?;
+    let (kind, schema_ref, provider_id, occurred_at, attributes, payload) = match kernel.family {
+        GitHubFamily::Audit => normalize_audit(kernel, values, &raw, actors)?,
+        GitHubFamily::Repository => normalize_repository(kernel, values)?,
+        GitHubFamily::PullRequest => normalize_pull_request(kernel, values)?,
+        GitHubFamily::DependabotAlert => normalize_dependabot(kernel, values)?,
+        GitHubFamily::SecretScanningAlert => normalize_secret_scanning(kernel, values)?,
+        GitHubFamily::OrganizationInventory => {
+            normalize_inventory(kernel, stage, values, observed_at)?
+        }
+    };
+    let definition = super::GitHubRuntimeDefinition::compile(kernel.family)?;
+    let contract = definition
+        .contract_for_kind(kind)
+        .ok_or(GitHubError::EventContractRejection)?;
+    if contract.schema_ref != schema_ref
+        || contract.required_attributes.iter().any(|key| {
+            attributes
+                .get(*key)
+                .is_none_or(|value| value.trim().is_empty())
+        })
+        || contract.required_payload_fields.iter().any(|key| {
+            payload
+                .get(*key)
+                .is_none_or(|value| value.is_null() || value.as_str().is_some_and(str::is_empty))
+        })
+    {
+        return Err(GitHubError::EventContractRejection);
+    }
+    let scope = Sha256::digest(format!(
+        "{}\0{}\0{}\0{}",
+        kernel.tenant_id, kind, provider_id, occurred_at
+    ));
+    let digest = scope[..10]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    Ok(GitHubRecord {
+        tenant_id: kernel.tenant_id.clone(),
+        event_id: format!(
+            "github-{}-{}-{digest}",
+            normalized_id(&kernel.tenant_id),
+            normalized_id(kernel.family.as_str())
+        ),
+        source_id: "github".to_owned(),
+        kind: kind.to_owned(),
+        schema_ref: schema_ref.to_owned(),
+        family: kernel.family.as_str().to_owned(),
+        provider_id,
+        occurred_at,
+        attributes,
+        payload,
+    })
+}
+
+pub(super) type Normalized = (
+    &'static str,
+    &'static str,
+    String,
+    String,
+    BTreeMap<String, String>,
+    Value,
+);
+
+fn normalize_repository(
+    kernel: &GitHubKernel,
+    values: &Map<String, Value>,
+) -> Result<Normalized, GitHubError> {
+    let name = required_string(values, "name")?;
+    let owner_login = string_at(values, "owner.login")
+        .or_else(|| {
+            string_at(values, "full_name")
+                .and_then(|value| value.split_once('/').map(|v| v.0.to_owned()))
+        })
+        .unwrap_or_else(|| kernel.owner.clone());
+    let full_name =
+        string_at(values, "full_name").unwrap_or_else(|| format!("{owner_login}/{name}"));
+    let provider_id = scalar_at(values, "id").unwrap_or_else(|| full_name.clone());
+    if provider_id.trim().is_empty() {
+        return Err(GitHubError::MissingStableIdentity);
+    }
+    let occurred_at = timestamp_first(values, &["updated_at", "pushed_at", "created_at"])?;
+    let created_at =
+        timestamp_optional(values, "created_at")?.unwrap_or_else(|| occurred_at.clone());
+    let mut payload = Map::new();
+    insert_number(&mut payload, "id", values.get("id"));
+    insert(&mut payload, "owner_login", owner_login.clone());
+    insert(&mut payload, "name", name.clone());
+    insert(&mut payload, "full_name", full_name.clone());
+    insert_optional(&mut payload, "url", string_at(values, "html_url"));
+    insert_optional(&mut payload, "visibility", string_at(values, "visibility"));
+    insert_bool(&mut payload, "private", bool_at(values, "private"));
+    insert_bool(&mut payload, "archived", bool_at(values, "archived"));
+    insert_bool(&mut payload, "fork", bool_at(values, "fork"));
+    insert_optional(
+        &mut payload,
+        "default_branch",
+        string_at(values, "default_branch"),
+    );
+    insert(&mut payload, "created_at", created_at);
+    insert(&mut payload, "updated_at", occurred_at.clone());
+    insert_optional(
+        &mut payload,
+        "pushed_at",
+        timestamp_optional(values, "pushed_at")?,
+    );
+    let security = [
+        (
+            "secret_scanning_enabled",
+            "security_and_analysis.secret_scanning.status",
+        ),
+        (
+            "secret_scanning_push_protection",
+            "security_and_analysis.secret_scanning_push_protection.status",
+        ),
+        (
+            "dependabot_security_updates_enabled",
+            "security_and_analysis.dependabot_security_updates.status",
+        ),
+    ];
+    for (target, source) in security {
+        insert_optional(&mut payload, target, string_at(values, source));
+    }
+    let mut attributes = BTreeMap::from([
+        (
+            "archived".to_owned(),
+            bool_at(values, "archived").to_string(),
+        ),
+        ("fork".to_owned(), bool_at(values, "fork").to_string()),
+        ("full_name".to_owned(), full_name.clone()),
+        ("name".to_owned(), name.clone()),
+        ("owner".to_owned(), kernel.owner.clone()),
+        ("owner_login".to_owned(), owner_login),
+        ("private".to_owned(), bool_at(values, "private").to_string()),
+        ("repo".to_owned(), name),
+        ("repository".to_owned(), full_name.clone()),
+        ("resource_id".to_owned(), provider_id.clone()),
+        ("resource_name".to_owned(), full_name),
+        ("resource_type".to_owned(), "code_repository".to_owned()),
+    ]);
+    copy(&mut attributes, values, "default_branch", "default_branch");
+    copy(&mut attributes, values, "html_url", "html_url");
+    copy(&mut attributes, values, "id", "repo_id");
+    copy(&mut attributes, values, "visibility", "visibility");
+    for (attribute, source) in [
+        ("secret_scanning", security[0].1),
+        ("secret_scanning_push_protection", security[1].1),
+        ("dependabot_security_updates", security[2].1),
+    ] {
+        copy(&mut attributes, values, source, attribute);
+    }
+    Ok((
+        "github.code.repository",
+        "github/code_repository/v1",
+        provider_id,
+        occurred_at,
+        attributes,
+        Value::Object(payload),
+    ))
+}
+
+fn normalize_pull_request(
+    kernel: &GitHubKernel,
+    values: &Map<String, Value>,
+) -> Result<Normalized, GitHubError> {
+    let number = positive_i64(values, "number")?;
+    let provider_id = number.to_string();
+    let occurred_at = timestamp_first(values, &["updated_at", "created_at"])?;
+    let repository = format!(
+        "{}/{}",
+        kernel.owner,
+        kernel.repository.as_deref().unwrap_or_default()
+    );
+    let created_at =
+        timestamp_optional(values, "created_at")?.unwrap_or_else(|| occurred_at.clone());
+    let author = string_at(values, "user.login").unwrap_or_default();
+    let head = string_at(values, "head.label").unwrap_or_default();
+    let base = string_at(values, "base.label").unwrap_or_default();
+    let state = required_string(values, "state")?;
+    let url = string_at(values, "html_url").unwrap_or_default();
+    let mut payload = Map::from_iter([
+        ("number".to_owned(), Value::from(number)),
+        ("repository".to_owned(), Value::from(repository.clone())),
+        (
+            "title".to_owned(),
+            Value::from(string_at(values, "title").unwrap_or_default()),
+        ),
+        ("state".to_owned(), Value::from(state.clone())),
+        ("url".to_owned(), Value::from(url.clone())),
+        ("author".to_owned(), Value::from(author.clone())),
+        ("draft".to_owned(), Value::from(bool_at(values, "draft"))),
+        ("head".to_owned(), Value::from(head.clone())),
+        ("base".to_owned(), Value::from(base.clone())),
+        ("created_at".to_owned(), Value::from(created_at)),
+        ("updated_at".to_owned(), Value::from(occurred_at.clone())),
+    ]);
+    insert_optional(
+        &mut payload,
+        "closed_at",
+        timestamp_optional(values, "closed_at")?,
+    );
+    insert_optional(
+        &mut payload,
+        "merged_at",
+        timestamp_optional(values, "merged_at")?,
+    );
+    let attributes = BTreeMap::from([
+        ("author".to_owned(), author),
+        ("base".to_owned(), base),
+        ("head".to_owned(), head),
+        ("html_url".to_owned(), url),
+        ("owner".to_owned(), kernel.owner.clone()),
+        ("pull_number".to_owned(), provider_id.clone()),
+        (
+            "repo".to_owned(),
+            kernel.repository.clone().unwrap_or_default(),
+        ),
+        ("repository".to_owned(), repository),
+        ("state".to_owned(), state),
+    ]);
+    Ok((
+        "github.pull_request",
+        "github/pull_request/v1",
+        provider_id,
+        occurred_at,
+        attributes,
+        Value::Object(payload),
+    ))
+}
+
+pub(super) fn required_string(
+    values: &Map<String, Value>,
+    path: &str,
+) -> Result<String, GitHubError> {
+    string_at(values, path).ok_or(GitHubError::InvalidProviderRecord)
+}
+
+pub(super) fn positive_i64(values: &Map<String, Value>, path: &str) -> Result<i64, GitHubError> {
+    value_at(values, path)
+        .and_then(Value::as_i64)
+        .filter(|value| *value > 0)
+        .ok_or(GitHubError::MissingStableIdentity)
+}
+
+pub(super) fn value_at<'a>(values: &'a Map<String, Value>, path: &str) -> Option<&'a Value> {
+    let mut value = values.get(path.split('.').next()?)?;
+    for part in path.split('.').skip(1) {
+        value = value.as_object()?.get(part)?;
+    }
+    Some(value)
+}
+
+pub(super) fn string_at(values: &Map<String, Value>, path: &str) -> Option<String> {
+    value_at(values, path)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+pub(super) fn scalar_at(values: &Map<String, Value>, path: &str) -> Option<String> {
+    match value_at(values, path)? {
+        Value::String(value) if !value.trim().is_empty() => Some(value.trim().to_owned()),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+pub(super) fn bool_at(values: &Map<String, Value>, path: &str) -> bool {
+    value_at(values, path)
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+pub(super) fn timestamp_first(
+    values: &Map<String, Value>,
+    paths: &[&str],
+) -> Result<String, GitHubError> {
+    for path in paths {
+        if let Some(value) = timestamp_optional(values, path)? {
+            return Ok(value);
+        }
+    }
+    Err(GitHubError::InvalidProviderRecord)
+}
+
+pub(super) fn timestamp_optional(
+    values: &Map<String, Value>,
+    path: &str,
+) -> Result<Option<String>, GitHubError> {
+    let Some(value) = value_at(values, path) else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let stamp = match value {
+        Value::String(value) => OffsetDateTime::parse(value, &Rfc3339)
+            .map_err(|_| GitHubError::InvalidProviderRecord)?,
+        Value::Number(value) => {
+            let millis = value.as_i64().ok_or(GitHubError::InvalidProviderRecord)?;
+            OffsetDateTime::from_unix_timestamp_nanos(i128::from(millis) * 1_000_000)
+                .map_err(|_| GitHubError::InvalidProviderRecord)?
+        }
+        _ => return Err(GitHubError::InvalidProviderRecord),
+    };
+    stamp
+        .format(&Rfc3339)
+        .map(Some)
+        .map_err(|_| GitHubError::InvalidProviderRecord)
+}
+
+pub(super) fn insert(map: &mut Map<String, Value>, key: &str, value: String) {
+    map.insert(key.to_owned(), Value::String(value));
+}
+
+pub(super) fn insert_optional(map: &mut Map<String, Value>, key: &str, value: Option<String>) {
+    if let Some(value) = value.filter(|value| !value.is_empty()) {
+        insert(map, key, value);
+    }
+}
+
+pub(super) fn insert_bool(map: &mut Map<String, Value>, key: &str, value: bool) {
+    map.insert(key.to_owned(), Value::Bool(value));
+}
+
+fn insert_number(map: &mut Map<String, Value>, key: &str, value: Option<&Value>) {
+    if let Some(Value::Number(value)) = value.filter(|value| value.as_i64().is_some_and(|v| v != 0))
+    {
+        map.insert(key.to_owned(), Value::Number(value.clone()));
+    }
+}
+
+pub(super) fn copy(
+    attributes: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    source: &str,
+    target: &str,
+) {
+    if let Some(value) = scalar_at(values, source) {
+        attributes.insert(target.to_owned(), value);
+    }
+}
+
+pub(super) fn normalized_id(value: &str) -> String {
+    value
+        .trim()
+        .chars()
+        .map(|character| match character {
+            '/' | ':' | ' ' | '\t' | '\n' => '-',
+            other => other,
+        })
+        .collect()
+}
+
+fn contains_key_recursive(value: &Value, forbidden: &str) -> bool {
+    match value {
+        Value::Object(values) => values.iter().any(|(key, value)| {
+            key.eq_ignore_ascii_case(forbidden) || contains_key_recursive(value, forbidden)
+        }),
+        Value::Array(values) => values
+            .iter()
+            .any(|value| contains_key_recursive(value, forbidden)),
+        _ => false,
+    }
+}

--- a/crates/source-runtime-next/src/github/normalize_audit.rs
+++ b/crates/source-runtime-next/src/github/normalize_audit.rs
@@ -1,0 +1,309 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+
+use super::{
+    GitHubActorResolution, GitHubError, GitHubKernel,
+    normalize::{
+        Normalized, bool_at, normalized_id, required_string, scalar_at, string_at, timestamp_first,
+        value_at,
+    },
+};
+
+const EXTRA_ATTRIBUTES: &[&str] = &[
+    "advanced_security_enabled",
+    "allowed_cidrs_compliant",
+    "allowlisted_destination",
+    "auth_control_weakened",
+    "branch",
+    "bypass_actor_added",
+    "change_type",
+    "changes",
+    "code_security_enabled",
+    "deletions_allowed",
+    "dependabot_alerts_enabled",
+    "dependabot_enabled",
+    "dependabot_security_updates_enabled",
+    "destination_allowlisted",
+    "destination_non_allowlisted",
+    "enforcement",
+    "ephemeral",
+    "force_pushes_allowed",
+    "github_advanced_security_enabled",
+    "hook_destination_allowlisted",
+    "hook_destination_non_allowlisted",
+    "hook_id",
+    "hook_url_allowlisted",
+    "hook_url_non_allowlisted",
+    "host_trusted",
+    "host_untrusted",
+    "integration",
+    "ip_allow_list_disabled",
+    "ip_allow_list_enabled",
+    "ip_allow_list_entries_compliant",
+    "is_ephemeral",
+    "is_registered",
+    "mfa_required",
+    "name",
+    "new_enforcement",
+    "non_allowlisted_cidr_count",
+    "non_allowlisted_cidrs",
+    "non_allowlisted_destination",
+    "number",
+    "oauth_app_restrictions_enabled",
+    "oauth_app_restrictions_enforced",
+    "permission",
+    "previous_visibility",
+    "private_forking_enabled",
+    "private_repository_forking_enabled",
+    "registered",
+    "repository_public",
+    "repository_secret_scanning_enabled",
+    "repository_vulnerability_alerts_enabled",
+    "required_review_removed",
+    "required_status_check_removed",
+    "ruleset_enforcement",
+    "ruleset_id",
+    "ruleset_name",
+    "runner_ephemeral",
+    "runner_group_name",
+    "runner_host_trusted",
+    "runner_id",
+    "runner_name",
+    "runner_registered",
+    "runner_scope",
+    "runner_state",
+    "runner_untrusted",
+    "saml_enabled",
+    "saml_enforced",
+    "saml_provider_settings_weakened",
+    "saml_required",
+    "saml_sso_enabled",
+    "secret_scanning_enabled",
+    "secret_scanning_push_protection_enabled",
+    "transport_protocol_name",
+    "trusted_host",
+    "two_factor_enforced",
+    "two_factor_required",
+    "two_factor_requirement_enabled",
+    "untrusted_host",
+    "url_allowlisted",
+    "url_non_allowlisted",
+    "user_agent",
+    "vulnerability_alerts_enabled",
+    "webhook_destination_allowlisted",
+    "webhook_destination_non_allowlisted",
+    "webhook_url_allowlisted",
+    "webhook_url_non_allowlisted",
+];
+
+pub(super) fn normalize_audit(
+    kernel: &GitHubKernel,
+    values: &Map<String, Value>,
+    raw: &Value,
+    actors: &[GitHubActorResolution],
+) -> Result<Normalized, GitHubError> {
+    let action = required_string(values, "action")?;
+    let occurred_at = timestamp_first(values, &["@timestamp", "created_at"])?;
+    let actor = string_at(values, "actor").unwrap_or_default();
+    let resolution = if actor.is_empty() {
+        None
+    } else {
+        Some(
+            actors
+                .iter()
+                .find(|item| item.actor == actor)
+                .ok_or_else(|| GitHubError::ActorResolutionRequired {
+                    actor: actor.clone(),
+                })?,
+        )
+    };
+    let org = string_at(values, "org").unwrap_or_else(|| kernel.owner.clone());
+    let resource_id = resource_id(values, &org);
+    let resource_type = resource_type(&action);
+    let scope = scope(values, &org);
+    let provider_id = string_at(values, "_document_id")
+        .unwrap_or_else(|| format!("{}:{}", normalized_id(&action), occurred_at));
+    let mut payload = Map::from_iter([
+        ("action".to_owned(), Value::from(action.clone())),
+        ("org".to_owned(), Value::from(org.clone())),
+    ]);
+    for (target, source) in [
+        ("actor", "actor"),
+        ("actor_ip", "actor_ip"),
+        ("business", "business"),
+        ("external_identity_nameid", "external_identity_nameid"),
+        ("external_identity_username", "external_identity_username"),
+        ("operation_type", "operation_type"),
+        ("programmatic_access_type", "programmatic_access_type"),
+        ("repo", "repo"),
+        ("user", "user"),
+        ("visibility", "visibility"),
+    ] {
+        insert_optional(&mut payload, target, string_at(values, source));
+    }
+    if let Some(resolution) = resolution {
+        insert_optional(
+            &mut payload,
+            "actor_type",
+            Some(resolution.actor_type.clone()),
+        );
+        insert_optional(&mut payload, "actor_email", resolution.actor_email.clone());
+    }
+    for (target, source) in [
+        ("actor_id", "actor_id"),
+        ("business_id", "business_id"),
+        ("user_id", "user_id"),
+    ] {
+        let value = value_at(values, source)
+            .and_then(Value::as_i64)
+            .filter(|value| *value > 0)
+            .or_else(|| {
+                (target == "actor_id")
+                    .then(|| resolution.and_then(|value| value.actor_id))
+                    .flatten()
+            });
+        if let Some(value) = value {
+            payload.insert(target.to_owned(), Value::from(value));
+        }
+    }
+    for field in ["actor_is_agent", "actor_is_bot", "public_repo"] {
+        if value_at(values, field).is_some() {
+            payload.insert(field.to_owned(), Value::from(bool_at(values, field)));
+        }
+    }
+    insert_optional(&mut payload, "resource_id", Some(resource_id.clone()));
+    insert_optional(&mut payload, "resource_type", Some(resource_type.clone()));
+    insert_optional(&mut payload, "scope", Some(scope.clone()));
+    payload.insert("raw".to_owned(), normalized_raw(values, raw)?);
+    let mut attributes = BTreeMap::from([
+        ("action".to_owned(), action.clone()),
+        ("family".to_owned(), "audit".to_owned()),
+        (
+            "operation_type".to_owned(),
+            string_at(values, "operation_type").unwrap_or_default(),
+        ),
+        ("org".to_owned(), org),
+        ("resource_id".to_owned(), resource_id),
+        ("resource_type".to_owned(), resource_type),
+        ("scope".to_owned(), scope),
+    ]);
+    for field in [
+        "actor",
+        "actor_id",
+        "external_identity_nameid",
+        "external_identity_username",
+        "org_id",
+        "programmatic_access_type",
+        "repo",
+        "token_id",
+        "user",
+        "user_id",
+        "visibility",
+    ] {
+        if let Some(value) = scalar_at(values, field) {
+            attributes.insert(field.to_owned(), value);
+        }
+    }
+    if let Some(resolution) = resolution {
+        attributes.insert("actor_type".to_owned(), resolution.actor_type.clone());
+        if let Some(email) = &resolution.actor_email {
+            attributes.insert("actor_email".to_owned(), email.clone());
+        }
+        if !attributes.contains_key("actor_id")
+            && let Some(id) = resolution.actor_id.filter(|id| *id > 0)
+        {
+            attributes.insert("actor_id".to_owned(), id.to_string());
+        }
+    }
+    for field in ["actor_is_agent", "actor_is_bot"] {
+        if value_at(values, field).is_some() {
+            attributes.insert(field.to_owned(), bool_at(values, field).to_string());
+        }
+    }
+    if action.starts_with("integration_installation.")
+        && let Some(value) = scalar_at(values, "installation.app_id")
+            .or_else(|| scalar_at(values, "installation.id"))
+    {
+        attributes.insert("github_app_id".to_owned(), value);
+    }
+    if action.starts_with("secret_scanning_alert.") {
+        for field in ["resolution", "state", "resolution_comment"] {
+            let value = scalar_at(values, &format!("secret_scanning_alert.{field}"))
+                .or_else(|| scalar_at(values, &format!("secret_scanning_alert.{field}")));
+            if let Some(value) = value {
+                attributes.insert(format!("secret_scanning_alert.{field}"), value);
+            }
+        }
+    }
+    for field in EXTRA_ATTRIBUTES {
+        if let Some(value) = scalar_at(values, field) {
+            attributes.insert((*field).to_owned(), value);
+        }
+    }
+    Ok((
+        "github.audit",
+        "github/audit/v1",
+        provider_id,
+        occurred_at,
+        attributes,
+        Value::Object(payload),
+    ))
+}
+
+fn resource_id(values: &Map<String, Value>, org: &str) -> String {
+    for path in [
+        "repo",
+        "repository",
+        "user",
+        "actor",
+        "hook_id",
+        "token_id",
+        "ruleset_id",
+    ] {
+        if let Some(value) = scalar_at(values, path) {
+            return value;
+        }
+    }
+    org.to_owned()
+}
+
+fn resource_type(action: &str) -> String {
+    action
+        .split_once('.')
+        .map(|value| value.0)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("organization")
+        .to_owned()
+}
+
+fn scope(values: &Map<String, Value>, org: &str) -> String {
+    if string_at(values, "repo").is_some() {
+        "repository".to_owned()
+    } else if string_at(values, "org").is_some() || !org.is_empty() {
+        "organization".to_owned()
+    } else {
+        "enterprise".to_owned()
+    }
+}
+
+fn insert_optional(map: &mut Map<String, Value>, key: &str, value: Option<String>) {
+    if let Some(value) = value.filter(|value| !value.is_empty()) {
+        map.insert(key.to_owned(), Value::from(value));
+    }
+}
+
+fn normalized_raw(values: &Map<String, Value>, raw: &Value) -> Result<Value, GitHubError> {
+    let mut normalized = raw
+        .as_object()
+        .cloned()
+        .ok_or(GitHubError::InvalidProviderRecord)?;
+    for key in ["@timestamp", "created_at"] {
+        if value_at(values, key).is_some_and(Value::is_number)
+            && let Some(value) = super::normalize::timestamp_optional(values, key)?
+        {
+            normalized.insert(key.to_owned(), Value::from(value));
+        }
+    }
+    Ok(Value::Object(normalized))
+}

--- a/crates/source-runtime-next/src/github/normalize_inventory.rs
+++ b/crates/source-runtime-next/src/github/normalize_inventory.rs
@@ -1,0 +1,189 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+
+use super::{
+    GitHubError, GitHubKernel,
+    normalize::{
+        Normalized, insert_optional, positive_i64, required_string, scalar_at, string_at,
+        timestamp_optional, value_at,
+    },
+};
+
+pub(super) fn normalize_inventory(
+    kernel: &GitHubKernel,
+    stage: &str,
+    values: &Map<String, Value>,
+    observed_at: Option<&str>,
+) -> Result<Normalized, GitHubError> {
+    let occurred_at = parse_observation(observed_at)?;
+    match stage {
+        "members" => member(kernel, values, "member", occurred_at),
+        "outside_collaborators" => member(kernel, values, "outside_collaborator", occurred_at),
+        "installations" => installation(kernel, values, occurred_at),
+        _ => Err(GitHubError::RequestScopeMismatch),
+    }
+}
+
+fn member(
+    kernel: &GitHubKernel,
+    values: &Map<String, Value>,
+    role: &str,
+    occurred_at: String,
+) -> Result<Normalized, GitHubError> {
+    let login = required_string(values, "login")?;
+    let id = positive_i64(values, "id")?;
+    let payload = Value::Object(Map::from_iter([
+        ("login".to_owned(), Value::from(login.clone())),
+        ("id".to_owned(), Value::from(id)),
+        ("role".to_owned(), Value::from(role)),
+        ("org".to_owned(), Value::from(kernel.owner.clone())),
+        (
+            "avatar_url".to_owned(),
+            Value::from(string_at(values, "avatar_url").unwrap_or_default()),
+        ),
+        (
+            "html_url".to_owned(),
+            Value::from(string_at(values, "html_url").unwrap_or_default()),
+        ),
+    ]));
+    let attributes = BTreeMap::from([
+        ("family".to_owned(), "org_inventory".to_owned()),
+        ("login".to_owned(), login.clone()),
+        ("owner".to_owned(), kernel.owner.clone()),
+        ("role".to_owned(), role.to_owned()),
+        ("user_id".to_owned(), id.to_string()),
+    ]);
+    Ok((
+        "github.org_member",
+        "github/org_member/v1",
+        format!("{role}:{login}"),
+        occurred_at,
+        attributes,
+        payload,
+    ))
+}
+
+fn installation(
+    kernel: &GitHubKernel,
+    values: &Map<String, Value>,
+    occurred_at: String,
+) -> Result<Normalized, GitHubError> {
+    let id = positive_i64(values, "id")?;
+    let app_slug = required_string(values, "app_slug")?;
+    let permissions = permission_pairs(values)?;
+    let events = string_array(values, "events")?;
+    let created_at = timestamp_optional(values, "created_at")?;
+    let updated_at = timestamp_optional(values, "updated_at")?;
+    let mut payload = Map::from_iter([
+        ("id".to_owned(), Value::from(id)),
+        ("app_slug".to_owned(), Value::from(app_slug.clone())),
+        ("org".to_owned(), Value::from(kernel.owner.clone())),
+    ]);
+    insert_optional(
+        &mut payload,
+        "target_type",
+        string_at(values, "target_type"),
+    );
+    insert_optional(
+        &mut payload,
+        "repository_selection",
+        string_at(values, "repository_selection"),
+    );
+    if !permissions.is_empty() {
+        payload.insert(
+            "permissions".to_owned(),
+            Value::Array(permissions.iter().cloned().map(Value::from).collect()),
+        );
+    }
+    if !events.is_empty() {
+        payload.insert(
+            "events".to_owned(),
+            Value::Array(events.iter().cloned().map(Value::from).collect()),
+        );
+    }
+    insert_optional(&mut payload, "created_at", created_at.clone());
+    insert_optional(&mut payload, "updated_at", updated_at.clone());
+    let mut attributes = BTreeMap::from([
+        ("app_slug".to_owned(), app_slug),
+        ("events".to_owned(), events.join(",")),
+        ("family".to_owned(), "org_inventory".to_owned()),
+        ("installation_id".to_owned(), id.to_string()),
+        ("owner".to_owned(), kernel.owner.clone()),
+        ("permissions".to_owned(), permissions.join(",")),
+    ]);
+    for (source, target) in [
+        ("repository_selection", "repository_selection"),
+        ("target_type", "target_type"),
+    ] {
+        if let Some(value) = scalar_at(values, source) {
+            attributes.insert(target.to_owned(), value);
+        }
+    }
+    if let Some(value) = created_at {
+        attributes.insert("created_at".to_owned(), value);
+    }
+    if let Some(value) = updated_at {
+        attributes.insert("updated_at".to_owned(), value);
+    }
+    Ok((
+        "github.org_installation",
+        "github/org_installation/v1",
+        id.to_string(),
+        occurred_at,
+        attributes,
+        Value::Object(payload),
+    ))
+}
+
+fn permission_pairs(values: &Map<String, Value>) -> Result<Vec<String>, GitHubError> {
+    let Some(permissions) = value_at(values, "permissions") else {
+        return Ok(Vec::new());
+    };
+    let permissions = permissions
+        .as_object()
+        .ok_or(GitHubError::InvalidProviderRecord)?;
+    if permissions.len() > 100 {
+        return Err(GitHubError::InvalidProviderRecord);
+    }
+    let mut result = permissions
+        .iter()
+        .map(|(name, value)| {
+            value
+                .as_str()
+                .map(|level| format!("{name}:{level}"))
+                .ok_or(GitHubError::InvalidProviderRecord)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    result.sort();
+    Ok(result)
+}
+
+fn string_array(values: &Map<String, Value>, path: &str) -> Result<Vec<String>, GitHubError> {
+    let Some(values) = value_at(values, path) else {
+        return Ok(Vec::new());
+    };
+    let values = values
+        .as_array()
+        .ok_or(GitHubError::InvalidProviderRecord)?;
+    if values.len() > 250 {
+        return Err(GitHubError::InvalidProviderRecord);
+    }
+    values
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+                .ok_or(GitHubError::InvalidProviderRecord)
+        })
+        .collect()
+}
+
+fn parse_observation(value: Option<&str>) -> Result<String, GitHubError> {
+    let value = value.ok_or(GitHubError::MissingConfiguration("observed_at"))?;
+    let map = Map::from_iter([("value".to_owned(), Value::from(value))]);
+    super::normalize::timestamp_optional(&map, "value")?.ok_or(GitHubError::InvalidProviderRecord)
+}

--- a/crates/source-runtime-next/src/github/normalize_security.rs
+++ b/crates/source-runtime-next/src/github/normalize_security.rs
@@ -1,0 +1,227 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+
+use super::{
+    GitHubError, GitHubKernel,
+    normalize::{
+        Normalized, bool_at, insert_optional, positive_i64, required_string, scalar_at, string_at,
+        timestamp_first, timestamp_optional, value_at,
+    },
+};
+
+pub(super) fn normalize_dependabot(
+    kernel: &GitHubKernel,
+    values: &Map<String, Value>,
+) -> Result<Normalized, GitHubError> {
+    let number = positive_i64(values, "number")?;
+    let occurred_at = timestamp_first(values, &["updated_at", "created_at"])?;
+    let created_at =
+        timestamp_optional(values, "created_at")?.unwrap_or_else(|| occurred_at.clone());
+    let repository = format!(
+        "{}/{}",
+        kernel.owner,
+        kernel.repository.as_deref().unwrap_or_default()
+    );
+    let state = required_string(values, "state")?;
+    let fields = [
+        ("url", "url"),
+        ("html_url", "html_url"),
+        ("ghsa_id", "security_advisory.ghsa_id"),
+        ("cve_id", "security_advisory.cve_id"),
+        ("advisory_summary", "security_advisory.summary"),
+        ("advisory_severity", "security_advisory.severity"),
+        ("vulnerability_severity", "security_vulnerability.severity"),
+        ("manifest_path", "dependency.manifest_path"),
+        ("dependency_scope", "dependency.scope"),
+        (
+            "vulnerable_version_range",
+            "security_vulnerability.vulnerable_version_range",
+        ),
+        (
+            "first_patched_version",
+            "security_vulnerability.first_patched_version.identifier",
+        ),
+        ("dismissed_by", "dismissed_by.login"),
+    ];
+    let ecosystem = string_at(values, "dependency.package.ecosystem")
+        .or_else(|| string_at(values, "security_vulnerability.package.ecosystem"));
+    let package = string_at(values, "dependency.package.name")
+        .or_else(|| string_at(values, "security_vulnerability.package.name"));
+    let mut payload = Map::from_iter([
+        ("number".to_owned(), Value::from(number)),
+        ("repository".to_owned(), Value::from(repository.clone())),
+        ("state".to_owned(), Value::from(state.clone())),
+        ("created_at".to_owned(), Value::from(created_at)),
+        ("updated_at".to_owned(), Value::from(occurred_at.clone())),
+    ]);
+    for (target, source) in fields {
+        insert_optional(&mut payload, target, string_at(values, source));
+    }
+    insert_optional(&mut payload, "ecosystem", ecosystem.clone());
+    insert_optional(&mut payload, "package_name", package.clone());
+    if let Some(id) = value_at(values, "dismissed_by.id")
+        .and_then(Value::as_i64)
+        .filter(|v| *v > 0)
+    {
+        payload.insert("dismissed_by_id".to_owned(), Value::from(id));
+    }
+    for field in ["dismissed_at", "fixed_at"] {
+        insert_optional(&mut payload, field, timestamp_optional(values, field)?);
+    }
+    let severity = string_at(values, "security_advisory.severity")
+        .or_else(|| string_at(values, "security_vulnerability.severity"))
+        .unwrap_or_default();
+    let mut attributes = BTreeMap::from([
+        ("alert_number".to_owned(), number.to_string()),
+        ("family".to_owned(), "dependabot_alert".to_owned()),
+        ("owner".to_owned(), kernel.owner.clone()),
+        (
+            "repo".to_owned(),
+            kernel.repository.clone().unwrap_or_default(),
+        ),
+        ("repository".to_owned(), repository),
+        ("severity".to_owned(), severity),
+        ("state".to_owned(), state),
+        (
+            "vulnerable_version_range".to_owned(),
+            string_at(values, "security_vulnerability.vulnerable_version_range")
+                .unwrap_or_default(),
+        ),
+    ]);
+    for (target, source) in [
+        ("advisory_cve_id", "security_advisory.cve_id"),
+        ("advisory_ghsa_id", "security_advisory.ghsa_id"),
+        ("advisory_severity", "security_advisory.severity"),
+        ("dependency_scope", "dependency.scope"),
+        ("dismissed_by", "dismissed_by.login"),
+        ("dismissed_by_id", "dismissed_by.id"),
+        (
+            "first_patched_version",
+            "security_vulnerability.first_patched_version.identifier",
+        ),
+        ("html_url", "html_url"),
+        ("manifest_path", "dependency.manifest_path"),
+        ("vulnerability_severity", "security_vulnerability.severity"),
+    ] {
+        if let Some(value) = scalar_at(values, source) {
+            attributes.insert(target.to_owned(), value);
+        }
+    }
+    if let Some(value) = ecosystem {
+        attributes.insert("ecosystem".to_owned(), value);
+    }
+    if let Some(value) = package {
+        attributes.insert("package".to_owned(), value);
+    }
+    Ok((
+        "github.dependabot_alert",
+        "github/dependabot_alert/v1",
+        number.to_string(),
+        occurred_at,
+        attributes,
+        Value::Object(payload),
+    ))
+}
+
+pub(super) fn normalize_secret_scanning(
+    kernel: &GitHubKernel,
+    values: &Map<String, Value>,
+) -> Result<Normalized, GitHubError> {
+    let number = positive_i64(values, "number")?;
+    let occurred_at = timestamp_first(values, &["updated_at", "created_at"])?;
+    let created_at =
+        timestamp_optional(values, "created_at")?.unwrap_or_else(|| occurred_at.clone());
+    let state = required_string(values, "state")?;
+    let repository = string_at(values, "repository.full_name").unwrap_or_default();
+    let mut payload = Map::from_iter([
+        ("number".to_owned(), Value::from(number)),
+        ("repository".to_owned(), Value::from(repository.clone())),
+        ("state".to_owned(), Value::from(state.clone())),
+        (
+            "push_protection_bypassed".to_owned(),
+            Value::from(bool_at(values, "push_protection_bypassed")),
+        ),
+        ("created_at".to_owned(), Value::from(created_at)),
+        ("updated_at".to_owned(), Value::from(occurred_at.clone())),
+    ]);
+    let strings = [
+        ("secret_type", "secret_type"),
+        ("secret_type_display_name", "secret_type_display_name"),
+        ("resolution", "resolution"),
+        ("resolution_comment", "resolution_comment"),
+        ("resolved_by", "resolved_by.login"),
+        (
+            "push_protection_bypassed_by",
+            "push_protection_bypassed_by.login",
+        ),
+        ("url", "url"),
+        ("html_url", "html_url"),
+    ];
+    for (target, source) in strings {
+        insert_optional(&mut payload, target, string_at(values, source));
+    }
+    for (target, source) in [
+        ("resolved_by_id", "resolved_by.id"),
+        (
+            "push_protection_bypassed_by_id",
+            "push_protection_bypassed_by.id",
+        ),
+    ] {
+        if let Some(id) = value_at(values, source)
+            .and_then(Value::as_i64)
+            .filter(|v| *v > 0)
+        {
+            payload.insert(target.to_owned(), Value::from(id));
+        }
+    }
+    for field in ["resolved_at", "push_protection_bypassed_at"] {
+        insert_optional(&mut payload, field, timestamp_optional(values, field)?);
+    }
+    let mut attributes = BTreeMap::from([
+        ("alert_number".to_owned(), number.to_string()),
+        ("family".to_owned(), "secret_scanning_alert".to_owned()),
+        ("owner".to_owned(), kernel.owner.clone()),
+        ("state".to_owned(), state),
+        (
+            "push_protection_bypassed".to_owned(),
+            bool_at(values, "push_protection_bypassed").to_string(),
+        ),
+    ]);
+    if !repository.is_empty() {
+        attributes.insert("repository".to_owned(), repository.clone());
+    }
+    for (target, source) in [
+        ("html_url", "html_url"),
+        ("resolution", "resolution"),
+        ("resolved_by", "resolved_by.login"),
+        ("resolved_by_id", "resolved_by.id"),
+        ("secret_type", "secret_type"),
+        ("secret_type_display_name", "secret_type_display_name"),
+        (
+            "push_protection_bypassed_by",
+            "push_protection_bypassed_by.login",
+        ),
+        (
+            "push_protection_bypassed_by_id",
+            "push_protection_bypassed_by.id",
+        ),
+    ] {
+        if let Some(value) = scalar_at(values, source) {
+            attributes.insert(target.to_owned(), value);
+        }
+    }
+    let identity_scope = if repository.is_empty() {
+        kernel.owner.clone()
+    } else {
+        repository
+    };
+    Ok((
+        "github.secret_scanning_alert",
+        "github/secret_scanning_alert/v1",
+        format!("{identity_scope}:{number}"),
+        occurred_at,
+        attributes,
+        Value::Object(payload),
+    ))
+}

--- a/crates/source-runtime-next/src/github/origin.rs
+++ b/crates/source-runtime-next/src/github/origin.rs
@@ -1,0 +1,88 @@
+use std::net::IpAddr;
+
+use reqwest::Url;
+
+use super::GitHubError;
+
+const MAX_NAME_BYTES: usize = 100;
+const MAX_TENANT_BYTES: usize = 128;
+
+pub(super) fn validate_base_url(value: &str) -> Result<Url, GitHubError> {
+    let mut url = Url::parse(value.trim()).map_err(|_| GitHubError::InvalidBaseUrl)?;
+    if url.scheme() != "https"
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port_or_known_default() != Some(443)
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(GitHubError::InvalidBaseUrl);
+    }
+    let host = url
+        .host_str()
+        .unwrap_or_default()
+        .trim_end_matches('.')
+        .to_ascii_lowercase();
+    if host == "localhost"
+        || host.ends_with(".localhost")
+        || host.ends_with(".local")
+        || !host.contains('.')
+        || host.parse::<IpAddr>().is_ok_and(unsafe_address)
+    {
+        return Err(GitHubError::UnsafeOrigin);
+    }
+    let path = url.path().trim_end_matches('/').to_owned();
+    url.set_path(if path.is_empty() { "/" } else { &path });
+    Ok(url)
+}
+
+pub(super) fn validate_tenant_id(value: &str) -> Result<String, GitHubError> {
+    bounded(value, MAX_TENANT_BYTES, GitHubError::InvalidTenantId)
+}
+
+pub(super) fn name(value: &str, field: &'static str) -> Result<String, GitHubError> {
+    let value = bounded(
+        value,
+        MAX_NAME_BYTES,
+        GitHubError::InvalidConfiguration(field),
+    )?;
+    if value.contains(['/', '?', '#', '\\']) || value == "." || value == ".." {
+        return Err(GitHubError::InvalidConfiguration(field));
+    }
+    Ok(value)
+}
+
+fn bounded(value: &str, maximum: usize, error: GitHubError) -> Result<String, GitHubError> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > maximum || value.chars().any(char::is_control) {
+        return Err(error);
+    }
+    Ok(value.to_owned())
+}
+
+fn unsafe_address(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(value) => {
+            let bytes = value.octets();
+            value.is_private()
+                || value.is_loopback()
+                || value.is_link_local()
+                || value.is_multicast()
+                || value.is_unspecified()
+                || (bytes[0] == 100 && (64..=127).contains(&bytes[1]))
+                || (bytes[0] == 192 && bytes[1] == 0 && bytes[2] == 2)
+                || (bytes[0] == 198 && bytes[1] == 51 && bytes[2] == 100)
+                || (bytes[0] == 203 && bytes[1] == 0 && bytes[2] == 113)
+        }
+        IpAddr::V6(value) => {
+            let segments = value.segments();
+            value.is_loopback()
+                || value.is_multicast()
+                || value.is_unspecified()
+                || value.is_unique_local()
+                || value.is_unicast_link_local()
+                || (segments[0] == 0x2001 && segments[1] == 0x0db8)
+        }
+    }
+}

--- a/crates/source-runtime-next/src/github/request.rs
+++ b/crates/source-runtime-next/src/github/request.rs
@@ -1,0 +1,362 @@
+use reqwest::Url;
+
+use super::{
+    GitHubError, GitHubFamily, GitHubFilters, GitHubKernel, GitHubRequest, GitHubRequestKind,
+    cursor::{CursorState, CursorToken, Stage},
+    origin::{name, validate_base_url, validate_tenant_id},
+};
+
+pub(super) const MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+const MAX_PHRASE_BYTES: usize = 512;
+
+impl GitHubRequest {
+    /// HTTP method for every supported read operation.
+    pub const fn method(&self) -> &'static str {
+        "GET"
+    }
+
+    /// Exact provider URL. The trusted host must authorize this origin before I/O.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Planned operation kind.
+    pub const fn kind(&self) -> GitHubRequestKind {
+        self.kind
+    }
+
+    /// Source family owning this request.
+    pub const fn family(&self) -> GitHubFamily {
+        self.family
+    }
+
+    /// Header populated only by the trusted host.
+    pub const fn authorization_header(&self) -> &'static str {
+        "Authorization"
+    }
+
+    /// GitHub accepts a token or an externally minted GitHub App bearer token.
+    pub const fn authorization_schemes(&self) -> &'static [&'static str] {
+        &["Bearer", "token"]
+    }
+
+    /// Public GitHub API version header.
+    pub const fn api_version(&self) -> &'static str {
+        "2022-11-28"
+    }
+
+    /// Required response media type.
+    pub const fn accept(&self) -> &'static str {
+        "application/vnd.github+json"
+    }
+
+    /// Portable requests never contain credential bytes or references.
+    pub const fn contains_credentials(&self) -> bool {
+        false
+    }
+
+    /// Redirects are denied so authentication cannot escape the declared origin.
+    pub const fn allows_redirects(&self) -> bool {
+        false
+    }
+
+    /// Host-side response byte bound.
+    pub const fn max_response_bytes(&self) -> usize {
+        MAX_RESPONSE_BYTES
+    }
+
+    /// Provider scopes or permissions required by this operation.
+    pub const fn required_permissions(&self) -> &'static [&'static str] {
+        match self.family {
+            GitHubFamily::Audit => &["read:audit_log"],
+            GitHubFamily::Repository | GitHubFamily::PullRequest => &["Metadata: read"],
+            GitHubFamily::DependabotAlert => &["Dependabot alerts: read"],
+            GitHubFamily::OrganizationInventory => &["Members: read"],
+            GitHubFamily::SecretScanningAlert => &["Secret scanning alerts: read"],
+        }
+    }
+}
+
+impl GitHubKernel {
+    /// Construct one closed GitHub source-family kernel.
+    pub fn new(
+        base_url: &str,
+        tenant_id: &str,
+        owner: &str,
+        repository: Option<&str>,
+        family: GitHubFamily,
+        filters: GitHubFilters,
+        per_page: Option<usize>,
+    ) -> Result<Self, GitHubError> {
+        let base_url = validate_base_url(base_url)?;
+        let tenant_id = validate_tenant_id(tenant_id)?;
+        let owner = name(owner, "owner")?;
+        let repository = repository
+            .map(|value| name(value, "repository"))
+            .transpose()?;
+        match family {
+            GitHubFamily::DependabotAlert | GitHubFamily::PullRequest if repository.is_none() => {
+                return Err(GitHubError::MissingConfiguration("repository"));
+            }
+            GitHubFamily::Audit
+            | GitHubFamily::OrganizationInventory
+            | GitHubFamily::SecretScanningAlert
+                if repository.is_some() =>
+            {
+                return Err(GitHubError::InvalidConfiguration("repository"));
+            }
+            _ => {}
+        }
+        validate_filters(family, &filters)?;
+        let per_page = per_page.unwrap_or(100);
+        if !(1..=100).contains(&per_page) {
+            return Err(GitHubError::InvalidConfiguration("per_page"));
+        }
+        Ok(Self {
+            base_url,
+            tenant_id,
+            owner,
+            repository,
+            family,
+            filters,
+            per_page,
+        })
+    }
+
+    /// Plan the next credential-free family operation from a durable cursor.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<GitHubRequest, GitHubError> {
+        let state = CursorState::decode(self.family, cursor)?;
+        let (path, stage) = self.path_for_stage(state.stage)?;
+        let mut request = GitHubRequest {
+            url: self.endpoint(&path),
+            kind: GitHubRequestKind::Family,
+            family: self.family,
+            stage,
+            cursor: cursor.map(ToOwned::to_owned),
+        };
+        if stage == "singleton" {
+            if cursor.is_some() {
+                return Err(GitHubError::InvalidCursor);
+            }
+            return Ok(request);
+        }
+        {
+            let mut query = request.url.query_pairs_mut();
+            query.append_pair("per_page", &self.per_page.to_string());
+            match state.token {
+                Some(CursorToken::After(value)) => query.append_pair("after", &value),
+                Some(CursorToken::Page(value)) => query.append_pair("page", &value.to_string()),
+                None => &mut query,
+            };
+            match self.family {
+                GitHubFamily::Audit => {
+                    query.append_pair(
+                        "include",
+                        self.filters.audit_include.as_deref().unwrap_or("all"),
+                    );
+                    query.append_pair(
+                        "order",
+                        self.filters.audit_order.as_deref().unwrap_or("desc"),
+                    );
+                    if let Some(phrase) = &self.filters.audit_phrase {
+                        query.append_pair("phrase", phrase);
+                    }
+                }
+                GitHubFamily::Repository => {
+                    query.append_pair("sort", "updated");
+                    query.append_pair("direction", "desc");
+                    query.append_pair("type", "all");
+                }
+                GitHubFamily::DependabotAlert => {
+                    if let Some(state) = &self.filters.dependabot_state {
+                        query.append_pair("state", state);
+                    }
+                    query.append_pair("sort", "updated");
+                    query.append_pair("direction", "desc");
+                }
+                GitHubFamily::PullRequest => {
+                    query.append_pair(
+                        "state",
+                        self.filters.pull_request_state.as_deref().unwrap_or("all"),
+                    );
+                    query.append_pair("sort", "updated");
+                    query.append_pair("direction", "desc");
+                }
+                GitHubFamily::SecretScanningAlert => {
+                    if let Some(state) = &self.filters.secret_scanning_state {
+                        query.append_pair("state", state);
+                    }
+                    query.append_pair("sort", "updated");
+                    query.append_pair("direction", "desc");
+                }
+                GitHubFamily::OrganizationInventory => {}
+            }
+        }
+        Ok(request)
+    }
+
+    /// Plan the declared repository user fallback after an organization-list 404.
+    pub fn plan_repository_user_fallback(
+        &self,
+        failed: &GitHubRequest,
+    ) -> Result<GitHubRequest, GitHubError> {
+        if self.family != GitHubFamily::Repository
+            || self.repository.is_some()
+            || failed != &self.plan(failed.cursor.as_deref())?
+        {
+            return Err(GitHubError::RequestScopeMismatch);
+        }
+        let mut request = failed.clone();
+        request.kind = GitHubRequestKind::RepositoryUserFallback;
+        request.url = self.endpoint(&format!("/users/{}/repos", self.owner));
+        let state = CursorState::decode(self.family, failed.cursor.as_deref())?;
+        {
+            let mut query = request.url.query_pairs_mut();
+            query.append_pair("per_page", &self.per_page.to_string());
+            if let Some(CursorToken::Page(page)) = state.token {
+                query.append_pair("page", &page.to_string());
+            }
+            query.append_pair("sort", "updated");
+            query.append_pair("direction", "desc");
+            query.append_pair("type", "all");
+        }
+        Ok(request)
+    }
+
+    /// Plan the bounded public user lookup required for a GitHub audit actor.
+    pub fn plan_actor_resolution(&self, actor: &str) -> Result<GitHubRequest, GitHubError> {
+        if self.family != GitHubFamily::Audit {
+            return Err(GitHubError::RequestScopeMismatch);
+        }
+        let actor = name(actor, "actor")?;
+        Ok(GitHubRequest {
+            url: self.endpoint(&format!("/users/{actor}")),
+            kind: GitHubRequestKind::AuditActor,
+            family: self.family,
+            stage: "actor",
+            cursor: None,
+        })
+    }
+
+    fn path_for_stage(&self, stage: Stage) -> Result<(String, &'static str), GitHubError> {
+        let value = match (self.family, stage) {
+            (GitHubFamily::Audit, Stage::Primary) => {
+                (format!("/orgs/{}/audit-log", self.owner), "primary")
+            }
+            (GitHubFamily::Repository, Stage::Primary) if self.repository.is_some() => (
+                format!(
+                    "/repos/{}/{}",
+                    self.owner,
+                    self.repository.as_deref().unwrap_or_default()
+                ),
+                "singleton",
+            ),
+            (GitHubFamily::Repository, Stage::Primary) => {
+                (format!("/orgs/{}/repos", self.owner), "primary")
+            }
+            (GitHubFamily::DependabotAlert, Stage::Primary) => (
+                format!(
+                    "/repos/{}/{}/dependabot/alerts",
+                    self.owner,
+                    self.repository.as_deref().unwrap_or_default()
+                ),
+                "primary",
+            ),
+            (GitHubFamily::PullRequest, Stage::Primary) => (
+                format!(
+                    "/repos/{}/{}/pulls",
+                    self.owner,
+                    self.repository.as_deref().unwrap_or_default()
+                ),
+                "primary",
+            ),
+            (GitHubFamily::SecretScanningAlert, Stage::Primary) => (
+                format!("/orgs/{}/secret-scanning/alerts", self.owner),
+                "primary",
+            ),
+            (GitHubFamily::OrganizationInventory, Stage::Members) => {
+                (format!("/orgs/{}/members", self.owner), "members")
+            }
+            (GitHubFamily::OrganizationInventory, Stage::Outside) => (
+                format!("/orgs/{}/outside_collaborators", self.owner),
+                "outside_collaborators",
+            ),
+            (GitHubFamily::OrganizationInventory, Stage::Installations) => (
+                format!("/orgs/{}/installations", self.owner),
+                "installations",
+            ),
+            _ => return Err(GitHubError::InvalidCursor),
+        };
+        Ok(value)
+    }
+
+    fn endpoint(&self, path: &str) -> Url {
+        let mut url = self.base_url.clone();
+        url.set_path(&format!(
+            "{}{}",
+            self.base_url.path().trim_end_matches('/'),
+            path
+        ));
+        url.set_query(None);
+        url.set_fragment(None);
+        url
+    }
+}
+
+fn validate_filters(family: GitHubFamily, filters: &GitHubFilters) -> Result<(), GitHubError> {
+    if filters
+        .audit_phrase
+        .as_ref()
+        .is_some_and(|value| value.len() > MAX_PHRASE_BYTES || value.chars().any(char::is_control))
+    {
+        return Err(GitHubError::InvalidConfiguration("audit_phrase"));
+    }
+    allowed(
+        filters.audit_include.as_deref(),
+        &["all", "web", "git"],
+        "audit_include",
+    )?;
+    allowed(
+        filters.audit_order.as_deref(),
+        &["asc", "desc"],
+        "audit_order",
+    )?;
+    allowed(
+        filters.pull_request_state.as_deref(),
+        &["all", "open", "closed"],
+        "pull_request_state",
+    )?;
+    allowed(
+        filters.dependabot_state.as_deref(),
+        &["auto_dismissed", "dismissed", "fixed", "open"],
+        "dependabot_state",
+    )?;
+    allowed(
+        filters.secret_scanning_state.as_deref(),
+        &["open", "resolved"],
+        "secret_scanning_state",
+    )?;
+    let audit = filters.audit_include.is_some()
+        || filters.audit_phrase.is_some()
+        || filters.audit_order.is_some();
+    if audit && family != GitHubFamily::Audit {
+        return Err(GitHubError::InvalidConfiguration("audit_filters"));
+    }
+    if filters.pull_request_state.is_some() && family != GitHubFamily::PullRequest {
+        return Err(GitHubError::InvalidConfiguration("pull_request_state"));
+    }
+    if filters.dependabot_state.is_some() && family != GitHubFamily::DependabotAlert {
+        return Err(GitHubError::InvalidConfiguration("dependabot_state"));
+    }
+    if filters.secret_scanning_state.is_some() && family != GitHubFamily::SecretScanningAlert {
+        return Err(GitHubError::InvalidConfiguration("secret_scanning_state"));
+    }
+    Ok(())
+}
+
+fn allowed(value: Option<&str>, allowed: &[&str], field: &'static str) -> Result<(), GitHubError> {
+    if value.is_some_and(|value| !allowed.contains(&value.trim())) {
+        return Err(GitHubError::InvalidConfiguration(field));
+    }
+    Ok(())
+}

--- a/crates/source-runtime-next/src/github/response.rs
+++ b/crates/source-runtime-next/src/github/response.rs
@@ -1,0 +1,334 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use super::{
+    GitHubActorResolution, GitHubCheckpointCandidate, GitHubContinuation, GitHubError,
+    GitHubFamily, GitHubKernel, GitHubPage, GitHubRequest, GitHubRequestKind,
+    cursor::encode_cursor,
+    normalize::{normalize_record, scalar_at},
+    request::MAX_RESPONSE_BYTES,
+};
+
+impl GitHubKernel {
+    /// Validate a page's durable progress candidate.
+    ///
+    /// This does not mutate a checkpoint. The trusted host must append and
+    /// project first, re-check its lease fence, and only then persist it.
+    pub fn checkpoint_candidate(
+        &self,
+        request: &GitHubRequest,
+        page: &GitHubPage,
+        prior_watermark: Option<&str>,
+    ) -> Result<GitHubCheckpointCandidate, GitHubError> {
+        self.validate_request(request)?;
+        if page.records.iter().any(|record| {
+            record.tenant_id != self.tenant_id || record.family != self.family.as_str()
+        }) {
+            return Err(GitHubError::TenantMismatch);
+        }
+        if let Some(cursor) = &page.next_cursor {
+            self.plan(Some(cursor))?;
+        }
+        let prior_watermark = prior_watermark.map(validate_watermark).transpose()?;
+        let watermark = page
+            .records
+            .iter()
+            .map(|record| record.occurred_at.clone())
+            .chain(prior_watermark)
+            .max();
+        Ok(GitHubCheckpointCandidate {
+            tenant_id: self.tenant_id.clone(),
+            family: self.family,
+            cursor: page.next_cursor.clone(),
+            watermark,
+        })
+    }
+
+    /// Classify a family response and normalize its bounded provider records.
+    ///
+    /// The trusted host owns DNS, connection establishment, egress policy,
+    /// deadlines, redirects, credential application, and response buffering.
+    #[allow(clippy::too_many_arguments)]
+    pub fn decode_http(
+        &self,
+        request: &GitHubRequest,
+        status: u16,
+        retry_after_seconds: Option<u64>,
+        continuation: GitHubContinuation,
+        body: &[u8],
+        observed_at: Option<&str>,
+        actor_resolutions: &[GitHubActorResolution],
+    ) -> Result<GitHubPage, GitHubError> {
+        self.validate_request(request)?;
+        if body.len() > MAX_RESPONSE_BYTES {
+            return Err(GitHubError::ResponseTooLarge);
+        }
+        if retry_after_seconds.is_some_and(|seconds| seconds > 3_600) {
+            return Err(GitHubError::InvalidRetryAfter);
+        }
+        match status {
+            200 => self.decode_success(request, continuation, body, observed_at, actor_resolutions),
+            401 => Err(GitHubError::AuthenticationRejected),
+            403 if retry_after_seconds.is_some() => Err(GitHubError::RateLimited {
+                retry_after_seconds,
+            }),
+            403 => Err(GitHubError::RequiredScopeMissing),
+            404 if self.family == GitHubFamily::Repository
+                && self.repository.is_none()
+                && request.kind == GitHubRequestKind::Family =>
+            {
+                Err(GitHubError::OrganizationNotFound)
+            }
+            429 => Err(GitHubError::RateLimited {
+                retry_after_seconds,
+            }),
+            500..=599 => Err(GitHubError::ProviderUnavailable { status }),
+            _ => Err(GitHubError::UnexpectedStatus { status }),
+        }
+    }
+
+    /// Decode one successful family response.
+    pub fn decode(
+        &self,
+        request: &GitHubRequest,
+        continuation: GitHubContinuation,
+        body: &[u8],
+        observed_at: Option<&str>,
+        actor_resolutions: &[GitHubActorResolution],
+    ) -> Result<GitHubPage, GitHubError> {
+        self.decode_http(
+            request,
+            200,
+            None,
+            continuation,
+            body,
+            observed_at,
+            actor_resolutions,
+        )
+    }
+
+    /// Decode a separately planned audit-actor public lookup.
+    pub fn decode_actor_resolution(
+        &self,
+        request: &GitHubRequest,
+        status: u16,
+        body: &[u8],
+    ) -> Result<GitHubActorResolution, GitHubError> {
+        if body.len() > MAX_RESPONSE_BYTES {
+            return Err(GitHubError::ResponseTooLarge);
+        }
+        if self.family != GitHubFamily::Audit
+            || request.kind != GitHubRequestKind::AuditActor
+            || request.family != self.family
+        {
+            return Err(GitHubError::RequestScopeMismatch);
+        }
+        let actor = request
+            .url
+            .path_segments()
+            .and_then(Iterator::last)
+            .filter(|value| !value.is_empty())
+            .ok_or(GitHubError::RequestScopeMismatch)?
+            .to_owned();
+        if status == 404 {
+            return Ok(GitHubActorResolution {
+                actor,
+                actor_type: "Unresolved".to_owned(),
+                actor_id: None,
+                actor_email: None,
+            });
+        }
+        match status {
+            200 => {}
+            401 => return Err(GitHubError::AuthenticationRejected),
+            403 => return Err(GitHubError::RequiredScopeMissing),
+            429 => {
+                return Err(GitHubError::RateLimited {
+                    retry_after_seconds: None,
+                });
+            }
+            500..=599 => return Err(GitHubError::ProviderUnavailable { status }),
+            _ => return Err(GitHubError::UnexpectedStatus { status }),
+        }
+        let value: Value =
+            serde_json::from_slice(body).map_err(|_| GitHubError::MalformedResponse)?;
+        reject_credential_material(&value)?;
+        let values = value.as_object().ok_or(GitHubError::MalformedResponse)?;
+        let login = scalar_at(values, "login").ok_or(GitHubError::InvalidProviderRecord)?;
+        if !login.eq_ignore_ascii_case(&actor) {
+            return Err(GitHubError::RequestScopeMismatch);
+        }
+        let actor_type = scalar_at(values, "type").unwrap_or_else(|| "User".to_owned());
+        let actor_id = values
+            .get("id")
+            .and_then(Value::as_i64)
+            .filter(|id| *id > 0);
+        let actor_email = scalar_at(values, "email");
+        Ok(GitHubActorResolution {
+            actor: login,
+            actor_type,
+            actor_id,
+            actor_email,
+        })
+    }
+
+    fn decode_success(
+        &self,
+        request: &GitHubRequest,
+        continuation: GitHubContinuation,
+        body: &[u8],
+        observed_at: Option<&str>,
+        actor_resolutions: &[GitHubActorResolution],
+    ) -> Result<GitHubPage, GitHubError> {
+        if continuation.after.is_some() && continuation.page.is_some() {
+            return Err(GitHubError::InvalidCursor);
+        }
+        let value: Value =
+            serde_json::from_slice(body).map_err(|_| GitHubError::MalformedResponse)?;
+        reject_credential_material(&value)?;
+        let records = response_records(self.family, request.stage, value)?;
+        if records.len() > self.per_page {
+            return Err(GitHubError::TooManyRecords);
+        }
+        let mut seen = BTreeMap::<String, Value>::new();
+        let mut normalized = Vec::with_capacity(records.len());
+        for raw in records {
+            let record = normalize_record(
+                self,
+                request.stage,
+                raw.clone(),
+                observed_at,
+                actor_resolutions,
+            )?;
+            match seen.get(&record.provider_id) {
+                Some(previous) if previous == &raw => continue,
+                Some(_) => return Err(GitHubError::ConflictingDuplicate),
+                None => {
+                    seen.insert(record.provider_id.clone(), raw);
+                    normalized.push(record);
+                }
+            }
+        }
+        let next_cursor = self.next_cursor(request, continuation)?;
+        Ok(GitHubPage {
+            records: normalized,
+            next_cursor,
+        })
+    }
+
+    fn next_cursor(
+        &self,
+        request: &GitHubRequest,
+        continuation: GitHubContinuation,
+    ) -> Result<Option<String>, GitHubError> {
+        let stage = match request.stage {
+            "primary" | "singleton" => "primary",
+            "members" => "members",
+            "outside_collaborators" => "outside",
+            "installations" => "installations",
+            _ => return Err(GitHubError::RequestScopeMismatch),
+        };
+        if let Some(cursor) =
+            encode_cursor(stage, continuation.after.as_deref(), continuation.page)?
+        {
+            return Ok(Some(cursor));
+        }
+        if self.family != GitHubFamily::OrganizationInventory {
+            return Ok(None);
+        }
+        match request.stage {
+            "members" => Ok(Some("github-v1|outside|page|1".to_owned())),
+            "outside_collaborators" => Ok(Some("github-v1|installations|page|1".to_owned())),
+            "installations" => Ok(None),
+            _ => Err(GitHubError::RequestScopeMismatch),
+        }
+    }
+
+    fn validate_request(&self, request: &GitHubRequest) -> Result<(), GitHubError> {
+        let expected = match request.kind {
+            GitHubRequestKind::Family => self.plan(request.cursor.as_deref())?,
+            GitHubRequestKind::RepositoryUserFallback => {
+                let primary = self.plan(request.cursor.as_deref())?;
+                self.plan_repository_user_fallback(&primary)?
+            }
+            GitHubRequestKind::AuditActor => return Err(GitHubError::RequestScopeMismatch),
+        };
+        if &expected != request {
+            return Err(GitHubError::RequestScopeMismatch);
+        }
+        Ok(())
+    }
+}
+
+fn validate_watermark(value: &str) -> Result<String, GitHubError> {
+    let values = serde_json::Map::from_iter([("watermark".to_owned(), Value::from(value))]);
+    super::normalize::timestamp_optional(&values, "watermark")?
+        .ok_or(GitHubError::InvalidProviderRecord)
+}
+
+fn response_records(
+    family: GitHubFamily,
+    stage: &str,
+    value: Value,
+) -> Result<Vec<Value>, GitHubError> {
+    if family == GitHubFamily::Repository && stage == "singleton" {
+        return value
+            .is_object()
+            .then(|| vec![value])
+            .ok_or(GitHubError::MalformedResponse);
+    }
+    if family == GitHubFamily::OrganizationInventory && stage == "installations" {
+        return value
+            .as_object()
+            .and_then(|values| values.get("installations"))
+            .and_then(Value::as_array)
+            .cloned()
+            .ok_or(GitHubError::MalformedResponse);
+    }
+    value
+        .as_array()
+        .cloned()
+        .ok_or(GitHubError::MalformedResponse)
+}
+
+fn reject_credential_material(value: &Value) -> Result<(), GitHubError> {
+    match value {
+        Value::Object(values) => {
+            for (key, value) in values {
+                let key = key.to_ascii_lowercase();
+                let credential_key = matches!(
+                    key.as_str(),
+                    "authorization"
+                        | "api_key"
+                        | "api_token"
+                        | "access_token"
+                        | "refresh_token"
+                        | "client_secret"
+                        | "private_key"
+                        | "password"
+                        | "token"
+                        | "secret"
+                );
+                if credential_key && !empty_value(value) {
+                    return Err(GitHubError::CredentialMaterial);
+                }
+                reject_credential_material(value)?;
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                reject_credential_material(value)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn empty_value(value: &Value) -> bool {
+    value.is_null()
+        || value.as_str().is_some_and(str::is_empty)
+        || value.as_array().is_some_and(Vec::is_empty)
+        || value.as_object().is_some_and(serde_json::Map::is_empty)
+}

--- a/crates/source-runtime-next/src/github/tests.rs
+++ b/crates/source-runtime-next/src/github/tests.rs
@@ -1,0 +1,590 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Value, json};
+
+use super::*;
+
+const AUDIT_RESPONSE: &[u8] =
+    include_bytes!("../../../../sources/github/testdata/api/audit/audit_log/response.json");
+const AUDIT_ORACLE: &[u8] = include_bytes!("../../../../sources/github/testdata/read_audit.json");
+const DEPENDABOT_RESPONSE: &[u8] = include_bytes!(
+    "../../../../sources/github/testdata/api/dependabot_alert/dependabot_alerts/response.json"
+);
+const DEPENDABOT_ORACLE: &[u8] =
+    include_bytes!("../../../../sources/github/testdata/read_dependabot_alert.json");
+const ORG_RESPONSE: &[u8] =
+    include_bytes!("../../../../sources/github/testdata/api/org_inventory/members/response.json");
+const ORG_ORACLE: &[u8] =
+    include_bytes!("../../../../sources/github/testdata/read_org_inventory.json");
+const PR_RESPONSE: &[u8] = include_bytes!(
+    "../../../../sources/github/testdata/api/pull_request/pull_requests/response.json"
+);
+const PR_ORACLE: &[u8] =
+    include_bytes!("../../../../sources/github/testdata/read_pull_request.json");
+const REPOSITORY_RESPONSE: &[u8] =
+    include_bytes!("../../../../sources/github/testdata/api/repository/repository/response.json");
+const REPOSITORY_ORACLE: &[u8] =
+    include_bytes!("../../../../sources/github/testdata/read_repository.json");
+const SECRET_RESPONSE: &[u8] = include_bytes!(
+    "../../../../sources/github/testdata/api/secret_scanning_alert/secret_scanning_alerts/response.json"
+);
+const SECRET_ORACLE: &[u8] =
+    include_bytes!("../../../../sources/github/testdata/read_secret_scanning_alert.json");
+const CATALOG: &[u8] = include_bytes!("../../../../sources/github/catalog.yaml");
+
+#[derive(serde::Deserialize)]
+struct CatalogWire {
+    event_contracts: Vec<EventContractWire>,
+}
+
+#[derive(serde::Deserialize)]
+struct EventContractWire {
+    kind: String,
+    schema_ref: String,
+    required_attributes: Vec<String>,
+    required_payload_fields: Vec<String>,
+}
+
+fn kernel(
+    tenant: &str,
+    owner: &str,
+    repository: Option<&str>,
+    family: GitHubFamily,
+) -> GitHubKernel {
+    GitHubKernel::new(
+        "https://api.github.com",
+        tenant,
+        owner,
+        repository,
+        family,
+        GitHubFilters::default(),
+        Some(100),
+    )
+    .expect("valid github fixture kernel")
+}
+
+#[test]
+fn compiles_only_the_six_bespoke_catalog_families() {
+    let families = [
+        GitHubFamily::Audit,
+        GitHubFamily::Repository,
+        GitHubFamily::DependabotAlert,
+        GitHubFamily::OrganizationInventory,
+        GitHubFamily::PullRequest,
+        GitHubFamily::SecretScanningAlert,
+    ];
+    let contracts = families
+        .into_iter()
+        .flat_map(|family| {
+            GitHubRuntimeDefinition::compile(family)
+                .expect("compiled family")
+                .event_contracts
+        })
+        .map(|contract| contract.kind)
+        .collect::<Vec<_>>();
+    assert_eq!(contracts.len(), 7);
+    assert!(contracts.contains(&"github.audit"));
+    assert!(contracts.contains(&"github.org_member"));
+    assert!(contracts.contains(&"github.org_installation"));
+    assert!(
+        !contracts
+            .iter()
+            .any(|kind| matches!(*kind, "github.issue" | "github.event" | "github.email"))
+    );
+    assert_eq!(
+        "issue".parse::<GitHubFamily>(),
+        Err(GitHubError::InvalidFamily)
+    );
+}
+
+#[test]
+fn compiled_contracts_match_the_provider_catalog_exactly() {
+    let catalog: CatalogWire = serde_saphyr::from_slice(CATALOG).expect("GitHub catalog YAML");
+    let families = [
+        GitHubFamily::Audit,
+        GitHubFamily::Repository,
+        GitHubFamily::DependabotAlert,
+        GitHubFamily::OrganizationInventory,
+        GitHubFamily::PullRequest,
+        GitHubFamily::SecretScanningAlert,
+    ];
+    let compiled = families
+        .into_iter()
+        .flat_map(|family| {
+            GitHubRuntimeDefinition::compile(family)
+                .expect("compiled family")
+                .event_contracts
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(catalog.event_contracts.len(), compiled.len());
+    for expected in catalog.event_contracts {
+        let actual = compiled
+            .iter()
+            .find(|contract| contract.kind == expected.kind)
+            .expect("catalog contract compiled");
+        assert_eq!(actual.schema_ref, expected.schema_ref);
+        assert!(
+            actual
+                .required_attributes
+                .iter()
+                .copied()
+                .eq(expected.required_attributes.iter().map(String::as_str))
+        );
+        assert!(
+            actual
+                .required_payload_fields
+                .iter()
+                .copied()
+                .eq(expected.required_payload_fields.iter().map(String::as_str))
+        );
+    }
+}
+
+#[test]
+fn plans_every_catalog_endpoint_without_credentials_or_redirects() {
+    let cases = [
+        (GitHubFamily::Audit, None, "/orgs/writer/audit-log"),
+        (GitHubFamily::Repository, None, "/orgs/writer/repos"),
+        (
+            GitHubFamily::Repository,
+            Some("cerebro"),
+            "/repos/writer/cerebro",
+        ),
+        (
+            GitHubFamily::DependabotAlert,
+            Some("cerebro"),
+            "/repos/writer/cerebro/dependabot/alerts",
+        ),
+        (
+            GitHubFamily::OrganizationInventory,
+            None,
+            "/orgs/writer/members",
+        ),
+        (
+            GitHubFamily::PullRequest,
+            Some("cerebro"),
+            "/repos/writer/cerebro/pulls",
+        ),
+        (
+            GitHubFamily::SecretScanningAlert,
+            None,
+            "/orgs/writer/secret-scanning/alerts",
+        ),
+    ];
+    for (family, repository, path) in cases {
+        let request = kernel("tenant-a", "writer", repository, family)
+            .plan(None)
+            .expect("planned request");
+        assert_eq!(request.method(), "GET");
+        assert_eq!(request.url().path(), path);
+        assert_eq!(request.authorization_header(), "Authorization");
+        assert_eq!(request.authorization_schemes(), &["Bearer", "token"]);
+        assert!(!request.contains_credentials());
+        assert!(!request.allows_redirects());
+        assert_eq!(request.max_response_bytes(), 8 * 1024 * 1024);
+        let serialized = format!("{request:?}").to_ascii_lowercase();
+        for forbidden in ["ghp_", "github_pat_", "client_secret", "private_key"] {
+            assert!(!serialized.contains(forbidden));
+        }
+    }
+}
+
+#[test]
+fn repository_fallback_and_inventory_cursor_stages_are_origin_restricted() {
+    let repository = kernel("tenant-a", "writer", None, GitHubFamily::Repository);
+    let primary = repository.plan(None).expect("org repositories");
+    let fallback = repository
+        .plan_repository_user_fallback(&primary)
+        .expect("user fallback");
+    assert_eq!(fallback.url().path(), "/users/writer/repos");
+    assert_eq!(fallback.url().origin(), primary.url().origin());
+
+    let inventory = kernel(
+        "tenant-a",
+        "writer",
+        None,
+        GitHubFamily::OrganizationInventory,
+    );
+    let members = inventory.plan(None).expect("members");
+    let page = inventory
+        .decode(
+            &members,
+            GitHubContinuation::default(),
+            b"[]",
+            Some("2026-08-21T00:00:00Z"),
+            &[],
+        )
+        .expect("members page");
+    let outside = inventory
+        .plan(page.next_cursor.as_deref())
+        .expect("outside collaborators");
+    assert_eq!(outside.url().path(), "/orgs/writer/outside_collaborators");
+    let page = inventory
+        .decode(
+            &outside,
+            GitHubContinuation::default(),
+            b"[]",
+            Some("2026-08-21T00:00:00Z"),
+            &[],
+        )
+        .expect("outside page");
+    let installations = inventory
+        .plan(page.next_cursor.as_deref())
+        .expect("installations");
+    assert_eq!(installations.url().path(), "/orgs/writer/installations");
+}
+
+#[test]
+fn github_fixture_outputs_match_the_go_oracle() {
+    let audit = kernel(
+        "api-playground",
+        "codeforamerica",
+        None,
+        GitHubFamily::Audit,
+    );
+    let audit_page = audit
+        .decode(
+            &audit.plan(None).expect("audit request"),
+            GitHubContinuation::default(),
+            AUDIT_RESPONSE,
+            None,
+            &[GitHubActorResolution {
+                actor: "octokit".to_owned(),
+                actor_type: "Unresolved".to_owned(),
+                actor_id: None,
+                actor_email: None,
+            }],
+        )
+        .expect("audit fixture");
+    assert_oracle(&audit_page.records, AUDIT_ORACLE);
+
+    let dependabot = kernel(
+        "coopernetes",
+        "coopernetes",
+        Some("PyGithub"),
+        GitHubFamily::DependabotAlert,
+    );
+    let dependabot_page = dependabot
+        .decode(
+            &dependabot.plan(None).expect("dependabot request"),
+            GitHubContinuation::default(),
+            DEPENDABOT_RESPONSE,
+            None,
+            &[],
+        )
+        .expect("dependabot fixture");
+    assert_oracle(&dependabot_page.records, DEPENDABOT_ORACLE);
+
+    let org = kernel(
+        "github",
+        "github",
+        None,
+        GitHubFamily::OrganizationInventory,
+    );
+    let org_page = org
+        .decode(
+            &org.plan(None).expect("member request"),
+            GitHubContinuation::default(),
+            ORG_RESPONSE,
+            Some("2026-07-18T08:32:55Z"),
+            &[],
+        )
+        .expect("org fixture");
+    assert_oracle(&org_page.records, ORG_ORACLE);
+
+    let pull = kernel(
+        "octocat",
+        "octocat",
+        Some("Hello-World"),
+        GitHubFamily::PullRequest,
+    );
+    let pull_page = pull
+        .decode(
+            &pull.plan(None).expect("pull request"),
+            GitHubContinuation::default(),
+            PR_RESPONSE,
+            None,
+            &[],
+        )
+        .expect("pull fixture");
+    assert_oracle(&pull_page.records, PR_ORACLE);
+
+    let repository = kernel(
+        "octocat",
+        "octocat",
+        Some("Hello-World"),
+        GitHubFamily::Repository,
+    );
+    let repository_page = repository
+        .decode(
+            &repository.plan(None).expect("repository request"),
+            GitHubContinuation::default(),
+            REPOSITORY_RESPONSE,
+            None,
+            &[],
+        )
+        .expect("repository fixture");
+    assert_oracle(&repository_page.records, REPOSITORY_ORACLE);
+
+    let secret = kernel("github", "github", None, GitHubFamily::SecretScanningAlert);
+    let secret_page = secret
+        .decode(
+            &secret.plan(None).expect("secret request"),
+            GitHubContinuation::default(),
+            SECRET_RESPONSE,
+            None,
+            &[],
+        )
+        .expect("secret fixture");
+    assert_oracle(&secret_page.records, SECRET_ORACLE);
+}
+
+#[test]
+fn organization_installation_contract_is_admitted_exactly() {
+    let inventory = kernel(
+        "tenant-a",
+        "writer",
+        None,
+        GitHubFamily::OrganizationInventory,
+    );
+    let request = inventory
+        .plan(Some("github-v1|installations|page|1"))
+        .expect("installation request");
+    let body = serde_json::to_vec(&json!({"installations": [{
+        "id": 42,
+        "app_slug": "dependabot",
+        "target_type": "Organization",
+        "repository_selection": "all",
+        "permissions": {"metadata": "read", "security_events": "read"},
+        "events": ["secret_scanning_alert"]
+    }]}))
+    .expect("fixture json");
+    let page = inventory
+        .decode(
+            &request,
+            GitHubContinuation::default(),
+            &body,
+            Some("2026-08-21T00:00:00Z"),
+            &[],
+        )
+        .expect("installation page");
+    let record = &page.records[0];
+    assert_eq!(record.kind, "github.org_installation");
+    assert_eq!(record.schema_ref, "github/org_installation/v1");
+    assert_eq!(record.attributes["installation_id"], "42");
+    assert_eq!(record.payload["org"], "writer");
+    assert_eq!(page.next_cursor, None);
+}
+
+#[test]
+fn audit_actor_resolution_is_explicit_and_bounded() {
+    let audit = kernel("tenant-a", "writer", None, GitHubFamily::Audit);
+    let request = audit.plan(None).expect("audit request");
+    let error = audit
+        .decode(
+            &request,
+            GitHubContinuation::default(),
+            br#"[{"@timestamp":1661836610662,"action":"org.add_member","actor":"octokit","org":"writer","user":"new"}]"#,
+            None,
+            &[],
+        )
+        .expect_err("resolution required");
+    assert_eq!(
+        error,
+        GitHubError::ActorResolutionRequired {
+            actor: "octokit".to_owned()
+        }
+    );
+    let lookup = audit
+        .plan_actor_resolution("octokit")
+        .expect("lookup request");
+    assert_eq!(lookup.url().path(), "/users/octokit");
+    let unresolved = audit
+        .decode_actor_resolution(&lookup, 404, b"{}")
+        .expect("unresolved actor");
+    assert_eq!(unresolved.actor_type, "Unresolved");
+}
+
+#[test]
+fn rejects_secrets_tenant_injection_conflicting_duplicates_and_unsafe_cursors() {
+    let repository = kernel(
+        "tenant-a",
+        "writer",
+        Some("cerebro"),
+        GitHubFamily::Repository,
+    );
+    let request = repository.plan(None).expect("request");
+    for body in [
+        br#"{"id":1,"name":"cerebro","full_name":"writer/cerebro","updated_at":"2026-08-21T00:00:00Z","access_token":"credential-bytes"}"#.as_slice(),
+        br#"{"id":1,"name":"cerebro","full_name":"writer/cerebro","updated_at":"2026-08-21T00:00:00Z","tenant_id":"attacker"}"#.as_slice(),
+    ] {
+        assert!(repository
+            .decode(&request, GitHubContinuation::default(), body, None, &[])
+            .is_err());
+    }
+    let list = kernel("tenant-a", "writer", None, GitHubFamily::Repository);
+    let list_request = list.plan(None).expect("list request");
+    let conflict = br#"[
+      {"id":1,"name":"a","full_name":"writer/a","updated_at":"2026-08-21T00:00:00Z"},
+      {"id":1,"name":"b","full_name":"writer/b","updated_at":"2026-08-21T00:00:00Z"}
+    ]"#;
+    assert_eq!(
+        list.decode(
+            &list_request,
+            GitHubContinuation::default(),
+            conflict,
+            None,
+            &[]
+        ),
+        Err(GitHubError::ConflictingDuplicate)
+    );
+    assert_eq!(
+        list.plan(Some("https://evil.example/page/2")),
+        Err(GitHubError::InvalidCursor)
+    );
+    assert_eq!(
+        list.decode(
+            &list_request,
+            GitHubContinuation {
+                after: Some("abc".to_owned()),
+                page: Some(2),
+            },
+            b"[]",
+            None,
+            &[],
+        ),
+        Err(GitHubError::InvalidCursor)
+    );
+}
+
+#[test]
+fn classifies_provider_failures_without_collapsing_them() {
+    let audit = kernel("tenant-a", "writer", None, GitHubFamily::Audit);
+    let request = audit.plan(None).expect("request");
+    let cases = [
+        (401, None, GitHubError::AuthenticationRejected),
+        (403, None, GitHubError::RequiredScopeMissing),
+        (
+            403,
+            Some(30),
+            GitHubError::RateLimited {
+                retry_after_seconds: Some(30),
+            },
+        ),
+        (
+            429,
+            Some(30),
+            GitHubError::RateLimited {
+                retry_after_seconds: Some(30),
+            },
+        ),
+        (503, None, GitHubError::ProviderUnavailable { status: 503 }),
+        (418, None, GitHubError::UnexpectedStatus { status: 418 }),
+    ];
+    for (status, retry_after, expected) in cases {
+        assert_eq!(
+            audit.decode_http(
+                &request,
+                status,
+                retry_after,
+                GitHubContinuation::default(),
+                b"{}",
+                None,
+                &[],
+            ),
+            Err(expected)
+        );
+    }
+}
+
+#[test]
+fn event_identity_is_stable_and_tenant_scoped() {
+    let body = br#"{"id":1,"name":"cerebro","full_name":"writer/cerebro","updated_at":"2026-08-21T00:00:00Z"}"#;
+    let first = normalized_repository("tenant-a", body);
+    let repeated = normalized_repository("tenant-a", body);
+    let other_tenant = normalized_repository("tenant-b", body);
+    assert_eq!(first.event_id, repeated.event_id);
+    assert_ne!(first.event_id, other_tenant.event_id);
+    assert_eq!(first.provider_id, other_tenant.provider_id);
+    assert_eq!(first.tenant_id, "tenant-a");
+}
+
+#[test]
+fn checkpoint_candidate_round_trips_and_preserves_prior_progress() {
+    let repository = kernel("tenant-a", "writer", None, GitHubFamily::Repository);
+    let request = repository.plan(None).expect("first page");
+    let page = repository
+        .decode(
+            &request,
+            GitHubContinuation {
+                after: None,
+                page: Some(2),
+            },
+            br#"[{"id":1,"name":"cerebro","full_name":"writer/cerebro","updated_at":"2026-08-21T00:00:00Z"}]"#,
+            None,
+            &[],
+        )
+        .expect("normalized first page");
+    let checkpoint = repository
+        .checkpoint_candidate(&request, &page, Some("2026-08-20T00:00:00Z"))
+        .expect("checkpoint candidate");
+    assert_eq!(checkpoint.tenant_id, "tenant-a");
+    assert_eq!(checkpoint.family, GitHubFamily::Repository);
+    assert_eq!(
+        checkpoint.watermark.as_deref(),
+        Some("2026-08-21T00:00:00Z")
+    );
+    let resumed = repository
+        .plan(checkpoint.cursor.as_deref())
+        .expect("round-tripped cursor");
+    assert_eq!(
+        resumed
+            .url()
+            .query_pairs()
+            .find(|(key, _)| key == "page")
+            .map(|(_, value)| value.into_owned()),
+        Some("2".to_owned())
+    );
+}
+
+fn normalized_repository(tenant: &str, body: &[u8]) -> GitHubRecord {
+    let kernel = kernel(tenant, "writer", Some("cerebro"), GitHubFamily::Repository);
+    kernel
+        .decode(
+            &kernel.plan(None).expect("request"),
+            GitHubContinuation::default(),
+            body,
+            None,
+            &[],
+        )
+        .expect("record")
+        .records
+        .remove(0)
+}
+
+fn assert_oracle(records: &[GitHubRecord], oracle: &[u8]) {
+    let oracle: Vec<Value> = serde_json::from_slice(oracle).expect("Go oracle JSON");
+    assert_eq!(records.len(), oracle.len());
+    for (record, expected) in records.iter().zip(oracle) {
+        assert_eq!(record.tenant_id, expected["tenant_id"]);
+        assert_eq!(record.source_id, expected["source_id"]);
+        assert_eq!(record.kind, expected["kind"]);
+        assert_eq!(record.schema_ref, expected["schema_ref"]);
+        assert_eq!(record.attributes, attributes(&expected["attributes"]));
+        assert_eq!(record.payload, expected["payload"]);
+    }
+}
+
+fn attributes(value: &Value) -> BTreeMap<String, String> {
+    value
+        .as_object()
+        .expect("oracle attributes")
+        .iter()
+        .map(|(key, value)| {
+            (
+                key.clone(),
+                value.as_str().expect("string attribute").to_owned(),
+            )
+        })
+        .collect()
+}

--- a/crates/source-runtime-next/src/github/types.rs
+++ b/crates/source-runtime-next/src/github/types.rs
@@ -1,0 +1,175 @@
+use std::{collections::BTreeMap, str::FromStr};
+
+use reqwest::Url;
+use serde_json::Value;
+
+use super::GitHubError;
+
+/// One bespoke GitHub source-catalog family.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum GitHubFamily {
+    /// Organization audit log.
+    Audit,
+    /// Organization or singleton repository inventory.
+    Repository,
+    /// Repository Dependabot alerts.
+    DependabotAlert,
+    /// Organization members, outside collaborators, and installations.
+    OrganizationInventory,
+    /// Repository pull requests.
+    PullRequest,
+    /// Organization secret-scanning alerts.
+    SecretScanningAlert,
+}
+
+impl GitHubFamily {
+    /// Source-catalog family identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Audit => "audit",
+            Self::Repository => "repository",
+            Self::DependabotAlert => "dependabot_alert",
+            Self::OrganizationInventory => "org_inventory",
+            Self::PullRequest => "pull_request",
+            Self::SecretScanningAlert => "secret_scanning_alert",
+        }
+    }
+}
+
+impl FromStr for GitHubFamily {
+    type Err = GitHubError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim() {
+            "audit" => Ok(Self::Audit),
+            "repository" => Ok(Self::Repository),
+            "dependabot_alert" => Ok(Self::DependabotAlert),
+            "org_inventory" => Ok(Self::OrganizationInventory),
+            "pull_request" => Ok(Self::PullRequest),
+            "secret_scanning_alert" => Ok(Self::SecretScanningAlert),
+            _ => Err(GitHubError::InvalidFamily),
+        }
+    }
+}
+
+/// Public, non-secret family selectors.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct GitHubFilters {
+    /// Audit inclusion mode (`all`, `web`, or `git`).
+    pub audit_include: Option<String>,
+    /// GitHub audit phrase expression.
+    pub audit_phrase: Option<String>,
+    /// Audit ordering (`asc` or `desc`).
+    pub audit_order: Option<String>,
+    /// Pull-request state (`all`, `open`, or `closed`).
+    pub pull_request_state: Option<String>,
+    /// Dependabot state (`auto_dismissed`, `dismissed`, `fixed`, or `open`).
+    pub dependabot_state: Option<String>,
+    /// Secret-scanning state (`open` or `resolved`).
+    pub secret_scanning_state: Option<String>,
+}
+
+/// Exact bounded operation selected by a planned request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GitHubRequestKind {
+    /// Primary family request.
+    Family,
+    /// `/users/{actor}` audit-actor lookup.
+    AuditActor,
+    /// `/users/{owner}/repos` fallback after organization lookup returns 404.
+    RepositoryUserFallback,
+}
+
+/// Provider continuation metadata admitted from response headers.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct GitHubContinuation {
+    /// Opaque GitHub `after`, cursor, or next-page token.
+    pub after: Option<String>,
+    /// Positive GitHub page number when the API returns page pagination.
+    pub page: Option<u32>,
+}
+
+/// Public audit-actor lookup result. It contains no token or private provider data.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GitHubActorResolution {
+    /// Requested actor login.
+    pub actor: String,
+    /// Resolved GitHub actor type, or `Unresolved` after a 404.
+    pub actor_type: String,
+    /// Positive provider user ID when resolved.
+    pub actor_id: Option<i64>,
+    /// Public provider email when present.
+    pub actor_email: Option<String>,
+}
+
+/// One credential-free GitHub request description.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GitHubRequest {
+    pub(super) url: Url,
+    pub(super) kind: GitHubRequestKind,
+    pub(super) family: GitHubFamily,
+    pub(super) stage: &'static str,
+    pub(super) cursor: Option<String>,
+}
+
+/// One normalized, tenant-scoped GitHub event candidate.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GitHubRecord {
+    /// Tenant from authenticated runtime context, never provider JSON.
+    pub tenant_id: String,
+    /// Deterministic tenant- and provider-identity-scoped event ID.
+    pub event_id: String,
+    /// Source identifier.
+    pub source_id: String,
+    /// Exact event kind.
+    pub kind: String,
+    /// Exact schema reference.
+    pub schema_ref: String,
+    /// Source family.
+    pub family: String,
+    /// Stable provider identity before tenant scoping.
+    pub provider_id: String,
+    /// Normalized RFC3339 occurrence time.
+    pub occurred_at: String,
+    /// Go-compatible projection attributes.
+    pub attributes: BTreeMap<String, String>,
+    /// Go-compatible normalized payload.
+    pub payload: Value,
+}
+
+/// One bounded normalized GitHub page.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GitHubPage {
+    /// Accepted normalized records in provider order.
+    pub records: Vec<GitHubRecord>,
+    /// Validated durable cursor. The host persists it only after append and projection succeed.
+    pub next_cursor: Option<String>,
+}
+
+/// Validated durable progress candidate returned to the trusted host.
+///
+/// The host may persist this only after every accepted record is appended and
+/// projected under the same live lease generation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GitHubCheckpointCandidate {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Source family whose progress is represented.
+    pub family: GitHubFamily,
+    /// Next validated provider cursor, or `None` for a terminal page.
+    pub cursor: Option<String>,
+    /// Highest normalized occurrence time seen so far.
+    pub watermark: Option<String>,
+}
+
+/// Provider-specific credential-free GitHub kernel.
+#[derive(Clone, Debug)]
+pub struct GitHubKernel {
+    pub(super) base_url: Url,
+    pub(super) tenant_id: String,
+    pub(super) owner: String,
+    pub(super) repository: Option<String>,
+    pub(super) family: GitHubFamily,
+    pub(super) filters: GitHubFilters,
+    pub(super) per_page: usize,
+}

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -22,6 +22,7 @@ mod email_domain_health;
 mod evidence_cas;
 mod fixture_parity;
 mod gcp;
+mod github;
 mod google_workspace;
 mod grc;
 mod http;
@@ -111,6 +112,11 @@ pub use fixture_parity::{
 pub use gcp::{
     GcpContentInspection, GcpDataClassification, GcpIamError, GcpIamFamily, GcpIamFilters,
     GcpIamKernel, GcpIamPage, GcpIamRecord, GcpIamRequest, GcpObjectContentKernel,
+};
+pub use github::{
+    GitHubActorResolution, GitHubCheckpointCandidate, GitHubContinuation, GitHubError,
+    GitHubEventContract, GitHubFamily, GitHubFilters, GitHubKernel, GitHubPage, GitHubRecord,
+    GitHubRequest, GitHubRequestKind, GitHubRuntimeDefinition,
 };
 pub use google_workspace::{
     GoogleWorkspaceError, GoogleWorkspaceFamily, GoogleWorkspaceFilters, GoogleWorkspaceKernel,

--- a/sources/github/projection_parity_test.go
+++ b/sources/github/projection_parity_test.go
@@ -1,0 +1,51 @@
+package github
+
+import (
+	"os"
+	"testing"
+
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceprojection"
+)
+
+func TestCheckedInGoOraclesReachBespokeGitHubProjections(t *testing.T) {
+	catalogBytes, err := catalogFS.ReadFile("catalog.yaml")
+	if err != nil {
+		t.Fatalf("read GitHub catalog: %v", err)
+	}
+	catalog, err := sourcecdk.LoadSourceCatalog(catalogBytes)
+	if err != nil {
+		t.Fatalf("load GitHub catalog: %v", err)
+	}
+	for _, family := range []string{
+		familyAudit,
+		familyRepository,
+		familyDependabot,
+		familyOrgInventory,
+		familyPullRequest,
+		familySecretScanning,
+	} {
+		t.Run(family, func(t *testing.T) {
+			events, err := sourcecdk.LoadFixtureEventsWithContracts(
+				os.DirFS("."),
+				"testdata/read_"+family+".json",
+				catalog.EventContracts,
+			)
+			if err != nil {
+				t.Fatalf("load %s Go oracle: %v", family, err)
+			}
+			if len(events) == 0 {
+				t.Fatalf("%s Go oracle has no events", family)
+			}
+			for _, event := range events {
+				entities, links, err := sourceprojection.ProjectEvent(event)
+				if err != nil {
+					t.Fatalf("project %s event %s: %v", event.Kind, event.Id, err)
+				}
+				if len(entities) == 0 && len(links) == 0 {
+					t.Fatalf("project %s event %s produced no graph delta", event.Kind, event.Id)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Scope

Adds the provider-local, credential-free Rust kernel for GitHub's six bespoke source families:

- audit (`github.audit`)
- repository (`github.code.repository`)
- Dependabot alert (`github.dependabot_alert`)
- organization inventory (`github.org_member`, `github.org_installation`)
- pull request (`github.pull_request`)
- secret-scanning alert (`github.secret_scanning_alert`)

The kernel compiles the exact checked-in event contracts, plans origin-restricted read requests, preserves organization-to-user repository fallback and audit actor resolution, validates provider responses, emits deterministic tenant-scoped identities, validates resumable cursors/checkpoint candidates, and retains typed provider/runtime failures with safe operator actions.

The request protocol contains no credential value or credential reference. Redirects are disabled. Response bytes, page sizes, cursors, nested organization inventory, duplicates, tenant injection, and credential-shaped response material fail closed.

## Parity and projection

Rust differential tests run the checked-in provider response fixtures for all six families and compare normalized attributes and payloads to the existing Go fixture oracle. A Go test admits every checked-in GitHub oracle event through its exact catalog contract and bespoke graph projector.

## Current validation

Passed on head before publication:

- `cargo fmt --all -- --check`
- `cargo test -p cerebro-source-runtime-next` (359 library tests, 4 worker tests)
- `cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings`
- `go test ./sources/github -run 'TestCheckedInGoOraclesReachBespokeGitHubProjections|TestSourceReplaysCaptured' -count=1`
- `go test ./sources/github ./internal/sourceprojection ./internal/sourceregistry ./internal/sourceruntime -count=1`
- local secret-pattern scan of the exact diff

Still running or pending at publication:

- focused Go race suite
- fixture-oracle/source-fixture/catalog checks
- structural and architecture checks
- hosted required checks

## Authority boundary

This PR does not change collection authority. Go remains authoritative, and the GitHub Go loader/registry exception remains in place because the shared source-execution host adapter, consecutive parity receipt retirement gate, deployment, live-provider collection, and authenticated product-path proof are outside this provider-local patch and are not yet satisfied.

No credentials, private routes, deployment configuration, reviewers, or protection changes are included.
