### PR TITLE
feat(source-runtime): add credential-free Anthropic Rust kernel

### DIFF
--- a/crates/source-runtime-next/src/anthropic.rs
+++ b/crates/source-runtime-next/src/anthropic.rs
@@ -1,0 +1,23 @@
+//! Credential-free Anthropic Admin and Compliance API runtime kernel.
+//!
+//! The kernel compiles the checked-in source family contract into bounded GET
+//! requests and canonical events. A trusted host remains responsible for
+//! credential resolution, authentication, network I/O, redirects, deadlines,
+//! and durable append/projection/checkpoint ordering.
+
+mod error;
+mod family;
+mod mappings;
+mod normalize;
+mod request;
+mod response;
+mod types;
+
+pub use error::AnthropicError;
+pub use family::{AnthropicAuthentication, AnthropicFamily};
+pub use types::{
+    AnthropicKernel, AnthropicPage, AnthropicRecord, AnthropicRequest, AnthropicScope,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/anthropic/error.rs
+++ b/crates/source-runtime-next/src/anthropic/error.rs
@@ -1,0 +1,83 @@
+//! Typed Anthropic provider failures with credential-free diagnostics.
+
+use std::{error::Error, fmt};
+
+/// Closed Anthropic request, provider, normalization, and admission failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AnthropicError {
+    /// Family is outside the checked-in Anthropic contract.
+    InvalidFamily,
+    /// Provider base URL is not one secure origin.
+    InvalidBaseUrl,
+    /// Trusted runtime tenant identity is absent or unsafe.
+    MissingTenantId,
+    /// A required family path parameter is absent.
+    MissingPathParameter,
+    /// A path or query parameter is unsafe or undeclared.
+    InvalidParameter,
+    /// Requested page size is outside the provider bound.
+    InvalidPageSize,
+    /// Provider continuation cursor is unsafe or non-round-trippable.
+    InvalidCursor,
+    /// Decode request does not belong to this family and origin.
+    RequestScopeMismatch,
+    /// Provider rejected the credential.
+    AuthenticationRejected,
+    /// Credential cannot read the requested Anthropic family or scope.
+    RequiredProviderScopeMissing,
+    /// Provider returned a rate limit.
+    ProviderRateLimit,
+    /// Provider or network is temporarily unavailable.
+    ProviderUnavailable,
+    /// Provider returned another unexpected status.
+    UnexpectedProviderStatus,
+    /// Response exceeded the compiled byte bound.
+    ResponseTooLarge,
+    /// Response JSON or list envelope is malformed.
+    MalformedResponse,
+    /// One provider item is not a record object.
+    InvalidRecord,
+    /// Provider record cannot produce a stable identity.
+    MissingStableIdentity,
+    /// Required event attribute or payload field is absent.
+    EventContractRejected,
+    /// One stable provider identity has conflicting content in a page.
+    DuplicateConflict,
+    /// Observation time is not a valid RFC 3339 timestamp.
+    InvalidObservedAt,
+}
+
+impl fmt::Display for AnthropicError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidFamily => "anthropic family is outside the compiled contract",
+            Self::InvalidBaseUrl => "anthropic base URL must be one secure origin",
+            Self::MissingTenantId => "anthropic trusted tenant identity is required",
+            Self::MissingPathParameter => "anthropic family path parameter is required",
+            Self::InvalidParameter => "anthropic request parameter is invalid",
+            Self::InvalidPageSize => "anthropic page size must be between 1 and 1000",
+            Self::InvalidCursor => "anthropic continuation cursor is invalid",
+            Self::RequestScopeMismatch => {
+                "anthropic response request does not match the compiled family origin"
+            }
+            Self::AuthenticationRejected => "anthropic authentication was rejected",
+            Self::RequiredProviderScopeMissing => {
+                "anthropic credential lacks the required provider scope"
+            }
+            Self::ProviderRateLimit => "anthropic provider rate limit was reached",
+            Self::ProviderUnavailable => "anthropic provider is unavailable",
+            Self::UnexpectedProviderStatus => "anthropic provider returned an unexpected status",
+            Self::ResponseTooLarge => "anthropic response exceeds the compiled byte bound",
+            Self::MalformedResponse => "anthropic response does not match the family contract",
+            Self::InvalidRecord => "anthropic provider record must be an object",
+            Self::MissingStableIdentity => "anthropic provider record identity is missing",
+            Self::EventContractRejected => "anthropic event contract rejected the record",
+            Self::DuplicateConflict => {
+                "anthropic duplicate provider identity has conflicting content"
+            }
+            Self::InvalidObservedAt => "anthropic observed_at must be RFC 3339",
+        })
+    }
+}
+
+impl Error for AnthropicError {}

