### PR TITLE
feat(source-runtime): add PagerDuty provider kernel

### DIFF
--- a/crates/source-runtime-next/src/pagerduty/cursor.rs
+++ b/crates/source-runtime-next/src/pagerduty/cursor.rs
@@ -1,0 +1,133 @@
+//! Go-compatible PagerDuty offset and integration fan-out continuations.
+
+use serde::{Deserialize, Serialize};
+
+use super::{PagerDutyError, PagerDutyFamily};
+
+const MAX_CURSOR_BYTES: usize = 4_096;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) struct CursorState {
+    pub(super) service_index: usize,
+    pub(super) offset: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CursorEnvelope {
+    #[serde(default)]
+    version: u8,
+    #[serde(default)]
+    source: String,
+    #[serde(default)]
+    family: String,
+    #[serde(default)]
+    mode: String,
+    #[serde(default)]
+    token: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct FanoutCursor {
+    index: usize,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    cursor: String,
+}
+
+#[derive(Serialize)]
+struct EncodedEnvelope<'a> {
+    version: u8,
+    source: &'a str,
+    mode: &'a str,
+    token: String,
+}
+
+pub(super) fn parse_cursor(
+    family: PagerDutyFamily,
+    service_count: usize,
+    raw: Option<&str>,
+) -> Result<CursorState, PagerDutyError> {
+    let raw = raw.map(str::trim).filter(|value| !value.is_empty());
+    let Some(raw) = raw else {
+        return Ok(CursorState::default());
+    };
+    validate_cursor_text(raw)?;
+    if !raw.starts_with('{') {
+        return Ok(CursorState {
+            offset: Some(parse_offset(raw)?),
+            ..CursorState::default()
+        });
+    }
+    let envelope: CursorEnvelope =
+        serde_json::from_str(raw).map_err(|_| PagerDutyError::InvalidCursor)?;
+    if !matches!(envelope.version, 0 | 1)
+        || (!envelope.source.is_empty() && envelope.source != "pagerduty")
+        || (!envelope.family.is_empty() && envelope.family != family.as_str())
+    {
+        return Err(PagerDutyError::InvalidCursor);
+    }
+    if family != PagerDutyFamily::Integration {
+        if !envelope.mode.is_empty() || envelope.token.is_empty() {
+            return Err(PagerDutyError::InvalidCursor);
+        }
+        return Ok(CursorState {
+            offset: Some(parse_offset(&envelope.token)?),
+            ..CursorState::default()
+        });
+    }
+    if envelope.mode != "fanout_path_param" || envelope.token.is_empty() {
+        return Err(PagerDutyError::InvalidCursor);
+    }
+    let inner: FanoutCursor =
+        serde_json::from_str(&envelope.token).map_err(|_| PagerDutyError::InvalidCursor)?;
+    if inner.index >= service_count {
+        return Err(PagerDutyError::InvalidCursor);
+    }
+    Ok(CursorState {
+        service_index: inner.index,
+        offset: (!inner.cursor.is_empty())
+            .then(|| parse_offset(&inner.cursor))
+            .transpose()?,
+    })
+}
+
+pub(super) fn encode_fanout_cursor(
+    service_index: usize,
+    offset: Option<u64>,
+) -> Result<String, PagerDutyError> {
+    let inner = serde_json::to_string(&FanoutCursor {
+        index: service_index,
+        cursor: offset.map(|value| value.to_string()).unwrap_or_default(),
+    })
+    .map_err(|_| PagerDutyError::InvalidCursor)?;
+    let encoded = serde_json::to_string(&EncodedEnvelope {
+        version: 1,
+        source: "pagerduty",
+        mode: "fanout_path_param",
+        token: inner,
+    })
+    .map_err(|_| PagerDutyError::InvalidCursor)?;
+    validate_cursor_text(&encoded)?;
+    Ok(encoded)
+}
+
+fn parse_offset(raw: &str) -> Result<u64, PagerDutyError> {
+    if raw.is_empty()
+        || raw.starts_with('+')
+        || raw.starts_with('-')
+        || !raw.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return Err(PagerDutyError::InvalidCursor);
+    }
+    raw.parse().map_err(|_| PagerDutyError::InvalidCursor)
+}
+
+fn validate_cursor_text(raw: &str) -> Result<(), PagerDutyError> {
+    if raw.len() > MAX_CURSOR_BYTES
+        || raw.chars().any(char::is_control)
+        || raw.starts_with("http://")
+        || raw.starts_with("https://")
+    {
+        return Err(PagerDutyError::InvalidCursor);
+    }
+    Ok(())
+}

--- a/crates/source-runtime-next/src/pagerduty/error.rs
+++ b/crates/source-runtime-next/src/pagerduty/error.rs
@@ -1,0 +1,77 @@
+//! Stable fail-closed PagerDuty kernel errors.
+
+use std::{error::Error, fmt};
+
+/// Typed PagerDuty request, response, identity, and provider failures.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PagerDutyError {
+    /// The configured API origin is not an allowlisted PagerDuty HTTPS origin.
+    InvalidBaseUrl,
+    /// The selected family is not in the closed PagerDuty definition.
+    InvalidFamily,
+    /// Source tenant identity is missing or malformed.
+    MissingTenantId,
+    /// The integration family has no bounded service scope.
+    MissingServiceId,
+    /// A service identifier is unsafe or ambiguous in a request path.
+    InvalidServiceId,
+    /// Page size is outside PagerDuty's inclusive 1 through 100 bound.
+    InvalidPageSize,
+    /// Continuation state is malformed, unsafe, or belongs to another scope.
+    InvalidCursor,
+    /// A request does not belong to the kernel that is decoding it.
+    RequestScopeMismatch,
+    /// PagerDuty rejected the configured credential.
+    AuthenticationRejected,
+    /// The credential lacks permission for the selected family.
+    PermissionDenied,
+    /// PagerDuty rate-limited the operation.
+    RateLimited,
+    /// PagerDuty or its network path is temporarily unavailable.
+    ProviderUnavailable,
+    /// PagerDuty returned a status outside the declared contract.
+    UnexpectedProviderStatus,
+    /// The response exceeds the eight-mebibyte kernel boundary.
+    ResponseTooLarge,
+    /// The response exceeds the declared page cardinality.
+    TooManyRecords,
+    /// The response envelope or one of its fields is malformed.
+    MalformedResponse,
+    /// A provider record has no stable PagerDuty identity.
+    MissingProviderIdentity,
+    /// A provider identity contains ambiguous or unsafe characters.
+    InvalidProviderIdentity,
+    /// Duplicate provider identities carried different canonical records.
+    ConflictingProviderIdentity,
+    /// A normalized record failed its exact event contract.
+    EventContractRejected,
+}
+
+impl fmt::Display for PagerDutyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidBaseUrl => "invalid PagerDuty API origin",
+            Self::InvalidFamily => "invalid PagerDuty family",
+            Self::MissingTenantId => "PagerDuty tenant identity is required",
+            Self::MissingServiceId => "PagerDuty integration service scope is required",
+            Self::InvalidServiceId => "invalid PagerDuty service identity",
+            Self::InvalidPageSize => "invalid PagerDuty page size",
+            Self::InvalidCursor => "invalid PagerDuty continuation",
+            Self::RequestScopeMismatch => "PagerDuty request scope mismatch",
+            Self::AuthenticationRejected => "PagerDuty authentication rejected",
+            Self::PermissionDenied => "PagerDuty permission denied",
+            Self::RateLimited => "PagerDuty rate limited",
+            Self::ProviderUnavailable => "PagerDuty provider unavailable",
+            Self::UnexpectedProviderStatus => "unexpected PagerDuty provider status",
+            Self::ResponseTooLarge => "PagerDuty response too large",
+            Self::TooManyRecords => "PagerDuty page contains too many records",
+            Self::MalformedResponse => "malformed PagerDuty response",
+            Self::MissingProviderIdentity => "PagerDuty provider identity is required",
+            Self::InvalidProviderIdentity => "invalid PagerDuty provider identity",
+            Self::ConflictingProviderIdentity => "conflicting PagerDuty provider identity",
+            Self::EventContractRejected => "PagerDuty event contract rejected",
+        })
+    }
+}
+
+impl Error for PagerDutyError {}

