### PR TITLE
feat(source-runtime): add Kubernetes Rust kernel

### DIFF
--- a/crates/source-runtime-next/src/kubernetes.rs
+++ b/crates/source-runtime-next/src/kubernetes.rs
@@ -1,0 +1,19 @@
+//! Credential-free Kubernetes provider kernel.
+
+mod cursor;
+mod error;
+mod family;
+mod model;
+mod normalize;
+mod projection;
+mod request;
+mod response;
+
+#[cfg(test)]
+mod tests;
+
+pub use error::KubernetesError;
+pub use family::{KubernetesFamily, KubernetesRuntimeDefinition};
+pub use model::{KubernetesPage, KubernetesRecord};
+pub use projection::{KubernetesProjection, KubernetesProjectionEntity, KubernetesProjectionLink};
+pub use request::{KubernetesConfig, KubernetesKernel, KubernetesRequest};

--- a/crates/source-runtime-next/src/kubernetes/cursor.rs
+++ b/crates/source-runtime-next/src/kubernetes/cursor.rs
@@ -1,0 +1,90 @@
+//! Kubernetes opaque continuation and two-stage RBAC cursor handling.
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde::{Deserialize, Serialize};
+
+use super::{KubernetesError, KubernetesFamily};
+
+const MAX_CURSOR_BYTES: usize = 4_096;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum RbacStage {
+    Role,
+    ClusterRole,
+    RoleBinding,
+    ClusterRoleBinding,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub(super) struct RbacCursor {
+    pub(super) stage: RbacStage,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub(super) token: String,
+}
+
+pub(super) fn bounded_token(value: Option<&str>) -> Result<Option<String>, KubernetesError> {
+    let value = value.map(str::trim).filter(|value| !value.is_empty());
+    if value.is_some_and(|value| {
+        value.len() > MAX_CURSOR_BYTES
+            || value.chars().any(char::is_control)
+            || value.starts_with("http://")
+            || value.starts_with("https://")
+    }) {
+        return Err(KubernetesError::InvalidCursor);
+    }
+    Ok(value.map(str::to_owned))
+}
+
+pub(super) fn decode_rbac_cursor(
+    family: KubernetesFamily,
+    value: Option<&str>,
+) -> Result<RbacCursor, KubernetesError> {
+    let initial = match family {
+        KubernetesFamily::RbacRole => RbacStage::Role,
+        KubernetesFamily::RbacBinding => RbacStage::RoleBinding,
+        _ => return Err(KubernetesError::InvalidCursor),
+    };
+    let Some(value) = bounded_token(value)? else {
+        return Ok(RbacCursor {
+            stage: initial,
+            token: String::new(),
+        });
+    };
+    let raw = URL_SAFE_NO_PAD
+        .decode(value)
+        .map_err(|_| KubernetesError::InvalidCursor)?;
+    if raw.len() > MAX_CURSOR_BYTES {
+        return Err(KubernetesError::InvalidCursor);
+    }
+    let cursor: RbacCursor =
+        serde_json::from_slice(&raw).map_err(|_| KubernetesError::InvalidCursor)?;
+    let valid_stage = matches!(
+        (family, cursor.stage),
+        (
+            KubernetesFamily::RbacRole,
+            RbacStage::Role | RbacStage::ClusterRole
+        ) | (
+            KubernetesFamily::RbacBinding,
+            RbacStage::RoleBinding | RbacStage::ClusterRoleBinding
+        )
+    );
+    if !valid_stage || bounded_token(Some(&cursor.token))?.as_deref() != nonempty(&cursor.token) {
+        return Err(KubernetesError::InvalidCursor);
+    }
+    Ok(cursor)
+}
+
+pub(super) fn encode_rbac_cursor(cursor: &RbacCursor) -> Result<String, KubernetesError> {
+    bounded_token(Some(&cursor.token))?;
+    let payload = serde_json::to_vec(cursor).map_err(|_| KubernetesError::InvalidCursor)?;
+    if payload.len() > MAX_CURSOR_BYTES {
+        return Err(KubernetesError::InvalidCursor);
+    }
+    Ok(URL_SAFE_NO_PAD.encode(payload))
+}
+
+fn nonempty(value: &str) -> Option<&str> {
+    let value = value.trim();
+    (!value.is_empty()).then_some(value)
+}

--- a/crates/source-runtime-next/src/kubernetes/error.rs
+++ b/crates/source-runtime-next/src/kubernetes/error.rs
@@ -1,0 +1,118 @@
+//! Stable fail-closed Kubernetes kernel errors.
+
+use std::{error::Error, fmt};
+
+/// Stable Kubernetes request, response, identity, and contract failures.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum KubernetesError {
+    /// The selected family is not in the checked source contract.
+    InvalidFamily,
+    /// The catalog family does not match the closed Kubernetes runtime contract.
+    InvalidRuntimeDefinition,
+    /// The source tenant is missing or invalid.
+    MissingTenantId,
+    /// A stable cluster identity is required.
+    MissingClusterIdentity,
+    /// The configured API server is not a closed HTTPS origin.
+    InvalidApiServer,
+    /// The requested page size is outside the inclusive 1 through 500 bound.
+    InvalidPageSize,
+    /// The provider continuation is malformed, oversized, or non-round-trippable.
+    InvalidCursor,
+    /// A request was not created by this exact family kernel.
+    RequestScopeMismatch,
+    /// The provider rejected authentication.
+    AuthenticationRejected,
+    /// The provider credential lacks the required Kubernetes RBAC permission.
+    PermissionDenied,
+    /// The provider asked the caller to retry later.
+    RateLimited,
+    /// The Kubernetes API server is temporarily unavailable.
+    ProviderUnavailable,
+    /// The provider returned a status outside the closed contract.
+    UnexpectedProviderStatus(u16),
+    /// The bounded host response exceeded eight mebibytes.
+    ResponseTooLarge,
+    /// The page exceeded the configured maximum record count.
+    TooManyRecords,
+    /// The response did not match the Kubernetes list or version contract.
+    MalformedResponse,
+    /// A provider object has no stable UID or declared composite fallback.
+    MissingStableIdentity,
+    /// Two different records reused the same provider identity.
+    ConflictingProviderIdentity,
+    /// A catalog-required normalized attribute is missing.
+    MissingRequiredAttribute(&'static str),
+    /// A catalog-required payload field is missing.
+    MissingRequiredPayloadField(&'static str),
+    /// A provider-controlled identity could not be encoded safely.
+    InvalidCanonicalIdentity,
+}
+
+impl fmt::Display for KubernetesError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidFamily => formatter.write_str("kubernetes family is not registered"),
+            Self::InvalidRuntimeDefinition => {
+                formatter.write_str("kubernetes catalog family does not match the runtime contract")
+            }
+            Self::MissingTenantId => formatter.write_str("kubernetes tenant_id is required"),
+            Self::MissingClusterIdentity => formatter
+                .write_str("kubernetes cluster_id or equivalent stable identity is required"),
+            Self::InvalidApiServer => {
+                formatter.write_str("kubernetes api_server must be a closed HTTPS origin")
+            }
+            Self::InvalidPageSize => {
+                formatter.write_str("kubernetes per_page must be between 1 and 500")
+            }
+            Self::InvalidCursor => formatter.write_str("kubernetes continuation is invalid"),
+            Self::RequestScopeMismatch => {
+                formatter.write_str("kubernetes request does not match the kernel")
+            }
+            Self::AuthenticationRejected => formatter
+                .write_str("kubernetes authentication was rejected; repair the credential binding"),
+            Self::PermissionDenied => formatter.write_str(
+                "kubernetes permission was denied; grant list access for the selected family",
+            ),
+            Self::RateLimited => formatter
+                .write_str("kubernetes request was rate limited; retry after provider backoff"),
+            Self::ProviderUnavailable => formatter
+                .write_str("kubernetes API server is unavailable; retry the bounded operation"),
+            Self::UnexpectedProviderStatus(status) => {
+                write!(formatter, "kubernetes returned unexpected status {status}")
+            }
+            Self::ResponseTooLarge => {
+                formatter.write_str("kubernetes response exceeds 8388608 bytes")
+            }
+            Self::TooManyRecords => {
+                formatter.write_str("kubernetes response exceeds the compiled record bound")
+            }
+            Self::MalformedResponse => {
+                formatter.write_str("kubernetes response does not match the selected family")
+            }
+            Self::MissingStableIdentity => {
+                formatter.write_str("kubernetes record has no stable identity")
+            }
+            Self::ConflictingProviderIdentity => formatter.write_str(
+                "kubernetes page contains conflicting records with one provider identity",
+            ),
+            Self::MissingRequiredAttribute(field) => {
+                write!(
+                    formatter,
+                    "kubernetes record is missing required attribute {field}"
+                )
+            }
+            Self::MissingRequiredPayloadField(field) => {
+                write!(
+                    formatter,
+                    "kubernetes record is missing required payload field {field}"
+                )
+            }
+            Self::InvalidCanonicalIdentity => formatter.write_str(
+                "kubernetes tenant or provider identity cannot form a canonical identity",
+            ),
+        }
+    }
+}
+
+impl Error for KubernetesError {}

--- a/crates/source-runtime-next/src/kubernetes/family.rs
+++ b/crates/source-runtime-next/src/kubernetes/family.rs
@@ -1,0 +1,227 @@
+//! Closed Kubernetes family and event-contract definitions.
+
+use std::str::FromStr;
+
+use super::KubernetesError;
+
+/// Kubernetes inventory and access families preserved from the Go source.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum KubernetesFamily {
+    /// Kubernetes cluster identity and server version.
+    Cluster,
+    /// Kubernetes namespaces.
+    Namespace,
+    /// Kubernetes nodes.
+    Node,
+    /// Kubernetes pod objects.
+    Pod,
+    /// Pod-derived workload objects.
+    Workload,
+    /// Pod container objects.
+    Container,
+    /// Kubernetes services.
+    Service,
+    /// Kubernetes ingresses.
+    Ingress,
+    /// Kubernetes service accounts.
+    ServiceAccount,
+    /// Kubernetes Role and ClusterRole objects.
+    RbacRole,
+    /// Kubernetes RoleBinding and ClusterRoleBinding objects.
+    RbacBinding,
+    /// AWS IRSA and GKE workload-identity bindings derived from service accounts.
+    WorkloadIdentityBinding,
+}
+
+/// One catalog family compiled into the closed Kubernetes runtime contract.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct KubernetesRuntimeDefinition {
+    family: KubernetesFamily,
+}
+
+impl KubernetesRuntimeDefinition {
+    /// Compile and fail closed on any source, family, event, schema, or field drift.
+    pub fn compile(
+        source_id: &str,
+        family_id: &str,
+        event_kind: &str,
+        schema_ref: &str,
+        required_attributes: &[String],
+        required_payload_fields: &[String],
+    ) -> Result<Self, KubernetesError> {
+        let family = KubernetesFamily::from_str(family_id)?;
+        let exact = source_id == "kubernetes"
+            && event_kind == family.event_kind()
+            && schema_ref == family.schema_ref()
+            && strings_equal(required_attributes, family.required_attributes())
+            && strings_equal(required_payload_fields, family.required_payload_fields());
+        exact
+            .then_some(Self { family })
+            .ok_or(KubernetesError::InvalidRuntimeDefinition)
+    }
+
+    /// Return the closed Kubernetes family.
+    pub const fn family(self) -> KubernetesFamily {
+        self.family
+    }
+
+    /// Return the exact admitted event kind.
+    pub const fn event_kind(self) -> &'static str {
+        self.family.event_kind()
+    }
+
+    /// Return the exact admitted schema reference.
+    pub const fn schema_ref(self) -> &'static str {
+        self.family.schema_ref()
+    }
+
+    /// Return the exact required event attributes.
+    pub const fn required_attributes(self) -> &'static [&'static str] {
+        self.family.required_attributes()
+    }
+
+    /// Return the exact required payload fields.
+    pub const fn required_payload_fields(self) -> &'static [&'static str] {
+        self.family.required_payload_fields()
+    }
+}
+
+fn strings_equal(actual: &[String], expected: &[&str]) -> bool {
+    actual
+        .iter()
+        .map(String::as_str)
+        .eq(expected.iter().copied())
+}
+
+impl KubernetesFamily {
+    /// Return the exact source catalog family identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cluster => "cluster",
+            Self::Namespace => "namespace",
+            Self::Node => "node",
+            Self::Pod => "pod",
+            Self::Workload => "workload",
+            Self::Container => "container",
+            Self::Service => "service",
+            Self::Ingress => "ingress",
+            Self::ServiceAccount => "service_account",
+            Self::RbacRole => "rbac_role",
+            Self::RbacBinding => "rbac_binding",
+            Self::WorkloadIdentityBinding => "workload_identity_binding",
+        }
+    }
+
+    /// Return the exact event kind admitted by the source catalog.
+    pub const fn event_kind(self) -> &'static str {
+        match self {
+            Self::Cluster => "kubernetes.cluster",
+            Self::Namespace => "kubernetes.namespace",
+            Self::Node => "kubernetes.node",
+            Self::Pod => "kubernetes.pod",
+            Self::Workload => "kubernetes.workload",
+            Self::Container => "kubernetes.container",
+            Self::Service => "kubernetes.service",
+            Self::Ingress => "kubernetes.ingress",
+            Self::ServiceAccount => "kubernetes.service_account",
+            Self::RbacRole => "kubernetes.rbac_role",
+            Self::RbacBinding => "kubernetes.rbac_binding",
+            Self::WorkloadIdentityBinding => "kubernetes.workload_identity_binding",
+        }
+    }
+
+    /// Return the exact schema reference admitted by the source catalog.
+    pub const fn schema_ref(self) -> &'static str {
+        match self {
+            Self::Cluster => "kubernetes/cluster/v1",
+            Self::Namespace => "kubernetes/namespace/v1",
+            Self::Node => "kubernetes/node/v1",
+            Self::Pod => "kubernetes/pod/v1",
+            Self::Workload => "kubernetes/workload/v1",
+            Self::Container => "kubernetes/container/v1",
+            Self::Service => "kubernetes/service/v1",
+            Self::Ingress => "kubernetes/ingress/v1",
+            Self::ServiceAccount => "kubernetes/service_account/v1",
+            Self::RbacRole => "kubernetes/rbac_role/v1",
+            Self::RbacBinding => "kubernetes/rbac_binding/v1",
+            Self::WorkloadIdentityBinding => "kubernetes/workload_identity_binding/v1",
+        }
+    }
+
+    pub(super) const fn initial_path(self) -> &'static str {
+        match self {
+            Self::Cluster => "/version",
+            Self::Namespace => "/api/v1/namespaces",
+            Self::Node => "/api/v1/nodes",
+            Self::Pod | Self::Workload | Self::Container => "/api/v1/pods",
+            Self::Service => "/api/v1/services",
+            Self::Ingress => "/apis/networking.k8s.io/v1/ingresses",
+            Self::ServiceAccount | Self::WorkloadIdentityBinding => "/api/v1/serviceaccounts",
+            Self::RbacRole => "/apis/rbac.authorization.k8s.io/v1/roles",
+            Self::RbacBinding => "/apis/rbac.authorization.k8s.io/v1/rolebindings",
+        }
+    }
+
+    pub(super) const fn required_attributes(self) -> &'static [&'static str] {
+        match self {
+            Self::Cluster => &["cluster_id", "cluster_name"],
+            Self::Namespace => &["cluster_id", "namespace"],
+            Self::Node => &["cluster_id", "node_name", "ready"],
+            Self::Pod | Self::Workload => &["cluster_id", "namespace", "workload_uid"],
+            Self::Container => &["cluster_id", "container_name", "namespace"],
+            Self::Service => &["cluster_id", "namespace", "service_name", "service_type"],
+            Self::Ingress => &["cluster_id", "ingress_name", "namespace"],
+            Self::ServiceAccount => &["cluster_id", "namespace", "service_account_name"],
+            Self::RbacRole => &["cluster_id", "role_kind", "role_name"],
+            Self::RbacBinding => &["binding_kind", "binding_name", "cluster_id", "role_name"],
+            Self::WorkloadIdentityBinding => &[
+                "cloud_provider",
+                "cluster_id",
+                "namespace",
+                "service_account_name",
+                "target_id",
+            ],
+        }
+    }
+
+    pub(super) const fn required_payload_fields(self) -> &'static [&'static str] {
+        match self {
+            Self::Cluster => &["cluster_id", "cluster_name"],
+            Self::Namespace => &["name", "uid"],
+            Self::Node => &["name", "node_info", "ready"],
+            Self::Pod => &["name", "namespace", "uid"],
+            Self::Workload => &["workload_kind", "workload_name", "workload_uid"],
+            Self::Container => &["container_name", "pod_uid"],
+            Self::Service => &["name", "namespace", "ports", "type"],
+            Self::Ingress => &["name", "namespace", "rules"],
+            Self::ServiceAccount => &["name", "namespace"],
+            Self::RbacRole => &["name", "role_kind", "rules"],
+            Self::RbacBinding => &["binding_kind", "name", "role_ref"],
+            Self::WorkloadIdentityBinding => {
+                &["cloud_provider", "service_account_name", "target_id"]
+            }
+        }
+    }
+}
+
+impl FromStr for KubernetesFamily {
+    type Err = KubernetesError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim() {
+            "cluster" => Ok(Self::Cluster),
+            "namespace" => Ok(Self::Namespace),
+            "node" => Ok(Self::Node),
+            "pod" => Ok(Self::Pod),
+            "workload" => Ok(Self::Workload),
+            "container" => Ok(Self::Container),
+            "service" => Ok(Self::Service),
+            "ingress" => Ok(Self::Ingress),
+            "service_account" => Ok(Self::ServiceAccount),
+            "rbac_role" => Ok(Self::RbacRole),
+            "rbac_binding" => Ok(Self::RbacBinding),
+            "workload_identity_binding" => Ok(Self::WorkloadIdentityBinding),
+            _ => Err(KubernetesError::InvalidFamily),
+        }
+    }
+}