--- a/crates/source-runtime-next/src/anthropic/family.rs
+++ b/crates/source-runtime-next/src/anthropic/family.rs
@@ -1,0 +1,439 @@
+//! Closed Anthropic family and provider contract definitions.
+
+use std::str::FromStr;
+
+use super::AnthropicError;
+
+/// Anthropic authentication capability required by one family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AnthropicAuthentication {
+    /// Admin API key in `x-api-key` or an OAuth bearer with `org:admin`.
+    AdminKeyOrOrgAdminBearer,
+    /// OAuth bearer with `org:admin`; Admin API keys are not accepted.
+    OrgAdminBearer,
+    /// Compliance Access Key in `x-api-key`.
+    ComplianceAccessKey,
+}
+
+/// Provider pagination contract for one family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PaginationKind {
+    None,
+    AfterId,
+    Page,
+}
+
+/// One scalar field selected from a provider record.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AttributeBinding {
+    pub(crate) name: &'static str,
+    pub(crate) paths: &'static [&'static str],
+}
+
+/// Closed Anthropic Admin and Compliance API family.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum AnthropicFamily {
+    /// Enterprise analytics cost buckets.
+    AnalyticsCost,
+    /// Organization API keys.
+    ApiKey,
+    /// Compliance audit activity.
+    ComplianceActivity,
+    /// Compliance directory groups.
+    ComplianceGroup,
+    /// Compliance directory group members.
+    ComplianceGroupMember,
+    /// Compliance directory organizations.
+    ComplianceOrganization,
+    /// Effective organization settings.
+    ComplianceOrganizationSetting,
+    /// Compliance directory organization users.
+    ComplianceOrganizationUser,
+    /// Claude projects exposed by the Compliance API.
+    ComplianceProject,
+    /// Claude project collaborators.
+    ComplianceProjectCollaborator,
+    /// Compliance directory roles.
+    ComplianceRole,
+    /// Compliance directory role permissions.
+    ComplianceRolePermission,
+    /// Admin usage cost report buckets.
+    CostReport,
+    /// External key configurations.
+    ExternalKey,
+    /// Workload identity federation issuers.
+    FederationIssuer,
+    /// Workload identity federation rules.
+    FederationRule,
+    /// Pending organization invites.
+    Invite,
+    /// Current organization profile.
+    Organization,
+    /// Organization rate limits.
+    RateLimit,
+    /// Workload service accounts.
+    ServiceAccount,
+    /// Effective spend limits.
+    SpendLimit,
+    /// Spend-limit increase requests.
+    SpendLimitIncreaseRequest,
+    /// Claude Code usage report buckets.
+    UsageReportClaudeCode,
+    /// Messages usage report buckets.
+    UsageReportMessage,
+    /// Organization users and roles.
+    User,
+    /// Organization workspaces.
+    Workspace,
+    /// Workspace members and roles.
+    WorkspaceMember,
+    /// Workspace rate limits.
+    WorkspaceRateLimit,
+}
+
+impl AnthropicFamily {
+    /// Every family retained by the Go Anthropic oracle.
+    pub const ALL: [Self; 28] = [
+        Self::AnalyticsCost,
+        Self::ApiKey,
+        Self::ComplianceActivity,
+        Self::ComplianceGroup,
+        Self::ComplianceGroupMember,
+        Self::ComplianceOrganization,
+        Self::ComplianceOrganizationSetting,
+        Self::ComplianceOrganizationUser,
+        Self::ComplianceProject,
+        Self::ComplianceProjectCollaborator,
+        Self::ComplianceRole,
+        Self::ComplianceRolePermission,
+        Self::CostReport,
+        Self::ExternalKey,
+        Self::FederationIssuer,
+        Self::FederationRule,
+        Self::Invite,
+        Self::Organization,
+        Self::RateLimit,
+        Self::ServiceAccount,
+        Self::SpendLimit,
+        Self::SpendLimitIncreaseRequest,
+        Self::UsageReportClaudeCode,
+        Self::UsageReportMessage,
+        Self::User,
+        Self::Workspace,
+        Self::WorkspaceMember,
+        Self::WorkspaceRateLimit,
+    ];
+
+    /// Return the exact Go source runtime family identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::AnalyticsCost => "analytics_cost",
+            Self::ApiKey => "api_key",
+            Self::ComplianceActivity => "compliance_activity",
+            Self::ComplianceGroup => "compliance_group",
+            Self::ComplianceGroupMember => "compliance_group_member",
+            Self::ComplianceOrganization => "compliance_organization",
+            Self::ComplianceOrganizationSetting => "compliance_organization_setting",
+            Self::ComplianceOrganizationUser => "compliance_organization_user",
+            Self::ComplianceProject => "compliance_project",
+            Self::ComplianceProjectCollaborator => "compliance_project_collaborator",
+            Self::ComplianceRole => "compliance_role",
+            Self::ComplianceRolePermission => "compliance_role_permission",
+            Self::CostReport => "cost_report",
+            Self::ExternalKey => "external_key",
+            Self::FederationIssuer => "federation_issuer",
+            Self::FederationRule => "federation_rule",
+            Self::Invite => "invite",
+            Self::Organization => "organization",
+            Self::RateLimit => "rate_limit",
+            Self::ServiceAccount => "service_account",
+            Self::SpendLimit => "spend_limit",
+            Self::SpendLimitIncreaseRequest => "spend_limit_increase_request",
+            Self::UsageReportClaudeCode => "usage_report_claude_code",
+            Self::UsageReportMessage => "usage_report_message",
+            Self::User => "user",
+            Self::Workspace => "workspace",
+            Self::WorkspaceMember => "workspace_member",
+            Self::WorkspaceRateLimit => "workspace_rate_limit",
+        }
+    }
+
+    /// Return the exact emitted event kind.
+    pub fn provider_kind(self) -> String {
+        format!("anthropic.{}", self.as_str())
+    }
+
+    /// Return the exact public event schema reference.
+    pub fn schema_ref(self) -> String {
+        format!("anthropic/{}/v1", self.as_str())
+    }
+
+    /// Return the exact provider path template.
+    pub const fn path(self) -> &'static str {
+        match self {
+            Self::AnalyticsCost => "/organizations/analytics/cost_report",
+            Self::ApiKey => "/organizations/api_keys",
+            Self::ComplianceActivity => "/compliance/activities",
+            Self::ComplianceGroup => "/compliance/groups",
+            Self::ComplianceGroupMember => "/compliance/groups/{group_id}/members",
+            Self::ComplianceOrganization => "/compliance/organizations",
+            Self::ComplianceOrganizationSetting => {
+                "/compliance/organizations/{organization_uuid}/settings"
+            }
+            Self::ComplianceOrganizationUser => {
+                "/compliance/organizations/{organization_uuid}/users"
+            }
+            Self::ComplianceProject => "/compliance/apps/projects",
+            Self::ComplianceProjectCollaborator => {
+                "/compliance/apps/projects/{project_id}/collaborators"
+            }
+            Self::ComplianceRole => "/compliance/organizations/{organization_uuid}/roles",
+            Self::ComplianceRolePermission => {
+                "/compliance/organizations/{organization_uuid}/roles/{role_id}/permissions"
+            }
+            Self::CostReport => "/organizations/cost_report",
+            Self::ExternalKey => "/organizations/external_keys",
+            Self::FederationIssuer => "/organizations/federation_issuers",
+            Self::FederationRule => "/organizations/federation_rules",
+            Self::Invite => "/organizations/invites",
+            Self::Organization => "/organizations/me",
+            Self::RateLimit => "/organizations/rate_limits",
+            Self::ServiceAccount => "/organizations/service_accounts",
+            Self::SpendLimit => "/organizations/spend_limits/effective",
+            Self::SpendLimitIncreaseRequest => "/organizations/spend_limit_increase_requests",
+            Self::UsageReportClaudeCode => "/organizations/usage_report/claude_code",
+            Self::UsageReportMessage => "/organizations/usage_report/messages",
+            Self::User => "/organizations/users",
+            Self::Workspace => "/organizations/workspaces",
+            Self::WorkspaceMember => "/organizations/workspaces/{workspace_id}/members",
+            Self::WorkspaceRateLimit => "/organizations/workspaces/{workspace_id}/rate_limits",
+        }
+    }
+
+    /// Return the provider authorization capability without credential material.
+    pub const fn authentication(self) -> AnthropicAuthentication {
+        match self {
+            Self::ServiceAccount | Self::FederationIssuer | Self::FederationRule => {
+                AnthropicAuthentication::OrgAdminBearer
+            }
+            Self::ComplianceActivity
+            | Self::ComplianceGroup
+            | Self::ComplianceGroupMember
+            | Self::ComplianceOrganization
+            | Self::ComplianceOrganizationSetting
+            | Self::ComplianceOrganizationUser
+            | Self::ComplianceProject
+            | Self::ComplianceProjectCollaborator
+            | Self::ComplianceRole
+            | Self::ComplianceRolePermission => AnthropicAuthentication::ComplianceAccessKey,
+            _ => AnthropicAuthentication::AdminKeyOrOrgAdminBearer,
+        }
+    }
+
+    pub(crate) const fn pagination(self) -> PaginationKind {
+        match self {
+            Self::Organization
+            | Self::ComplianceOrganization
+            | Self::ComplianceOrganizationSetting => PaginationKind::None,
+            Self::ExternalKey
+            | Self::AnalyticsCost
+            | Self::CostReport
+            | Self::UsageReportClaudeCode
+            | Self::UsageReportMessage
+            | Self::RateLimit
+            | Self::WorkspaceRateLimit
+            | Self::SpendLimit
+            | Self::SpendLimitIncreaseRequest
+            | Self::ComplianceOrganizationUser
+            | Self::ComplianceProject
+            | Self::ComplianceProjectCollaborator
+            | Self::ComplianceRole
+            | Self::ComplianceRolePermission
+            | Self::ComplianceGroup
+            | Self::ComplianceGroupMember => PaginationKind::Page,
+            _ => PaginationKind::AfterId,
+        }
+    }
+
+    pub(crate) const fn singleton(self) -> bool {
+        matches!(self, Self::Organization)
+    }
+
+    pub(crate) const fn path_parameters(self) -> &'static [&'static str] {
+        match self {
+            Self::ComplianceGroupMember => &["group_id"],
+            Self::ComplianceOrganizationSetting
+            | Self::ComplianceOrganizationUser
+            | Self::ComplianceRole => &["organization_uuid"],
+            Self::ComplianceRolePermission => &["organization_uuid", "role_id"],
+            Self::ComplianceProjectCollaborator => &["project_id"],
+            Self::WorkspaceMember | Self::WorkspaceRateLimit => &["workspace_id"],
+            _ => &[],
+        }
+    }
+
+    pub(crate) const fn query_parameters(self) -> &'static [(&'static str, &'static str)] {
+        match self {
+            Self::ApiKey => &[("status", "status"), ("workspace_id", "workspace_id")],
+            Self::Workspace => &[("include_archived", "include_archived")],
+            Self::RateLimit => &[("model", "model")],
+            Self::SpendLimit => &[
+                ("actor_ids[]", "actor_ids"),
+                ("period[]", "periods"),
+                ("user_ids[]", "user_ids"),
+            ],
+            Self::SpendLimitIncreaseRequest => {
+                &[("actor_ids[]", "actor_ids"), ("status[]", "status")]
+            }
+            Self::ComplianceActivity => &[
+                ("activity_types[]", "activity_types"),
+                ("actor_ids[]", "actor_ids"),
+                ("created_at.gt", "created_at_gt"),
+                ("created_at.gte", "created_at_gte"),
+                ("created_at.lt", "created_at_lt"),
+                ("created_at.lte", "created_at_lte"),
+                ("organization_ids[]", "organization_ids"),
+            ],
+            Self::AnalyticsCost
+            | Self::CostReport
+            | Self::UsageReportClaudeCode
+            | Self::UsageReportMessage => &[
+                ("api_key_ids[]", "api_key_ids"),
+                ("bucket_width", "bucket_width"),
+                ("context_window[]", "context_windows"),
+                ("ending_at", "ending_at"),
+                ("group_by[]", "group_by"),
+                ("inference_geos[]", "inference_geos"),
+                ("models[]", "models"),
+                ("service_tiers[]", "service_tiers"),
+                ("speeds[]", "speeds"),
+                ("starting_at", "starting_at"),
+                ("terminal_types[]", "terminal_types"),
+                ("workspace_ids[]", "workspace_ids"),
+            ],
+            _ => &[],
+        }
+    }
+
+    pub(crate) const fn list_keys(self) -> &'static [&'static str] {
+        match self {
+            Self::ComplianceOrganizationSetting => &["settings"],
+            _ => &[],
+        }
+    }
+
+    pub(crate) const fn id_paths(self) -> &'static [&'static str] {
+        match self {
+            Self::ComplianceOrganization => &["uuid", "id"],
+            Self::ComplianceOrganizationSetting => &["name"],
+            Self::ComplianceOrganizationUser => &["id", "user_id"],
+            Self::ComplianceRole => &["id", "role_id"],
+            Self::ComplianceRolePermission => &["id", "permission_id", "permission", "name"],
+            Self::ComplianceGroup => &["id", "group_id"],
+            Self::ComplianceGroupMember => &["user_id", "id", "email"],
+            Self::ComplianceProject => &["id", "project_id"],
+            Self::ComplianceProjectCollaborator => &[
+                "id",
+                "assignment_id",
+                "principal.id",
+                "user.id",
+                "group.id",
+                "organization.id",
+            ],
+            Self::RateLimit | Self::WorkspaceRateLimit => &["id", "group_type", "model", "name"],
+            Self::SpendLimit => &["spend_limit_id", "id", "scope.user_id", "actor.user_id"],
+            _ => &["id"],
+        }
+    }
+
+    pub(crate) const fn timestamp_paths(self) -> &'static [&'static str] {
+        match self {
+            Self::User | Self::WorkspaceMember => &["added_at"],
+            Self::Invite => &["created_at", "expires_at"],
+            Self::Workspace => &["created_at", "archived_at"],
+            Self::ApiKey | Self::ExternalKey => &["created_at", "last_used_at"],
+            Self::ServiceAccount
+            | Self::ComplianceActivity
+            | Self::ComplianceOrganization
+            | Self::ComplianceOrganizationUser => &["created_at"],
+            Self::FederationIssuer
+            | Self::FederationRule
+            | Self::ComplianceRole
+            | Self::ComplianceRolePermission
+            | Self::ComplianceGroup
+            | Self::ComplianceGroupMember
+            | Self::ComplianceProjectCollaborator
+            | Self::SpendLimit
+            | Self::SpendLimitIncreaseRequest => &["created_at", "updated_at"],
+            Self::ComplianceProject => &["created_at", "updated_at", "archived_at"],
+            Self::AnalyticsCost
+            | Self::CostReport
+            | Self::UsageReportClaudeCode
+            | Self::UsageReportMessage => &["start_time", "starting_at", "date"],
+            Self::RateLimit | Self::WorkspaceRateLimit => &["updated_at"],
+            Self::Organization | Self::ComplianceOrganizationSetting => &[],
+        }
+    }
+
+    pub(crate) const fn required_attributes(self) -> &'static [&'static str] {
+        match self {
+            Self::Organization => &["organization_id"],
+            Self::User => &["user_id"],
+            Self::Invite => &["invite_id"],
+            Self::Workspace => &["workspace_id"],
+            Self::WorkspaceMember => &["user_id", "workspace_id"],
+            Self::ApiKey => &["api_key_id"],
+            Self::ExternalKey => &["external_key_id"],
+            Self::ServiceAccount => &["service_account_id"],
+            Self::FederationIssuer => &["federation_issuer_id"],
+            Self::FederationRule => &["federation_rule_id"],
+            Self::AnalyticsCost
+            | Self::CostReport
+            | Self::UsageReportClaudeCode
+            | Self::UsageReportMessage
+            | Self::RateLimit
+            | Self::SpendLimit => &["external_id"],
+            Self::WorkspaceRateLimit => &["external_id", "workspace_id"],
+            Self::SpendLimitIncreaseRequest => &["request_id"],
+            Self::ComplianceActivity => &["activity_id"],
+            Self::ComplianceOrganization => &["organization_uuid"],
+            Self::ComplianceOrganizationUser => &["organization_uuid", "user_id"],
+            Self::ComplianceRole => &["organization_uuid", "role_id"],
+            Self::ComplianceRolePermission => &["organization_uuid", "role_id", "permission_id"],
+            Self::ComplianceGroup => &["group_id"],
+            Self::ComplianceGroupMember => &["group_id", "user_id"],
+            Self::ComplianceProject => &["project_id"],
+            Self::ComplianceProjectCollaborator => {
+                &["project_id", "principal_type", "principal_id", "role_id"]
+            }
+            Self::ComplianceOrganizationSetting => &["organization_uuid", "setting_name"],
+        }
+    }
+
+    pub(crate) const fn required_payload_fields(self) -> &'static [&'static str] {
+        match self {
+            Self::AnalyticsCost
+            | Self::CostReport
+            | Self::UsageReportClaudeCode
+            | Self::UsageReportMessage
+            | Self::RateLimit
+            | Self::WorkspaceRateLimit
+            | Self::SpendLimit
+            | Self::ComplianceProjectCollaborator => &[],
+            Self::ComplianceOrganization => &["uuid"],
+            Self::ComplianceOrganizationSetting => &["name"],
+            _ => &["id"],
+        }
+    }
+}
+
+impl FromStr for AnthropicFamily {
+    type Err = AnthropicError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|family| family.as_str() == value.trim())
+            .ok_or(AnthropicError::InvalidFamily)
+    }
+}