--- a/crates/source-runtime-next/src/pagerduty/mod.rs
+++ b/crates/source-runtime-next/src/pagerduty/mod.rs
@@ -1,0 +1,20 @@
+//! Credential-free PagerDuty responder-topology provider kernel.
+
+mod cursor;
+mod error;
+mod model;
+mod normalize;
+mod origin;
+mod projection;
+mod request;
+mod response;
+
+pub use error::PagerDutyError;
+pub use model::{PagerDutyFamily, PagerDutyFilters, PagerDutyPage, PagerDutyPlan, PagerDutyRecord};
+pub use projection::{
+    PagerDutyEntityFact, PagerDutyProjectionFacts, PagerDutyRelationFact, project_pagerduty_records,
+};
+pub use request::{PagerDutyKernel, PagerDutyRequest};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/pagerduty/model.rs
+++ b/crates/source-runtime-next/src/pagerduty/model.rs
@@ -1,0 +1,219 @@
+//! Closed PagerDuty family, plan, record, and page contracts.
+
+use std::{collections::BTreeMap, str::FromStr};
+
+use serde_json::Value;
+
+use super::PagerDutyError;
+
+/// PagerDuty responder-topology families preserved from the Go source oracle.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum PagerDutyFamily {
+    /// PagerDuty responders.
+    User,
+    /// PagerDuty teams.
+    Team,
+    /// PagerDuty incident-routing services.
+    Service,
+    /// PagerDuty responder schedules.
+    Schedule,
+    /// PagerDuty escalation policies.
+    EscalationPolicy,
+    /// PagerDuty service integrations.
+    Integration,
+    /// PagerDuty integration vendors.
+    Vendor,
+}
+
+impl PagerDutyFamily {
+    /// Every family in deterministic catalog order.
+    pub const ALL: [Self; 7] = [
+        Self::User,
+        Self::Team,
+        Self::Service,
+        Self::Schedule,
+        Self::EscalationPolicy,
+        Self::Integration,
+        Self::Vendor,
+    ];
+
+    /// Exact source-family identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Team => "team",
+            Self::Service => "service",
+            Self::Schedule => "schedule",
+            Self::EscalationPolicy => "escalation_policy",
+            Self::Integration => "integration",
+            Self::Vendor => "vendor",
+        }
+    }
+
+    /// Exact provider response-array key.
+    pub const fn response_key(self) -> &'static str {
+        match self {
+            Self::User => "users",
+            Self::Team => "teams",
+            Self::Service => "services",
+            Self::Schedule => "schedules",
+            Self::EscalationPolicy => "escalation_policies",
+            Self::Integration => "integrations",
+            Self::Vendor => "vendors",
+        }
+    }
+
+    /// Exact event kind admitted for this family.
+    pub const fn event_kind(self) -> &'static str {
+        match self {
+            Self::User => "pagerduty.user",
+            Self::Team => "pagerduty.team",
+            Self::Service => "pagerduty.service",
+            Self::Schedule => "pagerduty.schedule",
+            Self::EscalationPolicy => "pagerduty.escalation_policy",
+            Self::Integration => "pagerduty.integration",
+            Self::Vendor => "pagerduty.vendor",
+        }
+    }
+
+    /// Exact source schema admitted for this family.
+    pub const fn schema_ref(self) -> &'static str {
+        match self {
+            Self::User => "pagerduty/user/v1",
+            Self::Team => "pagerduty/team/v1",
+            Self::Service => "pagerduty/service/v1",
+            Self::Schedule => "pagerduty/schedule/v1",
+            Self::EscalationPolicy => "pagerduty/escalation_policy/v1",
+            Self::Integration => "pagerduty/integration/v1",
+            Self::Vendor => "pagerduty/vendor/v1",
+        }
+    }
+
+    /// Tenant-scoped provider-object URN kind used by the Go projector.
+    pub const fn urn_kind(self) -> &'static str {
+        match self {
+            Self::User => "pagerduty_user",
+            Self::Team => "pagerduty_team",
+            Self::Service => "pagerduty_service",
+            Self::Schedule => "pagerduty_schedule",
+            Self::EscalationPolicy => "pagerduty_escalation_policy",
+            Self::Integration => "pagerduty_integration",
+            Self::Vendor => "pagerduty_vendor",
+        }
+    }
+
+    /// Family-specific provider identity attribute required by the event contract.
+    pub const fn identity_attribute(self) -> &'static str {
+        match self {
+            Self::User => "user_id",
+            Self::Team => "team_id",
+            Self::Service => "service_id",
+            Self::Schedule => "schedule_id",
+            Self::EscalationPolicy => "escalation_policy_id",
+            Self::Integration => "integration_id",
+            Self::Vendor => "vendor_id",
+        }
+    }
+
+    /// Closed request path template.
+    pub const fn path_template(self) -> &'static str {
+        match self {
+            Self::User => "/users",
+            Self::Team => "/teams",
+            Self::Service => "/services",
+            Self::Schedule => "/schedules",
+            Self::EscalationPolicy => "/escalation_policies",
+            Self::Integration => "/services/{service_id}/integrations",
+            Self::Vendor => "/vendors",
+        }
+    }
+}
+
+impl FromStr for PagerDutyFamily {
+    type Err = PagerDutyError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim() {
+            "user" => Ok(Self::User),
+            "team" => Ok(Self::Team),
+            "service" => Ok(Self::Service),
+            "schedule" => Ok(Self::Schedule),
+            "escalation_policy" => Ok(Self::EscalationPolicy),
+            "integration" => Ok(Self::Integration),
+            "vendor" => Ok(Self::Vendor),
+            _ => Err(PagerDutyError::InvalidFamily),
+        }
+    }
+}
+
+/// Provider-local bounded configuration that contains no credential values.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct PagerDutyFilters {
+    /// Service fan-out scope for the integration family.
+    pub service_ids: Vec<String>,
+}
+
+/// Closed runtime definition for one PagerDuty family.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PagerDutyPlan {
+    /// Source ID.
+    pub source_id: &'static str,
+    /// Family ID.
+    pub family_id: &'static str,
+    /// HTTP method.
+    pub method: &'static str,
+    /// Allowed provider origin.
+    pub origin: String,
+    /// Closed request path template.
+    pub path_template: &'static str,
+    /// Response-array selector.
+    pub record_selector: String,
+    /// Stable provider identity field.
+    pub id_field: &'static str,
+    /// Event kind.
+    pub event_kind: &'static str,
+    /// Event schema reference.
+    pub schema_ref: &'static str,
+    /// Required normalized attributes.
+    pub required_attributes: Vec<&'static str>,
+    /// Required payload fields.
+    pub required_payload_fields: Vec<&'static str>,
+    /// Response byte ceiling.
+    pub max_response_bytes: usize,
+    /// Record-count ceiling.
+    pub max_records_per_page: usize,
+}
+
+/// One normalized PagerDuty provider record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PagerDutyRecord {
+    /// Closed family.
+    pub family: PagerDutyFamily,
+    /// Tenant bound by the execution context.
+    pub tenant_id: String,
+    /// Stable provider identity.
+    pub provider_id: String,
+    /// Go-compatible tenant- and request-scope-bound event identity.
+    pub event_id: String,
+    /// Exact event kind.
+    pub event_kind: String,
+    /// Exact event schema.
+    pub schema_ref: String,
+    /// Deterministic normalized attributes.
+    pub attributes: BTreeMap<String, String>,
+    /// Provider occurrence time or caller-supplied observation time.
+    pub occurred_at: String,
+    /// Exact raw provider object.
+    pub payload: Value,
+}
+
+/// One bounded PagerDuty page and its proposed progress.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PagerDutyPage {
+    /// Deduplicated records in provider order.
+    pub records: Vec<PagerDutyRecord>,
+    /// Exact Go-compatible continuation, when another provider or fan-out page remains.
+    pub next_cursor: Option<String>,
+    /// Proposed durable cursor. The host commits it only after append and projection.
+    pub checkpoint_cursor: Option<String>,
+}