--- a/crates/source-runtime-next/src/kubernetes/fixtures/go_oracle_contract.json
+++ b/crates/source-runtime-next/src/kubernetes/fixtures/go_oracle_contract.json
@@ -1,0 +1,17 @@
+{
+  "source_id": "kubernetes",
+  "families": [
+    {"id":"cluster","event_kind":"kubernetes.cluster","schema_ref":"kubernetes/cluster/v1","required_attributes":["cluster_id","cluster_name"],"required_payload_fields":["cluster_id","cluster_name"]},
+    {"id":"namespace","event_kind":"kubernetes.namespace","schema_ref":"kubernetes/namespace/v1","required_attributes":["cluster_id","namespace"],"required_payload_fields":["name","uid"]},
+    {"id":"node","event_kind":"kubernetes.node","schema_ref":"kubernetes/node/v1","required_attributes":["cluster_id","node_name","ready"],"required_payload_fields":["name","node_info","ready"]},
+    {"id":"pod","event_kind":"kubernetes.pod","schema_ref":"kubernetes/pod/v1","required_attributes":["cluster_id","namespace","workload_uid"],"required_payload_fields":["name","namespace","uid"]},
+    {"id":"workload","event_kind":"kubernetes.workload","schema_ref":"kubernetes/workload/v1","required_attributes":["cluster_id","namespace","workload_uid"],"required_payload_fields":["workload_kind","workload_name","workload_uid"]},
+    {"id":"container","event_kind":"kubernetes.container","schema_ref":"kubernetes/container/v1","required_attributes":["cluster_id","container_name","namespace"],"required_payload_fields":["container_name","pod_uid"]},
+    {"id":"service","event_kind":"kubernetes.service","schema_ref":"kubernetes/service/v1","required_attributes":["cluster_id","namespace","service_name","service_type"],"required_payload_fields":["name","namespace","ports","type"]},
+    {"id":"ingress","event_kind":"kubernetes.ingress","schema_ref":"kubernetes/ingress/v1","required_attributes":["cluster_id","ingress_name","namespace"],"required_payload_fields":["name","namespace","rules"]},
+    {"id":"service_account","event_kind":"kubernetes.service_account","schema_ref":"kubernetes/service_account/v1","required_attributes":["cluster_id","namespace","service_account_name"],"required_payload_fields":["name","namespace"]},
+    {"id":"rbac_role","event_kind":"kubernetes.rbac_role","schema_ref":"kubernetes/rbac_role/v1","required_attributes":["cluster_id","role_kind","role_name"],"required_payload_fields":["name","role_kind","rules"]},
+    {"id":"rbac_binding","event_kind":"kubernetes.rbac_binding","schema_ref":"kubernetes/rbac_binding/v1","required_attributes":["binding_kind","binding_name","cluster_id","role_name"],"required_payload_fields":["binding_kind","name","role_ref"]},
+    {"id":"workload_identity_binding","event_kind":"kubernetes.workload_identity_binding","schema_ref":"kubernetes/workload_identity_binding/v1","required_attributes":["cloud_provider","cluster_id","namespace","service_account_name","target_id"],"required_payload_fields":["cloud_provider","service_account_name","target_id"]}
+  ]
+}

--- a/crates/source-runtime-next/src/kubernetes/fixtures/projection_oracle.json
+++ b/crates/source-runtime-next/src/kubernetes/fixtures/projection_oracle.json
@@ -1,0 +1,63 @@
+{
+  "tenant_id": "writer",
+  "cases": [
+    {
+      "family": "pod",
+      "attributes": {
+        "cluster_id": "prod-cluster",
+        "namespace": "payments",
+        "resource_id": "pod-uid-1",
+        "resource_name": "payments-api",
+        "workload_uid": "pod-uid-1",
+        "service_account_name": "api",
+        "node_name": "node-a"
+      },
+      "payload": {"name":"payments-api","namespace":"payments","uid":"pod-uid-1"},
+      "expected_links": [
+        ["urn:cerebro:writer:kubernetes_pod:prod-cluster:payments:pod-uid-1","runs_as","urn:cerebro:writer:kubernetes_service_account:prod-cluster:payments:api"],
+        ["urn:cerebro:writer:kubernetes_service_account:prod-cluster:payments:api","belongs_to","urn:cerebro:writer:kubernetes_namespace:prod-cluster:payments"],
+        ["urn:cerebro:writer:kubernetes_namespace:prod-cluster:payments","belongs_to","urn:cerebro:writer:kubernetes_cluster:prod-cluster"],
+        ["urn:cerebro:writer:kubernetes_node:prod-cluster:node-a","belongs_to","urn:cerebro:writer:kubernetes_cluster:prod-cluster"],
+        ["urn:cerebro:writer:kubernetes_pod:prod-cluster:payments:pod-uid-1","associated_with","urn:cerebro:writer:kubernetes_node:prod-cluster:node-a"]
+      ]
+    },
+    {
+      "family": "workload_identity_binding",
+      "attributes": {
+        "cloud_provider": "gcp",
+        "cluster_id": "prod-cluster",
+        "namespace": "payments",
+        "relationship": "can_impersonate",
+        "service_account_name": "api",
+        "target_email": "payments-sa@writer-prod.iam.gserviceaccount.com",
+        "target_id": "payments-sa@writer-prod.iam.gserviceaccount.com",
+        "target_type": "service_account"
+      },
+      "payload": {"cloud_provider":"gcp","service_account_name":"api","target_id":"payments-sa@writer-prod.iam.gserviceaccount.com"},
+      "expected_links": [
+        ["urn:cerebro:writer:kubernetes_service_account:prod-cluster:payments:api","can_impersonate","urn:cerebro:writer:gcp_service_account:payments-sa@writer-prod.iam.gserviceaccount.com"],
+        ["urn:cerebro:writer:kubernetes_service_account:prod-cluster:payments:api","belongs_to","urn:cerebro:writer:kubernetes_namespace:prod-cluster:payments"],
+        ["urn:cerebro:writer:kubernetes_namespace:prod-cluster:payments","belongs_to","urn:cerebro:writer:kubernetes_cluster:prod-cluster"]
+      ]
+    },
+    {
+      "family": "rbac_binding",
+      "attributes": {
+        "binding_kind": "RoleBinding",
+        "binding_name": "reader",
+        "cluster_id": "prod-cluster",
+        "namespace": "payments",
+        "role_kind": "Role",
+        "role_name": "secret-reader",
+        "subject_refs": "[{\"kind\":\"ServiceAccount\",\"name\":\"deployer\",\"namespace\":\"platform\"}]"
+      },
+      "payload": {"binding_kind":"RoleBinding","name":"reader","role_ref":{"kind":"Role","name":"secret-reader"}},
+      "expected_links": [
+        ["urn:cerebro:writer:kubernetes_rbac_binding:prod-cluster:RoleBinding:payments:reader","attached_to","urn:cerebro:writer:kubernetes_rbac_role:prod-cluster:Role:payments:secret-reader"],
+        ["urn:cerebro:writer:kubernetes_service_account:prod-cluster:platform:deployer","assigned_to","urn:cerebro:writer:kubernetes_rbac_role:prod-cluster:Role:payments:secret-reader"],
+        ["urn:cerebro:writer:kubernetes_service_account:prod-cluster:platform:deployer","belongs_to","urn:cerebro:writer:kubernetes_namespace:prod-cluster:platform"],
+        ["urn:cerebro:writer:kubernetes_namespace:prod-cluster:platform","belongs_to","urn:cerebro:writer:kubernetes_cluster:prod-cluster"]
+      ]
+    }
+  ]
+}

--- a/crates/source-runtime-next/src/kubernetes/model.rs
+++ b/crates/source-runtime-next/src/kubernetes/model.rs
@@ -1,0 +1,41 @@
+//! Public Kubernetes normalized page contracts.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use super::KubernetesFamily;
+
+/// One normalized Kubernetes provider object.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KubernetesRecord {
+    /// Closed source family.
+    pub family: KubernetesFamily,
+    /// Stable provider UID or declared composite identity.
+    pub provider_id: String,
+    /// Go-compatible event identity within the tenant envelope.
+    pub event_id: String,
+    /// Collision-resistant tenant-scoped canonical identity.
+    pub canonical_urn: String,
+    /// Exact source event kind.
+    pub event_kind: String,
+    /// Exact source event schema.
+    pub schema_ref: String,
+    /// Normalized source and projection attributes.
+    pub attributes: BTreeMap<String, String>,
+    /// Go-compatible normalized payload.
+    pub payload: Value,
+    /// Provider creation time or caller-supplied observation time.
+    pub occurred_at: String,
+}
+
+/// One bounded Kubernetes page and its Go-compatible continuation/checkpoint.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KubernetesPage {
+    /// Deduplicated records in provider order.
+    pub records: Vec<KubernetesRecord>,
+    /// Exact continuation accepted by the Go source.
+    pub next_cursor: Option<String>,
+    /// Proposed durable checkpoint, never committed by this kernel.
+    pub proposed_checkpoint: Option<String>,
+}

--- a/crates/source-runtime-next/src/kubernetes/normalize.rs
+++ b/crates/source-runtime-next/src/kubernetes/normalize.rs
@@ -1,0 +1,90 @@
+//! Deterministic Kubernetes provider-object normalization.
+
+mod access;
+mod common;
+mod core;
+mod network;
+mod workload;
+
+use serde_json::Value;
+use time::OffsetDateTime;
+
+use super::{
+    KubernetesError, KubernetesFamily, KubernetesKernel, KubernetesRecord, KubernetesRequest,
+};
+
+pub(super) use core::normalize_cluster;
+
+pub(super) fn normalize_object(
+    kernel: &KubernetesKernel,
+    request: &KubernetesRequest,
+    raw: Value,
+    observed_at: OffsetDateTime,
+) -> Result<Vec<KubernetesRecord>, KubernetesError> {
+    let object = raw.as_object().ok_or(KubernetesError::MalformedResponse)?;
+    let metadata = object
+        .get("metadata")
+        .and_then(Value::as_object)
+        .ok_or(KubernetesError::MalformedResponse)?;
+    match kernel.family {
+        KubernetesFamily::Namespace => Ok(vec![core::normalize_namespace(
+            kernel,
+            object,
+            metadata,
+            observed_at,
+        )?]),
+        KubernetesFamily::Node => Ok(vec![core::normalize_node(
+            kernel,
+            object,
+            metadata,
+            observed_at,
+        )?]),
+        KubernetesFamily::Pod | KubernetesFamily::Workload => {
+            Ok(vec![workload::normalize_pod_like(
+                kernel,
+                object,
+                metadata,
+                observed_at,
+            )?])
+        }
+        KubernetesFamily::Container => {
+            workload::normalize_containers(kernel, object, metadata, observed_at)
+        }
+        KubernetesFamily::Service => Ok(vec![network::normalize_service(
+            kernel,
+            object,
+            metadata,
+            observed_at,
+        )?]),
+        KubernetesFamily::Ingress => Ok(vec![network::normalize_ingress(
+            kernel,
+            object,
+            metadata,
+            observed_at,
+        )?]),
+        KubernetesFamily::ServiceAccount => Ok(vec![access::normalize_service_account(
+            kernel,
+            object,
+            metadata,
+            observed_at,
+        )?]),
+        KubernetesFamily::WorkloadIdentityBinding => {
+            access::normalize_workload_identity(kernel, object, metadata, observed_at)
+        }
+        KubernetesFamily::RbacRole => Ok(vec![access::normalize_rbac_role(
+            kernel,
+            request,
+            object,
+            metadata,
+            observed_at,
+        )?]),
+        KubernetesFamily::RbacBinding => Ok(vec![access::normalize_rbac_binding(
+            kernel,
+            request,
+            object,
+            metadata,
+            observed_at,
+        )?]),
+        KubernetesFamily::Cluster => Err(KubernetesError::MalformedResponse),
+    }
+}

--- a/crates/source-runtime-next/src/kubernetes/normalize/access.rs
+++ b/crates/source-runtime-next/src/kubernetes/normalize/access.rs
@@ -1,0 +1,324 @@
+//! Service-account, workload-identity, and RBAC normalization.
+
+use serde_json::{Map, Value, json};
+use time::OffsetDateTime;
+
+use crate::kubernetes::{
+    KubernetesError, KubernetesFamily, KubernetesKernel, KubernetesRecord, KubernetesRequest,
+    cursor::RbacStage, request::first_nonempty,
+};
+
+use super::common::*;
+
+pub(super) fn normalize_service_account(
+    kernel: &KubernetesKernel,
+    object: &Map<String, Value>,
+    metadata: &Map<String, Value>,
+    observed_at: OffsetDateTime,
+) -> Result<KubernetesRecord, KubernetesError> {
+    let name = required(metadata, "name")?;
+    let namespace = required(metadata, "namespace")?;
+    let uid = first_nonempty(&[string(metadata, "uid"), name]);
+    let mut attributes = base_attributes(kernel, "service_account", uid, name, namespace);
+    attributes.insert("service_account_name".to_owned(), name.to_owned());
+    attributes.insert("uid".to_owned(), uid.to_owned());
+    if let Some(value) = object
+        .get("automountServiceAccountToken")
+        .and_then(Value::as_bool)
+    {
+        attributes.insert("automount_token".to_owned(), bool_string(value).to_owned());
+    }
+    let annotations = annotations(metadata);
+    insert_nonempty(
+        &mut attributes,
+        "aws_role_arn",
+        annotations
+            .get("eks.amazonaws.com/role-arn")
+            .map_or("", String::as_str),
+    );
+    insert_nonempty(
+        &mut attributes,
+        "gcp_service_account",
+        annotations
+            .get("iam.gke.io/gcp-service-account")
+            .map_or("", String::as_str),
+    );
+    let payload = json!({
+        "uid": uid,
+        "name": name,
+        "namespace": namespace,
+        "automount_service_account_token": object.get("automountServiceAccountToken").cloned().unwrap_or(Value::Null),
+        "annotations": serde_json::to_value(&annotations).unwrap_or_else(|_| json!({})),
+    });
+    build_record(
+        kernel,
+        RecordParts {
+            family: KubernetesFamily::ServiceAccount,
+            provider_id: uid.to_owned(),
+            event_id: format!(
+                "kubernetes-service-account-{}",
+                sha256(&format!("{}/{namespace}/{name}", kernel.cluster_id))
+            ),
+            canonical_urn: canonical_urn(
+                &kernel.tenant_id,
+                "kubernetes_service_account",
+                &[&kernel.cluster_id, namespace, name],
+            )?,
+            attributes,
+            payload,
+            occurred_at: object_time(metadata, observed_at),
+        },
+    )
+}
+
+pub(super) fn normalize_workload_identity(
+    kernel: &KubernetesKernel,
+    _object: &Map<String, Value>,
+    metadata: &Map<String, Value>,
+    observed_at: OffsetDateTime,
+) -> Result<Vec<KubernetesRecord>, KubernetesError> {
+    let name = required(metadata, "name")?;
+    let namespace = required(metadata, "namespace")?;
+    let uid = first_nonempty(&[string(metadata, "uid"), name]);
+    let annotations = annotations(metadata);
+    let bindings = [
+        (
+            "aws",
+            "role",
+            "irsa",
+            annotations.get("eks.amazonaws.com/role-arn"),
+        ),
+        (
+            "gcp",
+            "service_account",
+            "gke_workload_identity",
+            annotations.get("iam.gke.io/gcp-service-account"),
+        ),
+    ];
+    bindings
+        .into_iter()
+        .filter_map(|(provider, target_type, relationship, target)| {
+            target
+                .map(|target| (provider, target_type, relationship, target))
+                .filter(|(_, _, _, target)| !target.trim().is_empty())
+        })
+        .map(|(provider, target_type, relationship, target)| {
+            let mut attributes = base_attributes(kernel, "service_account", uid, name, namespace);
+            for (key, value) in [
+                ("service_account_name", name),
+                ("uid", uid),
+                ("cloud_provider", provider),
+                ("target_type", target_type),
+                ("target_id", target.as_str()),
+                ("relationship", relationship),
+            ] {
+                attributes.insert(key.to_owned(), value.to_owned());
+            }
+            match provider {
+                "aws" => {
+                    attributes.insert("aws_role_arn".to_owned(), target.clone());
+                    attributes.insert("cloud_principal_arn".to_owned(), target.clone());
+                }
+                "gcp" => {
+                    attributes.insert("gcp_service_account".to_owned(), target.clone());
+                    attributes.insert("target_email".to_owned(), target.clone());
+                    attributes.insert("cloud_principal_email".to_owned(), target.clone());
+                }
+                _ => {}
+            }
+            let payload = serde_json::to_value(&attributes)
+                .map_err(|_| KubernetesError::MalformedResponse)?;
+            let provider_id = format!("{namespace}/{name}/{provider}/{target}");
+            build_record(
+                kernel,
+                RecordParts {
+                    family: KubernetesFamily::WorkloadIdentityBinding,
+                    provider_id,
+                    event_id: format!(
+                        "kubernetes-workload-identity-binding-{}",
+                        sha256(&format!(
+                            "{}/{namespace}/{name}/{provider}/{target}",
+                            kernel.cluster_id
+                        ))
+                    ),
+                    canonical_urn: canonical_urn(
+                        &kernel.tenant_id,
+                        "kubernetes_workload_identity_binding",
+                        &[&kernel.cluster_id, namespace, name, provider, target],
+                    )?,
+                    attributes,
+                    payload,
+                    occurred_at: object_time(metadata, observed_at),
+                },
+            )
+        })
+        .collect()
+}
+
+pub(super) fn normalize_rbac_role(
+    kernel: &KubernetesKernel,
+    request: &KubernetesRequest,
+    object: &Map<String, Value>,
+    metadata: &Map<String, Value>,
+    observed_at: OffsetDateTime,
+) -> Result<KubernetesRecord, KubernetesError> {
+    let kind = match request.rbac_stage {
+        Some(RbacStage::Role) => "Role",
+        Some(RbacStage::ClusterRole) => "ClusterRole",
+        _ => return Err(KubernetesError::RequestScopeMismatch),
+    };
+    let name = required(metadata, "name")?;
+    let namespace = string(metadata, "namespace");
+    let uid = first_nonempty(&[string(metadata, "uid"), name]);
+    let rules = array_or_empty(object.get("rules"));
+    let scope = if namespace.is_empty() {
+        "cluster"
+    } else {
+        "namespace"
+    };
+    let mut attributes = base_attributes(kernel, "rbac_role", uid, name, namespace);
+    for (key, value) in [
+        ("uid", uid),
+        ("role_kind", kind),
+        ("role_name", name),
+        ("role_scope", scope),
+    ] {
+        attributes.insert(key.to_owned(), value.to_owned());
+    }
+    attributes.insert("rules".to_owned(), rbac_rule_summaries(&rules).join(";"));
+    for (attribute, field) in [
+        ("api_groups", "apiGroups"),
+        ("resources", "resources"),
+        ("verbs", "verbs"),
+    ] {
+        attributes.insert(
+            attribute.to_owned(),
+            nested_string_arrays(&rules, field).join(","),
+        );
+    }
+    let payload = json!({
+        "uid": uid,
+        "name": name,
+        "namespace": namespace,
+        "role_kind": kind,
+        "role_scope": scope,
+        "rules": rules,
+    });
+    build_record(
+        kernel,
+        RecordParts {
+            family: KubernetesFamily::RbacRole,
+            provider_id: uid.to_owned(),
+            event_id: format!(
+                "kubernetes-rbac-role-{}",
+                sha256(&format!(
+                    "{}/{kind}/{namespace}/{name}/{uid}",
+                    kernel.cluster_id
+                ))
+            ),
+            canonical_urn: canonical_urn(
+                &kernel.tenant_id,
+                "kubernetes_rbac_role",
+                &[
+                    &kernel.cluster_id,
+                    kind,
+                    first_nonempty(&[namespace, "cluster"]),
+                    name,
+                ],
+            )?,
+            attributes,
+            payload,
+            occurred_at: object_time(metadata, observed_at),
+        },
+    )
+}
+
+pub(super) fn normalize_rbac_binding(
+    kernel: &KubernetesKernel,
+    request: &KubernetesRequest,
+    object: &Map<String, Value>,
+    metadata: &Map<String, Value>,
+    observed_at: OffsetDateTime,
+) -> Result<KubernetesRecord, KubernetesError> {
+    let kind = match request.rbac_stage {
+        Some(RbacStage::RoleBinding) => "RoleBinding",
+        Some(RbacStage::ClusterRoleBinding) => "ClusterRoleBinding",
+        _ => return Err(KubernetesError::RequestScopeMismatch),
+    };
+    let name = required(metadata, "name")?;
+    let namespace = string(metadata, "namespace");
+    let uid = first_nonempty(&[string(metadata, "uid"), name]);
+    let role_ref = object
+        .get("roleRef")
+        .and_then(Value::as_object)
+        .ok_or(KubernetesError::MalformedResponse)?;
+    let role_name = required(role_ref, "name")?;
+    let subjects = array_or_empty(object.get("subjects"));
+    let subject_refs = rbac_subject_refs(&subjects, namespace);
+    let scope = if namespace.is_empty() {
+        "cluster"
+    } else {
+        "namespace"
+    };
+    let mut attributes = base_attributes(kernel, "rbac_binding", uid, name, namespace);
+    for (key, value) in [
+        ("uid", uid),
+        ("binding_kind", kind),
+        ("binding_name", name),
+        ("binding_scope", scope),
+        ("role_api_group", string(role_ref, "apiGroup")),
+        ("role_kind", string(role_ref, "kind")),
+        ("role_name", role_name),
+    ] {
+        insert_nonempty(&mut attributes, key, value);
+    }
+    attributes.insert("subject_count".to_owned(), subjects.len().to_string());
+    attributes.insert(
+        "subject_refs".to_owned(),
+        serde_json::to_string(&subject_refs).map_err(|_| KubernetesError::MalformedResponse)?,
+    );
+    attributes.insert(
+        "subject_kinds".to_owned(),
+        object_strings(&subjects, "kind").join(","),
+    );
+    attributes.insert(
+        "subject_names".to_owned(),
+        object_strings(&subjects, "name").join(","),
+    );
+    let payload = json!({
+        "uid": uid,
+        "name": name,
+        "namespace": namespace,
+        "binding_kind": kind,
+        "binding_scope": scope,
+        "role_ref": object.get("roleRef").cloned().unwrap_or(Value::Null),
+        "subjects": subjects,
+    });
+    build_record(
+        kernel,
+        RecordParts {
+            family: KubernetesFamily::RbacBinding,
+            provider_id: uid.to_owned(),
+            event_id: format!(
+                "kubernetes-rbac-binding-{}",
+                sha256(&format!(
+                    "{}/{kind}/{namespace}/{name}/{uid}",
+                    kernel.cluster_id
+                ))
+            ),
+            canonical_urn: canonical_urn(
+                &kernel.tenant_id,
+                "kubernetes_rbac_binding",
+                &[
+                    &kernel.cluster_id,
+                    kind,
+                    first_nonempty(&[namespace, "cluster"]),
+                    name,
+                ],
+            )?,
+            attributes,
+            payload,
+            occurred_at: object_time(metadata, observed_at),
+        },
+    )
+}

