### PR TITLE
feat: add credential-free Slack Rust source kernel

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -233,6 +233,7 @@ impl ProjectionClass {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CompiledFamily {
     id: String,
+    base_url: Option<String>,
     method: HttpMethod,
     path: String,
     record_selector: String,
@@ -257,6 +258,12 @@ pub struct CompiledFamily {
 impl CompiledFamily {
     pub fn id(&self) -> &str {
         &self.id
+    }
+
+    /// Public family-specific provider base URL, when it differs from the
+    /// source transport origin.
+    pub fn base_url(&self) -> Option<&str> {
+        self.base_url.as_deref()
     }
 
     pub fn method(&self) -> HttpMethod {
@@ -943,6 +950,8 @@ struct FamilyWire {
 #[derive(Default, Deserialize)]
 struct FamilyConfigWire {
     #[serde(default)]
+    base_url: String,
+    #[serde(default)]
     config_query: BTreeMap<String, String>,
     #[serde(default)]
     config_headers: BTreeMap<String, String>,
@@ -1603,6 +1612,10 @@ fn compile_family(
         .config
         .as_ref()
         .and_then(|config| optional(config.id_template.clone()));
+    let base_url = family
+        .config
+        .as_ref()
+        .and_then(|config| optional(config.base_url.trim().to_owned()));
     if id_template
         .as_deref()
         .is_some_and(|template| !valid_id_template(template))
@@ -1687,16 +1700,17 @@ fn compile_family(
             );
         }
     }
-    let provider_contract_verified = canonical_path_template(&family.path).is_some_and(|path| {
-        verified.contains(&(
-            family.id.clone(),
-            match method {
-                HttpMethod::Get => "GET".to_owned(),
-                HttpMethod::Post => "POST".to_owned(),
-            },
-            path,
-        ))
-    });
+    let provider_contract_verified = canonical_family_locator(base_url.as_deref(), &family.path)
+        .is_some_and(|path| {
+            verified.contains(&(
+                family.id.clone(),
+                match method {
+                    HttpMethod::Get => "GET".to_owned(),
+                    HttpMethod::Post => "POST".to_owned(),
+                },
+                path,
+            ))
+        });
     let authoritative = generic_runtime_supported
         && provider_contract_verified
         && path_parameters_configured
@@ -1743,6 +1757,7 @@ fn compile_family(
         authoritative,
         projection_authoritative,
         id: family_id,
+        base_url,
         method,
         path: family.path,
         record_selector,
@@ -1978,7 +1993,7 @@ fn verified_families(proof: Option<&ProofManifestWire>) -> BTreeSet<(String, Str
                 && (family.method.is_empty() || family.method == "GET" || family.method == "POST")
         })
         .filter_map(|family| {
-            canonical_path_template(&family.path).map(|path| {
+            canonical_contract_locator(&family.path).map(|path| {
                 (
                     family.id.clone(),
                     if family.method.is_empty() {
@@ -1997,6 +2012,7 @@ fn family_plan_digest(source: &CompiledSource, family: &CompiledFamily) -> Strin
     let payload = serde_json::json!({
         "source_id": source.id(),
         "family_id": family.id(),
+        "base_url": family.base_url(),
         "method": match family.method() {
             HttpMethod::Get => "GET",
             HttpMethod::Post => "POST",
@@ -2046,6 +2062,31 @@ fn canonical_path_template(path: &str) -> Option<String> {
         canonical.push_str(query);
     }
     Some(canonical)
+}
+
+fn canonical_family_locator(base_url: Option<&str>, path: &str) -> Option<String> {
+    let base_url = base_url.unwrap_or_default().trim().trim_end_matches('/');
+    if base_url.starts_with("https://") && !base_url.contains("${") {
+        return canonical_contract_locator(&format!("{base_url}{path}"));
+    }
+    canonical_path_template(path)
+}
+
+fn canonical_contract_locator(locator: &str) -> Option<String> {
+    if locator.starts_with('/') {
+        return canonical_path_template(locator);
+    }
+    let remainder = locator.strip_prefix("https://")?;
+    let (host, path) = remainder.split_once('/')?;
+    if host.is_empty()
+        || host.contains('@')
+        || host
+            .chars()
+            .any(|character| matches!(character, '?' | '#' | '\\'))
+    {
+        return None;
+    }
+    canonical_path_template(&format!("/{path}")).map(|path| format!("https://{host}{path}"))
 }
 
 fn path_parameter(segment: &str) -> Option<&str> {
@@ -3454,7 +3495,7 @@ mod tests {
     }
 
     #[test]
-    fn undeclared_query_scope_cannot_become_collection_authority() {
+    fn slack_membership_scope_compiles_to_collection_authority() {
         let root = repository_root();
         let catalog = SourceCatalog::load(
             root.join("internal/connectorcatalog/catalog"),
@@ -3468,8 +3509,13 @@ mod tests {
             .iter()
             .find(|family| family.id() == "channel_member")
             .unwrap();
-        assert!(!family.is_authoritative());
-        assert!(family.config_query().is_empty());
+        assert!(family.is_authoritative());
+        assert_eq!(
+            family.config_query().get("channel"),
+            Some(&PathParameterBinding::OptionalScalarConfig {
+                field: "channel_id".to_owned()
+            })
+        );
     }
 
     #[test]
@@ -3534,6 +3580,14 @@ mod tests {
         );
         assert_eq!(canonical_path_template("/accounts/prefix-{id}/users"), None);
         assert_eq!(canonical_path_template("/accounts/${config.id/users"), None);
+        assert_eq!(
+            canonical_family_locator(Some("https://api.slack.com/audit/v1"), "/logs"),
+            canonical_contract_locator("https://api.slack.com/audit/v1/logs")
+        );
+        assert_eq!(
+            canonical_contract_locator("https://user@example.test/logs"),
+            None
+        );
     }
 
     #[test]

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -37,6 +37,7 @@ mod runtime_config;
 mod sdk;
 mod security_tooling_map;
 mod sentinelone;
+mod slack;
 pub mod source_execution;
 mod trivy;
 mod twilio;
@@ -166,6 +167,10 @@ pub use security_tooling_map::{
 pub use sentinelone::{
     SentinelOneError, SentinelOneFamily, SentinelOneFilters, SentinelOneKernel, SentinelOneOutcome,
     SentinelOnePage, SentinelOneRecord, SentinelOneRequest,
+};
+pub use slack::{
+    SlackCheckpoint, SlackError, SlackFamily, SlackFilters, SlackKernel, SlackPage, SlackRecord,
+    SlackRequest,
 };
 pub use trivy::{TrivyError, TrivyFamily, TrivyKernel, TrivyPage, TrivyRecord};
 pub use twilio::{

--- a/crates/source-runtime-next/src/slack.rs
+++ b/crates/source-runtime-next/src/slack.rs
@@ -1,0 +1,20 @@
+//! Credential-free Slack request planning and response normalization.
+//!
+//! The kernel covers Slack Web API inventory and membership families plus the
+//! Enterprise Grid Audit Logs API. It never receives or applies credential
+//! bytes and performs no network or graph writes.
+
+mod cursor;
+mod error;
+mod family;
+mod normalize;
+mod request;
+mod response;
+mod types;
+
+pub use error::SlackError;
+pub use family::SlackFamily;
+pub use types::{SlackCheckpoint, SlackFilters, SlackKernel, SlackPage, SlackRecord, SlackRequest};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/slack/cursor.rs
+++ b/crates/source-runtime-next/src/slack/cursor.rs
@@ -1,0 +1,123 @@
+use serde::{Deserialize, Serialize};
+
+use super::{SlackError, SlackFamily};
+
+const MAX_CURSOR_BYTES: usize = 4_096;
+const AUDIT_CURSOR_MODE: &str = "rolling_window";
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(super) struct ParsedCursor {
+    pub(super) token: String,
+    pub(super) audit_window: Option<(String, String)>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct CursorEnvelope {
+    #[serde(default)]
+    version: u8,
+    #[serde(default)]
+    source: String,
+    #[serde(default)]
+    family: String,
+    #[serde(default)]
+    mode: String,
+    #[serde(default)]
+    token: String,
+    #[serde(default)]
+    extra: std::collections::BTreeMap<String, String>,
+}
+
+pub(super) fn parse(family: SlackFamily, value: Option<&str>) -> Result<ParsedCursor, SlackError> {
+    let value = value.unwrap_or_default().trim();
+    if value.is_empty() {
+        return Ok(ParsedCursor::default());
+    }
+    if !family.supports_cursor() {
+        return Err(SlackError::UnsupportedCursor);
+    }
+    if value.len() > MAX_CURSOR_BYTES || value.chars().any(char::is_control) {
+        return Err(SlackError::InvalidCursor);
+    }
+    if family == SlackFamily::AccessLog {
+        let page = value
+            .parse::<usize>()
+            .map_err(|_| SlackError::InvalidCursor)?;
+        if page == 0 || page > 1_000_000 {
+            return Err(SlackError::InvalidCursor);
+        }
+        return Ok(ParsedCursor {
+            token: page.to_string(),
+            audit_window: None,
+        });
+    }
+    if family == SlackFamily::AuditLog && value.starts_with('{') {
+        let envelope: CursorEnvelope =
+            serde_json::from_str(value).map_err(|_| SlackError::InvalidCursor)?;
+        let oldest = envelope
+            .extra
+            .get("oldest")
+            .map(String::as_str)
+            .unwrap_or("")
+            .trim();
+        let latest = envelope
+            .extra
+            .get("latest")
+            .map(String::as_str)
+            .unwrap_or("")
+            .trim();
+        if envelope.version != 1
+            || envelope.source.trim() != "slack"
+            || envelope.family.trim() != "audit_log"
+            || envelope.mode.trim() != AUDIT_CURSOR_MODE
+            || envelope.token.trim().is_empty()
+            || oldest.is_empty()
+            || latest.is_empty()
+            || !unix_seconds(oldest)
+            || !unix_seconds(latest)
+        {
+            return Err(SlackError::InvalidCursor);
+        }
+        return Ok(ParsedCursor {
+            token: envelope.token.trim().to_owned(),
+            audit_window: Some((oldest.to_owned(), latest.to_owned())),
+        });
+    }
+    Ok(ParsedCursor {
+        token: value.to_owned(),
+        audit_window: None,
+    })
+}
+
+pub(super) fn audit_next(
+    token: &str,
+    window: Option<&(String, String)>,
+) -> Result<Option<String>, SlackError> {
+    let token = token.trim();
+    if token.is_empty() {
+        return Ok(None);
+    }
+    if token.len() > MAX_CURSOR_BYTES || token.chars().any(char::is_control) {
+        return Err(SlackError::InvalidCursor);
+    }
+    let Some((oldest, latest)) = window else {
+        return Ok(Some(token.to_owned()));
+    };
+    let envelope = CursorEnvelope {
+        version: 1,
+        source: "slack".to_owned(),
+        family: "audit_log".to_owned(),
+        mode: AUDIT_CURSOR_MODE.to_owned(),
+        token: token.to_owned(),
+        extra: std::collections::BTreeMap::from([
+            ("latest".to_owned(), latest.to_owned()),
+            ("oldest".to_owned(), oldest.to_owned()),
+        ]),
+    };
+    serde_json::to_string(&envelope)
+        .map(Some)
+        .map_err(|_| SlackError::InvalidCursor)
+}
+
+pub(super) fn unix_seconds(value: &str) -> bool {
+    value.parse::<u64>().is_ok_and(|value| value > 0)
+}

--- a/crates/source-runtime-next/src/slack/error.rs
+++ b/crates/source-runtime-next/src/slack/error.rs
@@ -1,0 +1,89 @@
+use std::{error::Error, fmt};
+
+/// Closed Slack provider and kernel failure taxonomy.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SlackError {
+    /// Family identifier is outside the checked-in Slack contract.
+    InvalidFamily,
+    /// Provider origin is not a bounded credential-free HTTPS origin.
+    InvalidOrigin,
+    /// Authenticated tenant identity is missing or unsafe.
+    InvalidTenant,
+    /// Required family scope such as a channel or user-group ID is missing.
+    MissingScope,
+    /// Page size is outside the family bound.
+    InvalidPageSize,
+    /// Cursor does not match the selected family contract.
+    InvalidCursor,
+    /// A cursor was supplied to a non-paginated family.
+    UnsupportedCursor,
+    /// Request was decoded by another family or kernel.
+    RequestScopeMismatch,
+    /// Provider rejected the externally applied credential.
+    AuthenticationRejected,
+    /// Credential lacks the selected family's provider scope.
+    RequiredScopeMissing,
+    /// Provider asked the host to retry later.
+    RateLimited {
+        /// Bounded Retry-After delay, when supplied.
+        retry_after_seconds: Option<u64>,
+    },
+    /// Provider returned a retryable server status.
+    ProviderUnavailable {
+        /// HTTP status in the inclusive 500-599 range.
+        status: u16,
+    },
+    /// Provider returned another unsupported status.
+    UnexpectedStatus {
+        /// Unsupported HTTP status.
+        status: u16,
+    },
+    /// Response exceeded the compiled byte bound.
+    ResponseTooLarge,
+    /// Response did not match the selected Slack envelope.
+    MalformedResponse,
+    /// Provider record failed the family scalar/object contract.
+    InvalidRecord,
+    /// Provider response contained credential-bearing fields.
+    CredentialMaterial,
+    /// Provider payload attempted to supply the authenticated tenant identity.
+    TenantMismatch,
+    /// Provider record has no stable family identity.
+    MissingStableIdentity,
+    /// The same stable identity appeared with conflicting content.
+    ConflictingDuplicate,
+    /// Provider timestamp cannot be represented safely.
+    InvalidTimestamp,
+}
+
+impl fmt::Display for SlackError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidFamily => "slack family is invalid",
+            Self::InvalidOrigin => "slack origin must be a credential-free HTTPS origin",
+            Self::InvalidTenant => "slack tenant identity is invalid",
+            Self::MissingScope => "slack family scope is missing",
+            Self::InvalidPageSize => "slack page size is outside the family bound",
+            Self::InvalidCursor => "slack cursor is invalid",
+            Self::UnsupportedCursor => "slack family does not support cursors",
+            Self::RequestScopeMismatch => "slack request does not match the selected kernel",
+            Self::AuthenticationRejected => "slack rejected the externally applied credential",
+            Self::RequiredScopeMissing => "slack credential is missing the required scope",
+            Self::RateLimited { .. } => "slack rate limited the request",
+            Self::ProviderUnavailable { .. } => "slack provider is temporarily unavailable",
+            Self::UnexpectedStatus { .. } => "slack returned an unexpected HTTP status",
+            Self::ResponseTooLarge => "slack response exceeds the compiled byte bound",
+            Self::MalformedResponse => "slack response envelope is malformed",
+            Self::InvalidRecord => "slack record does not match the family contract",
+            Self::CredentialMaterial => "slack response contains credential material",
+            Self::TenantMismatch => "slack provider payload cannot supply the tenant identity",
+            Self::MissingStableIdentity => "slack record is missing a stable identity",
+            Self::ConflictingDuplicate => {
+                "slack stable identity was repeated with conflicting content"
+            }
+            Self::InvalidTimestamp => "slack provider timestamp is invalid",
+        })
+    }
+}
+
+impl Error for SlackError {}

--- a/crates/source-runtime-next/src/slack/family.rs
+++ b/crates/source-runtime-next/src/slack/family.rs
@@ -1,0 +1,132 @@
+use std::str::FromStr;
+
+use super::SlackError;
+
+/// Closed Slack source-family catalog.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum SlackFamily {
+    /// Slack workspace/team inventory.
+    Team,
+    /// Slack user inventory.
+    User,
+    /// Public and private channel inventory.
+    Channel,
+    /// Slack user-group inventory.
+    UserGroup,
+    /// Team access-log rows.
+    AccessLog,
+    /// User-to-channel membership.
+    ChannelMember,
+    /// User-to-user-group membership.
+    UserGroupMember,
+    /// Enterprise Grid audit-log entries.
+    AuditLog,
+}
+
+impl SlackFamily {
+    /// Stable source-family identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Team => "team",
+            Self::User => "user",
+            Self::Channel => "channel",
+            Self::UserGroup => "user_group",
+            Self::AccessLog => "access_log",
+            Self::ChannelMember => "channel_member",
+            Self::UserGroupMember => "user_group_member",
+            Self::AuditLog => "audit_log",
+        }
+    }
+
+    /// Exact event kind admitted for this family.
+    pub fn event_kind(self) -> String {
+        format!("slack.{}", self.as_str())
+    }
+
+    /// Exact event schema admitted for this family.
+    pub fn schema_ref(self) -> String {
+        format!("slack/{}/v1", self.as_str())
+    }
+
+    /// Provider method for this family.
+    pub const fn method(self) -> &'static str {
+        if matches!(self, Self::Team) {
+            "POST"
+        } else {
+            "GET"
+        }
+    }
+
+    /// Provider path for this family.
+    pub const fn path(self) -> &'static str {
+        match self {
+            Self::Team => "/auth.teams.list",
+            Self::User => "/users.list",
+            Self::Channel => "/conversations.list",
+            Self::UserGroup => "/usergroups.list",
+            Self::AccessLog => "/team.accessLogs",
+            Self::ChannelMember => "/conversations.members",
+            Self::UserGroupMember => "/usergroups.users.list",
+            Self::AuditLog => "/logs",
+        }
+    }
+
+    /// Required Slack provider scopes.
+    pub const fn required_scopes(self) -> &'static [&'static str] {
+        match self {
+            Self::Team | Self::AccessLog => &["team:read"],
+            Self::User => &["users:read", "users:read.email"],
+            Self::Channel | Self::ChannelMember => &["channels:read", "groups:read"],
+            Self::UserGroup | Self::UserGroupMember => &["usergroups:read"],
+            Self::AuditLog => &["auditlogs:read"],
+        }
+    }
+
+    pub(super) const fn uses_audit_origin(self) -> bool {
+        matches!(self, Self::AuditLog)
+    }
+
+    pub(super) const fn supports_cursor(self) -> bool {
+        !matches!(self, Self::UserGroup)
+    }
+
+    pub(super) const fn required_attributes(self) -> &'static [&'static str] {
+        match self {
+            Self::Team => &["team_id"],
+            Self::User => &["user_id"],
+            Self::Channel => &["channel_id"],
+            Self::UserGroup => &["group_id"],
+            Self::AccessLog => &["actor_id", "event_type"],
+            Self::ChannelMember => &["channel_id", "user_id"],
+            Self::UserGroupMember => &["usergroup_id", "user_id"],
+            Self::AuditLog => &["actor_id", "event_type"],
+        }
+    }
+
+    pub(super) const fn required_payload_fields(self) -> &'static [&'static str] {
+        match self {
+            Self::Team | Self::User | Self::Channel | Self::UserGroup | Self::AuditLog => &["id"],
+            Self::AccessLog => &["user_id"],
+            Self::ChannelMember => &["channel_id", "user_id"],
+            Self::UserGroupMember => &["usergroup_id", "user_id"],
+        }
+    }
+}
+
+impl FromStr for SlackFamily {
+    type Err = SlackError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim() {
+            "team" => Ok(Self::Team),
+            "user" => Ok(Self::User),
+            "channel" => Ok(Self::Channel),
+            "user_group" => Ok(Self::UserGroup),
+            "access_log" => Ok(Self::AccessLog),
+            "channel_member" => Ok(Self::ChannelMember),
+            "user_group_member" => Ok(Self::UserGroupMember),
+            "audit_log" => Ok(Self::AuditLog),
+            _ => Err(SlackError::InvalidFamily),
+        }
+    }
+}

--- a/crates/source-runtime-next/src/slack/normalize.rs
+++ b/crates/source-runtime-next/src/slack/normalize.rs
@@ -1,0 +1,378 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+
+use super::{SlackError, SlackFamily, SlackKernel, SlackRecord, request::safe_component};
+
+pub(super) fn normalize(kernel: &SlackKernel, value: &Value) -> Result<SlackRecord, SlackError> {
+    if contains_credential_material(value) {
+        return Err(SlackError::CredentialMaterial);
+    }
+    if contains_untrusted_tenant(value) {
+        return Err(SlackError::TenantMismatch);
+    }
+    let (payload, provider_id, mut attributes) = match kernel.family {
+        SlackFamily::Team => object_record(value, "id", "team_id")?,
+        SlackFamily::User => object_record(value, "id", "user_id")?,
+        SlackFamily::Channel => object_record(value, "id", "channel_id")?,
+        SlackFamily::UserGroup => object_record(value, "id", "group_id")?,
+        SlackFamily::AccessLog => access_log(value)?,
+        SlackFamily::ChannelMember => membership(
+            value,
+            "channel_id",
+            kernel.filters.channel_id.as_deref(),
+            "channel",
+        )?,
+        SlackFamily::UserGroupMember => membership(
+            value,
+            "usergroup_id",
+            kernel.filters.usergroup_id.as_deref(),
+            "user_group",
+        )?,
+        SlackFamily::AuditLog => audit_log(value)?,
+    };
+    base_attributes(kernel.family, &provider_id, &mut attributes);
+    if kernel.family == SlackFamily::AccessLog
+        && let Some(user_id) = attributes.get("user_id").cloned()
+    {
+        attributes.insert("external_id".to_owned(), user_id);
+    }
+    family_attributes(kernel.family, &payload, &mut attributes);
+    validate_contract(kernel.family, &attributes, &payload)?;
+    let occurred_at_unix_millis =
+        occurrence_time(kernel.family, &payload)?.unwrap_or(kernel.observed_at_unix_millis);
+    let event_id = event_id(&kernel.tenant_id, kernel.family, &provider_id);
+    Ok(SlackRecord {
+        tenant_id: kernel.tenant_id.clone(),
+        event_id,
+        kind: kernel.family.event_kind(),
+        schema_ref: kernel.family.schema_ref(),
+        family: kernel.family.as_str().to_owned(),
+        provider_id,
+        occurred_at_unix_millis,
+        attributes,
+        payload,
+    })
+}
+
+fn object_record(
+    value: &Value,
+    id_path: &str,
+    identity_attribute: &str,
+) -> Result<(Value, String, BTreeMap<String, String>), SlackError> {
+    let object = value.as_object().ok_or(SlackError::InvalidRecord)?;
+    let provider_id = required_string(object, id_path)?;
+    let attributes = BTreeMap::from([(identity_attribute.to_owned(), provider_id.clone())]);
+    Ok((value.clone(), provider_id, attributes))
+}
+
+fn membership(
+    value: &Value,
+    container_key: &str,
+    container: Option<&str>,
+    membership_type: &str,
+) -> Result<(Value, String, BTreeMap<String, String>), SlackError> {
+    let user_id = match value {
+        Value::String(value) => bounded_identity(value)?,
+        Value::Object(object) => required_string(object, "user_id")?,
+        _ => return Err(SlackError::InvalidRecord),
+    };
+    let container = container
+        .filter(|value| safe_component(value, 256))
+        .ok_or(SlackError::MissingScope)?;
+    let provider_id = format!("{container}-{user_id}");
+    let payload = Value::Object(Map::from_iter([
+        (
+            container_key.to_owned(),
+            Value::String(container.to_owned()),
+        ),
+        ("user_id".to_owned(), Value::String(user_id.clone())),
+    ]));
+    let attributes = BTreeMap::from([
+        (container_key.to_owned(), container.to_owned()),
+        ("membership_type".to_owned(), membership_type.to_owned()),
+        ("user_id".to_owned(), user_id),
+    ]);
+    Ok((payload, provider_id, attributes))
+}
+
+fn access_log(value: &Value) -> Result<(Value, String, BTreeMap<String, String>), SlackError> {
+    let object = value.as_object().ok_or(SlackError::InvalidRecord)?;
+    let user_id = required_string(object, "user_id")?;
+    let ip = required_string(object, "ip")?;
+    let provider_id = stable_join(&[&user_id, &ip]);
+    let attributes = BTreeMap::from([
+        ("actor_id".to_owned(), user_id.clone()),
+        ("event_type".to_owned(), "team_access".to_owned()),
+        ("ip_address".to_owned(), ip),
+        ("user_id".to_owned(), user_id),
+    ]);
+    Ok((value.clone(), provider_id, attributes))
+}
+
+fn audit_log(value: &Value) -> Result<(Value, String, BTreeMap<String, String>), SlackError> {
+    let object = value.as_object().ok_or(SlackError::InvalidRecord)?;
+    let provider_id = required_string(object, "id")?;
+    let actor_id =
+        first_text(value, &["actor.user.id", "actor.id"]).ok_or(SlackError::InvalidRecord)?;
+    let event_type = text_at(value, "action").ok_or(SlackError::InvalidRecord)?;
+    let attributes = BTreeMap::from([
+        ("actor_id".to_owned(), actor_id),
+        ("event_type".to_owned(), event_type),
+    ]);
+    Ok((value.clone(), provider_id, attributes))
+}
+
+fn base_attributes(
+    family: SlackFamily,
+    provider_id: &str,
+    attributes: &mut BTreeMap<String, String>,
+) {
+    for (key, value) in [
+        ("external_id", provider_id),
+        ("family", family.as_str()),
+        ("provider", "slack"),
+        ("source_product", "slack"),
+        ("source_provider", "slack"),
+    ] {
+        attributes.insert(key.to_owned(), value.to_owned());
+    }
+}
+
+fn family_attributes(
+    family: SlackFamily,
+    payload: &Value,
+    attributes: &mut BTreeMap<String, String>,
+) {
+    let mappings: &[(&str, &[&str])] = match family {
+        SlackFamily::Team => &[("name", &["name"]), ("domain", &["domain"])],
+        SlackFamily::User => &[
+            ("team_id", &["team_id"]),
+            ("email", &["profile.email", "email"]),
+            ("real_name", &["real_name", "profile.real_name"]),
+            ("name", &["name"]),
+            ("deleted", &["deleted"]),
+            ("is_admin", &["is_admin"]),
+            ("is_owner", &["is_owner"]),
+            ("is_primary_owner", &["is_primary_owner"]),
+            ("is_bot", &["is_bot"]),
+            ("is_restricted", &["is_restricted"]),
+            ("is_ultra_restricted", &["is_ultra_restricted"]),
+            ("has_2fa", &["has_2fa"]),
+            ("has_mfa", &["has_2fa"]),
+            ("two_factor_type", &["two_factor_type"]),
+        ],
+        SlackFamily::Channel => &[
+            ("team_id", &["context_team_id"]),
+            ("shared_team_ids", &["shared_team_ids", "internal_team_ids"]),
+            ("name", &["name"]),
+            ("is_private", &["is_private"]),
+            ("is_archived", &["is_archived"]),
+            ("creator", &["creator"]),
+            ("num_members", &["num_members"]),
+        ],
+        SlackFamily::UserGroup => &[
+            ("team_id", &["team_id"]),
+            ("handle", &["handle"]),
+            ("name", &["name"]),
+            ("description", &["description"]),
+            ("is_disabled", &["is_disabled"]),
+        ],
+        SlackFamily::AccessLog => &[
+            ("actor_name", &["username"]),
+            ("username", &["username"]),
+            ("user_agent", &["user_agent"]),
+            ("isp", &["isp"]),
+            ("country", &["country"]),
+            ("region", &["region"]),
+            ("login_count", &["count"]),
+        ],
+        SlackFamily::AuditLog => &[
+            ("actor_type", &["actor.type"]),
+            ("actor_name", &["actor.user.name", "actor.name"]),
+            ("actor_email", &["actor.user.email"]),
+            ("resource_type", &["entity.type"]),
+            (
+                "resource_id",
+                &[
+                    "entity.user.id",
+                    "entity.channel.id",
+                    "entity.file.id",
+                    "entity.id",
+                ],
+            ),
+            (
+                "resource_name",
+                &[
+                    "entity.user.name",
+                    "entity.channel.name",
+                    "entity.file.name",
+                    "entity.name",
+                ],
+            ),
+            (
+                "team_id",
+                &[
+                    "actor.user.team",
+                    "entity.user.team",
+                    "entity.channel.team",
+                    "context.team_id",
+                ],
+            ),
+            ("ip_address", &["context.ip_address"]),
+            ("user_agent", &["context.ua"]),
+        ],
+        SlackFamily::ChannelMember | SlackFamily::UserGroupMember => &[],
+    };
+    for (target, paths) in mappings {
+        if let Some(value) = first_text(payload, paths) {
+            attributes.insert((*target).to_owned(), value);
+        }
+    }
+}
+
+fn occurrence_time(family: SlackFamily, payload: &Value) -> Result<Option<i64>, SlackError> {
+    let paths: &[&str] = match family {
+        SlackFamily::Team | SlackFamily::ChannelMember | SlackFamily::UserGroupMember => &[],
+        SlackFamily::User => &["updated"],
+        SlackFamily::Channel => &["created", "updated"],
+        SlackFamily::UserGroup => &["date_update", "date_create"],
+        SlackFamily::AccessLog => &["date_last", "date_first"],
+        SlackFamily::AuditLog => &["date_create"],
+    };
+    for path in paths {
+        let Some(value) = value_at(payload, path) else {
+            continue;
+        };
+        let seconds = match value {
+            Value::Number(value) => value.as_i64(),
+            Value::String(value) => value.parse::<i64>().ok(),
+            _ => None,
+        }
+        .ok_or(SlackError::InvalidTimestamp)?;
+        return seconds
+            .checked_mul(1_000)
+            .map(Some)
+            .ok_or(SlackError::InvalidTimestamp);
+    }
+    Ok(None)
+}
+
+fn validate_contract(
+    family: SlackFamily,
+    attributes: &BTreeMap<String, String>,
+    payload: &Value,
+) -> Result<(), SlackError> {
+    if family.required_attributes().iter().any(|field| {
+        attributes
+            .get(*field)
+            .is_none_or(|value| value.trim().is_empty())
+    }) || family
+        .required_payload_fields()
+        .iter()
+        .any(|field| value_at(payload, field).is_none_or(Value::is_null))
+    {
+        return Err(SlackError::InvalidRecord);
+    }
+    Ok(())
+}
+
+fn required_string(object: &Map<String, Value>, key: &str) -> Result<String, SlackError> {
+    object
+        .get(key)
+        .and_then(Value::as_str)
+        .map(bounded_identity)
+        .transpose()?
+        .ok_or(SlackError::MissingStableIdentity)
+}
+
+fn bounded_identity(value: &str) -> Result<String, SlackError> {
+    let value = value.trim();
+    if !safe_component(value, 512) {
+        return Err(SlackError::MissingStableIdentity);
+    }
+    Ok(value.to_owned())
+}
+
+fn first_text(value: &Value, paths: &[&str]) -> Option<String> {
+    paths.iter().find_map(|path| text_at(value, path))
+}
+
+fn text_at(value: &Value, path: &str) -> Option<String> {
+    match value_at(value, path)? {
+        Value::String(value) => (!value.trim().is_empty()).then(|| value.trim().to_owned()),
+        Value::Bool(value) => Some(value.to_string()),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Array(values) => {
+            let values = values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .collect::<Vec<_>>();
+            (!values.is_empty()).then(|| values.join(","))
+        }
+        _ => None,
+    }
+}
+
+fn value_at<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    let mut current = value;
+    for part in path.split('.') {
+        current = current.as_object()?.get(part)?;
+    }
+    Some(current)
+}
+
+fn contains_credential_material(value: &Value) -> bool {
+    match value {
+        Value::Object(values) => values.iter().any(|(key, value)| {
+            matches!(
+                key.to_ascii_lowercase().as_str(),
+                "access_token"
+                    | "api_token"
+                    | "authorization"
+                    | "client_secret"
+                    | "cookie"
+                    | "password"
+                    | "refresh_token"
+                    | "token"
+            ) || contains_credential_material(value)
+        }),
+        Value::Array(values) => values.iter().any(contains_credential_material),
+        _ => false,
+    }
+}
+
+fn contains_untrusted_tenant(value: &Value) -> bool {
+    match value {
+        Value::Object(values) => values.iter().any(|(key, value)| {
+            key.eq_ignore_ascii_case("tenant_id") || contains_untrusted_tenant(value)
+        }),
+        Value::Array(values) => values.iter().any(contains_untrusted_tenant),
+        _ => false,
+    }
+}
+
+fn event_id(tenant_id: &str, family: SlackFamily, provider_id: &str) -> String {
+    let digest = stable_digest(&[tenant_id, family.as_str(), provider_id]);
+    format!("slack-{}-{digest}", family.as_str())
+}
+
+fn stable_join(values: &[&str]) -> String {
+    stable_digest(values)
+}
+
+fn stable_digest(values: &[&str]) -> String {
+    let mut digest = Sha256::new();
+    for value in values {
+        digest.update((value.len() as u64).to_be_bytes());
+        digest.update(value.as_bytes());
+    }
+    digest
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}

--- a/crates/source-runtime-next/src/slack/request.rs
+++ b/crates/source-runtime-next/src/slack/request.rs
@@ -1,0 +1,212 @@
+use std::net::IpAddr;
+
+use reqwest::Url;
+
+use super::{
+    SlackError, SlackFamily, SlackFilters, SlackKernel, SlackRequest,
+    cursor::{self, ParsedCursor},
+};
+
+pub(super) fn origin(value: &str) -> Result<Url, SlackError> {
+    let value = value.trim().trim_end_matches('/');
+    let parsed = Url::parse(value).map_err(|_| SlackError::InvalidOrigin)?;
+    if parsed.scheme() != "https"
+        || parsed.host_str().is_none()
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+        || parsed.port_or_known_default() != Some(443)
+    {
+        return Err(SlackError::InvalidOrigin);
+    }
+    if let Some(host) = parsed.host_str()
+        && let Ok(ip) = host.parse::<IpAddr>()
+        && (ip.is_loopback() || ip.is_unspecified() || is_private(ip))
+    {
+        return Err(SlackError::InvalidOrigin);
+    }
+    Ok(parsed)
+}
+
+fn is_private(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => ip.is_private() || ip.is_link_local() || ip.is_broadcast(),
+        IpAddr::V6(ip) => ip.is_unique_local() || ip.is_unicast_link_local(),
+    }
+}
+
+pub(super) fn safe_component(value: &str, maximum: usize) -> bool {
+    let value = value.trim();
+    !value.is_empty()
+        && value.len() <= maximum
+        && value == value.trim()
+        && !value.chars().any(char::is_control)
+}
+
+pub(super) fn validate_filters(
+    family: SlackFamily,
+    filters: &SlackFilters,
+) -> Result<(), SlackError> {
+    if family == SlackFamily::ChannelMember
+        && filters
+            .channel_id
+            .as_deref()
+            .is_none_or(|value| !safe_component(value, 256))
+    {
+        return Err(SlackError::MissingScope);
+    }
+    if family == SlackFamily::UserGroupMember
+        && filters
+            .usergroup_id
+            .as_deref()
+            .is_none_or(|value| !safe_component(value, 256))
+    {
+        return Err(SlackError::MissingScope);
+    }
+    for value in [
+        &filters.before,
+        &filters.action,
+        &filters.actor,
+        &filters.entity,
+        &filters.oldest,
+        &filters.latest,
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if !safe_component(value, 2_048) {
+            return Err(SlackError::MissingScope);
+        }
+    }
+    for value in [&filters.oldest, &filters.latest].into_iter().flatten() {
+        if !cursor::unix_seconds(value) {
+            return Err(SlackError::InvalidCursor);
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn plan(kernel: &SlackKernel, cursor: Option<&str>) -> Result<SlackRequest, SlackError> {
+    let parsed_cursor = cursor::parse(kernel.family, cursor)?;
+    let base = if kernel.family.uses_audit_origin() {
+        &kernel.audit_origin
+    } else {
+        &kernel.web_origin
+    };
+    let mut url = Url::parse(&format!(
+        "{}{}",
+        base.as_str().trim_end_matches('/'),
+        kernel.family.path()
+    ))
+    .map_err(|_| SlackError::InvalidOrigin)?;
+    if url.origin() != base.origin() {
+        return Err(SlackError::InvalidOrigin);
+    }
+    add_query(kernel, &parsed_cursor, &mut url)?;
+    let audit_window = parsed_cursor.audit_window.or_else(|| {
+        (kernel.family == SlackFamily::AuditLog)
+            .then(|| {
+                Some((
+                    kernel.filters.oldest.clone()?,
+                    kernel.filters.latest.clone()?,
+                ))
+            })
+            .flatten()
+    });
+    Ok(SlackRequest {
+        family: kernel.family,
+        url,
+        method: kernel.family.method(),
+        page_size: kernel.page_size,
+        audit_window,
+    })
+}
+
+fn add_query(kernel: &SlackKernel, cursor: &ParsedCursor, url: &mut Url) -> Result<(), SlackError> {
+    let mut pairs = Vec::<(&str, String)>::new();
+    match kernel.family {
+        SlackFamily::Team | SlackFamily::User => {
+            pairs.push(("limit", kernel.page_size.to_string()));
+        }
+        SlackFamily::Channel => {
+            pairs.extend([
+                ("exclude_archived", "false".to_owned()),
+                ("limit", kernel.page_size.to_string()),
+                ("types", "public_channel,private_channel".to_owned()),
+            ]);
+        }
+        SlackFamily::UserGroup => {}
+        SlackFamily::AccessLog => {
+            pairs.push(("count", kernel.page_size.to_string()));
+            pairs.push((
+                "page",
+                if cursor.token.is_empty() {
+                    "1".to_owned()
+                } else {
+                    cursor.token.clone()
+                },
+            ));
+            add_optional(&mut pairs, "before", kernel.filters.before.as_ref());
+        }
+        SlackFamily::ChannelMember => {
+            pairs.push((
+                "channel",
+                kernel
+                    .filters
+                    .channel_id
+                    .clone()
+                    .ok_or(SlackError::MissingScope)?,
+            ));
+            pairs.push(("limit", kernel.page_size.to_string()));
+        }
+        SlackFamily::UserGroupMember => {
+            pairs.push(("include_disabled", "true".to_owned()));
+            pairs.push(("limit", kernel.page_size.to_string()));
+            pairs.push((
+                "usergroup",
+                kernel
+                    .filters
+                    .usergroup_id
+                    .clone()
+                    .ok_or(SlackError::MissingScope)?,
+            ));
+        }
+        SlackFamily::AuditLog => {
+            pairs.push(("limit", kernel.page_size.to_string()));
+            add_optional(&mut pairs, "action", kernel.filters.action.as_ref());
+            add_optional(&mut pairs, "actor", kernel.filters.actor.as_ref());
+            add_optional(&mut pairs, "entity", kernel.filters.entity.as_ref());
+            let window = cursor.audit_window.as_ref();
+            let oldest = window
+                .map(|value| &value.0)
+                .or(kernel.filters.oldest.as_ref());
+            let latest = window
+                .map(|value| &value.1)
+                .or(kernel.filters.latest.as_ref());
+            add_optional(&mut pairs, "oldest", oldest);
+            add_optional(&mut pairs, "latest", latest);
+        }
+    }
+    if !cursor.token.is_empty() && kernel.family != SlackFamily::AccessLog {
+        pairs.push(("cursor", cursor.token.clone()));
+    }
+    pairs.sort_by(|left, right| left.0.cmp(right.0));
+    if !pairs.is_empty() {
+        let mut query = url.query_pairs_mut();
+        for (key, value) in pairs {
+            query.append_pair(key, &value);
+        }
+    }
+    Ok(())
+}
+
+fn add_optional(
+    pairs: &mut Vec<(&'static str, String)>,
+    key: &'static str,
+    value: Option<&String>,
+) {
+    if let Some(value) = value.filter(|value| !value.trim().is_empty()) {
+        pairs.push((key, value.trim().to_owned()));
+    }
+}

--- a/crates/source-runtime-next/src/slack/response.rs
+++ b/crates/source-runtime-next/src/slack/response.rs
@@ -1,0 +1,187 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use super::{
+    SlackCheckpoint, SlackError, SlackFamily, SlackKernel, SlackPage, SlackRequest, cursor,
+    normalize,
+};
+
+pub(super) const MAX_RESPONSE_BYTES: usize = 8 << 20;
+const MAX_UNPAGED_RECORDS: usize = 1_000;
+
+pub(super) fn decode(
+    kernel: &SlackKernel,
+    request: &SlackRequest,
+    status: u16,
+    retry_after: Option<&str>,
+    body: &[u8],
+) -> Result<SlackPage, SlackError> {
+    validate_request(kernel, request)?;
+    classify_status(status, retry_after)?;
+    if body.len() > MAX_RESPONSE_BYTES {
+        return Err(SlackError::ResponseTooLarge);
+    }
+    let root: Value = serde_json::from_slice(body).map_err(|_| SlackError::MalformedResponse)?;
+    classify_slack_envelope(&root)?;
+    let items = records(kernel.family, &root)?;
+    let maximum = if kernel.family == SlackFamily::UserGroup {
+        MAX_UNPAGED_RECORDS
+    } else {
+        request.page_size
+    };
+    if items.len() > maximum {
+        return Err(SlackError::MalformedResponse);
+    }
+    let mut by_identity = BTreeMap::<String, Vec<u8>>::new();
+    let mut records = Vec::with_capacity(items.len());
+    for item in items {
+        let record = normalize::normalize(kernel, item)?;
+        let canonical =
+            serde_json::to_vec(&record.payload).map_err(|_| SlackError::InvalidRecord)?;
+        match by_identity.get(&record.event_id) {
+            Some(existing) if existing == &canonical => continue,
+            Some(_) => return Err(SlackError::ConflictingDuplicate),
+            None => {
+                by_identity.insert(record.event_id.clone(), canonical);
+                records.push(record);
+            }
+        }
+    }
+    let next_cursor = next_cursor(kernel.family, request, &root)?;
+    let watermark_unix_millis = records
+        .iter()
+        .map(|record| record.occurred_at_unix_millis)
+        .max();
+    Ok(SlackPage {
+        records,
+        next_cursor: next_cursor.clone(),
+        checkpoint: SlackCheckpoint {
+            next_cursor,
+            watermark_unix_millis,
+        },
+    })
+}
+
+fn validate_request(kernel: &SlackKernel, request: &SlackRequest) -> Result<(), SlackError> {
+    let origin = if kernel.family.uses_audit_origin() {
+        &kernel.audit_origin
+    } else {
+        &kernel.web_origin
+    };
+    let expected_path = format!(
+        "{}{}",
+        origin.path().trim_end_matches('/'),
+        kernel.family.path()
+    );
+    if request.family != kernel.family
+        || request.method != kernel.family.method()
+        || request.url.origin() != origin.origin()
+        || request.url.path() != expected_path
+        || request.page_size != kernel.page_size
+    {
+        return Err(SlackError::RequestScopeMismatch);
+    }
+    Ok(())
+}
+
+fn classify_status(status: u16, retry_after: Option<&str>) -> Result<(), SlackError> {
+    match status {
+        200..=299 => Ok(()),
+        401 => Err(SlackError::AuthenticationRejected),
+        403 => Err(SlackError::RequiredScopeMissing),
+        429 => Err(SlackError::RateLimited {
+            retry_after_seconds: retry_after
+                .and_then(|value| value.trim().parse::<u64>().ok())
+                .filter(|value| *value <= 3_600),
+        }),
+        500..=599 => Err(SlackError::ProviderUnavailable { status }),
+        _ => Err(SlackError::UnexpectedStatus { status }),
+    }
+}
+
+fn classify_slack_envelope(root: &Value) -> Result<(), SlackError> {
+    let Some(object) = root.as_object() else {
+        return Err(SlackError::MalformedResponse);
+    };
+    match object.get("ok") {
+        None | Some(Value::Bool(true)) => Ok(()),
+        Some(Value::Bool(false)) => {
+            let code = object
+                .get("error")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            match code.trim() {
+                "invalid_auth" | "account_inactive" | "token_revoked" | "not_authed" => {
+                    Err(SlackError::AuthenticationRejected)
+                }
+                "missing_scope" | "not_allowed_token_type" => Err(SlackError::RequiredScopeMissing),
+                "ratelimited" => Err(SlackError::RateLimited {
+                    retry_after_seconds: None,
+                }),
+                _ => Err(SlackError::MalformedResponse),
+            }
+        }
+        Some(_) => Err(SlackError::MalformedResponse),
+    }
+}
+
+fn records(family: SlackFamily, root: &Value) -> Result<&[Value], SlackError> {
+    let key = match family {
+        SlackFamily::Team => "teams",
+        SlackFamily::User => "members",
+        SlackFamily::Channel => "channels",
+        SlackFamily::UserGroup => "usergroups",
+        SlackFamily::AccessLog => "logins",
+        SlackFamily::ChannelMember => "members",
+        SlackFamily::UserGroupMember => "users",
+        SlackFamily::AuditLog => "entries",
+    };
+    root.get(key)
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .ok_or(SlackError::MalformedResponse)
+}
+
+fn next_cursor(
+    family: SlackFamily,
+    request: &SlackRequest,
+    root: &Value,
+) -> Result<Option<String>, SlackError> {
+    if family == SlackFamily::UserGroup {
+        return Ok(None);
+    }
+    if family == SlackFamily::AccessLog {
+        let Some(paging) = root.get("paging").and_then(Value::as_object) else {
+            return Ok(None);
+        };
+        let page = paging.get("page").and_then(Value::as_u64).unwrap_or(0);
+        let pages = paging.get("pages").and_then(Value::as_u64).unwrap_or(0);
+        if page == 0 || pages == 0 || page >= pages {
+            return Ok(None);
+        }
+        return page
+            .checked_add(1)
+            .map(|page| Some(page.to_string()))
+            .ok_or(SlackError::InvalidCursor);
+    }
+    let token = root
+        .get("response_metadata")
+        .and_then(Value::as_object)
+        .and_then(|metadata| {
+            metadata
+                .get("next_cursor")
+                .or_else(|| metadata.get("cursor"))
+        })
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if family == SlackFamily::AuditLog {
+        cursor::audit_next(token, request.audit_window.as_ref())
+    } else if token.trim().is_empty() {
+        Ok(None)
+    } else if token.len() > 4_096 || token.chars().any(char::is_control) {
+        Err(SlackError::InvalidCursor)
+    } else {
+        Ok(Some(token.trim().to_owned()))
+    }
+}

--- a/crates/source-runtime-next/src/slack/tests.rs
+++ b/crates/source-runtime-next/src/slack/tests.rs
@@ -1,0 +1,492 @@
+use std::{collections::BTreeMap, str::FromStr};
+
+use cerebro_source_catalog::{CollectionAuthority, HttpMethod, SourceCatalog};
+use serde_json::{Value, json};
+
+use super::*;
+
+const WEB_ORIGIN: &str = "https://slack.com/api";
+const AUDIT_ORIGIN: &str = "https://api.slack.com/audit/v1";
+const OBSERVED_AT: i64 = 1_780_272_000_000;
+
+fn kernel(family: SlackFamily, filters: SlackFilters) -> SlackKernel {
+    SlackKernel::new(
+        WEB_ORIGIN,
+        AUDIT_ORIGIN,
+        "tenant",
+        family,
+        filters,
+        Some(2),
+        OBSERVED_AT,
+    )
+    .unwrap()
+}
+
+fn envelope(family: SlackFamily, records: Vec<Value>, next: Option<&str>) -> Vec<u8> {
+    let key = match family {
+        SlackFamily::Team => "teams",
+        SlackFamily::User => "members",
+        SlackFamily::Channel => "channels",
+        SlackFamily::UserGroup => "usergroups",
+        SlackFamily::AccessLog => "logins",
+        SlackFamily::ChannelMember => "members",
+        SlackFamily::UserGroupMember => "users",
+        SlackFamily::AuditLog => "entries",
+    };
+    let mut root = serde_json::Map::from_iter([(key.to_owned(), Value::Array(records))]);
+    if family != SlackFamily::AuditLog {
+        root.insert("ok".to_owned(), Value::Bool(true));
+    }
+    if let Some(next) = next {
+        root.insert("response_metadata".to_owned(), json!({"next_cursor": next}));
+    }
+    serde_json::to_vec(&Value::Object(root)).unwrap()
+}
+
+#[test]
+fn closed_family_catalog_matches_checked_in_source_contract() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let catalog = SourceCatalog::load(
+        root.join("internal/connectorcatalog/catalog"),
+        root.join("sources"),
+    )
+    .unwrap();
+    let source = catalog.get("slack").unwrap();
+    assert_eq!(source.authority(), CollectionAuthority::Authoritative);
+    let families = source
+        .families()
+        .iter()
+        .map(|family| (family.id().to_owned(), family))
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(families.len(), 8);
+    for name in [
+        "team",
+        "user",
+        "channel",
+        "user_group",
+        "access_log",
+        "channel_member",
+        "user_group_member",
+        "audit_log",
+    ] {
+        let contract = SlackFamily::from_str(name).unwrap();
+        let family = families[name];
+        assert!(family.is_authoritative(), "{name} must compile closed");
+        assert_eq!(family.path(), contract.path());
+        assert_eq!(
+            family.method(),
+            if contract.method() == "POST" {
+                HttpMethod::Post
+            } else {
+                HttpMethod::Get
+            }
+        );
+    }
+    assert_eq!(
+        families["audit_log"].base_url(),
+        Some("https://api.slack.com/audit/v1")
+    );
+    let oauth = source.oauth_authorization_code().unwrap();
+    for family in [
+        SlackFamily::Team,
+        SlackFamily::User,
+        SlackFamily::Channel,
+        SlackFamily::UserGroup,
+        SlackFamily::AccessLog,
+        SlackFamily::ChannelMember,
+        SlackFamily::UserGroupMember,
+        SlackFamily::AuditLog,
+    ] {
+        for scope in family.required_scopes() {
+            assert!(oauth.scopes().iter().any(|candidate| candidate == scope));
+        }
+    }
+}
+
+#[test]
+fn plans_every_family_without_credentials_and_locks_origins() {
+    let cases = [
+        (SlackFamily::Team, "/api/auth.teams.list"),
+        (SlackFamily::User, "/api/users.list"),
+        (SlackFamily::Channel, "/api/conversations.list"),
+        (SlackFamily::UserGroup, "/api/usergroups.list"),
+        (SlackFamily::AccessLog, "/api/team.accessLogs"),
+        (SlackFamily::ChannelMember, "/api/conversations.members"),
+        (SlackFamily::UserGroupMember, "/api/usergroups.users.list"),
+        (SlackFamily::AuditLog, "/audit/v1/logs"),
+    ];
+    for (family, path) in cases {
+        let filters = SlackFilters {
+            channel_id: Some("C1".to_owned()),
+            usergroup_id: Some("S1".to_owned()),
+            ..SlackFilters::default()
+        };
+        let request = kernel(family, filters).plan(None).unwrap();
+        assert_eq!(request.url().path(), path);
+        assert_eq!(request.method(), family.method());
+        assert_eq!(request.authorization_scheme(), "Bearer");
+        assert!(!request.follow_redirects());
+        let wire = request.url().as_str().as_bytes();
+        assert!(!wire.windows(6).any(|window| window == b"Bearer"));
+        assert!(!request.url().as_str().contains("token"));
+    }
+}
+
+#[test]
+fn deterministic_queries_and_cursor_rules_are_family_specific() {
+    let channel = kernel(SlackFamily::Channel, SlackFilters::default())
+        .plan(Some("cursor-1"))
+        .unwrap();
+    assert_eq!(
+        channel.url().query(),
+        Some(
+            "cursor=cursor-1&exclude_archived=false&limit=2&types=public_channel%2Cprivate_channel"
+        )
+    );
+    let membership = kernel(
+        SlackFamily::ChannelMember,
+        SlackFilters {
+            channel_id: Some("C1".to_owned()),
+            ..SlackFilters::default()
+        },
+    )
+    .plan(Some("cursor-2"))
+    .unwrap();
+    assert_eq!(
+        membership.url().query(),
+        Some("channel=C1&cursor=cursor-2&limit=2")
+    );
+    let access = kernel(SlackFamily::AccessLog, SlackFilters::default())
+        .plan(Some("4"))
+        .unwrap();
+    assert_eq!(access.url().query(), Some("count=2&page=4"));
+    assert_eq!(
+        kernel(SlackFamily::AccessLog, SlackFilters::default()).plan(Some("cursor")),
+        Err(SlackError::InvalidCursor)
+    );
+    assert_eq!(
+        kernel(SlackFamily::UserGroup, SlackFilters::default()).plan(Some("cursor")),
+        Err(SlackError::UnsupportedCursor)
+    );
+}
+
+#[test]
+fn inventory_and_membership_families_normalize_go_oracle_shapes() {
+    let cases = [
+        (
+            SlackFamily::Team,
+            SlackFilters::default(),
+            json!({"id":"T1","name":"Writer","domain":"writer"}),
+            "team_id",
+            "T1",
+        ),
+        (
+            SlackFamily::User,
+            SlackFilters::default(),
+            json!({"id":"U1","team_id":"T1","name":"alice","profile":{"email":"alice@example.test"},"is_admin":true,"has_2fa":false,"updated":1780272000}),
+            "user_id",
+            "U1",
+        ),
+        (
+            SlackFamily::Channel,
+            SlackFilters::default(),
+            json!({"id":"C1","name":"general","context_team_id":"T1","creator":"U1","is_private":false,"is_archived":false,"created":1780272000}),
+            "channel_id",
+            "C1",
+        ),
+        (
+            SlackFamily::UserGroup,
+            SlackFilters::default(),
+            json!({"id":"S1","team_id":"T1","handle":"eng","name":"Engineering","date_update":1780272000}),
+            "group_id",
+            "S1",
+        ),
+        (
+            SlackFamily::ChannelMember,
+            SlackFilters {
+                channel_id: Some("C1".to_owned()),
+                ..SlackFilters::default()
+            },
+            json!("U1"),
+            "channel_id",
+            "C1",
+        ),
+        (
+            SlackFamily::UserGroupMember,
+            SlackFilters {
+                usergroup_id: Some("S1".to_owned()),
+                ..SlackFilters::default()
+            },
+            json!("U1"),
+            "usergroup_id",
+            "S1",
+        ),
+    ];
+    for (family, filters, value, identity_key, identity_value) in cases {
+        let kernel = kernel(family, filters);
+        let request = kernel.plan(None).unwrap();
+        let page = kernel
+            .decode(&request, 200, None, &envelope(family, vec![value], None))
+            .unwrap();
+        assert_eq!(page.records.len(), 1);
+        let record = &page.records[0];
+        assert_eq!(record.kind, family.event_kind());
+        assert_eq!(record.schema_ref, family.schema_ref());
+        assert_eq!(record.attributes[identity_key], identity_value);
+        assert_eq!(record.tenant_id, "tenant");
+        assert_eq!(record.occurred_at_unix_millis, OBSERVED_AT);
+    }
+}
+
+#[test]
+fn checked_in_go_oracle_fixtures_have_exact_rust_semantic_parity() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    for family in [
+        SlackFamily::Team,
+        SlackFamily::User,
+        SlackFamily::Channel,
+        SlackFamily::UserGroup,
+        SlackFamily::AccessLog,
+        SlackFamily::ChannelMember,
+        SlackFamily::UserGroupMember,
+        SlackFamily::AuditLog,
+    ] {
+        let fixture = std::fs::read(
+            root.join("sources/slack/testdata")
+                .join(format!("read_{}.json", family.as_str())),
+        )
+        .unwrap();
+        let expected: Vec<Value> = serde_json::from_slice(&fixture).unwrap();
+        let expected = expected.first().unwrap();
+        let expected_attributes = expected["attributes"]
+            .as_object()
+            .unwrap()
+            .iter()
+            .map(|(key, value)| (key.clone(), value.as_str().unwrap().to_owned()))
+            .collect::<BTreeMap<_, _>>();
+        let filters = SlackFilters {
+            channel_id: expected_attributes.get("channel_id").cloned(),
+            usergroup_id: expected_attributes.get("usergroup_id").cloned(),
+            oldest: (family == SlackFamily::AuditLog).then(|| "1780270000".to_owned()),
+            latest: (family == SlackFamily::AuditLog).then(|| "1780273000".to_owned()),
+            ..SlackFilters::default()
+        };
+        let kernel = kernel(family, filters);
+        let request = kernel.plan(None).unwrap();
+        let page = kernel
+            .decode(
+                &request,
+                200,
+                None,
+                &envelope(family, vec![expected["payload"].clone()], None),
+            )
+            .unwrap();
+        let actual = page.records.first().unwrap();
+        assert_eq!(
+            actual.kind,
+            expected["kind"].as_str().unwrap(),
+            "{family:?}"
+        );
+        assert_eq!(
+            actual.schema_ref,
+            expected["schema_ref"].as_str().unwrap(),
+            "{family:?}"
+        );
+        assert_eq!(actual.attributes, expected_attributes, "{family:?}");
+        assert_eq!(actual.payload, expected["payload"], "{family:?}");
+    }
+}
+
+#[test]
+fn access_and_audit_families_preserve_activity_context() {
+    let access = kernel(SlackFamily::AccessLog, SlackFilters::default());
+    let request = access.plan(None).unwrap();
+    let body = serde_json::to_vec(&json!({
+        "ok":true,
+        "logins":[{"user_id":"U1","username":"alice","ip":"203.0.113.10","user_agent":"Mozilla/5.0","count":3,"date_first":1780271000,"date_last":1780272000}],
+        "paging":{"page":1,"pages":2}
+    })).unwrap();
+    let page = access.decode(&request, 200, None, &body).unwrap();
+    let record = &page.records[0];
+    assert_eq!(record.attributes["actor_id"], "U1");
+    assert_eq!(record.attributes["event_type"], "team_access");
+    assert_eq!(record.attributes["external_id"], "U1");
+    assert_eq!(record.attributes["ip_address"], "203.0.113.10");
+    assert_eq!(page.next_cursor.as_deref(), Some("2"));
+
+    let audit = kernel(
+        SlackFamily::AuditLog,
+        SlackFilters {
+            oldest: Some("1780270000".to_owned()),
+            latest: Some("1780273000".to_owned()),
+            ..SlackFilters::default()
+        },
+    );
+    let request = audit.plan(None).unwrap();
+    let value = json!({
+        "id":"Ev1","date_create":1780272000,"action":"user_login",
+        "actor":{"type":"user","user":{"id":"U1","name":"alice","email":"alice@example.test","team":"T1"}},
+        "entity":{"type":"user","user":{"id":"U2","name":"bob","team":"T1"}},
+        "context":{"ip_address":"203.0.113.10","ua":"Mozilla/5.0"}
+    });
+    let page = audit
+        .decode(
+            &request,
+            200,
+            None,
+            &envelope(SlackFamily::AuditLog, vec![value], Some("cursor-2")),
+        )
+        .unwrap();
+    let record = &page.records[0];
+    assert_eq!(record.attributes["actor_id"], "U1");
+    assert_eq!(record.attributes["resource_id"], "U2");
+    assert_eq!(record.attributes["team_id"], "T1");
+    let next = page.next_cursor.as_deref().unwrap();
+    assert!(next.contains("\"mode\":\"rolling_window\""));
+    let resumed = audit.plan(Some(next)).unwrap();
+    assert_eq!(
+        resumed
+            .url()
+            .query_pairs()
+            .find(|(key, _)| key == "oldest")
+            .unwrap()
+            .1,
+        "1780270000"
+    );
+}
+
+#[test]
+fn identity_is_tenant_scoped_and_duplicate_conflicts_fail_closed() {
+    let value = json!({"id":"U1","name":"alice"});
+    let body = envelope(SlackFamily::User, vec![value.clone()], None);
+    let first = kernel(SlackFamily::User, SlackFilters::default());
+    let first_record = first
+        .decode(&first.plan(None).unwrap(), 200, None, &body)
+        .unwrap()
+        .records
+        .remove(0);
+    let second = SlackKernel::new(
+        WEB_ORIGIN,
+        AUDIT_ORIGIN,
+        "other-tenant",
+        SlackFamily::User,
+        SlackFilters::default(),
+        Some(2),
+        OBSERVED_AT,
+    )
+    .unwrap();
+    let second_record = second
+        .decode(&second.plan(None).unwrap(), 200, None, &body)
+        .unwrap()
+        .records
+        .remove(0);
+    assert_ne!(first_record.event_id, second_record.event_id);
+
+    let conflict = envelope(
+        SlackFamily::User,
+        vec![value, json!({"id":"U1","name":"mallory"})],
+        None,
+    );
+    assert_eq!(
+        first.decode(&first.plan(None).unwrap(), 200, None, &conflict),
+        Err(SlackError::ConflictingDuplicate)
+    );
+}
+
+#[test]
+fn provider_failures_and_secret_material_remain_typed() {
+    let kernel = kernel(SlackFamily::User, SlackFilters::default());
+    let request = kernel.plan(None).unwrap();
+    assert_eq!(
+        kernel.decode(&request, 401, None, b"{}"),
+        Err(SlackError::AuthenticationRejected)
+    );
+    assert_eq!(
+        kernel.decode(&request, 403, None, b"{}"),
+        Err(SlackError::RequiredScopeMissing)
+    );
+    assert_eq!(
+        kernel.decode(&request, 429, Some("30"), b"{}"),
+        Err(SlackError::RateLimited {
+            retry_after_seconds: Some(30)
+        })
+    );
+    assert_eq!(
+        kernel.decode(&request, 503, None, b"{}"),
+        Err(SlackError::ProviderUnavailable { status: 503 })
+    );
+    let missing_scope = br#"{"ok":false,"error":"missing_scope","needed":"users:read"}"#;
+    assert_eq!(
+        kernel.decode(&request, 200, None, missing_scope),
+        Err(SlackError::RequiredScopeMissing)
+    );
+    let secret = envelope(
+        SlackFamily::User,
+        vec![json!({"id":"U1","profile":{"access_token":"fixture-secret"}})],
+        None,
+    );
+    assert_eq!(
+        kernel.decode(&request, 200, None, &secret),
+        Err(SlackError::CredentialMaterial)
+    );
+    let tenant = envelope(
+        SlackFamily::User,
+        vec![json!({"id":"U1","tenant_id":"untrusted"})],
+        None,
+    );
+    assert_eq!(
+        kernel.decode(&request, 200, None, &tenant),
+        Err(SlackError::TenantMismatch)
+    );
+}
+
+#[test]
+fn origins_and_bounds_fail_closed() {
+    assert!(matches!(
+        SlackKernel::new(
+            "http://slack.com/api",
+            AUDIT_ORIGIN,
+            "tenant",
+            SlackFamily::User,
+            SlackFilters::default(),
+            Some(100),
+            OBSERVED_AT,
+        ),
+        Err(SlackError::InvalidOrigin)
+    ));
+    assert!(matches!(
+        SlackKernel::new(
+            "https://127.0.0.1/api",
+            AUDIT_ORIGIN,
+            "tenant",
+            SlackFamily::User,
+            SlackFilters::default(),
+            Some(100),
+            OBSERVED_AT,
+        ),
+        Err(SlackError::InvalidOrigin)
+    ));
+    assert!(matches!(
+        SlackKernel::new(
+            WEB_ORIGIN,
+            AUDIT_ORIGIN,
+            "tenant",
+            SlackFamily::User,
+            SlackFilters::default(),
+            Some(101),
+            OBSERVED_AT,
+        ),
+        Err(SlackError::InvalidPageSize)
+    ));
+    let kernel = kernel(SlackFamily::User, SlackFilters::default());
+    let request = kernel.plan(None).unwrap();
+    assert_eq!(
+        kernel.decode(
+            &request,
+            200,
+            None,
+            &vec![b' '; request.max_response_bytes() + 1]
+        ),
+        Err(SlackError::ResponseTooLarge)
+    );
+}

--- a/crates/source-runtime-next/src/slack/types.rs
+++ b/crates/source-runtime-next/src/slack/types.rs
@@ -1,0 +1,168 @@
+use std::collections::BTreeMap;
+
+use reqwest::Url;
+use serde_json::Value;
+
+use super::{SlackError, SlackFamily, request, response};
+
+/// Public, non-secret selectors for one Slack family request.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct SlackFilters {
+    /// Channel selected for `channel_member`.
+    pub channel_id: Option<String>,
+    /// User group selected for `user_group_member`.
+    pub usergroup_id: Option<String>,
+    /// Access-log upper time bound.
+    pub before: Option<String>,
+    /// Audit action filter.
+    pub action: Option<String>,
+    /// Audit actor filter.
+    pub actor: Option<String>,
+    /// Audit entity filter.
+    pub entity: Option<String>,
+    /// Audit lower Unix-second bound.
+    pub oldest: Option<String>,
+    /// Audit upper Unix-second bound.
+    pub latest: Option<String>,
+}
+
+/// Credential-free request intent for the trusted Slack HTTP host.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SlackRequest {
+    pub(super) family: SlackFamily,
+    pub(super) url: Url,
+    pub(super) method: &'static str,
+    pub(super) page_size: usize,
+    pub(super) audit_window: Option<(String, String)>,
+}
+
+impl SlackRequest {
+    /// Fully planned provider URL.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+    /// Provider HTTP method.
+    pub fn method(&self) -> &'static str {
+        self.method
+    }
+    /// Authentication scheme the trusted host applies outside this kernel.
+    pub fn authorization_scheme(&self) -> &'static str {
+        "Bearer"
+    }
+    /// Expected response media type.
+    pub fn accept(&self) -> &'static str {
+        "application/json"
+    }
+    /// Redirect handling required of the trusted host.
+    pub fn follow_redirects(&self) -> bool {
+        false
+    }
+    /// Maximum admitted response bytes.
+    pub fn max_response_bytes(&self) -> usize {
+        super::response::MAX_RESPONSE_BYTES
+    }
+}
+
+/// One canonical Slack event record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SlackRecord {
+    /// Authenticated tenant identity.
+    pub tenant_id: String,
+    /// Deterministic tenant-scoped event identity.
+    pub event_id: String,
+    /// Exact event kind.
+    pub kind: String,
+    /// Exact event schema.
+    pub schema_ref: String,
+    /// Stable family identifier.
+    pub family: String,
+    /// Stable provider identity used for dedupe.
+    pub provider_id: String,
+    /// Provider occurrence time, or caller observation time when absent.
+    pub occurred_at_unix_millis: i64,
+    /// Canonical scalar event attributes.
+    pub attributes: BTreeMap<String, String>,
+    /// Bounded provider payload admitted by the family contract.
+    pub payload: Value,
+}
+
+/// Proposed provider progress; durable commit remains outside the kernel.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SlackCheckpoint {
+    /// Provider continuation, when another page exists.
+    pub next_cursor: Option<String>,
+    /// Latest admitted provider occurrence time.
+    pub watermark_unix_millis: Option<i64>,
+}
+
+/// One normalized Slack response page.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SlackPage {
+    /// Deduplicated canonical records.
+    pub records: Vec<SlackRecord>,
+    /// Provider continuation, when another page exists.
+    pub next_cursor: Option<String>,
+    /// Proposed progress for the durable host.
+    pub checkpoint: SlackCheckpoint,
+}
+
+/// Closed credential-free Slack provider kernel.
+#[derive(Clone, Debug)]
+pub struct SlackKernel {
+    pub(super) web_origin: Url,
+    pub(super) audit_origin: Url,
+    pub(super) tenant_id: String,
+    pub(super) family: SlackFamily,
+    pub(super) filters: SlackFilters,
+    pub(super) page_size: usize,
+    pub(super) observed_at_unix_millis: i64,
+}
+
+impl SlackKernel {
+    /// Construct one family kernel from public execution context only.
+    pub fn new(
+        web_origin: &str,
+        audit_origin: &str,
+        tenant_id: &str,
+        family: SlackFamily,
+        filters: SlackFilters,
+        page_size: Option<usize>,
+        observed_at_unix_millis: i64,
+    ) -> Result<Self, SlackError> {
+        let web_origin = request::origin(web_origin)?;
+        let audit_origin = request::origin(audit_origin)?;
+        if !request::safe_component(tenant_id, 128) {
+            return Err(SlackError::InvalidTenant);
+        }
+        let page_size = page_size.unwrap_or(100);
+        if page_size == 0 || page_size > 100 {
+            return Err(SlackError::InvalidPageSize);
+        }
+        request::validate_filters(family, &filters)?;
+        Ok(Self {
+            web_origin,
+            audit_origin,
+            tenant_id: tenant_id.to_owned(),
+            family,
+            filters,
+            page_size,
+            observed_at_unix_millis,
+        })
+    }
+
+    /// Plan one bounded origin-restricted provider request.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<SlackRequest, SlackError> {
+        request::plan(self, cursor)
+    }
+
+    /// Decode one provider response under the exact planned request.
+    pub fn decode(
+        &self,
+        request: &SlackRequest,
+        status: u16,
+        retry_after: Option<&str>,
+        body: &[u8],
+    ) -> Result<SlackPage, SlackError> {
+        response::decode(self, request, status, retry_after, body)
+    }
+}