--- a/crates/source-runtime-next/src/pagerduty/normalize.rs
+++ b/crates/source-runtime-next/src/pagerduty/normalize.rs
@@ -1,0 +1,312 @@
+//! Deterministic Go-compatible PagerDuty record normalization.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{PagerDutyError, PagerDutyFamily, PagerDutyRecord};
+
+pub(super) fn require_tenant(value: &str) -> Result<String, PagerDutyError> {
+    let value = value.trim();
+    if value.is_empty()
+        || value.len() > 128
+        || value.chars().any(char::is_control)
+        || value.contains('/')
+        || value.contains(':')
+    {
+        return Err(PagerDutyError::MissingTenantId);
+    }
+    Ok(value.to_owned())
+}
+
+pub(super) fn require_safe_identity(value: &str) -> Result<(), PagerDutyError> {
+    if value.is_empty()
+        || value.len() > 512
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    {
+        return Err(PagerDutyError::InvalidProviderIdentity);
+    }
+    Ok(())
+}
+
+pub(super) fn normalize_record(
+    family: PagerDutyFamily,
+    tenant_id: &str,
+    origin: &str,
+    path: &str,
+    configured_service_id: Option<&str>,
+    payload: Value,
+    observed_at: OffsetDateTime,
+) -> Result<PagerDutyRecord, PagerDutyError> {
+    let object = payload
+        .as_object()
+        .ok_or(PagerDutyError::MalformedResponse)?;
+    let provider_id = scalar(object.get("id")).ok_or(PagerDutyError::MissingProviderIdentity)?;
+    require_safe_identity(&provider_id)?;
+
+    let mut attributes = BTreeMap::from([
+        ("external_id".to_owned(), provider_id.clone()),
+        ("family".to_owned(), family.as_str().to_owned()),
+        ("provider".to_owned(), "pagerduty".to_owned()),
+        ("source_product".to_owned(), "pagerduty".to_owned()),
+        ("source_provider".to_owned(), "pagerduty".to_owned()),
+        (family.identity_attribute().to_owned(), provider_id.clone()),
+    ]);
+
+    match family {
+        PagerDutyFamily::User => insert_fields(
+            &mut attributes,
+            object,
+            &[
+                ("name", &["name"]),
+                ("email", &["email"]),
+                ("role", &["role"]),
+                ("time_zone", &["time_zone"]),
+                ("job_title", &["job_title"]),
+            ],
+        ),
+        PagerDutyFamily::Team => insert_fields(
+            &mut attributes,
+            object,
+            &[("name", &["name"]), ("description", &["description"])],
+        ),
+        PagerDutyFamily::Service => insert_fields(
+            &mut attributes,
+            object,
+            &[
+                ("name", &["name"]),
+                ("summary", &["summary"]),
+                ("status", &["status"]),
+                ("html_url", &["html_url"]),
+                ("escalation_policy_id", &["escalation_policy.id"]),
+                (
+                    "escalation_policy_name",
+                    &["escalation_policy.summary", "escalation_policy.name"],
+                ),
+            ],
+        ),
+        PagerDutyFamily::Schedule => insert_fields(
+            &mut attributes,
+            object,
+            &[
+                ("name", &["name"]),
+                ("summary", &["summary"]),
+                ("time_zone", &["time_zone"]),
+                ("html_url", &["html_url"]),
+            ],
+        ),
+        PagerDutyFamily::EscalationPolicy => insert_fields(
+            &mut attributes,
+            object,
+            &[
+                ("name", &["name"]),
+                ("summary", &["summary"]),
+                ("num_loops", &["num_loops"]),
+                ("html_url", &["html_url"]),
+            ],
+        ),
+        PagerDutyFamily::Integration => {
+            let service_id = configured_service_id.ok_or(PagerDutyError::MissingServiceId)?;
+            require_safe_identity(service_id).map_err(|_| PagerDutyError::InvalidServiceId)?;
+            attributes.insert("service_id".to_owned(), service_id.to_owned());
+            insert_fields(
+                &mut attributes,
+                object,
+                &[
+                    ("name", &["name"]),
+                    ("summary", &["summary"]),
+                    ("service_name", &["service.summary", "service.name"]),
+                    ("vendor_id", &["vendor.id"]),
+                    ("vendor_name", &["vendor.summary", "vendor.name"]),
+                ],
+            );
+        }
+        PagerDutyFamily::Vendor => insert_fields(
+            &mut attributes,
+            object,
+            &[
+                ("name", &["name"]),
+                ("summary", &["summary"]),
+                ("website_url", &["website_url"]),
+            ],
+        ),
+    }
+
+    validate_event_contract(family, &attributes, object)?;
+    let occurred_at = provider_time(family, object)
+        .unwrap_or(observed_at)
+        .format(&Rfc3339)
+        .map_err(|_| PagerDutyError::EventContractRejected)?;
+    let payload = sanitize_payload(payload);
+    Ok(PagerDutyRecord {
+        family,
+        tenant_id: tenant_id.to_owned(),
+        provider_id: provider_id.clone(),
+        event_id: event_id(tenant_id, origin, path, family, &provider_id),
+        event_kind: family.event_kind().to_owned(),
+        schema_ref: family.schema_ref().to_owned(),
+        attributes,
+        occurred_at,
+        payload,
+    })
+}
+
+fn sanitize_payload(value: Value) -> Value {
+    match value {
+        Value::Object(object) => Value::Object(
+            object
+                .into_iter()
+                .filter(|(key, _)| !secret_field(key))
+                .map(|(key, value)| (key, sanitize_payload(value)))
+                .collect(),
+        ),
+        Value::Array(values) => Value::Array(values.into_iter().map(sanitize_payload).collect()),
+        other => other,
+    }
+}
+
+fn secret_field(key: &str) -> bool {
+    let key = key.trim().to_ascii_lowercase().replace('-', "_");
+    matches!(
+        key.as_str(),
+        "token"
+            | "access_token"
+            | "api_token"
+            | "api_key"
+            | "integration_key"
+            | "routing_key"
+            | "password"
+            | "secret"
+            | "client_secret"
+            | "private_key"
+            | "authorization"
+            | "cookie"
+            | "set_cookie"
+            | "session_cookie"
+    ) || key.ends_with("_token")
+        || key.ends_with("_password")
+        || key.ends_with("_secret")
+        || key.ends_with("_api_key")
+        || key.ends_with("_private_key")
+        || key.ends_with("_cookie")
+}
+
+fn insert_fields(
+    attributes: &mut BTreeMap<String, String>,
+    object: &serde_json::Map<String, Value>,
+    mappings: &[(&str, &[&str])],
+) {
+    for (attribute, paths) in mappings {
+        if let Some(value) = first_path(object, paths) {
+            attributes.insert((*attribute).to_owned(), value);
+        }
+    }
+}
+
+fn first_path(object: &serde_json::Map<String, Value>, paths: &[&str]) -> Option<String> {
+    paths.iter().find_map(|path| value_at(object, path))
+}
+
+fn value_at(object: &serde_json::Map<String, Value>, path: &str) -> Option<String> {
+    let mut value = object.get(path.split('.').next()?)?;
+    for part in path.split('.').skip(1) {
+        value = value.as_object()?.get(part)?;
+    }
+    scalar(Some(value))
+}
+
+fn scalar(value: Option<&Value>) -> Option<String> {
+    let value = match value? {
+        Value::String(value) => value.trim().to_owned(),
+        Value::Number(value) => value.to_string(),
+        Value::Bool(value) => value.to_string(),
+        _ => return None,
+    };
+    (!value.is_empty()).then_some(value)
+}
+
+fn validate_event_contract(
+    family: PagerDutyFamily,
+    attributes: &BTreeMap<String, String>,
+    object: &serde_json::Map<String, Value>,
+) -> Result<(), PagerDutyError> {
+    for key in [
+        "external_id",
+        "family",
+        "source_provider",
+        "source_product",
+        family.identity_attribute(),
+    ] {
+        if attributes.get(key).is_none_or(String::is_empty) {
+            return Err(PagerDutyError::EventContractRejected);
+        }
+    }
+    if scalar(object.get("id")).is_none() {
+        return Err(PagerDutyError::EventContractRejected);
+    }
+    if family == PagerDutyFamily::Integration
+        && attributes.get("service_id").is_none_or(String::is_empty)
+    {
+        return Err(PagerDutyError::EventContractRejected);
+    }
+    Ok(())
+}
+
+fn provider_time(
+    family: PagerDutyFamily,
+    object: &serde_json::Map<String, Value>,
+) -> Option<OffsetDateTime> {
+    let keys: &[&str] = if family == PagerDutyFamily::Service {
+        &["created_at", "updated_at", "timestamp"]
+    } else {
+        &["updated_at", "created_at", "timestamp"]
+    };
+    keys.iter().find_map(|key| {
+        scalar(object.get(*key)).and_then(|value| OffsetDateTime::parse(&value, &Rfc3339).ok())
+    })
+}
+
+fn event_id(
+    tenant_id: &str,
+    origin: &str,
+    path: &str,
+    family: PagerDutyFamily,
+    provider_id: &str,
+) -> String {
+    let scope = Sha256::digest([origin.as_bytes(), b"\0", path.as_bytes()].concat());
+    format!(
+        "pagerduty-{}-{}-{}-{}",
+        normalize_id(tenant_id),
+        hex_prefix(&scope, 12),
+        normalize_id(family.as_str()),
+        normalize_id(provider_id)
+    )
+}
+
+fn normalize_id(value: &str) -> String {
+    let value = value.trim();
+    if value.is_empty() {
+        return "unknown".to_owned();
+    }
+    value
+        .chars()
+        .map(|character| match character {
+            ' ' | '/' | ':' | '\t' | '\n' => '-',
+            other => other,
+        })
+        .collect()
+}
+
+fn hex_prefix(bytes: &[u8], length: usize) -> String {
+    use std::fmt::Write as _;
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(&mut output, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    output.truncate(length);
+    output
+}

--- a/crates/source-runtime-next/src/pagerduty/origin.rs
+++ b/crates/source-runtime-next/src/pagerduty/origin.rs
@@ -1,0 +1,30 @@
+//! PagerDuty API-origin validation.
+
+use reqwest::Url;
+
+use super::PagerDutyError;
+
+pub(super) const DEFAULT_BASE_URL: &str = "https://api.pagerduty.com";
+
+pub(super) fn validate_origin(raw: Option<&str>) -> Result<Url, PagerDutyError> {
+    let mut url = Url::parse(raw.unwrap_or(DEFAULT_BASE_URL).trim())
+        .map_err(|_| PagerDutyError::InvalidBaseUrl)?;
+    let host = url.host_str().ok_or(PagerDutyError::InvalidBaseUrl)?;
+    if url.scheme() != "https"
+        || !matches!(host, "api.pagerduty.com" | "api.eu.pagerduty.com")
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port().is_some_and(|port| port != 443)
+        || !matches!(url.path(), "" | "/")
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(PagerDutyError::InvalidBaseUrl);
+    }
+    url.set_path("/");
+    Ok(url)
+}
+
+pub(super) fn origin_string(url: &Url) -> String {
+    url.origin().ascii_serialization()
+}

