### PR TITLE
fix(source-runtime): accept terminal Okta pages

### DIFF
--- a/crates/source-runtime-next/src/okta/response.rs
+++ b/crates/source-runtime-next/src/okta/response.rs
@@ -56,7 +56,7 @@ impl OktaKernel {
             .url
             .query_pairs()
             .find_map(|(name, value)| (name == "after").then(|| value.into_owned()));
-        if next_cursor.as_deref() == input_after.as_deref() {
+        if next_cursor.is_some() && next_cursor.as_deref() == input_after.as_deref() {
             return Err(OktaError::InvalidCursor);
         }
         let proposed_checkpoint = normalized.last().map(|record| record.occurred_at.clone());

--- a/crates/source-runtime-next/src/okta/tests.rs
+++ b/crates/source-runtime-next/src/okta/tests.rs
@@ -361,6 +361,31 @@ fn link_cursor_is_origin_locked_and_assignment_phase_round_trips() {
 }
 
 #[test]
+fn terminal_page_without_a_cursor_is_valid() {
+    let kernel = OktaKernel::new(
+        ORIGIN,
+        TENANT,
+        OktaFamily::User,
+        OktaFilters::default(),
+        None,
+    )
+    .unwrap();
+    let page = kernel
+        .decode(
+            &kernel.plan(None).unwrap(),
+            OktaResponse {
+                status: 200,
+                body: br#"[{"id":"u1","lastUpdated":"2026-08-21T12:00:00Z"}]"#,
+                link_header: None,
+            },
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(page.records.len(), 1);
+    assert_eq!(page.next_cursor, None);
+}
+
+#[test]
 fn typed_provider_failures_remain_distinct() {
     let kernel = OktaKernel::new(
         ORIGIN,


### PR DESCRIPTION
## Scope

Forward repair for #2436. A terminal Okta response has no next cursor. The decoder previously compared `None` with the absent input cursor and classified a valid terminal page as `InvalidCursor`.

This change rejects only a repeated non-empty continuation and adds a focused terminal-page regression test. It does not change the Go loader, source authority, credentials, deployment configuration, or provider access.

## Evidence

- Hosted exact-head Rust test from #2436 compiled the selected crates and isolated three failures to the same terminal cursor guard; 380 source-runtime tests passed before those three assertions.
- Direct Rust 2024 format check and `git diff --check` pass for this repair.
- `go test ./sources/okta ./sources/internal/oktaasset ./sources/internal/oktaevent ./internal/sourceregistry` passes.
- Staged and committed leak scans pass.

The PR remains draft until the hosted Rust tests and Clippy gate pass on this exact head.