### PR TITLE
test(source-runtime): keep Anthropic parity boundary public

### DIFF
--- a/crates/source-runtime-next/src/anthropic/tests.rs
+++ b/crates/source-runtime-next/src/anthropic/tests.rs
@@ -86,20 +86,13 @@ fn all_go_oracle_fixtures_have_semantic_event_parity() {
 }
 
 #[test]
-fn every_family_is_in_the_go_catalog_and_projection_oracle() {
+fn every_family_is_in_the_go_catalog_oracle() {
     let root = repository_root();
     let catalog = fs::read_to_string(root.join("sources/anthropic/catalog.yaml")).unwrap();
-    let projection =
-        fs::read_to_string(root.join("internal/sourceprojection/registry.go")).unwrap();
     for family in AnthropicFamily::ALL {
         assert!(
             catalog.contains(&format!("kind: anthropic.{}", family.as_str())),
             "missing catalog event {}",
-            family.as_str()
-        );
-        assert!(
-            projection.contains(&format!("\"anthropic.{}\"", family.as_str())),
-            "missing projection {}",
             family.as_str()
         );
     }


### PR DESCRIPTION
## Scope

Forward repair for #2441: remove the Rust test dependency on the Go-private `internal/sourceprojection` implementation path. Rust continues to validate all 28 families against the public Anthropic source catalog and provider fixtures. Projection parity stays in its owning Go `internal/sourceprojection` suite.

## Evidence

- `make check-arch`
- `cargo fmt --all -- --check`
- `cargo test -p cerebro-source-runtime-next anthropic:: --lib` (6 passed)
- `cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings`
- `./scripts/leak_check.sh range origin/main...HEAD`

No production behavior, event contract, loader authority, credentials, or deployment configuration changes.