### PR TITLE
test(source-runtime): reject repeated Okta cursors

### DIFF
--- a/crates/source-runtime-next/src/okta/response.rs
+++ b/crates/source-runtime-next/src/okta/response.rs
@@ -56,7 +56,17 @@ impl OktaKernel {
             .url
             .query_pairs()
             .find_map(|(name, value)| (name == "after").then(|| value.into_owned()));
-        if next_cursor.is_some() && next_cursor.as_deref() == input_after.as_deref() {
+        let input_cursor = input_after.map(|cursor| {
+            if request.family == super::OktaFamily::AppAssignment {
+                format!(
+                    "{}:{cursor}",
+                    request.assignment_phase.as_deref().unwrap_or("users")
+                )
+            } else {
+                cursor
+            }
+        });
+        if next_cursor.is_some() && next_cursor == input_cursor {
             return Err(OktaError::InvalidCursor);
         }
         let proposed_checkpoint = normalized.last().map(|record| record.occurred_at.clone());

--- a/crates/source-runtime-next/src/okta/tests.rs
+++ b/crates/source-runtime-next/src/okta/tests.rs
@@ -386,6 +386,53 @@ fn terminal_page_without_a_cursor_is_valid() {
 }
 
 #[test]
+fn repeated_non_empty_cursors_are_rejected() {
+    let user = OktaKernel::new(
+        ORIGIN,
+        TENANT,
+        OktaFamily::User,
+        OktaFilters::default(),
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        user.decode(
+            &user.plan(Some("same")).unwrap(),
+            OktaResponse {
+                status: 200,
+                body: b"[]",
+                link_header: Some("</api/v1/users?after=same&limit=10>; rel=\"next\"")
+            },
+            observed_at()
+        ),
+        Err(OktaError::InvalidCursor)
+    );
+
+    let assignment = OktaKernel::new(
+        ORIGIN,
+        TENANT,
+        OktaFamily::AppAssignment,
+        filters(OktaFamily::AppAssignment),
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        assignment.decode(
+            &assignment.plan(Some("groups:same")).unwrap(),
+            OktaResponse {
+                status: 200,
+                body: b"[]",
+                link_header: Some(
+                    "</api/v1/apps/example-f0a6c6d9df5c0037/groups?after=same&limit=10>; rel=\"next\""
+                )
+            },
+            observed_at()
+        ),
+        Err(OktaError::InvalidCursor)
+    );
+}
+
+#[test]
 fn typed_provider_failures_remain_distinct() {
     let kernel = OktaKernel::new(
         ORIGIN,


### PR DESCRIPTION
## Summary
- reject repeated non-empty Okta cursors without rejecting terminal pages
- compare phase-qualified application-assignment cursors
- cover ordinary and phased cursor loops

## Validation
- cargo fmt --all -- --check
- cargo test -p cerebro-source-runtime-next okta (19 passed)
- cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings
- go test ./sources/okta ./sources/internal/oktaasset ./sources/internal/oktaevent ./internal/sourceregistry
- make fixture-oracle-check
- make source-fixture-check catalog-check
- make check-arch
- scripts/leak_check.sh staged and range