--- a/crates/source-runtime-next/src/anthropic/mappings.rs
+++ b/crates/source-runtime-next/src/anthropic/mappings.rs
@@ -1,0 +1,278 @@
+//! Anthropic provider-field to canonical event-attribute mappings.
+
+use super::family::{AnthropicFamily, AttributeBinding};
+
+macro_rules! binding {
+    ($name:literal => $($path:literal)|+ $(,)?) => {
+        AttributeBinding { name: $name, paths: &[$($path),+] }
+    };
+}
+
+impl AnthropicFamily {
+    pub(crate) const fn attributes(self) -> &'static [AttributeBinding] {
+        match self {
+            Self::Organization => &[
+                binding!("organization_id" => "id"),
+                binding!("name" => "name"),
+                binding!("type" => "type"),
+            ],
+            Self::User => &[
+                binding!("user_id" => "id"),
+                binding!("name" => "name"),
+                binding!("email" => "email"),
+                binding!("role" => "role"),
+                binding!("status" => "status"),
+                binding!("added_at" => "added_at"),
+            ],
+            Self::Invite => &[
+                binding!("invite_id" => "id"),
+                binding!("email" => "email"),
+                binding!("role" => "role"),
+                binding!("status" => "status"),
+                binding!("created_at" => "created_at"),
+                binding!("expires_at" => "expires_at"),
+            ],
+            Self::Workspace => &[
+                binding!("workspace_id" => "id"),
+                binding!("name" => "name"),
+                binding!("display_color" => "display_color"),
+                binding!("created_at" => "created_at"),
+                binding!("archived_at" => "archived_at"),
+            ],
+            Self::WorkspaceMember => &[
+                binding!("workspace_id" => "workspace_id"),
+                binding!("user_id" => "id"|"user_id"),
+                binding!("email" => "email"),
+                binding!("name" => "name"),
+                binding!("workspace_role" => "workspace_role"|"role"),
+                binding!("added_at" => "added_at"),
+            ],
+            Self::ApiKey => &[
+                binding!("api_key_id" => "id"),
+                binding!("name" => "name"),
+                binding!("status" => "status"),
+                binding!("workspace_id" => "workspace_id"|"workspace.id"),
+                binding!("owner_user_id" => "created_by.id"|"owner.id"|"user_id"),
+                binding!("created_at" => "created_at"),
+                binding!("last_used_at" => "last_used_at"),
+            ],
+            Self::ExternalKey => &[
+                binding!("external_key_id" => "id"),
+                binding!("name" => "name"),
+                binding!("status" => "status"),
+                binding!("provider" => "provider"),
+                binding!("workspace_id" => "workspace_id"|"workspace.id"),
+                binding!("created_at" => "created_at"),
+                binding!("last_used_at" => "last_used_at"),
+            ],
+            Self::ServiceAccount => &[
+                binding!("service_account_id" => "id"),
+                binding!("name" => "name"),
+                binding!("status" => "status"),
+                binding!("description" => "description"),
+                binding!("created_at" => "created_at"),
+            ],
+            Self::FederationIssuer => &[
+                binding!("federation_issuer_id" => "id"),
+                binding!("issuer" => "issuer"),
+                binding!("name" => "name"),
+                binding!("status" => "status"),
+                binding!("created_at" => "created_at"),
+                binding!("updated_at" => "updated_at"),
+            ],
+            Self::FederationRule => &[
+                binding!("federation_rule_id" => "id"),
+                binding!("issuer_id" => "issuer_id"|"federation_issuer_id"),
+                binding!("service_account_id" => "service_account_id"),
+                binding!("subject" => "subject"),
+                binding!("scopes" => "scopes"),
+                binding!("created_at" => "created_at"),
+                binding!("updated_at" => "updated_at"),
+            ],
+            Self::AnalyticsCost
+            | Self::CostReport
+            | Self::UsageReportClaudeCode
+            | Self::UsageReportMessage => REPORT,
+            Self::RateLimit | Self::WorkspaceRateLimit => RATE_LIMIT,
+            Self::SpendLimit => SPEND_LIMIT,
+            Self::SpendLimitIncreaseRequest => SPEND_LIMIT_REQUEST,
+            Self::ComplianceActivity => COMPLIANCE_ACTIVITY,
+            Self::ComplianceOrganization => &[
+                binding!("organization_uuid" => "uuid"),
+                binding!("organization_id" => "id"|"organization_id"),
+                binding!("name" => "name"),
+                binding!("created_at" => "created_at"),
+            ],
+            Self::ComplianceOrganizationUser => &[
+                binding!("organization_uuid" => "organization_uuid"),
+                binding!("user_id" => "id"|"user_id"),
+                binding!("name" => "full_name"|"name"),
+                binding!("email" => "email"),
+                binding!("role" => "organization_role"|"role"),
+                binding!("organization_role" => "organization_role"|"role"),
+                binding!("created_at" => "created_at"),
+            ],
+            Self::ComplianceRole => &[
+                binding!("organization_uuid" => "organization_uuid"),
+                binding!("role_id" => "id"|"role_id"),
+                binding!("name" => "name"),
+                binding!("description" => "description"),
+                binding!("created_at" => "created_at"),
+                binding!("updated_at" => "updated_at"),
+            ],
+            Self::ComplianceRolePermission => ROLE_PERMISSION,
+            Self::ComplianceGroup => &[
+                binding!("group_id" => "id"|"group_id"),
+                binding!("group_name" => "name"),
+                binding!("name" => "name"),
+                binding!("description" => "description"),
+                binding!("source_type" => "source_type"),
+                binding!("roles" => "roles"),
+                binding!("created_at" => "created_at"),
+                binding!("updated_at" => "updated_at"),
+            ],
+            Self::ComplianceGroupMember => &[
+                binding!("group_id" => "group_id"),
+                binding!("user_id" => "user_id"|"id"),
+                binding!("email" => "email"),
+                binding!("created_at" => "created_at"),
+                binding!("updated_at" => "updated_at"),
+            ],
+            Self::ComplianceProject => PROJECT,
+            Self::ComplianceProjectCollaborator => PROJECT_COLLABORATOR,
+            Self::ComplianceOrganizationSetting => &[
+                binding!("organization_uuid" => "organization_uuid"),
+                binding!("setting_name" => "name"),
+                binding!("setting_type" => "type"),
+                binding!("setting_value" => "value"),
+            ],
+        }
+    }
+}
+
+const REPORT: &[AttributeBinding] = &[
+    binding!("start_time" => "start_time"|"starting_at"|"date"),
+    binding!("end_time" => "end_time"|"ending_at"),
+    binding!("workspace_id" => "workspace_id"),
+    binding!("user_id" => "user_id"),
+    binding!("api_key_id" => "api_key_id"),
+    binding!("model" => "model"),
+    binding!("cost_usd" => "cost_usd"|"cost"),
+    binding!("input_tokens" => "input_tokens"),
+    binding!("output_tokens" => "output_tokens"),
+    binding!("request_count" => "request_count"|"requests"),
+    binding!("organization_id" => "organization_id"),
+];
+
+const RATE_LIMIT: &[AttributeBinding] = &[
+    binding!("rate_limit_id" => "id"),
+    binding!("group_type" => "group_type"),
+    binding!("name" => "name"),
+    binding!("model" => "model"),
+    binding!("models" => "models"),
+    binding!("workspace_id" => "workspace_id"),
+    binding!("limits" => "limits"),
+    binding!("requests_per_minute" => "requests_per_minute"|"rpm"),
+    binding!("tokens_per_minute" => "tokens_per_minute"|"tpm"),
+    binding!("input_tokens" => "input_tokens"),
+    binding!("output_tokens" => "output_tokens"),
+    binding!("updated_at" => "updated_at"),
+];
+
+const SPEND_LIMIT: &[AttributeBinding] = &[
+    binding!("spend_limit_id" => "spend_limit_id"|"id"),
+    binding!("scope_type" => "scope.type"),
+    binding!("user_id" => "scope.user_id"|"actor.user_id"),
+    binding!("actor_email" => "actor.email_address"|"actor.email"),
+    binding!("amount" => "amount"),
+    binding!("currency" => "currency"),
+    binding!("period" => "period"),
+    binding!("source_type" => "source.type"),
+    binding!("period_to_date_spend" => "period_to_date_spend"),
+    binding!("created_at" => "created_at"),
+    binding!("updated_at" => "updated_at"),
+];
+
+const SPEND_LIMIT_REQUEST: &[AttributeBinding] = &[
+    binding!("request_id" => "id"),
+    binding!("user_id" => "scope.user_id"|"actor.user_id"),
+    binding!("actor_email" => "actor.email_address"|"actor.email"),
+    binding!("status" => "status"),
+    binding!("amount" => "amount"),
+    binding!("currency" => "currency"),
+    binding!("period" => "period"),
+    binding!("created_at" => "created_at"),
+    binding!("updated_at" => "updated_at"),
+];
+
+const COMPLIANCE_ACTIVITY: &[AttributeBinding] = &[
+    binding!("activity_id" => "id"),
+    binding!("activity_type" => "type"),
+    binding!("organization_id" => "organization_id"),
+    binding!("organization_uuid" => "organization_uuid"),
+    binding!("actor_type" => "actor.type"),
+    binding!("actor_user_id" => "actor.user_id"),
+    binding!("actor_api_key_id" => "actor.api_key_id"),
+    binding!("actor_admin_api_key_id" => "actor.admin_api_key_id"),
+    binding!("actor_email" => "actor.email_address"|"actor.email"|"actor.unauthenticated_email_address"),
+    binding!("actor_ip_address" => "actor.ip_address"),
+    binding!("actor_user_agent" => "actor.user_agent"),
+    binding!("actor_workos_event_id" => "actor.workos_event_id"),
+    binding!("actor_directory_id" => "actor.directory_id"),
+    binding!("actor_idp_connection_type" => "actor.idp_connection_type"),
+    binding!("claude_chat_id" => "claude_chat_id"|"chat_id"|"chat.id"),
+    binding!("claude_file_id" => "claude_file_id"|"file_id"|"file.id"),
+    binding!("claude_project_id" => "claude_project_id"|"project_id"|"project.id"),
+    binding!("file_id" => "claude_file_id"|"file_id"|"file.id"),
+    binding!("filename" => "filename"|"file.name"),
+    binding!("project_id" => "claude_project_id"|"project_id"|"project.id"),
+    binding!("created_at" => "created_at"),
+];
+
+const ROLE_PERMISSION: &[AttributeBinding] = &[
+    binding!("organization_uuid" => "organization_uuid"),
+    binding!("role_id" => "role_id"),
+    binding!("permission_id" => "id"|"permission_id"|"permission"|"name"),
+    binding!("permission" => "permission"|"permission_id"|"id"|"name"),
+    binding!("permission_name" => "name"|"permission"|"permission_id"|"id"),
+    binding!("permission_description" => "description"),
+    binding!("action" => "action"),
+    binding!("resource_type" => "resource_type"|"resource"),
+    binding!("scope" => "scope"),
+    binding!("category" => "category"|"type"),
+    binding!("created_at" => "created_at"),
+    binding!("updated_at" => "updated_at"),
+];
+
+const PROJECT: &[AttributeBinding] = &[
+    binding!("project_id" => "id"|"project_id"),
+    binding!("name" => "name"|"title"),
+    binding!("description" => "description"),
+    binding!("organization_id" => "organization.id"|"organization_id"),
+    binding!("organization_uuid" => "organization.uuid"|"organization_uuid"|"organization.id"|"organization_id"),
+    binding!("creator_user_id" => "created_by.id"|"creator.id"|"owner.id"|"created_by_user_id"|"user_id"),
+    binding!("creator_email" => "created_by.email"|"creator.email"|"owner.email"|"email"),
+    binding!("status" => "status"),
+    binding!("visibility" => "visibility"),
+    binding!("created_at" => "created_at"),
+    binding!("updated_at" => "updated_at"),
+    binding!("archived_at" => "archived_at"),
+];
+
+const PROJECT_COLLABORATOR: &[AttributeBinding] = &[
+    binding!("project_id" => "project_id"),
+    binding!("assignment_id" => "id"|"assignment_id"),
+    binding!("principal_type" => "principal.type"|"principal_type"|"type"|"collaborator_type"),
+    binding!("principal_id" => "principal.id"|"principal.user_id"|"principal.group_id"|"user.id"|"user_id"|"group.id"|"group_id"|"organization.id"|"organization_uuid"|"organization_id"|"id"),
+    binding!("user_id" => "user.id"|"user_id"|"principal.user_id"|"principal.id"),
+    binding!("group_id" => "group.id"|"group_id"|"principal.group_id"),
+    binding!("email" => "principal.email"|"user.email"|"email"),
+    binding!("name" => "principal.name"|"user.name"|"group.name"|"name"),
+    binding!("organization_id" => "organization.id"|"organization_id"),
+    binding!("organization_uuid" => "organization.uuid"|"organization_uuid"|"organization.id"|"organization_id"),
+    binding!("role_id" => "role.id"|"role_id"|"role"),
+    binding!("role" => "role.name"|"role.id"|"role_id"),
+    binding!("role_name" => "role.name"|"role_name"|"role.id"|"role_id"),
+    binding!("created_at" => "created_at"),
+    binding!("updated_at" => "updated_at"),
+];