--- a/crates/source-runtime-next/src/pagerduty/projection.rs
+++ b/crates/source-runtime-next/src/pagerduty/projection.rs
@@ -1,0 +1,357 @@
+//! PagerDuty responder-topology semantic projection facts.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::Value;
+
+use super::{PagerDutyFamily, PagerDutyRecord};
+
+/// One tenant-scoped semantic entity emitted by PagerDuty projection.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct PagerDutyEntityFact {
+    /// Stable tenant-scoped URN.
+    pub urn: String,
+    /// Go-compatible entity type.
+    pub entity_type: String,
+    /// Human-readable label.
+    pub label: String,
+    /// Stable semantic attributes.
+    pub attributes: BTreeMap<String, String>,
+}
+
+/// One semantic PagerDuty responder-topology relation.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct PagerDutyRelationFact {
+    /// Source entity URN.
+    pub from_urn: String,
+    /// Closed Go-compatible relation.
+    pub relation: String,
+    /// Target entity URN.
+    pub to_urn: String,
+}
+
+/// Deterministic PagerDuty projection facts used for Go/Rust parity.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct PagerDutyProjectionFacts {
+    /// Deduplicated entities sorted by semantic identity.
+    pub entities: Vec<PagerDutyEntityFact>,
+    /// Deduplicated relations sorted by semantic identity.
+    pub relations: Vec<PagerDutyRelationFact>,
+}
+
+/// Project normalized records into responder identity and escalation-coverage facts.
+pub fn project_pagerduty_records(records: &[PagerDutyRecord]) -> PagerDutyProjectionFacts {
+    let mut entities = BTreeMap::new();
+    let mut relations = BTreeSet::new();
+    for record in records {
+        project_record(record, &mut entities, &mut relations);
+    }
+    PagerDutyProjectionFacts {
+        entities: entities.into_values().collect(),
+        relations: relations.into_iter().collect(),
+    }
+}
+
+fn project_record(
+    record: &PagerDutyRecord,
+    entities: &mut BTreeMap<String, PagerDutyEntityFact>,
+    relations: &mut BTreeSet<PagerDutyRelationFact>,
+) {
+    let primary_urn = provider_urn(
+        &record.tenant_id,
+        record.family.urn_kind(),
+        &record.provider_id,
+    );
+    let mut attributes = record.attributes.clone();
+    if record.family == PagerDutyFamily::Service {
+        let has_escalation = attributes
+            .get("escalation_policy_id")
+            .is_some_and(|value| !value.is_empty());
+        attributes.insert(
+            "has_escalation_policy".to_owned(),
+            has_escalation.to_string(),
+        );
+        let active = !matches!(
+            attributes.get("status").map(|value| value.to_ascii_lowercase()),
+            Some(value) if matches!(value.as_str(), "disabled" | "deleted" | "inactive" | "removed")
+        );
+        attributes.insert("active".to_owned(), active.to_string());
+    }
+    add_entity(
+        entities,
+        PagerDutyEntityFact {
+            urn: primary_urn.clone(),
+            entity_type: record.event_kind.clone(),
+            label: label(&record.attributes, &record.provider_id),
+            attributes,
+        },
+    );
+
+    match record.family {
+        PagerDutyFamily::User => {
+            if let Some(email) = record
+                .attributes
+                .get("email")
+                .filter(|value| !value.is_empty())
+            {
+                let normalized = email.trim().to_ascii_lowercase();
+                let identifier_urn = format!(
+                    "urn:cerebro:{}:identifier:email:{}",
+                    record.tenant_id, normalized
+                );
+                let identity_urn = format!(
+                    "urn:cerebro:{}:identity:email:{}",
+                    record.tenant_id, normalized
+                );
+                add_entity(
+                    entities,
+                    context_entity(
+                        identifier_urn.clone(),
+                        "identifier.email",
+                        &normalized,
+                        "value",
+                        &normalized,
+                    ),
+                );
+                add_entity(
+                    entities,
+                    context_entity(
+                        identity_urn.clone(),
+                        "identity.email",
+                        &normalized,
+                        "value",
+                        &normalized,
+                    ),
+                );
+                add_relation(relations, &primary_urn, "has_identifier", &identifier_urn);
+                add_relation(
+                    relations,
+                    &primary_urn,
+                    "represents_identity",
+                    &identity_urn,
+                );
+                add_relation(relations, &identity_urn, "has_identifier", &identifier_urn);
+                add_relation(
+                    relations,
+                    &identifier_urn,
+                    "represents_identity",
+                    &identity_urn,
+                );
+            }
+        }
+        PagerDutyFamily::Service => {
+            if let Some(policy_id) = record
+                .attributes
+                .get("escalation_policy_id")
+                .filter(|value| !value.is_empty())
+            {
+                let policy_urn = provider_urn(
+                    &record.tenant_id,
+                    PagerDutyFamily::EscalationPolicy.urn_kind(),
+                    policy_id,
+                );
+                let policy_label = record
+                    .attributes
+                    .get("escalation_policy_name")
+                    .map(String::as_str)
+                    .unwrap_or(policy_id);
+                add_entity(
+                    entities,
+                    context_entity(
+                        policy_urn.clone(),
+                        PagerDutyFamily::EscalationPolicy.event_kind(),
+                        policy_label,
+                        "escalation_policy_id",
+                        policy_id,
+                    ),
+                );
+                add_relation(relations, &primary_urn, "depends_on", &policy_urn);
+                add_relation(relations, &policy_urn, "supports", &primary_urn);
+            }
+        }
+        PagerDutyFamily::EscalationPolicy => {
+            project_policy_context(record, &primary_urn, entities, relations);
+        }
+        PagerDutyFamily::Integration => {
+            if let Some(service_id) = record
+                .attributes
+                .get("service_id")
+                .filter(|value| !value.is_empty())
+            {
+                let service_urn = provider_urn(
+                    &record.tenant_id,
+                    PagerDutyFamily::Service.urn_kind(),
+                    service_id,
+                );
+                let service_label = record
+                    .attributes
+                    .get("service_name")
+                    .map(String::as_str)
+                    .unwrap_or(service_id);
+                add_entity(
+                    entities,
+                    context_entity(
+                        service_urn.clone(),
+                        PagerDutyFamily::Service.event_kind(),
+                        service_label,
+                        "service_id",
+                        service_id,
+                    ),
+                );
+                add_relation(relations, &primary_urn, "belongs_to", &service_urn);
+                add_relation(relations, &service_urn, "contains", &primary_urn);
+            }
+            if let Some(vendor_id) = record
+                .attributes
+                .get("vendor_id")
+                .filter(|value| !value.is_empty())
+            {
+                let vendor_urn = provider_urn(
+                    &record.tenant_id,
+                    PagerDutyFamily::Vendor.urn_kind(),
+                    vendor_id,
+                );
+                let vendor_label = record
+                    .attributes
+                    .get("vendor_name")
+                    .map(String::as_str)
+                    .unwrap_or(vendor_id);
+                add_entity(
+                    entities,
+                    context_entity(
+                        vendor_urn.clone(),
+                        PagerDutyFamily::Vendor.event_kind(),
+                        vendor_label,
+                        "vendor_id",
+                        vendor_id,
+                    ),
+                );
+                add_relation(relations, &primary_urn, "depends_on", &vendor_urn);
+            }
+        }
+        PagerDutyFamily::Team | PagerDutyFamily::Schedule | PagerDutyFamily::Vendor => {}
+    }
+}
+
+fn project_policy_context(
+    record: &PagerDutyRecord,
+    primary_urn: &str,
+    entities: &mut BTreeMap<String, PagerDutyEntityFact>,
+    relations: &mut BTreeSet<PagerDutyRelationFact>,
+) {
+    if let Some(teams) = record.payload.get("teams").and_then(Value::as_array) {
+        for team in teams {
+            let Some(id) = string_at(team, "id") else {
+                continue;
+            };
+            let urn = provider_urn(&record.tenant_id, PagerDutyFamily::Team.urn_kind(), id);
+            let label = string_at(team, "summary")
+                .or_else(|| string_at(team, "name"))
+                .unwrap_or(id);
+            add_entity(
+                entities,
+                context_entity(
+                    urn.clone(),
+                    PagerDutyFamily::Team.event_kind(),
+                    label,
+                    "team_id",
+                    id,
+                ),
+            );
+            add_relation(relations, primary_urn, "belongs_to", &urn);
+            add_relation(relations, &urn, "contains", primary_urn);
+        }
+    }
+    let Some(rules) = record
+        .payload
+        .get("escalation_rules")
+        .and_then(Value::as_array)
+    else {
+        return;
+    };
+    for rule in rules {
+        let Some(targets) = rule.get("targets").and_then(Value::as_array) else {
+            continue;
+        };
+        for target in targets {
+            let (family, attribute) = match string_at(target, "type") {
+                Some("schedule_reference") => (PagerDutyFamily::Schedule, "schedule_id"),
+                Some("user_reference") => (PagerDutyFamily::User, "user_id"),
+                _ => continue,
+            };
+            let Some(id) = string_at(target, "id") else {
+                continue;
+            };
+            let urn = provider_urn(&record.tenant_id, family.urn_kind(), id);
+            let label = string_at(target, "summary")
+                .or_else(|| string_at(target, "name"))
+                .unwrap_or(id);
+            add_entity(
+                entities,
+                context_entity(urn.clone(), family.event_kind(), label, attribute, id),
+            );
+            add_relation(relations, primary_urn, "depends_on", &urn);
+        }
+    }
+}
+
+fn context_entity(
+    urn: String,
+    entity_type: &str,
+    label: &str,
+    attribute: &str,
+    attribute_value: &str,
+) -> PagerDutyEntityFact {
+    PagerDutyEntityFact {
+        urn,
+        entity_type: entity_type.to_owned(),
+        label: label.to_owned(),
+        attributes: BTreeMap::from([(attribute.to_owned(), attribute_value.to_owned())]),
+    }
+}
+
+fn add_entity(entities: &mut BTreeMap<String, PagerDutyEntityFact>, incoming: PagerDutyEntityFact) {
+    if let Some(existing) = entities.get_mut(&incoming.urn) {
+        if incoming.attributes.len() > existing.attributes.len() {
+            existing.entity_type = incoming.entity_type.clone();
+            existing.label = incoming.label.clone();
+        }
+        existing.attributes.extend(incoming.attributes);
+    } else {
+        entities.insert(incoming.urn.clone(), incoming);
+    }
+}
+
+fn add_relation(
+    relations: &mut BTreeSet<PagerDutyRelationFact>,
+    from_urn: &str,
+    relation: &str,
+    to_urn: &str,
+) {
+    relations.insert(PagerDutyRelationFact {
+        from_urn: from_urn.to_owned(),
+        relation: relation.to_owned(),
+        to_urn: to_urn.to_owned(),
+    });
+}
+
+fn provider_urn(tenant_id: &str, kind: &str, provider_id: &str) -> String {
+    format!("urn:cerebro:{tenant_id}:{kind}:{provider_id}")
+}
+
+fn label(attributes: &BTreeMap<String, String>, fallback: &str) -> String {
+    attributes
+        .get("name")
+        .or_else(|| attributes.get("summary"))
+        .filter(|value| !value.is_empty())
+        .cloned()
+        .unwrap_or_else(|| fallback.to_owned())
+}
+
+fn string_at<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
+    value
+        .get(key)?
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}