--- a/internal/connectorcatalog/catalog/collaboration-productivity/slack.yaml
+++ b/internal/connectorcatalog/catalog/collaboration-productivity/slack.yaml
@@ -32,7 +32,31 @@ entries:
         - help: Slack Audit Logs API host. Keep the default unless using a test endpoint.
           key: audit_log_base_url
           label: Audit Logs API host
-      description: Collects Slack workspaces, users, channels, user groups, memberships, team access logs, and Enterprise Grid audit logs and projects them into the Cerebro graph for inventory, access review, membership review, login review, and collaboration audit context.
+        - help: Optional channel selected for channel membership collection.
+          key: channel_id
+          label: Channel ID
+        - help: Optional user group selected for user group membership collection.
+          key: usergroup_id
+          label: User group ID
+        - help: Optional Unix timestamp upper bound for team access logs.
+          key: before
+          label: Access log before
+        - help: Optional Enterprise audit action filter.
+          key: action
+          label: Audit action
+        - help: Optional Enterprise audit actor filter.
+          key: actor
+          label: Audit actor
+        - help: Optional Enterprise audit entity filter.
+          key: entity
+          label: Audit entity
+        - help: Optional Enterprise audit lower Unix timestamp bound.
+          key: oldest
+          label: Audit oldest
+        - help: Optional Enterprise audit upper Unix timestamp bound.
+          key: latest
+          label: Audit latest
+      description: Slack collaboration governance source covering workspaces, users, public and private channels, user groups, memberships, team access logs, and Enterprise Grid audit logs. The runtime emits team context, user privilege and MFA enrollment posture, channel ownership context, membership edges, login activity, and audit events for graph projection and review.
       display_name: Slack
       id: builtin_catalog-slack
       ingest:
@@ -68,7 +92,10 @@ entries:
           projection:
             fields:
               domain: domain
+              name: name
               team_id: id
+            static_fields:
+              source_product: slack
             template: asset
           record_selector: $.teams[*]
         - coverage:
@@ -101,9 +128,23 @@ entries:
           permissions_needed: [users:read, users:read.email]
           projection:
             fields:
+              deleted: deleted
               email: profile.email
               has_mfa: has_2fa
+              has_2fa: has_2fa
+              is_admin: is_admin
+              is_bot: is_bot
+              is_owner: is_owner
+              is_primary_owner: is_primary_owner
+              is_restricted: is_restricted
+              is_ultra_restricted: is_ultra_restricted
+              name: name
+              real_name: real_name|profile.real_name
+              team_id: team_id
+              two_factor_type: two_factor_type
               user_id: id
+            static_fields:
+              source_product: slack
             template: identity_user
           record_selector: $.members[*]
         - coverage:
@@ -138,7 +179,14 @@ entries:
             fields:
               channel_id: id
               creator: creator
+              is_archived: is_archived
+              is_private: is_private
+              name: name
+              num_members: num_members
+              shared_team_ids: shared_team_ids|internal_team_ids
               team_id: context_team_id
+            static_fields:
+              source_product: slack
             template: asset
           record_selector: $.channels[*]
           static_query:
@@ -171,9 +219,14 @@ entries:
           permissions_needed: [usergroups:read]
           projection:
             fields:
+              description: description
               group_id: id
               handle: handle
+              is_disabled: is_disabled
+              name: name
               team_id: team_id
+            static_fields:
+              source_product: slack
             template: identity_group
           record_selector: $.usergroups[*]
         - coverage:
@@ -211,8 +264,16 @@ entries:
           projection:
             fields:
               actor_id: user_id
+              actor_name: username
               event_type: team_access
               ip_address: ip
+              login_count: count
+              user_agent: user_agent
+              user_id: user_id
+              username: username
+            static_fields:
+              event_type: team_access
+              source_product: slack
             template: audit_event
           record_selector: $.logins[*]
         - coverage:
@@ -232,6 +293,10 @@ entries:
             urn_kind: slack_channel_member
           config_query:
             channel: channel_id
+          config:
+            config_attributes:
+              channel_id: channel_id
+            id_template: ${channel_id}-${user_id}
           id: channel_member
           id_field: user_id
           label: Channel members
@@ -249,6 +314,9 @@ entries:
             fields:
               channel_id: channel_id
               user_id: user_id
+            static_fields:
+              membership_type: channel
+              source_product: slack
             template: group_membership
           read:
             path_params: [channel_id]