--- a/crates/source-runtime-next/src/anthropic/normalize.rs
+++ b/crates/source-runtime-next/src/anthropic/normalize.rs
@@ -1,0 +1,180 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, UtcOffset, format_description::well_known::Rfc3339};
+
+use super::{AnthropicError, AnthropicFamily, AnthropicRecord};
+
+pub(super) fn normalize_record(
+    family: AnthropicFamily,
+    tenant_id: &str,
+    base_url: &str,
+    operation_path: &str,
+    path_parameters: &BTreeMap<String, String>,
+    observed_at: &str,
+    mut payload: Value,
+) -> Result<AnthropicRecord, AnthropicError> {
+    let object = payload.as_object().ok_or(AnthropicError::InvalidRecord)?;
+    if contains_untrusted_tenant(object) || contains_secret_material(&payload) {
+        return Err(AnthropicError::InvalidRecord);
+    }
+    let object = payload
+        .as_object_mut()
+        .ok_or(AnthropicError::InvalidRecord)?;
+    for (key, value) in path_parameters {
+        object
+            .entry(key.clone())
+            .or_insert_with(|| Value::String(value.clone()));
+    }
+    let object = payload.as_object().ok_or(AnthropicError::InvalidRecord)?;
+    for field in family.required_payload_fields() {
+        if value_at(object, field).is_none_or(Value::is_null) {
+            return Err(AnthropicError::EventContractRejected);
+        }
+    }
+    let provider_id = first_value(object, family.id_paths()).unwrap_or_else(|| {
+        let digest = Sha256::digest(serde_json::to_vec(&payload).unwrap_or_default());
+        digest[..12]
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
+    });
+    if provider_id.trim().is_empty() || provider_id.len() > 4_096 {
+        return Err(AnthropicError::MissingStableIdentity);
+    }
+
+    let mut fields = BTreeMap::from([
+        ("external_id".to_owned(), provider_id.clone()),
+        ("family".to_owned(), family.as_str().to_owned()),
+        ("provider".to_owned(), "anthropic".to_owned()),
+        ("source_product".to_owned(), "anthropic".to_owned()),
+        ("source_provider".to_owned(), "anthropic".to_owned()),
+    ]);
+    for (key, value) in path_parameters {
+        fields.insert(key.clone(), value.clone());
+    }
+    for binding in family.attributes() {
+        if let Some(value) = first_value(object, binding.paths) {
+            fields.insert(binding.name.to_owned(), value);
+        }
+    }
+    if family.required_attributes().iter().any(|field| {
+        fields
+            .get(*field)
+            .is_none_or(|value| value.trim().is_empty())
+    }) {
+        return Err(AnthropicError::EventContractRejected);
+    }
+
+    let occurred_at = first_value(object, family.timestamp_paths())
+        .and_then(|value| canonical_timestamp(&value))
+        .or_else(|| canonical_timestamp(observed_at))
+        .ok_or(AnthropicError::InvalidObservedAt)?;
+    let event_id = event_id(tenant_id, base_url, operation_path, family, &provider_id);
+    Ok(AnthropicRecord {
+        tenant_id: tenant_id.to_owned(),
+        event_id,
+        provider_id,
+        provider_kind: family.provider_kind(),
+        schema_ref: family.schema_ref(),
+        fields,
+        payload,
+        occurred_at,
+    })
+}
+
+fn first_value(object: &Map<String, Value>, paths: &[&str]) -> Option<String> {
+    paths
+        .iter()
+        .find_map(|path| value_at(object, path).and_then(value_string))
+}
+
+fn value_at<'a>(object: &'a Map<String, Value>, path: &str) -> Option<&'a Value> {
+    let mut parts = path.split('.');
+    let mut value = object.get(parts.next()?)?;
+    for part in parts {
+        value = value.as_object()?.get(part)?;
+    }
+    Some(value)
+}
+
+fn value_string(value: &Value) -> Option<String> {
+    let text = match value {
+        Value::Null => return None,
+        Value::String(value) => value.trim().to_owned(),
+        Value::Number(value) => value.to_string(),
+        Value::Bool(value) => value.to_string(),
+        Value::Array(_) => serde_json::to_string(value).ok()?,
+        Value::Object(_) => serde_json::to_string(value).ok()?,
+    };
+    (!text.is_empty()).then_some(text)
+}
+
+fn canonical_timestamp(value: &str) -> Option<String> {
+    OffsetDateTime::parse(value.trim(), &Rfc3339)
+        .ok()?
+        .to_offset(UtcOffset::UTC)
+        .format(&Rfc3339)
+        .ok()
+}
+
+fn event_id(
+    tenant_id: &str,
+    base_url: &str,
+    operation_path: &str,
+    family: AnthropicFamily,
+    provider_id: &str,
+) -> String {
+    let scope = Sha256::digest(format!("{base_url}\0{operation_path}"));
+    let scope = scope[..6]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!(
+        "anthropic-{}-{scope}-{}-{}",
+        normalize_id(tenant_id),
+        normalize_id(family.as_str()),
+        normalize_id(provider_id)
+    )
+}
+
+fn normalize_id(value: &str) -> String {
+    let value = value.trim();
+    if value.is_empty() {
+        return "unknown".to_owned();
+    }
+    value
+        .chars()
+        .map(|character| match character {
+            ' ' | '/' | ':' | '\t' | '\n' => '-',
+            other => other,
+        })
+        .collect()
+}
+
+fn contains_untrusted_tenant(object: &Map<String, Value>) -> bool {
+    ["tenant", "tenant_id", "tenantId"]
+        .iter()
+        .any(|key| object.contains_key(*key))
+}
+
+fn contains_secret_material(value: &Value) -> bool {
+    match value {
+        Value::Object(object) => object.iter().any(|(key, value)| {
+            matches!(
+                key.to_ascii_lowercase().as_str(),
+                "authorization"
+                    | "access_token"
+                    | "refresh_token"
+                    | "api_key"
+                    | "client_secret"
+                    | "password"
+                    | "private_key"
+                    | "session_cookie"
+            ) || contains_secret_material(value)
+        }),
+        Value::Array(values) => values.iter().any(contains_secret_material),
+        _ => false,
+    }
+}

