### PR TITLE
test(cloudflare): cover semantic JSON parity

### DIFF
--- a/crates/source-runtime-next/src/cloudflare/tests.rs
+++ b/crates/source-runtime-next/src/cloudflare/tests.rs
@@ -99,6 +99,29 @@ fn scope_for(family: CloudflareFamily, event: &OracleEvent) -> Option<String> {
     }
 }
 
+fn attributes_semantically_equal(actual: &str, expected: &str) -> bool {
+    match (
+        serde_json::from_str::<Value>(actual),
+        serde_json::from_str::<Value>(expected),
+    ) {
+        (Ok(actual), Ok(expected)) => actual == expected,
+        _ => actual == expected,
+    }
+}
+
+#[test]
+fn json_attribute_parity_ignores_object_key_order_only() {
+    assert!(attributes_semantically_equal(
+        r#"{"name":"SESSION_STORE","type":"kv_namespace","namespace_id":"kv-session"}"#,
+        r#"{"name":"SESSION_STORE","namespace_id":"kv-session","type":"kv_namespace"}"#,
+    ));
+    assert!(!attributes_semantically_equal(
+        r#"{"type":"kv_namespace"}"#,
+        r#"{"type":"secret_text"}"#,
+    ));
+    assert!(!attributes_semantically_equal("worker-a", "worker-b"));
+}
+
 #[test]
 fn family_vocabulary_is_closed_and_contract_bound() {
     assert_eq!(CloudflareFamily::ALL.len(), 16);
@@ -215,19 +238,11 @@ fn every_go_oracle_family_normalizes_with_semantic_parity() {
                 .attributes
                 .get(key)
                 .unwrap_or_else(|| panic!("{} missing attribute {key}", family.as_str()));
-            if let (Ok(actual_json), Ok(expected_json)) = (
-                serde_json::from_str::<Value>(actual),
-                serde_json::from_str::<Value>(expected),
-            ) {
-                assert_eq!(
-                    actual_json,
-                    expected_json,
-                    "{} JSON attribute {key}",
-                    family.as_str()
-                );
-                continue;
-            }
-            assert_eq!(actual, expected, "{} attribute {key}", family.as_str());
+            assert!(
+                attributes_semantically_equal(actual, expected),
+                "{} attribute {key}",
+                family.as_str()
+            );
         }
     }
 }


### PR DESCRIPTION
Hardens the Cloudflare semantic JSON comparison merged in PR #2450.

The functional comparison is already on main. This focused follow-up extracts it into a reusable helper and adds a dedicated regression proving that JSON object key order is ignored while semantic JSON differences and ordinary string differences remain failures.

Go remains the authoritative Cloudflare collector. This changes test structure and regression coverage only.

Local validation after rebasing onto main 7e061307aa99869d2e93368ac09d3990f2c0cb03:
- semantic parity test repeated 5 times: passed
- cargo test -p cerebro-source-runtime-next cloudflare::tests -- --nocapture: 14 passed
- cargo fmt --all -- --check: passed
- cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings: passed
- git diff --check: passed

Hosted validation is pending on the rebased head.