@@ -270,6 +338,10 @@ entries:
             urn_kind: slack_user_group_member
           config_query:
             usergroup: usergroup_id
+          config:
+            config_attributes:
+              usergroup_id: usergroup_id
+            id_template: ${usergroup_id}-${user_id}
           id: user_group_member
           id_field: user_id
           label: User group members
@@ -287,6 +359,9 @@ entries:
             fields:
               user_id: user_id
               usergroup_id: usergroup_id
+            static_fields:
+              membership_type: user_group
+              source_product: slack
             template: group_membership
           read:
             path_params: [usergroup_id]
@@ -310,6 +385,12 @@ entries:
             urn_kind: slack_audit_log
           config:
             base_url: https://api.slack.com/audit/v1
+            config_query:
+              action: action
+              actor: actor
+              entity: entity
+              latest: latest
+              oldest: oldest
           id: audit_log
           id_field: id
           label: Enterprise audit logs
@@ -325,10 +406,19 @@ entries:
           permissions_needed: [auditlogs:read]
           projection:
             fields:
+              actor_email: actor.user.email
               actor_id: actor.user.id
+              actor_name: actor.user.name|actor.name
+              actor_type: actor.type
               event_type: action
-              resource_id: entity.id
+              ip_address: context.ip_address
+              resource_id: entity.user.id|entity.channel.id|entity.file.id|entity.id
+              resource_name: entity.user.name|entity.channel.name|entity.file.name|entity.name
               resource_type: entity.type