--- a/crates/source-runtime-next/src/pagerduty/request.rs
+++ b/crates/source-runtime-next/src/pagerduty/request.rs
@@ -1,0 +1,215 @@
+//! Credential-free PagerDuty request planning.
+
+use reqwest::Url;
+
+use super::{
+    PagerDutyError, PagerDutyFamily, PagerDutyFilters, PagerDutyPlan,
+    cursor::{CursorState, parse_cursor},
+    normalize::{require_safe_identity, require_tenant},
+    origin::{origin_string, validate_origin},
+};
+
+pub(super) const MAX_RESPONSE_BYTES: usize = 8 << 20;
+pub(super) const MAX_RECORDS_PER_PAGE: usize = 100;
+const DEFAULT_PAGE_SIZE: usize = 100;
+
+/// One planned PagerDuty request without an authorization header or credential value.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PagerDutyRequest {
+    pub(super) url: Url,
+    pub(super) family: PagerDutyFamily,
+    pub(super) service_id: Option<String>,
+    pub(super) cursor: CursorState,
+}
+
+impl PagerDutyRequest {
+    /// Exact origin-restricted provider URL. A trusted host applies credentials before I/O.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Provider authentication scheme metadata without credential material.
+    pub const fn authorization_scheme(&self) -> &'static str {
+        "Token token="
+    }
+
+    /// Required response media type.
+    pub const fn accept(&self) -> &'static str {
+        "application/json"
+    }
+}
+
+/// Bounded request/response kernel for PagerDuty responder topology.
+#[derive(Clone, Debug)]
+pub struct PagerDutyKernel {
+    pub(super) base_url: Url,
+    pub(super) origin: String,
+    pub(super) tenant_id: String,
+    pub(super) family: PagerDutyFamily,
+    pub(super) service_ids: Vec<String>,
+    pub(super) page_size: usize,
+}
+
+impl PagerDutyKernel {
+    /// Construct a kernel from public configuration only.
+    pub fn new(
+        base_url: Option<&str>,
+        tenant_id: &str,
+        family: PagerDutyFamily,
+        filters: PagerDutyFilters,
+        page_size: Option<usize>,
+    ) -> Result<Self, PagerDutyError> {
+        let base_url = validate_origin(base_url)?;
+        let tenant_id = require_tenant(tenant_id)?;
+        let mut service_ids = Vec::new();
+        for service_id in filters.service_ids {
+            let service_id = service_id.trim().to_owned();
+            if service_id.is_empty() || service_ids.contains(&service_id) {
+                continue;
+            }
+            require_safe_identity(&service_id).map_err(|_| PagerDutyError::InvalidServiceId)?;
+            service_ids.push(service_id);
+        }
+        if family == PagerDutyFamily::Integration && service_ids.is_empty() {
+            return Err(PagerDutyError::MissingServiceId);
+        }
+        if family != PagerDutyFamily::Integration && !service_ids.is_empty() {
+            return Err(PagerDutyError::InvalidFamily);
+        }
+        let page_size = page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+        if !(1..=MAX_RECORDS_PER_PAGE).contains(&page_size) {
+            return Err(PagerDutyError::InvalidPageSize);
+        }
+        Ok(Self {
+            origin: origin_string(&base_url),
+            base_url,
+            tenant_id,
+            family,
+            service_ids,
+            page_size,
+        })
+    }
+
+    /// This kernel cannot receive provider credential values.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+
+    /// Compile this family into its exact closed runtime definition.
+    pub fn definition(&self) -> PagerDutyPlan {
+        PagerDutyPlan {
+            source_id: "pagerduty",
+            family_id: self.family.as_str(),
+            method: "GET",
+            origin: self.origin.clone(),
+            path_template: self.family.path_template(),
+            record_selector: format!("$.{}[*]", self.family.response_key()),
+            id_field: "id",
+            event_kind: self.family.event_kind(),
+            schema_ref: self.family.schema_ref(),
+            required_attributes: vec![
+                "external_id",
+                "family",
+                "source_provider",
+                "source_product",
+                self.family.identity_attribute(),
+            ],
+            required_payload_fields: vec!["id"],
+            max_response_bytes: MAX_RESPONSE_BYTES,
+            max_records_per_page: MAX_RECORDS_PER_PAGE,
+        }
+    }
+
+    /// Plan one bounded origin-restricted page without performing I/O.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<PagerDutyRequest, PagerDutyError> {
+        let state = parse_cursor(self.family, self.service_ids.len(), cursor)?;
+        let service_id = if self.family == PagerDutyFamily::Integration {
+            Some(
+                self.service_ids
+                    .get(state.service_index)
+                    .cloned()
+                    .ok_or(PagerDutyError::InvalidCursor)?,
+            )
+        } else {
+            None
+        };
+        let mut url = self.base_url.clone();
+        {
+            let mut segments = url
+                .path_segments_mut()
+                .map_err(|_| PagerDutyError::InvalidBaseUrl)?;
+            match self.family {
+                PagerDutyFamily::User => segments.push("users"),
+                PagerDutyFamily::Team => segments.push("teams"),
+                PagerDutyFamily::Service => segments.push("services"),
+                PagerDutyFamily::Schedule => segments.push("schedules"),
+                PagerDutyFamily::EscalationPolicy => segments.push("escalation_policies"),
+                PagerDutyFamily::Integration => {
+                    segments.push("services");
+                    segments.push(
+                        service_id
+                            .as_deref()
+                            .ok_or(PagerDutyError::MissingServiceId)?,
+                    );
+                    segments.push("integrations")
+                }
+                PagerDutyFamily::Vendor => segments.push("vendors"),
+            };
+        }
+        {
+            let mut query = url.query_pairs_mut();
+            query.append_pair("limit", &self.page_size.to_string());
+            if let Some(offset) = state.offset {
+                query.append_pair("offset", &offset.to_string());
+            }
+        }
+        let request = PagerDutyRequest {
+            url,
+            family: self.family,
+            service_id,
+            cursor: state,
+        };
+        self.validate_request(&request)?;
+        Ok(request)
+    }
+
+    pub(super) fn validate_request(
+        &self,
+        request: &PagerDutyRequest,
+    ) -> Result<(), PagerDutyError> {
+        if request.family != self.family
+            || request.url.origin() != self.base_url.origin()
+            || request.url.fragment().is_some()
+            || request.url.path() != self.expected_path(request.service_id.as_deref())?
+        {
+            return Err(PagerDutyError::RequestScopeMismatch);
+        }
+        let mut limit = None;
+        let mut offset = None;
+        for (key, value) in request.url.query_pairs() {
+            match key.as_ref() {
+                "limit" if limit.is_none() => limit = Some(value.into_owned()),
+                "offset" if offset.is_none() => offset = Some(value.into_owned()),
+                _ => return Err(PagerDutyError::RequestScopeMismatch),
+            }
+        }
+        let expected_limit = self.page_size.to_string();
+        let expected_offset = request.cursor.offset.map(|value| value.to_string());
+        if limit.as_deref() != Some(expected_limit.as_str())
+            || offset.as_deref() != expected_offset.as_deref()
+        {
+            return Err(PagerDutyError::RequestScopeMismatch);
+        }
+        Ok(())
+    }
+
+    fn expected_path(&self, service_id: Option<&str>) -> Result<String, PagerDutyError> {
+        Ok(match self.family {
+            PagerDutyFamily::Integration => format!(
+                "/services/{}/integrations",
+                service_id.ok_or(PagerDutyError::MissingServiceId)?
+            ),
+            _ => self.family.path_template().to_owned(),
+        })
+    }
+}