--- a/crates/source-runtime-next/src/kubernetes/normalize/common.rs
+++ b/crates/source-runtime-next/src/kubernetes/normalize/common.rs
@@ -1,0 +1,564 @@
+//! Shared deterministic Kubernetes normalization primitives.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use crate::kubernetes::{
+    KubernetesError, KubernetesFamily, KubernetesKernel, KubernetesRecord, request::first_nonempty,
+};
+
+pub(super) struct RecordParts {
+    pub(super) family: KubernetesFamily,
+    pub(super) provider_id: String,
+    pub(super) event_id: String,
+    pub(super) canonical_urn: String,
+    pub(super) attributes: BTreeMap<String, String>,
+    pub(super) payload: Value,
+    pub(super) occurred_at: String,
+}
+
+pub(super) fn build_record(
+    kernel: &KubernetesKernel,
+    parts: RecordParts,
+) -> Result<KubernetesRecord, KubernetesError> {
+    let RecordParts {
+        family,
+        provider_id,
+        event_id,
+        canonical_urn,
+        mut attributes,
+        payload,
+        occurred_at,
+    } = parts;
+    if provider_id.trim().is_empty() {
+        return Err(KubernetesError::MissingStableIdentity);
+    }
+    attributes.retain(|key, value| !key.trim().is_empty() && !value.trim().is_empty());
+    if canonical_urn.len() > 2_048 || event_id.len() > 512 {
+        return Err(KubernetesError::InvalidCanonicalIdentity);
+    }
+    attributes.insert("family".to_owned(), family.as_str().to_owned());
+    attributes.insert("tenant_id".to_owned(), kernel.tenant_id.clone());
+    Ok(KubernetesRecord {
+        family,
+        provider_id,
+        event_id,
+        canonical_urn,
+        event_kind: family.event_kind().to_owned(),
+        schema_ref: family.schema_ref().to_owned(),
+        attributes,
+        payload,
+        occurred_at,
+    })
+}
+
+pub(super) fn base_attributes(
+    kernel: &KubernetesKernel,
+    resource_type: &str,
+    resource_id: &str,
+    resource_name: &str,
+    namespace: &str,
+) -> BTreeMap<String, String> {
+    let mut attributes = BTreeMap::from([
+        ("cluster_id".to_owned(), kernel.cluster_id.clone()),
+        ("cluster_name".to_owned(), kernel.cluster_name.clone()),
+        ("resource_id".to_owned(), resource_id.to_owned()),
+        ("resource_name".to_owned(), resource_name.to_owned()),
+        ("resource_type".to_owned(), resource_type.to_owned()),
+    ]);
+    for (key, value) in [
+        ("namespace", namespace),
+        ("external_id", &kernel.external_id),
+        ("cloud_provider", &kernel.cloud_provider),
+        ("cloud_account_id", &kernel.cloud_account_id),
+    ] {
+        insert_nonempty(&mut attributes, key, value);
+    }
+    attributes
+}
+
+pub(super) fn canonical_urn(
+    tenant: &str,
+    kind: &str,
+    segments: &[&str],
+) -> Result<String, KubernetesError> {
+    let mut values = Vec::with_capacity(segments.len());
+    for value in segments {
+        let value = value.trim();
+        if value.is_empty() || value.len() > 512 || value.chars().any(char::is_control) {
+            return Err(KubernetesError::InvalidCanonicalIdentity);
+        }
+        values.push(percent_encode(value));
+    }
+    Ok(format!(
+        "urn:cerebro:{}:{kind}:{}",
+        percent_encode(tenant),
+        values.join(":")
+    ))
+}
+
+pub(super) fn percent_encode(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut output = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            output.push(char::from(byte));
+        } else {
+            output.push('%');
+            output.push(char::from(HEX[(byte >> 4) as usize]));
+            output.push(char::from(HEX[(byte & 0x0f) as usize]));
+        }
+    }
+    output
+}
+
+pub(super) fn required<'a>(
+    object: &'a Map<String, Value>,
+    field: &str,
+) -> Result<&'a str, KubernetesError> {
+    let value = string(object, field);
+    (!value.is_empty())
+        .then_some(value)
+        .ok_or(KubernetesError::MissingStableIdentity)
+}
+
+pub(super) fn string<'a>(object: &'a Map<String, Value>, field: &str) -> &'a str {
+    object
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or("")
+}
+
+pub(super) fn pointer_string<'a>(object: &'a Map<String, Value>, pointer: &str) -> &'a str {
+    json_pointer(object, pointer)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or("")
+}
+
+pub(super) fn pointer_bool(object: &Map<String, Value>, pointer: &str) -> bool {
+    json_pointer(object, pointer)
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+pub(super) fn json_pointer<'a>(object: &'a Map<String, Value>, pointer: &str) -> Option<&'a Value> {
+    let mut parts = pointer.split('/');
+    if parts.next() != Some("") {
+        return None;
+    }
+    let first = parts.next()?;
+    let mut value = object.get(first)?;
+    for part in parts {
+        let part = part.replace("~1", "/").replace("~0", "~");
+        value = match value {
+            Value::Object(map) => map.get(&part)?,
+            Value::Array(items) => items.get(part.parse::<usize>().ok()?)?,
+            _ => return None,
+        };
+    }
+    Some(value)
+}
+
+pub(super) fn bool_field(object: &Map<String, Value>, field: &str) -> bool {
+    object.get(field).and_then(Value::as_bool).unwrap_or(false)
+}
+
+pub(super) fn optional_value(object: &Map<String, Value>, field: &str) -> Value {
+    object.get(field).cloned().unwrap_or(Value::Null)
+}
+
+pub(super) fn optional_string(value: &str) -> Value {
+    if value.is_empty() {
+        Value::Null
+    } else {
+        Value::String(value.to_owned())
+    }
+}
+
+pub(super) fn insert_nonempty(attributes: &mut BTreeMap<String, String>, key: &str, value: &str) {
+    let value = value.trim();
+    if !value.is_empty() {
+        attributes.insert(key.to_owned(), value.to_owned());
+    }
+}
+
+pub(super) fn insert_json(
+    attributes: &mut BTreeMap<String, String>,
+    key: &str,
+    value: Option<&Value>,
+) {
+    let Some(value) = value else {
+        return;
+    };
+    if !value.is_null()
+        && let Ok(encoded) = serde_json::to_string(value)
+    {
+        attributes.insert(key.to_owned(), encoded);
+    }
+}
+
+pub(super) fn array_or_empty(value: Option<&Value>) -> Vec<Value> {
+    value.and_then(Value::as_array).cloned().unwrap_or_default()
+}
+
+pub(super) fn string_array(value: Option<&Value>) -> Vec<String> {
+    let mut values = value
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    values.sort();
+    values.dedup();
+    values
+}
+
+pub(super) fn object_strings(values: &[Value], field: &str) -> Vec<String> {
+    let mut result = values
+        .iter()
+        .filter_map(Value::as_object)
+        .filter_map(|object| object.get(field))
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    result.sort();
+    result.dedup();
+    result
+}
+
+pub(super) fn nested_string_arrays(values: &[Value], field: &str) -> Vec<String> {
+    let mut result = values
+        .iter()
+        .filter_map(Value::as_object)
+        .filter_map(|object| object.get(field))
+        .filter_map(Value::as_array)
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    result.sort();
+    result.dedup();
+    result
+}
+
+pub(super) fn annotations(metadata: &Map<String, Value>) -> BTreeMap<String, String> {
+    metadata
+        .get("annotations")
+        .and_then(Value::as_object)
+        .into_iter()
+        .flatten()
+        .filter_map(|(key, value)| {
+            if !matches!(
+                key.as_str(),
+                "eks.amazonaws.com/role-arn" | "iam.gke.io/gcp-service-account"
+            ) {
+                return None;
+            }
+            value
+                .as_str()
+                .map(|value| (key.clone(), value.trim().to_owned()))
+        })
+        .filter(|(_, value)| !value.is_empty())
+        .collect()
+}
+
+pub(super) fn node_ready(object: &Map<String, Value>) -> bool {
+    json_pointer(object, "/status/conditions")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_object)
+        .any(|condition| {
+            string(condition, "type") == "Ready" && string(condition, "status") == "True"
+        })
+}
+
+pub(super) fn node_address<'a>(object: &'a Map<String, Value>, kind: &str) -> &'a str {
+    json_pointer(object, "/status/addresses")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_object)
+        .find(|address| string(address, "type") == kind)
+        .map(|address| string(address, "address"))
+        .unwrap_or("")
+}
+
+pub(super) fn named_objects(value: Option<&Value>) -> BTreeMap<&str, &Map<String, Value>> {
+    value
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_object)
+        .filter_map(|object| {
+            let name = string(object, "name");
+            (!name.is_empty()).then_some((name, object))
+        })
+        .collect()
+}
+
+pub(super) fn container_images(object: &Map<String, Value>) -> Vec<String> {
+    let mut images = json_pointer(object, "/spec/containers")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_object)
+        .map(|container| string(container, "image"))
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    images.shrink_to_fit();
+    images
+}
+
+pub(super) fn container_image_digests(object: &Map<String, Value>) -> Vec<String> {
+    let mut digests = json_pointer(object, "/status/containerStatuses")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_object)
+        .map(|status| image_digest(string(status, "imageID")))
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    digests.sort();
+    digests
+}
+
+pub(super) fn image_digest(value: &str) -> &str {
+    value
+        .rfind("@sha256:")
+        .map(|index| &value[index + 1..])
+        .or_else(|| value.rfind("sha256:").map(|index| &value[index..]))
+        .unwrap_or("")
+}
+
+pub(super) fn container_state(object: &Map<String, Value>) -> &'static str {
+    let Some(state) = object.get("state").and_then(Value::as_object) else {
+        return "";
+    };
+    for key in ["running", "waiting", "terminated"] {
+        if state.get(key).is_some_and(|value| !value.is_null()) {
+            return key;
+        }
+    }
+    ""
+}
+
+pub(super) fn load_balancer_values(object: &Map<String, Value>, field: &str) -> Vec<String> {
+    let values = array_or_empty(json_pointer(object, "/status/loadBalancer/ingress"));
+    object_strings(&values, field)
+}
+
+pub(super) fn service_ports(object: &Map<String, Value>) -> Vec<Value> {
+    let mut ports = json_pointer(object, "/spec/ports")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_object)
+        .map(|port| {
+            let mut value = BTreeMap::from([
+                ("name".to_owned(), scalar_string(port.get("name"))),
+                ("protocol".to_owned(), scalar_string(port.get("protocol"))),
+                ("port".to_owned(), scalar_string(port.get("port"))),
+                (
+                    "target_port".to_owned(),
+                    scalar_string(port.get("targetPort")),
+                ),
+            ]);
+            let node_port = scalar_string(port.get("nodePort"));
+            if !matches!(node_port.as_str(), "" | "0") {
+                value.insert("node_port".to_owned(), node_port);
+            }
+            serde_json::to_value(value).unwrap_or(Value::Null)
+        })
+        .collect::<Vec<_>>();
+    ports.sort_by_key(|value| {
+        format!(
+            "{}:{}",
+            value.get("port").and_then(Value::as_str).unwrap_or(""),
+            value.get("name").and_then(Value::as_str).unwrap_or("")
+        )
+    });
+    ports
+}
+
+fn scalar_string(value: Option<&Value>) -> String {
+    value
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| value.and_then(Value::as_i64).map(|value| value.to_string()))
+        .unwrap_or_else(|| "0".to_owned())
+}
+
+pub(super) fn ingress_hosts(rules: &[Value]) -> Vec<String> {
+    object_strings(rules, "host")
+}
+
+pub(super) fn ingress_backends(object: &Map<String, Value>) -> Vec<String> {
+    let mut values = BTreeSet::new();
+    if let Some(service) =
+        json_pointer(object, "/spec/defaultBackend/service").and_then(Value::as_object)
+        && let Some(value) = ingress_service(service)
+    {
+        values.insert(value);
+    }
+    for rule in json_pointer(object, "/spec/rules")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        for path in rule
+            .pointer("/http/paths")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            if let Some(service) = path.pointer("/backend/service").and_then(Value::as_object)
+                && let Some(value) = ingress_service(service)
+            {
+                values.insert(value);
+            }
+        }
+    }
+    values.into_iter().collect()
+}
+
+pub(super) fn ingress_service(service: &Map<String, Value>) -> Option<String> {
+    let name = string(service, "name");
+    if name.is_empty() {
+        return None;
+    }
+    let port = json_pointer(service, "/port/name")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            json_pointer(service, "/port/number")
+                .and_then(Value::as_i64)
+                .map(|_| "")
+        });
+    let port = if let Some(port) = port.filter(|value| !value.is_empty()) {
+        port.to_owned()
+    } else {
+        json_pointer(service, "/port/number")
+            .and_then(Value::as_i64)
+            .map(|value| value.to_string())
+            .unwrap_or_default()
+    };
+    Some(if port.is_empty() {
+        name.to_owned()
+    } else {
+        format!("{name}:{port}")
+    })
+}
+
+pub(super) fn ingress_rule_summaries(rules: &[Value]) -> Vec<Value> {
+    let mut values = BTreeSet::new();
+    for rule in rules {
+        let host = rule
+            .get("host")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("*");
+        for path in rule
+            .pointer("/http/paths")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let path_value = path.get("path").and_then(Value::as_str).unwrap_or("");
+            if let Some(service) = path.pointer("/backend/service").and_then(Value::as_object)
+                && let Some(service) = ingress_service(service)
+            {
+                values.insert(format!("{host}:{path_value}->{service}"));
+            }
+        }
+    }
+    values.into_iter().map(Value::String).collect()
+}
+
+pub(super) fn rbac_rule_summaries(rules: &[Value]) -> Vec<String> {
+    let mut values = rules
+        .iter()
+        .filter_map(Value::as_object)
+        .map(|rule| {
+            format!(
+                "{}:{}:{}",
+                string_array(rule.get("apiGroups")).join(","),
+                string_array(rule.get("resources")).join(","),
+                string_array(rule.get("verbs")).join(",")
+            )
+        })
+        .collect::<Vec<_>>();
+    values.sort();
+    values
+}
+
+pub(super) fn rbac_subject_refs(subjects: &[Value], binding_namespace: &str) -> Vec<Value> {
+    let mut refs = subjects
+        .iter()
+        .filter_map(Value::as_object)
+        .filter_map(|subject| {
+            let kind = string(subject, "kind");
+            let name = string(subject, "name");
+            if kind.is_empty() || name.is_empty() {
+                return None;
+            }
+            let namespace = if kind == "ServiceAccount" {
+                first_nonempty(&[string(subject, "namespace"), binding_namespace, "default"])
+            } else {
+                string(subject, "namespace")
+            };
+            let mut value = Map::from_iter([
+                ("kind".to_owned(), Value::String(kind.to_owned())),
+                ("name".to_owned(), Value::String(name.to_owned())),
+            ]);
+            if !namespace.is_empty() {
+                value.insert("namespace".to_owned(), Value::String(namespace.to_owned()));
+            }
+            Some(Value::Object(value))
+        })
+        .collect::<Vec<_>>();
+    refs.sort_by_key(Value::to_string);
+    refs
+}
+
+pub(super) fn object_time(metadata: &Map<String, Value>, fallback: OffsetDateTime) -> String {
+    OffsetDateTime::parse(string(metadata, "creationTimestamp"), &Rfc3339)
+        .ok()
+        .unwrap_or(fallback)
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| observed_at_string(fallback))
+}
+
+pub(super) fn observed_at_string(value: OffsetDateTime) -> String {
+    value
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
+}
+
+pub(super) fn bool_string(value: bool) -> &'static str {
+    if value { "true" } else { "false" }
+}
+
+pub(super) fn sha256(value: &str) -> String {
+    let digest = Sha256::digest(value.as_bytes());
+    digest
+        .iter()
+        .fold(String::with_capacity(64), |mut output, byte| {
+            use std::fmt::Write as _;
+            write!(&mut output, "{byte:02x}").expect("writing to String cannot fail");
+            output
+        })
+}