+              team_id: actor.user.team|entity.user.team|entity.channel.team|context.team_id
+              user_agent: context.ua
+            static_fields:
+              source_product: slack
             template: audit_event
           record_selector: $.entries[*]
       schema_version: cerebro.integration/v1

--- a/internal/sourceregistry/registry.go
+++ b/internal/sourceregistry/registry.go
@@ -61,7 +61,6 @@ import (
 	sdksource "github.com/writer/cerebro/sources/sdk"
 	securitytoolingmapsource "github.com/writer/cerebro/sources/securitytoolingmap"
 	sentinelonesource "github.com/writer/cerebro/sources/sentinelone"
-	slacksource "github.com/writer/cerebro/sources/slack"
 	snyksource "github.com/writer/cerebro/sources/snyk"
 	tailscalesource "github.com/writer/cerebro/sources/tailscale"
 	trivysource "github.com/writer/cerebro/sources/trivy"
@@ -395,12 +394,6 @@ var builtinSourceLoaders = []builtinSourceLoader{
 		name: "sentinelone",
 		load: func() (sourcecdk.Source, error) {
 			return sentinelonesource.New()
-		},
-	},
-	{
-		name: "slack",
-		load: func() (sourcecdk.Source, error) {
-			return slacksource.New()
 		},
 	},
 	{

--- a/internal/sourceregistry/registry_test.go
+++ b/internal/sourceregistry/registry_test.go
@@ -321,7 +321,6 @@ func TestBuiltinKeepsOnlyCatalogCompatibilityExceptionsAsStaticLoaders(t *testin
 		"openai":                true,
 		"pagerduty":             true,
 		"sailpoint_identitynow": true,
-		"slack":                 true,
 		"snyk":                  true,
 		"tailscale":             true,
 		"writer":                true,

--- a/sources/slack/source_test.go
+++ b/sources/slack/source_test.go
@@ -5,12 +5,18 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/connectorcatalog"
+	"github.com/writer/cerebro/internal/connectordefinitions"
 	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/sources/catalogruntime"
 )
 
 func TestNewLoadsCatalog(t *testing.T) {
@@ -20,6 +26,99 @@ func TestNewLoadsCatalog(t *testing.T) {
 	}
 	if got := source.Spec().GetId(); got != "slack" {
 		t.Fatalf("Spec().Id = %q, want slack", got)
+	}
+}
+
+func TestCatalogRuntimeMatchesCheckedInSlackOracleFixtures(t *testing.T) {
+	entry, ok, err := connectorcatalog.BuiltinEntry("slack")
+	if err != nil {
+		t.Fatalf("BuiltinEntry(slack) error = %v", err)
+	}
+	if !ok {
+		t.Fatal("BuiltinEntry(slack) ok = false")
+	}
+	listKeys := map[string]string{
+		familyTeam: "teams", familyUser: "members", familyChannel: "channels",
+		familyUserGroup: "usergroups", familyAccessLog: "logins",
+		familyChannelMember: "members", familyUserGroupMember: "users", familyAuditLog: "entries",
+	}
+	for _, familyID := range []string{
+		familyTeam, familyUser, familyChannel, familyUserGroup, familyAccessLog,
+		familyChannelMember, familyUserGroupMember, familyAuditLog,
+	} {
+		t.Run(familyID, func(t *testing.T) {
+			fixturePath := filepath.Join("testdata", "read_"+familyID+".json")
+			expected, err := sourcecdk.LoadFixtureEvents(os.DirFS("."), fixturePath)
+			if err != nil {
+				t.Fatalf("LoadFixtureEvents(%s) error = %v", fixturePath, err)
+			}
+			if len(expected) != 1 {
+				t.Fatalf("oracle events = %d, want 1", len(expected))
+			}
+			body, err := json.Marshal(map[string]any{
+				"ok":               true,
+				listKeys[familyID]: []json.RawMessage{expected[0].Payload},
+			})
+			if err != nil {
+				t.Fatalf("encode provider response: %v", err)
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(body)
+			}))
+			defer server.Close()
+
+			definition := entry.Definition
+			transport := *definition.Transport
+			transport.BaseURL = server.URL
+			definition.Transport = &transport
+			definition.ResourceFamilies = append([]connectordefinitions.ResourceFamily(nil), definition.ResourceFamilies...)
+			for index := range definition.ResourceFamilies {
+				family := &definition.ResourceFamilies[index]
+				if family.ID == familyAuditLog && family.Config != nil {
+					config := *family.Config
+					config.BaseURL = server.URL
+					family.Config = &config
+				}
+			}
+			source, err := catalogruntime.NewDefinitionWithValidationOptions(
+				definition,
+				catalogruntime.ValidationOptions{AllowLoopbackBaseURL: true},
+			)
+			if err != nil {
+				t.Fatalf("NewDefinitionWithValidationOptions() error = %v", err)
+			}
+			config := map[string]string{
+				"base_url": server.URL, "family": familyID, "tenant_id": "writer", "token": "fixture-token",
+				"channel_id": "C1", "usergroup_id": "S1",
+			}
+			pull, err := source.Read(context.Background(), sourcecdk.NewConfig(config), nil)
+			if err != nil {
+				t.Fatalf("catalog Read() error = %v", err)
+			}
+			if len(pull.Events) != 1 {
+				t.Fatalf("catalog events = %d, want 1", len(pull.Events))
+			}
+			actual := pull.Events[0]
+			if actual.Kind != expected[0].Kind || actual.SchemaRef != expected[0].SchemaRef {
+				t.Fatalf("contract = %s %s, want %s %s", actual.Kind, actual.SchemaRef, expected[0].Kind, expected[0].SchemaRef)
+			}
+			for key, want := range expected[0].Attributes {
+				if got := actual.Attributes[key]; got != want {
+					t.Fatalf("attribute %s = %q, want %q", key, got, want)
+				}
+			}
+			var actualPayload, expectedPayload any
+			if err := json.Unmarshal(actual.Payload, &actualPayload); err != nil {
+				t.Fatalf("decode actual payload: %v", err)
+			}
+			if err := json.Unmarshal(expected[0].Payload, &expectedPayload); err != nil {
+				t.Fatalf("decode expected payload: %v", err)
+			}
+			if !reflect.DeepEqual(actualPayload, expectedPayload) {
+				t.Fatalf("payload = %#v, want %#v", actualPayload, expectedPayload)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- compile all eight Slack families into a closed credential-free Rust request and response kernel
- preserve tenant-scoped identities, bounded pagination, typed provider failures, exact event contracts, and checked-in Go oracle semantic parity
- bind Slack catalog filters, membership identity context, and portable source metadata, then retire the concrete Go registry loader through the shared catalog runtime

## Local validation
- cargo fmt --all -- --check
- cargo test -p cerebro-source-catalog (22 passed)
- cargo test -p cerebro-source-runtime-next slack (10 passed)
- cargo clippy -p cerebro-source-catalog -p cerebro-source-runtime-next --all-targets -- -D warnings
- GOTOOLCHAIN=go1.26.6 go test ./sources/slack ./internal/connectorcatalog ./internal/sourceregistry ./internal/sourceprojection -count=1
- GOTOOLCHAIN=go1.26.6 go test -race ./sources/slack -run TestCatalogRuntimeMatchesCheckedInSlackOracleFixtures|TestReadSlack -count=1
- make fixture-oracle-check
- make source-fixture-check
- make catalog-check
- make sourcegen-check
- GOTOOLCHAIN=go1.26.6 make check-structural check-structural-test check-arch
- GOTOOLCHAIN=go1.26.6 make connector-contract-check
- GOTOOLCHAIN=go1.26.6 make detection-catalog-check

## Validation boundaries
- local full projection parity could not complete because the streamed workspace exhausted generated-output capacity; the required hosted matrix is the authoritative replacement path
- live provider and authenticated product-path proof require an authorized Slack provider identity and a deployed merged revision
- no credentials or provider records are stored in fixtures, events, receipts, logs, or graph properties