--- a/crates/source-runtime-next/src/pagerduty/response.rs
+++ b/crates/source-runtime-next/src/pagerduty/response.rs
@@ -1,0 +1,145 @@
+//! Bounded PagerDuty response decoding and progress calculation.
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+use time::OffsetDateTime;
+
+use super::{
+    PagerDutyError, PagerDutyFamily, PagerDutyKernel, PagerDutyPage, PagerDutyRequest,
+    cursor::encode_fanout_cursor,
+    normalize::normalize_record,
+    request::{MAX_RECORDS_PER_PAGE, MAX_RESPONSE_BYTES},
+};
+
+impl PagerDutyKernel {
+    /// Decode one trusted-host response and return normalized records plus proposed progress.
+    pub fn decode(
+        &self,
+        request: &PagerDutyRequest,
+        status_code: u16,
+        body: &[u8],
+        observed_at: OffsetDateTime,
+    ) -> Result<PagerDutyPage, PagerDutyError> {
+        self.validate_request(request)?;
+        classify_status(status_code)?;
+        if body.len() > MAX_RESPONSE_BYTES {
+            return Err(PagerDutyError::ResponseTooLarge);
+        }
+        let envelope: Value =
+            serde_json::from_slice(body).map_err(|_| PagerDutyError::MalformedResponse)?;
+        let object = envelope
+            .as_object()
+            .ok_or(PagerDutyError::MalformedResponse)?;
+        let raw_records = object
+            .get(self.family.response_key())
+            .and_then(Value::as_array)
+            .ok_or(PagerDutyError::MalformedResponse)?;
+        if raw_records.len() > MAX_RECORDS_PER_PAGE || raw_records.len() > self.page_size {
+            return Err(PagerDutyError::TooManyRecords);
+        }
+        let mut seen = HashMap::<String, usize>::new();
+        let mut records: Vec<super::PagerDutyRecord> = Vec::with_capacity(raw_records.len());
+        for payload in raw_records {
+            let record = normalize_record(
+                self.family,
+                &self.tenant_id,
+                &self.origin,
+                request.url.path(),
+                request.service_id.as_deref(),
+                payload.clone(),
+                observed_at,
+            )?;
+            if let Some(index) = seen.get(&record.provider_id).copied() {
+                if records.get(index) != Some(&record) {
+                    return Err(PagerDutyError::ConflictingProviderIdentity);
+                }
+                continue;
+            }
+            seen.insert(record.provider_id.clone(), records.len());
+            records.push(record);
+        }
+        let provider_next = provider_next_offset(object, request)?;
+        let next_cursor = self.next_cursor(request, provider_next)?;
+        let checkpoint_cursor = if records.is_empty() {
+            None
+        } else {
+            provider_next
+                .map(|offset| offset.to_string())
+                .or_else(|| records.last().map(|record| record.provider_id.clone()))
+        };
+        Ok(PagerDutyPage {
+            records,
+            next_cursor,
+            checkpoint_cursor,
+        })
+    }
+
+    fn next_cursor(
+        &self,
+        request: &PagerDutyRequest,
+        provider_next: Option<u64>,
+    ) -> Result<Option<String>, PagerDutyError> {
+        if self.family != PagerDutyFamily::Integration {
+            return Ok(provider_next.map(|offset| offset.to_string()));
+        }
+        if let Some(offset) = provider_next {
+            return encode_fanout_cursor(request.cursor.service_index, Some(offset)).map(Some);
+        }
+        let next_index = request.cursor.service_index + 1;
+        if next_index < self.service_ids.len() {
+            return encode_fanout_cursor(next_index, None).map(Some);
+        }
+        Ok(None)
+    }
+}
+
+fn provider_next_offset(
+    object: &serde_json::Map<String, Value>,
+    request: &PagerDutyRequest,
+) -> Result<Option<u64>, PagerDutyError> {
+    let more = match object.get("more") {
+        None => false,
+        Some(Value::Bool(value)) => *value,
+        Some(Value::Number(value)) => value.as_u64() == Some(1),
+        Some(Value::String(value)) => matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "true" | "1" | "yes"
+        ),
+        _ => return Err(PagerDutyError::MalformedResponse),
+    };
+    if !more {
+        return Ok(None);
+    }
+    let offset = unsigned(object.get("offset")).ok_or(PagerDutyError::MalformedResponse)?;
+    let limit = unsigned(object.get("limit")).ok_or(PagerDutyError::MalformedResponse)?;
+    if limit == 0 || limit > MAX_RECORDS_PER_PAGE as u64 {
+        return Err(PagerDutyError::MalformedResponse);
+    }
+    if request.cursor.offset.unwrap_or(0) != offset {
+        return Err(PagerDutyError::InvalidCursor);
+    }
+    offset
+        .checked_add(limit)
+        .map(Some)
+        .ok_or(PagerDutyError::InvalidCursor)
+}
+
+fn unsigned(value: Option<&Value>) -> Option<u64> {
+    match value? {
+        Value::Number(value) => value.as_u64(),
+        Value::String(value) => value.trim().parse().ok(),
+        _ => None,
+    }
+}
+
+fn classify_status(status: u16) -> Result<(), PagerDutyError> {
+    match status {
+        200 => Ok(()),
+        401 => Err(PagerDutyError::AuthenticationRejected),
+        403 => Err(PagerDutyError::PermissionDenied),
+        429 => Err(PagerDutyError::RateLimited),
+        500..=599 => Err(PagerDutyError::ProviderUnavailable),
+        _ => Err(PagerDutyError::UnexpectedProviderStatus),
+    }
+}