--- a/crates/source-runtime-next/src/kubernetes/normalize/core.rs
+++ b/crates/source-runtime-next/src/kubernetes/normalize/core.rs
@@ -1,0 +1,201 @@
+//! Cluster, namespace, and node normalization.
+
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value, json};
+use time::OffsetDateTime;
+
+use crate::kubernetes::{
+    KubernetesError, KubernetesFamily, KubernetesKernel, KubernetesRecord, request::first_nonempty,
+};
+
+use super::common::*;
+
+pub(in crate::kubernetes) fn normalize_cluster(
+    kernel: &KubernetesKernel,
+    response: Value,
+    observed_at: OffsetDateTime,
+) -> Result<KubernetesRecord, KubernetesError> {
+    let object = response
+        .as_object()
+        .ok_or(KubernetesError::MalformedResponse)?;
+    let mut attributes = BTreeMap::from([
+        ("cluster_id".to_owned(), kernel.cluster_id.clone()),
+        ("cluster_name".to_owned(), kernel.cluster_name.clone()),
+    ]);
+    insert_nonempty(&mut attributes, "external_id", &kernel.external_id);
+    insert_nonempty(&mut attributes, "cloud_provider", &kernel.cloud_provider);
+    insert_nonempty(
+        &mut attributes,
+        "cloud_account_id",
+        &kernel.cloud_account_id,
+    );
+    for (attribute, provider) in [
+        ("git_version", "gitVersion"),
+        ("version_major", "major"),
+        ("version_minor", "minor"),
+        ("platform", "platform"),
+    ] {
+        insert_nonempty(&mut attributes, attribute, string(object, provider));
+    }
+    let payload = json!({
+        "cluster_id": kernel.cluster_id,
+        "cluster_name": kernel.cluster_name,
+        "external_id": optional_string(&kernel.external_id),
+        "git_version": optional_value(object, "gitVersion"),
+        "major": optional_value(object, "major"),
+        "minor": optional_value(object, "minor"),
+        "platform": optional_value(object, "platform"),
+        "cloud_provider": optional_string(&kernel.cloud_provider),
+        "cloud_account_id": optional_string(&kernel.cloud_account_id),
+    });
+    build_record(
+        kernel,
+        RecordParts {
+            family: KubernetesFamily::Cluster,
+            provider_id: kernel.cluster_id.clone(),
+            event_id: format!("kubernetes-cluster-{}", kernel.cluster_id),
+            canonical_urn: canonical_urn(
+                &kernel.tenant_id,
+                "kubernetes_cluster",
+                &[&kernel.cluster_id],
+            )?,
+            attributes,
+            payload,
+            occurred_at: observed_at_string(observed_at),
+        },
+    )
+}
+
+pub(super) fn normalize_namespace(
+    kernel: &KubernetesKernel,
+    object: &Map<String, Value>,
+    metadata: &Map<String, Value>,
+    observed_at: OffsetDateTime,
+) -> Result<KubernetesRecord, KubernetesError> {
+    let name = required(metadata, "name")?;
+    let uid = required(metadata, "uid")?;
+    let mut attributes = base_attributes(kernel, "namespace", uid, name, name);
+    attributes.insert("namespace".to_owned(), name.to_owned());
+    let payload = json!({
+        "uid": uid,
+        "name": name,
+        "status": json_pointer(object, "/status/phase").cloned().unwrap_or(Value::String(String::new())),
+    });
+    build_record(
+        kernel,
+        RecordParts {
+            family: KubernetesFamily::Namespace,
+            provider_id: uid.to_owned(),
+            event_id: format!("kubernetes-namespace-{uid}"),
+            canonical_urn: canonical_urn(
+                &kernel.tenant_id,
+                "kubernetes_namespace",
+                &[&kernel.cluster_id, uid],
+            )?,
+            attributes,
+            payload,
+            occurred_at: object_time(metadata, observed_at),
+        },
+    )
+}
+
+pub(super) fn normalize_node(
+    kernel: &KubernetesKernel,
+    object: &Map<String, Value>,
+    metadata: &Map<String, Value>,
+    observed_at: OffsetDateTime,
+) -> Result<KubernetesRecord, KubernetesError> {
+    let name = required(metadata, "name")?;
+    let uid = first_nonempty(&[string(metadata, "uid"), name]);
+    let ready = node_ready(object);
+    let mut attributes = base_attributes(kernel, "node", uid, name, "");
+    for (key, value) in [
+        ("uid", uid),
+        ("node_name", name),
+        ("ready", bool_string(ready)),
+        ("provider_id", pointer_string(object, "/spec/providerID")),
+        ("pod_cidr", pointer_string(object, "/spec/podCIDR")),
+        ("internal_ip", node_address(object, "InternalIP")),
+        ("external_ip", node_address(object, "ExternalIP")),
+        (
+            "kernel_version",
+            pointer_string(object, "/status/nodeInfo/kernelVersion"),
+        ),
+        (
+            "kubelet_version",
+            pointer_string(object, "/status/nodeInfo/kubeletVersion"),
+        ),
+        (
+            "container_runtime_version",
+            pointer_string(object, "/status/nodeInfo/containerRuntimeVersion"),
+        ),
+        (
+            "os_image",
+            pointer_string(object, "/status/nodeInfo/osImage"),
+        ),
+        (
+            "operating_system",
+            pointer_string(object, "/status/nodeInfo/operatingSystem"),
+        ),
+        (
+            "architecture",
+            pointer_string(object, "/status/nodeInfo/architecture"),
+        ),
+    ] {
+        insert_nonempty(&mut attributes, key, value);
+    }
+    attributes.insert(
+        "unschedulable".to_owned(),
+        bool_string(pointer_bool(object, "/spec/unschedulable")).to_owned(),
+    );
+    for (key, pointer) in [
+        ("pod_cidrs", "/spec/podCIDRs"),
+        ("labels", "/metadata/labels"),
+        ("taints", "/spec/taints"),
+        ("capacity", "/status/capacity"),
+        ("allocatable", "/status/allocatable"),
+    ] {
+        insert_json(&mut attributes, key, json_pointer(object, pointer));
+    }
+    let payload = json!({
+        "uid": uid,
+        "name": name,
+        "provider_id": json_pointer(object, "/spec/providerID").cloned().unwrap_or(Value::String(String::new())),
+        "unschedulable": pointer_bool(object, "/spec/unschedulable"),
+        "pod_cidr": json_pointer(object, "/spec/podCIDR").cloned().unwrap_or(Value::String(String::new())),
+        "pod_cidrs": array_or_empty(json_pointer(object, "/spec/podCIDRs")),
+        "taints": array_or_empty(json_pointer(object, "/spec/taints")),
+        "labels": json_pointer(object, "/metadata/labels").cloned().unwrap_or_else(|| json!({})),
+        "annotations": json!({}),
+        "addresses": array_or_empty(json_pointer(object, "/status/addresses")),
+        "conditions": array_or_empty(json_pointer(object, "/status/conditions")),
+        "capacity": json_pointer(object, "/status/capacity").cloned().unwrap_or_else(|| json!({})),
+        "allocatable": json_pointer(object, "/status/allocatable").cloned().unwrap_or_else(|| json!({})),
+        "node_info": json_pointer(object, "/status/nodeInfo").cloned().unwrap_or_else(|| json!({})),
+        "ready": ready,
+        "internal_ip": node_address(object, "InternalIP"),
+        "external_ip": node_address(object, "ExternalIP"),
+        "kubelet_version": pointer_string(object, "/status/nodeInfo/kubeletVersion"),
+        "container_runtime": pointer_string(object, "/status/nodeInfo/containerRuntimeVersion"),
+    });
+    build_record(
+        kernel,
+        RecordParts {
+            family: KubernetesFamily::Node,
+            provider_id: uid.to_owned(),
+            event_id: format!(
+                "kubernetes-node-{}",
+                sha256(&format!("{}/{name}", kernel.cluster_id))
+            ),
+            canonical_urn: canonical_urn(
+                &kernel.tenant_id,
+                "kubernetes_node",
+                &[&kernel.cluster_id, name],
+            )?,
+            attributes,
+            payload,
+            occurred_at: object_time(metadata, observed_at),
+        },
+    )
+}

--- a/crates/source-runtime-next/src/kubernetes/normalize/network.rs
+++ b/crates/source-runtime-next/src/kubernetes/normalize/network.rs
@@ -1,0 +1,169 @@
+//! Service and ingress normalization.
+
+use serde_json::{Map, Value, json};
+use time::OffsetDateTime;
+
+use crate::kubernetes::{
+    KubernetesError, KubernetesFamily, KubernetesKernel, KubernetesRecord, request::first_nonempty,
+};
+
+use super::common::*;
+
+pub(super) fn normalize_service(
+    kernel: &KubernetesKernel,
+    object: &Map<String, Value>,
+    metadata: &Map<String, Value>,
+    observed_at: OffsetDateTime,
+) -> Result<KubernetesRecord, KubernetesError> {
+    let name = required(metadata, "name")?;
+    let namespace = required(metadata, "namespace")?;
+    let uid = first_nonempty(&[string(metadata, "uid"), name]);
+    let service_type = pointer_string(object, "/spec/type");
+    if service_type.is_empty() {
+        return Err(KubernetesError::MissingRequiredPayloadField("type"));
+    }
+    let ports = service_ports(object);
+    let external_ips = string_array(json_pointer(object, "/spec/externalIPs")).join(",");
+    let load_balancer_ips = load_balancer_values(object, "ip").join(",");
+    let load_balancer_hostnames = load_balancer_values(object, "hostname").join(",");
+    let mut attributes = base_attributes(kernel, "service", uid, name, namespace);
+    for (key, value) in [
+        ("uid", uid),
+        ("service_name", name),
+        ("service_type", service_type),
+        ("cluster_ip", pointer_string(object, "/spec/clusterIP")),
+        (
+            "external_name",
+            pointer_string(object, "/spec/externalName"),
+        ),
+        ("external_ips", external_ips.as_str()),
+        ("load_balancer_ips", load_balancer_ips.as_str()),
+        ("load_balancer_hostnames", load_balancer_hostnames.as_str()),
+    ] {
+        insert_nonempty(&mut attributes, key, value);
+    }
+    insert_json(&mut attributes, "ports", Some(&Value::Array(ports.clone())));
+    insert_json(
+        &mut attributes,
+        "selector",
+        json_pointer(object, "/spec/selector"),
+    );
+    let payload = json!({
+        "uid": uid,
+        "name": name,
+        "namespace": namespace,
+        "type": service_type,
+        "cluster_ip": pointer_string(object, "/spec/clusterIP"),
+        "cluster_ips": array_or_empty(json_pointer(object, "/spec/clusterIPs")),
+        "external_ips": array_or_empty(json_pointer(object, "/spec/externalIPs")),
+        "external_name": pointer_string(object, "/spec/externalName"),
+        "ip_families": array_or_empty(json_pointer(object, "/spec/ipFamilies")),
+        "ports": array_or_empty(json_pointer(object, "/spec/ports")),
+        "selector": json_pointer(object, "/spec/selector").cloned().unwrap_or_else(|| json!({})),
+        "load_balancer_ingress": array_or_empty(json_pointer(object, "/status/loadBalancer/ingress")),
+        "load_balancer_ips": load_balancer_values(object, "ip"),
+        "load_balancer_hostnames": load_balancer_values(object, "hostname"),
+        "labels": json_pointer(object, "/metadata/labels").cloned().unwrap_or_else(|| json!({})),
+        "annotations": json!({}),
+    });
+    build_record(
+        kernel,
+        RecordParts {
+            family: KubernetesFamily::Service,
+            provider_id: uid.to_owned(),
+            event_id: format!(
+                "kubernetes-service-{}",
+                sha256(&format!("{}/{namespace}/{name}", kernel.cluster_id))
+            ),
+            canonical_urn: canonical_urn(
+                &kernel.tenant_id,
+                "kubernetes_service",
+                &[&kernel.cluster_id, namespace, name],
+            )?,
+            attributes,
+            payload,
+            occurred_at: object_time(metadata, observed_at),
+        },
+    )
+}
+
+pub(super) fn normalize_ingress(
+    kernel: &KubernetesKernel,
+    object: &Map<String, Value>,
+    metadata: &Map<String, Value>,
+    observed_at: OffsetDateTime,
+) -> Result<KubernetesRecord, KubernetesError> {
+    let name = required(metadata, "name")?;
+    let namespace = required(metadata, "namespace")?;
+    let uid = first_nonempty(&[string(metadata, "uid"), name]);
+    let rules = array_or_empty(json_pointer(object, "/spec/rules"));
+    let hosts = ingress_hosts(&rules);
+    let tls = array_or_empty(json_pointer(object, "/spec/tls"));
+    let tls_hosts = nested_string_arrays(&tls, "hosts");
+    let tls_secrets = object_strings(&tls, "secretName");
+    let backends = ingress_backends(object);
+    let joined_hosts = hosts.join(",");
+    let joined_tls_hosts = tls_hosts.join(",");
+    let joined_tls_secrets = tls_secrets.join(",");
+    let joined_backends = backends.join(",");
+    let load_balancer_ips = load_balancer_values(object, "ip").join(",");
+    let load_balancer_hostnames = load_balancer_values(object, "hostname").join(",");
+    let mut attributes = base_attributes(kernel, "ingress", uid, name, namespace);
+    for (key, value) in [
+        ("uid", uid),
+        ("ingress_name", name),
+        (
+            "ingress_class_name",
+            pointer_string(object, "/spec/ingressClassName"),
+        ),
+        ("hosts", joined_hosts.as_str()),
+        ("tls_hosts", joined_tls_hosts.as_str()),
+        ("tls_secret_names", joined_tls_secrets.as_str()),
+        ("backend_services", joined_backends.as_str()),
+        ("load_balancer_ips", load_balancer_ips.as_str()),
+        ("load_balancer_hostnames", load_balancer_hostnames.as_str()),
+    ] {
+        insert_nonempty(&mut attributes, key, value);
+    }
+    insert_json(
+        &mut attributes,
+        "rules",
+        Some(&Value::Array(ingress_rule_summaries(&rules))),
+    );
+    let payload = json!({
+        "uid": uid,
+        "name": name,
+        "namespace": namespace,
+        "ingress_class_name": json_pointer(object, "/spec/ingressClassName").cloned().unwrap_or(Value::Null),
+        "rules": rules,
+        "tls": tls,
+        "default_backend": json_pointer(object, "/spec/defaultBackend").cloned().unwrap_or(Value::Null),
+        "load_balancer_ingress": array_or_empty(json_pointer(object, "/status/loadBalancer/ingress")),
+        "hosts": hosts,
+        "tls_hosts": tls_hosts,
+        "backend_services": backends,
+        "load_balancer_ips": load_balancer_values(object, "ip"),
+        "load_balancer_hostnames": load_balancer_values(object, "hostname"),
+        "labels": json_pointer(object, "/metadata/labels").cloned().unwrap_or_else(|| json!({})),
+        "annotations": json!({}),
+    });
+    build_record(
+        kernel,
+        RecordParts {
+            family: KubernetesFamily::Ingress,
+            provider_id: uid.to_owned(),
+            event_id: format!(
+                "kubernetes-ingress-{}",
+                sha256(&format!("{}/{namespace}/{name}", kernel.cluster_id))
+            ),
+            canonical_urn: canonical_urn(
+                &kernel.tenant_id,
+                "kubernetes_ingress",
+                &[&kernel.cluster_id, namespace, name],
+            )?,
+            attributes,
+            payload,
+            occurred_at: object_time(metadata, observed_at),
+        },
+    )
+}