--- a/crates/source-runtime-next/src/anthropic/request.rs
+++ b/crates/source-runtime-next/src/anthropic/request.rs
@@ -1,0 +1,266 @@
+use std::net::IpAddr;
+
+use reqwest::Url;
+
+use super::{
+    AnthropicError, AnthropicKernel, AnthropicRequest, AnthropicScope, family::PaginationKind,
+};
+
+pub(super) const MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+pub(super) const MAX_RECORDS: usize = 1_000;
+const DEFAULT_PAGE_SIZE: usize = 100;
+const MAX_CURSOR_BYTES: usize = 4_096;
+const MAX_TENANT_BYTES: usize = 256;
+
+impl AnthropicRequest {
+    /// Return the provider method for this read-only operation.
+    pub const fn method(&self) -> &'static str {
+        "GET"
+    }
+
+    /// Return the exact provider URL for trusted-host authorization and I/O.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Return the required credential capability without credential material.
+    pub const fn authentication(&self) -> super::AnthropicAuthentication {
+        self.authentication
+    }
+
+    /// Return the static provider API-version header.
+    pub const fn api_version_header(&self) -> (&'static str, &'static str) {
+        ("anthropic-version", "2023-06-01")
+    }
+
+    /// The portable request never contains resolved credential bytes.
+    pub const fn contains_credentials(&self) -> bool {
+        false
+    }
+
+    /// Redirects are denied so authentication cannot leave the compiled origin.
+    pub const fn allows_redirects(&self) -> bool {
+        false
+    }
+
+    /// Return the response byte bound the host must enforce before decode.
+    pub const fn max_response_bytes(&self) -> usize {
+        MAX_RESPONSE_BYTES
+    }
+}
+
+impl AnthropicKernel {
+    /// Compile one family into a closed, credential-free runtime definition.
+    pub fn new(
+        base_url: &str,
+        tenant_id: &str,
+        family: super::AnthropicFamily,
+        scope: AnthropicScope,
+        page_size: Option<usize>,
+    ) -> Result<Self, AnthropicError> {
+        let base_url = validate_base_url(base_url)?;
+        let tenant_id = validate_tenant(tenant_id)?;
+        let page_size = page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+        if !(1..=MAX_RECORDS).contains(&page_size) {
+            return Err(AnthropicError::InvalidPageSize);
+        }
+        validate_scope(family, &scope)?;
+        Ok(Self {
+            base_url,
+            tenant_id,
+            family,
+            scope,
+            page_size,
+        })
+    }
+
+    /// Plan one origin-restricted provider request from a prior checkpoint.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<AnthropicRequest, AnthropicError> {
+        let cursor = validate_cursor(self.family.pagination(), cursor)?;
+        let mut path = self.family.path().to_owned();
+        for name in self.family.path_parameters() {
+            let value = self
+                .scope
+                .path_parameters
+                .get(*name)
+                .ok_or(AnthropicError::MissingPathParameter)?;
+            path = path.replace(&format!("{{{name}}}"), &encode_path_segment(value));
+        }
+        let mut url = self.base_url.clone();
+        let full_path = format!("{}{}", self.base_url.path().trim_end_matches('/'), path);
+        url.set_path(&full_path);
+        url.set_query(None);
+        {
+            let mut query = url.query_pairs_mut();
+            for (provider_name, scope_name) in self.family.query_parameters() {
+                if let Some(value) = self.scope.query_parameters.get(*scope_name) {
+                    if provider_name.ends_with("[]") {
+                        for part in value
+                            .split(',')
+                            .map(str::trim)
+                            .filter(|part| !part.is_empty())
+                        {
+                            query.append_pair(provider_name, part);
+                        }
+                    } else {
+                        query.append_pair(provider_name, value);
+                    }
+                }
+            }
+            match self.family.pagination() {
+                PaginationKind::None => {}
+                PaginationKind::AfterId => {
+                    query.append_pair("limit", &self.page_size.to_string());
+                    if let Some(cursor) = cursor.as_deref() {
+                        query.append_pair("after_id", cursor);
+                    }
+                }
+                PaginationKind::Page => {
+                    query.append_pair("limit", &self.page_size.to_string());
+                    if let Some(cursor) = cursor.as_deref() {
+                        query.append_pair("page", cursor);
+                    }
+                }
+            }
+        }
+        Ok(AnthropicRequest {
+            url,
+            operation_path: path,
+            family: self.family,
+            cursor,
+            authentication: self.family.authentication(),
+        })
+    }
+}
+
+fn validate_base_url(value: &str) -> Result<Url, AnthropicError> {
+    let mut url = Url::parse(value.trim()).map_err(|_| AnthropicError::InvalidBaseUrl)?;
+    if url.scheme() != "https"
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port_or_known_default() != Some(443)
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(AnthropicError::InvalidBaseUrl);
+    }
+    let host = url.host_str().ok_or(AnthropicError::InvalidBaseUrl)?;
+    let host = host.trim_end_matches('.').to_ascii_lowercase();
+    if host == "localhost"
+        || host.ends_with(".localhost")
+        || host.ends_with(".local")
+        || !host.contains('.')
+        || host.parse::<IpAddr>().is_ok_and(unsafe_address)
+    {
+        return Err(AnthropicError::InvalidBaseUrl);
+    }
+    let path = url.path().trim_end_matches('/').to_owned();
+    url.set_path(if path.is_empty() { "/" } else { &path });
+    Ok(url)
+}
+
+fn unsafe_address(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => {
+            let octets = address.octets();
+            address.is_private()
+                || address.is_loopback()
+                || address.is_link_local()
+                || address.is_multicast()
+                || address.is_unspecified()
+                || (octets[0] == 100 && (64..=127).contains(&octets[1]))
+                || (octets[0] == 192 && octets[1] == 0 && octets[2] == 2)
+                || (octets[0] == 198 && octets[1] == 51 && octets[2] == 100)
+                || (octets[0] == 203 && octets[1] == 0 && octets[2] == 113)
+        }
+        IpAddr::V6(address) => {
+            let segments = address.segments();
+            address.is_loopback()
+                || address.is_multicast()
+                || address.is_unspecified()
+                || address.is_unique_local()
+                || address.is_unicast_link_local()
+                || (segments[0] == 0x2001 && segments[1] == 0x0db8)
+        }
+    }
+}
+
+fn validate_tenant(value: &str) -> Result<String, AnthropicError> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > MAX_TENANT_BYTES || value.chars().any(char::is_control) {
+        return Err(AnthropicError::MissingTenantId);
+    }
+    Ok(value.to_owned())
+}
+
+fn validate_scope(
+    family: super::AnthropicFamily,
+    scope: &AnthropicScope,
+) -> Result<(), AnthropicError> {
+    for required in family.path_parameters() {
+        let value = scope
+            .path_parameters
+            .get(*required)
+            .ok_or(AnthropicError::MissingPathParameter)?;
+        validate_parameter(value)?;
+    }
+    if scope.path_parameters.keys().any(|key| {
+        !family
+            .path_parameters()
+            .iter()
+            .any(|declared| declared == key)
+    }) || scope.query_parameters.keys().any(|key| {
+        !family
+            .query_parameters()
+            .iter()
+            .any(|(_, declared)| declared == key)
+    }) {
+        return Err(AnthropicError::InvalidParameter);
+    }
+    for value in scope.query_parameters.values() {
+        validate_parameter(value)?;
+    }
+    Ok(())
+}
+
+fn validate_parameter(value: &str) -> Result<(), AnthropicError> {
+    if value.is_empty()
+        || value.len() > 4_096
+        || value.trim() != value
+        || value.chars().any(char::is_control)
+    {
+        return Err(AnthropicError::InvalidParameter);
+    }
+    Ok(())
+}
+
+fn encode_path_segment(value: &str) -> String {
+    value
+        .as_bytes()
+        .iter()
+        .map(|byte| match *byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                char::from(*byte).to_string()
+            }
+            other => format!("%{other:02X}"),
+        })
+        .collect()
+}
+
+fn validate_cursor(
+    pagination: PaginationKind,
+    value: Option<&str>,
+) -> Result<Option<String>, AnthropicError> {
+    let Some(value) = value else { return Ok(None) };
+    let value = value.trim();
+    if pagination == PaginationKind::None
+        || value.is_empty()
+        || value.len() > MAX_CURSOR_BYTES
+        || value.chars().any(char::is_control)
+        || value.contains("://")
+    {
+        return Err(AnthropicError::InvalidCursor);
+    }
+    Ok(Some(value.to_owned()))
+}