--- a/crates/source-runtime-next/src/pagerduty/tests.rs
+++ b/crates/source-runtime-next/src/pagerduty/tests.rs
@@ -1,0 +1,620 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Value, json};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::*;
+
+const OBSERVED_AT: &str = "2026-06-01T00:00:00Z";
+const SECRET_CANARY: &str = "pagerduty-secret-test-value";
+
+#[test]
+fn closed_definition_covers_exact_pagerduty_families() {
+    let got = PagerDutyFamily::ALL
+        .into_iter()
+        .map(|family| {
+            let kernel = kernel(family, "writer", None);
+            let plan = kernel.definition();
+            assert_eq!(plan.source_id, "pagerduty");
+            assert_eq!(plan.family_id, family.as_str());
+            assert_eq!(plan.method, "GET");
+            assert_eq!(plan.origin, "https://api.pagerduty.com");
+            assert_eq!(plan.path_template, family.path_template());
+            assert_eq!(
+                plan.record_selector,
+                format!("$.{}[*]", family.response_key())
+            );
+            assert_eq!(plan.id_field, "id");
+            assert_eq!(plan.event_kind, family.event_kind());
+            assert_eq!(plan.schema_ref, family.schema_ref());
+            assert_eq!(plan.required_payload_fields, ["id"]);
+            assert!(
+                plan.required_attributes
+                    .contains(&family.identity_attribute())
+            );
+            family.as_str()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        got,
+        [
+            "user",
+            "team",
+            "service",
+            "schedule",
+            "escalation_policy",
+            "integration",
+            "vendor",
+        ]
+    );
+}
+
+#[test]
+fn requests_are_bounded_origin_locked_and_credential_free() {
+    for family in PagerDutyFamily::ALL {
+        let kernel = kernel(family, "writer", Some(25));
+        assert!(!PagerDutyKernel::requires_credentials());
+        let request = kernel.plan(None).unwrap();
+        assert_eq!(
+            request.url().origin().ascii_serialization(),
+            "https://api.pagerduty.com"
+        );
+        assert_eq!(
+            request
+                .url()
+                .query_pairs()
+                .find(|(key, _)| key == "limit")
+                .unwrap()
+                .1,
+            "25"
+        );
+        assert!(request.url().query_pairs().all(|(key, _)| key != "offset"));
+        assert_eq!(request.authorization_scheme(), "Token token=");
+        assert_eq!(request.accept(), "application/json");
+        let debug = format!("{kernel:?}{request:?}");
+        assert!(!debug.contains(SECRET_CANARY));
+        assert!(!debug.contains("Authorization"));
+    }
+}
+
+#[test]
+fn go_fixture_semantic_parity_covers_all_families() {
+    for family in PagerDutyFamily::ALL {
+        let fixture = go_fixture(family);
+        let expected = fixture.as_array().unwrap().first().unwrap();
+        let payload = expected.get("payload").unwrap().clone();
+        let body = serde_json::to_vec(&json!({family.response_key(): [payload]})).unwrap();
+        let kernel = kernel(family, "tenant", None);
+        let request = kernel.plan(None).unwrap();
+        let page = kernel.decode(&request, 200, &body, observed_at()).unwrap();
+        assert_eq!(page.records.len(), 1, "family={}", family.as_str());
+        let record = &page.records[0];
+        assert_eq!(record.event_kind, expected["kind"].as_str().unwrap());
+        assert_eq!(record.schema_ref, expected["schema_ref"].as_str().unwrap());
+        assert_eq!(record.payload, expected["payload"]);
+        let expected_occurred_at = if family == PagerDutyFamily::Service {
+            // The Go HTTP runtime declares created_at as the service TimestampKeys oracle.
+            // Its replay fixture envelope has a later fixture-only observation timestamp.
+            expected["payload"]["created_at"].as_str().unwrap()
+        } else {
+            expected["occurred_at"].as_str().unwrap()
+        };
+        assert_eq!(record.occurred_at, expected_occurred_at);
+        let attributes: BTreeMap<String, String> =
+            serde_json::from_value(expected["attributes"].clone()).unwrap();
+        assert_eq!(record.attributes, attributes, "family={}", family.as_str());
+        assert!(record.event_id.starts_with("pagerduty-tenant-"));
+        assert_eq!(
+            page.checkpoint_cursor.as_deref(),
+            Some(record.provider_id.as_str())
+        );
+        assert!(page.next_cursor.is_none());
+    }
+}
+
+#[test]
+fn offset_pagination_round_trips_and_advances_checkpoint_after_decode_only() {
+    let kernel = kernel(PagerDutyFamily::User, "writer", Some(2));
+    let first_request = kernel.plan(None).unwrap();
+    let first = kernel
+        .decode(
+            &first_request,
+            200,
+            &serde_json::to_vec(&json!({
+                "users": [{"id":"PU1"},{"id":"PU2"}],
+                "limit": 2,
+                "offset": 0,
+                "more": true
+            }))
+            .unwrap(),
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(first.next_cursor.as_deref(), Some("2"));
+    assert_eq!(first.checkpoint_cursor.as_deref(), Some("2"));
+    let second_request = kernel.plan(first.next_cursor.as_deref()).unwrap();
+    assert_eq!(
+        second_request
+            .url()
+            .query_pairs()
+            .find(|(key, _)| key == "offset")
+            .unwrap()
+            .1,
+        "2"
+    );
+    let second = kernel
+        .decode(
+            &second_request,
+            200,
+            &serde_json::to_vec(&json!({
+                "users": [{"id":"PU3"}],
+                "limit": 2,
+                "offset": 2,
+                "more": false
+            }))
+            .unwrap(),
+            observed_at(),
+        )
+        .unwrap();
+    assert!(second.next_cursor.is_none());
+    assert_eq!(second.checkpoint_cursor.as_deref(), Some("PU3"));
+}
+
+#[test]
+fn empty_pages_can_continue_without_proposing_a_checkpoint() {
+    let kernel = kernel(PagerDutyFamily::Team, "writer", Some(10));
+    let request = kernel.plan(None).unwrap();
+    let page = kernel
+        .decode(
+            &request,
+            200,
+            br#"{"teams":[],"limit":10,"offset":0,"more":true}"#,
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(page.next_cursor.as_deref(), Some("10"));
+    assert!(page.checkpoint_cursor.is_none());
+}
+
+#[test]
+fn integration_cursor_preserves_service_fanout_and_provider_offset() {
+    let kernel = PagerDutyKernel::new(
+        None,
+        "writer",
+        PagerDutyFamily::Integration,
+        PagerDutyFilters {
+            service_ids: vec!["PS1".to_owned(), "PS2".to_owned()],
+        },
+        Some(1),
+    )
+    .unwrap();
+    let first_request = kernel.plan(None).unwrap();
+    assert_eq!(first_request.url().path(), "/services/PS1/integrations");
+    let first = decode_integration(&kernel, &first_request, "PI1", true, 0);
+    let first_cursor = first.next_cursor.unwrap();
+    assert_eq!(
+        first_cursor,
+        r#"{"version":1,"source":"pagerduty","mode":"fanout_path_param","token":"{\"index\":0,\"cursor\":\"1\"}"}"#
+    );
+    assert_eq!(first.checkpoint_cursor.as_deref(), Some("1"));
+
+    let second_request = kernel.plan(Some(&first_cursor)).unwrap();
+    assert_eq!(second_request.url().path(), "/services/PS1/integrations");
+    assert_eq!(
+        second_request
+            .url()
+            .query_pairs()
+            .find(|(key, _)| key == "offset")
+            .unwrap()
+            .1,
+        "1"
+    );
+    let second = decode_integration(&kernel, &second_request, "PI2", false, 1);
+    let second_cursor = second.next_cursor.unwrap();
+    assert_eq!(
+        second_cursor,
+        r#"{"version":1,"source":"pagerduty","mode":"fanout_path_param","token":"{\"index\":1}"}"#
+    );
+    assert_eq!(second.checkpoint_cursor.as_deref(), Some("PI2"));
+
+    let third_request = kernel.plan(Some(&second_cursor)).unwrap();
+    assert_eq!(third_request.url().path(), "/services/PS2/integrations");
+    let third = decode_integration(&kernel, &third_request, "PI3", false, 0);
+    assert!(third.next_cursor.is_none());
+    assert_eq!(third.records[0].attributes["service_id"], "PS2");
+}
+
+#[test]
+fn identity_is_tenant_scoped_and_duplicate_content_is_idempotent() {
+    let body = br#"{"users":[{"id":"PU1","name":"Alice"},{"id":"PU1","name":"Alice"}]}"#;
+    let writer = kernel(PagerDutyFamily::User, "writer", None);
+    let other = kernel(PagerDutyFamily::User, "other", None);
+    let writer_page = writer
+        .decode(&writer.plan(None).unwrap(), 200, body, observed_at())
+        .unwrap();
+    let other_page = other
+        .decode(&other.plan(None).unwrap(), 200, body, observed_at())
+        .unwrap();
+    assert_eq!(writer_page.records.len(), 1);
+    assert_ne!(
+        writer_page.records[0].event_id,
+        other_page.records[0].event_id
+    );
+    assert_ne!(
+        primary_urn(&writer_page.records),
+        primary_urn(&other_page.records)
+    );
+}
+
+#[test]
+fn secret_shaped_provider_fields_do_not_reach_events_or_graph_facts() {
+    let kernel = kernel(PagerDutyFamily::User, "writer", None);
+    let body = serde_json::to_vec(&json!({
+        "users": [{
+            "id": "PU1",
+            "name": "Alice",
+            "api_key": SECRET_CANARY,
+            "nested": {"password": SECRET_CANARY},
+            "safe_metadata": "preserved"
+        }]
+    }))
+    .unwrap();
+    let page = kernel
+        .decode(&kernel.plan(None).unwrap(), 200, &body, observed_at())
+        .unwrap();
+    let record = page.records.first().unwrap();
+    assert_eq!(record.payload["safe_metadata"].as_str(), Some("preserved"));
+    assert!(record.payload.get("api_key").is_none());
+    assert!(record.payload["nested"].get("password").is_none());
+    assert!(
+        !serde_json::to_string(&record.payload)
+            .unwrap()
+            .contains(SECRET_CANARY)
+    );
+    assert!(!format!("{:?}", project_pagerduty_records(&page.records)).contains(SECRET_CANARY));
+}
+
+#[test]
+fn responder_identity_and_escalation_coverage_projection_matches_go_semantics() {
+    let mut records = Vec::new();
+    for family in PagerDutyFamily::ALL {
+        let fixture = go_fixture(family);
+        let expected = fixture.as_array().unwrap().first().unwrap();
+        let body = serde_json::to_vec(&json!({
+            family.response_key(): [expected["payload"].clone()]
+        }))
+        .unwrap();
+        let kernel = kernel(family, "tenant", None);
+        records.extend(
+            kernel
+                .decode(&kernel.plan(None).unwrap(), 200, &body, observed_at())
+                .unwrap()
+                .records,
+        );
+    }
+    let projection = project_pagerduty_records(&records);
+    assert_entity(
+        &projection,
+        "urn:cerebro:tenant:pagerduty_user:PU1",
+        "pagerduty.user",
+    );
+    assert_entity(
+        &projection,
+        "urn:cerebro:tenant:pagerduty_team:PT1",
+        "pagerduty.team",
+    );
+    assert_entity(
+        &projection,
+        "urn:cerebro:tenant:pagerduty_service:PS1",
+        "pagerduty.service",
+    );
+    assert_entity(
+        &projection,
+        "urn:cerebro:tenant:pagerduty_schedule:PSC1",
+        "pagerduty.schedule",
+    );
+    assert_entity(
+        &projection,
+        "urn:cerebro:tenant:pagerduty_escalation_policy:PE1",
+        "pagerduty.escalation_policy",
+    );
+    assert_entity(
+        &projection,
+        "urn:cerebro:tenant:pagerduty_integration:PI1",
+        "pagerduty.integration",
+    );
+    assert_entity(
+        &projection,
+        "urn:cerebro:tenant:pagerduty_vendor:PV1",
+        "pagerduty.vendor",
+    );
+    assert_relation(
+        &projection,
+        "urn:cerebro:tenant:pagerduty_service:PS1",
+        "depends_on",
+        "urn:cerebro:tenant:pagerduty_escalation_policy:PE1",
+    );
+    assert_relation(
+        &projection,
+        "urn:cerebro:tenant:pagerduty_escalation_policy:PE1",
+        "belongs_to",
+        "urn:cerebro:tenant:pagerduty_team:PT1",
+    );
+    assert_relation(
+        &projection,
+        "urn:cerebro:tenant:pagerduty_escalation_policy:PE1",
+        "depends_on",
+        "urn:cerebro:tenant:pagerduty_schedule:PSC1",
+    );
+    assert_relation(
+        &projection,
+        "urn:cerebro:tenant:pagerduty_escalation_policy:PE1",
+        "depends_on",
+        "urn:cerebro:tenant:pagerduty_user:PU1",
+    );
+    assert_relation(
+        &projection,
+        "urn:cerebro:tenant:pagerduty_integration:PI1",
+        "belongs_to",
+        "urn:cerebro:tenant:pagerduty_service:PS1",
+    );
+    assert_relation(
+        &projection,
+        "urn:cerebro:tenant:pagerduty_integration:PI1",
+        "depends_on",
+        "urn:cerebro:tenant:pagerduty_vendor:PV1",
+    );
+    assert_relation(
+        &projection,
+        "urn:cerebro:tenant:pagerduty_user:PU1",
+        "has_identifier",
+        "urn:cerebro:tenant:identifier:email:alice@example.test",
+    );
+    assert_relation(
+        &projection,
+        "urn:cerebro:tenant:pagerduty_user:PU1",
+        "represents_identity",
+        "urn:cerebro:tenant:identity:email:alice@example.test",
+    );
+}
+
+#[test]
+fn failures_are_distinct_and_fail_closed() {
+    assert_eq!(
+        PagerDutyKernel::new(
+            Some("http://api.pagerduty.com"),
+            "writer",
+            PagerDutyFamily::User,
+            PagerDutyFilters::default(),
+            None
+        )
+        .unwrap_err(),
+        PagerDutyError::InvalidBaseUrl
+    );
+    assert_eq!(
+        PagerDutyKernel::new(
+            None,
+            "",
+            PagerDutyFamily::User,
+            PagerDutyFilters::default(),
+            None
+        )
+        .unwrap_err(),
+        PagerDutyError::MissingTenantId
+    );
+    assert_eq!(
+        PagerDutyKernel::new(
+            None,
+            "writer",
+            PagerDutyFamily::Integration,
+            PagerDutyFilters::default(),
+            None
+        )
+        .unwrap_err(),
+        PagerDutyError::MissingServiceId
+    );
+    assert_eq!(
+        PagerDutyKernel::new(
+            None,
+            "writer",
+            PagerDutyFamily::User,
+            PagerDutyFilters::default(),
+            Some(101)
+        )
+        .unwrap_err(),
+        PagerDutyError::InvalidPageSize
+    );
+
+    let kernel = kernel(PagerDutyFamily::User, "writer", None);
+    for cursor in ["https://evil.test/next", "-1", "+1", "not-a-number"] {
+        assert_eq!(
+            kernel.plan(Some(cursor)).unwrap_err(),
+            PagerDutyError::InvalidCursor
+        );
+    }
+    for (status, expected) in [
+        (401, PagerDutyError::AuthenticationRejected),
+        (403, PagerDutyError::PermissionDenied),
+        (429, PagerDutyError::RateLimited),
+        (503, PagerDutyError::ProviderUnavailable),
+        (418, PagerDutyError::UnexpectedProviderStatus),
+    ] {
+        assert_eq!(
+            kernel
+                .decode(&kernel.plan(None).unwrap(), status, b"{}", observed_at())
+                .unwrap_err(),
+            expected
+        );
+    }
+    assert_eq!(
+        kernel
+            .decode(&kernel.plan(None).unwrap(), 200, b"{}", observed_at())
+            .unwrap_err(),
+        PagerDutyError::MalformedResponse
+    );
+    assert_eq!(
+        kernel
+            .decode(
+                &kernel.plan(None).unwrap(),
+                200,
+                br#"{"users":[{}]}"#,
+                observed_at()
+            )
+            .unwrap_err(),
+        PagerDutyError::MissingProviderIdentity
+    );
+    assert_eq!(
+        kernel
+            .decode(
+                &kernel.plan(None).unwrap(),
+                200,
+                br#"{"users":[{"id":"PU/1"}]}"#,
+                observed_at()
+            )
+            .unwrap_err(),
+        PagerDutyError::InvalidProviderIdentity
+    );
+    assert_eq!(
+        kernel
+            .decode(
+                &kernel.plan(None).unwrap(),
+                200,
+                br#"{"users":[{"id":"PU1","name":"Alice"},{"id":"PU1","name":"Mallory"}]}"#,
+                observed_at()
+            )
+            .unwrap_err(),
+        PagerDutyError::ConflictingProviderIdentity
+    );
+    assert_eq!(
+        kernel
+            .decode(
+                &kernel.plan(None).unwrap(),
+                200,
+                &vec![b' '; request::MAX_RESPONSE_BYTES + 1],
+                observed_at()
+            )
+            .unwrap_err(),
+        PagerDutyError::ResponseTooLarge
+    );
+    let too_many = (0..=request::MAX_RECORDS_PER_PAGE)
+        .map(|index| json!({"id": format!("PU{index}")}))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        kernel
+            .decode(
+                &kernel.plan(None).unwrap(),
+                200,
+                &serde_json::to_vec(&json!({"users": too_many})).unwrap(),
+                observed_at()
+            )
+            .unwrap_err(),
+        PagerDutyError::TooManyRecords
+    );
+}
+
+fn kernel(family: PagerDutyFamily, tenant: &str, page_size: Option<usize>) -> PagerDutyKernel {
+    PagerDutyKernel::new(
+        None,
+        tenant,
+        family,
+        PagerDutyFilters {
+            service_ids: if family == PagerDutyFamily::Integration {
+                vec!["PS1".to_owned()]
+            } else {
+                Vec::new()
+            },
+        },
+        page_size,
+    )
+    .unwrap()
+}
+
+fn decode_integration(
+    kernel: &PagerDutyKernel,
+    request: &PagerDutyRequest,
+    id: &str,
+    more: bool,
+    offset: u64,
+) -> PagerDutyPage {
+    kernel
+        .decode(
+            request,
+            200,
+            &serde_json::to_vec(&json!({
+                "integrations": [{"id": id}],
+                "limit": 1,
+                "offset": offset,
+                "more": more
+            }))
+            .unwrap(),
+            observed_at(),
+        )
+        .unwrap()
+}
+
+fn observed_at() -> OffsetDateTime {
+    OffsetDateTime::parse(OBSERVED_AT, &Rfc3339).unwrap()
+}
+
+fn primary_urn(records: &[PagerDutyRecord]) -> String {
+    let record = records.first().unwrap();
+    project_pagerduty_records(records)
+        .entities
+        .into_iter()
+        .find(|entity| entity.entity_type == record.event_kind)
+        .unwrap()
+        .urn
+}
+
+fn go_fixture(family: PagerDutyFamily) -> Value {
+    serde_json::from_str(match family {
+        PagerDutyFamily::User => include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../sources/pagerduty/testdata/read_user.json"
+        )),
+        PagerDutyFamily::Team => include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../sources/pagerduty/testdata/read_team.json"
+        )),
+        PagerDutyFamily::Service => include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../sources/pagerduty/testdata/read_service.json"
+        )),
+        PagerDutyFamily::Schedule => include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../sources/pagerduty/testdata/read_schedule.json"
+        )),
+        PagerDutyFamily::EscalationPolicy => include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../sources/pagerduty/testdata/read_escalation_policy.json"
+        )),
+        PagerDutyFamily::Integration => include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../sources/pagerduty/testdata/read_integration.json"
+        )),
+        PagerDutyFamily::Vendor => include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../sources/pagerduty/testdata/read_vendor.json"
+        )),
+    })
+    .unwrap()
+}
+
+fn assert_entity(projection: &PagerDutyProjectionFacts, urn: &str, entity_type: &str) {
+    let found: Option<&PagerDutyEntityFact> = projection
+        .entities
+        .iter()
+        .find(|entity| entity.urn == urn && entity.entity_type == entity_type);
+    assert!(found.is_some(), "missing entity {urn} ({entity_type})");
+}
+
+fn assert_relation(projection: &PagerDutyProjectionFacts, from: &str, relation: &str, to: &str) {
+    let found: Option<&PagerDutyRelationFact> = projection
+        .relations
+        .iter()
+        .find(|edge| edge.from_urn == from && edge.relation == relation && edge.to_urn == to);
+    assert!(
+        found.is_some(),
+        "missing relation {from} -[{relation}]-> {to}"
+    );
+}