--- a/crates/source-runtime-next/src/kubernetes/normalize/workload.rs
+++ b/crates/source-runtime-next/src/kubernetes/normalize/workload.rs
@@ -1,0 +1,193 @@
+//! Pod, workload, and container normalization.
+
+use serde_json::{Map, Value, json};
+use time::OffsetDateTime;
+
+use crate::kubernetes::{
+    KubernetesError, KubernetesFamily, KubernetesKernel, KubernetesRecord, request::first_nonempty,
+};
+
+use super::common::*;
+
+pub(super) fn normalize_pod_like(
+    kernel: &KubernetesKernel,
+    object: &Map<String, Value>,
+    metadata: &Map<String, Value>,
+    observed_at: OffsetDateTime,
+) -> Result<KubernetesRecord, KubernetesError> {
+    let name = required(metadata, "name")?;
+    let namespace = required(metadata, "namespace")?;
+    let uid = required(metadata, "uid")?;
+    let service_account = first_nonempty(&[
+        pointer_string(object, "/spec/serviceAccountName"),
+        "default",
+    ]);
+    let images = container_images(object);
+    let digests = container_image_digests(object);
+    let joined_images = images.join(",");
+    let joined_digests = digests.join(",");
+    let mut attributes = base_attributes(kernel, "pod", uid, name, namespace);
+    for (key, value) in [
+        ("uid", uid),
+        ("workload_uid", uid),
+        ("workload_kind", "Pod"),
+        ("workload_name", name),
+        ("service_account_name", service_account),
+        ("node_name", pointer_string(object, "/spec/nodeName")),
+        ("image", joined_images.as_str()),
+        ("image_digest", joined_digests.as_str()),
+    ] {
+        insert_nonempty(&mut attributes, key, value);
+    }
+    for (key, pointer) in [
+        ("host_network", "/spec/hostNetwork"),
+        ("host_pid", "/spec/hostPID"),
+        ("host_ipc", "/spec/hostIPC"),
+    ] {
+        attributes.insert(
+            key.to_owned(),
+            bool_string(pointer_bool(object, pointer)).to_owned(),
+        );
+    }
+    let payload = json!({
+        "uid": uid,
+        "name": name,
+        "namespace": namespace,
+        "workload_uid": uid,
+        "workload_kind": "Pod",
+        "workload_name": name,
+        "service_account_name": service_account,
+        "node_name": pointer_string(object, "/spec/nodeName"),
+        "host_network": pointer_bool(object, "/spec/hostNetwork"),
+        "host_pid": pointer_bool(object, "/spec/hostPID"),
+        "host_ipc": pointer_bool(object, "/spec/hostIPC"),
+        "automount_service_account_token": json_pointer(object, "/spec/automountServiceAccountToken").cloned().unwrap_or(Value::Null),
+        "phase": pointer_string(object, "/status/phase"),
+        "labels": json_pointer(object, "/metadata/labels").cloned().unwrap_or_else(|| json!({})),
+        "images": images,
+        "image_digests": digests,
+    });
+    let canonical_kind = if kernel.family == KubernetesFamily::Pod {
+        "kubernetes_pod"
+    } else {
+        "kubernetes_workload"
+    };
+    let canonical = canonical_urn(
+        &kernel.tenant_id,
+        canonical_kind,
+        &[&kernel.cluster_id, namespace, uid],
+    )?;
+    build_record(
+        kernel,
+        RecordParts {
+            family: kernel.family,
+            provider_id: uid.to_owned(),
+            event_id: format!("kubernetes-pod-{uid}"),
+            canonical_urn: canonical,
+            attributes,
+            payload,
+            occurred_at: object_time(metadata, observed_at),
+        },
+    )
+}
+
+pub(super) fn normalize_containers(
+    kernel: &KubernetesKernel,
+    object: &Map<String, Value>,
+    metadata: &Map<String, Value>,
+    observed_at: OffsetDateTime,
+) -> Result<Vec<KubernetesRecord>, KubernetesError> {
+    let pod_name = required(metadata, "name")?;
+    let namespace = required(metadata, "namespace")?;
+    let pod_uid = required(metadata, "uid")?;
+    let containers = json_pointer(object, "/spec/containers")
+        .and_then(Value::as_array)
+        .ok_or(KubernetesError::MalformedResponse)?;
+    let statuses = named_objects(json_pointer(object, "/status/containerStatuses"));
+    containers
+        .iter()
+        .map(|container| {
+            let container = container
+                .as_object()
+                .ok_or(KubernetesError::MalformedResponse)?;
+            let name = required(container, "name")?;
+            let status = statuses.get(name).copied();
+            let mut attributes = base_attributes(kernel, "container", pod_uid, pod_name, namespace);
+            for (key, value) in [
+                ("uid", pod_uid),
+                ("workload_uid", pod_uid),
+                ("workload_kind", "Pod"),
+                ("workload_name", pod_name),
+                ("container_name", name),
+                ("image", string(container, "image")),
+                ("image_pull_policy", string(container, "imagePullPolicy")),
+            ] {
+                insert_nonempty(&mut attributes, key, value);
+            }
+            if let Some(status) = status {
+                attributes.insert(
+                    "status_ready".to_owned(),
+                    bool_string(bool_field(status, "ready")).to_owned(),
+                );
+                attributes.insert(
+                    "status_started".to_owned(),
+                    bool_string(bool_field(status, "started")).to_owned(),
+                );
+                insert_nonempty(&mut attributes, "status_image_id", string(status, "imageID"));
+                insert_nonempty(
+                    &mut attributes,
+                    "image_digest",
+                    image_digest(string(status, "imageID")),
+                );
+                insert_nonempty(&mut attributes, "status_state", container_state(status));
+            }
+            if let Some(security) = container.get("securityContext").and_then(Value::as_object) {
+                for (attribute, field) in [
+                    ("allow_privilege_escalation", "allowPrivilegeEscalation"),
+                    ("run_as_non_root", "runAsNonRoot"),
+                    ("privileged", "privileged"),
+                ] {
+                    if let Some(value) = security.get(field).and_then(Value::as_bool) {
+                        attributes.insert(attribute.to_owned(), bool_string(value).to_owned());
+                    }
+                }
+                if let Some(value) = security.get("runAsUser").and_then(Value::as_i64) {
+                    attributes.insert("run_as_user".to_owned(), value.to_string());
+                }
+            }
+            let status_image_id = status.map(|value| string(value, "imageID")).unwrap_or("");
+            let payload = json!({
+                "pod_uid": pod_uid,
+                "pod_name": pod_name,
+                "namespace": namespace,
+                "container_name": name,
+                "image": string(container, "image"),
+                "image_pull_policy": string(container, "imagePullPolicy"),
+                "status_image_id": status_image_id,
+                "image_digest": image_digest(status_image_id),
+                "ready": status.map(|value| bool_field(value, "ready")).unwrap_or(false),
+                "restart_count": status.and_then(|value| value.get("restartCount")).cloned().unwrap_or(json!(0)),
+            });
+            let provider_id = format!("{pod_uid}/{name}");
+            build_record(
+                kernel,
+                RecordParts {
+                    family: KubernetesFamily::Container,
+                    provider_id,
+                    event_id: format!(
+                        "kubernetes-container-{}",
+                        sha256(&format!("{pod_uid}/{name}"))
+                    ),
+                    canonical_urn: canonical_urn(
+                        &kernel.tenant_id,
+                        "kubernetes_container",
+                        &[&kernel.cluster_id, namespace, pod_uid, name],
+                    )?,
+                    attributes,
+                    payload,
+                    occurred_at: object_time(metadata, observed_at),
+                },
+            )
+        })
+        .collect()
+}

--- a/crates/source-runtime-next/src/kubernetes/projection.rs
+++ b/crates/source-runtime-next/src/kubernetes/projection.rs
@@ -1,0 +1,440 @@
+//! Provider-local semantic projection facts used for Go/Rust parity.
+
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+
+use super::{KubernetesError, KubernetesFamily, KubernetesRecord};
+
+/// One normalized Kubernetes projection entity.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct KubernetesProjectionEntity {
+    /// Tenant-scoped canonical entity identity.
+    pub urn: String,
+    /// Closed entity kind.
+    pub kind: String,
+    /// Provider label retained for operator reads.
+    pub label: String,
+}
+
+/// One normalized Kubernetes projection relationship.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct KubernetesProjectionLink {
+    /// Tenant-scoped source entity identity.
+    pub from_urn: String,
+    /// Closed semantic relation.
+    pub relation: String,
+    /// Tenant-scoped target entity identity.
+    pub to_urn: String,
+}
+
+/// Deterministic semantic projection facts for one normalized record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KubernetesProjection {
+    /// Stable entities in canonical order.
+    pub entities: Vec<KubernetesProjectionEntity>,
+    /// Stable relationships in canonical order.
+    pub links: Vec<KubernetesProjectionLink>,
+}
+
+impl KubernetesRecord {
+    /// Compute provider-local semantic facts without a graph or store handle.
+    pub fn project(&self) -> Result<KubernetesProjection, KubernetesError> {
+        let tenant = required_attr(self, "tenant_id")?;
+        let cluster = required_attr(self, "cluster_id")?;
+        let mut entities = BTreeSet::new();
+        let mut links = BTreeSet::new();
+        let primary_urn = projected_record_urn(self, tenant, cluster)?;
+        let primary_kind = if self.family == KubernetesFamily::WorkloadIdentityBinding {
+            "kubernetes.service_account".to_owned()
+        } else {
+            self.event_kind.clone()
+        };
+        entities.insert(KubernetesProjectionEntity {
+            urn: primary_urn.clone(),
+            kind: primary_kind,
+            label: record_label(self),
+        });
+        let cluster_urn = urn(tenant, "kubernetes_cluster", &[cluster]);
+        entities.insert(KubernetesProjectionEntity {
+            urn: cluster_urn.clone(),
+            kind: "kubernetes.cluster".to_owned(),
+            label: self
+                .attributes
+                .get("cluster_name")
+                .cloned()
+                .unwrap_or_else(|| cluster.to_owned()),
+        });
+        if self.family == KubernetesFamily::Node {
+            links.insert(link(&primary_urn, "belongs_to", &cluster_urn));
+        }
+        let namespace = self.attributes.get("namespace").map(String::as_str);
+        let namespace_urn = namespace.map(|namespace| {
+            let value = urn(tenant, "kubernetes_namespace", &[cluster, namespace]);
+            entities.insert(KubernetesProjectionEntity {
+                urn: value.clone(),
+                kind: "kubernetes.namespace".to_owned(),
+                label: namespace.to_owned(),
+            });
+            if self.family != KubernetesFamily::Namespace {
+                links.insert(link(&primary_urn, "belongs_to", &value));
+            }
+            links.insert(link(&value, "belongs_to", &cluster_urn));
+            value
+        });
+        match self.family {
+            KubernetesFamily::Pod | KubernetesFamily::Workload => {
+                if let (Some(namespace), Some(account)) = (
+                    namespace,
+                    self.attributes
+                        .get("service_account_name")
+                        .map(String::as_str),
+                ) {
+                    let account_urn = urn(
+                        tenant,
+                        "kubernetes_service_account",
+                        &[cluster, namespace, account],
+                    );
+                    entities.insert(KubernetesProjectionEntity {
+                        urn: account_urn.clone(),
+                        kind: "kubernetes.service_account".to_owned(),
+                        label: account.to_owned(),
+                    });
+                    links.insert(link(&primary_urn, "runs_as", &account_urn));
+                    if let Some(namespace_urn) = namespace_urn.as_ref() {
+                        links.insert(link(&account_urn, "belongs_to", namespace_urn));
+                    }
+                }
+                if let Some(node) = self
+                    .attributes
+                    .get("node_name")
+                    .filter(|value| !value.is_empty())
+                {
+                    let node_urn = urn(tenant, "kubernetes_node", &[cluster, node]);
+                    entities.insert(KubernetesProjectionEntity {
+                        urn: node_urn.clone(),
+                        kind: "kubernetes.node".to_owned(),
+                        label: node.clone(),
+                    });
+                    links.insert(link(&node_urn, "belongs_to", &cluster_urn));
+                    links.insert(link(&primary_urn, "associated_with", &node_urn));
+                }
+            }
+            KubernetesFamily::Container => {
+                if let (Some(namespace), Some(pod_uid)) = (
+                    namespace,
+                    self.payload.get("pod_uid").and_then(Value::as_str),
+                ) {
+                    let pod_urn = urn(
+                        tenant,
+                        "kubernetes_workload",
+                        &[cluster, namespace, pod_uid],
+                    );
+                    entities.insert(KubernetesProjectionEntity {
+                        urn: pod_urn.clone(),
+                        kind: "kubernetes.workload".to_owned(),
+                        label: self
+                            .payload
+                            .get("pod_name")
+                            .and_then(Value::as_str)
+                            .unwrap_or(pod_uid)
+                            .to_owned(),
+                    });
+                    links.insert(link(&primary_urn, "belongs_to", &pod_urn));
+                    links.insert(link(&pod_urn, "contains", &primary_urn));
+                    if let Some(namespace_urn) = namespace_urn.as_ref() {
+                        links.insert(link(&pod_urn, "belongs_to", namespace_urn));
+                    }
+                }
+            }
+            KubernetesFamily::Ingress => {
+                if let Some(namespace) = namespace {
+                    for backend in csv_attr(self, "backend_services") {
+                        let name = backend.split(':').next().unwrap_or("").trim();
+                        if name.is_empty() {
+                            continue;
+                        }
+                        let service_urn =
+                            urn(tenant, "kubernetes_service", &[cluster, namespace, name]);
+                        entities.insert(KubernetesProjectionEntity {
+                            urn: service_urn.clone(),
+                            kind: "kubernetes.service".to_owned(),
+                            label: name.to_owned(),
+                        });
+                        links.insert(link(&primary_urn, "can_reach", &service_urn));
+                    }
+                }
+            }
+            KubernetesFamily::RbacBinding => {
+                let role_kind = required_attr(self, "role_kind")?;
+                let role_name = required_attr(self, "role_name")?;
+                let scope = if role_kind == "ClusterRole" {
+                    "cluster"
+                } else {
+                    namespace.unwrap_or("cluster")
+                };
+                let role_urn = urn(
+                    tenant,
+                    "kubernetes_rbac_role",
+                    &[cluster, role_kind, scope, role_name],
+                );
+                entities.insert(KubernetesProjectionEntity {
+                    urn: role_urn.clone(),
+                    kind: "kubernetes.rbac_role".to_owned(),
+                    label: role_name.to_owned(),
+                });
+                links.insert(link(&primary_urn, "attached_to", &role_urn));
+                if namespace.is_none() {
+                    links.insert(link(&primary_urn, "belongs_to", &cluster_urn));
+                }
+                for subject in subject_refs(self)? {
+                    let subject_kind = subject
+                        .get("kind")
+                        .and_then(Value::as_str)
+                        .unwrap_or("subject");
+                    let subject_name = subject.get("name").and_then(Value::as_str).unwrap_or("");
+                    if subject_name.is_empty() {
+                        continue;
+                    }
+                    let subject_namespace = subject
+                        .get("namespace")
+                        .and_then(Value::as_str)
+                        .filter(|value| !value.is_empty())
+                        .unwrap_or("cluster");
+                    let (subject_type, subject_segments): (&str, Vec<&str>) =
+                        if subject_kind.eq_ignore_ascii_case("ServiceAccount") {
+                            (
+                                "kubernetes_service_account",
+                                vec![cluster, subject_namespace, subject_name],
+                            )
+                        } else if subject_kind.eq_ignore_ascii_case("Group") {
+                            ("kubernetes_group", vec![cluster, subject_name])
+                        } else {
+                            ("kubernetes_user", vec![cluster, subject_name])
+                        };
+                    let subject_urn = urn(tenant, subject_type, &subject_segments);
+                    entities.insert(KubernetesProjectionEntity {
+                        urn: subject_urn.clone(),
+                        kind: format!(
+                            "kubernetes.{}",
+                            subject_type.trim_start_matches("kubernetes_")
+                        ),
+                        label: subject_name.to_owned(),
+                    });
+                    links.insert(link(&subject_urn, "assigned_to", &role_urn));
+                    if subject_kind.eq_ignore_ascii_case("ServiceAccount") {
+                        let subject_namespace_urn = urn(
+                            tenant,
+                            "kubernetes_namespace",
+                            &[cluster, subject_namespace],
+                        );
+                        entities.insert(KubernetesProjectionEntity {
+                            urn: subject_namespace_urn.clone(),
+                            kind: "kubernetes.namespace".to_owned(),
+                            label: subject_namespace.to_owned(),
+                        });
+                        links.insert(link(&subject_urn, "belongs_to", &subject_namespace_urn));
+                        links.insert(link(&subject_namespace_urn, "belongs_to", &cluster_urn));
+                    }
+                }
+            }
+            KubernetesFamily::WorkloadIdentityBinding => {
+                let provider = required_attr(self, "cloud_provider")?;
+                let target = required_attr(self, "target_id")?;
+                let (target_type, target_kind) = if provider == "gcp" {
+                    ("gcp_service_account", "gcp.service_account")
+                } else {
+                    ("aws_role", "aws.role")
+                };
+                let target_urn = urn(tenant, target_type, &[target]);
+                entities.insert(KubernetesProjectionEntity {
+                    urn: target_urn.clone(),
+                    kind: target_kind.to_owned(),
+                    label: target.to_owned(),
+                });
+                let relation = if provider == "gcp" {
+                    "can_impersonate"
+                } else {
+                    "can_assume"
+                };
+                links.insert(link(&primary_urn, relation, &target_urn));
+            }
+            KubernetesFamily::Cluster
+            | KubernetesFamily::Namespace
+            | KubernetesFamily::Service
+            | KubernetesFamily::ServiceAccount
+            | KubernetesFamily::Node => {}
+            KubernetesFamily::RbacRole => {
+                if namespace.is_none() {
+                    links.insert(link(&primary_urn, "belongs_to", &cluster_urn));
+                }
+            }
+        }
+        Ok(KubernetesProjection {
+            entities: entities.into_iter().collect(),
+            links: links.into_iter().collect(),
+        })
+    }
+}
+
+fn projected_record_urn(
+    record: &KubernetesRecord,
+    tenant: &str,
+    cluster: &str,
+) -> Result<String, KubernetesError> {
+    let namespace = record
+        .attributes
+        .get("namespace")
+        .map_or("default", String::as_str);
+    let value = match record.family {
+        KubernetesFamily::Cluster => urn(tenant, "kubernetes_cluster", &[cluster]),
+        KubernetesFamily::Namespace => urn(tenant, "kubernetes_namespace", &[cluster, namespace]),
+        KubernetesFamily::Node => urn(
+            tenant,
+            "kubernetes_node",
+            &[cluster, required_attr(record, "node_name")?],
+        ),
+        KubernetesFamily::Pod => urn(
+            tenant,
+            "kubernetes_pod",
+            &[cluster, namespace, required_attr(record, "resource_id")?],
+        ),
+        KubernetesFamily::Workload => urn(
+            tenant,
+            "kubernetes_workload",
+            &[cluster, namespace, required_attr(record, "workload_uid")?],
+        ),
+        KubernetesFamily::Container => urn(
+            tenant,
+            "kubernetes_container",
+            &[
+                cluster,
+                namespace,
+                required_attr(record, "resource_id")?,
+                required_attr(record, "container_name")?,
+            ],
+        ),
+        KubernetesFamily::Service => urn(
+            tenant,
+            "kubernetes_service",
+            &[cluster, namespace, required_attr(record, "service_name")?],
+        ),
+        KubernetesFamily::Ingress => urn(
+            tenant,
+            "kubernetes_ingress",
+            &[cluster, namespace, required_attr(record, "ingress_name")?],
+        ),
+        KubernetesFamily::ServiceAccount | KubernetesFamily::WorkloadIdentityBinding => urn(
+            tenant,
+            "kubernetes_service_account",
+            &[
+                cluster,
+                namespace,
+                required_attr(record, "service_account_name")?,
+            ],
+        ),
+        KubernetesFamily::RbacRole => urn(
+            tenant,
+            "kubernetes_rbac_role",
+            &[
+                cluster,
+                required_attr(record, "role_kind")?,
+                record
+                    .attributes
+                    .get("namespace")
+                    .map_or("cluster", String::as_str),
+                required_attr(record, "role_name")?,
+            ],
+        ),
+        KubernetesFamily::RbacBinding => urn(
+            tenant,
+            "kubernetes_rbac_binding",
+            &[
+                cluster,
+                required_attr(record, "binding_kind")?,
+                record
+                    .attributes
+                    .get("namespace")
+                    .map_or("cluster", String::as_str),
+                required_attr(record, "binding_name")?,
+            ],
+        ),
+    };
+    Ok(value)
+}
+
+fn required_attr<'a>(
+    record: &'a KubernetesRecord,
+    field: &'static str,
+) -> Result<&'a str, KubernetesError> {
+    record
+        .attributes
+        .get(field)
+        .map(String::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or(KubernetesError::MissingRequiredAttribute(field))
+}
+
+fn record_label(record: &KubernetesRecord) -> String {
+    for field in [
+        "cluster_name",
+        "resource_name",
+        "workload_name",
+        "service_account_name",
+        "role_name",
+        "binding_name",
+        "container_name",
+    ] {
+        if let Some(value) = record
+            .attributes
+            .get(field)
+            .filter(|value| !value.is_empty())
+        {
+            return value.clone();
+        }
+    }
+    record.provider_id.clone()
+}
+
+fn csv_attr<'a>(record: &'a KubernetesRecord, field: &str) -> impl Iterator<Item = &'a str> {
+    record
+        .attributes
+        .get(field)
+        .map(String::as_str)
+        .unwrap_or("")
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn subject_refs(record: &KubernetesRecord) -> Result<Vec<Value>, KubernetesError> {
+    let raw = record
+        .attributes
+        .get("subject_refs")
+        .ok_or(KubernetesError::MissingRequiredAttribute("subject_refs"))?;
+    serde_json::from_str(raw).map_err(|_| KubernetesError::MalformedResponse)
+}
+
+fn link(from: &str, relation: &str, to: &str) -> KubernetesProjectionLink {
+    KubernetesProjectionLink {
+        from_urn: from.to_owned(),
+        relation: relation.to_owned(),
+        to_urn: to.to_owned(),
+    }
+}
+
+fn urn(tenant: &str, kind: &str, segments: &[&str]) -> String {
+    format!(
+        "urn:cerebro:{}:{kind}:{}",
+        encode(tenant),
+        segments
+            .iter()
+            .map(|segment| encode(segment))
+            .collect::<Vec<_>>()
+            .join(":")
+    )
+}
+
+fn encode(value: &str) -> String {
+    value.trim().to_owned()
+}

