### PR TITLE
feat(sources): add credential-free OpenAI Rust runtime

### DIFF
--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -178,7 +178,7 @@ jobs:
           '
           summary="$(docker run --rm "${CANDIDATE_IMAGE}" catalog-summary)"
           test "$(jq -r .sources <<<"${summary}")" -eq 799
-          test "$(jq -r .families <<<"${summary}")" -eq 3938
+          test "$(jq -r .families <<<"${summary}")" -eq 3973
       - name: Start disposable PostgreSQL, Neo4j, and JetStream
         run: |
           set -euo pipefail
@@ -246,7 +246,7 @@ jobs:
             | .checks += [
                 {name:"rust_entrypoint",status:"passed",evidence:"image starts cerebro-platform directly"},
                 {name:"go_binary_absent",status:"passed",evidence:"/usr/local/bin/cerebro is absent"},
-                {name:"source_catalog",status:"passed",evidence:"799 sources and 3938 families loaded"}
+                {name:"source_catalog",status:"passed",evidence:"799 sources and 3973 families loaded"}
               ]
           ' .dist/rust-only-e2e/rust-only-e2e-receipt.json \
             > .dist/rust-only-e2e/receipt.tmp

--- a/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
+++ b/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
@@ -108,8 +108,8 @@ fn rust_candidate_build_never_invokes_go_or_emulation() {
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- seed",
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- verify",
         r#"test "$(jq -r .sources <<<"${summary}")" -eq 799"#,
-        r#"test "$(jq -r .families <<<"${summary}")" -eq 3938"#,
-        r#"evidence:"799 sources and 3938 families loaded""#,
+        r#"test "$(jq -r .families <<<"${summary}")" -eq 3973"#,
+        r#"evidence:"799 sources and 3973 families loaded""#,
         "cerebro.rust-only-e2e/v1",
         "cerebro.rust-only-candidate/v1",
     ] {

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -926,6 +926,8 @@ struct CredentialFieldWire {
 struct FamilyWire {
     id: String,
     #[serde(default)]
+    singleton: bool,
+    #[serde(default)]
     method: String,
     path: String,
     #[serde(default)]
@@ -1616,10 +1618,9 @@ fn compile_family(
         .config
         .as_ref()
         .and_then(|config| optional(config.base_url.trim().to_owned()));
-    if id_template
-        .as_deref()
-        .is_some_and(|template| !valid_id_template(template))
-    {
+    if id_template.as_deref().is_some_and(|template| {
+        !(valid_id_template(template) || family.singleton && valid_singleton_id_literal(template))
+    }) {
         return invalid(
             path,
             &format!("family {} id_template is invalid", family.id),
@@ -1854,6 +1855,15 @@ fn valid_id_template(template: &str) -> bool {
         rest = &rest[field_end + 1..];
     }
     placeholders > 0 && !rest.contains('{') && !rest.contains('}')
+}
+
+fn valid_singleton_id_literal(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 1_024
+        && value.trim() == value
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':' | b'/')
+        })
 }
 
 fn validate_id_field(
@@ -2707,7 +2717,7 @@ mod tests {
         .unwrap();
         let summary = catalog.summary();
         assert_eq!(summary.sources, 799);
-        assert_eq!(summary.families, 3_938);
+        assert_eq!(summary.families, 3_973);
         assert_eq!(summary.push_sources, 1);
         assert_eq!(summary.push_families, 10);
         assert_eq!(
@@ -3426,6 +3436,16 @@ mod tests {
             "${{field}}{}",
             "x".repeat(1_024)
         )));
+        assert!(valid_singleton_id_literal("organization:data_retention"));
+        for invalid in [
+            "",
+            " leading",
+            "trailing ",
+            "contains${field}",
+            "line\nbreak",
+        ] {
+            assert!(!valid_singleton_id_literal(invalid), "{invalid:?}");
+        }
     }
 
     #[test]
@@ -3600,7 +3620,7 @@ mod tests {
         .unwrap();
         let report = catalog.unsupported_feature_report();
         assert_eq!(report.total_sources, 799);
-        assert_eq!(report.total_families, 3_938);
+        assert_eq!(report.total_families, 3_973);
         assert_eq!(report.families.len(), report.total_families);
         assert!(report.missing_family_reports.is_empty());
         assert_eq!(
@@ -3649,7 +3669,7 @@ mod tests {
         )
         .unwrap();
         let report = catalog.authority_readiness_report();
-        assert_eq!(report.total_families, 3_938);
+        assert_eq!(report.total_families, 3_973);
         assert_eq!(report.rust_authoritative_families, 0);
         assert_eq!(report.shadow_or_go_families, report.total_families);
         let aws_bedrock = report

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -32,6 +32,7 @@ mod kubernetes;
 mod linode;
 mod mapper;
 mod okta;
+mod openai;
 mod panopticon;
 mod protocol;
 mod provider_failure;
@@ -148,6 +149,10 @@ pub use linode::{LinodeError, LinodeKernel, LinodePage, LinodeRecord, LinodeRequ
 pub use mapper::{CatalogGraphMapper, CatalogMapperError, IdentityResolutionSnapshot};
 pub use okta::{
     OktaError, OktaFamily, OktaFilters, OktaKernel, OktaPage, OktaRecord, OktaRequest, OktaResponse,
+};
+pub use openai::{
+    OpenAiAuthRequirement, OpenAiCheckpoint, OpenAiError, OpenAiFamily, OpenAiKernel, OpenAiPage,
+    OpenAiRecord, OpenAiRequest, OpenAiRequestInput,
 };
 pub use panopticon::{
     PanopticonError, PanopticonFamily, PanopticonKernel, PanopticonOutcome, PanopticonPage,

--- a/crates/source-runtime-next/src/openai.rs
+++ b/crates/source-runtime-next/src/openai.rs
@@ -1,0 +1,19 @@
+//! Credential-free OpenAI organization-governance collection kernel.
+//!
+//! The kernel compiles the closed OpenAI family table into bounded request
+//! descriptions and normalizes provider response bytes. Authentication bytes,
+//! redirect handling, and network execution remain outside this module.
+
+mod error;
+mod family;
+mod normalize;
+mod request;
+mod response;
+
+pub use error::OpenAiError;
+pub use family::OpenAiFamily;
+pub use request::{OpenAiAuthRequirement, OpenAiKernel, OpenAiRequest, OpenAiRequestInput};
+pub use response::{OpenAiCheckpoint, OpenAiPage, OpenAiRecord};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/openai/error.rs
+++ b/crates/source-runtime-next/src/openai/error.rs
@@ -1,0 +1,85 @@
+//! Typed OpenAI provider failures.
+
+use std::{error::Error, fmt};
+
+/// A bounded failure produced by the credential-free OpenAI kernel.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum OpenAiError {
+    /// A required public configuration value was not supplied.
+    MissingConfiguration(&'static str),
+    /// The trusted runtime tenant identity is invalid.
+    InvalidTenant,
+    /// A family is outside the closed OpenAI runtime table.
+    UnknownFamily,
+    /// A request attempted to pass credential-shaped configuration to the kernel.
+    CredentialMaterialRejected,
+    /// The prior provider continuation is invalid.
+    InvalidCursor,
+    /// The provider rejected authentication.
+    AuthenticationRejected,
+    /// The provider credential lacks the required organization scope.
+    PermissionDenied,
+    /// The provider rate limited this operation.
+    RateLimited,
+    /// Provider transport or a retryable upstream status failed.
+    ProviderUnavailable(u16),
+    /// The provider returned an unexpected non-success status.
+    UnexpectedStatus(u16),
+    /// Provider response bytes exceed the family limit.
+    ResponseTooLarge,
+    /// Provider bytes do not match the closed response contract.
+    MalformedResponse,
+    /// A record has no stable provider identity.
+    MissingStableIdentity,
+    /// A provider record contradicts the trusted request scope.
+    TenantMismatch,
+    /// A normalized record does not satisfy its event contract.
+    EventContractRejected,
+    /// The same event identity was reused for different canonical content.
+    DuplicateConflict,
+}
+
+impl fmt::Display for OpenAiError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingConfiguration(field) => {
+                write!(formatter, "missing OpenAI configuration {field}")
+            }
+            Self::InvalidTenant => formatter.write_str("OpenAI tenant identity is invalid"),
+            Self::UnknownFamily => {
+                formatter.write_str("OpenAI family is not in the closed runtime table")
+            }
+            Self::CredentialMaterialRejected => {
+                formatter.write_str("OpenAI kernel input cannot contain credential material")
+            }
+            Self::InvalidCursor => formatter.write_str("OpenAI continuation cursor is invalid"),
+            Self::AuthenticationRejected => formatter.write_str("OpenAI rejected authentication"),
+            Self::PermissionDenied => formatter.write_str("OpenAI organization scope is missing"),
+            Self::RateLimited => formatter.write_str("OpenAI rate limit exceeded"),
+            Self::ProviderUnavailable(status) => {
+                write!(formatter, "OpenAI provider unavailable with HTTP {status}")
+            }
+            Self::UnexpectedStatus(status) => {
+                write!(formatter, "OpenAI returned unexpected HTTP {status}")
+            }
+            Self::ResponseTooLarge => formatter.write_str("OpenAI response exceeds the byte limit"),
+            Self::MalformedResponse => {
+                formatter.write_str("OpenAI response does not match the family contract")
+            }
+            Self::MissingStableIdentity => {
+                formatter.write_str("OpenAI record is missing a stable identity")
+            }
+            Self::TenantMismatch => {
+                formatter.write_str("OpenAI record contradicts the requested scope")
+            }
+            Self::EventContractRejected => {
+                formatter.write_str("OpenAI record violates the event contract")
+            }
+            Self::DuplicateConflict => {
+                formatter.write_str("OpenAI event identity has conflicting content")
+            }
+        }
+    }
+}
+
+impl Error for OpenAiError {}

--- a/crates/source-runtime-next/src/openai/family.rs
+++ b/crates/source-runtime-next/src/openai/family.rs
@@ -1,0 +1,876 @@
+//! Closed OpenAI family contracts shared by request planning and decoding.
+
+use super::OpenAiError;
+
+pub(super) const SOURCE_ID: &str = "openai";
+pub(super) const ORIGIN: &str = "https://api.openai.com";
+pub(super) const BASE_PATH: &str = "/v1";
+pub(super) const MAX_RESPONSE_BYTES: usize = 8 << 20;
+pub(super) const MAX_RECORDS_PER_PAGE: usize = 10_000;
+pub(super) const DEFAULT_PAGE_SIZE: usize = 100;
+pub(super) const MAX_PAGE_SIZE: usize = 1_000;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum Pagination {
+    Cursor,
+    Page,
+    None,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(super) struct FamilySpec {
+    pub(super) id: &'static str,
+    pub(super) path: &'static str,
+    pub(super) path_parameters: &'static [&'static str],
+    pub(super) pagination: Pagination,
+    pub(super) id_paths: &'static [&'static str],
+    pub(super) timestamp_paths: &'static [&'static str],
+    pub(super) attributes: &'static [(&'static str, &'static str)],
+    pub(super) required_attributes: &'static [&'static str],
+    pub(super) required_payload_fields: &'static [&'static str],
+    pub(super) allowed_query: &'static [(&'static str, &'static str)],
+    pub(super) singleton_identity: Option<&'static str>,
+}
+
+/// One family in the closed OpenAI organization-governance runtime table.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct OpenAiFamily(&'static FamilySpec);
+
+impl OpenAiFamily {
+    /// Parse an exact OpenAI family identifier.
+    pub fn parse(value: &str) -> Result<Self, OpenAiError> {
+        FAMILY_SPECS
+            .iter()
+            .find(|spec| spec.id == value)
+            .map(Self)
+            .ok_or(OpenAiError::UnknownFamily)
+    }
+
+    /// Return every supported family in stable catalog order.
+    pub fn all() -> impl ExactSizeIterator<Item = Self> {
+        FAMILY_SPECS.iter().map(Self)
+    }
+
+    /// Return the exact source-catalog family identifier.
+    pub fn id(self) -> &'static str {
+        self.0.id
+    }
+
+    /// Return the exact emitted event kind.
+    pub fn event_kind(self) -> String {
+        format!("{SOURCE_ID}.{}", self.id())
+    }
+
+    /// Return the exact emitted event schema.
+    pub fn schema_ref(self) -> String {
+        format!("{SOURCE_ID}/{}/v1", self.id())
+    }
+
+    pub(super) fn spec(self) -> &'static FamilySpec {
+        self.0
+    }
+}
+
+const STANDARD_QUERY: &[(&str, &str)] = &[];
+const AUDIT_QUERY: &[(&str, &str)] = &[
+    ("actor_emails", "actor_emails"),
+    ("actor_ids", "actor_ids"),
+    ("effective_at_gt", "effective_at[gt]"),
+    ("effective_at_gte", "effective_at[gte]"),
+    ("effective_at_lt", "effective_at[lt]"),
+    ("effective_at_lte", "effective_at[lte]"),
+    ("event_types", "event_types"),
+    ("project_ids", "project_ids"),
+    ("resource_ids", "resource_ids"),
+    ("tenant_only", "tenant_only"),
+];
+const USAGE_QUERY: &[(&str, &str)] = &[
+    ("api_key_ids", "api_key_ids"),
+    ("batch", "batch"),
+    ("bucket_width", "bucket_width"),
+    ("end_time", "end_time"),
+    ("group_by", "group_by"),
+    ("models", "models"),
+    ("project_ids", "project_ids"),
+    ("start_time", "start_time"),
+    ("user_ids", "user_ids"),
+];
+
+const USER_ATTRS: &[(&str, &str)] = &[
+    ("user_id", "id"),
+    ("name", "name"),
+    ("email", "email"),
+    ("role", "role"),
+    ("status", "status"),
+    ("added_at", "added_at"),
+];
+const PROJECT_ATTRS: &[(&str, &str)] = &[
+    ("project_id", "id"),
+    ("name", "name"),
+    ("status", "status"),
+    ("created_at", "created_at"),
+    ("archived_at", "archived_at"),
+    ("external_key_id", "external_key_id"),
+];
+const SERVICE_ACCOUNT_ATTRS: &[(&str, &str)] = &[
+    ("service_account_id", "id"),
+    ("project_id", "project_id"),
+    ("name", "name"),
+    ("role", "role"),
+    ("created_at", "created_at"),
+];
+const API_KEY_ATTRS: &[(&str, &str)] = &[
+    ("api_key_id", "id"),
+    ("project_id", "project_id"),
+    ("name", "name"),
+    ("owner_user_id", "owner.user.id"),
+    ("owner_service_account_id", "owner.service_account.id"),
+    ("owner_type", "owner.type"),
+    ("status", "status"),
+    ("created_at", "created_at"),
+    ("last_used_at", "last_used_at"),
+];
+const ADMIN_KEY_ATTRS: &[(&str, &str)] = &[
+    ("api_key_id", "id"),
+    ("name", "name"),
+    ("owner_id", "owner.id"),
+    ("owner_name", "owner.name"),
+    ("owner_object", "owner.object"),
+    ("owner_role", "owner.role"),
+    ("owner_type", "owner.type"),
+    ("status", "status"),
+    ("created_at", "created_at"),
+    ("last_used_at", "last_used_at"),
+];
+const INVITE_ATTRS: &[(&str, &str)] = &[
+    ("invite_id", "id"),
+    ("email", "email"),
+    ("role", "role"),
+    ("status", "status"),
+    ("projects", "projects"),
+    ("created_at", "created_at"),
+    ("accepted_at", "accepted_at"),
+    ("expires_at", "expires_at"),
+];
+const ROLE_ATTRS: &[(&str, &str)] = &[
+    ("role_id", "id"),
+    ("name", "name"),
+    ("description", "description"),
+    ("permissions", "permissions"),
+    ("resource_type", "resource_type"),
+    ("predefined_role", "predefined_role"),
+    ("created_at", "created_at"),
+    ("updated_at", "updated_at"),
+    ("created_by", "created_by"),
+];
+const GROUP_ATTRS: &[(&str, &str)] = &[
+    ("group_id", "id"),
+    ("name", "name"),
+    ("created_at", "created_at"),
+    ("updated_at", "updated_at"),
+];
+const MEMBER_ATTRS: &[(&str, &str)] = &[
+    ("user_id", "id|user_id"),
+    ("email", "email"),
+    ("name", "name"),
+    ("role", "role"),
+    ("added_at", "added_at"),
+];
+const RETENTION_ATTRS: &[(&str, &str)] = &[("retention_type", "type"), ("object", "object")];
+const SPEND_ATTRS: &[(&str, &str)] = &[
+    ("spend_alert_id", "id"),
+    ("name", "name"),
+    ("status", "status"),
+    ("threshold", "threshold"),
+    ("threshold_amount", "threshold_amount"),
+    ("created_at", "created_at"),
+    ("updated_at", "updated_at"),
+];
+const CERT_ATTRS: &[(&str, &str)] = &[
+    ("certificate_id", "id"),
+    ("name", "name"),
+    ("active", "active"),
+    ("created_at", "created_at"),
+    ("valid_at", "certificate_details.valid_at"),
+    ("expires_at", "certificate_details.expires_at"),
+];
+const USAGE_ATTRS: &[(&str, &str)] = &[
+    ("start_time", "start_time"),
+    ("end_time", "end_time"),
+    ("result_count", "results.__count"),
+    ("input_tokens", "results.input_tokens.__sum|input_tokens"),
+    ("output_tokens", "results.output_tokens.__sum|output_tokens"),
+    (
+        "num_model_requests",
+        "results.num_model_requests.__sum|num_model_requests",
+    ),
+    ("project_id", "project_id"),
+    ("user_id", "user_id"),
+    ("api_key_id", "api_key_id"),
+    ("model", "model"),
+    ("line_item", "line_item"),
+    ("amount_value", "amount.value|amount"),
+    ("amount_currency", "amount.currency"),
+    ("organization_object", "object"),
+];
+const RATE_LIMIT_ATTRS: &[(&str, &str)] = &[
+    ("rate_limit_id", "id"),
+    ("model", "model"),
+    ("created_at", "created_at"),
+    ("updated_at", "updated_at"),
+    ("max_requests_per_1_minute", "max_requests_per_1_minute"),
+    ("max_tokens_per_1_minute", "max_tokens_per_1_minute"),
+    ("max_images_per_1_minute", "max_images_per_1_minute"),
+    ("max_requests_per_1_day", "max_requests_per_1_day"),
+    (
+        "batch_1_day_max_input_tokens",
+        "batch_1_day_max_input_tokens",
+    ),
+];
+const MODEL_PERMISSION_ATTRS: &[(&str, &str)] = &[("mode", "mode"), ("model_ids", "model_ids")];
+const TOOL_PERMISSION_ATTRS: &[(&str, &str)] = &[
+    ("code_interpreter_enabled", "code_interpreter.enabled"),
+    ("file_search_enabled", "file_search.enabled"),
+    ("image_generation_enabled", "image_generation.enabled"),
+    ("mcp_enabled", "mcp.enabled"),
+    ("web_search_enabled", "web_search.enabled"),
+];
+const AUDIT_ATTRS: &[(&str, &str)] = &[
+    (
+        "api_key_id",
+        "api_key.created.id|api_key.updated.id|api_key.deleted.id|api_key.id|api_key_id",
+    ),
+    ("audit_log_id", "id"),
+    ("actor_api_key_id", "actor.api_key.id"),
+    ("actor_city", "actor.session.ip_address_details.city"),
+    ("actor_country", "actor.session.ip_address_details.country"),
+    (
+        "actor_email",
+        "actor.session.user.email|actor.api_key.user.email|actor.user.email|actor.email",
+    ),
+    (
+        "actor_id",
+        "actor.session.user.id|actor.api_key.user.id|actor.api_key.service_account.id|actor.api_key.id|actor.user.id|actor.service_account.id|actor.id",
+    ),
+    ("actor_ip_address", "actor.session.ip_address"),
+    ("actor_region", "actor.session.ip_address_details.region"),
+    (
+        "actor_service_account_id",
+        "actor.api_key.service_account.id|actor.service_account.id",
+    ),
+    ("actor_type", "actor.type|actor.api_key.type"),
+    ("actor_user_agent", "actor.session.user_agent"),
+    (
+        "actor_user_id",
+        "actor.session.user.id|actor.api_key.user.id|actor.user.id",
+    ),
+    (
+        "certificate_id",
+        "certificate.created.id|certificate.updated.id|certificate.deleted.id",
+    ),
+    (
+        "certificate_name",
+        "certificate.created.name|certificate.updated.name|certificate.deleted.name",
+    ),
+    ("effective_at", "effective_at"),
+    ("event_type", "type|event_type"),
+    (
+        "external_key_id",
+        "external_key.registered.id|external_key.removed.id",
+    ),
+    (
+        "group_id",
+        "group.created.id|group.updated.id|group.deleted.id",
+    ),
+    (
+        "group_name",
+        "group.created.data.group_name|group.updated.changes_requested.group_name",
+    ),
+    ("invite_email", "invite.sent.data.email"),
+    (
+        "invite_id",
+        "invite.sent.id|invite.accepted.id|invite.deleted.id",
+    ),
+    ("invite_role", "invite.sent.data.role"),
+    (
+        "ip_allowlist_id",
+        "ip_allowlist.created.id|ip_allowlist.updated.id|ip_allowlist.deleted.id",
+    ),
+    (
+        "ip_allowlist_name",
+        "ip_allowlist.created.name|ip_allowlist.deleted.name",
+    ),
+    (
+        "organization_id",
+        "organization.updated.id|organization_id|org_id",
+    ),
+    (
+        "principal_id",
+        "role.assignment.created.principal_id|role.assignment.deleted.principal_id",
+    ),
+    (
+        "principal_type",
+        "role.assignment.created.principal_type|role.assignment.deleted.principal_type",
+    ),
+    (
+        "project_id",
+        "project.created.id|project.updated.id|project.archived.id|project.deleted.id|checkpoint.permission.created.data.project_id|project.id|project_id",
+    ),
+    (
+        "rate_limit_id",
+        "rate_limit.updated.id|rate_limit.deleted.id",
+    ),
+    (
+        "resource_id",
+        "role.assignment.created.resource_id|role.assignment.deleted.resource_id|role.bound_to_resource.resource_id|role.unbound_from_resource.resource_id|resource.deleted.id",
+    ),
+    (
+        "resource_type",
+        "role.assignment.created.resource_type|role.assignment.deleted.resource_type|role.bound_to_resource.resource_type|role.unbound_from_resource.resource_type|resource.deleted.type",
+    ),
+    (
+        "role_assignment_id",
+        "role.assignment.created.id|role.assignment.deleted.id",
+    ),
+    (
+        "role_id",
+        "role.created.id|role.updated.id|role.deleted.id|role.bound_to_resource.role_id|role.unbound_from_resource.role_id",
+    ),
+    (
+        "role_name",
+        "role.created.data.role_name|role.updated.changes_requested.role_name|role.bound_to_resource.role_name|role.unbound_from_resource.role_name",
+    ),
+    (
+        "service_account_id",
+        "service_account.created.id|service_account.updated.id|service_account.deleted.id",
+    ),
+    ("user_id", "user.added.id|user.updated.id|user.deleted.id"),
+];
+
+macro_rules! family {
+    ($id:literal, $path:literal, $params:expr, $pagination:expr, $ids:expr, $times:expr, $attrs:expr, $required:expr, $payload:expr, $query:expr, $singleton:expr) => {
+        FamilySpec {
+            id: $id,
+            path: $path,
+            path_parameters: $params,
+            pagination: $pagination,
+            id_paths: $ids,
+            timestamp_paths: $times,
+            attributes: $attrs,
+            required_attributes: $required,
+            required_payload_fields: $payload,
+            allowed_query: $query,
+            singleton_identity: $singleton,
+        }
+    };
+}
+
+const FAMILY_SPECS: &[FamilySpec] = &[
+    family!(
+        "user",
+        "/organization/users",
+        &[],
+        Pagination::Cursor,
+        &["id"],
+        &["added_at"],
+        USER_ATTRS,
+        &["user_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "project",
+        "/organization/projects",
+        &[],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at"],
+        PROJECT_ATTRS,
+        &["project_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "service_account",
+        "/organization/projects/default/service_accounts",
+        &[],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at"],
+        SERVICE_ACCOUNT_ATTRS,
+        &["service_account_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "api_key",
+        "/organization/projects/default/api_keys",
+        &[],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at", "last_used_at"],
+        API_KEY_ATTRS,
+        &["api_key_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "admin_api_key",
+        "/organization/admin_api_keys",
+        &[],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at", "last_used_at"],
+        ADMIN_KEY_ATTRS,
+        &["api_key_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "audit_log",
+        "/organization/audit_logs",
+        &[],
+        Pagination::Cursor,
+        &["id"],
+        &["effective_at", "created_at"],
+        AUDIT_ATTRS,
+        &["audit_log_id"],
+        &["id"],
+        AUDIT_QUERY,
+        None
+    ),
+    family!(
+        "invite",
+        "/organization/invites",
+        &[],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at"],
+        INVITE_ATTRS,
+        &["invite_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "role",
+        "/organization/roles",
+        &[],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at", "updated_at"],
+        ROLE_ATTRS,
+        &["role_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "user_role",
+        "/organization/users/{user_id}/roles",
+        &["user_id"],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at", "updated_at"],
+        ROLE_ATTRS,
+        &["role_id", "user_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "group",
+        "/organization/groups",
+        &[],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at", "updated_at"],
+        GROUP_ATTRS,
+        &["group_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "group_user",
+        "/organization/groups/{group_id}/users",
+        &["group_id"],
+        Pagination::Cursor,
+        &["id", "user_id"],
+        &["added_at", "created_at"],
+        MEMBER_ATTRS,
+        &["group_id", "user_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "group_role",
+        "/organization/groups/{group_id}/roles",
+        &["group_id"],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at", "updated_at"],
+        ROLE_ATTRS,
+        &["group_id", "role_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "data_retention",
+        "/organization/data_retention",
+        &[],
+        Pagination::None,
+        &[],
+        &[],
+        RETENTION_ATTRS,
+        &["external_id"],
+        &[],
+        STANDARD_QUERY,
+        Some("organization:data_retention")
+    ),
+    family!(
+        "spend_alert",
+        "/organization/spend_alerts",
+        &[],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at", "updated_at"],
+        SPEND_ATTRS,
+        &["spend_alert_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "certificate",
+        "/organization/certificates",
+        &[],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at", "certificate_details.expires_at"],
+        CERT_ATTRS,
+        &["certificate_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "usage_audio_speech",
+        "/organization/usage/audio_speeches",
+        &[],
+        Pagination::Page,
+        &["id"],
+        &["start_time", "end_time"],
+        USAGE_ATTRS,
+        &["external_id"],
+        &[],
+        USAGE_QUERY,
+        None
+    ),
+    family!(
+        "usage_audio_transcription",
+        "/organization/usage/audio_transcriptions",
+        &[],
+        Pagination::Page,
+        &["id"],
+        &["start_time", "end_time"],
+        USAGE_ATTRS,
+        &["external_id"],
+        &[],
+        USAGE_QUERY,
+        None
+    ),
+    family!(
+        "usage_code_interpreter_session",
+        "/organization/usage/code_interpreter_sessions",
+        &[],
+        Pagination::Page,
+        &["id"],
+        &["start_time", "end_time"],
+        USAGE_ATTRS,
+        &["external_id"],
+        &[],
+        USAGE_QUERY,
+        None
+    ),
+    family!(
+        "usage_completion",
+        "/organization/usage/completions",
+        &[],
+        Pagination::Page,
+        &["id"],
+        &["start_time", "end_time"],
+        USAGE_ATTRS,
+        &["external_id"],
+        &[],
+        USAGE_QUERY,
+        None
+    ),
+    family!(
+        "usage_embedding",
+        "/organization/usage/embeddings",
+        &[],
+        Pagination::Page,
+        &["id"],
+        &["start_time", "end_time"],
+        USAGE_ATTRS,
+        &["external_id"],
+        &[],
+        USAGE_QUERY,
+        None
+    ),
+    family!(
+        "usage_image",
+        "/organization/usage/images",
+        &[],
+        Pagination::Page,
+        &["id"],
+        &["start_time", "end_time"],
+        USAGE_ATTRS,
+        &["external_id"],
+        &[],
+        USAGE_QUERY,
+        None
+    ),
+    family!(
+        "usage_moderation",
+        "/organization/usage/moderations",
+        &[],
+        Pagination::Page,
+        &["id"],
+        &["start_time", "end_time"],
+        USAGE_ATTRS,
+        &["external_id"],
+        &[],
+        USAGE_QUERY,
+        None
+    ),
+    family!(
+        "usage_vector_store",
+        "/organization/usage/vector_stores",
+        &[],
+        Pagination::Page,
+        &["id"],
+        &["start_time", "end_time"],
+        USAGE_ATTRS,
+        &["external_id"],
+        &[],
+        USAGE_QUERY,
+        None
+    ),
+    family!(
+        "usage_file_search_call",
+        "/organization/usage/file_search_calls",
+        &[],
+        Pagination::Page,
+        &["id"],
+        &["start_time", "end_time"],
+        USAGE_ATTRS,
+        &["external_id"],
+        &[],
+        USAGE_QUERY,
+        None
+    ),
+    family!(
+        "usage_web_search_call",
+        "/organization/usage/web_search_calls",
+        &[],
+        Pagination::Page,
+        &["id"],
+        &["start_time", "end_time"],
+        USAGE_ATTRS,
+        &["external_id"],
+        &[],
+        USAGE_QUERY,
+        None
+    ),
+    family!(
+        "cost",
+        "/organization/costs",
+        &[],
+        Pagination::Page,
+        &["id"],
+        &["start_time", "end_time"],
+        USAGE_ATTRS,
+        &["external_id"],
+        &[],
+        USAGE_QUERY,
+        None
+    ),
+    family!(
+        "project_user",
+        "/organization/projects/{project_id}/users",
+        &["project_id"],
+        Pagination::Cursor,
+        &["id", "user_id"],
+        &["added_at"],
+        MEMBER_ATTRS,
+        &["project_id", "user_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "project_user_role",
+        "/projects/{project_id}/users/{user_id}/roles",
+        &["project_id", "user_id"],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at", "updated_at"],
+        ROLE_ATTRS,
+        &["project_id", "role_id", "user_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "project_service_account",
+        "/organization/projects/{project_id}/service_accounts",
+        &["project_id"],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at"],
+        SERVICE_ACCOUNT_ATTRS,
+        &["project_id", "service_account_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "project_api_key",
+        "/organization/projects/{project_id}/api_keys",
+        &["project_id"],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at", "last_used_at"],
+        API_KEY_ATTRS,
+        &["api_key_id", "project_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "project_rate_limit",
+        "/organization/projects/{project_id}/rate_limits",
+        &["project_id"],
+        Pagination::Cursor,
+        &["id", "model"],
+        &["updated_at", "created_at"],
+        RATE_LIMIT_ATTRS,
+        &["external_id", "project_id"],
+        &[],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "project_model_permission",
+        "/organization/projects/{project_id}/model_permissions",
+        &["project_id"],
+        Pagination::None,
+        &[],
+        &[],
+        MODEL_PERMISSION_ATTRS,
+        &["external_id", "project_id"],
+        &[],
+        STANDARD_QUERY,
+        Some("{project_id}:model_permissions")
+    ),
+    family!(
+        "project_hosted_tool_permission",
+        "/organization/projects/{project_id}/hosted_tool_permissions",
+        &["project_id"],
+        Pagination::None,
+        &[],
+        &[],
+        TOOL_PERMISSION_ATTRS,
+        &["external_id", "project_id"],
+        &[],
+        STANDARD_QUERY,
+        Some("{project_id}:hosted_tool_permissions")
+    ),
+    family!(
+        "project_group",
+        "/organization/projects/{project_id}/groups",
+        &["project_id"],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at", "updated_at"],
+        GROUP_ATTRS,
+        &["group_id", "project_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "project_group_role",
+        "/organization/projects/{project_id}/groups/{group_id}/roles",
+        &["project_id", "group_id"],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at", "updated_at"],
+        ROLE_ATTRS,
+        &["group_id", "project_id", "role_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "project_role",
+        "/projects/{project_id}/roles",
+        &["project_id"],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at", "updated_at"],
+        ROLE_ATTRS,
+        &["project_id", "role_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "project_data_retention",
+        "/organization/projects/{project_id}/data_retention",
+        &["project_id"],
+        Pagination::None,
+        &[],
+        &[],
+        RETENTION_ATTRS,
+        &["external_id", "project_id"],
+        &[],
+        STANDARD_QUERY,
+        Some("{project_id}:data_retention")
+    ),
+    family!(
+        "project_spend_alert",
+        "/organization/projects/{project_id}/spend_alerts",
+        &["project_id"],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at", "updated_at"],
+        SPEND_ATTRS,
+        &["project_id", "spend_alert_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+    family!(
+        "project_certificate",
+        "/organization/projects/{project_id}/certificates",
+        &["project_id"],
+        Pagination::Cursor,
+        &["id"],
+        &["created_at", "certificate_details.expires_at"],
+        CERT_ATTRS,
+        &["certificate_id", "project_id"],
+        &["id"],
+        STANDARD_QUERY,
+        None
+    ),
+];

--- a/crates/source-runtime-next/src/openai/normalize.rs
+++ b/crates/source-runtime-next/src/openai/normalize.rs
@@ -1,0 +1,418 @@
+//! Strict OpenAI response decoding and event-contract admission.
+
+use std::collections::{BTreeMap, btree_map::Entry};
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use super::{
+    OpenAiCheckpoint, OpenAiError, OpenAiKernel, OpenAiPage, OpenAiRecord, OpenAiRequestInput,
+    family::{BASE_PATH, MAX_RECORDS_PER_PAGE, MAX_RESPONSE_BYTES, ORIGIN, Pagination, SOURCE_ID},
+};
+
+pub(super) fn decode_page(
+    kernel: &OpenAiKernel,
+    input: &OpenAiRequestInput,
+    status_code: u16,
+    response_body: &[u8],
+    observed_at_unix_millis: i64,
+) -> Result<OpenAiPage, OpenAiError> {
+    classify_status(status_code)?;
+    if response_body.len() > MAX_RESPONSE_BYTES {
+        return Err(OpenAiError::ResponseTooLarge);
+    }
+    if observed_at_unix_millis <= 0 {
+        return Err(OpenAiError::MalformedResponse);
+    }
+    // Re-plan so decoding is bound to the same validated public scope and cursor.
+    let planned = kernel.plan(input)?;
+    let root: Value =
+        serde_json::from_slice(response_body).map_err(|_| OpenAiError::MalformedResponse)?;
+    let spec = kernel.family().spec();
+    let (provider_records, next_cursor) = match spec.pagination {
+        Pagination::None => (vec![singleton_record(root)?], None),
+        Pagination::Cursor => {
+            let records = root
+                .get("data")
+                .and_then(Value::as_array)
+                .cloned()
+                .ok_or(OpenAiError::MalformedResponse)?;
+            let has_more = root
+                .get("has_more")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            let next = first_string(&root, &["next", "last_id"]);
+            if has_more && next.is_none() {
+                return Err(OpenAiError::InvalidCursor);
+            }
+            (records, next)
+        }
+        Pagination::Page => {
+            let records = root
+                .get("data")
+                .and_then(Value::as_array)
+                .cloned()
+                .ok_or(OpenAiError::MalformedResponse)?;
+            (records, first_string(&root, &["next_page"]))
+        }
+    };
+    if provider_records.len() > MAX_RECORDS_PER_PAGE {
+        return Err(OpenAiError::ResponseTooLarge);
+    }
+    if next_cursor.as_deref().is_some_and(|cursor| {
+        cursor.is_empty()
+            || cursor.len() > 4 << 10
+            || cursor.trim() != cursor
+            || cursor.chars().any(char::is_control)
+    }) {
+        return Err(OpenAiError::InvalidCursor);
+    }
+
+    let request_path = planned
+        .url
+        .strip_prefix(&format!("{ORIGIN}{BASE_PATH}"))
+        .and_then(|value| value.split('?').next())
+        .ok_or(OpenAiError::MalformedResponse)?;
+    let mut deduped = BTreeMap::<String, (String, OpenAiRecord)>::new();
+    for provider_record in provider_records {
+        let record = normalize_record(
+            kernel,
+            input,
+            request_path,
+            provider_record,
+            observed_at_unix_millis,
+        )?;
+        let digest = canonical_record_digest(&record)?;
+        match deduped.entry(record.event_id.clone()) {
+            Entry::Vacant(entry) => {
+                entry.insert((digest, record));
+            }
+            Entry::Occupied(entry) if entry.get().0 == digest => {}
+            Entry::Occupied(_) => return Err(OpenAiError::DuplicateConflict),
+        }
+    }
+    let records = deduped
+        .into_values()
+        .map(|(_, record)| record)
+        .collect::<Vec<_>>();
+    let proposed_checkpoint =
+        (!records.is_empty() || next_cursor.is_some()).then(|| OpenAiCheckpoint {
+            cursor_opaque: next_cursor.clone(),
+            last_provider_id: records.last().map(|record| record.provider_id.clone()),
+            watermark_unix_millis: records.last().map_or(observed_at_unix_millis, |record| {
+                record.occurred_at_unix_millis
+            }),
+        });
+    Ok(OpenAiPage {
+        records,
+        next_cursor,
+        proposed_checkpoint,
+    })
+}
+
+fn normalize_record(
+    kernel: &OpenAiKernel,
+    input: &OpenAiRequestInput,
+    request_path: &str,
+    mut payload: Value,
+    observed_at_unix_millis: i64,
+) -> Result<OpenAiRecord, OpenAiError> {
+    let spec = kernel.family().spec();
+    reject_credential_material(&payload)?;
+    if matches!(spec.id, "api_key" | "admin_api_key" | "project_api_key")
+        && payload.get("value").is_some()
+    {
+        return Err(OpenAiError::EventContractRejected);
+    }
+    let object = payload
+        .as_object_mut()
+        .ok_or(OpenAiError::MalformedResponse)?;
+    if let Some(provider_tenant) = object.get("tenant_id")
+        && provider_tenant.as_str() != Some(kernel.tenant_id())
+    {
+        return Err(OpenAiError::TenantMismatch);
+    }
+    object.remove("tenant_id");
+    for (parameter, expected) in &input.path_parameters {
+        if let Some(actual) = object.get(parameter).and_then(scalar_string)
+            && actual != *expected
+        {
+            return Err(OpenAiError::TenantMismatch);
+        }
+        object
+            .entry(parameter.clone())
+            .or_insert_with(|| Value::String(expected.clone()));
+    }
+    let provider_id = if let Some(identity_template) = spec.singleton_identity {
+        render_singleton_identity(identity_template, &input.path_parameters)?
+    } else {
+        first_expression(&payload, spec.id_paths)
+            .filter(|value| safe_identity(value))
+            .ok_or(OpenAiError::MissingStableIdentity)?
+    };
+    if !safe_identity(&provider_id) {
+        return Err(OpenAiError::MissingStableIdentity);
+    }
+    for field in spec.required_payload_fields {
+        if first_expression(&payload, &[*field]).is_none() {
+            return Err(OpenAiError::EventContractRejected);
+        }
+    }
+    let mut attributes = BTreeMap::from([
+        ("external_id".to_owned(), provider_id.clone()),
+        ("family".to_owned(), spec.id.to_owned()),
+        ("provider".to_owned(), SOURCE_ID.to_owned()),
+        ("source_product".to_owned(), SOURCE_ID.to_owned()),
+        ("source_provider".to_owned(), SOURCE_ID.to_owned()),
+    ]);
+    for (key, value) in &input.path_parameters {
+        attributes.insert(key.clone(), value.clone());
+    }
+    for (attribute, expression) in spec.attributes {
+        if let Some(value) = first_expression(&payload, &[*expression]) {
+            attributes.insert((*attribute).to_owned(), value);
+        }
+    }
+    if spec.id == "admin_api_key" {
+        attributes.insert("key_class".to_owned(), "admin".to_owned());
+        attributes.insert("privileged".to_owned(), "true".to_owned());
+    }
+    for required in spec.required_attributes {
+        if attributes
+            .get(*required)
+            .is_none_or(|value| value.is_empty())
+        {
+            return Err(OpenAiError::EventContractRejected);
+        }
+    }
+    let occurred_at_unix_millis = spec
+        .timestamp_paths
+        .iter()
+        .find_map(|path| value_at_path(&payload, path).and_then(timestamp_millis))
+        .unwrap_or(observed_at_unix_millis);
+    let event_id = go_event_id(kernel.tenant_id(), request_path, spec.id, &provider_id);
+    Ok(OpenAiRecord {
+        event_id,
+        tenant_id: kernel.tenant_id().to_owned(),
+        source_id: SOURCE_ID.to_owned(),
+        family: spec.id.to_owned(),
+        provider_kind: kernel.family().event_kind(),
+        schema_ref: kernel.family().schema_ref(),
+        provider_id,
+        occurred_at_unix_millis,
+        attributes,
+        payload,
+    })
+}
+
+fn reject_credential_material(value: &Value) -> Result<(), OpenAiError> {
+    match value {
+        Value::Object(object) => {
+            for (key, value) in object {
+                let key = key.to_ascii_lowercase().replace('-', "_");
+                if matches!(
+                    key.as_str(),
+                    "api_key"
+                        | "access_token"
+                        | "refresh_token"
+                        | "authorization"
+                        | "client_secret"
+                        | "cookie"
+                        | "password"
+                        | "private_key"
+                        | "secret"
+                        | "token"
+                ) {
+                    return Err(OpenAiError::EventContractRejected);
+                }
+                reject_credential_material(value)?;
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                reject_credential_material(value)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn render_singleton_identity(
+    template: &str,
+    path_parameters: &BTreeMap<String, String>,
+) -> Result<String, OpenAiError> {
+    let mut identity = template.to_owned();
+    for (parameter, value) in path_parameters {
+        identity = identity.replace(&format!("{{{parameter}}}"), value);
+    }
+    if identity.contains('{') || identity.contains('}') {
+        return Err(OpenAiError::MissingStableIdentity);
+    }
+    Ok(identity)
+}
+
+fn singleton_record(root: Value) -> Result<Value, OpenAiError> {
+    let Some(object) = root.as_object() else {
+        return Err(OpenAiError::MalformedResponse);
+    };
+    if object.len() == 1
+        && let Some(data) = object.get("data")
+        && data.is_object()
+    {
+        return Ok(data.clone());
+    }
+    Ok(root)
+}
+
+fn classify_status(status: u16) -> Result<(), OpenAiError> {
+    match status {
+        200..=299 => Ok(()),
+        401 => Err(OpenAiError::AuthenticationRejected),
+        403 => Err(OpenAiError::PermissionDenied),
+        429 => Err(OpenAiError::RateLimited),
+        408 | 425 | 500..=599 => Err(OpenAiError::ProviderUnavailable(status)),
+        _ => Err(OpenAiError::UnexpectedStatus(status)),
+    }
+}
+
+fn first_string(root: &Value, paths: &[&str]) -> Option<String> {
+    paths
+        .iter()
+        .find_map(|path| value_at_path(root, path).and_then(scalar_string))
+        .filter(|value| !value.is_empty())
+}
+
+fn first_expression(root: &Value, expressions: &[&str]) -> Option<String> {
+    expressions.iter().find_map(|expression| {
+        expression
+            .split('|')
+            .find_map(|path| expression_value(root, path))
+    })
+}
+
+fn expression_value(root: &Value, path: &str) -> Option<String> {
+    if let Some(prefix) = path.strip_suffix(".__count") {
+        return value_at_path(root, prefix)
+            .and_then(Value::as_array)
+            .map(|values| values.len().to_string());
+    }
+    if let Some(prefix) = path.strip_suffix(".__sum") {
+        let (array_path, value_path) = prefix.rsplit_once('.')?;
+        let sum = value_at_path(root, array_path)?
+            .as_array()?
+            .iter()
+            .filter_map(|value| value_at_path(value, value_path))
+            .filter_map(number_as_i128)
+            .sum::<i128>();
+        return Some(sum.to_string());
+    }
+    let value = value_at_path(root, path)?;
+    scalar_string(value).or_else(|| serde_json::to_string(value).ok())
+}
+
+fn value_at_path<'a>(root: &'a Value, path: &str) -> Option<&'a Value> {
+    let parts = path.trim_start_matches("$.").split('.').collect::<Vec<_>>();
+    value_at_parts(root, &parts)
+}
+
+fn value_at_parts<'a>(current: &'a Value, parts: &[&str]) -> Option<&'a Value> {
+    if parts.is_empty() {
+        return Some(current);
+    }
+    let object = current.as_object()?;
+    for end in 1..=parts.len() {
+        let key = parts[..end].join(".");
+        if let Some(next) = object.get(&key)
+            && let Some(value) = value_at_parts(next, &parts[end..])
+        {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn scalar_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) => Some(value.clone()),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn number_as_i128(value: &Value) -> Option<i128> {
+    value
+        .as_i64()
+        .map(i128::from)
+        .or_else(|| value.as_u64().map(i128::from))
+}
+
+fn timestamp_millis(value: &Value) -> Option<i64> {
+    if let Some(seconds) = value.as_i64() {
+        return Some(if seconds > 1_000_000_000_000 {
+            seconds
+        } else {
+            seconds.saturating_mul(1_000)
+        });
+    }
+    let raw = value.as_str()?;
+    if let Ok(seconds) = raw.parse::<i64>() {
+        return Some(if seconds > 1_000_000_000_000 {
+            seconds
+        } else {
+            seconds.saturating_mul(1_000)
+        });
+    }
+    time::OffsetDateTime::parse(raw, &time::format_description::well_known::Rfc3339)
+        .ok()
+        .map(|time| time.unix_timestamp_nanos().div_euclid(1_000_000) as i64)
+}
+
+fn safe_identity(value: &str) -> bool {
+    !value.is_empty()
+        && value.trim() == value
+        && value.len() <= 1 << 10
+        && !value.chars().any(char::is_control)
+}
+
+fn go_event_id(tenant_id: &str, path: &str, family: &str, provider_id: &str) -> String {
+    let scope = Sha256::digest(format!("{ORIGIN}{BASE_PATH}\0{path}").as_bytes());
+    format!(
+        "{SOURCE_ID}-{}-{}-{}-{}",
+        normalize_id(tenant_id),
+        hex_bytes(&scope[..6]),
+        normalize_id(family),
+        normalize_id(provider_id)
+    )
+}
+
+fn normalize_id(value: &str) -> String {
+    let value = value.trim();
+    if value.is_empty() {
+        return "unknown".to_owned();
+    }
+    value
+        .chars()
+        .map(|character| match character {
+            ' ' | '/' | ':' | '\t' | '\n' => '-',
+            other => other,
+        })
+        .collect()
+}
+
+fn canonical_record_digest(record: &OpenAiRecord) -> Result<String, OpenAiError> {
+    let bytes = serde_json::to_vec(record).map_err(|_| OpenAiError::MalformedResponse)?;
+    Ok(hex_bytes(&Sha256::digest(bytes)))
+}
+
+fn hex_bytes(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    bytes.iter().fold(
+        String::with_capacity(bytes.len() * 2),
+        |mut output, byte| {
+            write!(&mut output, "{byte:02x}").expect("writing to a String cannot fail");
+            output
+        },
+    )
+}

--- a/crates/source-runtime-next/src/openai/request.rs
+++ b/crates/source-runtime-next/src/openai/request.rs
@@ -1,0 +1,243 @@
+//! Bounded OpenAI request planning without credential bytes.
+
+use std::collections::BTreeMap;
+
+use reqwest::Url;
+use serde::Serialize;
+
+use super::{
+    OpenAiError, OpenAiFamily,
+    family::{BASE_PATH, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, MAX_RESPONSE_BYTES, ORIGIN, Pagination},
+};
+
+const MAX_CONFIG_VALUE_BYTES: usize = 4 << 10;
+const MAX_CURSOR_BYTES: usize = 4 << 10;
+
+/// Public, credential-free inputs for one OpenAI page request.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct OpenAiRequestInput {
+    /// Values used only for declared provider path parameters.
+    pub path_parameters: BTreeMap<String, String>,
+    /// Values used only for declared provider query filters.
+    pub query_parameters: BTreeMap<String, String>,
+    /// Requested provider page size, bounded to 1 through 1,000.
+    pub page_size: Option<usize>,
+    /// Opaque Go-compatible provider continuation.
+    pub cursor: Option<String>,
+}
+
+/// Authentication metadata consumed by the trusted host.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct OpenAiAuthRequirement {
+    /// Declared credential operation; never a credential value.
+    pub operation: String,
+    /// Header name to be populated by the trusted host.
+    pub header: String,
+    /// Authorization scheme to be applied by the trusted host.
+    pub scheme: String,
+}
+
+/// One bounded, origin-restricted OpenAI HTTP request description.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct OpenAiRequest {
+    /// Exact source family.
+    pub family: String,
+    /// Always `GET` for this provider slice.
+    pub method: String,
+    /// Fully rendered provider URL with public parameters only.
+    pub url: String,
+    /// Accepted response media type.
+    pub accept: String,
+    /// Maximum response bytes the host may return to the kernel.
+    pub max_response_bytes: usize,
+    /// Redirects are always disabled.
+    pub allow_redirects: bool,
+    /// External authentication operation metadata.
+    pub auth: OpenAiAuthRequirement,
+}
+
+/// Credential-free OpenAI organization-governance planning and decode kernel.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OpenAiKernel {
+    family: OpenAiFamily,
+    tenant_id: String,
+}
+
+impl OpenAiKernel {
+    /// Bind a trusted tenant to one exact OpenAI family.
+    pub fn new(family: OpenAiFamily, tenant_id: impl Into<String>) -> Result<Self, OpenAiError> {
+        let tenant_id = tenant_id.into();
+        if tenant_id.is_empty()
+            || tenant_id.trim() != tenant_id
+            || tenant_id.len() > 256
+            || tenant_id.chars().any(char::is_control)
+        {
+            return Err(OpenAiError::InvalidTenant);
+        }
+        Ok(Self { family, tenant_id })
+    }
+
+    /// Return whether the kernel accepts credential material.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+
+    /// Return the trusted tenant identity.
+    pub fn tenant_id(&self) -> &str {
+        &self.tenant_id
+    }
+
+    /// Return the exact provider family.
+    pub fn family(&self) -> OpenAiFamily {
+        self.family
+    }
+
+    /// Compile public inputs into a bounded, origin-locked GET request.
+    pub fn plan(&self, input: &OpenAiRequestInput) -> Result<OpenAiRequest, OpenAiError> {
+        validate_public_input(input)?;
+        let spec = self.family.spec();
+        if input.path_parameters.len() != spec.path_parameters.len() {
+            return Err(OpenAiError::MissingConfiguration("path parameter"));
+        }
+        let mut path = spec.path.to_owned();
+        for parameter in spec.path_parameters {
+            let value = input
+                .path_parameters
+                .get(*parameter)
+                .ok_or(OpenAiError::MissingConfiguration(parameter))?;
+            path = path.replace(&format!("{{{parameter}}}"), &encode_path_segment(value));
+        }
+        if input
+            .path_parameters
+            .keys()
+            .any(|parameter| !spec.path_parameters.contains(&parameter.as_str()))
+        {
+            return Err(OpenAiError::MissingConfiguration("unknown path parameter"));
+        }
+
+        let mut url = Url::parse(&format!("{ORIGIN}{BASE_PATH}{path}"))
+            .map_err(|_| OpenAiError::MissingConfiguration("provider path"))?;
+        if url.scheme() != "https"
+            || url.host_str() != Some("api.openai.com")
+            || url.port_or_known_default() != Some(443)
+        {
+            return Err(OpenAiError::MissingConfiguration("provider origin"));
+        }
+        let allowed_query = spec
+            .allowed_query
+            .iter()
+            .copied()
+            .collect::<BTreeMap<_, _>>();
+        if input
+            .query_parameters
+            .keys()
+            .any(|key| !allowed_query.contains_key(key.as_str()))
+        {
+            return Err(OpenAiError::MissingConfiguration("unknown query parameter"));
+        }
+        {
+            let mut query = url.query_pairs_mut();
+            for (input_name, value) in &input.query_parameters {
+                query.append_pair(allowed_query[input_name.as_str()], value);
+            }
+            match spec.pagination {
+                Pagination::Cursor => {
+                    if let Some(cursor) = input.cursor.as_deref() {
+                        query.append_pair("after", cursor);
+                    }
+                    query.append_pair(
+                        "limit",
+                        &input.page_size.unwrap_or(DEFAULT_PAGE_SIZE).to_string(),
+                    );
+                }
+                Pagination::Page => {
+                    if let Some(cursor) = input.cursor.as_deref() {
+                        query.append_pair("page", cursor);
+                    }
+                    query.append_pair(
+                        "limit",
+                        &input.page_size.unwrap_or(DEFAULT_PAGE_SIZE).to_string(),
+                    );
+                }
+                Pagination::None => {
+                    if input.cursor.is_some() || input.page_size.is_some() {
+                        return Err(OpenAiError::InvalidCursor);
+                    }
+                }
+            }
+        }
+        Ok(OpenAiRequest {
+            family: self.family.id().to_owned(),
+            method: "GET".to_owned(),
+            url: url.to_string(),
+            accept: "application/json".to_owned(),
+            max_response_bytes: MAX_RESPONSE_BYTES,
+            allow_redirects: false,
+            auth: OpenAiAuthRequirement {
+                operation: "openai.admin_api_key_bearer".to_owned(),
+                header: "Authorization".to_owned(),
+                scheme: "Bearer".to_owned(),
+            },
+        })
+    }
+}
+
+fn validate_public_input(input: &OpenAiRequestInput) -> Result<(), OpenAiError> {
+    if input
+        .page_size
+        .is_some_and(|size| size == 0 || size > MAX_PAGE_SIZE)
+    {
+        return Err(OpenAiError::MissingConfiguration("page_size"));
+    }
+    if let Some(cursor) = input.cursor.as_deref()
+        && !safe_public_value(cursor, MAX_CURSOR_BYTES)
+    {
+        return Err(OpenAiError::InvalidCursor);
+    }
+    for (key, value) in input
+        .path_parameters
+        .iter()
+        .chain(input.query_parameters.iter())
+    {
+        if !safe_public_value(key, 128) || !safe_public_value(value, MAX_CONFIG_VALUE_BYTES) {
+            return Err(OpenAiError::MissingConfiguration("public request value"));
+        }
+        let key = key.to_ascii_lowercase();
+        if [
+            "api_key",
+            "token",
+            "authorization",
+            "cookie",
+            "client_secret",
+            "password",
+        ]
+        .iter()
+        .any(|marker| key.contains(marker))
+        {
+            return Err(OpenAiError::CredentialMaterialRejected);
+        }
+    }
+    Ok(())
+}
+
+fn safe_public_value(value: &str, max_bytes: usize) -> bool {
+    !value.is_empty()
+        && value.trim() == value
+        && value.len() <= max_bytes
+        && !value.chars().any(char::is_control)
+}
+
+fn encode_path_segment(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push('%');
+            encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+            encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+        }
+    }
+    encoded
+}

--- a/crates/source-runtime-next/src/openai/response.rs
+++ b/crates/source-runtime-next/src/openai/response.rs
@@ -1,0 +1,74 @@
+//! OpenAI page and canonical record types.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+use serde_json::Value;
+
+use super::{OpenAiError, request::OpenAiKernel};
+
+/// Proposed Go-compatible durable progress after a decoded page.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct OpenAiCheckpoint {
+    /// Exact provider continuation; absent on a terminal page.
+    pub cursor_opaque: Option<String>,
+    /// Last accepted provider identity for idempotent restart accounting.
+    pub last_provider_id: Option<String>,
+    /// Provider occurrence time in Unix milliseconds.
+    pub watermark_unix_millis: i64,
+}
+
+/// One tenant-scoped, contract-valid OpenAI provider record.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct OpenAiRecord {
+    /// Stable tenant-scoped event identity matching the Go oracle contract.
+    pub event_id: String,
+    /// Trusted tenant identity.
+    pub tenant_id: String,
+    /// Always `openai`.
+    pub source_id: String,
+    /// Exact source family.
+    pub family: String,
+    /// Exact emitted event kind.
+    pub provider_kind: String,
+    /// Exact emitted event schema.
+    pub schema_ref: String,
+    /// Stable provider identity within the family and request scope.
+    pub provider_id: String,
+    /// Provider occurrence time, or the trusted observation time.
+    pub occurred_at_unix_millis: i64,
+    /// Deterministic normalized event attributes.
+    pub attributes: BTreeMap<String, String>,
+    /// Original provider object with trusted path scope injected when absent.
+    pub payload: Value,
+}
+
+/// One bounded OpenAI provider page.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct OpenAiPage {
+    /// Accepted records after deterministic deduplication.
+    pub records: Vec<OpenAiRecord>,
+    /// Exact provider continuation, unchanged for Go rollback compatibility.
+    pub next_cursor: Option<String>,
+    /// Proposed durable progress; the kernel never commits it.
+    pub proposed_checkpoint: Option<OpenAiCheckpoint>,
+}
+
+impl OpenAiKernel {
+    /// Decode one bounded provider response into canonical records and proposed progress.
+    pub fn decode(
+        &self,
+        input: &super::OpenAiRequestInput,
+        status_code: u16,
+        response_body: &[u8],
+        observed_at_unix_millis: i64,
+    ) -> Result<OpenAiPage, OpenAiError> {
+        super::normalize::decode_page(
+            self,
+            input,
+            status_code,
+            response_body,
+            observed_at_unix_millis,
+        )
+    }
+}

--- a/crates/source-runtime-next/src/openai/tests.rs
+++ b/crates/source-runtime-next/src/openai/tests.rs
@@ -1,0 +1,423 @@
+use std::{collections::BTreeMap, fs, path::PathBuf};
+
+use cerebro_source_catalog::{CollectionAuthority, SourceCatalog};
+use serde_json::{Value, json};
+
+use super::{OpenAiError, OpenAiFamily, OpenAiKernel, OpenAiRequestInput, family::Pagination};
+
+const OBSERVED_AT_MILLIS: i64 = 1_780_272_000_000;
+
+#[test]
+fn closed_family_table_matches_the_go_catalog() {
+    let expected = [
+        "user",
+        "project",
+        "service_account",
+        "api_key",
+        "admin_api_key",
+        "audit_log",
+        "invite",
+        "role",
+        "user_role",
+        "group",
+        "group_user",
+        "group_role",
+        "data_retention",
+        "spend_alert",
+        "certificate",
+        "usage_audio_speech",
+        "usage_audio_transcription",
+        "usage_code_interpreter_session",
+        "usage_completion",
+        "usage_embedding",
+        "usage_image",
+        "usage_moderation",
+        "usage_vector_store",
+        "usage_file_search_call",
+        "usage_web_search_call",
+        "cost",
+        "project_user",
+        "project_user_role",
+        "project_service_account",
+        "project_api_key",
+        "project_rate_limit",
+        "project_model_permission",
+        "project_hosted_tool_permission",
+        "project_group",
+        "project_group_role",
+        "project_role",
+        "project_data_retention",
+        "project_spend_alert",
+        "project_certificate",
+    ];
+    let actual = OpenAiFamily::all()
+        .map(OpenAiFamily::id)
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+    assert_eq!(OpenAiFamily::all().len(), 39);
+    assert_eq!(
+        OpenAiFamily::parse("model"),
+        Err(OpenAiError::UnknownFamily)
+    );
+}
+
+#[test]
+fn connector_catalog_compiles_the_same_closed_authoritative_family_set() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let catalog = SourceCatalog::load(
+        root.join("internal/connectorcatalog/catalog"),
+        root.join("sources"),
+    )
+    .expect("compile source catalog");
+    let source = catalog.get("openai").expect("compiled OpenAI source");
+    assert_eq!(source.authority(), CollectionAuthority::Authoritative);
+    let compiled = source
+        .families()
+        .iter()
+        .map(|family| family.id())
+        .collect::<std::collections::BTreeSet<_>>();
+    let closed = OpenAiFamily::all()
+        .map(OpenAiFamily::id)
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(compiled, closed);
+    assert!(
+        source
+            .families()
+            .iter()
+            .all(|family| family.is_authoritative())
+    );
+}
+
+#[test]
+fn request_plan_is_credential_free_and_origin_restricted() {
+    let kernel = kernel("audit_log", "tenant-a");
+    let input = OpenAiRequestInput {
+        query_parameters: BTreeMap::from([
+            ("effective_at_gte".to_owned(), "1711471533".to_owned()),
+            ("resource_ids".to_owned(), "proj_123".to_owned()),
+        ]),
+        page_size: Some(2),
+        cursor: Some("cursor-2".to_owned()),
+        ..OpenAiRequestInput::default()
+    };
+    let request = kernel.plan(&input).expect("plan request");
+    assert_eq!(request.method, "GET");
+    assert!(
+        request
+            .url
+            .starts_with("https://api.openai.com/v1/organization/audit_logs?")
+    );
+    assert!(request.url.contains("effective_at%5Bgte%5D=1711471533"));
+    assert!(request.url.contains("after=cursor-2"));
+    assert!(request.url.contains("limit=2"));
+    assert!(!request.allow_redirects);
+    assert_eq!(request.max_response_bytes, 8 << 20);
+    assert!(!OpenAiKernel::requires_credentials());
+
+    let protocol = serde_json::to_string(&request).expect("serialize protocol");
+    assert!(protocol.contains("openai.admin_api_key_bearer"));
+    for forbidden in [
+        "credential-material",
+        "api_key\":",
+        "token\":",
+        "client_secret",
+        "cookie\":",
+    ] {
+        assert!(!protocol.to_ascii_lowercase().contains(forbidden));
+    }
+}
+
+#[test]
+fn request_plan_percent_encodes_scope_and_rejects_secret_shaped_inputs() {
+    let project_kernel = kernel("project_user", "tenant-a");
+    let input = OpenAiRequestInput {
+        path_parameters: BTreeMap::from([("project_id".to_owned(), "project/a b".to_owned())]),
+        ..OpenAiRequestInput::default()
+    };
+    let request = project_kernel.plan(&input).expect("plan scoped request");
+    assert!(request.url.contains("/projects/project%2Fa%20b/users"));
+
+    let secret = OpenAiRequestInput {
+        query_parameters: BTreeMap::from([("api_key".to_owned(), "redacted".to_owned())]),
+        ..OpenAiRequestInput::default()
+    };
+    assert_eq!(
+        kernel("user", "tenant-a").plan(&secret),
+        Err(OpenAiError::CredentialMaterialRejected)
+    );
+}
+
+#[test]
+fn singleton_families_have_stable_semantic_identity_and_no_cursor() {
+    let kernel = kernel("project_model_permission", "tenant-a");
+    let input = OpenAiRequestInput {
+        path_parameters: BTreeMap::from([("project_id".to_owned(), "proj_1".to_owned())]),
+        ..OpenAiRequestInput::default()
+    };
+    let page = kernel
+        .decode(
+            &input,
+            200,
+            br#"{"object":"project.model_permissions","mode":"allow","model_ids":["gpt-4o"]}"#,
+            OBSERVED_AT_MILLIS,
+        )
+        .expect("decode singleton");
+    assert_eq!(page.records[0].provider_id, "proj_1:model_permissions");
+    assert_eq!(page.records[0].attributes["project_id"], "proj_1");
+    assert_eq!(page.records[0].attributes["model_ids"], r#"["gpt-4o"]"#);
+    assert_eq!(page.next_cursor, None);
+
+    let cursor_input = OpenAiRequestInput {
+        path_parameters: input.path_parameters,
+        cursor: Some("not-valid-for-singletons".to_owned()),
+        ..OpenAiRequestInput::default()
+    };
+    assert_eq!(kernel.plan(&cursor_input), Err(OpenAiError::InvalidCursor));
+}
+
+#[test]
+fn all_go_projection_fixtures_match_rust_semantics() {
+    for family in OpenAiFamily::all() {
+        let expected = read_fixture(family.id());
+        let expected_event = expected
+            .as_array()
+            .and_then(|events| events.first())
+            .expect("fixture event");
+        let payload = expected_event["payload"].clone();
+        let expected_attributes = expected_event["attributes"]
+            .as_object()
+            .expect("fixture attributes");
+        let input = fixture_input(family, expected_attributes);
+        let response = match family.spec().pagination {
+            Pagination::None => payload,
+            Pagination::Cursor => json!({"data": [payload], "has_more": false}),
+            Pagination::Page => json!({"data": [payload]}),
+        };
+        let bytes = serde_json::to_vec(&response).expect("encode provider response");
+        let page = kernel(family.id(), "tenant")
+            .decode(&input, 200, &bytes, OBSERVED_AT_MILLIS)
+            .unwrap_or_else(|error| panic!("{} fixture failed: {error}", family.id()));
+        assert_eq!(page.records.len(), 1, "{} record count", family.id());
+        let record = &page.records[0];
+        assert_eq!(
+            record.provider_kind,
+            expected_event["kind"].as_str().unwrap()
+        );
+        assert_eq!(
+            record.schema_ref,
+            expected_event["schema_ref"].as_str().unwrap()
+        );
+        assert_eq!(
+            record.source_id,
+            expected_event["source_id"].as_str().unwrap()
+        );
+        assert_eq!(
+            record.tenant_id,
+            expected_event["tenant_id"].as_str().unwrap()
+        );
+        let mut expected_payload = expected_event["payload"].clone();
+        for (parameter, value) in &input.path_parameters {
+            expected_payload
+                .as_object_mut()
+                .expect("fixture payload object")
+                .entry(parameter.clone())
+                .or_insert_with(|| Value::String(value.clone()));
+        }
+        assert_eq!(record.payload, expected_payload);
+        for (key, expected_value) in expected_attributes {
+            assert_eq!(
+                record.attributes.get(key).map(String::as_str),
+                expected_value.as_str(),
+                "{} attribute {key}",
+                family.id()
+            );
+        }
+    }
+}
+
+#[test]
+fn cursor_and_checkpoint_are_bounded_proposals() {
+    let input = OpenAiRequestInput::default();
+    let page = kernel("user", "tenant-a")
+        .decode(
+            &input,
+            200,
+            br#"{"data":[{"id":"user_1","added_at":1711471533}],"has_more":true,"next":"cursor-2"}"#,
+            OBSERVED_AT_MILLIS,
+        )
+        .expect("decode page");
+    assert_eq!(
+        page.records[0].event_id,
+        "openai-tenant-a-0d8a96046d12-user-user_1"
+    );
+    assert_eq!(page.next_cursor.as_deref(), Some("cursor-2"));
+    let checkpoint = page.proposed_checkpoint.expect("checkpoint proposal");
+    assert_eq!(checkpoint.cursor_opaque.as_deref(), Some("cursor-2"));
+    assert_eq!(checkpoint.last_provider_id.as_deref(), Some("user_1"));
+    assert_eq!(checkpoint.watermark_unix_millis, 1_711_471_533_000);
+
+    let invalid = kernel("user", "tenant-a").decode(
+        &input,
+        200,
+        br#"{"data":[],"has_more":true}"#,
+        OBSERVED_AT_MILLIS,
+    );
+    assert_eq!(invalid, Err(OpenAiError::InvalidCursor));
+}
+
+#[test]
+fn interrupted_collection_resumes_without_identity_drift() {
+    let kernel = kernel("user", "tenant-a");
+    let first_input = OpenAiRequestInput::default();
+    let first_body = br#"{"data":[{"id":"user_1"}],"has_more":true,"next":"cursor-2"}"#;
+    let first = kernel
+        .decode(&first_input, 200, first_body, OBSERVED_AT_MILLIS)
+        .expect("first page");
+    let resumed_input = OpenAiRequestInput {
+        cursor: first.next_cursor.clone(),
+        ..OpenAiRequestInput::default()
+    };
+    let resumed_request = kernel.plan(&resumed_input).expect("resume request");
+    assert!(resumed_request.url.contains("after=cursor-2"));
+    let second = kernel
+        .decode(
+            &resumed_input,
+            200,
+            br#"{"data":[{"id":"user_2"}],"has_more":false}"#,
+            OBSERVED_AT_MILLIS + 1,
+        )
+        .expect("resumed page");
+    assert_eq!(second.next_cursor, None);
+    assert_eq!(
+        second
+            .proposed_checkpoint
+            .as_ref()
+            .and_then(|checkpoint| checkpoint.cursor_opaque.as_deref()),
+        None
+    );
+    let replayed = kernel
+        .decode(&first_input, 200, first_body, OBSERVED_AT_MILLIS)
+        .expect("replayed first page");
+    assert_eq!(first.records[0].event_id, replayed.records[0].event_id);
+    assert_ne!(first.records[0].event_id, second.records[0].event_id);
+}
+
+#[test]
+fn duplicate_identity_is_idempotent_but_conflicting_content_fails_closed() {
+    let input = OpenAiRequestInput::default();
+    let duplicate = br#"{"data":[{"id":"user_1","role":"owner"},{"id":"user_1","role":"owner"}],"has_more":false}"#;
+    let page = kernel("user", "tenant-a")
+        .decode(&input, 200, duplicate, OBSERVED_AT_MILLIS)
+        .expect("deduplicate equal records");
+    assert_eq!(page.records.len(), 1);
+
+    let conflict = br#"{"data":[{"id":"user_1","role":"owner"},{"id":"user_1","role":"member"}],"has_more":false}"#;
+    assert_eq!(
+        kernel("user", "tenant-a").decode(&input, 200, conflict, OBSERVED_AT_MILLIS),
+        Err(OpenAiError::DuplicateConflict)
+    );
+}
+
+#[test]
+fn tenant_scope_is_trusted_and_changes_identity() {
+    let input = OpenAiRequestInput {
+        path_parameters: BTreeMap::from([("project_id".to_owned(), "proj_1".to_owned())]),
+        ..OpenAiRequestInput::default()
+    };
+    let bytes = br#"{"data":[{"id":"user_1"}],"has_more":false}"#;
+    let first = kernel("project_user", "tenant-a")
+        .decode(&input, 200, bytes, OBSERVED_AT_MILLIS)
+        .expect("tenant a");
+    let second = kernel("project_user", "tenant-b")
+        .decode(&input, 200, bytes, OBSERVED_AT_MILLIS)
+        .expect("tenant b");
+    assert_ne!(first.records[0].event_id, second.records[0].event_id);
+
+    let contradiction = br#"{"data":[{"id":"user_1","project_id":"proj_other"}],"has_more":false}"#;
+    assert_eq!(
+        kernel("project_user", "tenant-a").decode(&input, 200, contradiction, OBSERVED_AT_MILLIS),
+        Err(OpenAiError::TenantMismatch)
+    );
+}
+
+#[test]
+fn provider_payload_cannot_inject_tenant_or_credential_material() {
+    let input = OpenAiRequestInput::default();
+    let wrong_tenant = br#"{"data":[{"id":"user_1","tenant_id":"tenant-b"}],"has_more":false}"#;
+    assert_eq!(
+        kernel("user", "tenant-a").decode(&input, 200, wrong_tenant, OBSERVED_AT_MILLIS),
+        Err(OpenAiError::TenantMismatch)
+    );
+
+    let credential =
+        br#"{"data":[{"id":"user_1","token":"credential-material"}],"has_more":false}"#;
+    let error = kernel("user", "tenant-a")
+        .decode(&input, 200, credential, OBSERVED_AT_MILLIS)
+        .expect_err("credential-shaped payload must fail closed");
+    assert_eq!(error, OpenAiError::EventContractRejected);
+    assert!(!error.to_string().contains("credential-material"));
+
+    let key_value = br#"{"data":[{"id":"key_1","value":"credential-material"}],"has_more":false}"#;
+    assert_eq!(
+        kernel("api_key", "tenant-a").decode(&input, 200, key_value, OBSERVED_AT_MILLIS),
+        Err(OpenAiError::EventContractRejected)
+    );
+}
+
+#[test]
+fn provider_statuses_remain_distinct_and_response_size_is_bounded() {
+    let kernel = kernel("user", "tenant-a");
+    let input = OpenAiRequestInput::default();
+    for (status, expected) in [
+        (401, OpenAiError::AuthenticationRejected),
+        (403, OpenAiError::PermissionDenied),
+        (429, OpenAiError::RateLimited),
+        (503, OpenAiError::ProviderUnavailable(503)),
+        (418, OpenAiError::UnexpectedStatus(418)),
+    ] {
+        assert_eq!(
+            kernel.decode(&input, status, b"{}", OBSERVED_AT_MILLIS),
+            Err(expected)
+        );
+    }
+    let oversized = vec![b' '; (8 << 20) + 1];
+    assert_eq!(
+        kernel.decode(&input, 200, &oversized, OBSERVED_AT_MILLIS),
+        Err(OpenAiError::ResponseTooLarge)
+    );
+}
+
+fn kernel(family: &str, tenant_id: &str) -> OpenAiKernel {
+    OpenAiKernel::new(
+        OpenAiFamily::parse(family).expect("known family"),
+        tenant_id,
+    )
+    .expect("valid tenant")
+}
+
+fn fixture_input(
+    family: OpenAiFamily,
+    attributes: &serde_json::Map<String, Value>,
+) -> OpenAiRequestInput {
+    let mut path_parameters = BTreeMap::new();
+    for parameter in family.spec().path_parameters {
+        let value = attributes
+            .get(*parameter)
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("{} fixture missing {parameter}", family.id()));
+        path_parameters.insert((*parameter).to_owned(), value.to_owned());
+    }
+    OpenAiRequestInput {
+        path_parameters,
+        ..OpenAiRequestInput::default()
+    }
+}
+
+fn read_fixture(family: &str) -> Value {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../sources/openai/testdata")
+        .join(format!("read_{family}.json"));
+    let bytes = fs::read(&path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    serde_json::from_slice(&bytes)
+        .unwrap_or_else(|error| panic!("decode {}: {error}", path.display()))
+}

--- a/internal/connectorcatalog/catalog/business-data-grc/openai.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/openai.yaml
@@ -1,193 +1,2168 @@
 entries:
-- classifier_output: supported
-  definition:
-    auth:
-      credential_fields:
-      - key: token
-        label: Bearer token
-        reference_only: true
-        required: true
-        secret: true
-      model: bearer_token
-      requires_references: true
-    categories:
-    - saas
-    config_fields:
-    - help: Path parameter inferred from the OpenAPI operation.
-      key: fine_tune_id
-      label: Fine Tune Id
-      required: true
-    description: "Collects event, file, fine tune, and model from OpenAI and projects them into the Cerebro graph as audit events and assets for owner, account, evidence, and compliance context."
-    display_name: OpenAI
-    id: builtin_catalog-openai
-    resource_families:
-    - coverage:
-      - families:
-        - event
-        high_value: true
-        evidence_types:
-        - logging_configuration
-        control_domains:
-        - logging_monitoring
-        id: audit_events
-        support: partial
-        title: Event
-        type: audit_event
-      default_enabled: true
-      event:
-        kind: openai.event
-        required_payload_fields:
-        - created_at
-        schema_ref: openai/event/v1
-        urn_kind: openai_event
-      event_kind: event
-      id: event
-      id_field: created_at
-      label: Event
-      list_key: data
-      method: GET
-      name_field: created_at
-      pagination:
-        type: none
-      path: "/fine-tunes/${config.fine_tune_id}/events"
-      projection:
-        fields:
-          id: created_at
-          name: created_at
-          provider_id: created_at
-        template: audit_event
-      record_selector: "$.data[*]"
-    - coverage:
-      - families:
-        - file
-        id: file
-        support: partial
-        title: File
-        type: entity_family
-      event:
-        kind: openai.file
-        required_payload_fields:
-        - id
-        schema_ref: openai/file/v1
-        urn_kind: openai_file
-      event_kind: file
-      id: file
-      id_field: id
-      label: File
-      list_key: data
-      method: GET
-      name_field: bytes
-      pagination:
-        type: none
-      path: "/files"
-      projection:
-        fields:
-          id: id
-          name: bytes
-          resource_id: id
-          resource_name: bytes
-          resource_type: file
-        template: asset
-      record_selector: "$.data[*]"
-    - coverage:
-      - families:
-        - fine_tune
-        id: fine_tune
-        support: partial
-        title: Fine Tune
-        type: entity_family
-      event:
-        kind: openai.fine_tune
-        required_payload_fields:
-        - id
-        schema_ref: openai/fine_tune/v1
-        urn_kind: openai_fine_tune
-      event_kind: fine_tune
-      id: fine_tune
-      id_field: id
-      label: Fine Tune
-      list_key: data
-      method: GET
-      name_field: created_at
-      pagination:
-        type: none
-      path: "/fine-tunes"
-      projection:
-        fields:
-          id: id
-          name: created_at
-          resource_id: id
-          resource_name: created_at
-          resource_type: fine_tune
-        template: asset
-      record_selector: "$.data[*]"
-    - coverage:
-      - families:
-        - model
-        id: model
-        support: partial
-        title: Model
-        type: entity_family
-      event:
-        kind: openai.model
-        required_payload_fields:
-        - id
-        schema_ref: openai/model/v1
-        urn_kind: openai_model
-      event_kind: model
-      id: model
-      id_field: id
-      label: Model
-      list_key: data
-      method: GET
-      name_field: created
-      pagination:
-        type: none
-      path: "/models"
-      projection:
-        fields:
-          id: id
-          name: created
-          resource_id: id
-          resource_name: created
-          resource_type: model
-        template: asset
-      record_selector: "$.data[*]"
-    schema_version: cerebro.integration/v1
-    scope_options:
-    - default_enabled: true
-      families:
-      - event
-      id: event
-      label: Event
-    - families:
-      - file
-      id: file
-      label: File
-    - families:
-      - fine_tune
-      id: fine_tune
-      label: Fine Tune
-    - families:
-      - model
-      id: model
-      label: Model
-    source_id: openai
-    tenant_id: builtin_catalog
-    transport:
-      base_url: https://api.openai.com/v1
-      retry:
-        backoff: exponential
-        max_attempts: 3
-        retry_after_header: Retry-After
-        statuses:
-        - 429
-        - 500
-        - 502
-        - 503
-        - 504
-      verification:
-        expect_status:
-        - 200
-        method: GET
-        path: "/fine-tunes/${config.fine_tune_id}/events"
+    - classifier_output: supported
+      definition:
+        auth:
+            credential_fields:
+                - key: token
+                  label: OpenAI admin API key reference
+                  reference_only: true
+                  required: true
+                  secret: true
+            model: bearer_token
+            requires_references: true
+        categories:
+            - saas
+            - ai
+        config_fields:
+            - key: actor_emails
+              label: actor emails
+            - key: actor_ids
+              label: actor ids
+            - key: api_key_ids
+              label: api key ids
+            - key: batch
+              label: batch
+            - key: bucket_width
+              label: bucket width
+            - key: effective_at_gt
+              label: effective at gt
+            - key: effective_at_gte
+              label: effective at gte
+            - key: effective_at_lt
+              label: effective at lt
+            - key: effective_at_lte
+              label: effective at lte
+            - key: end_time
+              label: end time
+            - key: event_types
+              label: event types
+            - key: group_by
+              label: group by
+            - key: group_id
+              label: group id
+            - key: models
+              label: models
+            - key: project_id
+              label: project id
+            - key: project_ids
+              label: project ids
+            - key: resource_ids
+              label: resource ids
+            - key: start_time
+              label: start time
+            - key: tenant_only
+              label: tenant only
+            - key: user_id
+              label: user id
+            - key: user_ids
+              label: user ids
+        description: Collects OpenAI organization governance, access, projects, credentials, usage, costs, retention, spend controls, certificates, rate limits, and model and tool permissions.
+        display_name: OpenAI
+        id: builtin_catalog-openai
+        resource_families:
+            - coverage:
+                - families:
+                    - user
+                  high_value: false
+                  id: user
+                  support: supported
+                  title: user
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.user
+                required_attributes:
+                    - user_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/user/v1
+                urn_kind: openai_user
+              id: user
+              id_field: id
+              label: user
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/users
+              projection:
+                fields:
+                    added_at: added_at
+                    email: email
+                    name: name
+                    role: role
+                    status: status
+                    user_id: id
+                static_fields:
+                    source_product: openai
+                template: identity_user
+              record_selector: $.data[*]
+            - coverage:
+                - families:
+                    - project
+                  high_value: false
+                  id: project
+                  support: supported
+                  title: project
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.project
+                required_attributes:
+                    - project_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/project/v1
+                urn_kind: openai_project
+              id: project
+              id_field: id
+              label: project
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/projects
+              projection:
+                fields:
+                    archived_at: archived_at
+                    created_at: created_at
+                    external_key_id: external_key_id
+                    name: name
+                    project_id: id
+                    status: status
+                static_fields:
+                    source_product: openai
+                template: asset
+              record_selector: $.data[*]
+            - coverage:
+                - families:
+                    - service_account
+                  high_value: false
+                  id: service_account
+                  support: supported
+                  title: service account
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.service_account
+                required_attributes:
+                    - service_account_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/service_account/v1
+                urn_kind: openai_service_account
+              id: service_account
+              id_field: id
+              label: service account
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/projects/default/service_accounts
+              projection:
+                fields:
+                    created_at: created_at
+                    name: name
+                    project_id: project_id
+                    role: role
+                    service_account_id: id
+                static_fields:
+                    source_product: openai
+                template: identity_application
+              record_selector: $.data[*]
+            - coverage:
+                - families:
+                    - api_key
+                  high_value: false
+                  id: api_key
+                  support: supported
+                  title: api key
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.api_key
+                required_attributes:
+                    - api_key_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/api_key/v1
+                urn_kind: openai_api_key
+              id: api_key
+              id_field: id
+              label: api key
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/projects/default/api_keys
+              projection:
+                fields:
+                    api_key_id: id
+                    created_at: created_at
+                    last_used_at: last_used_at
+                    name: name
+                    owner_service_account_id: owner.service_account.id
+                    owner_type: owner.type
+                    owner_user_id: owner.user.id
+                    project_id: project_id
+                    status: status
+                static_fields:
+                    source_product: openai
+                template: secret
+              record_selector: $.data[*]
+            - coverage:
+                - families:
+                    - admin_api_key
+                  high_value: false
+                  id: admin_api_key
+                  support: supported
+                  title: admin api key
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.admin_api_key
+                required_attributes:
+                    - api_key_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/admin_api_key/v1
+                urn_kind: openai_admin_api_key
+              id: admin_api_key
+              id_field: id
+              label: admin api key
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/admin_api_keys
+              projection:
+                fields:
+                    api_key_id: id
+                    created_at: created_at
+                    last_used_at: last_used_at
+                    name: name
+                    owner_id: owner.id
+                    owner_name: owner.name
+                    owner_object: owner.object
+                    owner_role: owner.role
+                    owner_type: owner.type
+                    status: status
+                static_fields:
+                    key_class: admin
+                    privileged: "true"
+                    source_product: openai
+                template: secret
+              record_selector: $.data[*]
+            - config_query:
+                actor_emails: actor_emails
+                actor_ids: actor_ids
+                effective_at[gt]: effective_at_gt
+                effective_at[gte]: effective_at_gte
+                effective_at[lt]: effective_at_lt
+                effective_at[lte]: effective_at_lte
+                event_types: event_types
+                project_ids: project_ids
+                resource_ids: resource_ids
+                tenant_only: tenant_only
+              coverage:
+                - families:
+                    - audit_log
+                  control_domains:
+                    - logging_monitoring
+                  evidence_types:
+                    - logging_configuration
+                  high_value: true
+                  id: audit_log
+                  support: supported
+                  title: audit log
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.audit_log
+                required_attributes:
+                    - audit_log_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/audit_log/v1
+                urn_kind: openai_audit_log
+              id: audit_log
+              id_field: id
+              label: audit log
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/audit_logs
+              projection:
+                fields:
+                    actor_api_key_id: actor.api_key.id
+                    actor_city: actor.session.ip_address_details.city
+                    actor_country: actor.session.ip_address_details.country
+                    actor_email: actor.session.user.email|actor.api_key.user.email|actor.user.email|actor.email
+                    actor_id: actor.session.user.id|actor.api_key.user.id|actor.api_key.service_account.id|actor.api_key.id|actor.user.id|actor.service_account.id|actor.id
+                    actor_ip_address: actor.session.ip_address
+                    actor_region: actor.session.ip_address_details.region
+                    actor_service_account_id: actor.api_key.service_account.id|actor.service_account.id
+                    actor_type: actor.type|actor.api_key.type
+                    actor_user_agent: actor.session.user_agent
+                    actor_user_id: actor.session.user.id|actor.api_key.user.id|actor.user.id
+                    api_key_id: api_key.created.id|api_key.updated.id|api_key.deleted.id|api_key.id|api_key_id
+                    audit_log_id: id
+                    certificate_id: certificate.created.id|certificate.updated.id|certificate.deleted.id
+                    certificate_name: certificate.created.name|certificate.updated.name|certificate.deleted.name
+                    effective_at: effective_at
+                    event_type: type|event_type
+                    external_key_id: external_key.registered.id|external_key.removed.id
+                    group_id: group.created.id|group.updated.id|group.deleted.id
+                    group_name: group.created.data.group_name|group.updated.changes_requested.group_name
+                    invite_email: invite.sent.data.email
+                    invite_id: invite.sent.id|invite.accepted.id|invite.deleted.id
+                    invite_role: invite.sent.data.role
+                    ip_allowlist_id: ip_allowlist.created.id|ip_allowlist.updated.id|ip_allowlist.deleted.id
+                    ip_allowlist_name: ip_allowlist.created.name|ip_allowlist.deleted.name
+                    organization_id: organization.updated.id|organization_id|org_id
+                    principal_id: role.assignment.created.principal_id|role.assignment.deleted.principal_id
+                    principal_type: role.assignment.created.principal_type|role.assignment.deleted.principal_type
+                    project_id: project.created.id|project.updated.id|project.archived.id|project.deleted.id|checkpoint.permission.created.data.project_id|project.id|project_id
+                    rate_limit_id: rate_limit.updated.id|rate_limit.deleted.id
+                    resource_id: role.assignment.created.resource_id|role.assignment.deleted.resource_id|role.bound_to_resource.resource_id|role.unbound_from_resource.resource_id|resource.deleted.id
+                    resource_type: role.assignment.created.resource_type|role.assignment.deleted.resource_type|role.bound_to_resource.resource_type|role.unbound_from_resource.resource_type|resource.deleted.type
+                    role_assignment_id: role.assignment.created.id|role.assignment.deleted.id
+                    role_id: role.created.id|role.updated.id|role.deleted.id|role.bound_to_resource.role_id|role.unbound_from_resource.role_id
+                    role_name: role.created.data.role_name|role.updated.changes_requested.role_name|role.bound_to_resource.role_name|role.unbound_from_resource.role_name
+                    service_account_id: service_account.created.id|service_account.updated.id|service_account.deleted.id
+                    user_id: user.added.id|user.updated.id|user.deleted.id
+                static_fields:
+                    source_product: openai
+                template: audit_event
+              record_selector: $.data[*]
+            - coverage:
+                - families:
+                    - invite
+                  high_value: false
+                  id: invite
+                  support: supported
+                  title: invite
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.invite
+                required_attributes:
+                    - invite_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/invite/v1
+                urn_kind: openai_invite
+              id: invite
+              id_field: id
+              label: invite
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/invites
+              projection:
+                fields:
+                    accepted_at: accepted_at
+                    created_at: created_at
+                    email: email
+                    expires_at: expires_at
+                    invite_id: id
+                    projects: projects
+                    role: role
+                    status: status
+                static_fields:
+                    source_product: openai
+                template: identity_user
+              record_selector: $.data[*]
+            - coverage:
+                - families:
+                    - role
+                  high_value: false
+                  id: role
+                  support: supported
+                  title: role
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.role
+                required_attributes:
+                    - role_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/role/v1
+                urn_kind: openai_role
+              id: role
+              id_field: id
+              label: role
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/roles
+              projection:
+                fields:
+                    created_at: created_at
+                    created_by: created_by
+                    description: description
+                    name: name
+                    permissions: permissions
+                    predefined_role: predefined_role
+                    resource_type: resource_type
+                    role_id: id
+                    updated_at: updated_at
+                static_fields:
+                    source_product: openai
+                template: policy
+              record_selector: $.data[*]
+            - config:
+                config_attributes:
+                    user_id: user_id
+              coverage:
+                - families:
+                    - user_role
+                  high_value: false
+                  id: user_role
+                  support: supported
+                  title: user role
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.user_role
+                required_attributes:
+                    - role_id
+                    - user_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/user_role/v1
+                urn_kind: openai_user_role
+              id: user_role
+              id_field: id
+              label: user role
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/users/{user_id}/roles
+              projection:
+                fields:
+                    created_at: created_at
+                    created_by: created_by
+                    description: description
+                    name: name
+                    permissions: permissions
+                    predefined_role: predefined_role
+                    resource_type: resource_type
+                    role_id: id
+                    updated_at: updated_at
+                static_fields:
+                    source_product: openai
+                template: policy
+              read:
+                path_params:
+                    - user_id
+              record_selector: $.data[*]
+            - coverage:
+                - families:
+                    - group
+                  high_value: false
+                  id: group
+                  support: supported
+                  title: group
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.group
+                required_attributes:
+                    - group_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/group/v1
+                urn_kind: openai_group
+              id: group
+              id_field: id
+              label: group
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/groups
+              projection:
+                fields:
+                    created_at: created_at
+                    group_id: id
+                    name: name
+                    updated_at: updated_at
+                static_fields:
+                    source_product: openai
+                template: identity_group
+              record_selector: $.data[*]
+            - config:
+                config_attributes:
+                    group_id: group_id
+              coverage:
+                - families:
+                    - group_user
+                  high_value: false
+                  id: group_user
+                  support: supported
+                  title: group user
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.group_user
+                required_attributes:
+                    - group_id
+                    - user_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/group_user/v1
+                urn_kind: openai_group_user
+              id: group_user
+              id_field: id|user_id
+              label: group user
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/groups/{group_id}/users
+              projection:
+                fields:
+                    added_at: added_at
+                    email: email
+                    group_id: group_id
+                    name: name
+                    role: role
+                    user_id: id|user_id
+                static_fields:
+                    source_product: openai
+                template: group_membership
+              read:
+                path_params:
+                    - group_id
+              record_selector: $.data[*]
+            - config:
+                config_attributes:
+                    group_id: group_id
+              coverage:
+                - families:
+                    - group_role
+                  high_value: false
+                  id: group_role
+                  support: supported
+                  title: group role
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.group_role
+                required_attributes:
+                    - group_id
+                    - role_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/group_role/v1
+                urn_kind: openai_group_role
+              id: group_role
+              id_field: id
+              label: group role
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/groups/{group_id}/roles
+              projection:
+                fields:
+                    created_at: created_at
+                    created_by: created_by
+                    description: description
+                    name: name
+                    permissions: permissions
+                    predefined_role: predefined_role
+                    resource_type: resource_type
+                    role_id: id
+                    updated_at: updated_at
+                static_fields:
+                    source_product: openai
+                template: policy
+              read:
+                path_params:
+                    - group_id
+              record_selector: $.data[*]
+            - config:
+                id_template: organization:data_retention
+              coverage:
+                - families:
+                    - data_retention
+                  high_value: false
+                  id: data_retention
+                  support: supported
+                  title: data retention
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.data_retention
+                required_attributes:
+                    - external_id
+                schema_ref: openai/data_retention/v1
+                urn_kind: openai_data_retention
+              id: data_retention
+              id_field: id
+              label: data retention
+              method: GET
+              pagination:
+                disable_page_size: true
+                type: none
+              path: /organization/data_retention
+              projection:
+                fields:
+                    object: object
+                    retention_type: type
+                static_fields:
+                    source_product: openai
+                template: policy
+              read:
+                disable_page_size: true
+                singleton: true
+                singleton_fallback_id: data_retention
+              record_selector: $
+              singleton: true
+            - coverage:
+                - families:
+                    - spend_alert
+                  high_value: false
+                  id: spend_alert
+                  support: supported
+                  title: spend alert
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.spend_alert
+                required_attributes:
+                    - spend_alert_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/spend_alert/v1
+                urn_kind: openai_spend_alert
+              id: spend_alert
+              id_field: id
+              label: spend alert
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/spend_alerts
+              projection:
+                fields:
+                    created_at: created_at
+                    name: name
+                    spend_alert_id: id
+                    status: status
+                    threshold: threshold
+                    threshold_amount: threshold_amount
+                    updated_at: updated_at
+                static_fields:
+                    source_product: openai
+                template: alert
+              record_selector: $.data[*]
+            - coverage:
+                - families:
+                    - certificate
+                  high_value: false
+                  id: certificate
+                  support: supported
+                  title: certificate
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.certificate
+                required_attributes:
+                    - certificate_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/certificate/v1
+                urn_kind: openai_certificate
+              id: certificate
+              id_field: id
+              label: certificate
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/certificates
+              projection:
+                fields:
+                    active: active
+                    certificate_id: id
+                    created_at: created_at
+                    expires_at: certificate_details.expires_at
+                    name: name
+                    valid_at: certificate_details.valid_at
+                static_fields:
+                    source_product: openai
+                template: asset
+              record_selector: $.data[*]
+            - config_query:
+                api_key_ids: api_key_ids
+                batch: batch
+                bucket_width: bucket_width
+                end_time: end_time
+                group_by: group_by
+                models: models
+                project_ids: project_ids
+                start_time: start_time
+                user_ids: user_ids
+              coverage:
+                - families:
+                    - usage_audio_speech
+                  high_value: false
+                  id: usage_audio_speech
+                  support: supported
+                  title: usage audio speech
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.usage_audio_speech
+                required_attributes:
+                    - external_id
+                schema_ref: openai/usage_audio_speech/v1
+                urn_kind: openai_usage_audio_speech
+              id: usage_audio_speech
+              id_field: id
+              label: usage audio speech
+              method: GET
+              pagination:
+                cursor_json_path: $.next_page
+                cursor_param: page
+                next_cursor_keys:
+                    - next_page
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/usage/audio_speeches
+              projection:
+                fields:
+                    amount_currency: amount.currency
+                    amount_value: amount.value|amount
+                    api_key_id: api_key_id
+                    end_time: end_time
+                    input_tokens: results.input_tokens.__sum|input_tokens
+                    line_item: line_item
+                    model: model
+                    num_model_requests: results.num_model_requests.__sum|num_model_requests
+                    organization_object: object
+                    output_tokens: results.output_tokens.__sum|output_tokens
+                    project_id: project_id
+                    result_count: results.__count
+                    start_time: start_time
+                    user_id: user_id
+                static_fields:
+                    source_product: openai
+                template: asset
+              record_selector: $.data[*]
+            - config_query:
+                api_key_ids: api_key_ids
+                batch: batch
+                bucket_width: bucket_width
+                end_time: end_time
+                group_by: group_by
+                models: models
+                project_ids: project_ids
+                start_time: start_time
+                user_ids: user_ids
+              coverage:
+                - families:
+                    - usage_audio_transcription
+                  high_value: false
+                  id: usage_audio_transcription
+                  support: supported
+                  title: usage audio transcription
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.usage_audio_transcription
+                required_attributes:
+                    - external_id
+                schema_ref: openai/usage_audio_transcription/v1
+                urn_kind: openai_usage_audio_transcription
+              id: usage_audio_transcription
+              id_field: id
+              label: usage audio transcription
+              method: GET
+              pagination:
+                cursor_json_path: $.next_page
+                cursor_param: page
+                next_cursor_keys:
+                    - next_page
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/usage/audio_transcriptions
+              projection:
+                fields:
+                    amount_currency: amount.currency
+                    amount_value: amount.value|amount
+                    api_key_id: api_key_id
+                    end_time: end_time
+                    input_tokens: results.input_tokens.__sum|input_tokens
+                    line_item: line_item
+                    model: model
+                    num_model_requests: results.num_model_requests.__sum|num_model_requests
+                    organization_object: object
+                    output_tokens: results.output_tokens.__sum|output_tokens
+                    project_id: project_id
+                    result_count: results.__count
+                    start_time: start_time
+                    user_id: user_id
+                static_fields:
+                    source_product: openai
+                template: asset
+              record_selector: $.data[*]
+            - config_query:
+                api_key_ids: api_key_ids
+                batch: batch
+                bucket_width: bucket_width
+                end_time: end_time
+                group_by: group_by
+                models: models
+                project_ids: project_ids
+                start_time: start_time
+                user_ids: user_ids
+              coverage:
+                - families:
+                    - usage_code_interpreter_session
+                  high_value: false
+                  id: usage_code_interpreter_session
+                  support: supported
+                  title: usage code interpreter session
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.usage_code_interpreter_session
+                required_attributes:
+                    - external_id
+                schema_ref: openai/usage_code_interpreter_session/v1
+                urn_kind: openai_usage_code_interpreter_session
+              id: usage_code_interpreter_session
+              id_field: id
+              label: usage code interpreter session
+              method: GET
+              pagination:
+                cursor_json_path: $.next_page
+                cursor_param: page
+                next_cursor_keys:
+                    - next_page
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/usage/code_interpreter_sessions
+              projection:
+                fields:
+                    amount_currency: amount.currency
+                    amount_value: amount.value|amount
+                    api_key_id: api_key_id
+                    end_time: end_time
+                    input_tokens: results.input_tokens.__sum|input_tokens
+                    line_item: line_item
+                    model: model
+                    num_model_requests: results.num_model_requests.__sum|num_model_requests
+                    organization_object: object
+                    output_tokens: results.output_tokens.__sum|output_tokens
+                    project_id: project_id
+                    result_count: results.__count
+                    start_time: start_time
+                    user_id: user_id
+                static_fields:
+                    source_product: openai
+                template: asset
+              record_selector: $.data[*]
+            - config_query:
+                api_key_ids: api_key_ids
+                batch: batch
+                bucket_width: bucket_width
+                end_time: end_time
+                group_by: group_by
+                models: models
+                project_ids: project_ids
+                start_time: start_time
+                user_ids: user_ids
+              coverage:
+                - families:
+                    - usage_completion
+                  high_value: false
+                  id: usage_completion
+                  support: supported
+                  title: usage completion
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.usage_completion
+                required_attributes:
+                    - external_id
+                schema_ref: openai/usage_completion/v1
+                urn_kind: openai_usage_completion
+              id: usage_completion
+              id_field: id
+              label: usage completion
+              method: GET
+              pagination:
+                cursor_json_path: $.next_page
+                cursor_param: page
+                next_cursor_keys:
+                    - next_page
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/usage/completions
+              projection:
+                fields:
+                    amount_currency: amount.currency
+                    amount_value: amount.value|amount
+                    api_key_id: api_key_id
+                    end_time: end_time
+                    input_tokens: results.input_tokens.__sum|input_tokens
+                    line_item: line_item
+                    model: model
+                    num_model_requests: results.num_model_requests.__sum|num_model_requests
+                    organization_object: object
+                    output_tokens: results.output_tokens.__sum|output_tokens
+                    project_id: project_id
+                    result_count: results.__count
+                    start_time: start_time
+                    user_id: user_id
+                static_fields:
+                    source_product: openai
+                template: asset
+              record_selector: $.data[*]
+            - config_query:
+                api_key_ids: api_key_ids
+                batch: batch
+                bucket_width: bucket_width
+                end_time: end_time
+                group_by: group_by
+                models: models
+                project_ids: project_ids
+                start_time: start_time
+                user_ids: user_ids
+              coverage:
+                - families:
+                    - usage_embedding
+                  high_value: false
+                  id: usage_embedding
+                  support: supported
+                  title: usage embedding
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.usage_embedding
+                required_attributes:
+                    - external_id
+                schema_ref: openai/usage_embedding/v1
+                urn_kind: openai_usage_embedding
+              id: usage_embedding
+              id_field: id
+              label: usage embedding
+              method: GET
+              pagination:
+                cursor_json_path: $.next_page
+                cursor_param: page
+                next_cursor_keys:
+                    - next_page
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/usage/embeddings
+              projection:
+                fields:
+                    amount_currency: amount.currency
+                    amount_value: amount.value|amount
+                    api_key_id: api_key_id
+                    end_time: end_time
+                    input_tokens: results.input_tokens.__sum|input_tokens
+                    line_item: line_item
+                    model: model
+                    num_model_requests: results.num_model_requests.__sum|num_model_requests
+                    organization_object: object
+                    output_tokens: results.output_tokens.__sum|output_tokens
+                    project_id: project_id
+                    result_count: results.__count
+                    start_time: start_time
+                    user_id: user_id
+                static_fields:
+                    source_product: openai
+                template: asset
+              record_selector: $.data[*]
+            - config_query:
+                api_key_ids: api_key_ids
+                batch: batch
+                bucket_width: bucket_width
+                end_time: end_time
+                group_by: group_by
+                models: models
+                project_ids: project_ids
+                start_time: start_time
+                user_ids: user_ids
+              coverage:
+                - families:
+                    - usage_image
+                  high_value: false
+                  id: usage_image
+                  support: supported
+                  title: usage image
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.usage_image
+                required_attributes:
+                    - external_id
+                schema_ref: openai/usage_image/v1
+                urn_kind: openai_usage_image
+              id: usage_image
+              id_field: id
+              label: usage image
+              method: GET
+              pagination:
+                cursor_json_path: $.next_page
+                cursor_param: page
+                next_cursor_keys:
+                    - next_page
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/usage/images
+              projection:
+                fields:
+                    amount_currency: amount.currency
+                    amount_value: amount.value|amount
+                    api_key_id: api_key_id
+                    end_time: end_time
+                    input_tokens: results.input_tokens.__sum|input_tokens
+                    line_item: line_item
+                    model: model
+                    num_model_requests: results.num_model_requests.__sum|num_model_requests
+                    organization_object: object
+                    output_tokens: results.output_tokens.__sum|output_tokens
+                    project_id: project_id
+                    result_count: results.__count
+                    start_time: start_time
+                    user_id: user_id
+                static_fields:
+                    source_product: openai
+                template: asset
+              record_selector: $.data[*]
+            - config_query:
+                api_key_ids: api_key_ids
+                batch: batch
+                bucket_width: bucket_width
+                end_time: end_time
+                group_by: group_by
+                models: models
+                project_ids: project_ids
+                start_time: start_time
+                user_ids: user_ids
+              coverage:
+                - families:
+                    - usage_moderation
+                  high_value: false
+                  id: usage_moderation
+                  support: supported
+                  title: usage moderation
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.usage_moderation
+                required_attributes:
+                    - external_id
+                schema_ref: openai/usage_moderation/v1
+                urn_kind: openai_usage_moderation
+              id: usage_moderation
+              id_field: id
+              label: usage moderation
+              method: GET
+              pagination:
+                cursor_json_path: $.next_page
+                cursor_param: page
+                next_cursor_keys:
+                    - next_page
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/usage/moderations
+              projection:
+                fields:
+                    amount_currency: amount.currency
+                    amount_value: amount.value|amount
+                    api_key_id: api_key_id
+                    end_time: end_time
+                    input_tokens: results.input_tokens.__sum|input_tokens
+                    line_item: line_item
+                    model: model
+                    num_model_requests: results.num_model_requests.__sum|num_model_requests
+                    organization_object: object
+                    output_tokens: results.output_tokens.__sum|output_tokens
+                    project_id: project_id
+                    result_count: results.__count
+                    start_time: start_time
+                    user_id: user_id
+                static_fields:
+                    source_product: openai
+                template: asset
+              record_selector: $.data[*]
+            - config_query:
+                api_key_ids: api_key_ids
+                batch: batch
+                bucket_width: bucket_width
+                end_time: end_time
+                group_by: group_by
+                models: models
+                project_ids: project_ids
+                start_time: start_time
+                user_ids: user_ids
+              coverage:
+                - families:
+                    - usage_vector_store
+                  high_value: false
+                  id: usage_vector_store
+                  support: supported
+                  title: usage vector store
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.usage_vector_store
+                required_attributes:
+                    - external_id
+                schema_ref: openai/usage_vector_store/v1
+                urn_kind: openai_usage_vector_store
+              id: usage_vector_store
+              id_field: id
+              label: usage vector store
+              method: GET
+              pagination:
+                cursor_json_path: $.next_page
+                cursor_param: page
+                next_cursor_keys:
+                    - next_page
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/usage/vector_stores
+              projection:
+                fields:
+                    amount_currency: amount.currency
+                    amount_value: amount.value|amount
+                    api_key_id: api_key_id
+                    end_time: end_time
+                    input_tokens: results.input_tokens.__sum|input_tokens
+                    line_item: line_item
+                    model: model
+                    num_model_requests: results.num_model_requests.__sum|num_model_requests
+                    organization_object: object
+                    output_tokens: results.output_tokens.__sum|output_tokens
+                    project_id: project_id
+                    result_count: results.__count
+                    start_time: start_time
+                    user_id: user_id
+                static_fields:
+                    source_product: openai
+                template: asset
+              record_selector: $.data[*]
+            - config_query:
+                api_key_ids: api_key_ids
+                batch: batch
+                bucket_width: bucket_width
+                end_time: end_time
+                group_by: group_by
+                models: models
+                project_ids: project_ids
+                start_time: start_time
+                user_ids: user_ids
+              coverage:
+                - families:
+                    - usage_file_search_call
+                  high_value: false
+                  id: usage_file_search_call
+                  support: supported
+                  title: usage file search call
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.usage_file_search_call
+                required_attributes:
+                    - external_id
+                schema_ref: openai/usage_file_search_call/v1
+                urn_kind: openai_usage_file_search_call
+              id: usage_file_search_call
+              id_field: id
+              label: usage file search call
+              method: GET
+              pagination:
+                cursor_json_path: $.next_page
+                cursor_param: page
+                next_cursor_keys:
+                    - next_page
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/usage/file_search_calls
+              projection:
+                fields:
+                    amount_currency: amount.currency
+                    amount_value: amount.value|amount
+                    api_key_id: api_key_id
+                    end_time: end_time
+                    input_tokens: results.input_tokens.__sum|input_tokens
+                    line_item: line_item
+                    model: model
+                    num_model_requests: results.num_model_requests.__sum|num_model_requests
+                    organization_object: object
+                    output_tokens: results.output_tokens.__sum|output_tokens
+                    project_id: project_id
+                    result_count: results.__count
+                    start_time: start_time
+                    user_id: user_id
+                static_fields:
+                    source_product: openai
+                template: asset
+              record_selector: $.data[*]
+            - config_query:
+                api_key_ids: api_key_ids
+                batch: batch
+                bucket_width: bucket_width
+                end_time: end_time
+                group_by: group_by
+                models: models
+                project_ids: project_ids
+                start_time: start_time
+                user_ids: user_ids
+              coverage:
+                - families:
+                    - usage_web_search_call
+                  high_value: false
+                  id: usage_web_search_call
+                  support: supported
+                  title: usage web search call
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.usage_web_search_call
+                required_attributes:
+                    - external_id
+                schema_ref: openai/usage_web_search_call/v1
+                urn_kind: openai_usage_web_search_call
+              id: usage_web_search_call
+              id_field: id
+              label: usage web search call
+              method: GET
+              pagination:
+                cursor_json_path: $.next_page
+                cursor_param: page
+                next_cursor_keys:
+                    - next_page
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/usage/web_search_calls
+              projection:
+                fields:
+                    amount_currency: amount.currency
+                    amount_value: amount.value|amount
+                    api_key_id: api_key_id
+                    end_time: end_time
+                    input_tokens: results.input_tokens.__sum|input_tokens
+                    line_item: line_item
+                    model: model
+                    num_model_requests: results.num_model_requests.__sum|num_model_requests
+                    organization_object: object
+                    output_tokens: results.output_tokens.__sum|output_tokens
+                    project_id: project_id
+                    result_count: results.__count
+                    start_time: start_time
+                    user_id: user_id
+                static_fields:
+                    source_product: openai
+                template: asset
+              record_selector: $.data[*]
+            - config_query:
+                api_key_ids: api_key_ids
+                batch: batch
+                bucket_width: bucket_width
+                end_time: end_time
+                group_by: group_by
+                models: models
+                project_ids: project_ids
+                start_time: start_time
+                user_ids: user_ids
+              coverage:
+                - families:
+                    - cost
+                  high_value: false
+                  id: cost
+                  support: supported
+                  title: cost
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.cost
+                required_attributes:
+                    - external_id
+                schema_ref: openai/cost/v1
+                urn_kind: openai_cost
+              id: cost
+              id_field: id
+              label: cost
+              method: GET
+              pagination:
+                cursor_json_path: $.next_page
+                cursor_param: page
+                next_cursor_keys:
+                    - next_page
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/costs
+              projection:
+                fields:
+                    amount_currency: amount.currency
+                    amount_value: amount.value|amount
+                    api_key_id: api_key_id
+                    end_time: end_time
+                    input_tokens: results.input_tokens.__sum|input_tokens
+                    line_item: line_item
+                    model: model
+                    num_model_requests: results.num_model_requests.__sum|num_model_requests
+                    organization_object: object
+                    output_tokens: results.output_tokens.__sum|output_tokens
+                    project_id: project_id
+                    result_count: results.__count
+                    start_time: start_time
+                    user_id: user_id
+                static_fields:
+                    source_product: openai
+                template: asset
+              record_selector: $.data[*]
+            - config:
+                config_attributes:
+                    project_id: project_id
+              coverage:
+                - families:
+                    - project_user
+                  high_value: false
+                  id: project_user
+                  support: supported
+                  title: project user
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.project_user
+                required_attributes:
+                    - project_id
+                    - user_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/project_user/v1
+                urn_kind: openai_project_user
+              id: project_user
+              id_field: id|user_id
+              label: project user
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/projects/{project_id}/users
+              projection:
+                fields:
+                    added_at: added_at
+                    email: email
+                    name: name
+                    project_id: project_id
+                    role: role
+                    user_id: id|user_id
+                static_fields:
+                    source_product: openai
+                template: group_membership
+              read:
+                path_params:
+                    - project_id
+              record_selector: $.data[*]
+            - config:
+                config_attributes:
+                    project_id: project_id
+                    user_id: user_id
+              coverage:
+                - families:
+                    - project_user_role
+                  high_value: false
+                  id: project_user_role
+                  support: supported
+                  title: project user role
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.project_user_role
+                required_attributes:
+                    - project_id
+                    - role_id
+                    - user_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/project_user_role/v1
+                urn_kind: openai_project_user_role
+              id: project_user_role
+              id_field: id
+              label: project user role
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /projects/{project_id}/users/{user_id}/roles
+              projection:
+                fields:
+                    created_at: created_at
+                    created_by: created_by
+                    description: description
+                    name: name
+                    permissions: permissions
+                    predefined_role: predefined_role
+                    resource_type: resource_type
+                    role_id: id
+                    updated_at: updated_at
+                static_fields:
+                    source_product: openai
+                template: policy
+              read:
+                path_params:
+                    - project_id
+                    - user_id
+              record_selector: $.data[*]
+            - config:
+                config_attributes:
+                    project_id: project_id
+              coverage:
+                - families:
+                    - project_service_account
+                  high_value: false
+                  id: project_service_account
+                  support: supported
+                  title: project service account
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.project_service_account
+                required_attributes:
+                    - project_id
+                    - service_account_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/project_service_account/v1
+                urn_kind: openai_project_service_account
+              id: project_service_account
+              id_field: id
+              label: project service account
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/projects/{project_id}/service_accounts
+              projection:
+                fields:
+                    created_at: created_at
+                    name: name
+                    project_id: project_id
+                    role: role
+                    service_account_id: id
+                static_fields:
+                    source_product: openai
+                template: identity_application
+              read:
+                path_params:
+                    - project_id
+              record_selector: $.data[*]
+            - config:
+                config_attributes:
+                    project_id: project_id
+              coverage:
+                - families:
+                    - project_api_key
+                  high_value: false
+                  id: project_api_key
+                  support: supported
+                  title: project api key
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.project_api_key
+                required_attributes:
+                    - api_key_id
+                    - project_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/project_api_key/v1
+                urn_kind: openai_project_api_key
+              id: project_api_key
+              id_field: id
+              label: project api key
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/projects/{project_id}/api_keys
+              projection:
+                fields:
+                    api_key_id: id
+                    created_at: created_at
+                    last_used_at: last_used_at
+                    name: name
+                    owner_service_account_id: owner.service_account.id
+                    owner_type: owner.type
+                    owner_user_id: owner.user.id
+                    project_id: project_id
+                    status: status
+                static_fields:
+                    source_product: openai
+                template: secret
+              read:
+                path_params:
+                    - project_id
+              record_selector: $.data[*]
+            - config:
+                config_attributes:
+                    project_id: project_id
+              coverage:
+                - families:
+                    - project_rate_limit
+                  high_value: false
+                  id: project_rate_limit
+                  support: supported
+                  title: project rate limit
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.project_rate_limit
+                required_attributes:
+                    - external_id
+                    - project_id
+                schema_ref: openai/project_rate_limit/v1
+                urn_kind: openai_project_rate_limit
+              id: project_rate_limit
+              id_field: id|model
+              label: project rate limit
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/projects/{project_id}/rate_limits
+              projection:
+                fields:
+                    batch_1_day_max_input_tokens: batch_1_day_max_input_tokens
+                    max_images_per_1_minute: max_images_per_1_minute
+                    max_requests_per_1_day: max_requests_per_1_day
+                    max_requests_per_1_minute: max_requests_per_1_minute
+                    max_tokens_per_1_minute: max_tokens_per_1_minute
+                    model: model
+                    project_id: project_id
+                    rate_limit_id: id
+                    created_at: created_at
+                    updated_at: updated_at
+                static_fields:
+                    source_product: openai
+                template: policy
+              read:
+                path_params:
+                    - project_id
+              record_selector: $.data[*]
+            - config:
+                config_attributes:
+                    project_id: project_id
+                id_template: ${project_id}:model_permissions
+              coverage:
+                - families:
+                    - project_model_permission
+                  high_value: false
+                  id: project_model_permission
+                  support: supported
+                  title: project model permission
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.project_model_permission
+                required_attributes:
+                    - external_id
+                    - project_id
+                schema_ref: openai/project_model_permission/v1
+                urn_kind: openai_project_model_permission
+              id: project_model_permission
+              id_field: id
+              label: project model permission
+              method: GET
+              pagination:
+                disable_page_size: true
+                type: none
+              path: /organization/projects/{project_id}/model_permissions
+              projection:
+                fields:
+                    mode: mode
+                    model_ids: model_ids
+                    project_id: project_id
+                static_fields:
+                    source_product: openai
+                template: policy
+              read:
+                disable_page_size: true
+                path_params:
+                    - project_id
+                singleton: true
+                singleton_fallback_id: project_model_permission
+              record_selector: $
+              singleton: true
+            - config:
+                config_attributes:
+                    project_id: project_id
+                id_template: ${project_id}:hosted_tool_permissions
+              coverage:
+                - families:
+                    - project_hosted_tool_permission
+                  high_value: false
+                  id: project_hosted_tool_permission
+                  support: supported
+                  title: project hosted tool permission
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.project_hosted_tool_permission
+                required_attributes:
+                    - external_id
+                    - project_id
+                schema_ref: openai/project_hosted_tool_permission/v1
+                urn_kind: openai_project_hosted_tool_permission
+              id: project_hosted_tool_permission
+              id_field: id
+              label: project hosted tool permission
+              method: GET
+              pagination:
+                disable_page_size: true
+                type: none
+              path: /organization/projects/{project_id}/hosted_tool_permissions
+              projection:
+                fields:
+                    code_interpreter_enabled: code_interpreter.enabled
+                    file_search_enabled: file_search.enabled
+                    image_generation_enabled: image_generation.enabled
+                    mcp_enabled: mcp.enabled
+                    project_id: project_id
+                    web_search_enabled: web_search.enabled
+                static_fields:
+                    source_product: openai
+                template: policy
+              read:
+                disable_page_size: true
+                path_params:
+                    - project_id
+                singleton: true
+                singleton_fallback_id: project_hosted_tool_permission
+              record_selector: $
+              singleton: true
+            - config:
+                config_attributes:
+                    project_id: project_id
+              coverage:
+                - families:
+                    - project_group
+                  high_value: false
+                  id: project_group
+                  support: supported
+                  title: project group
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.project_group
+                required_attributes:
+                    - group_id
+                    - project_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/project_group/v1
+                urn_kind: openai_project_group
+              id: project_group
+              id_field: id
+              label: project group
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/projects/{project_id}/groups
+              projection:
+                fields:
+                    created_at: created_at
+                    group_id: id
+                    name: name
+                    project_id: project_id
+                    updated_at: updated_at
+                static_fields:
+                    source_product: openai
+                template: identity_group
+              read:
+                path_params:
+                    - project_id
+              record_selector: $.data[*]
+            - config:
+                config_attributes:
+                    group_id: group_id
+                    project_id: project_id
+              coverage:
+                - families:
+                    - project_group_role
+                  high_value: false
+                  id: project_group_role
+                  support: supported
+                  title: project group role
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.project_group_role
+                required_attributes:
+                    - group_id
+                    - project_id
+                    - role_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/project_group_role/v1
+                urn_kind: openai_project_group_role
+              id: project_group_role
+              id_field: id
+              label: project group role
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/projects/{project_id}/groups/{group_id}/roles
+              projection:
+                fields:
+                    created_at: created_at
+                    created_by: created_by
+                    description: description
+                    name: name
+                    permissions: permissions
+                    predefined_role: predefined_role
+                    resource_type: resource_type
+                    role_id: id
+                    updated_at: updated_at
+                static_fields:
+                    source_product: openai
+                template: policy
+              read:
+                path_params:
+                    - project_id
+                    - group_id
+              record_selector: $.data[*]
+            - config:
+                config_attributes:
+                    project_id: project_id
+              coverage:
+                - families:
+                    - project_role
+                  high_value: false
+                  id: project_role
+                  support: supported
+                  title: project role
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.project_role
+                required_attributes:
+                    - project_id
+                    - role_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/project_role/v1
+                urn_kind: openai_project_role
+              id: project_role
+              id_field: id
+              label: project role
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /projects/{project_id}/roles
+              projection:
+                fields:
+                    created_at: created_at
+                    created_by: created_by
+                    description: description
+                    name: name
+                    permissions: permissions
+                    predefined_role: predefined_role
+                    resource_type: resource_type
+                    role_id: id
+                    updated_at: updated_at
+                static_fields:
+                    source_product: openai
+                template: policy
+              read:
+                path_params:
+                    - project_id
+              record_selector: $.data[*]
+            - config:
+                config_attributes:
+                    project_id: project_id
+                id_template: ${project_id}:data_retention
+              coverage:
+                - families:
+                    - project_data_retention
+                  high_value: false
+                  id: project_data_retention
+                  support: supported
+                  title: project data retention
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.project_data_retention
+                required_attributes:
+                    - external_id
+                    - project_id
+                schema_ref: openai/project_data_retention/v1
+                urn_kind: openai_project_data_retention
+              id: project_data_retention
+              id_field: id
+              label: project data retention
+              method: GET
+              pagination:
+                disable_page_size: true
+                type: none
+              path: /organization/projects/{project_id}/data_retention
+              projection:
+                fields:
+                    object: object
+                    project_id: project_id
+                    retention_type: type
+                static_fields:
+                    source_product: openai
+                template: policy
+              read:
+                disable_page_size: true
+                path_params:
+                    - project_id
+                singleton: true
+                singleton_fallback_id: project_data_retention
+              record_selector: $
+              singleton: true
+            - config:
+                config_attributes:
+                    project_id: project_id
+              coverage:
+                - families:
+                    - project_spend_alert
+                  high_value: false
+                  id: project_spend_alert
+                  support: supported
+                  title: project spend alert
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.project_spend_alert
+                required_attributes:
+                    - project_id
+                    - spend_alert_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/project_spend_alert/v1
+                urn_kind: openai_project_spend_alert
+              id: project_spend_alert
+              id_field: id
+              label: project spend alert
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/projects/{project_id}/spend_alerts
+              projection:
+                fields:
+                    created_at: created_at
+                    name: name
+                    project_id: project_id
+                    spend_alert_id: id
+                    status: status
+                    threshold: threshold
+                    threshold_amount: threshold_amount
+                    updated_at: updated_at
+                static_fields:
+                    source_product: openai
+                template: alert
+              read:
+                path_params:
+                    - project_id
+              record_selector: $.data[*]
+            - config:
+                config_attributes:
+                    project_id: project_id
+              coverage:
+                - families:
+                    - project_certificate
+                  high_value: false
+                  id: project_certificate
+                  support: supported
+                  title: project certificate
+                  type: entity_family
+              default_enabled: true
+              event:
+                kind: openai.project_certificate
+                required_attributes:
+                    - certificate_id
+                    - project_id
+                required_payload_fields:
+                    - id
+                schema_ref: openai/project_certificate/v1
+                urn_kind: openai_project_certificate
+              id: project_certificate
+              id_field: id
+              label: project certificate
+              method: GET
+              pagination:
+                cursor_json_path: $.next
+                cursor_param: after
+                has_more_key: has_more
+                next_cursor_keys:
+                    - next
+                    - last_id
+                page_size: 100
+                page_size_param: limit
+                type: cursor
+              path: /organization/projects/{project_id}/certificates
+              projection:
+                fields:
+                    active: active
+                    certificate_id: id
+                    created_at: created_at
+                    expires_at: certificate_details.expires_at
+                    name: name
+                    project_id: project_id
+                    valid_at: certificate_details.valid_at
+                static_fields:
+                    source_product: openai
+                template: asset
+              read:
+                path_params:
+                    - project_id
+              record_selector: $.data[*]
+        schema_version: cerebro.integration/v1
+        scope_options:
+            - default_enabled: true
+              families:
+                - user
+                - project
+                - service_account
+                - api_key
+                - admin_api_key
+                - audit_log
+                - invite
+                - role
+                - user_role
+                - group
+                - group_user
+                - group_role
+                - data_retention
+                - spend_alert
+                - certificate
+                - usage_audio_speech
+                - usage_audio_transcription
+                - usage_code_interpreter_session
+                - usage_completion
+                - usage_embedding
+                - usage_image
+                - usage_moderation
+                - usage_vector_store
+                - usage_file_search_call
+                - usage_web_search_call
+                - cost
+                - project_user
+                - project_user_role
+                - project_service_account
+                - project_api_key
+                - project_rate_limit
+                - project_model_permission
+                - project_hosted_tool_permission
+                - project_group
+                - project_group_role
+                - project_role
+                - project_data_retention
+                - project_spend_alert
+                - project_certificate
+              id: openai_governance
+              label: OpenAI governance
+        source_id: openai
+        tenant_id: builtin_catalog
+        transport:
+            base_url: https://api.openai.com/v1
+            retry:
+                backoff: exponential
+                max_attempts: 3
+                retry_after_header: Retry-After
+                statuses:
+                    - 429
+                    - 500
+                    - 502
+                    - 503
+                    - 504
+            verification:
+                expect_status:
+                    - 200
+                method: GET
+                path: /organization/users

--- a/internal/connectorcatalog/catalog/business-data-grc/openai.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/openai.yaml
@@ -1,2168 +1,2314 @@
 entries:
-    - classifier_output: supported
-      definition:
-        auth:
-            credential_fields:
-                - key: token
-                  label: OpenAI admin API key reference
-                  reference_only: true
-                  required: true
-                  secret: true
-            model: bearer_token
-            requires_references: true
-        categories:
-            - saas
-            - ai
-        config_fields:
-            - key: actor_emails
-              label: actor emails
-            - key: actor_ids
-              label: actor ids
-            - key: api_key_ids
-              label: api key ids
-            - key: batch
-              label: batch
-            - key: bucket_width
-              label: bucket width
-            - key: effective_at_gt
-              label: effective at gt
-            - key: effective_at_gte
-              label: effective at gte
-            - key: effective_at_lt
-              label: effective at lt
-            - key: effective_at_lte
-              label: effective at lte
-            - key: end_time
-              label: end time
-            - key: event_types
-              label: event types
-            - key: group_by
-              label: group by
-            - key: group_id
-              label: group id
-            - key: models
-              label: models
-            - key: project_id
-              label: project id
-            - key: project_ids
-              label: project ids
-            - key: resource_ids
-              label: resource ids
-            - key: start_time
-              label: start time
-            - key: tenant_only
-              label: tenant only
-            - key: user_id
-              label: user id
-            - key: user_ids
-              label: user ids
-        description: Collects OpenAI organization governance, access, projects, credentials, usage, costs, retention, spend controls, certificates, rate limits, and model and tool permissions.
-        display_name: OpenAI
-        id: builtin_catalog-openai
-        resource_families:
-            - coverage:
-                - families:
-                    - user
-                  high_value: false
-                  id: user
-                  support: supported
-                  title: user
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.user
-                required_attributes:
-                    - user_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/user/v1
-                urn_kind: openai_user
-              id: user
-              id_field: id
-              label: user
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/users
-              projection:
-                fields:
-                    added_at: added_at
-                    email: email
-                    name: name
-                    role: role
-                    status: status
-                    user_id: id
-                static_fields:
-                    source_product: openai
-                template: identity_user
-              record_selector: $.data[*]
-            - coverage:
-                - families:
-                    - project
-                  high_value: false
-                  id: project
-                  support: supported
-                  title: project
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.project
-                required_attributes:
-                    - project_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/project/v1
-                urn_kind: openai_project
-              id: project
-              id_field: id
-              label: project
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/projects
-              projection:
-                fields:
-                    archived_at: archived_at
-                    created_at: created_at
-                    external_key_id: external_key_id
-                    name: name
-                    project_id: id
-                    status: status
-                static_fields:
-                    source_product: openai
-                template: asset
-              record_selector: $.data[*]
-            - coverage:
-                - families:
-                    - service_account
-                  high_value: false
-                  id: service_account
-                  support: supported
-                  title: service account
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.service_account
-                required_attributes:
-                    - service_account_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/service_account/v1
-                urn_kind: openai_service_account
-              id: service_account
-              id_field: id
-              label: service account
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/projects/default/service_accounts
-              projection:
-                fields:
-                    created_at: created_at
-                    name: name
-                    project_id: project_id
-                    role: role
-                    service_account_id: id
-                static_fields:
-                    source_product: openai
-                template: identity_application
-              record_selector: $.data[*]
-            - coverage:
-                - families:
-                    - api_key
-                  high_value: false
-                  id: api_key
-                  support: supported
-                  title: api key
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.api_key
-                required_attributes:
-                    - api_key_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/api_key/v1
-                urn_kind: openai_api_key
-              id: api_key
-              id_field: id
-              label: api key
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/projects/default/api_keys
-              projection:
-                fields:
-                    api_key_id: id
-                    created_at: created_at
-                    last_used_at: last_used_at
-                    name: name
-                    owner_service_account_id: owner.service_account.id
-                    owner_type: owner.type
-                    owner_user_id: owner.user.id
-                    project_id: project_id
-                    status: status
-                static_fields:
-                    source_product: openai
-                template: secret
-              record_selector: $.data[*]
-            - coverage:
-                - families:
-                    - admin_api_key
-                  high_value: false
-                  id: admin_api_key
-                  support: supported
-                  title: admin api key
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.admin_api_key
-                required_attributes:
-                    - api_key_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/admin_api_key/v1
-                urn_kind: openai_admin_api_key
-              id: admin_api_key
-              id_field: id
-              label: admin api key
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/admin_api_keys
-              projection:
-                fields:
-                    api_key_id: id
-                    created_at: created_at
-                    last_used_at: last_used_at
-                    name: name
-                    owner_id: owner.id
-                    owner_name: owner.name
-                    owner_object: owner.object
-                    owner_role: owner.role
-                    owner_type: owner.type
-                    status: status
-                static_fields:
-                    key_class: admin
-                    privileged: "true"
-                    source_product: openai
-                template: secret
-              record_selector: $.data[*]
-            - config_query:
-                actor_emails: actor_emails
-                actor_ids: actor_ids
-                effective_at[gt]: effective_at_gt
-                effective_at[gte]: effective_at_gte
-                effective_at[lt]: effective_at_lt
-                effective_at[lte]: effective_at_lte
-                event_types: event_types
-                project_ids: project_ids
-                resource_ids: resource_ids
-                tenant_only: tenant_only
-              coverage:
-                - families:
-                    - audit_log
-                  control_domains:
-                    - logging_monitoring
-                  evidence_types:
-                    - logging_configuration
-                  high_value: true
-                  id: audit_log
-                  support: supported
-                  title: audit log
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.audit_log
-                required_attributes:
-                    - audit_log_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/audit_log/v1
-                urn_kind: openai_audit_log
-              id: audit_log
-              id_field: id
-              label: audit log
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/audit_logs
-              projection:
-                fields:
-                    actor_api_key_id: actor.api_key.id
-                    actor_city: actor.session.ip_address_details.city
-                    actor_country: actor.session.ip_address_details.country
-                    actor_email: actor.session.user.email|actor.api_key.user.email|actor.user.email|actor.email
-                    actor_id: actor.session.user.id|actor.api_key.user.id|actor.api_key.service_account.id|actor.api_key.id|actor.user.id|actor.service_account.id|actor.id
-                    actor_ip_address: actor.session.ip_address
-                    actor_region: actor.session.ip_address_details.region
-                    actor_service_account_id: actor.api_key.service_account.id|actor.service_account.id
-                    actor_type: actor.type|actor.api_key.type
-                    actor_user_agent: actor.session.user_agent
-                    actor_user_id: actor.session.user.id|actor.api_key.user.id|actor.user.id
-                    api_key_id: api_key.created.id|api_key.updated.id|api_key.deleted.id|api_key.id|api_key_id
-                    audit_log_id: id
-                    certificate_id: certificate.created.id|certificate.updated.id|certificate.deleted.id
-                    certificate_name: certificate.created.name|certificate.updated.name|certificate.deleted.name
-                    effective_at: effective_at
-                    event_type: type|event_type
-                    external_key_id: external_key.registered.id|external_key.removed.id
-                    group_id: group.created.id|group.updated.id|group.deleted.id
-                    group_name: group.created.data.group_name|group.updated.changes_requested.group_name
-                    invite_email: invite.sent.data.email
-                    invite_id: invite.sent.id|invite.accepted.id|invite.deleted.id
-                    invite_role: invite.sent.data.role
-                    ip_allowlist_id: ip_allowlist.created.id|ip_allowlist.updated.id|ip_allowlist.deleted.id
-                    ip_allowlist_name: ip_allowlist.created.name|ip_allowlist.deleted.name
-                    organization_id: organization.updated.id|organization_id|org_id
-                    principal_id: role.assignment.created.principal_id|role.assignment.deleted.principal_id
-                    principal_type: role.assignment.created.principal_type|role.assignment.deleted.principal_type
-                    project_id: project.created.id|project.updated.id|project.archived.id|project.deleted.id|checkpoint.permission.created.data.project_id|project.id|project_id
-                    rate_limit_id: rate_limit.updated.id|rate_limit.deleted.id
-                    resource_id: role.assignment.created.resource_id|role.assignment.deleted.resource_id|role.bound_to_resource.resource_id|role.unbound_from_resource.resource_id|resource.deleted.id
-                    resource_type: role.assignment.created.resource_type|role.assignment.deleted.resource_type|role.bound_to_resource.resource_type|role.unbound_from_resource.resource_type|resource.deleted.type
-                    role_assignment_id: role.assignment.created.id|role.assignment.deleted.id
-                    role_id: role.created.id|role.updated.id|role.deleted.id|role.bound_to_resource.role_id|role.unbound_from_resource.role_id
-                    role_name: role.created.data.role_name|role.updated.changes_requested.role_name|role.bound_to_resource.role_name|role.unbound_from_resource.role_name
-                    service_account_id: service_account.created.id|service_account.updated.id|service_account.deleted.id
-                    user_id: user.added.id|user.updated.id|user.deleted.id
-                static_fields:
-                    source_product: openai
-                template: audit_event
-              record_selector: $.data[*]
-            - coverage:
-                - families:
-                    - invite
-                  high_value: false
-                  id: invite
-                  support: supported
-                  title: invite
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.invite
-                required_attributes:
-                    - invite_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/invite/v1
-                urn_kind: openai_invite
-              id: invite
-              id_field: id
-              label: invite
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/invites
-              projection:
-                fields:
-                    accepted_at: accepted_at
-                    created_at: created_at
-                    email: email
-                    expires_at: expires_at
-                    invite_id: id
-                    projects: projects
-                    role: role
-                    status: status
-                static_fields:
-                    source_product: openai
-                template: identity_user
-              record_selector: $.data[*]
-            - coverage:
-                - families:
-                    - role
-                  high_value: false
-                  id: role
-                  support: supported
-                  title: role
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.role
-                required_attributes:
-                    - role_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/role/v1
-                urn_kind: openai_role
-              id: role
-              id_field: id
-              label: role
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/roles
-              projection:
-                fields:
-                    created_at: created_at
-                    created_by: created_by
-                    description: description
-                    name: name
-                    permissions: permissions
-                    predefined_role: predefined_role
-                    resource_type: resource_type
-                    role_id: id
-                    updated_at: updated_at
-                static_fields:
-                    source_product: openai
-                template: policy
-              record_selector: $.data[*]
-            - config:
-                config_attributes:
-                    user_id: user_id
-              coverage:
-                - families:
-                    - user_role
-                  high_value: false
-                  id: user_role
-                  support: supported
-                  title: user role
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.user_role
-                required_attributes:
-                    - role_id
-                    - user_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/user_role/v1
-                urn_kind: openai_user_role
-              id: user_role
-              id_field: id
-              label: user role
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/users/{user_id}/roles
-              projection:
-                fields:
-                    created_at: created_at
-                    created_by: created_by
-                    description: description
-                    name: name
-                    permissions: permissions
-                    predefined_role: predefined_role
-                    resource_type: resource_type
-                    role_id: id
-                    updated_at: updated_at
-                static_fields:
-                    source_product: openai
-                template: policy
-              read:
-                path_params:
-                    - user_id
-              record_selector: $.data[*]
-            - coverage:
-                - families:
-                    - group
-                  high_value: false
-                  id: group
-                  support: supported
-                  title: group
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.group
-                required_attributes:
-                    - group_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/group/v1
-                urn_kind: openai_group
-              id: group
-              id_field: id
-              label: group
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/groups
-              projection:
-                fields:
-                    created_at: created_at
-                    group_id: id
-                    name: name
-                    updated_at: updated_at
-                static_fields:
-                    source_product: openai
-                template: identity_group
-              record_selector: $.data[*]
-            - config:
-                config_attributes:
-                    group_id: group_id
-              coverage:
-                - families:
-                    - group_user
-                  high_value: false
-                  id: group_user
-                  support: supported
-                  title: group user
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.group_user
-                required_attributes:
-                    - group_id
-                    - user_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/group_user/v1
-                urn_kind: openai_group_user
-              id: group_user
-              id_field: id|user_id
-              label: group user
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/groups/{group_id}/users
-              projection:
-                fields:
-                    added_at: added_at
-                    email: email
-                    group_id: group_id
-                    name: name
-                    role: role
-                    user_id: id|user_id
-                static_fields:
-                    source_product: openai
-                template: group_membership
-              read:
-                path_params:
-                    - group_id
-              record_selector: $.data[*]
-            - config:
-                config_attributes:
-                    group_id: group_id
-              coverage:
-                - families:
-                    - group_role
-                  high_value: false
-                  id: group_role
-                  support: supported
-                  title: group role
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.group_role
-                required_attributes:
-                    - group_id
-                    - role_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/group_role/v1
-                urn_kind: openai_group_role
-              id: group_role
-              id_field: id
-              label: group role
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/groups/{group_id}/roles
-              projection:
-                fields:
-                    created_at: created_at
-                    created_by: created_by
-                    description: description
-                    name: name
-                    permissions: permissions
-                    predefined_role: predefined_role
-                    resource_type: resource_type
-                    role_id: id
-                    updated_at: updated_at
-                static_fields:
-                    source_product: openai
-                template: policy
-              read:
-                path_params:
-                    - group_id
-              record_selector: $.data[*]
-            - config:
-                id_template: organization:data_retention
-              coverage:
-                - families:
-                    - data_retention
-                  high_value: false
-                  id: data_retention
-                  support: supported
-                  title: data retention
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.data_retention
-                required_attributes:
-                    - external_id
-                schema_ref: openai/data_retention/v1
-                urn_kind: openai_data_retention
-              id: data_retention
-              id_field: id
-              label: data retention
-              method: GET
-              pagination:
-                disable_page_size: true
-                type: none
-              path: /organization/data_retention
-              projection:
-                fields:
-                    object: object
-                    retention_type: type
-                static_fields:
-                    source_product: openai
-                template: policy
-              read:
-                disable_page_size: true
-                singleton: true
-                singleton_fallback_id: data_retention
-              record_selector: $
-              singleton: true
-            - coverage:
-                - families:
-                    - spend_alert
-                  high_value: false
-                  id: spend_alert
-                  support: supported
-                  title: spend alert
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.spend_alert
-                required_attributes:
-                    - spend_alert_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/spend_alert/v1
-                urn_kind: openai_spend_alert
-              id: spend_alert
-              id_field: id
-              label: spend alert
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/spend_alerts
-              projection:
-                fields:
-                    created_at: created_at
-                    name: name
-                    spend_alert_id: id
-                    status: status
-                    threshold: threshold
-                    threshold_amount: threshold_amount
-                    updated_at: updated_at
-                static_fields:
-                    source_product: openai
-                template: alert
-              record_selector: $.data[*]
-            - coverage:
-                - families:
-                    - certificate
-                  high_value: false
-                  id: certificate
-                  support: supported
-                  title: certificate
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.certificate
-                required_attributes:
-                    - certificate_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/certificate/v1
-                urn_kind: openai_certificate
-              id: certificate
-              id_field: id
-              label: certificate
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/certificates
-              projection:
-                fields:
-                    active: active
-                    certificate_id: id
-                    created_at: created_at
-                    expires_at: certificate_details.expires_at
-                    name: name
-                    valid_at: certificate_details.valid_at
-                static_fields:
-                    source_product: openai
-                template: asset
-              record_selector: $.data[*]
-            - config_query:
-                api_key_ids: api_key_ids
-                batch: batch
-                bucket_width: bucket_width
-                end_time: end_time
-                group_by: group_by
-                models: models
-                project_ids: project_ids
-                start_time: start_time
-                user_ids: user_ids
-              coverage:
-                - families:
-                    - usage_audio_speech
-                  high_value: false
-                  id: usage_audio_speech
-                  support: supported
-                  title: usage audio speech
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.usage_audio_speech
-                required_attributes:
-                    - external_id
-                schema_ref: openai/usage_audio_speech/v1
-                urn_kind: openai_usage_audio_speech
-              id: usage_audio_speech
-              id_field: id
-              label: usage audio speech
-              method: GET
-              pagination:
-                cursor_json_path: $.next_page
-                cursor_param: page
-                next_cursor_keys:
-                    - next_page
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/usage/audio_speeches
-              projection:
-                fields:
-                    amount_currency: amount.currency
-                    amount_value: amount.value|amount
-                    api_key_id: api_key_id
-                    end_time: end_time
-                    input_tokens: results.input_tokens.__sum|input_tokens
-                    line_item: line_item
-                    model: model
-                    num_model_requests: results.num_model_requests.__sum|num_model_requests
-                    organization_object: object
-                    output_tokens: results.output_tokens.__sum|output_tokens
-                    project_id: project_id
-                    result_count: results.__count
-                    start_time: start_time
-                    user_id: user_id
-                static_fields:
-                    source_product: openai
-                template: asset
-              record_selector: $.data[*]
-            - config_query:
-                api_key_ids: api_key_ids
-                batch: batch
-                bucket_width: bucket_width
-                end_time: end_time
-                group_by: group_by
-                models: models
-                project_ids: project_ids
-                start_time: start_time
-                user_ids: user_ids
-              coverage:
-                - families:
-                    - usage_audio_transcription
-                  high_value: false
-                  id: usage_audio_transcription
-                  support: supported
-                  title: usage audio transcription
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.usage_audio_transcription
-                required_attributes:
-                    - external_id
-                schema_ref: openai/usage_audio_transcription/v1
-                urn_kind: openai_usage_audio_transcription
-              id: usage_audio_transcription
-              id_field: id
-              label: usage audio transcription
-              method: GET
-              pagination:
-                cursor_json_path: $.next_page
-                cursor_param: page
-                next_cursor_keys:
-                    - next_page
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/usage/audio_transcriptions
-              projection:
-                fields:
-                    amount_currency: amount.currency
-                    amount_value: amount.value|amount
-                    api_key_id: api_key_id
-                    end_time: end_time
-                    input_tokens: results.input_tokens.__sum|input_tokens
-                    line_item: line_item
-                    model: model
-                    num_model_requests: results.num_model_requests.__sum|num_model_requests
-                    organization_object: object
-                    output_tokens: results.output_tokens.__sum|output_tokens
-                    project_id: project_id
-                    result_count: results.__count
-                    start_time: start_time
-                    user_id: user_id
-                static_fields:
-                    source_product: openai
-                template: asset
-              record_selector: $.data[*]
-            - config_query:
-                api_key_ids: api_key_ids
-                batch: batch
-                bucket_width: bucket_width
-                end_time: end_time
-                group_by: group_by
-                models: models
-                project_ids: project_ids
-                start_time: start_time
-                user_ids: user_ids
-              coverage:
-                - families:
-                    - usage_code_interpreter_session
-                  high_value: false
-                  id: usage_code_interpreter_session
-                  support: supported
-                  title: usage code interpreter session
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.usage_code_interpreter_session
-                required_attributes:
-                    - external_id
-                schema_ref: openai/usage_code_interpreter_session/v1
-                urn_kind: openai_usage_code_interpreter_session
-              id: usage_code_interpreter_session
-              id_field: id
-              label: usage code interpreter session
-              method: GET
-              pagination:
-                cursor_json_path: $.next_page
-                cursor_param: page
-                next_cursor_keys:
-                    - next_page
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/usage/code_interpreter_sessions
-              projection:
-                fields:
-                    amount_currency: amount.currency
-                    amount_value: amount.value|amount
-                    api_key_id: api_key_id
-                    end_time: end_time
-                    input_tokens: results.input_tokens.__sum|input_tokens
-                    line_item: line_item
-                    model: model
-                    num_model_requests: results.num_model_requests.__sum|num_model_requests
-                    organization_object: object
-                    output_tokens: results.output_tokens.__sum|output_tokens
-                    project_id: project_id
-                    result_count: results.__count
-                    start_time: start_time
-                    user_id: user_id
-                static_fields:
-                    source_product: openai
-                template: asset
-              record_selector: $.data[*]
-            - config_query:
-                api_key_ids: api_key_ids
-                batch: batch
-                bucket_width: bucket_width
-                end_time: end_time
-                group_by: group_by
-                models: models
-                project_ids: project_ids
-                start_time: start_time
-                user_ids: user_ids
-              coverage:
-                - families:
-                    - usage_completion
-                  high_value: false
-                  id: usage_completion
-                  support: supported
-                  title: usage completion
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.usage_completion
-                required_attributes:
-                    - external_id
-                schema_ref: openai/usage_completion/v1
-                urn_kind: openai_usage_completion
-              id: usage_completion
-              id_field: id
-              label: usage completion
-              method: GET
-              pagination:
-                cursor_json_path: $.next_page
-                cursor_param: page
-                next_cursor_keys:
-                    - next_page
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/usage/completions
-              projection:
-                fields:
-                    amount_currency: amount.currency
-                    amount_value: amount.value|amount
-                    api_key_id: api_key_id
-                    end_time: end_time
-                    input_tokens: results.input_tokens.__sum|input_tokens
-                    line_item: line_item
-                    model: model
-                    num_model_requests: results.num_model_requests.__sum|num_model_requests
-                    organization_object: object
-                    output_tokens: results.output_tokens.__sum|output_tokens
-                    project_id: project_id
-                    result_count: results.__count
-                    start_time: start_time
-                    user_id: user_id
-                static_fields:
-                    source_product: openai
-                template: asset
-              record_selector: $.data[*]
-            - config_query:
-                api_key_ids: api_key_ids
-                batch: batch
-                bucket_width: bucket_width
-                end_time: end_time
-                group_by: group_by
-                models: models
-                project_ids: project_ids
-                start_time: start_time
-                user_ids: user_ids
-              coverage:
-                - families:
-                    - usage_embedding
-                  high_value: false
-                  id: usage_embedding
-                  support: supported
-                  title: usage embedding
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.usage_embedding
-                required_attributes:
-                    - external_id
-                schema_ref: openai/usage_embedding/v1
-                urn_kind: openai_usage_embedding
-              id: usage_embedding
-              id_field: id
-              label: usage embedding
-              method: GET
-              pagination:
-                cursor_json_path: $.next_page
-                cursor_param: page
-                next_cursor_keys:
-                    - next_page
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/usage/embeddings
-              projection:
-                fields:
-                    amount_currency: amount.currency
-                    amount_value: amount.value|amount
-                    api_key_id: api_key_id
-                    end_time: end_time
-                    input_tokens: results.input_tokens.__sum|input_tokens
-                    line_item: line_item
-                    model: model
-                    num_model_requests: results.num_model_requests.__sum|num_model_requests
-                    organization_object: object
-                    output_tokens: results.output_tokens.__sum|output_tokens
-                    project_id: project_id
-                    result_count: results.__count
-                    start_time: start_time
-                    user_id: user_id
-                static_fields:
-                    source_product: openai
-                template: asset
-              record_selector: $.data[*]
-            - config_query:
-                api_key_ids: api_key_ids
-                batch: batch
-                bucket_width: bucket_width
-                end_time: end_time
-                group_by: group_by
-                models: models
-                project_ids: project_ids
-                start_time: start_time
-                user_ids: user_ids
-              coverage:
-                - families:
-                    - usage_image
-                  high_value: false
-                  id: usage_image
-                  support: supported
-                  title: usage image
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.usage_image
-                required_attributes:
-                    - external_id
-                schema_ref: openai/usage_image/v1
-                urn_kind: openai_usage_image
-              id: usage_image
-              id_field: id
-              label: usage image
-              method: GET
-              pagination:
-                cursor_json_path: $.next_page
-                cursor_param: page
-                next_cursor_keys:
-                    - next_page
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/usage/images
-              projection:
-                fields:
-                    amount_currency: amount.currency
-                    amount_value: amount.value|amount
-                    api_key_id: api_key_id
-                    end_time: end_time
-                    input_tokens: results.input_tokens.__sum|input_tokens
-                    line_item: line_item
-                    model: model
-                    num_model_requests: results.num_model_requests.__sum|num_model_requests
-                    organization_object: object
-                    output_tokens: results.output_tokens.__sum|output_tokens
-                    project_id: project_id
-                    result_count: results.__count
-                    start_time: start_time
-                    user_id: user_id
-                static_fields:
-                    source_product: openai
-                template: asset
-              record_selector: $.data[*]
-            - config_query:
-                api_key_ids: api_key_ids
-                batch: batch
-                bucket_width: bucket_width
-                end_time: end_time
-                group_by: group_by
-                models: models
-                project_ids: project_ids
-                start_time: start_time
-                user_ids: user_ids
-              coverage:
-                - families:
-                    - usage_moderation
-                  high_value: false
-                  id: usage_moderation
-                  support: supported
-                  title: usage moderation
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.usage_moderation
-                required_attributes:
-                    - external_id
-                schema_ref: openai/usage_moderation/v1
-                urn_kind: openai_usage_moderation
-              id: usage_moderation
-              id_field: id
-              label: usage moderation
-              method: GET
-              pagination:
-                cursor_json_path: $.next_page
-                cursor_param: page
-                next_cursor_keys:
-                    - next_page
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/usage/moderations
-              projection:
-                fields:
-                    amount_currency: amount.currency
-                    amount_value: amount.value|amount
-                    api_key_id: api_key_id
-                    end_time: end_time
-                    input_tokens: results.input_tokens.__sum|input_tokens
-                    line_item: line_item
-                    model: model
-                    num_model_requests: results.num_model_requests.__sum|num_model_requests
-                    organization_object: object
-                    output_tokens: results.output_tokens.__sum|output_tokens
-                    project_id: project_id
-                    result_count: results.__count
-                    start_time: start_time
-                    user_id: user_id
-                static_fields:
-                    source_product: openai
-                template: asset
-              record_selector: $.data[*]
-            - config_query:
-                api_key_ids: api_key_ids
-                batch: batch
-                bucket_width: bucket_width
-                end_time: end_time
-                group_by: group_by
-                models: models
-                project_ids: project_ids
-                start_time: start_time
-                user_ids: user_ids
-              coverage:
-                - families:
-                    - usage_vector_store
-                  high_value: false
-                  id: usage_vector_store
-                  support: supported
-                  title: usage vector store
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.usage_vector_store
-                required_attributes:
-                    - external_id
-                schema_ref: openai/usage_vector_store/v1
-                urn_kind: openai_usage_vector_store
-              id: usage_vector_store
-              id_field: id
-              label: usage vector store
-              method: GET
-              pagination:
-                cursor_json_path: $.next_page
-                cursor_param: page
-                next_cursor_keys:
-                    - next_page
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/usage/vector_stores
-              projection:
-                fields:
-                    amount_currency: amount.currency
-                    amount_value: amount.value|amount
-                    api_key_id: api_key_id
-                    end_time: end_time
-                    input_tokens: results.input_tokens.__sum|input_tokens
-                    line_item: line_item
-                    model: model
-                    num_model_requests: results.num_model_requests.__sum|num_model_requests
-                    organization_object: object
-                    output_tokens: results.output_tokens.__sum|output_tokens
-                    project_id: project_id
-                    result_count: results.__count
-                    start_time: start_time
-                    user_id: user_id
-                static_fields:
-                    source_product: openai
-                template: asset
-              record_selector: $.data[*]
-            - config_query:
-                api_key_ids: api_key_ids
-                batch: batch
-                bucket_width: bucket_width
-                end_time: end_time
-                group_by: group_by
-                models: models
-                project_ids: project_ids
-                start_time: start_time
-                user_ids: user_ids
-              coverage:
-                - families:
-                    - usage_file_search_call
-                  high_value: false
-                  id: usage_file_search_call
-                  support: supported
-                  title: usage file search call
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.usage_file_search_call
-                required_attributes:
-                    - external_id
-                schema_ref: openai/usage_file_search_call/v1
-                urn_kind: openai_usage_file_search_call
-              id: usage_file_search_call
-              id_field: id
-              label: usage file search call
-              method: GET
-              pagination:
-                cursor_json_path: $.next_page
-                cursor_param: page
-                next_cursor_keys:
-                    - next_page
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/usage/file_search_calls
-              projection:
-                fields:
-                    amount_currency: amount.currency
-                    amount_value: amount.value|amount
-                    api_key_id: api_key_id
-                    end_time: end_time
-                    input_tokens: results.input_tokens.__sum|input_tokens
-                    line_item: line_item
-                    model: model
-                    num_model_requests: results.num_model_requests.__sum|num_model_requests
-                    organization_object: object
-                    output_tokens: results.output_tokens.__sum|output_tokens
-                    project_id: project_id
-                    result_count: results.__count
-                    start_time: start_time
-                    user_id: user_id
-                static_fields:
-                    source_product: openai
-                template: asset
-              record_selector: $.data[*]
-            - config_query:
-                api_key_ids: api_key_ids
-                batch: batch
-                bucket_width: bucket_width
-                end_time: end_time
-                group_by: group_by
-                models: models
-                project_ids: project_ids
-                start_time: start_time
-                user_ids: user_ids
-              coverage:
-                - families:
-                    - usage_web_search_call
-                  high_value: false
-                  id: usage_web_search_call
-                  support: supported
-                  title: usage web search call
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.usage_web_search_call
-                required_attributes:
-                    - external_id
-                schema_ref: openai/usage_web_search_call/v1
-                urn_kind: openai_usage_web_search_call
-              id: usage_web_search_call
-              id_field: id
-              label: usage web search call
-              method: GET
-              pagination:
-                cursor_json_path: $.next_page
-                cursor_param: page
-                next_cursor_keys:
-                    - next_page
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/usage/web_search_calls
-              projection:
-                fields:
-                    amount_currency: amount.currency
-                    amount_value: amount.value|amount
-                    api_key_id: api_key_id
-                    end_time: end_time
-                    input_tokens: results.input_tokens.__sum|input_tokens
-                    line_item: line_item
-                    model: model
-                    num_model_requests: results.num_model_requests.__sum|num_model_requests
-                    organization_object: object
-                    output_tokens: results.output_tokens.__sum|output_tokens
-                    project_id: project_id
-                    result_count: results.__count
-                    start_time: start_time
-                    user_id: user_id
-                static_fields:
-                    source_product: openai
-                template: asset
-              record_selector: $.data[*]
-            - config_query:
-                api_key_ids: api_key_ids
-                batch: batch
-                bucket_width: bucket_width
-                end_time: end_time
-                group_by: group_by
-                models: models
-                project_ids: project_ids
-                start_time: start_time
-                user_ids: user_ids
-              coverage:
-                - families:
-                    - cost
-                  high_value: false
-                  id: cost
-                  support: supported
-                  title: cost
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.cost
-                required_attributes:
-                    - external_id
-                schema_ref: openai/cost/v1
-                urn_kind: openai_cost
-              id: cost
-              id_field: id
-              label: cost
-              method: GET
-              pagination:
-                cursor_json_path: $.next_page
-                cursor_param: page
-                next_cursor_keys:
-                    - next_page
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/costs
-              projection:
-                fields:
-                    amount_currency: amount.currency
-                    amount_value: amount.value|amount
-                    api_key_id: api_key_id
-                    end_time: end_time
-                    input_tokens: results.input_tokens.__sum|input_tokens
-                    line_item: line_item
-                    model: model
-                    num_model_requests: results.num_model_requests.__sum|num_model_requests
-                    organization_object: object
-                    output_tokens: results.output_tokens.__sum|output_tokens
-                    project_id: project_id
-                    result_count: results.__count
-                    start_time: start_time
-                    user_id: user_id
-                static_fields:
-                    source_product: openai
-                template: asset
-              record_selector: $.data[*]
-            - config:
-                config_attributes:
-                    project_id: project_id
-              coverage:
-                - families:
-                    - project_user
-                  high_value: false
-                  id: project_user
-                  support: supported
-                  title: project user
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.project_user
-                required_attributes:
-                    - project_id
-                    - user_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/project_user/v1
-                urn_kind: openai_project_user
-              id: project_user
-              id_field: id|user_id
-              label: project user
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/projects/{project_id}/users
-              projection:
-                fields:
-                    added_at: added_at
-                    email: email
-                    name: name
-                    project_id: project_id
-                    role: role
-                    user_id: id|user_id
-                static_fields:
-                    source_product: openai
-                template: group_membership
-              read:
-                path_params:
-                    - project_id
-              record_selector: $.data[*]
-            - config:
-                config_attributes:
-                    project_id: project_id
-                    user_id: user_id
-              coverage:
-                - families:
-                    - project_user_role
-                  high_value: false
-                  id: project_user_role
-                  support: supported
-                  title: project user role
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.project_user_role
-                required_attributes:
-                    - project_id
-                    - role_id
-                    - user_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/project_user_role/v1
-                urn_kind: openai_project_user_role
-              id: project_user_role
-              id_field: id
-              label: project user role
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /projects/{project_id}/users/{user_id}/roles
-              projection:
-                fields:
-                    created_at: created_at
-                    created_by: created_by
-                    description: description
-                    name: name
-                    permissions: permissions
-                    predefined_role: predefined_role
-                    resource_type: resource_type
-                    role_id: id
-                    updated_at: updated_at
-                static_fields:
-                    source_product: openai
-                template: policy
-              read:
-                path_params:
-                    - project_id
-                    - user_id
-              record_selector: $.data[*]
-            - config:
-                config_attributes:
-                    project_id: project_id
-              coverage:
-                - families:
-                    - project_service_account
-                  high_value: false
-                  id: project_service_account
-                  support: supported
-                  title: project service account
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.project_service_account
-                required_attributes:
-                    - project_id
-                    - service_account_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/project_service_account/v1
-                urn_kind: openai_project_service_account
-              id: project_service_account
-              id_field: id
-              label: project service account
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/projects/{project_id}/service_accounts
-              projection:
-                fields:
-                    created_at: created_at
-                    name: name
-                    project_id: project_id
-                    role: role
-                    service_account_id: id
-                static_fields:
-                    source_product: openai
-                template: identity_application
-              read:
-                path_params:
-                    - project_id
-              record_selector: $.data[*]
-            - config:
-                config_attributes:
-                    project_id: project_id
-              coverage:
-                - families:
-                    - project_api_key
-                  high_value: false
-                  id: project_api_key
-                  support: supported
-                  title: project api key
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.project_api_key
-                required_attributes:
-                    - api_key_id
-                    - project_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/project_api_key/v1
-                urn_kind: openai_project_api_key
-              id: project_api_key
-              id_field: id
-              label: project api key
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/projects/{project_id}/api_keys
-              projection:
-                fields:
-                    api_key_id: id
-                    created_at: created_at
-                    last_used_at: last_used_at
-                    name: name
-                    owner_service_account_id: owner.service_account.id
-                    owner_type: owner.type
-                    owner_user_id: owner.user.id
-                    project_id: project_id
-                    status: status
-                static_fields:
-                    source_product: openai
-                template: secret
-              read:
-                path_params:
-                    - project_id
-              record_selector: $.data[*]
-            - config:
-                config_attributes:
-                    project_id: project_id
-              coverage:
-                - families:
-                    - project_rate_limit
-                  high_value: false
-                  id: project_rate_limit
-                  support: supported
-                  title: project rate limit
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.project_rate_limit
-                required_attributes:
-                    - external_id
-                    - project_id
-                schema_ref: openai/project_rate_limit/v1
-                urn_kind: openai_project_rate_limit
-              id: project_rate_limit
-              id_field: id|model
-              label: project rate limit
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/projects/{project_id}/rate_limits
-              projection:
-                fields:
-                    batch_1_day_max_input_tokens: batch_1_day_max_input_tokens
-                    max_images_per_1_minute: max_images_per_1_minute
-                    max_requests_per_1_day: max_requests_per_1_day
-                    max_requests_per_1_minute: max_requests_per_1_minute
-                    max_tokens_per_1_minute: max_tokens_per_1_minute
-                    model: model
-                    project_id: project_id
-                    rate_limit_id: id
-                    created_at: created_at
-                    updated_at: updated_at
-                static_fields:
-                    source_product: openai
-                template: policy
-              read:
-                path_params:
-                    - project_id
-              record_selector: $.data[*]
-            - config:
-                config_attributes:
-                    project_id: project_id
-                id_template: ${project_id}:model_permissions
-              coverage:
-                - families:
-                    - project_model_permission
-                  high_value: false
-                  id: project_model_permission
-                  support: supported
-                  title: project model permission
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.project_model_permission
-                required_attributes:
-                    - external_id
-                    - project_id
-                schema_ref: openai/project_model_permission/v1
-                urn_kind: openai_project_model_permission
-              id: project_model_permission
-              id_field: id
-              label: project model permission
-              method: GET
-              pagination:
-                disable_page_size: true
-                type: none
-              path: /organization/projects/{project_id}/model_permissions
-              projection:
-                fields:
-                    mode: mode
-                    model_ids: model_ids
-                    project_id: project_id
-                static_fields:
-                    source_product: openai
-                template: policy
-              read:
-                disable_page_size: true
-                path_params:
-                    - project_id
-                singleton: true
-                singleton_fallback_id: project_model_permission
-              record_selector: $
-              singleton: true
-            - config:
-                config_attributes:
-                    project_id: project_id
-                id_template: ${project_id}:hosted_tool_permissions
-              coverage:
-                - families:
-                    - project_hosted_tool_permission
-                  high_value: false
-                  id: project_hosted_tool_permission
-                  support: supported
-                  title: project hosted tool permission
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.project_hosted_tool_permission
-                required_attributes:
-                    - external_id
-                    - project_id
-                schema_ref: openai/project_hosted_tool_permission/v1
-                urn_kind: openai_project_hosted_tool_permission
-              id: project_hosted_tool_permission
-              id_field: id
-              label: project hosted tool permission
-              method: GET
-              pagination:
-                disable_page_size: true
-                type: none
-              path: /organization/projects/{project_id}/hosted_tool_permissions
-              projection:
-                fields:
-                    code_interpreter_enabled: code_interpreter.enabled
-                    file_search_enabled: file_search.enabled
-                    image_generation_enabled: image_generation.enabled
-                    mcp_enabled: mcp.enabled
-                    project_id: project_id
-                    web_search_enabled: web_search.enabled
-                static_fields:
-                    source_product: openai
-                template: policy
-              read:
-                disable_page_size: true
-                path_params:
-                    - project_id
-                singleton: true
-                singleton_fallback_id: project_hosted_tool_permission
-              record_selector: $
-              singleton: true
-            - config:
-                config_attributes:
-                    project_id: project_id
-              coverage:
-                - families:
-                    - project_group
-                  high_value: false
-                  id: project_group
-                  support: supported
-                  title: project group
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.project_group
-                required_attributes:
-                    - group_id
-                    - project_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/project_group/v1
-                urn_kind: openai_project_group
-              id: project_group
-              id_field: id
-              label: project group
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/projects/{project_id}/groups
-              projection:
-                fields:
-                    created_at: created_at
-                    group_id: id
-                    name: name
-                    project_id: project_id
-                    updated_at: updated_at
-                static_fields:
-                    source_product: openai
-                template: identity_group
-              read:
-                path_params:
-                    - project_id
-              record_selector: $.data[*]
-            - config:
-                config_attributes:
-                    group_id: group_id
-                    project_id: project_id
-              coverage:
-                - families:
-                    - project_group_role
-                  high_value: false
-                  id: project_group_role
-                  support: supported
-                  title: project group role
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.project_group_role
-                required_attributes:
-                    - group_id
-                    - project_id
-                    - role_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/project_group_role/v1
-                urn_kind: openai_project_group_role
-              id: project_group_role
-              id_field: id
-              label: project group role
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/projects/{project_id}/groups/{group_id}/roles
-              projection:
-                fields:
-                    created_at: created_at
-                    created_by: created_by
-                    description: description
-                    name: name
-                    permissions: permissions
-                    predefined_role: predefined_role
-                    resource_type: resource_type
-                    role_id: id
-                    updated_at: updated_at
-                static_fields:
-                    source_product: openai
-                template: policy
-              read:
-                path_params:
-                    - project_id
-                    - group_id
-              record_selector: $.data[*]
-            - config:
-                config_attributes:
-                    project_id: project_id
-              coverage:
-                - families:
-                    - project_role
-                  high_value: false
-                  id: project_role
-                  support: supported
-                  title: project role
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.project_role
-                required_attributes:
-                    - project_id
-                    - role_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/project_role/v1
-                urn_kind: openai_project_role
-              id: project_role
-              id_field: id
-              label: project role
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /projects/{project_id}/roles
-              projection:
-                fields:
-                    created_at: created_at
-                    created_by: created_by
-                    description: description
-                    name: name
-                    permissions: permissions
-                    predefined_role: predefined_role
-                    resource_type: resource_type
-                    role_id: id
-                    updated_at: updated_at
-                static_fields:
-                    source_product: openai
-                template: policy
-              read:
-                path_params:
-                    - project_id
-              record_selector: $.data[*]
-            - config:
-                config_attributes:
-                    project_id: project_id
-                id_template: ${project_id}:data_retention
-              coverage:
-                - families:
-                    - project_data_retention
-                  high_value: false
-                  id: project_data_retention
-                  support: supported
-                  title: project data retention
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.project_data_retention
-                required_attributes:
-                    - external_id
-                    - project_id
-                schema_ref: openai/project_data_retention/v1
-                urn_kind: openai_project_data_retention
-              id: project_data_retention
-              id_field: id
-              label: project data retention
-              method: GET
-              pagination:
-                disable_page_size: true
-                type: none
-              path: /organization/projects/{project_id}/data_retention
-              projection:
-                fields:
-                    object: object
-                    project_id: project_id
-                    retention_type: type
-                static_fields:
-                    source_product: openai
-                template: policy
-              read:
-                disable_page_size: true
-                path_params:
-                    - project_id
-                singleton: true
-                singleton_fallback_id: project_data_retention
-              record_selector: $
-              singleton: true
-            - config:
-                config_attributes:
-                    project_id: project_id
-              coverage:
-                - families:
-                    - project_spend_alert
-                  high_value: false
-                  id: project_spend_alert
-                  support: supported
-                  title: project spend alert
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.project_spend_alert
-                required_attributes:
-                    - project_id
-                    - spend_alert_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/project_spend_alert/v1
-                urn_kind: openai_project_spend_alert
-              id: project_spend_alert
-              id_field: id
-              label: project spend alert
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/projects/{project_id}/spend_alerts
-              projection:
-                fields:
-                    created_at: created_at
-                    name: name
-                    project_id: project_id
-                    spend_alert_id: id
-                    status: status
-                    threshold: threshold
-                    threshold_amount: threshold_amount
-                    updated_at: updated_at
-                static_fields:
-                    source_product: openai
-                template: alert
-              read:
-                path_params:
-                    - project_id
-              record_selector: $.data[*]
-            - config:
-                config_attributes:
-                    project_id: project_id
-              coverage:
-                - families:
-                    - project_certificate
-                  high_value: false
-                  id: project_certificate
-                  support: supported
-                  title: project certificate
-                  type: entity_family
-              default_enabled: true
-              event:
-                kind: openai.project_certificate
-                required_attributes:
-                    - certificate_id
-                    - project_id
-                required_payload_fields:
-                    - id
-                schema_ref: openai/project_certificate/v1
-                urn_kind: openai_project_certificate
-              id: project_certificate
-              id_field: id
-              label: project certificate
-              method: GET
-              pagination:
-                cursor_json_path: $.next
-                cursor_param: after
-                has_more_key: has_more
-                next_cursor_keys:
-                    - next
-                    - last_id
-                page_size: 100
-                page_size_param: limit
-                type: cursor
-              path: /organization/projects/{project_id}/certificates
-              projection:
-                fields:
-                    active: active
-                    certificate_id: id
-                    created_at: created_at
-                    expires_at: certificate_details.expires_at
-                    name: name
-                    project_id: project_id
-                    valid_at: certificate_details.valid_at
-                static_fields:
-                    source_product: openai
-                template: asset
-              read:
-                path_params:
-                    - project_id
-              record_selector: $.data[*]
-        schema_version: cerebro.integration/v1
-        scope_options:
-            - default_enabled: true
+  - classifier_output: supported
+    definition:
+      auth:
+        credential_fields:
+          - key: token
+            label: OpenAI admin API key reference
+            reference_only: true
+            required: true
+            secret: true
+        model: bearer_token
+        requires_references: true
+      categories:
+        - saas
+        - ai
+      config_fields:
+        - key: actor_emails
+          label: actor emails
+        - key: actor_ids
+          label: actor ids
+        - key: api_key_ids
+          label: api key ids
+        - key: batch
+          label: batch
+        - key: bucket_width
+          label: bucket width
+        - key: effective_at_gt
+          label: effective at gt
+        - key: effective_at_gte
+          label: effective at gte
+        - key: effective_at_lt
+          label: effective at lt
+        - key: effective_at_lte
+          label: effective at lte
+        - key: end_time
+          label: end time
+        - key: event_types
+          label: event types
+        - key: group_by
+          label: group by
+        - key: group_id
+          label: group id
+        - key: models
+          label: models
+        - key: project_id
+          label: project id
+        - key: project_ids
+          label: project ids
+        - key: resource_ids
+          label: resource ids
+        - key: start_time
+          label: start time
+        - key: tenant_only
+          label: tenant only
+        - key: user_id
+          label: user id
+        - key: user_ids
+          label: user ids
+      description: Collects OpenAI organization governance, access, projects, credentials, usage, costs, retention, spend controls, certificates, rate limits, and model and tool permissions.
+      display_name: OpenAI
+      id: builtin_catalog-openai
+      resource_families:
+        - coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
               families:
                 - user
+              id: user
+              support: supported
+              title: user
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.user
+            required_attributes:
+              - user_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/user/v1
+            urn_kind: openai_user
+          id: user
+          id_field: id
+          label: user
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/users
+          projection:
+            fields:
+              added_at: added_at
+              email: email
+              name: name
+              role: role
+              status: status
+              user_id: id
+            static_fields:
+              source_product: openai
+            template: identity_user
+          record_selector: $.data[*]
+        - coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - project
+              id: project
+              support: supported
+              title: project
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.project
+            required_attributes:
+              - project_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/project/v1
+            urn_kind: openai_project
+          id: project
+          id_field: id
+          label: project
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/projects
+          projection:
+            fields:
+              archived_at: archived_at
+              created_at: created_at
+              external_key_id: external_key_id
+              name: name
+              project_id: id
+              status: status
+            static_fields:
+              source_product: openai
+            template: asset
+          record_selector: $.data[*]
+        - coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - service_account
+              id: service_account
+              support: supported
+              title: service account
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.service_account
+            required_attributes:
+              - service_account_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/service_account/v1
+            urn_kind: openai_service_account
+          id: service_account
+          id_field: id
+          label: service account
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/projects/default/service_accounts
+          projection:
+            fields:
+              created_at: created_at
+              name: name
+              project_id: project_id
+              role: role
+              service_account_id: id
+            static_fields:
+              source_product: openai
+            template: identity_application
+          record_selector: $.data[*]
+        - coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - api_key
+              id: api_key
+              support: supported
+              title: api key
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.api_key
+            required_attributes:
+              - api_key_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/api_key/v1
+            urn_kind: openai_api_key
+          id: api_key
+          id_field: id
+          label: api key
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/projects/default/api_keys
+          projection:
+            fields:
+              api_key_id: id
+              created_at: created_at
+              last_used_at: last_used_at
+              name: name
+              owner_service_account_id: owner.service_account.id
+              owner_type: owner.type
+              owner_user_id: owner.user.id
+              project_id: project_id
+              status: status
+            static_fields:
+              source_product: openai
+            template: secret
+          record_selector: $.data[*]
+        - coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - admin_api_key
+              id: admin_api_key
+              support: supported
+              title: admin api key
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.admin_api_key
+            required_attributes:
+              - api_key_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/admin_api_key/v1
+            urn_kind: openai_admin_api_key
+          id: admin_api_key
+          id_field: id
+          label: admin api key
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/admin_api_keys
+          projection:
+            fields:
+              api_key_id: id
+              created_at: created_at
+              last_used_at: last_used_at
+              name: name
+              owner_id: owner.id
+              owner_name: owner.name
+              owner_object: owner.object
+              owner_role: owner.role
+              owner_type: owner.type
+              status: status
+            static_fields:
+              key_class: admin
+              privileged: "true"
+              source_product: openai
+            template: secret
+          record_selector: $.data[*]
+        - config_query:
+            actor_emails: actor_emails
+            actor_ids: actor_ids
+            effective_at[gt]: effective_at_gt
+            effective_at[gte]: effective_at_gte
+            effective_at[lt]: effective_at_lt
+            effective_at[lte]: effective_at_lte
+            event_types: event_types
+            project_ids: project_ids
+            resource_ids: resource_ids
+            tenant_only: tenant_only
+          coverage:
+            - control_domains:
+                - logging_monitoring
+              evidence_types:
+                - logging_configuration
+              families:
                 - audit_log
+              high_value: true
+              id: audit_log
+              support: supported
+              title: audit log
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.audit_log
+            required_attributes:
+              - audit_log_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/audit_log/v1
+            urn_kind: openai_audit_log
+          id: audit_log
+          id_field: id
+          label: audit log
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/audit_logs
+          projection:
+            fields:
+              actor_api_key_id: actor.api_key.id
+              actor_city: actor.session.ip_address_details.city
+              actor_country: actor.session.ip_address_details.country
+              actor_email: actor.session.user.email|actor.api_key.user.email|actor.user.email|actor.email
+              actor_id: actor.session.user.id|actor.api_key.user.id|actor.api_key.service_account.id|actor.api_key.id|actor.user.id|actor.service_account.id|actor.id
+              actor_ip_address: actor.session.ip_address
+              actor_region: actor.session.ip_address_details.region
+              actor_service_account_id: actor.api_key.service_account.id|actor.service_account.id
+              actor_type: actor.type|actor.api_key.type
+              actor_user_agent: actor.session.user_agent
+              actor_user_id: actor.session.user.id|actor.api_key.user.id|actor.user.id
+              api_key_id: api_key.created.id|api_key.updated.id|api_key.deleted.id|api_key.id|api_key_id
+              audit_log_id: id
+              certificate_id: certificate.created.id|certificate.updated.id|certificate.deleted.id
+              certificate_name: certificate.created.name|certificate.updated.name|certificate.deleted.name
+              effective_at: effective_at
+              event_type: type|event_type
+              external_key_id: external_key.registered.id|external_key.removed.id
+              group_id: group.created.id|group.updated.id|group.deleted.id
+              group_name: group.created.data.group_name|group.updated.changes_requested.group_name
+              invite_email: invite.sent.data.email
+              invite_id: invite.sent.id|invite.accepted.id|invite.deleted.id
+              invite_role: invite.sent.data.role
+              ip_allowlist_id: ip_allowlist.created.id|ip_allowlist.updated.id|ip_allowlist.deleted.id
+              ip_allowlist_name: ip_allowlist.created.name|ip_allowlist.deleted.name
+              organization_id: organization.updated.id|organization_id|org_id
+              principal_id: role.assignment.created.principal_id|role.assignment.deleted.principal_id
+              principal_type: role.assignment.created.principal_type|role.assignment.deleted.principal_type
+              project_id: project.created.id|project.updated.id|project.archived.id|project.deleted.id|checkpoint.permission.created.data.project_id|project.id|project_id
+              rate_limit_id: rate_limit.updated.id|rate_limit.deleted.id
+              resource_id: role.assignment.created.resource_id|role.assignment.deleted.resource_id|role.bound_to_resource.resource_id|role.unbound_from_resource.resource_id|resource.deleted.id
+              resource_type: role.assignment.created.resource_type|role.assignment.deleted.resource_type|role.bound_to_resource.resource_type|role.unbound_from_resource.resource_type|resource.deleted.type
+              role_assignment_id: role.assignment.created.id|role.assignment.deleted.id
+              role_id: role.created.id|role.updated.id|role.deleted.id|role.bound_to_resource.role_id|role.unbound_from_resource.role_id
+              role_name: role.created.data.role_name|role.updated.changes_requested.role_name|role.bound_to_resource.role_name|role.unbound_from_resource.role_name
+              service_account_id: service_account.created.id|service_account.updated.id|service_account.deleted.id
+              user_id: user.added.id|user.updated.id|user.deleted.id
+            static_fields:
+              source_product: openai
+            template: audit_event
+          record_selector: $.data[*]
+        - coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - invite
+              id: invite
+              support: supported
+              title: invite
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.invite
+            required_attributes:
+              - invite_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/invite/v1
+            urn_kind: openai_invite
+          id: invite
+          id_field: id
+          label: invite
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/invites
+          projection:
+            fields:
+              accepted_at: accepted_at
+              created_at: created_at
+              email: email
+              expires_at: expires_at
+              invite_id: id
+              projects: projects
+              role: role
+              status: status
+            static_fields:
+              source_product: openai
+            template: identity_user
+          record_selector: $.data[*]
+        - coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - role
+              id: role
+              support: supported
+              title: role
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.role
+            required_attributes:
+              - role_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/role/v1
+            urn_kind: openai_role
+          id: role
+          id_field: id
+          label: role
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/roles
+          projection:
+            fields:
+              created_at: created_at
+              created_by: created_by
+              description: description
+              name: name
+              permissions: permissions
+              predefined_role: predefined_role
+              resource_type: resource_type
+              role_id: id
+              updated_at: updated_at
+            static_fields:
+              source_product: openai
+            template: policy
+          record_selector: $.data[*]
+        - config:
+            config_attributes:
+              user_id: user_id
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - user_role
+              id: user_role
+              support: supported
+              title: user role
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.user_role
+            required_attributes:
+              - role_id
+              - user_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/user_role/v1
+            urn_kind: openai_user_role
+          id: user_role
+          id_field: id
+          label: user role
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/users/{user_id}/roles
+          projection:
+            fields:
+              created_at: created_at
+              created_by: created_by
+              description: description
+              name: name
+              permissions: permissions
+              predefined_role: predefined_role
+              resource_type: resource_type
+              role_id: id
+              updated_at: updated_at
+            static_fields:
+              source_product: openai
+            template: policy
+          read:
+            path_params:
+              - user_id
+          record_selector: $.data[*]
+        - coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - group
+              id: group
+              support: supported
+              title: group
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.group
+            required_attributes:
+              - group_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/group/v1
+            urn_kind: openai_group
+          id: group
+          id_field: id
+          label: group
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/groups
+          projection:
+            fields:
+              created_at: created_at
+              group_id: id
+              name: name
+              updated_at: updated_at
+            static_fields:
+              source_product: openai
+            template: identity_group
+          record_selector: $.data[*]
+        - config:
+            config_attributes:
+              group_id: group_id
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - group_user
+              id: group_user
+              support: supported
+              title: group user
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.group_user
+            required_attributes:
+              - group_id
+              - user_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/group_user/v1
+            urn_kind: openai_group_user
+          id: group_user
+          id_field: id|user_id
+          label: group user
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/groups/{group_id}/users
+          projection:
+            fields:
+              added_at: added_at
+              email: email
+              group_id: group_id
+              name: name
+              role: role
+              user_id: id|user_id
+            static_fields:
+              source_product: openai
+            template: group_membership
+          read:
+            path_params:
+              - group_id
+          record_selector: $.data[*]
+        - config:
+            config_attributes:
+              group_id: group_id
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - group_role
+              id: group_role
+              support: supported
+              title: group role
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.group_role
+            required_attributes:
+              - group_id
+              - role_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/group_role/v1
+            urn_kind: openai_group_role
+          id: group_role
+          id_field: id
+          label: group role
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/groups/{group_id}/roles
+          projection:
+            fields:
+              created_at: created_at
+              created_by: created_by
+              description: description
+              name: name
+              permissions: permissions
+              predefined_role: predefined_role
+              resource_type: resource_type
+              role_id: id
+              updated_at: updated_at
+            static_fields:
+              source_product: openai
+            template: policy
+          read:
+            path_params:
+              - group_id
+          record_selector: $.data[*]
+        - config:
+            id_template: organization:data_retention
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - data_retention
+              id: data_retention
+              support: supported
+              title: data retention
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.data_retention
+            required_attributes:
+              - external_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/data_retention/v1
+            urn_kind: openai_data_retention
+          id: data_retention
+          id_field: id
+          label: data retention
+          method: GET
+          pagination:
+            disable_page_size: true
+            type: none
+          path: /organization/data_retention
+          projection:
+            fields:
+              object: object
+              retention_type: type
+            static_fields:
+              source_product: openai
+            template: policy
+          read:
+            disable_page_size: true
+            singleton: true
+            singleton_fallback_id: data_retention
+          record_selector: $
+          singleton: true
+        - coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - spend_alert
+              id: spend_alert
+              support: supported
+              title: spend alert
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.spend_alert
+            required_attributes:
+              - spend_alert_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/spend_alert/v1
+            urn_kind: openai_spend_alert
+          id: spend_alert
+          id_field: id
+          label: spend alert
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/spend_alerts
+          projection:
+            fields:
+              created_at: created_at
+              name: name
+              spend_alert_id: id
+              status: status
+              threshold: threshold
+              threshold_amount: threshold_amount
+              updated_at: updated_at
+            static_fields:
+              source_product: openai
+            template: alert
+          record_selector: $.data[*]
+        - coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - certificate
+              id: certificate
+              support: supported
+              title: certificate
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.certificate
+            required_attributes:
+              - certificate_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/certificate/v1
+            urn_kind: openai_certificate
+          id: certificate
+          id_field: id
+          label: certificate
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/certificates
+          projection:
+            fields:
+              active: active
+              certificate_id: id
+              created_at: created_at
+              expires_at: certificate_details.expires_at
+              name: name
+              valid_at: certificate_details.valid_at
+            static_fields:
+              source_product: openai
+            template: asset
+          record_selector: $.data[*]
+        - config_query:
+            api_key_ids: api_key_ids
+            batch: batch
+            bucket_width: bucket_width
+            end_time: end_time
+            group_by: group_by
+            models: models
+            project_ids: project_ids
+            start_time: start_time
+            user_ids: user_ids
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - usage_audio_speech
+              id: usage_audio_speech
+              support: supported
+              title: usage audio speech
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.usage_audio_speech
+            required_attributes:
+              - external_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/usage_audio_speech/v1
+            urn_kind: openai_usage_audio_speech
+          id: usage_audio_speech
+          id_field: id
+          label: usage audio speech
+          method: GET
+          pagination:
+            cursor_json_path: $.next_page
+            cursor_param: page
+            next_cursor_keys:
+              - next_page
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/usage/audio_speeches
+          projection:
+            fields:
+              amount_currency: amount.currency
+              amount_value: amount.value|amount
+              api_key_id: api_key_id
+              end_time: end_time
+              input_tokens: results.input_tokens.__sum|input_tokens
+              line_item: line_item
+              model: model
+              num_model_requests: results.num_model_requests.__sum|num_model_requests
+              organization_object: object
+              output_tokens: results.output_tokens.__sum|output_tokens
+              project_id: project_id
+              result_count: results.__count
+              start_time: start_time
+              user_id: user_id
+            static_fields:
+              source_product: openai
+            template: asset
+          record_selector: $.data[*]
+        - config_query:
+            api_key_ids: api_key_ids
+            batch: batch
+            bucket_width: bucket_width
+            end_time: end_time
+            group_by: group_by
+            models: models
+            project_ids: project_ids
+            start_time: start_time
+            user_ids: user_ids
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - usage_audio_transcription
+              id: usage_audio_transcription
+              support: supported
+              title: usage audio transcription
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.usage_audio_transcription
+            required_attributes:
+              - external_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/usage_audio_transcription/v1
+            urn_kind: openai_usage_audio_transcription
+          id: usage_audio_transcription
+          id_field: id
+          label: usage audio transcription
+          method: GET
+          pagination:
+            cursor_json_path: $.next_page
+            cursor_param: page
+            next_cursor_keys:
+              - next_page
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/usage/audio_transcriptions
+          projection:
+            fields:
+              amount_currency: amount.currency
+              amount_value: amount.value|amount
+              api_key_id: api_key_id
+              end_time: end_time
+              input_tokens: results.input_tokens.__sum|input_tokens
+              line_item: line_item
+              model: model
+              num_model_requests: results.num_model_requests.__sum|num_model_requests
+              organization_object: object
+              output_tokens: results.output_tokens.__sum|output_tokens
+              project_id: project_id
+              result_count: results.__count
+              start_time: start_time
+              user_id: user_id
+            static_fields:
+              source_product: openai
+            template: asset
+          record_selector: $.data[*]
+        - config_query:
+            api_key_ids: api_key_ids
+            batch: batch
+            bucket_width: bucket_width
+            end_time: end_time
+            group_by: group_by
+            models: models
+            project_ids: project_ids
+            start_time: start_time
+            user_ids: user_ids
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - usage_code_interpreter_session
+              id: usage_code_interpreter_session
+              support: supported
+              title: usage code interpreter session
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.usage_code_interpreter_session
+            required_attributes:
+              - external_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/usage_code_interpreter_session/v1
+            urn_kind: openai_usage_code_interpreter_session
+          id: usage_code_interpreter_session
+          id_field: id
+          label: usage code interpreter session
+          method: GET
+          pagination:
+            cursor_json_path: $.next_page
+            cursor_param: page
+            next_cursor_keys:
+              - next_page
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/usage/code_interpreter_sessions
+          projection:
+            fields:
+              amount_currency: amount.currency
+              amount_value: amount.value|amount
+              api_key_id: api_key_id
+              end_time: end_time
+              input_tokens: results.input_tokens.__sum|input_tokens
+              line_item: line_item
+              model: model
+              num_model_requests: results.num_model_requests.__sum|num_model_requests
+              organization_object: object
+              output_tokens: results.output_tokens.__sum|output_tokens
+              project_id: project_id
+              result_count: results.__count
+              start_time: start_time
+              user_id: user_id
+            static_fields:
+              source_product: openai
+            template: asset
+          record_selector: $.data[*]
+        - config_query:
+            api_key_ids: api_key_ids
+            batch: batch
+            bucket_width: bucket_width
+            end_time: end_time
+            group_by: group_by
+            models: models
+            project_ids: project_ids
+            start_time: start_time
+            user_ids: user_ids
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - usage_completion
+              id: usage_completion
+              support: supported
+              title: usage completion
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.usage_completion
+            required_attributes:
+              - external_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/usage_completion/v1
+            urn_kind: openai_usage_completion
+          id: usage_completion
+          id_field: id
+          label: usage completion
+          method: GET
+          pagination:
+            cursor_json_path: $.next_page
+            cursor_param: page
+            next_cursor_keys:
+              - next_page
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/usage/completions
+          projection:
+            fields:
+              amount_currency: amount.currency
+              amount_value: amount.value|amount
+              api_key_id: api_key_id
+              end_time: end_time
+              input_tokens: results.input_tokens.__sum|input_tokens
+              line_item: line_item
+              model: model
+              num_model_requests: results.num_model_requests.__sum|num_model_requests
+              organization_object: object
+              output_tokens: results.output_tokens.__sum|output_tokens
+              project_id: project_id
+              result_count: results.__count
+              start_time: start_time
+              user_id: user_id
+            static_fields:
+              source_product: openai
+            template: asset
+          record_selector: $.data[*]
+        - config_query:
+            api_key_ids: api_key_ids
+            batch: batch
+            bucket_width: bucket_width
+            end_time: end_time
+            group_by: group_by
+            models: models
+            project_ids: project_ids
+            start_time: start_time
+            user_ids: user_ids
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - usage_embedding
+              id: usage_embedding
+              support: supported
+              title: usage embedding
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.usage_embedding
+            required_attributes:
+              - external_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/usage_embedding/v1
+            urn_kind: openai_usage_embedding
+          id: usage_embedding
+          id_field: id
+          label: usage embedding
+          method: GET
+          pagination:
+            cursor_json_path: $.next_page
+            cursor_param: page
+            next_cursor_keys:
+              - next_page
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/usage/embeddings
+          projection:
+            fields:
+              amount_currency: amount.currency
+              amount_value: amount.value|amount
+              api_key_id: api_key_id
+              end_time: end_time
+              input_tokens: results.input_tokens.__sum|input_tokens
+              line_item: line_item
+              model: model
+              num_model_requests: results.num_model_requests.__sum|num_model_requests
+              organization_object: object
+              output_tokens: results.output_tokens.__sum|output_tokens
+              project_id: project_id
+              result_count: results.__count
+              start_time: start_time
+              user_id: user_id
+            static_fields:
+              source_product: openai
+            template: asset
+          record_selector: $.data[*]
+        - config_query:
+            api_key_ids: api_key_ids
+            batch: batch
+            bucket_width: bucket_width
+            end_time: end_time
+            group_by: group_by
+            models: models
+            project_ids: project_ids
+            start_time: start_time
+            user_ids: user_ids
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - usage_image
+              id: usage_image
+              support: supported
+              title: usage image
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.usage_image
+            required_attributes:
+              - external_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/usage_image/v1
+            urn_kind: openai_usage_image
+          id: usage_image
+          id_field: id
+          label: usage image
+          method: GET
+          pagination:
+            cursor_json_path: $.next_page
+            cursor_param: page
+            next_cursor_keys:
+              - next_page
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/usage/images
+          projection:
+            fields:
+              amount_currency: amount.currency
+              amount_value: amount.value|amount
+              api_key_id: api_key_id
+              end_time: end_time
+              input_tokens: results.input_tokens.__sum|input_tokens
+              line_item: line_item
+              model: model
+              num_model_requests: results.num_model_requests.__sum|num_model_requests
+              organization_object: object
+              output_tokens: results.output_tokens.__sum|output_tokens
+              project_id: project_id
+              result_count: results.__count
+              start_time: start_time
+              user_id: user_id
+            static_fields:
+              source_product: openai
+            template: asset
+          record_selector: $.data[*]
+        - config_query:
+            api_key_ids: api_key_ids
+            batch: batch
+            bucket_width: bucket_width
+            end_time: end_time
+            group_by: group_by
+            models: models
+            project_ids: project_ids
+            start_time: start_time
+            user_ids: user_ids
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - usage_moderation
+              id: usage_moderation
+              support: supported
+              title: usage moderation
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.usage_moderation
+            required_attributes:
+              - external_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/usage_moderation/v1
+            urn_kind: openai_usage_moderation
+          id: usage_moderation
+          id_field: id
+          label: usage moderation
+          method: GET
+          pagination:
+            cursor_json_path: $.next_page
+            cursor_param: page
+            next_cursor_keys:
+              - next_page
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/usage/moderations
+          projection:
+            fields:
+              amount_currency: amount.currency
+              amount_value: amount.value|amount
+              api_key_id: api_key_id
+              end_time: end_time
+              input_tokens: results.input_tokens.__sum|input_tokens
+              line_item: line_item
+              model: model
+              num_model_requests: results.num_model_requests.__sum|num_model_requests
+              organization_object: object
+              output_tokens: results.output_tokens.__sum|output_tokens
+              project_id: project_id
+              result_count: results.__count
+              start_time: start_time
+              user_id: user_id
+            static_fields:
+              source_product: openai
+            template: asset
+          record_selector: $.data[*]
+        - config_query:
+            api_key_ids: api_key_ids
+            batch: batch
+            bucket_width: bucket_width
+            end_time: end_time
+            group_by: group_by
+            models: models
+            project_ids: project_ids
+            start_time: start_time
+            user_ids: user_ids
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - usage_vector_store
+              id: usage_vector_store
+              support: supported
+              title: usage vector store
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.usage_vector_store
+            required_attributes:
+              - external_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/usage_vector_store/v1
+            urn_kind: openai_usage_vector_store
+          id: usage_vector_store
+          id_field: id
+          label: usage vector store
+          method: GET
+          pagination:
+            cursor_json_path: $.next_page
+            cursor_param: page
+            next_cursor_keys:
+              - next_page
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/usage/vector_stores
+          projection:
+            fields:
+              amount_currency: amount.currency
+              amount_value: amount.value|amount
+              api_key_id: api_key_id
+              end_time: end_time
+              input_tokens: results.input_tokens.__sum|input_tokens
+              line_item: line_item
+              model: model
+              num_model_requests: results.num_model_requests.__sum|num_model_requests
+              organization_object: object
+              output_tokens: results.output_tokens.__sum|output_tokens
+              project_id: project_id
+              result_count: results.__count
+              start_time: start_time
+              user_id: user_id
+            static_fields:
+              source_product: openai
+            template: asset
+          record_selector: $.data[*]
+        - config_query:
+            api_key_ids: api_key_ids
+            batch: batch
+            bucket_width: bucket_width
+            end_time: end_time
+            group_by: group_by
+            models: models
+            project_ids: project_ids
+            start_time: start_time
+            user_ids: user_ids
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - usage_file_search_call
+              id: usage_file_search_call
+              support: supported
+              title: usage file search call
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.usage_file_search_call
+            required_attributes:
+              - external_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/usage_file_search_call/v1
+            urn_kind: openai_usage_file_search_call
+          id: usage_file_search_call
+          id_field: id
+          label: usage file search call
+          method: GET
+          pagination:
+            cursor_json_path: $.next_page
+            cursor_param: page
+            next_cursor_keys:
+              - next_page
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/usage/file_search_calls
+          projection:
+            fields:
+              amount_currency: amount.currency
+              amount_value: amount.value|amount
+              api_key_id: api_key_id
+              end_time: end_time
+              input_tokens: results.input_tokens.__sum|input_tokens
+              line_item: line_item
+              model: model
+              num_model_requests: results.num_model_requests.__sum|num_model_requests
+              organization_object: object
+              output_tokens: results.output_tokens.__sum|output_tokens
+              project_id: project_id
+              result_count: results.__count
+              start_time: start_time
+              user_id: user_id
+            static_fields:
+              source_product: openai
+            template: asset
+          record_selector: $.data[*]
+        - config_query:
+            api_key_ids: api_key_ids
+            batch: batch
+            bucket_width: bucket_width
+            end_time: end_time
+            group_by: group_by
+            models: models
+            project_ids: project_ids
+            start_time: start_time
+            user_ids: user_ids
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - usage_web_search_call
+              id: usage_web_search_call
+              support: supported
+              title: usage web search call
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.usage_web_search_call
+            required_attributes:
+              - external_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/usage_web_search_call/v1
+            urn_kind: openai_usage_web_search_call
+          id: usage_web_search_call
+          id_field: id
+          label: usage web search call
+          method: GET
+          pagination:
+            cursor_json_path: $.next_page
+            cursor_param: page
+            next_cursor_keys:
+              - next_page
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/usage/web_search_calls
+          projection:
+            fields:
+              amount_currency: amount.currency
+              amount_value: amount.value|amount
+              api_key_id: api_key_id
+              end_time: end_time
+              input_tokens: results.input_tokens.__sum|input_tokens
+              line_item: line_item
+              model: model
+              num_model_requests: results.num_model_requests.__sum|num_model_requests
+              organization_object: object
+              output_tokens: results.output_tokens.__sum|output_tokens
+              project_id: project_id
+              result_count: results.__count
+              start_time: start_time
+              user_id: user_id
+            static_fields:
+              source_product: openai
+            template: asset
+          record_selector: $.data[*]
+        - config_query:
+            api_key_ids: api_key_ids
+            batch: batch
+            bucket_width: bucket_width
+            end_time: end_time
+            group_by: group_by
+            models: models
+            project_ids: project_ids
+            start_time: start_time
+            user_ids: user_ids
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - cost
+              id: cost
+              support: supported
+              title: cost
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.cost
+            required_attributes:
+              - external_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/cost/v1
+            urn_kind: openai_cost
+          id: cost
+          id_field: id
+          label: cost
+          method: GET
+          pagination:
+            cursor_json_path: $.next_page
+            cursor_param: page
+            next_cursor_keys:
+              - next_page
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/costs
+          projection:
+            fields:
+              amount_currency: amount.currency
+              amount_value: amount.value|amount
+              api_key_id: api_key_id
+              end_time: end_time
+              input_tokens: results.input_tokens.__sum|input_tokens
+              line_item: line_item
+              model: model
+              num_model_requests: results.num_model_requests.__sum|num_model_requests
+              organization_object: object
+              output_tokens: results.output_tokens.__sum|output_tokens
+              project_id: project_id
+              result_count: results.__count
+              start_time: start_time
+              user_id: user_id
+            static_fields:
+              source_product: openai
+            template: asset
+          record_selector: $.data[*]
+        - config:
+            config_attributes:
+              project_id: project_id
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - project_user
+              id: project_user
+              support: supported
+              title: project user
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.project_user
+            required_attributes:
+              - project_id
+              - user_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/project_user/v1
+            urn_kind: openai_project_user
+          id: project_user
+          id_field: id|user_id
+          label: project user
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/projects/{project_id}/users
+          projection:
+            fields:
+              added_at: added_at
+              email: email
+              name: name
+              project_id: project_id
+              role: role
+              user_id: id|user_id
+            static_fields:
+              source_product: openai
+            template: group_membership
+          read:
+            path_params:
+              - project_id
+          record_selector: $.data[*]
+        - config:
+            config_attributes:
+              project_id: project_id
+              user_id: user_id
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - project_user_role
+              id: project_user_role
+              support: supported
+              title: project user role
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.project_user_role
+            required_attributes:
+              - project_id
+              - role_id
+              - user_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/project_user_role/v1
+            urn_kind: openai_project_user_role
+          id: project_user_role
+          id_field: id
+          label: project user role
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /projects/{project_id}/users/{user_id}/roles
+          projection:
+            fields:
+              created_at: created_at
+              created_by: created_by
+              description: description
+              name: name
+              permissions: permissions
+              predefined_role: predefined_role
+              resource_type: resource_type
+              role_id: id
+              updated_at: updated_at
+            static_fields:
+              source_product: openai
+            template: policy
+          read:
+            path_params:
+              - project_id
+              - user_id
+          record_selector: $.data[*]
+        - config:
+            config_attributes:
+              project_id: project_id
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - project_service_account
+              id: project_service_account
+              support: supported
+              title: project service account
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.project_service_account
+            required_attributes:
+              - project_id
+              - service_account_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/project_service_account/v1
+            urn_kind: openai_project_service_account
+          id: project_service_account
+          id_field: id
+          label: project service account
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/projects/{project_id}/service_accounts
+          projection:
+            fields:
+              created_at: created_at
+              name: name
+              project_id: project_id
+              role: role
+              service_account_id: id
+            static_fields:
+              source_product: openai
+            template: identity_application
+          read:
+            path_params:
+              - project_id
+          record_selector: $.data[*]
+        - config:
+            config_attributes:
+              project_id: project_id
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - project_api_key
+              id: project_api_key
+              support: supported
+              title: project api key
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.project_api_key
+            required_attributes:
+              - api_key_id
+              - project_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/project_api_key/v1
+            urn_kind: openai_project_api_key
+          id: project_api_key
+          id_field: id
+          label: project api key
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/projects/{project_id}/api_keys
+          projection:
+            fields:
+              api_key_id: id
+              created_at: created_at
+              last_used_at: last_used_at
+              name: name
+              owner_service_account_id: owner.service_account.id
+              owner_type: owner.type
+              owner_user_id: owner.user.id
+              project_id: project_id
+              status: status
+            static_fields:
+              source_product: openai
+            template: secret
+          read:
+            path_params:
+              - project_id
+          record_selector: $.data[*]
+        - config:
+            config_attributes:
+              project_id: project_id
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - project_rate_limit
+              id: project_rate_limit
+              support: supported
+              title: project rate limit
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.project_rate_limit
+            required_attributes:
+              - external_id
+              - project_id
+            required_payload_fields:
+              - id|model
+            schema_ref: openai/project_rate_limit/v1
+            urn_kind: openai_project_rate_limit
+          id: project_rate_limit
+          id_field: id|model
+          label: project rate limit
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/projects/{project_id}/rate_limits
+          projection:
+            fields:
+              batch_1_day_max_input_tokens: batch_1_day_max_input_tokens
+              created_at: created_at
+              max_images_per_1_minute: max_images_per_1_minute
+              max_requests_per_1_day: max_requests_per_1_day
+              max_requests_per_1_minute: max_requests_per_1_minute
+              max_tokens_per_1_minute: max_tokens_per_1_minute
+              model: model
+              project_id: project_id
+              rate_limit_id: id
+              updated_at: updated_at
+            static_fields:
+              source_product: openai
+            template: policy
+          read:
+            path_params:
+              - project_id
+          record_selector: $.data[*]
+        - config:
+            config_attributes:
+              project_id: project_id
+            id_template: ${project_id}:model_permissions
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - project_model_permission
+              id: project_model_permission
+              support: supported
+              title: project model permission
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.project_model_permission
+            required_attributes:
+              - external_id
+              - project_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/project_model_permission/v1
+            urn_kind: openai_project_model_permission
+          id: project_model_permission
+          id_field: id
+          label: project model permission
+          method: GET
+          pagination:
+            disable_page_size: true
+            type: none
+          path: /organization/projects/{project_id}/model_permissions
+          projection:
+            fields:
+              mode: mode
+              model_ids: model_ids
+              project_id: project_id
+            static_fields:
+              source_product: openai
+            template: policy
+          read:
+            disable_page_size: true
+            path_params:
+              - project_id
+            singleton: true
+            singleton_fallback_id: project_model_permission
+          record_selector: $
+          singleton: true
+        - config:
+            config_attributes:
+              project_id: project_id
+            id_template: ${project_id}:hosted_tool_permissions
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - project_hosted_tool_permission
+              id: project_hosted_tool_permission
+              support: supported
+              title: project hosted tool permission
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.project_hosted_tool_permission
+            required_attributes:
+              - external_id
+              - project_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/project_hosted_tool_permission/v1
+            urn_kind: openai_project_hosted_tool_permission
+          id: project_hosted_tool_permission
+          id_field: id
+          label: project hosted tool permission
+          method: GET
+          pagination:
+            disable_page_size: true
+            type: none
+          path: /organization/projects/{project_id}/hosted_tool_permissions
+          projection:
+            fields:
+              code_interpreter_enabled: code_interpreter.enabled
+              file_search_enabled: file_search.enabled
+              image_generation_enabled: image_generation.enabled
+              mcp_enabled: mcp.enabled
+              project_id: project_id
+              web_search_enabled: web_search.enabled
+            static_fields:
+              source_product: openai
+            template: policy
+          read:
+            disable_page_size: true
+            path_params:
+              - project_id
+            singleton: true
+            singleton_fallback_id: project_hosted_tool_permission
+          record_selector: $
+          singleton: true
+        - config:
+            config_attributes:
+              project_id: project_id
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - project_group
+              id: project_group
+              support: supported
+              title: project group
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.project_group
+            required_attributes:
+              - group_id
+              - project_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/project_group/v1
+            urn_kind: openai_project_group
+          id: project_group
+          id_field: id
+          label: project group
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/projects/{project_id}/groups
+          projection:
+            fields:
+              created_at: created_at
+              group_id: id
+              name: name
+              project_id: project_id
+              updated_at: updated_at
+            static_fields:
+              source_product: openai
+            template: identity_group
+          read:
+            path_params:
+              - project_id
+          record_selector: $.data[*]
+        - config:
+            config_attributes:
+              group_id: group_id
+              project_id: project_id
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - project_group_role
+              id: project_group_role
+              support: supported
+              title: project group role
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.project_group_role
+            required_attributes:
+              - group_id
+              - project_id
+              - role_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/project_group_role/v1
+            urn_kind: openai_project_group_role
+          id: project_group_role
+          id_field: id
+          label: project group role
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/projects/{project_id}/groups/{group_id}/roles
+          projection:
+            fields:
+              created_at: created_at
+              created_by: created_by
+              description: description
+              name: name
+              permissions: permissions
+              predefined_role: predefined_role
+              resource_type: resource_type
+              role_id: id
+              updated_at: updated_at
+            static_fields:
+              source_product: openai
+            template: policy
+          read:
+            path_params:
+              - project_id
+              - group_id
+          record_selector: $.data[*]
+        - config:
+            config_attributes:
+              project_id: project_id
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - project_role
+              id: project_role
+              support: supported
+              title: project role
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.project_role
+            required_attributes:
+              - project_id
+              - role_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/project_role/v1
+            urn_kind: openai_project_role
+          id: project_role
+          id_field: id
+          label: project role
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /projects/{project_id}/roles
+          projection:
+            fields:
+              created_at: created_at
+              created_by: created_by
+              description: description
+              name: name
+              permissions: permissions
+              predefined_role: predefined_role
+              resource_type: resource_type
+              role_id: id
+              updated_at: updated_at
+            static_fields:
+              source_product: openai
+            template: policy
+          read:
+            path_params:
+              - project_id
+          record_selector: $.data[*]
+        - config:
+            config_attributes:
+              project_id: project_id
+            id_template: ${project_id}:data_retention
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - project_data_retention
+              id: project_data_retention
+              support: supported
+              title: project data retention
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.project_data_retention
+            required_attributes:
+              - external_id
+              - project_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/project_data_retention/v1
+            urn_kind: openai_project_data_retention
+          id: project_data_retention
+          id_field: id
+          label: project data retention
+          method: GET
+          pagination:
+            disable_page_size: true
+            type: none
+          path: /organization/projects/{project_id}/data_retention
+          projection:
+            fields:
+              object: object
+              project_id: project_id
+              retention_type: type
+            static_fields:
+              source_product: openai
+            template: policy
+          read:
+            disable_page_size: true
+            path_params:
+              - project_id
+            singleton: true
+            singleton_fallback_id: project_data_retention
+          record_selector: $
+          singleton: true
+        - config:
+            config_attributes:
+              project_id: project_id
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - project_spend_alert
+              id: project_spend_alert
+              support: supported
+              title: project spend alert
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.project_spend_alert
+            required_attributes:
+              - project_id
+              - spend_alert_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/project_spend_alert/v1
+            urn_kind: openai_project_spend_alert
+          id: project_spend_alert
+          id_field: id
+          label: project spend alert
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/projects/{project_id}/spend_alerts
+          projection:
+            fields:
+              created_at: created_at
+              name: name
+              project_id: project_id
+              spend_alert_id: id
+              status: status
+              threshold: threshold
+              threshold_amount: threshold_amount
+              updated_at: updated_at
+            static_fields:
+              source_product: openai
+            template: alert
+          read:
+            path_params:
+              - project_id
+          record_selector: $.data[*]
+        - config:
+            config_attributes:
+              project_id: project_id
+          coverage:
+            - control_domains:
+                - asset_inventory
+              evidence_types:
+                - source_snapshot
+              families:
                 - project_certificate
-              id: openai_governance
-              label: OpenAI governance
-        source_id: openai
-        tenant_id: builtin_catalog
-        transport:
-            base_url: https://api.openai.com/v1
-            retry:
-                backoff: exponential
-                max_attempts: 3
-                retry_after_header: Retry-After
-                statuses:
-                    - 429
-                    - 500
-                    - 502
-                    - 503
-                    - 504
-            verification:
-                expect_status:
-                    - 200
-                method: GET
-                path: /organization/users
+              id: project_certificate
+              support: supported
+              title: project certificate
+              type: entity_family
+          default_enabled: true
+          event:
+            kind: openai.project_certificate
+            required_attributes:
+              - certificate_id
+              - project_id
+            required_payload_fields:
+              - id
+            schema_ref: openai/project_certificate/v1
+            urn_kind: openai_project_certificate
+          id: project_certificate
+          id_field: id
+          label: project certificate
+          method: GET
+          pagination:
+            cursor_json_path: $.next
+            cursor_param: after
+            has_more_key: has_more
+            next_cursor_keys:
+              - next
+              - last_id
+            page_size: 100
+            page_size_param: limit
+            type: cursor
+          path: /organization/projects/{project_id}/certificates
+          projection:
+            fields:
+              active: active
+              certificate_id: id
+              created_at: created_at
+              expires_at: certificate_details.expires_at
+              name: name
+              project_id: project_id
+              valid_at: certificate_details.valid_at
+            static_fields:
+              source_product: openai
+            template: asset
+          read:
+            path_params:
+              - project_id
+          record_selector: $.data[*]
+      schema_version: cerebro.integration/v1
+      scope_options:
+        - default_enabled: true
+          families:
+            - user
+            - project
+            - service_account
+            - api_key
+            - admin_api_key
+            - audit_log
+            - invite
+            - role
+            - user_role
+            - group
+            - group_user
+            - group_role
+            - data_retention
+            - spend_alert
+            - certificate
+            - usage_audio_speech
+            - usage_audio_transcription
+            - usage_code_interpreter_session
+            - usage_completion
+            - usage_embedding
+            - usage_image
+            - usage_moderation
+            - usage_vector_store
+            - usage_file_search_call
+            - usage_web_search_call
+            - cost
+            - project_user
+            - project_user_role
+            - project_service_account
+            - project_api_key
+            - project_rate_limit
+            - project_model_permission
+            - project_hosted_tool_permission
+            - project_group
+            - project_group_role
+            - project_role
+            - project_data_retention
+            - project_spend_alert
+            - project_certificate
+          id: openai_governance
+          label: OpenAI governance
+      source_id: openai
+      tenant_id: builtin_catalog
+      transport:
+        base_url: https://api.openai.com/v1
+        retry:
+          backoff: exponential
+          max_attempts: 3
+          retry_after_header: Retry-After
+          statuses:
+            - 429
+            - 500
+            - 502
+            - 503
+            - 504
+        verification:
+          expect_status:
+            - 200
+          method: GET
+          path: /organization/users

--- a/sources/openai/catalog_runtime_parity_test.go
+++ b/sources/openai/catalog_runtime_parity_test.go
@@ -1,0 +1,114 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/writer/cerebro/internal/connectorcatalog"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/sources/internal/catalogruntime"
+)
+
+func TestCatalogRuntimeMatchesGoOracleFixtures(t *testing.T) {
+	entry, ok, err := connectorcatalog.BuiltinEntry(sourceID)
+	if err != nil {
+		t.Fatalf("BuiltinEntry(%q) error = %v", sourceID, err)
+	}
+	if !ok {
+		t.Fatalf("BuiltinEntry(%q) not found", sourceID)
+	}
+	for _, family := range openAIFamilies() {
+		family := family
+		t.Run(family.Name, func(t *testing.T) {
+			expected := readOracleEvent(t, family.Name)
+			payload, err := json.Marshal(expected.Payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			response := payload
+			if !family.Singleton {
+				response, err = json.Marshal(map[string]any{"data": []json.RawMessage{payload}, "has_more": false})
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.Header().Set("Content-Type", "application/json")
+				_, _ = writer.Write(response)
+			}))
+			defer server.Close()
+
+			manual, err := New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			manual.inner.AllowLoopbackBaseURL = true
+			compiled, err := catalogruntime.NewDefinitionWithValidationOptions(entry.Definition, catalogruntime.ValidationOptions{AllowLoopbackBaseURL: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			values := map[string]string{
+				"api_key":   "credential-reference-fixture", // #nosec G101 -- non-secret fixture reference.
+				"token":     "credential-reference-fixture", // #nosec G101 -- non-secret fixture reference.
+				"base_url":  server.URL,
+				"family":    family.Name,
+				"tenant_id": expected.TenantID,
+			}
+			for _, parameter := range family.PathParams {
+				values[parameter] = expected.Attributes[parameter]
+			}
+			cfg := sourcecdk.NewConfig(values)
+			goPull, err := manual.Read(context.Background(), cfg, nil)
+			if err != nil {
+				t.Fatalf("manual Read() error = %v", err)
+			}
+			rustPull, err := compiled.Read(context.Background(), cfg, nil)
+			if err != nil {
+				t.Fatalf("catalog Read() error = %v", err)
+			}
+			if len(goPull.Events) != 1 || len(rustPull.Events) != 1 {
+				t.Fatalf("event counts = manual %d catalog %d, want 1 each", len(goPull.Events), len(rustPull.Events))
+			}
+			goEvent, catalogEvent := goPull.Events[0], rustPull.Events[0]
+			if catalogEvent.Id != goEvent.Id || catalogEvent.Kind != goEvent.Kind || catalogEvent.SchemaRef != goEvent.SchemaRef || catalogEvent.SourceId != goEvent.SourceId || catalogEvent.TenantId != goEvent.TenantId {
+				t.Fatalf("identity contract mismatch:\nmanual=%#v\ncatalog=%#v", goEvent, catalogEvent)
+			}
+			if string(catalogEvent.Payload) != string(goEvent.Payload) {
+				t.Fatalf("payload mismatch:\nmanual=%s\ncatalog=%s", goEvent.Payload, catalogEvent.Payload)
+			}
+			for attribute, want := range goEvent.Attributes {
+				if got := catalogEvent.Attributes[attribute]; got != want {
+					t.Fatalf("catalog attribute %s = %q, want Go oracle %q", attribute, got, want)
+				}
+			}
+		})
+	}
+}
+
+type oracleEvent struct {
+	TenantID   string            `json:"tenant_id"`
+	Payload    json.RawMessage   `json:"payload"`
+	Attributes map[string]string `json:"attributes"`
+}
+
+func readOracleEvent(t *testing.T, family string) oracleEvent {
+	t.Helper()
+	path := filepath.Join("testdata", "read_"+family+".json")
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var events []oracleEvent
+	if err := json.Unmarshal(bytes, &events); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("%s fixture has %d events, want 1", path, len(events))
+	}
+	return events[0]
+}

--- a/sources/openai/catalog_runtime_parity_test.go
+++ b/sources/openai/catalog_runtime_parity_test.go
@@ -99,7 +99,7 @@ type oracleEvent struct {
 func readOracleEvent(t *testing.T, family string) oracleEvent {
 	t.Helper()
 	path := filepath.Join("testdata", "read_"+family+".json")
-	bytes, err := os.ReadFile(path)
+	bytes, err := os.ReadFile(path) // #nosec G304 -- family comes from the closed OpenAI catalog table.
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sources/openai/source.go
+++ b/sources/openai/source.go
@@ -134,6 +134,16 @@ func openAISingletonFamily(name string, path string, urnKind string, attrs map[s
 		f.CursorParam = ""
 		f.NextCursorKeys = nil
 		f.HasMoreKey = ""
+		switch name {
+		case "data_retention":
+			f.Config.IDTemplate = "organization:data_retention"
+		case "project_model_permission":
+			f.Config.IDTemplate = "${project_id}:model_permissions"
+		case "project_hosted_tool_permission":
+			f.Config.IDTemplate = "${project_id}:hosted_tool_permissions"
+		case "project_data_retention":
+			f.Config.IDTemplate = "${project_id}:data_retention"
+		}
 	})...)
 }
 


### PR DESCRIPTION
## Summary

- compile all 39 OpenAI organization-governance families into a closed Rust runtime definition
- plan bounded credential-free requests restricted to `https://api.openai.com:443`, with deterministic query/path encoding and no redirect authority in the kernel
- validate provider statuses and response bounds, normalize exact event contracts, preserve tenant-scoped Go-compatible identities, and propose bounded cursors/checkpoints
- compare every checked-in OpenAI Go oracle fixture with Rust semantics and compare the generic catalog runtime with the handwritten Go oracle
- preserve organization users, groups, roles, projects, API/admin keys, service accounts, usage, costs, retention, spend controls, certificates, rate limits, and model/tool permissions

## Security and durability invariants

- kernel request protocol contains authentication requirements but no credential values or secret references
- credential-shaped configuration and provider payload fields fail closed without echoing values
- provider payloads cannot supply authenticated tenant identity
- scheme, host, port, method, page size, cursor size, response bytes, record count, and query/path inputs are bounded
- duplicate identities are idempotent only for identical content; conflicting content is rejected
- terminal pages cannot emit cursors, invalid continuations cannot produce checkpoint proposals, and interrupted collection resumes with stable identities
- provider failures remain typed across authentication, permission, rate-limit, availability, unexpected-status, malformed-response, cursor, identity, tenant, and event-contract classes

## Local validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p cerebro-source-catalog -p cerebro-source-runtime-next --no-fail-fast` (22 catalog, 471 runtime, 17 integration; all passed)
- `cargo test --locked -p cerebro-source-runtime-next 'openai::tests' --no-fail-fast` (12 passed)
- `cargo test --locked -p cerebro-platform --test rust_only_runtime_contract` (6 passed)
- `cargo clippy --locked -p cerebro-source-catalog -p cerebro-source-runtime-next --all-targets --all-features -- -D warnings`
- `go test ./sources/openai ./sources/internal/catalogruntime ./internal/connectorcatalog ./internal/connectordefinitions ./internal/sourceprojection ./internal/sourceregistry -count=1`
- `go test -race ./sources/openai ./sources/internal/catalogruntime ./internal/sourceprojection ./internal/sourceregistry -count=1`
- `make sourcegen-test`
- `make catalog-check fixture-oracle-check source-fixture-check`
- `make connector-catalog-fidelity-check sourcegen-check connector-catalog-review`
- `make check-structural check-structural-test check-arch`
- `make docs-drift-check readme-check`
- `./scripts/leak_check.sh`

## Delivery boundary

- This PR retains the handwritten Go source as the fixture oracle.
- This branch is based on `main` after #2435 retired compile-time standard Go loaders. No OpenAI loader exception remains.
- Live-provider and authenticated product-path proof require an authorized read-only OpenAI test identity and deployed runtime; neither credential material nor private deployment configuration is included here.