--- a/crates/source-runtime-next/tests/pagerduty_provider.rs
+++ b/crates/source-runtime-next/tests/pagerduty_provider.rs
@@ -1,0 +1,2 @@
+#[path = "../src/pagerduty/mod.rs"]
+mod pagerduty;


### PR DESCRIPTION
## Scope

- add a credential-free PagerDuty request/response kernel for users, teams, services, schedules, escalation policies, integrations, and vendors
- compile each family into a closed origin-restricted request and exact event contract
- preserve Go-compatible offset and service-fanout cursors, deterministic tenant-scoped identities, duplicate handling, and proposed checkpoints
- normalize the existing Go fixture corpus and emit responder identity plus escalation-coverage semantic facts
- bound responses and cursors, preserve typed provider failures, and omit secret-shaped provider fields from event payloads and graph facts

## Current boundary

This is the provider-local kernel and parity slice. It deliberately does not modify the independently owned shared runtime dispatcher/catalog bridge or the Go source registry. The existing Go loader remains authoritative until the shared Rust execution seam admits PagerDuty and the configured retirement gate permits removal. No generated contract changed.

## Validation

Exact head: `bf40e51780b0c16e4b658a10438132d93408c449`; exact Git tree: `d0116ac2fd5e8749594945e3abc828c5d3953942`.

Passed against that exact tree:

- `cargo fmt --all -- --check`
- `cargo test --locked -p cerebro-platform -p cerebro-source-catalog -p cerebro-source-runtime-next`
  - platform: 279 passed, 7 environment-dependent ignored
  - Rust-only runtime contracts: 6 passed
  - source catalog: 22 passed
  - source runtime: 371 passed
  - source worker: 4 passed
  - Linode integration regression: 7 passed
  - PagerDuty provider: 10 passed
- `cargo clippy --locked -p cerebro-platform -p cerebro-source-catalog -p cerebro-source-runtime-next --all-targets --all-features -- -D warnings`
- `go test -race ./sources/pagerduty ./internal/sourceprojection -run 'PagerDuty' -count=1`
- `go run ./tools/sourcefixture verify -root .` (138 bundles, 34 sources, 126 families)
- `make catalog-check`
- `./scripts/leak_check.sh range origin/main...HEAD`
- direct `rustfmt --edition 2024 --check` and `git diff --check`

`make check-structural-test check-arch` passed before the clean rebase; the exact-head local rerun is unavailable because the Mac Go cache is incomplete and the DDESK linter module requires Go 1.26, which that desk cannot install. Hosted structural checks remain the exact-head authority for this gate. Local managed Cargo also exits 75 at capacity preflight, so exact-head Cargo validation used the authorized DDESK workspace without changing local source authority.

## Evidence state

- live provider: not run; no PagerDuty credential or authorized test identity is available in this public-repository lane
- deployment: not applicable to this provider-local draft
- product path: not yet wired; blocked on the independently owned shared Rust execution seam and later authority retirement