--- a/crates/source-runtime-next/src/kubernetes/request.rs
+++ b/crates/source-runtime-next/src/kubernetes/request.rs
@@ -1,0 +1,321 @@
+//! Credential-free Kubernetes request planning and origin enforcement.
+
+use std::fmt;
+
+use reqwest::Url;
+
+use super::{
+    KubernetesError, KubernetesFamily, KubernetesRuntimeDefinition,
+    cursor::{RbacStage, bounded_token, decode_rbac_cursor},
+};
+
+const DEFAULT_PAGE_SIZE: usize = 100;
+const MAX_PAGE_SIZE: usize = 500;
+const MAX_RESPONSE_BYTES: usize = 8 << 20;
+
+/// Public, credential-free Kubernetes runtime configuration.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KubernetesConfig {
+    /// Tenant sealed by the authenticated runtime context.
+    pub tenant_id: String,
+    /// Exact Kubernetes API server origin selected by the trusted host.
+    pub api_server: String,
+    /// Stable cluster identity used by the Go source and graph projection.
+    pub cluster_id: String,
+    /// Operator-facing cluster name.
+    pub cluster_name: String,
+    /// Optional provider external identity.
+    pub external_id: String,
+    /// Optional normalized cloud provider.
+    pub cloud_provider: String,
+    /// Optional cloud account, project, or subscription identity.
+    pub cloud_account_id: String,
+    /// Provider page size in the inclusive 1 through 500 range.
+    pub per_page: usize,
+}
+
+impl KubernetesConfig {
+    /// Construct the smallest valid public configuration.
+    pub fn new(
+        tenant_id: impl Into<String>,
+        api_server: impl Into<String>,
+        cluster_id: impl Into<String>,
+        cluster_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            tenant_id: tenant_id.into(),
+            api_server: api_server.into(),
+            cluster_id: cluster_id.into(),
+            cluster_name: cluster_name.into(),
+            external_id: String::new(),
+            cloud_provider: String::new(),
+            cloud_account_id: String::new(),
+            per_page: DEFAULT_PAGE_SIZE,
+        }
+    }
+}
+
+/// One origin-locked Kubernetes request plan without credential material.
+#[derive(Clone, Eq, PartialEq)]
+pub struct KubernetesRequest {
+    pub(super) url: Url,
+    pub(super) family: KubernetesFamily,
+    pub(super) rbac_stage: Option<RbacStage>,
+}
+
+impl fmt::Debug for KubernetesRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("KubernetesRequest")
+            .field("method", &self.method())
+            .field("origin", &self.url.origin().ascii_serialization())
+            .field("path", &self.url.path())
+            .field("family", &self.family)
+            .field("redirects_allowed", &self.allows_redirects())
+            .field("max_response_bytes", &self.max_response_bytes())
+            .finish()
+    }
+}
+
+impl KubernetesRequest {
+    /// Return the provider method for this read-only operation.
+    pub const fn method(&self) -> &'static str {
+        "GET"
+    }
+
+    /// Return the exact provider URL. The trusted host must authorize it before I/O.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Return the credential-free authentication mode owned by the trusted host.
+    pub const fn authentication_mode(&self) -> &'static str {
+        "host_managed_kubernetes"
+    }
+
+    /// The portable request never contains kubeconfig or resolved credential bytes.
+    pub const fn contains_credentials(&self) -> bool {
+        false
+    }
+
+    /// Redirects are denied so authentication cannot leave the compiled origin.
+    pub const fn allows_redirects(&self) -> bool {
+        false
+    }
+
+    /// Return the required response media type.
+    pub const fn accept(&self) -> &'static str {
+        "application/json"
+    }
+
+    /// Return the response body bound enforced before decoding.
+    pub const fn max_response_bytes(&self) -> usize {
+        MAX_RESPONSE_BYTES
+    }
+}
+
+/// Bounded request and normalization kernel for one Kubernetes family.
+#[derive(Clone, Debug)]
+pub struct KubernetesKernel {
+    pub(super) api_server: Url,
+    pub(super) tenant_id: String,
+    pub(super) cluster_id: String,
+    pub(super) cluster_name: String,
+    pub(super) external_id: String,
+    pub(super) cloud_provider: String,
+    pub(super) cloud_account_id: String,
+    pub(super) family: KubernetesFamily,
+    pub(super) page_size: usize,
+}
+
+impl KubernetesKernel {
+    /// Construct a kernel from one exact catalog-compiled runtime definition.
+    pub fn compile(
+        config: KubernetesConfig,
+        definition: KubernetesRuntimeDefinition,
+    ) -> Result<Self, KubernetesError> {
+        Self::new(config, definition.family())
+    }
+
+    pub(super) fn new(
+        config: KubernetesConfig,
+        family: KubernetesFamily,
+    ) -> Result<Self, KubernetesError> {
+        let tenant_id = required_identity(&config.tenant_id, KubernetesError::MissingTenantId)?;
+        let scoped_cluster_id = scoped_cluster_id(&config.cloud_account_id, &config.cluster_name);
+        let cluster_id = required_identity(
+            first_nonempty(&[
+                &config.cluster_id,
+                &config.external_id,
+                &scoped_cluster_id,
+                &config.cluster_name,
+            ]),
+            KubernetesError::MissingClusterIdentity,
+        )?;
+        let cluster_name = first_nonempty(&[
+            &config.cluster_name,
+            &config.external_id,
+            &config.cluster_id,
+        ]);
+        let api_server = validate_origin(&config.api_server)?;
+        if !(1..=MAX_PAGE_SIZE).contains(&config.per_page) {
+            return Err(KubernetesError::InvalidPageSize);
+        }
+        Ok(Self {
+            api_server,
+            tenant_id,
+            cluster_id,
+            cluster_name: if cluster_name.is_empty() {
+                "cluster".to_owned()
+            } else {
+                cluster_name.to_owned()
+            },
+            external_id: config.external_id.trim().to_owned(),
+            cloud_provider: normalize_identifier(&config.cloud_provider),
+            cloud_account_id: config.cloud_account_id.trim().to_owned(),
+            family,
+            page_size: config.per_page,
+        })
+    }
+
+    /// This kernel accepts no kubeconfig, token, certificate, or other credential value.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+
+    /// Plan one bounded provider request using only an opaque prior continuation.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<KubernetesRequest, KubernetesError> {
+        let (path, token, stage) = match self.family {
+            KubernetesFamily::RbacRole | KubernetesFamily::RbacBinding => {
+                let cursor = decode_rbac_cursor(self.family, cursor)?;
+                let path = match cursor.stage {
+                    RbacStage::Role => "/apis/rbac.authorization.k8s.io/v1/roles",
+                    RbacStage::ClusterRole => "/apis/rbac.authorization.k8s.io/v1/clusterroles",
+                    RbacStage::RoleBinding => "/apis/rbac.authorization.k8s.io/v1/rolebindings",
+                    RbacStage::ClusterRoleBinding => {
+                        "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings"
+                    }
+                };
+                (
+                    path,
+                    bounded_token(Some(&cursor.token))?,
+                    Some(cursor.stage),
+                )
+            }
+            _ => (self.family.initial_path(), bounded_token(cursor)?, None),
+        };
+        let mut url = self.api_server.clone();
+        url.set_path(path);
+        if self.family != KubernetesFamily::Cluster {
+            let mut query = url.query_pairs_mut();
+            query.append_pair("limit", &self.page_size.to_string());
+            if let Some(token) = token {
+                query.append_pair("continue", &token);
+            }
+        }
+        Ok(KubernetesRequest {
+            url,
+            family: self.family,
+            rbac_stage: stage,
+        })
+    }
+
+    pub(super) fn validate_request(
+        &self,
+        request: &KubernetesRequest,
+    ) -> Result<(), KubernetesError> {
+        if request.family != self.family
+            || request.url.origin() != self.api_server.origin()
+            || request.url.fragment().is_some()
+            || request.url.username() != ""
+            || request.url.password().is_some()
+        {
+            return Err(KubernetesError::RequestScopeMismatch);
+        }
+        let expected_path = match request.rbac_stage {
+            Some(RbacStage::Role) => "/apis/rbac.authorization.k8s.io/v1/roles",
+            Some(RbacStage::ClusterRole) => "/apis/rbac.authorization.k8s.io/v1/clusterroles",
+            Some(RbacStage::RoleBinding) => "/apis/rbac.authorization.k8s.io/v1/rolebindings",
+            Some(RbacStage::ClusterRoleBinding) => {
+                "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings"
+            }
+            None => self.family.initial_path(),
+        };
+        if request.url.path() != expected_path {
+            return Err(KubernetesError::RequestScopeMismatch);
+        }
+        if self.family == KubernetesFamily::Cluster {
+            return request
+                .url
+                .query()
+                .is_none()
+                .then_some(())
+                .ok_or(KubernetesError::RequestScopeMismatch);
+        }
+        let mut limit = None;
+        let mut continuation = None;
+        for (key, value) in request.url.query_pairs() {
+            match key.as_ref() {
+                "limit" if limit.is_none() => limit = Some(value.into_owned()),
+                "continue" if continuation.is_none() => {
+                    continuation = Some(value.into_owned());
+                }
+                _ => return Err(KubernetesError::RequestScopeMismatch),
+            }
+        }
+        let expected_limit = self.page_size.to_string();
+        if limit.as_deref() != Some(expected_limit.as_str())
+            || bounded_token(continuation.as_deref())? != continuation
+        {
+            return Err(KubernetesError::RequestScopeMismatch);
+        }
+        Ok(())
+    }
+}
+
+fn validate_origin(value: &str) -> Result<Url, KubernetesError> {
+    let mut url = Url::parse(value.trim()).map_err(|_| KubernetesError::InvalidApiServer)?;
+    if url.scheme() != "https"
+        || url.host_str().is_none()
+        || url.username() != ""
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || !matches!(url.path(), "" | "/")
+    {
+        return Err(KubernetesError::InvalidApiServer);
+    }
+    url.set_path("");
+    Ok(url)
+}
+
+fn required_identity(value: &str, error: KubernetesError) -> Result<String, KubernetesError> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > 512 || value.chars().any(char::is_control) {
+        return Err(error);
+    }
+    Ok(value.to_owned())
+}
+
+fn scoped_cluster_id(account: &str, cluster: &str) -> String {
+    if account.trim().is_empty() || cluster.trim().is_empty() {
+        return String::new();
+    }
+    format!("{}:{}", account.trim(), cluster.trim())
+}
+
+pub(super) fn first_nonempty<'a>(values: &[&'a str]) -> &'a str {
+    values
+        .iter()
+        .map(|value| value.trim())
+        .find(|value| !value.is_empty())
+        .unwrap_or("")
+}
+
+fn normalize_identifier(value: &str) -> String {
+    value.trim().to_ascii_lowercase().replace([' ', '-'], "_")
+}
+
+pub(super) const fn max_response_bytes() -> usize {
+    MAX_RESPONSE_BYTES
+}

