### PR TITLE
fix(ci): refresh Rust candidate catalog count

### DIFF
--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -178,7 +178,7 @@ jobs:
           '
           summary="$(docker run --rm "${CANDIDATE_IMAGE}" catalog-summary)"
           test "$(jq -r .sources <<<"${summary}")" -eq 799
-          test "$(jq -r .families <<<"${summary}")" -eq 3926
+          test "$(jq -r .families <<<"${summary}")" -eq 3938
       - name: Start disposable PostgreSQL, Neo4j, and JetStream
         run: |
           set -euo pipefail
@@ -246,7 +246,7 @@ jobs:
             | .checks += [
                 {name:"rust_entrypoint",status:"passed",evidence:"image starts cerebro-platform directly"},
                 {name:"go_binary_absent",status:"passed",evidence:"/usr/local/bin/cerebro is absent"},
-                {name:"source_catalog",status:"passed",evidence:"799 sources and 3926 families loaded"}
+                {name:"source_catalog",status:"passed",evidence:"799 sources and 3938 families loaded"}
               ]
           ' .dist/rust-only-e2e/rust-only-e2e-receipt.json \
             > .dist/rust-only-e2e/receipt.tmp

--- a/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
+++ b/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
@@ -108,8 +108,8 @@ fn rust_candidate_build_never_invokes_go_or_emulation() {
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- seed",
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- verify",
         r#"test "$(jq -r .sources <<<"${summary}")" -eq 799"#,
-        r#"test "$(jq -r .families <<<"${summary}")" -eq 3926"#,
-        r#"evidence:"799 sources and 3926 families loaded""#,
+        r#"test "$(jq -r .families <<<"${summary}")" -eq 3938"#,
+        r#"evidence:"799 sources and 3938 families loaded""#,
         "cerebro.rust-only-e2e/v1",
         "cerebro.rust-only-candidate/v1",
     ] {


### PR DESCRIPTION
## Summary

- update the Rust-only candidate catalog assertion from 3,926 to the current compiled 3,938 families
- keep the emitted qualification receipt and its workflow contract test on the same count
- repair the post-merge current-main failure from run 32559223331 without changing provider/runtime behavior

## Local validation

- `cargo fmt --all -- --check`
- `cargo test -p cerebro-platform --test rust_only_runtime_contract` (6 passed)
- `cargo test -p cerebro-source-catalog` (22 passed)
- `cargo clippy -p cerebro-platform --test rust_only_runtime_contract -- -D warnings`
- `actionlint .github/workflows/rust-only-candidate.yml`
- `git diff --check`

## Failure classification

Current main compiles 799 sources and 3,938 families after #2439. The Rust-only candidate workflow still required 3,926 families, so the signed candidate passed image construction and binary checks but failed the stale summary assertion before runtime startup.