--- a/crates/source-runtime-next/src/anthropic/response.rs
+++ b/crates/source-runtime-next/src/anthropic/response.rs
@@ -1,0 +1,189 @@
+use std::collections::BTreeMap;
+
+use reqwest::Url;
+use serde_json::Value;
+
+use super::{
+    AnthropicError, AnthropicKernel, AnthropicPage, AnthropicRequest,
+    family::PaginationKind,
+    normalize::normalize_record,
+    request::{MAX_RECORDS, MAX_RESPONSE_BYTES},
+};
+
+impl AnthropicKernel {
+    /// Classify a provider status and decode a bounded response body.
+    pub fn decode_http(
+        &self,
+        request: &AnthropicRequest,
+        status: u16,
+        body: &[u8],
+        observed_at: &str,
+    ) -> Result<AnthropicPage, AnthropicError> {
+        if body.len() > MAX_RESPONSE_BYTES {
+            return Err(AnthropicError::ResponseTooLarge);
+        }
+        if request.family != self.family || request != &self.plan(request.cursor.as_deref())? {
+            return Err(AnthropicError::RequestScopeMismatch);
+        }
+        match status {
+            200 => self.decode_success(request, body, observed_at),
+            401 => Err(AnthropicError::AuthenticationRejected),
+            403 => Err(AnthropicError::RequiredProviderScopeMissing),
+            429 => Err(AnthropicError::ProviderRateLimit),
+            500..=599 => Err(AnthropicError::ProviderUnavailable),
+            _ => Err(AnthropicError::UnexpectedProviderStatus),
+        }
+    }
+
+    /// Decode a successful provider response for a request planned by this kernel.
+    pub fn decode(
+        &self,
+        request: &AnthropicRequest,
+        body: &[u8],
+        observed_at: &str,
+    ) -> Result<AnthropicPage, AnthropicError> {
+        self.decode_http(request, 200, body, observed_at)
+    }
+
+    fn decode_success(
+        &self,
+        request: &AnthropicRequest,
+        body: &[u8],
+        observed_at: &str,
+    ) -> Result<AnthropicPage, AnthropicError> {
+        let response: Value =
+            serde_json::from_slice(body).map_err(|_| AnthropicError::MalformedResponse)?;
+        let payloads = records(self.family, &response)?;
+        if payloads.len() > self.page_size || payloads.len() > MAX_RECORDS {
+            return Err(AnthropicError::ResponseTooLarge);
+        }
+        let mut seen = BTreeMap::<String, Value>::new();
+        let mut normalized = Vec::with_capacity(payloads.len());
+        for payload in payloads {
+            let record = normalize_record(
+                self.family,
+                &self.tenant_id,
+                self.base_url.as_str().trim_end_matches('/'),
+                &request.operation_path,
+                &self.scope.path_parameters,
+                observed_at,
+                payload,
+            )?;
+            match seen.get(&record.provider_id) {
+                Some(existing) if existing == &record.payload => continue,
+                Some(_) => return Err(AnthropicError::DuplicateConflict),
+                None => {
+                    seen.insert(record.provider_id.clone(), record.payload.clone());
+                    normalized.push(record);
+                }
+            }
+        }
+        let next_cursor = continuation(self, &response)?;
+        let checkpoint_cursor = normalized.last().map(|record| {
+            next_cursor
+                .clone()
+                .unwrap_or_else(|| record.provider_id.clone())
+        });
+        let watermark = normalized.last().map(|record| record.occurred_at.clone());
+        Ok(AnthropicPage {
+            records: normalized,
+            next_cursor,
+            checkpoint_cursor,
+            watermark,
+        })
+    }
+}
+
+fn records(family: super::AnthropicFamily, response: &Value) -> Result<Vec<Value>, AnthropicError> {
+    if let Some(records) = response.as_array() {
+        return Ok(records.clone());
+    }
+    let object = response
+        .as_object()
+        .ok_or(AnthropicError::MalformedResponse)?;
+    if family.singleton() {
+        for key in ["data", "result", "item", "record"] {
+            if let Some(value) = object.get(key).filter(|value| value.is_object()) {
+                return Ok(vec![value.clone()]);
+            }
+        }
+        return Ok(vec![response.clone()]);
+    }
+    let compact = family.as_str().replace('_', "");
+    let mut keys = family.list_keys().to_vec();
+    keys.extend(["data", "items", "results", "records", family.as_str()]);
+    let plural = format!("{}s", family.as_str());
+    let compact_plural = format!("{compact}s");
+    for key in keys
+        .into_iter()
+        .map(str::to_owned)
+        .chain([plural, compact, compact_plural])
+    {
+        if let Some(values) = object.get(&key).and_then(Value::as_array) {
+            return Ok(values.clone());
+        }
+    }
+    Err(AnthropicError::MalformedResponse)
+}
+
+fn continuation(
+    kernel: &AnthropicKernel,
+    response: &Value,
+) -> Result<Option<String>, AnthropicError> {
+    if kernel.family.pagination() == PaginationKind::None {
+        return Ok(None);
+    }
+    let Some(object) = response.as_object() else {
+        return Ok(None);
+    };
+    if object.get("has_more").and_then(Value::as_bool) == Some(false) {
+        return Ok(None);
+    }
+    let raw = ["last_id", "next_page", "next_cursor", "cursor"]
+        .iter()
+        .find_map(|key| object.get(*key).and_then(scalar_string))
+        .or_else(|| {
+            ["pagination", "page", "meta"]
+                .iter()
+                .filter_map(|key| object.get(*key).and_then(Value::as_object))
+                .find_map(|nested| {
+                    ["last_id", "next_page", "next_cursor", "cursor", "next"]
+                        .iter()
+                        .find_map(|key| nested.get(*key).and_then(scalar_string))
+                })
+        });
+    raw.map(|value| normalize_continuation(kernel, &value))
+        .transpose()
+}
+
+fn normalize_continuation(kernel: &AnthropicKernel, raw: &str) -> Result<String, AnthropicError> {
+    let raw = raw.trim();
+    if raw.is_empty() || raw.len() > 4_096 || raw.chars().any(char::is_control) {
+        return Err(AnthropicError::InvalidCursor);
+    }
+    let cursor = if let Ok(url) = Url::parse(raw) {
+        if url.origin() != kernel.base_url.origin() {
+            return Err(AnthropicError::InvalidCursor);
+        }
+        let key = match kernel.family.pagination() {
+            PaginationKind::Page => "page",
+            PaginationKind::AfterId => "after_id",
+            PaginationKind::None => return Err(AnthropicError::InvalidCursor),
+        };
+        url.query_pairs()
+            .find_map(|(name, value)| (name == key).then(|| value.into_owned()))
+            .ok_or(AnthropicError::InvalidCursor)?
+    } else {
+        raw.to_owned()
+    };
+    kernel.plan(Some(&cursor))?;
+    Ok(cursor)
+}
+
+fn scalar_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) if !value.trim().is_empty() => Some(value.trim().to_owned()),
+        Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}