--- a/crates/source-runtime-next/src/kubernetes/response.rs
+++ b/crates/source-runtime-next/src/kubernetes/response.rs
@@ -1,0 +1,147 @@
+//! Bounded Kubernetes response decoding, status classification, and continuation.
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+use time::OffsetDateTime;
+
+use super::{
+    KubernetesError, KubernetesFamily, KubernetesKernel, KubernetesPage, KubernetesRequest,
+    cursor::{RbacCursor, RbacStage, bounded_token, encode_rbac_cursor},
+    normalize::{normalize_cluster, normalize_object},
+    request::max_response_bytes,
+};
+
+const MAX_NORMALIZED_RECORDS: usize = 500;
+
+impl KubernetesKernel {
+    /// Decode one provider response after the trusted host has enforced the body bound.
+    pub fn decode(
+        &self,
+        request: &KubernetesRequest,
+        status: u16,
+        body: &[u8],
+        observed_at: OffsetDateTime,
+    ) -> Result<KubernetesPage, KubernetesError> {
+        self.validate_request(request)?;
+        classify_status(status)?;
+        if body.len() > max_response_bytes() {
+            return Err(KubernetesError::ResponseTooLarge);
+        }
+        let value: Value =
+            serde_json::from_slice(body).map_err(|_| KubernetesError::MalformedResponse)?;
+        if self.family == KubernetesFamily::Cluster {
+            let record = normalize_cluster(self, value, observed_at)?;
+            self.validate_record_contract(&record)?;
+            return Ok(KubernetesPage {
+                records: vec![record],
+                next_cursor: None,
+                proposed_checkpoint: None,
+            });
+        }
+        let object = value
+            .as_object()
+            .ok_or(KubernetesError::MalformedResponse)?;
+        let items = object
+            .get("items")
+            .and_then(Value::as_array)
+            .ok_or(KubernetesError::MalformedResponse)?;
+        if items.len() > self.page_size {
+            return Err(KubernetesError::TooManyRecords);
+        }
+        let mut records = Vec::new();
+        let mut seen = HashMap::<String, usize>::new();
+        for item in items {
+            for record in normalize_object(self, request, item.clone(), observed_at)? {
+                self.validate_record_contract(&record)?;
+                if let Some(index) = seen.get(&record.provider_id).copied() {
+                    if records.get(index) != Some(&record) {
+                        return Err(KubernetesError::ConflictingProviderIdentity);
+                    }
+                    continue;
+                }
+                seen.insert(record.provider_id.clone(), records.len());
+                records.push(record);
+                if records.len() > MAX_NORMALIZED_RECORDS {
+                    return Err(KubernetesError::TooManyRecords);
+                }
+            }
+        }
+        let provider_cursor = object
+            .get("metadata")
+            .and_then(Value::as_object)
+            .and_then(|metadata| metadata.get("continue"))
+            .and_then(Value::as_str);
+        let next_cursor = self.next_cursor(request, provider_cursor)?;
+        Ok(KubernetesPage {
+            records,
+            proposed_checkpoint: next_cursor.clone(),
+            next_cursor,
+        })
+    }
+
+    fn next_cursor(
+        &self,
+        request: &KubernetesRequest,
+        provider_cursor: Option<&str>,
+    ) -> Result<Option<String>, KubernetesError> {
+        let provider_cursor = bounded_token(provider_cursor)?;
+        let Some(stage) = request.rbac_stage else {
+            return Ok(provider_cursor);
+        };
+        if let Some(token) = provider_cursor {
+            return encode_rbac_cursor(&RbacCursor { stage, token }).map(Some);
+        }
+        let next_stage = match stage {
+            RbacStage::Role => Some(RbacStage::ClusterRole),
+            RbacStage::RoleBinding => Some(RbacStage::ClusterRoleBinding),
+            RbacStage::ClusterRole | RbacStage::ClusterRoleBinding => None,
+        };
+        next_stage
+            .map(|stage| {
+                encode_rbac_cursor(&RbacCursor {
+                    stage,
+                    token: String::new(),
+                })
+            })
+            .transpose()
+    }
+
+    fn validate_record_contract(
+        &self,
+        record: &super::KubernetesRecord,
+    ) -> Result<(), KubernetesError> {
+        if record.family != self.family
+            || record.event_kind != self.family.event_kind()
+            || record.schema_ref != self.family.schema_ref()
+        {
+            return Err(KubernetesError::MalformedResponse);
+        }
+        for field in self.family.required_attributes() {
+            if record
+                .attributes
+                .get(*field)
+                .is_none_or(|value| value.trim().is_empty())
+            {
+                return Err(KubernetesError::MissingRequiredAttribute(field));
+            }
+        }
+        for field in self.family.required_payload_fields() {
+            if record.payload.get(*field).is_none_or(Value::is_null) {
+                return Err(KubernetesError::MissingRequiredPayloadField(field));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn classify_status(status: u16) -> Result<(), KubernetesError> {
+    match status {
+        200 => Ok(()),
+        401 => Err(KubernetesError::AuthenticationRejected),
+        403 => Err(KubernetesError::PermissionDenied),
+        429 => Err(KubernetesError::RateLimited),
+        500..=599 => Err(KubernetesError::ProviderUnavailable),
+        other => Err(KubernetesError::UnexpectedProviderStatus(other)),
+    }
+}

--- a/crates/source-runtime-next/src/kubernetes/tests.rs
+++ b/crates/source-runtime-next/src/kubernetes/tests.rs
@@ -1,0 +1,533 @@
+use std::str::FromStr;
+
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::*;
+
+const LIST_META: &str = r#""metadata":{"continue":"next-token"}"#;
+
+fn observed_at() -> OffsetDateTime {
+    OffsetDateTime::parse("2026-06-01T00:00:00Z", &Rfc3339).unwrap()
+}
+
+fn config(tenant: &str) -> KubernetesConfig {
+    let mut config = KubernetesConfig::new(
+        tenant,
+        "https://kubernetes.example.test",
+        "prod-cluster",
+        "Production Cluster",
+    );
+    config.cloud_provider = "AWS".to_owned();
+    config.cloud_account_id = "account-a".to_owned();
+    config
+}
+
+fn kernel(family: KubernetesFamily) -> KubernetesKernel {
+    KubernetesKernel::new(config("tenant-a"), family).unwrap()
+}
+
+fn list(item: &str) -> Vec<u8> {
+    format!(r#"{{{LIST_META},"items":[{item}]}}"#).into_bytes()
+}
+
+#[test]
+fn closed_family_contract_covers_every_go_runtime_family() {
+    let families = [
+        ("cluster", KubernetesFamily::Cluster),
+        ("namespace", KubernetesFamily::Namespace),
+        ("node", KubernetesFamily::Node),
+        ("pod", KubernetesFamily::Pod),
+        ("workload", KubernetesFamily::Workload),
+        ("container", KubernetesFamily::Container),
+        ("service", KubernetesFamily::Service),
+        ("ingress", KubernetesFamily::Ingress),
+        ("service_account", KubernetesFamily::ServiceAccount),
+        ("rbac_role", KubernetesFamily::RbacRole),
+        ("rbac_binding", KubernetesFamily::RbacBinding),
+        (
+            "workload_identity_binding",
+            KubernetesFamily::WorkloadIdentityBinding,
+        ),
+    ];
+    for (name, family) in families {
+        assert_eq!(KubernetesFamily::from_str(name).unwrap(), family);
+        assert_eq!(family.as_str(), name);
+        assert_eq!(family.event_kind(), format!("kubernetes.{name}"));
+        assert_eq!(family.schema_ref(), format!("kubernetes/{name}/v1"));
+        assert!(!family.required_attributes().is_empty());
+        assert!(!family.required_payload_fields().is_empty());
+    }
+    assert_eq!(
+        KubernetesFamily::from_str("secret"),
+        Err(KubernetesError::InvalidFamily)
+    );
+}
+
+#[test]
+fn checked_fixture_compiles_to_the_exact_closed_go_catalog_contract() {
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/go_oracle_contract.json")).unwrap();
+    assert_eq!(fixture["source_id"], "kubernetes");
+    let families = fixture["families"].as_array().unwrap();
+    assert_eq!(families.len(), 12);
+    for contract in families {
+        let required_attributes: Vec<String> =
+            serde_json::from_value(contract["required_attributes"].clone()).unwrap();
+        let required_payload_fields: Vec<String> =
+            serde_json::from_value(contract["required_payload_fields"].clone()).unwrap();
+        let definition = KubernetesRuntimeDefinition::compile(
+            fixture["source_id"].as_str().unwrap(),
+            contract["id"].as_str().unwrap(),
+            contract["event_kind"].as_str().unwrap(),
+            contract["schema_ref"].as_str().unwrap(),
+            &required_attributes,
+            &required_payload_fields,
+        )
+        .unwrap();
+        let family = definition.family();
+        assert_eq!(contract["event_kind"], family.event_kind());
+        assert_eq!(contract["schema_ref"], family.schema_ref());
+        assert_eq!(
+            contract["required_attributes"],
+            serde_json::to_value(family.required_attributes()).unwrap()
+        );
+        assert_eq!(
+            contract["required_payload_fields"],
+            serde_json::to_value(family.required_payload_fields()).unwrap()
+        );
+        KubernetesKernel::compile(config("tenant-a"), definition).unwrap();
+    }
+    assert_eq!(
+        KubernetesRuntimeDefinition::compile(
+            "kubernetes",
+            "pod",
+            "kubernetes.pod",
+            "kubernetes/pod/v2",
+            &["cluster_id".to_owned()],
+            &["uid".to_owned()],
+        ),
+        Err(KubernetesError::InvalidRuntimeDefinition)
+    );
+}
+
+#[test]
+fn projection_fixture_matches_the_go_oracle_links() {
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/projection_oracle.json")).unwrap();
+    let tenant = fixture["tenant_id"].as_str().unwrap();
+    for test_case in fixture["cases"].as_array().unwrap() {
+        let family = KubernetesFamily::from_str(test_case["family"].as_str().unwrap()).unwrap();
+        let mut attributes: std::collections::BTreeMap<String, String> =
+            serde_json::from_value(test_case["attributes"].clone()).unwrap();
+        attributes.insert("tenant_id".to_owned(), tenant.to_owned());
+        let record = KubernetesRecord {
+            family,
+            provider_id: format!("fixture-{}", family.as_str()),
+            event_id: format!("kubernetes-rust-parity-{}", family.as_str()),
+            canonical_urn: format!("urn:cerebro:{tenant}:fixture:{}", family.as_str()),
+            event_kind: family.event_kind().to_owned(),
+            schema_ref: family.schema_ref().to_owned(),
+            attributes,
+            payload: test_case["payload"].clone(),
+            occurred_at: "1970-01-01T00:00:00Z".to_owned(),
+        };
+        let projection = record.project().unwrap();
+        for expected in test_case["expected_links"].as_array().unwrap() {
+            let expected = expected.as_array().unwrap();
+            assert!(projection.links.iter().any(|link| {
+                link.from_urn == expected[0].as_str().unwrap()
+                    && link.relation == expected[1].as_str().unwrap()
+                    && link.to_urn == expected[2].as_str().unwrap()
+            }));
+        }
+    }
+}
+
+#[test]
+fn plans_origin_locked_credential_free_requests_and_round_trips_continuations() {
+    let cases = [
+        (KubernetesFamily::Cluster, "/version", false),
+        (KubernetesFamily::Namespace, "/api/v1/namespaces", true),
+        (KubernetesFamily::Node, "/api/v1/nodes", true),
+        (KubernetesFamily::Pod, "/api/v1/pods", true),
+        (KubernetesFamily::Workload, "/api/v1/pods", true),
+        (KubernetesFamily::Container, "/api/v1/pods", true),
+        (KubernetesFamily::Service, "/api/v1/services", true),
+        (
+            KubernetesFamily::Ingress,
+            "/apis/networking.k8s.io/v1/ingresses",
+            true,
+        ),
+        (
+            KubernetesFamily::ServiceAccount,
+            "/api/v1/serviceaccounts",
+            true,
+        ),
+        (
+            KubernetesFamily::WorkloadIdentityBinding,
+            "/api/v1/serviceaccounts",
+            true,
+        ),
+    ];
+    for (family, path, paged) in cases {
+        let request = kernel(family).plan(paged.then_some("continue-1")).unwrap();
+        assert_eq!(request.url().path(), path);
+        assert_eq!(
+            request.url().origin().ascii_serialization(),
+            "https://kubernetes.example.test"
+        );
+        assert_eq!(request.authentication_mode(), "host_managed_kubernetes");
+        assert_eq!(request.method(), "GET");
+        assert!(!request.contains_credentials());
+        assert!(!request.allows_redirects());
+        assert_eq!(request.accept(), "application/json");
+        assert_eq!(request.max_response_bytes(), 8 << 20);
+        assert!(!KubernetesKernel::requires_credentials());
+        let rendered = format!("{request:?}").to_ascii_lowercase();
+        for forbidden in ["password", "secret", "token", "kubeconfig", "certificate"] {
+            assert!(!rendered.contains(forbidden));
+        }
+        if paged {
+            assert_eq!(request.url().query(), Some("limit=100&continue=continue-1"));
+        } else {
+            assert_eq!(request.url().query(), None);
+        }
+    }
+}
+
+#[test]
+fn decodes_cluster_namespace_node_workload_pod_and_container_semantics() {
+    let cluster = kernel(KubernetesFamily::Cluster)
+        .decode(
+            &kernel(KubernetesFamily::Cluster).plan(None).unwrap(),
+            200,
+            br#"{"gitVersion":"v1.35.0","major":"1","minor":"35","platform":"linux/amd64"}"#,
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(
+        cluster.records[0].event_id,
+        "kubernetes-cluster-prod-cluster"
+    );
+    assert_eq!(cluster.records[0].attributes["git_version"], "v1.35.0");
+
+    let namespace_item = r#"{
+        "metadata":{"name":"payments","uid":"namespace-1","creationTimestamp":"2026-06-01T00:00:00Z"},
+        "status":{"phase":"Active"}
+    }"#;
+    let namespace_kernel = kernel(KubernetesFamily::Namespace);
+    let namespace = namespace_kernel
+        .decode(
+            &namespace_kernel.plan(None).unwrap(),
+            200,
+            &list(namespace_item),
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(namespace.records[0].attributes["namespace"], "payments");
+    assert_eq!(namespace.next_cursor.as_deref(), Some("next-token"));
+    assert_eq!(namespace.proposed_checkpoint, namespace.next_cursor);
+
+    let node_item = r#"{
+        "metadata":{"name":"node-a","uid":"node-1"},
+        "spec":{"providerID":"aws:///zone/i-1","unschedulable":true},
+        "status":{"addresses":[{"type":"InternalIP","address":"10.0.0.1"}],
+          "conditions":[{"type":"Ready","status":"True"}],
+          "nodeInfo":{"kubeletVersion":"v1.35.0","containerRuntimeVersion":"containerd://1.7","architecture":"amd64"}}
+    }"#;
+    let node_kernel = kernel(KubernetesFamily::Node);
+    let node = node_kernel
+        .decode(
+            &node_kernel.plan(None).unwrap(),
+            200,
+            &list(node_item),
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(node.records[0].attributes["ready"], "true");
+    assert_eq!(node.records[0].attributes["internal_ip"], "10.0.0.1");
+
+    let pod_item = r#"{
+        "metadata":{"name":"api","namespace":"payments","uid":"pod-1"},
+        "spec":{"serviceAccountName":"api","nodeName":"node-a","hostNetwork":false,
+          "containers":[{"name":"app","image":"example/app:1","imagePullPolicy":"IfNotPresent",
+            "securityContext":{"runAsNonRoot":true,"privileged":false}}]},
+        "status":{"phase":"Running","containerStatuses":[{"name":"app","imageID":"example/app@sha256:aaaa",
+          "ready":true,"started":true,"restartCount":0,"state":{"running":{}}}]}
+    }"#;
+    for family in [KubernetesFamily::Pod, KubernetesFamily::Workload] {
+        let kernel = kernel(family);
+        let page = kernel
+            .decode(
+                &kernel.plan(None).unwrap(),
+                200,
+                &list(pod_item),
+                observed_at(),
+            )
+            .unwrap();
+        assert_eq!(page.records[0].attributes["workload_uid"], "pod-1");
+        assert_eq!(page.records[0].attributes["service_account_name"], "api");
+        assert!(
+            page.records[0]
+                .project()
+                .unwrap()
+                .links
+                .iter()
+                .any(|link| link.relation == "runs_as")
+        );
+    }
+    let container_kernel = kernel(KubernetesFamily::Container);
+    let containers = container_kernel
+        .decode(
+            &container_kernel.plan(None).unwrap(),
+            200,
+            &list(pod_item),
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(containers.records.len(), 1);
+    assert_eq!(containers.records[0].provider_id, "pod-1/app");
+    assert_eq!(
+        containers.records[0].attributes["image_digest"],
+        "sha256:aaaa"
+    );
+    assert_eq!(containers.records[0].attributes["run_as_non_root"], "true");
+}
+
+#[test]
+fn decodes_service_ingress_service_account_and_workload_identity_semantics() {
+    let service_item = r#"{
+        "metadata":{"name":"payments","namespace":"payments","uid":"service-1"},
+        "spec":{"type":"LoadBalancer","clusterIP":"10.96.0.10","externalIPs":["203.0.113.10"],
+          "ports":[{"name":"https","protocol":"TCP","port":443,"targetPort":8443,"nodePort":30443}],
+          "selector":{"app":"payments"}},
+        "status":{"loadBalancer":{"ingress":[{"hostname":"payments.example.test"}]}}
+    }"#;
+    let service_kernel = kernel(KubernetesFamily::Service);
+    let service = service_kernel
+        .decode(
+            &service_kernel.plan(None).unwrap(),
+            200,
+            &list(service_item),
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(
+        service.records[0].attributes["service_type"],
+        "LoadBalancer"
+    );
+    assert!(service.records[0].attributes["ports"].contains("30443"));
+
+    let ingress_item = r#"{
+        "metadata":{"name":"payments","namespace":"payments","uid":"ingress-1"},
+        "spec":{"ingressClassName":"nginx","tls":[{"hosts":["payments.example.test"],"secretName":"tls"}],
+          "rules":[{"host":"payments.example.test","http":{"paths":[{"path":"/","backend":{"service":{"name":"payments","port":{"number":443}}}}]}}]},
+        "status":{"loadBalancer":{"ingress":[{"ip":"198.51.100.30"}]}}
+    }"#;
+    let ingress_kernel = kernel(KubernetesFamily::Ingress);
+    let ingress = ingress_kernel
+        .decode(
+            &ingress_kernel.plan(None).unwrap(),
+            200,
+            &list(ingress_item),
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(
+        ingress.records[0].attributes["backend_services"],
+        "payments:443"
+    );
+    assert!(
+        ingress.records[0]
+            .project()
+            .unwrap()
+            .links
+            .iter()
+            .any(|link| link.relation == "can_reach")
+    );
+
+    let service_account_item = r#"{
+        "metadata":{"name":"api","namespace":"payments","uid":"sa-1","annotations":{
+          "eks.amazonaws.com/role-arn":"arn:aws:iam::account-a:role/api",
+          "iam.gke.io/gcp-service-account":"api@example.iam.gserviceaccount.com"}},
+        "automountServiceAccountToken":false
+    }"#;
+    let account_kernel = kernel(KubernetesFamily::ServiceAccount);
+    let account = account_kernel
+        .decode(
+            &account_kernel.plan(None).unwrap(),
+            200,
+            &list(service_account_item),
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(account.records[0].attributes["automount_token"], "false");
+    let identity_kernel = kernel(KubernetesFamily::WorkloadIdentityBinding);
+    let identities = identity_kernel
+        .decode(
+            &identity_kernel.plan(None).unwrap(),
+            200,
+            &list(service_account_item),
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(identities.records.len(), 2);
+    assert_eq!(identities.records[0].attributes["cloud_provider"], "aws");
+    assert_eq!(identities.records[1].attributes["cloud_provider"], "gcp");
+    assert!(identities.records.iter().all(|record| {
+        record
+            .project()
+            .unwrap()
+            .links
+            .iter()
+            .any(|link| matches!(link.relation.as_str(), "can_assume" | "can_impersonate"))
+    }));
+}
+
+#[test]
+fn rbac_cursor_stages_round_trip_without_skipping_roles_or_bindings() {
+    let role_kernel = kernel(KubernetesFamily::RbacRole);
+    let role_request = role_kernel.plan(None).unwrap();
+    assert_eq!(
+        role_request.url().path(),
+        "/apis/rbac.authorization.k8s.io/v1/roles"
+    );
+    let role_page = role_kernel
+        .decode(
+            &role_request,
+            200,
+            br#"{"metadata":{"continue":""},"items":[{"metadata":{"name":"secret-reader","namespace":"payments","uid":"role-1"},"rules":[{"apiGroups":[""],"resources":["secrets"],"verbs":["get","list"]}]}]}"#,
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(role_page.records[0].attributes["verbs"], "get,list");
+    let cluster_request = role_kernel.plan(role_page.next_cursor.as_deref()).unwrap();
+    assert_eq!(
+        cluster_request.url().path(),
+        "/apis/rbac.authorization.k8s.io/v1/clusterroles"
+    );
+    let binding_kernel = kernel(KubernetesFamily::RbacBinding);
+    let binding_request = binding_kernel.plan(None).unwrap();
+    let binding = binding_kernel
+        .decode(
+            &binding_request,
+            200,
+            br#"{"metadata":{"continue":""},"items":[{"metadata":{"name":"reader","namespace":"payments","uid":"binding-1"},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"Role","name":"secret-reader"},"subjects":[{"kind":"ServiceAccount","name":"api","namespace":"payments"},{"kind":"User","name":"alice@example.test"}]}]}"#,
+            observed_at(),
+        )
+        .unwrap();
+    assert_eq!(binding.records[0].attributes["subject_count"], "2");
+    assert!(
+        binding.records[0]
+            .project()
+            .unwrap()
+            .links
+            .iter()
+            .any(|link| link.relation == "assigned_to")
+    );
+    assert!(
+        binding_kernel
+            .plan(binding.next_cursor.as_deref())
+            .unwrap()
+            .url()
+            .path()
+            .ends_with("/clusterrolebindings")
+    );
+}
+
+#[test]
+fn failures_are_typed_and_tenant_scoped_identities_do_not_collide() {
+    for (status, expected) in [
+        (401, KubernetesError::AuthenticationRejected),
+        (403, KubernetesError::PermissionDenied),
+        (429, KubernetesError::RateLimited),
+        (503, KubernetesError::ProviderUnavailable),
+        (418, KubernetesError::UnexpectedProviderStatus(418)),
+    ] {
+        let kernel = kernel(KubernetesFamily::Namespace);
+        assert_eq!(
+            kernel.decode(&kernel.plan(None).unwrap(), status, b"{}", observed_at()),
+            Err(expected)
+        );
+    }
+    assert_eq!(
+        KubernetesKernel::new(
+            KubernetesConfig::new("tenant", "http://cluster.test", "cluster", "cluster"),
+            KubernetesFamily::Node,
+        )
+        .unwrap_err(),
+        KubernetesError::InvalidApiServer
+    );
+    assert_eq!(
+        kernel(KubernetesFamily::Node).plan(Some("https://evil.test/next")),
+        Err(KubernetesError::InvalidCursor)
+    );
+
+    let response = list(r#"{"metadata":{"name":"payments","uid":"namespace-1"}}"#);
+    let a = KubernetesKernel::new(config("tenant-a"), KubernetesFamily::Namespace).unwrap();
+    let b = KubernetesKernel::new(config("tenant-b"), KubernetesFamily::Namespace).unwrap();
+    let a_record = &a
+        .decode(&a.plan(None).unwrap(), 200, &response, observed_at())
+        .unwrap()
+        .records[0];
+    let b_record = &b
+        .decode(&b.plan(None).unwrap(), 200, &response, observed_at())
+        .unwrap()
+        .records[0];
+    assert_ne!(a_record.canonical_urn, b_record.canonical_urn);
+    assert_eq!(a_record.provider_id, b_record.provider_id);
+    assert_eq!(a_record.event_id, b_record.event_id);
+}
+
+#[test]
+fn rejects_origin_cursor_identity_and_tenant_tampering_without_secret_echo() {
+    let namespace_kernel = kernel(KubernetesFamily::Namespace);
+    let mut escaped = namespace_kernel.plan(None).unwrap();
+    escaped.url = "https://evil.example.test/api/v1/namespaces"
+        .parse()
+        .unwrap();
+    assert_eq!(
+        namespace_kernel.decode(&escaped, 200, b"{}", observed_at()),
+        Err(KubernetesError::RequestScopeMismatch)
+    );
+    assert_eq!(
+        namespace_kernel.plan(Some(&"x".repeat(4_097))),
+        Err(KubernetesError::InvalidCursor)
+    );
+
+    let response = list(
+        r#"{"metadata":{"name":"api","namespace":"payments","uid":"sa-1","tenant_id":"attacker","annotations":{"password":"credential-secret-sentinel","eks.amazonaws.com/role-arn":"arn:aws:iam::account-a:role/api"}},"tenant_id":"attacker"}"#,
+    );
+    let account_kernel = kernel(KubernetesFamily::ServiceAccount);
+    let mut page = account_kernel
+        .decode(
+            &account_kernel.plan(None).unwrap(),
+            200,
+            &response,
+            observed_at(),
+        )
+        .unwrap();
+    let record = page.records.remove(0);
+    assert_eq!(record.attributes["tenant_id"], "tenant-a");
+    assert!(record.canonical_urn.starts_with("urn:cerebro:tenant-a:"));
+    let safe_output = format!(
+        "{record:?} {:?}",
+        record.project().expect("project safe provider record")
+    );
+    assert!(!safe_output.contains("credential-secret-sentinel"));
+    assert!(!safe_output.contains("attacker"));
+
+    let conflicting = br#"{"metadata":{"continue":""},"items":[
+      {"metadata":{"name":"one","uid":"same"}},
+      {"metadata":{"name":"two","uid":"same"}}
+    ]}"#;
+    assert_eq!(
+        namespace_kernel.decode(
+            &namespace_kernel.plan(None).unwrap(),
+            200,
+            conflicting,
+            observed_at(),
+        ),
+        Err(KubernetesError::ConflictingProviderIdentity)
+    );
+}

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -27,6 +27,7 @@ mod github;
 mod google_workspace;
 mod grc;
 mod http;
+mod kubernetes;
 mod linode;
 mod mapper;
 mod okta;
@@ -132,6 +133,11 @@ pub use google_workspace::{
 };
 pub use grc::{GrcError, GrcFamily, GrcKernel, GrcPage, GrcRecord, GrcRequest};
 pub use http::{HttpConnectorError, HttpProviderAccess, HttpSourceConnector, ResolvedAuth};
+pub use kubernetes::{
+    KubernetesConfig, KubernetesError, KubernetesFamily, KubernetesKernel, KubernetesPage,
+    KubernetesProjection, KubernetesProjectionEntity, KubernetesProjectionLink, KubernetesRecord,
+    KubernetesRequest, KubernetesRuntimeDefinition,
+};
 pub use linode::{LinodeError, LinodeKernel, LinodePage, LinodeRecord, LinodeRequest};
 pub use mapper::{CatalogGraphMapper, CatalogMapperError, IdentityResolutionSnapshot};
 pub use okta::{

--- a/internal/sourceprojection/kubernetes_rust_parity_test.go
+++ b/internal/sourceprojection/kubernetes_rust_parity_test.go
@@ -1,0 +1,58 @@
+package sourceprojection
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+type kubernetesRustProjectionFixture struct {
+	TenantID string                         `json:"tenant_id"`
+	Cases    []kubernetesRustProjectionCase `json:"cases"`
+}
+
+type kubernetesRustProjectionCase struct {
+	Family        string            `json:"family"`
+	Attributes    map[string]string `json:"attributes"`
+	Payload       json.RawMessage   `json:"payload"`
+	ExpectedLinks [][3]string       `json:"expected_links"`
+}
+
+func TestKubernetesRustProjectionFixtureMatchesGoOracle(t *testing.T) {
+	raw, err := os.ReadFile("../../crates/source-runtime-next/src/kubernetes/fixtures/projection_oracle.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture kubernetesRustProjectionFixture
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatalf("decode Kubernetes Rust projection fixture: %v", err)
+	}
+	for _, testCase := range fixture.Cases {
+		t.Run(testCase.Family, func(t *testing.T) {
+			state := &projectionRecorder{}
+			service := New(state, nil)
+			_, err := service.Project(context.Background(), &cerebrov1.EventEnvelope{
+				Id:         "kubernetes-rust-parity-" + testCase.Family,
+				TenantId:   fixture.TenantID,
+				SourceId:   "kubernetes",
+				Kind:       "kubernetes." + testCase.Family,
+				SchemaRef:  "kubernetes/" + testCase.Family + "/v1",
+				Attributes: testCase.Attributes,
+				Payload:    testCase.Payload,
+				OccurredAt: timestamppb.New(time.Unix(0, 0).UTC()),
+			})
+			if err != nil {
+				t.Fatalf("project Go oracle event: %v", err)
+			}
+			for _, link := range testCase.ExpectedLinks {
+				assertProjectedLink(t, state, link[0], link[1], link[2])
+			}
+		})
+	}
+}

--- a/sources/internal/kubernetes/rust_contract_parity_test.go
+++ b/sources/internal/kubernetes/rust_contract_parity_test.go
@@ -1,0 +1,83 @@
+package kubernetesinternal
+
+import (
+	"encoding/json"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+type rustContractParityFixture struct {
+	SourceID string                     `json:"source_id"`
+	Families []rustContractParityFamily `json:"families"`
+}
+
+type rustContractParityFamily struct {
+	ID                    string   `json:"id"`
+	EventKind             string   `json:"event_kind"`
+	SchemaRef             string   `json:"schema_ref"`
+	RequiredAttributes    []string `json:"required_attributes"`
+	RequiredPayloadFields []string `json:"required_payload_fields"`
+}
+
+func TestRustContractParityFixtureMatchesGoOracle(t *testing.T) {
+	fixtureBytes, err := readRustContractParityFixture()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture rustContractParityFixture
+	if err := json.Unmarshal(fixtureBytes, &fixture); err != nil {
+		t.Fatalf("decode Rust contract parity fixture: %v", err)
+	}
+	catalogBytes, err := catalogFS.ReadFile("catalog.internal.yaml")
+	if err != nil {
+		t.Fatalf("read Go Kubernetes catalog: %v", err)
+	}
+	catalog, err := sourcecdk.LoadSourceCatalog(catalogBytes)
+	if err != nil {
+		t.Fatalf("compile Go Kubernetes catalog: %v", err)
+	}
+	if fixture.SourceID != catalog.Spec.GetId() {
+		t.Fatalf("fixture source_id = %q, want %q", fixture.SourceID, catalog.Spec.GetId())
+	}
+	publicCatalogBytes, err := os.ReadFile("../../../sources/kubernetes/catalog.yaml")
+	if err != nil {
+		t.Fatalf("read public Kubernetes catalog: %v", err)
+	}
+	publicCatalog, err := sourcecdk.LoadSourceCatalog(publicCatalogBytes)
+	if err != nil {
+		t.Fatalf("compile public Kubernetes catalog: %v", err)
+	}
+	if len(fixture.Families) != len(catalog.EventContracts) {
+		t.Fatalf("fixture families = %d, Go event contracts = %d", len(fixture.Families), len(catalog.EventContracts))
+	}
+	contracts := make(map[string]sourcecdk.EventContract, len(catalog.EventContracts))
+	for _, contract := range catalog.EventContracts {
+		contracts[contract.Kind] = contract
+	}
+	seen := map[string]struct{}{}
+	for _, family := range fixture.Families {
+		if !slices.Contains(publicCatalog.RuntimeFamilies, family.ID) {
+			t.Fatalf("Rust family %q is absent from the public runtime catalog", family.ID)
+		}
+		if _, duplicate := seen[family.ID]; duplicate {
+			t.Fatalf("duplicate Rust family %q", family.ID)
+		}
+		seen[family.ID] = struct{}{}
+		contract, ok := contracts[family.EventKind]
+		if !ok {
+			t.Fatalf("Rust event kind %q is absent from the Go catalog", family.EventKind)
+		}
+		if contract.SchemaRef != family.SchemaRef ||
+			!slices.Equal(contract.RequiredAttributes, family.RequiredAttributes) ||
+			!slices.Equal(contract.RequiredPayloadFields, family.RequiredPayloadFields) {
+			t.Fatalf("Rust family %q contract drift: fixture=%#v Go=%#v", family.ID, family, contract)
+		}
+	}
+}
+
+func readRustContractParityFixture() ([]byte, error) {
+	return os.ReadFile("../../../crates/source-runtime-next/src/kubernetes/fixtures/go_oracle_contract.json")
+}


### PR DESCRIPTION
## Scope

Add a credential-free Kubernetes request/response kernel to `cerebro-source-runtime-next` for all twelve catalog families:

- cluster, namespace, node, workload, pod, container
- service, ingress, service account
- RBAC role, RBAC binding, workload identity binding

The kernel compiles exact catalog contracts, plans bounded origin-locked requests, validates provider responses, normalizes deterministic tenant-scoped identities, preserves Kubernetes continuation and RBAC stage cursors, rejects conflicting duplicates, and produces projection facts matching the existing Go oracle.

## Security invariants

- Kubernetes authentication remains host-managed; no kubeconfig, bearer token, certificate, or resolved credential enters the kernel contract.
- Requests are HTTPS-only, exact-origin, GET-only, bounded to 8 MiB, and deny redirects.
- Debug output excludes continuation queries and credential-shaped field names.
- Untrusted provider tenant fields and arbitrary annotations cannot enter normalized records or graph facts.
- Only the two provider annotations required for AWS IRSA and GCP workload identity semantics are retained.

## Parity

- Closed catalog fixture covers all twelve Kubernetes families.
- Projection fixture covers pod, GCP workload identity, and cross-namespace RBAC semantics through both Rust and the Go projector.
- Go oracle code remains for differential tests.

## Local validation

Passing on `b813a7e2094945e5f1b4b1af25d3a45f33df8ccc` rebased onto `231758fb02d4b25fd37b9b99b883841bac2817ee`:

- `cargo fmt --all -- --check`
- `cargo check --locked -p cerebro-source-runtime-next --tests`
- `cargo test --locked -p cerebro-platform -p cerebro-source-catalog -p cerebro-source-runtime-next --quiet` — 759 passed, 7 ignored
- `cargo clippy --locked -p cerebro-platform -p cerebro-source-catalog -p cerebro-source-runtime-next --all-targets --all-features -- -D warnings`
- `go test ./internal/sourceprojection ./sources/internal/kubernetes ./internal/sourceregistry ./internal/sourceruntime/... -count=1`
- `make source-fixture-check` — 138 bundles, 34 sources, 126 families; all fixture packages passed
- `make catalog-check sourcegen-check connector-contract-check`
- `make check-structural check-structural-test check-arch`
- `./scripts/leak_check.sh staged`
- `git diff --cached --check`

## Authority boundary

This PR publishes the provider-local kernel and parity proof. It does not claim Kubernetes production authority, deployment, live-provider proof, or authenticated product-path proof. The landed shared source-execution host currently accepts only public-DNS bearer-token HTTPS operations; Kubernetes host-managed kubeconfig, client-certificate, exec-plugin, in-cluster authentication, and private API origins remain outside that contract. This branch therefore retains the Kubernetes compatibility loader and Go oracle rather than removing the only runnable provider path prematurely.