--- a/crates/source-runtime-next/src/anthropic/tests.rs
+++ b/crates/source-runtime-next/src/anthropic/tests.rs
@@ -1,0 +1,358 @@
+use std::{collections::BTreeMap, fs, path::PathBuf};
+
+use serde_json::{Value, json};
+
+use super::{
+    AnthropicAuthentication, AnthropicError, AnthropicFamily, AnthropicKernel, AnthropicScope,
+};
+
+const BASE_URL: &str = "https://api.anthropic.com/v1";
+const OBSERVED_AT: &str = "2026-06-01T00:00:00Z";
+
+#[test]
+fn all_go_oracle_fixtures_have_semantic_event_parity() {
+    assert_eq!(AnthropicFamily::ALL.len(), 28);
+    for family in AnthropicFamily::ALL {
+        let expected = fixture(family);
+        let event = expected
+            .as_array()
+            .and_then(|events| events.first())
+            .expect("one Go oracle event");
+        let payload = event.get("payload").cloned().expect("fixture payload");
+        let attributes = event
+            .get("attributes")
+            .and_then(Value::as_object)
+            .expect("fixture attributes");
+        let scope = scope_from_fixture(family, attributes);
+        let kernel = AnthropicKernel::new(BASE_URL, "tenant", family, scope, None).unwrap();
+        let request = kernel.plan(None).unwrap();
+        let response = if family.singleton() {
+            payload.clone()
+        } else if family.list_keys().contains(&"settings") {
+            json!({"settings": [payload.clone()]})
+        } else {
+            json!({"data": [payload.clone()], "has_more": false})
+        };
+        let page = kernel
+            .decode(
+                &request,
+                &serde_json::to_vec(&response).unwrap(),
+                event.get("occurred_at").and_then(Value::as_str).unwrap(),
+            )
+            .unwrap_or_else(|error| panic!("{} fixture failed: {error}", family.as_str()));
+        assert_eq!(page.records.len(), 1, "{} count", family.as_str());
+        let actual = &page.records[0];
+        assert_eq!(actual.tenant_id, "tenant", "{} tenant", family.as_str());
+        assert_eq!(actual.payload, payload, "{} payload", family.as_str());
+        assert_eq!(
+            actual.provider_kind,
+            event.get("kind").and_then(Value::as_str).unwrap(),
+            "{} kind",
+            family.as_str()
+        );
+        assert_eq!(
+            actual.schema_ref,
+            event.get("schema_ref").and_then(Value::as_str).unwrap(),
+            "{} schema",
+            family.as_str()
+        );
+        let expected_timestamp = family
+            .timestamp_paths()
+            .iter()
+            .find_map(|path| value_at(&payload, path).and_then(Value::as_str))
+            .unwrap_or_else(|| event.get("occurred_at").and_then(Value::as_str).unwrap());
+        assert_eq!(
+            actual.occurred_at,
+            expected_timestamp,
+            "{} timestamp",
+            family.as_str()
+        );
+        for (key, value) in attributes {
+            assert_eq!(
+                actual.fields.get(key).map(String::as_str),
+                value.as_str(),
+                "{} attribute {key}",
+                family.as_str()
+            );
+        }
+        assert_eq!(
+            page.checkpoint_cursor.as_deref(),
+            Some(actual.provider_id.as_str()),
+            "{} checkpoint",
+            family.as_str()
+        );
+        assert_eq!(page.watermark.as_deref(), Some(actual.occurred_at.as_str()));
+    }
+}
+
+#[test]
+fn every_family_is_in_the_go_catalog_and_projection_oracle() {
+    let root = repository_root();
+    let catalog = fs::read_to_string(root.join("sources/anthropic/catalog.yaml")).unwrap();
+    let projection =
+        fs::read_to_string(root.join("internal/sourceprojection/registry.go")).unwrap();
+    for family in AnthropicFamily::ALL {
+        assert!(
+            catalog.contains(&format!("kind: anthropic.{}", family.as_str())),
+            "missing catalog event {}",
+            family.as_str()
+        );
+        assert!(
+            projection.contains(&format!("\"anthropic.{}\"", family.as_str())),
+            "missing projection {}",
+            family.as_str()
+        );
+    }
+}
+
+#[test]
+fn requests_are_bounded_origin_restricted_and_credential_free() {
+    for family in AnthropicFamily::ALL {
+        let scope = family
+            .path_parameters()
+            .iter()
+            .map(|key| ((*key).to_owned(), "scope_123".to_owned()))
+            .collect();
+        let kernel = AnthropicKernel::new(
+            BASE_URL,
+            "tenant-a",
+            family,
+            AnthropicScope {
+                path_parameters: scope,
+                query_parameters: BTreeMap::new(),
+            },
+            Some(100),
+        )
+        .unwrap();
+        let request = kernel.plan(None).unwrap();
+        assert_eq!(request.method(), "GET");
+        assert_eq!(
+            request.url().origin(),
+            reqwest::Url::parse(BASE_URL).unwrap().origin()
+        );
+        assert!(request.url().path().starts_with("/v1/"));
+        assert!(!request.contains_credentials());
+        assert!(!request.allows_redirects());
+        assert_eq!(request.max_response_bytes(), 8 * 1024 * 1024);
+        assert_eq!(
+            request.api_version_header(),
+            ("anthropic-version", "2023-06-01")
+        );
+        assert_eq!(request.authentication(), family.authentication());
+        assert!(!format!("{request:?}").contains("test-secret-value"));
+    }
+    assert_eq!(
+        AnthropicFamily::ServiceAccount.authentication(),
+        AnthropicAuthentication::OrgAdminBearer
+    );
+    assert_eq!(
+        AnthropicFamily::ComplianceActivity.authentication(),
+        AnthropicAuthentication::ComplianceAccessKey
+    );
+
+    let encoded = AnthropicKernel::new(
+        BASE_URL,
+        "tenant",
+        AnthropicFamily::ComplianceGroupMember,
+        AnthropicScope {
+            path_parameters: BTreeMap::from([("group_id".to_owned(), "group/../other".to_owned())]),
+            query_parameters: BTreeMap::new(),
+        },
+        None,
+    )
+    .unwrap()
+    .plan(None)
+    .unwrap();
+    assert!(encoded.url().as_str().contains("group%2F..%2Fother"));
+    assert_eq!(
+        encoded.url().origin(),
+        reqwest::Url::parse(BASE_URL).unwrap().origin()
+    );
+}
+
+#[test]
+fn cursor_checkpoint_and_duplicate_rules_fail_closed() {
+    let kernel = AnthropicKernel::new(
+        BASE_URL,
+        "tenant",
+        AnthropicFamily::User,
+        AnthropicScope::default(),
+        Some(10),
+    )
+    .unwrap();
+    let first = kernel.plan(None).unwrap();
+    let payload = json!({"id":"user_1","name":"Ada","added_at":OBSERVED_AT});
+    let page = kernel
+        .decode(
+            &first,
+            &serde_json::to_vec(&json!({
+                "data":[payload.clone(), payload.clone()],
+                "has_more":true,
+                "last_id":"user_1"
+            }))
+            .unwrap(),
+            OBSERVED_AT,
+        )
+        .unwrap();
+    assert_eq!(page.records.len(), 1);
+    assert_eq!(page.next_cursor.as_deref(), Some("user_1"));
+    assert_eq!(page.checkpoint_cursor.as_deref(), Some("user_1"));
+    assert!(
+        kernel
+            .plan(page.next_cursor.as_deref())
+            .unwrap()
+            .url()
+            .query()
+            .unwrap()
+            .contains("after_id=user_1")
+    );
+
+    let conflict = json!({"data":[payload, {"id":"user_1","name":"Grace"}]});
+    assert_eq!(
+        kernel.decode(&first, &serde_json::to_vec(&conflict).unwrap(), OBSERVED_AT),
+        Err(AnthropicError::DuplicateConflict)
+    );
+
+    let page_kernel = AnthropicKernel::new(
+        BASE_URL,
+        "tenant",
+        AnthropicFamily::CostReport,
+        AnthropicScope::default(),
+        Some(10),
+    )
+    .unwrap();
+    let request = page_kernel.plan(None).unwrap();
+    let response = json!({"data":[], "next_page":"https://api.anthropic.com/v1/organizations/cost_report?page=page-2"});
+    let page = page_kernel
+        .decode(
+            &request,
+            &serde_json::to_vec(&response).unwrap(),
+            OBSERVED_AT,
+        )
+        .unwrap();
+    assert_eq!(page.next_cursor.as_deref(), Some("page-2"));
+    assert!(
+        page_kernel
+            .plan(page.next_cursor.as_deref())
+            .unwrap()
+            .url()
+            .query()
+            .unwrap()
+            .contains("page=page-2")
+    );
+    assert_eq!(page.checkpoint_cursor, None);
+    let escaped = json!({"data":[], "next_page":"https://example.com/?page=2"});
+    assert_eq!(
+        page_kernel.decode(
+            &request,
+            &serde_json::to_vec(&escaped).unwrap(),
+            OBSERVED_AT
+        ),
+        Err(AnthropicError::InvalidCursor)
+    );
+}
+
+#[test]
+fn provider_failures_and_secret_or_tenant_payloads_stay_typed() {
+    let kernel = AnthropicKernel::new(
+        BASE_URL,
+        "trusted-tenant",
+        AnthropicFamily::User,
+        AnthropicScope::default(),
+        None,
+    )
+    .unwrap();
+    let request = kernel.plan(None).unwrap();
+    for (status, expected) in [
+        (401, AnthropicError::AuthenticationRejected),
+        (403, AnthropicError::RequiredProviderScopeMissing),
+        (429, AnthropicError::ProviderRateLimit),
+        (503, AnthropicError::ProviderUnavailable),
+        (418, AnthropicError::UnexpectedProviderStatus),
+    ] {
+        assert_eq!(
+            kernel.decode_http(&request, status, b"{}", OBSERVED_AT),
+            Err(expected)
+        );
+    }
+    for record in [
+        json!({"id":"user_1","tenant_id":"attacker"}),
+        json!({"id":"user_1","access_token":"test-secret-value"}),
+    ] {
+        let result = kernel.decode(
+            &request,
+            &serde_json::to_vec(&json!({"data":[record]})).unwrap(),
+            OBSERVED_AT,
+        );
+        assert_eq!(result, Err(AnthropicError::InvalidRecord));
+        assert!(!format!("{result:?}").contains("test-secret-value"));
+    }
+}
+
+#[test]
+fn identities_are_deterministic_and_tenant_scoped() {
+    let body = serde_json::to_vec(&json!({
+        "data":[{"id":"user_1","added_at":OBSERVED_AT}], "has_more":false
+    }))
+    .unwrap();
+    let event_id = |tenant: &str| {
+        let kernel = AnthropicKernel::new(
+            BASE_URL,
+            tenant,
+            AnthropicFamily::User,
+            AnthropicScope::default(),
+            None,
+        )
+        .unwrap();
+        let request = kernel.plan(None).unwrap();
+        kernel.decode(&request, &body, OBSERVED_AT).unwrap().records[0]
+            .event_id
+            .clone()
+    };
+    assert_eq!(event_id("tenant-a"), event_id("tenant-a"));
+    assert_ne!(event_id("tenant-a"), event_id("tenant-b"));
+}
+
+fn fixture(family: AnthropicFamily) -> Value {
+    let path = repository_root().join(format!(
+        "sources/anthropic/testdata/read_{}.json",
+        family.as_str()
+    ));
+    serde_json::from_slice(&fs::read(path).unwrap()).unwrap()
+}
+
+fn scope_from_fixture(
+    family: AnthropicFamily,
+    attributes: &serde_json::Map<String, Value>,
+) -> AnthropicScope {
+    let path_parameters = family
+        .path_parameters()
+        .iter()
+        .map(|name| {
+            (
+                (*name).to_owned(),
+                attributes
+                    .get(*name)
+                    .and_then(Value::as_str)
+                    .unwrap_or_else(|| panic!("fixture missing path parameter {name}"))
+                    .to_owned(),
+            )
+        })
+        .collect();
+    AnthropicScope {
+        path_parameters,
+        query_parameters: BTreeMap::new(),
+    }
+}
+
+fn repository_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn value_at<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    let mut value = value;
+    for part in path.split('.') {
+        value = value.as_object()?.get(part)?;
+    }
+    Some(value)
+}

--- a/crates/source-runtime-next/src/anthropic/types.rs
+++ b/crates/source-runtime-next/src/anthropic/types.rs
@@ -1,0 +1,69 @@
+use std::collections::BTreeMap;
+
+use reqwest::Url;
+use serde_json::Value;
+
+use super::{AnthropicAuthentication, AnthropicFamily};
+
+/// Provider selectors and required path identifiers for one bounded operation.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AnthropicScope {
+    /// Values substituted into declared provider path parameters.
+    pub path_parameters: BTreeMap<String, String>,
+    /// Values copied into declared provider query parameters.
+    pub query_parameters: BTreeMap<String, String>,
+}
+
+/// One credential-free Anthropic GET operation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AnthropicRequest {
+    pub(super) url: Url,
+    pub(super) operation_path: String,
+    pub(super) family: AnthropicFamily,
+    pub(super) cursor: Option<String>,
+    pub(super) authentication: AnthropicAuthentication,
+}
+
+/// One normalized, tenant-scoped Anthropic event.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AnthropicRecord {
+    /// Tenant from the authenticated runtime context, never the provider payload.
+    pub tenant_id: String,
+    /// Go-compatible deterministic event identity.
+    pub event_id: String,
+    /// Provider-owned stable identity selected by the family contract.
+    pub provider_id: String,
+    /// Exact emitted event kind.
+    pub provider_kind: String,
+    /// Exact admitted event schema.
+    pub schema_ref: String,
+    /// Canonical scalar attributes admitted by the source contract.
+    pub fields: BTreeMap<String, String>,
+    /// Canonical provider payload with trusted path scope injected.
+    pub payload: Value,
+    /// Provider timestamp, or the trusted observation time when absent.
+    pub occurred_at: String,
+}
+
+/// One bounded Anthropic provider page.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AnthropicPage {
+    /// Normalized records in provider order after exact duplicate collapse.
+    pub records: Vec<AnthropicRecord>,
+    /// Validated provider continuation to plan the next request.
+    pub next_cursor: Option<String>,
+    /// Cursor eligible for durable persistence after append and projection commit.
+    pub checkpoint_cursor: Option<String>,
+    /// Last accepted occurrence time for restart and parity receipts.
+    pub watermark: Option<String>,
+}
+
+/// Provider-specific credential-free request and response kernel.
+#[derive(Clone, Debug)]
+pub struct AnthropicKernel {
+    pub(super) base_url: Url,
+    pub(super) tenant_id: String,
+    pub(super) family: AnthropicFamily,
+    pub(super) scope: AnthropicScope,
+    pub(super) page_size: usize,
+}

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -4,6 +4,7 @@
 //! Rust-native source collection and graph admission boundary.
 
 mod amplitude;
+mod anthropic;
 mod append_log;
 mod archetype;
 mod aurelius;
@@ -40,6 +41,10 @@ mod vulnview;
 pub use amplitude::{
     AmplitudeError, AmplitudeFamily, AmplitudeKernel, AmplitudePage, AmplitudeRecord,
     AmplitudeRequest,
+};
+pub use anthropic::{
+    AnthropicAuthentication, AnthropicError, AnthropicFamily, AnthropicKernel, AnthropicPage,
+    AnthropicRecord, AnthropicRequest, AnthropicScope,
 };
 pub use append_log::{AppendLogDecodeError, CommittedSourceEvent, CommittedSourceInput};
 pub use archetype::{


### PR DESCRIPTION
## Scope

- compile all 28 checked-in Anthropic Admin and Compliance API families into one closed Rust runtime contract
- plan bounded same-origin GET requests without credential values, with explicit Admin, org-admin bearer, and Compliance access capabilities
- validate response envelopes, normalize exact event kinds and schemas, preserve deterministic tenant-scoped identities, reject conflicting duplicates, and validate opaque checkpoints
- retain Go fixture and projection oracles for semantic parity

## Local evidence

- `cargo fmt --all -- --check`
- `cargo test -p cerebro-source-runtime-next anthropic:: --lib` (6 passed)
- `cargo test -p cerebro-source-runtime-next --lib` (366 passed)
- `cargo test --locked -p cerebro-platform -p cerebro-source-catalog -p cerebro-source-runtime-next` (terminal success)
- `cargo clippy --locked -p cerebro-platform -p cerebro-source-catalog -p cerebro-source-runtime-next --all-targets --all-features -- -D warnings`
- `go test ./sources/anthropic ./internal/sourceprojection ./internal/sourceregistry -count=1`
- `./scripts/leak_check.sh staged`

Catalog, fixture, structural, and architecture gates are still running and will be reported separately.

## Authority boundary

This is the provider-local credential-free kernel. The trusted host continues to own credential resolution, authentication, egress, redirects, deadlines, response buffering, durable append/projection/checkpoint ordering, and lease fencing. The existing Go Anthropic loader remains authoritative until shared host wiring, configured parity-retirement evidence, and repository promotion gates pass. This draft does not claim live-provider, deployment, or product-path proof.