### PR TITLE
feat(source-runtime): add credential-free Asana kernel

### DIFF
--- a/crates/source-runtime-next/src/asana.rs
+++ b/crates/source-runtime-next/src/asana.rs
@@ -1,0 +1,27 @@
+//! Credential-free Asana request, normalization, and projection kernel.
+//!
+//! The trusted host owns credential resolution, authentication, redirects,
+//! deadlines, and bounded network I/O. This module accepts public source
+//! configuration and already-bounded provider response bytes only.
+//! Durable progress remains a host-side post-append and post-projection action.
+
+mod catalog;
+mod error;
+mod family;
+mod normalize;
+mod origin;
+mod projection;
+mod request;
+mod response;
+mod types;
+
+pub use catalog::{AsanaEventContract, AsanaRuntimeDefinition};
+pub use error::AsanaError;
+pub use family::AsanaFamily;
+pub use projection::{
+    AsanaEntityFact, AsanaProjectionFacts, AsanaRelationFact, project_asana_records,
+};
+pub use types::{AsanaCheckpointCandidate, AsanaKernel, AsanaPage, AsanaRecord, AsanaRequest};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/asana/catalog.rs
+++ b/crates/source-runtime-next/src/asana/catalog.rs
@@ -1,0 +1,65 @@
+use super::{AsanaError, AsanaFamily};
+
+/// One exact event contract compiled from `sources/asana/catalog.yaml`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AsanaEventContract {
+    /// Exact provider event kind.
+    pub kind: &'static str,
+    /// Exact schema reference.
+    pub schema_ref: &'static str,
+    /// Required normalized attributes.
+    pub required_attributes: &'static [&'static str],
+    /// Required normalized payload fields.
+    pub required_payload_fields: &'static [&'static str],
+}
+
+/// Closed runtime definition for one Asana family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AsanaRuntimeDefinition {
+    /// Source identifier.
+    pub source_id: &'static str,
+    /// Selected family.
+    pub family: AsanaFamily,
+    /// Exact event contract.
+    pub event_contract: AsanaEventContract,
+    /// Asana families are bounded pull operations.
+    pub pull: bool,
+}
+
+impl AsanaRuntimeDefinition {
+    /// Compile one catalog family into a closed definition.
+    pub fn compile(family: AsanaFamily) -> Result<Self, AsanaError> {
+        let event_contract = match family {
+            AsanaFamily::Users => AsanaEventContract {
+                kind: "asana.users",
+                schema_ref: "asana/users/v1",
+                required_attributes: &["tenant_id", "source_event_id", "user_id"],
+                required_payload_fields: &["gid"],
+            },
+            AsanaFamily::Projects => AsanaEventContract {
+                kind: "asana.projects",
+                schema_ref: "asana/projects/v1",
+                required_attributes: &[
+                    "tenant_id",
+                    "source_event_id",
+                    "resource_urn",
+                    "resource_type",
+                    "resource_id",
+                ],
+                required_payload_fields: &["gid"],
+            },
+            AsanaFamily::AuditEvents => AsanaEventContract {
+                kind: "asana.audit_events",
+                schema_ref: "asana/audit_events/v1",
+                required_attributes: &["tenant_id", "source_event_id", "event_type", "actor_id"],
+                required_payload_fields: &["gid"],
+            },
+        };
+        Ok(Self {
+            source_id: "asana",
+            family,
+            event_contract,
+            pull: true,
+        })
+    }
+}

--- a/crates/source-runtime-next/src/asana/error.rs
+++ b/crates/source-runtime-next/src/asana/error.rs
@@ -1,0 +1,167 @@
+use std::{error::Error, fmt};
+
+/// Bounded Asana provider and runtime failure taxonomy.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AsanaError {
+    /// Family is outside the closed catalog.
+    InvalidFamily,
+    /// Required public configuration is missing.
+    MissingConfiguration(&'static str),
+    /// Public configuration is malformed.
+    InvalidConfiguration(&'static str),
+    /// Base URL is not a credential-free HTTPS origin.
+    InvalidBaseUrl,
+    /// Origin is local, private, or otherwise unsafe.
+    UnsafeOrigin,
+    /// Authenticated tenant context is missing or malformed.
+    InvalidTenantId,
+    /// Trusted host has no credential reference.
+    MissingCredentialReference,
+    /// Trusted host could not redeem the credential lease.
+    CredentialUnavailable,
+    /// Durable cursor is invalid or cannot round-trip.
+    InvalidCursor,
+    /// Request does not belong to this kernel.
+    RequestScopeMismatch,
+    /// Provider rejected authentication.
+    AuthenticationRejected,
+    /// Credential lacks Asana audit or workspace scope.
+    RequiredScopeMissing,
+    /// Trusted host denied provider egress.
+    EgressDenied,
+    /// Provider DNS lookup failed.
+    DnsFailure,
+    /// Provider connection failed.
+    ConnectionFailure,
+    /// Provider operation timed out.
+    ProviderTimeout,
+    /// Provider requested a bounded retry.
+    RateLimited {
+        /// Bounded retry delay supplied by the provider.
+        retry_after_seconds: Option<u64>,
+    },
+    /// Provider returned a retryable server failure.
+    ProviderUnavailable {
+        /// Provider status in the 500-599 range.
+        status: u16,
+    },
+    /// Provider returned an unexpected status.
+    UnexpectedStatus {
+        /// Provider status outside the typed cases.
+        status: u16,
+    },
+    /// Retry delay is outside the persistence bound.
+    InvalidRetryAfter,
+    /// Response exceeds the host-declared byte bound.
+    ResponseTooLarge,
+    /// Response exceeds the planned record count.
+    TooManyRecords,
+    /// Response JSON does not match the selected family.
+    MalformedResponse,
+    /// Provider record violates the family shape.
+    InvalidProviderRecord,
+    /// Provider record has no stable identity.
+    MissingStableIdentity,
+    /// Provider payload attempted to provide tenant context.
+    TenantMismatch,
+    /// Credential-shaped material crossed into the kernel.
+    CredentialMaterial,
+    /// Duplicate provider identity has conflicting content.
+    ConflictingDuplicate,
+    /// Normalized record failed the exact compiled event contract.
+    EventContractRejection,
+    /// Durable append failed.
+    AppendFailure,
+    /// Projection failed.
+    ProjectionFailure,
+    /// Runtime lost its source lease.
+    LeaseLoss,
+    /// Runtime authority or generation is stale.
+    StaleAuthority,
+    /// Internal runtime failure.
+    InternalRuntimeFailure,
+}
+
+impl AsanaError {
+    /// Next safe operator action without provider content.
+    pub const fn operator_action(&self) -> &'static str {
+        match self {
+            Self::InvalidFamily
+            | Self::MissingConfiguration(_)
+            | Self::InvalidConfiguration(_)
+            | Self::InvalidBaseUrl
+            | Self::UnsafeOrigin
+            | Self::InvalidTenantId
+            | Self::MissingCredentialReference => "repair source configuration",
+            Self::CredentialUnavailable | Self::AuthenticationRejected => {
+                "repair credential binding"
+            }
+            Self::RequiredScopeMissing => "grant the required provider scope",
+            Self::RateLimited { .. }
+            | Self::ProviderUnavailable { .. }
+            | Self::DnsFailure
+            | Self::ConnectionFailure
+            | Self::ProviderTimeout => "retry the collection later",
+            Self::EgressDenied => "repair trusted-host egress policy",
+            Self::InvalidCursor => "restart from the last committed checkpoint",
+            Self::MalformedResponse
+            | Self::InvalidProviderRecord
+            | Self::MissingStableIdentity
+            | Self::TenantMismatch
+            | Self::CredentialMaterial
+            | Self::ConflictingDuplicate
+            | Self::EventContractRejection => "inspect quarantined provider records",
+            Self::AppendFailure | Self::ProjectionFailure => "repair the durable commit path",
+            Self::LeaseLoss | Self::StaleAuthority => "restart under the current lease",
+            Self::RequestScopeMismatch
+            | Self::InvalidRetryAfter
+            | Self::ResponseTooLarge
+            | Self::TooManyRecords
+            | Self::UnexpectedStatus { .. }
+            | Self::InternalRuntimeFailure => "repair the forward runtime implementation",
+        }
+    }
+}
+
+impl fmt::Display for AsanaError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidFamily => "asana family is invalid",
+            Self::MissingConfiguration(_) => "asana source configuration is missing",
+            Self::InvalidConfiguration(_) => "asana source configuration is invalid",
+            Self::InvalidBaseUrl => "asana base URL must be a credential-free HTTPS origin",
+            Self::UnsafeOrigin => "asana base URL contains an unsafe origin",
+            Self::InvalidTenantId => "asana tenant ID is invalid",
+            Self::MissingCredentialReference => "asana credential reference is missing",
+            Self::CredentialUnavailable => "asana credential lease is unavailable",
+            Self::InvalidCursor => "asana cursor is invalid or not round-trippable",
+            Self::RequestScopeMismatch => "asana request does not match the kernel",
+            Self::AuthenticationRejected => "asana rejected authentication",
+            Self::RequiredScopeMissing => "asana credential lacks required scope",
+            Self::EgressDenied => "asana egress was denied",
+            Self::DnsFailure => "asana DNS resolution failed",
+            Self::ConnectionFailure => "asana connection failed",
+            Self::ProviderTimeout => "asana operation timed out",
+            Self::RateLimited { .. } => "asana rate limited the operation",
+            Self::ProviderUnavailable { .. } => "asana is temporarily unavailable",
+            Self::UnexpectedStatus { .. } => "asana returned an unexpected status",
+            Self::InvalidRetryAfter => "asana retry delay exceeds its bound",
+            Self::ResponseTooLarge => "asana response exceeds its byte bound",
+            Self::TooManyRecords => "asana response exceeds its record bound",
+            Self::MalformedResponse => "asana response is malformed",
+            Self::InvalidProviderRecord => "asana provider record is invalid",
+            Self::MissingStableIdentity => "asana record has no stable identity",
+            Self::TenantMismatch => "asana payload attempted to supply tenant context",
+            Self::CredentialMaterial => "asana payload contains credential-shaped material",
+            Self::ConflictingDuplicate => "asana duplicate identity has conflicting content",
+            Self::EventContractRejection => "asana event failed its catalog contract",
+            Self::AppendFailure => "asana append failed",
+            Self::ProjectionFailure => "asana projection failed",
+            Self::LeaseLoss => "asana runtime lost its lease",
+            Self::StaleAuthority => "asana runtime authority is stale",
+            Self::InternalRuntimeFailure => "asana runtime failed internally",
+        })
+    }
+}
+
+impl Error for AsanaError {}

--- a/crates/source-runtime-next/src/asana/family.rs
+++ b/crates/source-runtime-next/src/asana/family.rs
@@ -1,0 +1,57 @@
+use std::str::FromStr;
+
+use super::AsanaError;
+
+/// Closed Asana source-catalog family vocabulary.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum AsanaFamily {
+    /// Workspace user inventory.
+    Users,
+    /// Workspace project inventory.
+    Projects,
+    /// Workspace audit log events.
+    AuditEvents,
+}
+
+impl AsanaFamily {
+    /// Every supported family in catalog order.
+    pub const ALL: [Self; 3] = [Self::Users, Self::Projects, Self::AuditEvents];
+
+    /// Exact catalog family identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Users => "users",
+            Self::Projects => "projects",
+            Self::AuditEvents => "audit_events",
+        }
+    }
+
+    /// Exact event kind admitted by the catalog.
+    pub const fn event_kind(self) -> &'static str {
+        match self {
+            Self::Users => "asana.users",
+            Self::Projects => "asana.projects",
+            Self::AuditEvents => "asana.audit_events",
+        }
+    }
+
+    /// Exact event schema admitted by the catalog.
+    pub const fn schema_ref(self) -> &'static str {
+        match self {
+            Self::Users => "asana/users/v1",
+            Self::Projects => "asana/projects/v1",
+            Self::AuditEvents => "asana/audit_events/v1",
+        }
+    }
+}
+
+impl FromStr for AsanaFamily {
+    type Err = AsanaError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|family| family.as_str() == value.trim())
+            .ok_or(AsanaError::InvalidFamily)
+    }
+}

--- a/crates/source-runtime-next/src/asana/normalize.rs
+++ b/crates/source-runtime-next/src/asana/normalize.rs
@@ -1,0 +1,279 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{AsanaError, AsanaFamily, AsanaKernel, AsanaRecord};
+
+pub(super) fn normalize(
+    kernel: &AsanaKernel,
+    raw: Value,
+    observed_at: &str,
+) -> Result<AsanaRecord, AsanaError> {
+    reject_untrusted(&raw, 0)?;
+    let values = raw.as_object().ok_or(AsanaError::InvalidProviderRecord)?;
+    let provider_id = provider_component(
+        &string_first(values, &["gid", "id"]).ok_or(AsanaError::MissingStableIdentity)?,
+    )?;
+    let occurred_at = occurred_at(kernel.family, values, observed_at)?;
+    let (attributes, payload) = match kernel.family {
+        AsanaFamily::Users => normalize_user(kernel, values)?,
+        AsanaFamily::Projects => normalize_project(kernel, values)?,
+        AsanaFamily::AuditEvents => normalize_audit(kernel, values)?,
+    };
+    let definition = super::AsanaRuntimeDefinition::compile(kernel.family)?;
+    let contract = definition.event_contract;
+    if contract.kind != kernel.family.event_kind()
+        || contract.schema_ref != kernel.family.schema_ref()
+        || contract.required_attributes.iter().any(|field| {
+            attributes
+                .get(*field)
+                .is_none_or(|value| value.trim().is_empty())
+        })
+        || contract.required_payload_fields.iter().any(|field| {
+            payload
+                .get(*field)
+                .is_none_or(|value| value.is_null() || value.as_str().is_some_and(str::is_empty))
+        })
+    {
+        return Err(AsanaError::EventContractRejection);
+    }
+    let digest = Sha256::digest(format!(
+        "{}\0{}\0{}",
+        kernel.tenant_id,
+        kernel.family.as_str(),
+        provider_id
+    ));
+    let suffix = digest[..10]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    Ok(AsanaRecord {
+        tenant_id: kernel.tenant_id.clone(),
+        event_id: format!("asana-{}-{suffix}", kernel.family.as_str()),
+        provider_id,
+        family: kernel.family,
+        kind: kernel.family.event_kind().to_owned(),
+        schema_ref: kernel.family.schema_ref().to_owned(),
+        occurred_at,
+        attributes,
+        payload,
+    })
+}
+
+fn normalize_user(
+    kernel: &AsanaKernel,
+    values: &Map<String, Value>,
+) -> Result<(BTreeMap<String, String>, Value), AsanaError> {
+    let id = provider_component(&required(values, "gid")?)?;
+    let name = string_first(values, &["name", "display_name"]).unwrap_or_else(|| id.clone());
+    let email = string_first(values, &["email", "primary_email"]).unwrap_or_default();
+    let resource_urn = urn(&kernel.tenant_id, "runtime_users", &id);
+    let status = string_first(values, &["status"]).unwrap_or_else(|| {
+        if values.get("enabled").and_then(Value::as_bool) == Some(false) {
+            "inactive".to_owned()
+        } else {
+            "active".to_owned()
+        }
+    });
+    let mut attributes = BTreeMap::from([
+        ("display_name".to_owned(), name.clone()),
+        ("resource_id".to_owned(), id.clone()),
+        ("resource_name".to_owned(), name),
+        ("resource_type".to_owned(), "identity_user".to_owned()),
+        ("resource_urn".to_owned(), resource_urn.clone()),
+        ("source_event_id".to_owned(), id.clone()),
+        ("status".to_owned(), status),
+        ("tenant_id".to_owned(), kernel.tenant_id.clone()),
+        ("user_id".to_owned(), id),
+    ]);
+    if !email.is_empty() {
+        attributes.insert("email".to_owned(), email);
+    }
+    let mut payload = values.clone();
+    payload.insert("resource_urn".to_owned(), Value::from(resource_urn));
+    Ok((attributes, Value::Object(payload)))
+}
+
+fn normalize_project(
+    kernel: &AsanaKernel,
+    values: &Map<String, Value>,
+) -> Result<(BTreeMap<String, String>, Value), AsanaError> {
+    let id = provider_component(&required(values, "gid")?)?;
+    let name = string_first(values, &["name"]).unwrap_or_else(|| id.clone());
+    let resource_urn = urn(&kernel.tenant_id, "runtime_projects", &id);
+    let mut attributes = BTreeMap::from([
+        ("resource_id".to_owned(), id.clone()),
+        ("resource_name".to_owned(), name),
+        ("resource_type".to_owned(), "project".to_owned()),
+        ("resource_urn".to_owned(), resource_urn),
+        ("source_event_id".to_owned(), id),
+        ("tenant_id".to_owned(), kernel.tenant_id.clone()),
+    ]);
+    copy(
+        &mut attributes,
+        values,
+        "evidence_cas.digest",
+        "evidence_cas_digest",
+    );
+    copy(
+        &mut attributes,
+        values,
+        "evidence_cas.uri",
+        "evidence_cas_uri",
+    );
+    let mut payload = values.clone();
+    payload.remove("evidence_cas");
+    Ok((attributes, Value::Object(payload)))
+}
+
+fn normalize_audit(
+    kernel: &AsanaKernel,
+    values: &Map<String, Value>,
+) -> Result<(BTreeMap<String, String>, Value), AsanaError> {
+    let id = provider_component(&required(values, "gid")?)?;
+    let actor_id = provider_component(
+        &string_first(values, &["actor.gid", "actor.id"])
+            .ok_or(AsanaError::InvalidProviderRecord)?,
+    )?;
+    let event_type = string_first(values, &["event_type", "event_name", "action", "type"])
+        .ok_or(AsanaError::InvalidProviderRecord)?;
+    let mut attributes = BTreeMap::from([
+        ("actor_id".to_owned(), actor_id),
+        ("event_type".to_owned(), event_type),
+        ("source_event_id".to_owned(), id),
+        ("tenant_id".to_owned(), kernel.tenant_id.clone()),
+    ]);
+    for (source, target) in [
+        ("actor.email", "actor_email"),
+        ("actor.name", "actor_name"),
+        ("created_at", "created_at"),
+        ("created_at", "observed_at"),
+        ("resource.gid", "resource_id"),
+        ("resource.name", "resource_name"),
+        ("resource.resource_type", "resource_type"),
+        ("resource_urn", "resource_urn"),
+    ] {
+        copy(&mut attributes, values, source, target);
+    }
+    if !attributes.contains_key("resource_id") {
+        copy(&mut attributes, values, "target.gid", "resource_id");
+    }
+    if let Some(resource_id) = attributes.get("resource_id").cloned() {
+        attributes.insert("resource_id".to_owned(), provider_component(&resource_id)?);
+    }
+    if let Some(resource_urn) = attributes.get("resource_urn") {
+        let prefix = format!("urn:cerebro:{}:", kernel.tenant_id);
+        if !resource_urn.starts_with(&prefix) {
+            return Err(AsanaError::TenantMismatch);
+        }
+    }
+    Ok((attributes, Value::Object(values.clone())))
+}
+
+fn occurred_at(
+    family: AsanaFamily,
+    values: &Map<String, Value>,
+    observed_at: &str,
+) -> Result<String, AsanaError> {
+    let candidate = match family {
+        AsanaFamily::Users => string_first(values, &["observed_at", "updated_at", "last_seen_at"])
+            .unwrap_or_else(|| observed_at.to_owned()),
+        AsanaFamily::Projects => string_first(
+            values,
+            &["observed_at", "modified_at", "updated_at", "created_at"],
+        )
+        .unwrap_or_else(|| observed_at.to_owned()),
+        AsanaFamily::AuditEvents => {
+            string_first(values, &["observed_at", "created_at", "updated_at"])
+                .unwrap_or_else(|| observed_at.to_owned())
+        }
+    };
+    OffsetDateTime::parse(&candidate, &Rfc3339)
+        .map(|value| value.format(&Rfc3339).unwrap_or(candidate))
+        .map_err(|_| AsanaError::InvalidProviderRecord)
+}
+
+fn required(values: &Map<String, Value>, path: &str) -> Result<String, AsanaError> {
+    string_at(values, path).ok_or(AsanaError::MissingStableIdentity)
+}
+
+fn provider_component(value: &str) -> Result<String, AsanaError> {
+    let value = value.trim();
+    if value.is_empty()
+        || value.len() > 512
+        || value.chars().any(char::is_control)
+        || value.contains([':', '/', '\\'])
+    {
+        return Err(AsanaError::MissingStableIdentity);
+    }
+    Ok(value.to_owned())
+}
+
+fn string_first(values: &Map<String, Value>, paths: &[&str]) -> Option<String> {
+    paths.iter().find_map(|path| string_at(values, path))
+}
+
+fn string_at(values: &Map<String, Value>, path: &str) -> Option<String> {
+    let mut value = values.get(path.split('.').next()?)?;
+    for segment in path.split('.').skip(1) {
+        value = value.get(segment)?;
+    }
+    match value {
+        Value::String(value) => (!value.trim().is_empty()).then(|| value.trim().to_owned()),
+        Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn copy(
+    target: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    source: &str,
+    key: &str,
+) {
+    if let Some(value) = string_at(values, source) {
+        target.insert(key.to_owned(), value);
+    }
+}
+
+fn reject_untrusted(value: &Value, depth: usize) -> Result<(), AsanaError> {
+    if depth > 32 {
+        return Err(AsanaError::InvalidProviderRecord);
+    }
+    match value {
+        Value::Object(values) => {
+            for (key, value) in values {
+                let key = key.to_ascii_lowercase();
+                if key == "tenant_id" {
+                    return Err(AsanaError::TenantMismatch);
+                }
+                if matches!(
+                    key.as_str(),
+                    "token"
+                        | "access_token"
+                        | "refresh_token"
+                        | "client_secret"
+                        | "password"
+                        | "private_key"
+                        | "authorization"
+                ) {
+                    return Err(AsanaError::CredentialMaterial);
+                }
+                reject_untrusted(value, depth + 1)?;
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                reject_untrusted(value, depth + 1)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn urn(tenant: &str, kind: &str, provider_id: &str) -> String {
+    format!("urn:cerebro:{tenant}:{kind}:{provider_id}")
+}

--- a/crates/source-runtime-next/src/asana/origin.rs
+++ b/crates/source-runtime-next/src/asana/origin.rs
@@ -1,0 +1,53 @@
+use std::net::IpAddr;
+
+use reqwest::Url;
+
+use super::AsanaError;
+
+pub(super) fn validate_origin(value: &str) -> Result<Url, AsanaError> {
+    let mut url = Url::parse(value.trim()).map_err(|_| AsanaError::InvalidBaseUrl)?;
+    if url.scheme() != "https"
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port_or_known_default() != Some(443)
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(AsanaError::InvalidBaseUrl);
+    }
+    let host = url.host_str().unwrap_or_default().trim_end_matches('.');
+    if host.eq_ignore_ascii_case("localhost")
+        || host.ends_with(".localhost")
+        || host.ends_with(".local")
+        || !host.contains('.')
+        || host.parse::<IpAddr>().is_ok_and(unsafe_ip)
+    {
+        return Err(AsanaError::UnsafeOrigin);
+    }
+    let path = url.path().trim_end_matches('/').to_owned();
+    url.set_path(&path);
+    Ok(url)
+}
+
+pub(super) fn bounded(value: &str, max: usize) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()
+        && value.len() <= max
+        && !value.chars().any(char::is_control)
+        && !value.contains(['/', '\\', ':']))
+    .then(|| value.to_owned())
+}
+
+fn unsafe_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => {
+            ip.is_private()
+                || ip.is_loopback()
+                || ip.is_link_local()
+                || ip.is_unspecified()
+                || ip.is_multicast()
+        }
+        IpAddr::V6(ip) => ip.is_loopback() || ip.is_unspecified() || ip.is_multicast(),
+    }
+}

--- a/crates/source-runtime-next/src/asana/projection.rs
+++ b/crates/source-runtime-next/src/asana/projection.rs
@@ -1,0 +1,104 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::{AsanaFamily, AsanaRecord};
+
+/// One deterministic tenant-scoped Asana projection entity.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct AsanaEntityFact {
+    /// Canonical entity URN.
+    pub urn: String,
+    /// Closed entity type.
+    pub entity_type: String,
+    /// Human-readable label.
+    pub label: String,
+}
+
+/// One deterministic Asana projection relation.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct AsanaRelationFact {
+    /// Source entity URN.
+    pub from_urn: String,
+    /// Closed semantic relation.
+    pub relation: String,
+    /// Target entity URN.
+    pub to_urn: String,
+}
+
+/// Provider-local projection facts used for Go/Rust parity.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AsanaProjectionFacts {
+    /// Deduplicated entities in canonical order.
+    pub entities: Vec<AsanaEntityFact>,
+    /// Deduplicated relations in canonical order.
+    pub relations: Vec<AsanaRelationFact>,
+}
+
+/// Project normalized Asana records into identity, project, and audit context.
+pub fn project_asana_records(records: &[AsanaRecord]) -> AsanaProjectionFacts {
+    let mut entities = BTreeMap::<String, AsanaEntityFact>::new();
+    let mut relations = BTreeSet::new();
+    for record in records {
+        match record.family {
+            AsanaFamily::Users | AsanaFamily::Projects => {
+                if let Some(urn) = record.attributes.get("resource_urn") {
+                    entities.insert(
+                        urn.clone(),
+                        AsanaEntityFact {
+                            urn: urn.clone(),
+                            entity_type: record.attributes["resource_type"].clone(),
+                            label: record
+                                .attributes
+                                .get("resource_name")
+                                .cloned()
+                                .unwrap_or_else(|| record.provider_id.clone()),
+                        },
+                    );
+                }
+            }
+            AsanaFamily::AuditEvents => {
+                let actor_id = &record.attributes["actor_id"];
+                let actor_urn =
+                    format!("urn:cerebro:{}:runtime_users:{actor_id}", record.tenant_id);
+                entities.insert(
+                    actor_urn.clone(),
+                    AsanaEntityFact {
+                        urn: actor_urn.clone(),
+                        entity_type: "identity_user".to_owned(),
+                        label: record
+                            .attributes
+                            .get("actor_name")
+                            .cloned()
+                            .unwrap_or_else(|| actor_id.clone()),
+                    },
+                );
+                if let Some(resource_urn) = record.attributes.get("resource_urn") {
+                    entities.insert(
+                        resource_urn.clone(),
+                        AsanaEntityFact {
+                            urn: resource_urn.clone(),
+                            entity_type: record
+                                .attributes
+                                .get("resource_type")
+                                .cloned()
+                                .unwrap_or_else(|| "resource".to_owned()),
+                            label: record
+                                .attributes
+                                .get("resource_name")
+                                .cloned()
+                                .unwrap_or_else(|| resource_urn.clone()),
+                        },
+                    );
+                    relations.insert(AsanaRelationFact {
+                        from_urn: actor_urn,
+                        relation: "performed_action_on".to_owned(),
+                        to_urn: resource_urn.clone(),
+                    });
+                }
+            }
+        }
+    }
+    AsanaProjectionFacts {
+        entities: entities.into_values().collect(),
+        relations: relations.into_iter().collect(),
+    }
+}

--- a/crates/source-runtime-next/src/asana/request.rs
+++ b/crates/source-runtime-next/src/asana/request.rs
@@ -1,0 +1,146 @@
+use super::{
+    AsanaError, AsanaFamily, AsanaKernel, AsanaRequest,
+    origin::{bounded, validate_origin},
+};
+
+pub(super) const MAX_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
+const MAX_CURSOR_BYTES: usize = 2_048;
+
+impl AsanaRequest {
+    /// HTTP method.
+    pub const fn method(&self) -> &'static str {
+        "GET"
+    }
+
+    /// Exact origin-restricted provider URL.
+    pub fn url(&self) -> &reqwest::Url {
+        &self.url
+    }
+
+    /// Family owning this request.
+    pub const fn family(&self) -> AsanaFamily {
+        self.family
+    }
+
+    /// Header populated by the trusted host.
+    pub const fn authorization_header(&self) -> &'static str {
+        "Authorization"
+    }
+
+    /// Scheme applied outside this kernel.
+    pub const fn authorization_scheme(&self) -> &'static str {
+        "Bearer"
+    }
+
+    /// Required provider response media type.
+    pub const fn accept(&self) -> &'static str {
+        "application/json"
+    }
+
+    /// Portable requests contain no credential bytes or references.
+    pub const fn contains_credentials(&self) -> bool {
+        false
+    }
+
+    /// Redirects are disabled by the trusted host.
+    pub const fn allows_redirects(&self) -> bool {
+        false
+    }
+
+    /// Host response byte limit.
+    pub const fn max_response_bytes(&self) -> usize {
+        MAX_RESPONSE_BYTES
+    }
+
+    /// Provider permission required by the family.
+    pub const fn required_scope(&self) -> &'static str {
+        match self.family {
+            AsanaFamily::AuditEvents => "workspace audit log access",
+            AsanaFamily::Users | AsanaFamily::Projects => "workspace read access",
+        }
+    }
+}
+
+impl AsanaKernel {
+    /// Construct a closed credential-free kernel.
+    pub fn new(
+        base_url: &str,
+        tenant_id: &str,
+        workspace_gid: &str,
+        family: AsanaFamily,
+        page_size: Option<usize>,
+    ) -> Result<Self, AsanaError> {
+        let base_url = validate_origin(base_url)?;
+        let tenant_id = bounded(tenant_id, 128).ok_or(AsanaError::InvalidTenantId)?;
+        let workspace_gid =
+            bounded(workspace_gid, 128).ok_or(AsanaError::MissingConfiguration("workspace_gid"))?;
+        let page_size = page_size.unwrap_or(100);
+        if !(1..=100).contains(&page_size) {
+            return Err(AsanaError::InvalidConfiguration("page_size"));
+        }
+        Ok(Self {
+            base_url,
+            tenant_id,
+            workspace_gid,
+            family,
+            page_size,
+        })
+    }
+
+    /// Kernel protocol never accepts credential material.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+
+    /// Plan one bounded provider page from an optional durable offset.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<AsanaRequest, AsanaError> {
+        let cursor = cursor.map(validate_cursor).transpose()?;
+        let suffix = match self.family {
+            AsanaFamily::Users => "/users".to_owned(),
+            AsanaFamily::Projects => "/projects".to_owned(),
+            AsanaFamily::AuditEvents => {
+                format!("/workspaces/{}/audit_log_events", self.workspace_gid)
+            }
+        };
+        let mut url = self.base_url.clone();
+        url.set_path(&format!(
+            "{}{}",
+            self.base_url.path().trim_end_matches('/'),
+            suffix
+        ));
+        {
+            let mut query = url.query_pairs_mut();
+            query.append_pair("limit", &self.page_size.to_string());
+            if matches!(self.family, AsanaFamily::Users | AsanaFamily::Projects) {
+                query.append_pair("workspace", &self.workspace_gid);
+            }
+            if let Some(cursor) = &cursor {
+                query.append_pair("offset", cursor);
+            }
+        }
+        Ok(AsanaRequest {
+            url,
+            family: self.family,
+            cursor,
+        })
+    }
+
+    pub(super) fn validate_request(&self, request: &AsanaRequest) -> Result<(), AsanaError> {
+        if request != &self.plan(request.cursor.as_deref())? {
+            return Err(AsanaError::RequestScopeMismatch);
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn validate_cursor(value: &str) -> Result<String, AsanaError> {
+    let value = value.trim();
+    if value.is_empty()
+        || value.len() > MAX_CURSOR_BYTES
+        || value.chars().any(char::is_control)
+        || value.contains(['&', '=', '#', '?'])
+    {
+        return Err(AsanaError::InvalidCursor);
+    }
+    Ok(value.to_owned())
+}

--- a/crates/source-runtime-next/src/asana/response.rs
+++ b/crates/source-runtime-next/src/asana/response.rs
@@ -1,0 +1,131 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    AsanaCheckpointCandidate, AsanaError, AsanaKernel, AsanaPage, AsanaRequest,
+    normalize::normalize,
+    request::{MAX_RESPONSE_BYTES, validate_cursor},
+};
+
+impl AsanaKernel {
+    /// Classify status and normalize one provider page.
+    pub fn decode_http(
+        &self,
+        request: &AsanaRequest,
+        status: u16,
+        retry_after_seconds: Option<u64>,
+        body: &[u8],
+        observed_at: &str,
+    ) -> Result<AsanaPage, AsanaError> {
+        self.validate_request(request)?;
+        if body.len() > MAX_RESPONSE_BYTES {
+            return Err(AsanaError::ResponseTooLarge);
+        }
+        if retry_after_seconds.is_some_and(|seconds| seconds > 3_600) {
+            return Err(AsanaError::InvalidRetryAfter);
+        }
+        match status {
+            200 => {}
+            401 => return Err(AsanaError::AuthenticationRejected),
+            403 => return Err(AsanaError::RequiredScopeMissing),
+            429 => {
+                return Err(AsanaError::RateLimited {
+                    retry_after_seconds,
+                });
+            }
+            500..=599 => return Err(AsanaError::ProviderUnavailable { status }),
+            _ => return Err(AsanaError::UnexpectedStatus { status }),
+        }
+        let value: Value =
+            serde_json::from_slice(body).map_err(|_| AsanaError::MalformedResponse)?;
+        let envelope = value.as_object().ok_or(AsanaError::MalformedResponse)?;
+        let records = envelope
+            .get("data")
+            .and_then(Value::as_array)
+            .ok_or(AsanaError::MalformedResponse)?;
+        if records.len() > self.page_size {
+            return Err(AsanaError::TooManyRecords);
+        }
+        let mut seen = BTreeMap::<String, Value>::new();
+        let mut normalized = Vec::with_capacity(records.len());
+        for raw in records {
+            let record = normalize(self, raw.clone(), observed_at)?;
+            match seen.get(&record.provider_id) {
+                Some(previous) if previous == raw => continue,
+                Some(_) => return Err(AsanaError::ConflictingDuplicate),
+                None => {
+                    seen.insert(record.provider_id.clone(), raw.clone());
+                    normalized.push(record);
+                }
+            }
+        }
+        let next_cursor = match envelope.get("next_page") {
+            None | Some(Value::Null) => None,
+            Some(Value::Object(page)) => Some(
+                page.get("offset")
+                    .and_then(Value::as_str)
+                    .ok_or(AsanaError::InvalidCursor)
+                    .and_then(validate_cursor)?,
+            ),
+            Some(_) => return Err(AsanaError::InvalidCursor),
+        };
+        if next_cursor.is_some() && next_cursor == request.cursor {
+            return Err(AsanaError::InvalidCursor);
+        }
+        Ok(AsanaPage {
+            records: normalized,
+            next_cursor,
+        })
+    }
+
+    /// Decode a normal HTTP 200 response.
+    pub fn decode(
+        &self,
+        request: &AsanaRequest,
+        body: &[u8],
+        observed_at: &str,
+    ) -> Result<AsanaPage, AsanaError> {
+        self.decode_http(request, 200, None, body, observed_at)
+    }
+
+    /// Validate a checkpoint candidate for post-append/project persistence.
+    pub fn checkpoint_candidate(
+        &self,
+        request: &AsanaRequest,
+        page: &AsanaPage,
+        prior_watermark: Option<&str>,
+    ) -> Result<AsanaCheckpointCandidate, AsanaError> {
+        self.validate_request(request)?;
+        if page
+            .records
+            .iter()
+            .any(|record| record.tenant_id != self.tenant_id || record.family != self.family)
+        {
+            return Err(AsanaError::TenantMismatch);
+        }
+        if let Some(cursor) = &page.next_cursor {
+            self.plan(Some(cursor))?;
+        }
+        let prior = prior_watermark.map(valid_time).transpose()?;
+        let watermark = page
+            .records
+            .iter()
+            .map(|record| record.occurred_at.clone())
+            .chain(prior)
+            .max();
+        Ok(AsanaCheckpointCandidate {
+            tenant_id: self.tenant_id.clone(),
+            family: self.family,
+            cursor: page.next_cursor.clone(),
+            watermark,
+        })
+    }
+}
+
+fn valid_time(value: &str) -> Result<String, AsanaError> {
+    OffsetDateTime::parse(value, &Rfc3339)
+        .map(|time| time.format(&Rfc3339).unwrap_or_else(|_| value.to_owned()))
+        .map_err(|_| AsanaError::InvalidProviderRecord)
+}

--- a/crates/source-runtime-next/src/asana/tests.rs
+++ b/crates/source-runtime-next/src/asana/tests.rs
@@ -1,0 +1,330 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Value, json};
+
+use super::*;
+
+const CATALOG: &[u8] = include_bytes!("../../../../sources/asana/catalog.yaml");
+const USERS_ORACLE: &[u8] = include_bytes!("../../../../sources/asana/testdata/read_users.json");
+const PROJECTS_ORACLE: &[u8] =
+    include_bytes!("../../../../sources/asana/testdata/read_projects.json");
+const AUDIT_ORACLE: &[u8] =
+    include_bytes!("../../../../sources/asana/testdata/read_audit_events.json");
+
+#[derive(serde::Deserialize)]
+struct CatalogWire {
+    runtime_families: Vec<String>,
+    event_contracts: Vec<EventContractWire>,
+}
+
+#[derive(serde::Deserialize)]
+struct EventContractWire {
+    kind: String,
+    schema_ref: String,
+    required_attributes: Vec<String>,
+    required_payload_fields: Vec<String>,
+}
+
+fn kernel(tenant: &str, family: AsanaFamily) -> AsanaKernel {
+    AsanaKernel::new(
+        "https://app.asana.com/api/1.0",
+        tenant,
+        "workspace-1",
+        family,
+        Some(100),
+    )
+    .expect("valid Asana kernel")
+}
+
+#[test]
+fn closed_runtime_definition_matches_catalog_exactly() {
+    let catalog: CatalogWire = serde_saphyr::from_slice(CATALOG).expect("Asana catalog YAML");
+    assert_eq!(
+        catalog.runtime_families,
+        ["users", "projects", "audit_events"]
+    );
+    let definitions = AsanaFamily::ALL
+        .into_iter()
+        .map(|family| AsanaRuntimeDefinition::compile(family).expect("compiled family"))
+        .collect::<Vec<_>>();
+    assert!(definitions.iter().all(|definition| definition.pull));
+    assert_eq!(catalog.event_contracts.len(), definitions.len());
+    for expected in catalog.event_contracts {
+        let actual = definitions
+            .iter()
+            .map(|definition| definition.event_contract)
+            .find(|contract| contract.kind == expected.kind)
+            .expect("catalog contract compiled");
+        assert_eq!(actual.schema_ref, expected.schema_ref);
+        assert!(
+            actual
+                .required_attributes
+                .iter()
+                .copied()
+                .eq(expected.required_attributes.iter().map(String::as_str))
+        );
+        assert!(
+            actual
+                .required_payload_fields
+                .iter()
+                .copied()
+                .eq(expected.required_payload_fields.iter().map(String::as_str))
+        );
+    }
+    assert_eq!(
+        "tasks".parse::<AsanaFamily>(),
+        Err(AsanaError::InvalidFamily)
+    );
+}
+
+#[test]
+fn plans_all_families_without_credentials_or_redirects() {
+    for (family, path) in [
+        (AsanaFamily::Users, "/api/1.0/users"),
+        (AsanaFamily::Projects, "/api/1.0/projects"),
+        (
+            AsanaFamily::AuditEvents,
+            "/api/1.0/workspaces/workspace-1/audit_log_events",
+        ),
+    ] {
+        let request = kernel("tenant-a", family).plan(None).expect("request");
+        assert_eq!(request.method(), "GET");
+        assert_eq!(request.url().path(), path);
+        assert_eq!(
+            request
+                .url()
+                .query_pairs()
+                .find(|(key, _)| key == "limit")
+                .map(|(_, value)| value.into_owned()),
+            Some("100".to_owned())
+        );
+        assert_eq!(request.authorization_header(), "Authorization");
+        assert_eq!(request.authorization_scheme(), "Bearer");
+        assert!(!request.contains_credentials());
+        assert!(!request.allows_redirects());
+        assert_eq!(request.max_response_bytes(), 4 * 1024 * 1024);
+        let debug = format!("{request:?}").to_ascii_lowercase();
+        for forbidden in ["test-token", "access_token", "client_secret", "private_key"] {
+            assert!(!debug.contains(forbidden));
+        }
+    }
+    assert!(!AsanaKernel::requires_credentials());
+}
+
+#[test]
+fn provider_fixtures_match_go_oracles_and_projection_facts() {
+    let users = kernel("tenant", AsanaFamily::Users)
+        .decode(
+            &kernel("tenant", AsanaFamily::Users).plan(None).unwrap(),
+            &serde_json::to_vec(&json!({"data": [{
+                "id": "user-1", "gid": "user-1", "name": "User One",
+                "email": "user@example.test",
+                "created_at": "2026-05-01T00:00:00Z", "enabled": true
+            }]}))
+            .unwrap(),
+            "2026-06-01T00:00:00Z",
+        )
+        .expect("users fixture");
+    assert_oracle(&users.records, USERS_ORACLE);
+
+    let projects_kernel = kernel("tenant", AsanaFamily::Projects);
+    let projects = projects_kernel
+        .decode(
+            &projects_kernel.plan(None).unwrap(),
+            &serde_json::to_vec(&json!({"data": [{
+                "id": "project-1", "gid": "project-1", "name": "Security Evidence",
+                "archived": false, "created_at": "2026-05-15T00:00:00Z",
+                "modified_at": "2026-06-01T00:00:00Z",
+                "evidence_cas": {"digest": "sha256:test", "uri": "cas://cases/asana-project-project-1"}
+            }]})).unwrap(),
+            "2026-06-01T00:00:00Z",
+        )
+        .expect("projects fixture");
+    assert_oracle(&projects.records, PROJECTS_ORACLE);
+
+    let audit_kernel = kernel("tenant", AsanaFamily::AuditEvents);
+    let audit = audit_kernel
+        .decode(
+            &audit_kernel.plan(None).unwrap(),
+            &serde_json::to_vec(&json!({"data": [{
+                "id": "audit-1", "gid": "audit-1", "created_at": "2026-06-01T00:00:00Z",
+                "event_type": "project.created",
+                "actor": {"id": "legacy-user-1", "gid": "user-1", "email": "user@example.test", "name": "User One"},
+                "resource": {"id": "legacy-project-1", "gid": "project-1", "type": "legacy_project", "resource_type": "project", "name": "Security Evidence"},
+                "target_name": "Target Fallback"
+            }]})).unwrap(),
+            "2026-06-01T00:00:00Z",
+        )
+        .expect("audit fixture");
+    assert_oracle(&audit.records, AUDIT_ORACLE);
+
+    let projection = project_asana_records(&[
+        users.records[0].clone(),
+        projects.records[0].clone(),
+        audit.records[0].clone(),
+    ]);
+    assert!(projection.entities.iter().any(|entity| entity.urn
+        == "urn:cerebro:tenant:runtime_users:user-1"
+        && entity.entity_type == "identity_user"));
+    assert!(projection.entities.iter().any(|entity| entity.urn
+        == "urn:cerebro:tenant:runtime_projects:project-1"
+        && entity.entity_type == "project"));
+    assert!(
+        projection.relations.is_empty(),
+        "audit oracle intentionally has no trusted resource_urn"
+    );
+}
+
+#[test]
+fn cursor_checkpoint_and_restart_are_round_trippable() {
+    let kernel = kernel("tenant-a", AsanaFamily::Projects);
+    let request = kernel.plan(None).unwrap();
+    let page = kernel
+        .decode(
+            &request,
+            br#"{"data":[{"gid":"project-1","name":"Evidence","modified_at":"2026-08-22T00:00:00Z"}],"next_page":{"offset":"cursor-2"}}"#,
+            "2026-08-22T00:00:00Z",
+        )
+        .unwrap();
+    let checkpoint = kernel
+        .checkpoint_candidate(&request, &page, Some("2026-08-21T00:00:00Z"))
+        .unwrap();
+    assert_eq!(checkpoint.cursor.as_deref(), Some("cursor-2"));
+    assert_eq!(
+        checkpoint.watermark.as_deref(),
+        Some("2026-08-22T00:00:00Z")
+    );
+    let resumed = kernel.plan(checkpoint.cursor.as_deref()).unwrap();
+    assert_eq!(
+        resumed
+            .url()
+            .query_pairs()
+            .find(|(key, _)| key == "offset")
+            .map(|(_, value)| value.into_owned()),
+        Some("cursor-2".to_owned())
+    );
+    assert_eq!(
+        kernel.decode(
+            &resumed,
+            br#"{"data":[],"next_page":{"offset":"cursor-2"}}"#,
+            "2026-08-22T00:00:00Z"
+        ),
+        Err(AsanaError::InvalidCursor)
+    );
+}
+
+#[test]
+fn rejects_secret_tenant_duplicate_origin_and_provider_failures() {
+    assert!(matches!(
+        AsanaKernel::new(
+            "http://app.asana.com",
+            "tenant",
+            "workspace",
+            AsanaFamily::Users,
+            None
+        ),
+        Err(AsanaError::InvalidBaseUrl)
+    ));
+    assert!(matches!(
+        AsanaKernel::new(
+            "https://127.0.0.1",
+            "tenant",
+            "workspace",
+            AsanaFamily::Users,
+            None
+        ),
+        Err(AsanaError::UnsafeOrigin)
+    ));
+    let tenant_kernel = kernel("tenant", AsanaFamily::Users);
+    let request = tenant_kernel.plan(None).unwrap();
+    for body in [
+        br#"{"data":[{"gid":"user-1","tenant_id":"attacker"}]}"#.as_slice(),
+        br#"{"data":[{"gid":"user-1","profile":{"access_token":"secret-sentinel"}}]}"#.as_slice(),
+    ] {
+        assert!(matches!(
+            tenant_kernel.decode(&request, body, "2026-08-22T00:00:00Z"),
+            Err(AsanaError::TenantMismatch | AsanaError::CredentialMaterial)
+        ));
+    }
+    assert_eq!(
+        tenant_kernel.decode(
+            &request,
+            br#"{"data":[{"gid":"user-1","name":"One"},{"gid":"user-1","name":"Two"}]}"#,
+            "2026-08-22T00:00:00Z"
+        ),
+        Err(AsanaError::ConflictingDuplicate)
+    );
+    let other = kernel("tenant-b", AsanaFamily::Users)
+        .decode(
+            &kernel("tenant-b", AsanaFamily::Users).plan(None).unwrap(),
+            br#"{"data":[{"gid":"user-1","name":"One"}]}"#,
+            "2026-08-22T00:00:00Z",
+        )
+        .unwrap();
+    let first = tenant_kernel
+        .decode(
+            &request,
+            br#"{"data":[{"gid":"user-1","name":"One"}]}"#,
+            "2026-08-22T00:00:00Z",
+        )
+        .unwrap();
+    assert_ne!(first.records[0].event_id, other.records[0].event_id);
+    assert_eq!(
+        first.records[0].attributes["resource_urn"],
+        "urn:cerebro:tenant:runtime_users:user-1"
+    );
+    assert_eq!(
+        tenant_kernel.decode_http(&request, 401, None, b"", "2026-08-22T00:00:00Z"),
+        Err(AsanaError::AuthenticationRejected)
+    );
+    assert_eq!(
+        tenant_kernel.decode_http(&request, 403, None, b"", "2026-08-22T00:00:00Z"),
+        Err(AsanaError::RequiredScopeMissing)
+    );
+    assert_eq!(
+        tenant_kernel.decode_http(&request, 429, Some(30), b"", "2026-08-22T00:00:00Z"),
+        Err(AsanaError::RateLimited {
+            retry_after_seconds: Some(30)
+        })
+    );
+    assert_eq!(
+        tenant_kernel.decode_http(&request, 503, None, b"", "2026-08-22T00:00:00Z"),
+        Err(AsanaError::ProviderUnavailable { status: 503 })
+    );
+    let diagnostics = format!(
+        "{:?}",
+        tenant_kernel.decode(
+            &request,
+            br#"{"data":[{"gid":"user-1","password":"secret-sentinel"}]}"#,
+            "2026-08-22T00:00:00Z"
+        )
+    );
+    assert!(!diagnostics.contains("secret-sentinel"));
+}
+
+fn assert_oracle(records: &[AsanaRecord], oracle: &[u8]) {
+    let oracle: Vec<Value> = serde_json::from_slice(oracle).expect("Go oracle JSON");
+    assert_eq!(records.len(), oracle.len());
+    for (record, expected) in records.iter().zip(oracle) {
+        assert_eq!(record.tenant_id, expected["tenant_id"]);
+        assert_eq!(record.kind, expected["kind"]);
+        assert_eq!(record.schema_ref, expected["schema_ref"]);
+        assert_eq!(record.occurred_at, expected["occurred_at"]);
+        assert_eq!(record.attributes, attributes(&expected["attributes"]));
+        assert_eq!(record.payload, expected["payload"]);
+    }
+}
+
+fn attributes(value: &Value) -> BTreeMap<String, String> {
+    value
+        .as_object()
+        .expect("oracle attributes")
+        .iter()
+        .map(|(key, value)| {
+            (
+                key.clone(),
+                value.as_str().expect("string attribute").to_owned(),
+            )
+        })
+        .collect()
+}

--- a/crates/source-runtime-next/src/asana/types.rs
+++ b/crates/source-runtime-next/src/asana/types.rs
@@ -1,0 +1,69 @@
+use std::collections::BTreeMap;
+
+use reqwest::Url;
+use serde_json::Value;
+
+use super::AsanaFamily;
+
+/// One credential-free Asana request plan.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AsanaRequest {
+    pub(super) url: Url,
+    pub(super) family: AsanaFamily,
+    pub(super) cursor: Option<String>,
+}
+
+/// One normalized tenant-scoped Asana event candidate.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AsanaRecord {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Stable tenant- and provider-scoped event identity.
+    pub event_id: String,
+    /// Stable provider object identity.
+    pub provider_id: String,
+    /// Exact family.
+    pub family: AsanaFamily,
+    /// Exact event kind.
+    pub kind: String,
+    /// Exact schema reference.
+    pub schema_ref: String,
+    /// Normalized RFC3339 occurrence time.
+    pub occurred_at: String,
+    /// Deterministic projection attributes.
+    pub attributes: BTreeMap<String, String>,
+    /// Credential-free normalized provider payload.
+    pub payload: Value,
+}
+
+/// One bounded normalized Asana page.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AsanaPage {
+    /// Accepted records in provider order.
+    pub records: Vec<AsanaRecord>,
+    /// Validated continuation persisted only after durable commit.
+    pub next_cursor: Option<String>,
+}
+
+/// Validated checkpoint candidate for post-append/project persistence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AsanaCheckpointCandidate {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Selected family.
+    pub family: AsanaFamily,
+    /// Validated next cursor.
+    pub cursor: Option<String>,
+    /// Highest normalized occurrence time.
+    pub watermark: Option<String>,
+}
+
+/// Closed Asana kernel for one tenant, workspace, and family.
+#[derive(Clone, Debug)]
+pub struct AsanaKernel {
+    pub(super) base_url: Url,
+    pub(super) tenant_id: String,
+    pub(super) workspace_gid: String,
+    pub(super) family: AsanaFamily,
+    pub(super) page_size: usize,
+}

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -7,6 +7,8 @@ mod amplitude;
 mod anthropic;
 mod append_log;
 mod archetype;
+// Provider-local work-management runtime kernel.
+mod asana;
 mod aurelius;
 mod aws_account;
 mod aws_codebuild;
@@ -58,6 +60,11 @@ pub use archetype::{
     ArchetypeError, ArchetypeFamily, ArchetypeKernel, ArchetypePage, ArchetypeRecord,
     ArchetypeRepository, ArchetypeRequest, ArchetypeRequestKind, ArchetypeScan,
     VulnerabilityCollectionState,
+};
+pub use asana::{
+    AsanaCheckpointCandidate, AsanaEntityFact, AsanaError, AsanaEventContract, AsanaFamily,
+    AsanaKernel, AsanaPage, AsanaProjectionFacts, AsanaRecord, AsanaRelationFact, AsanaRequest,
+    AsanaRuntimeDefinition, project_asana_records,
 };
 pub use aurelius::{
     AureliusCursor, AureliusError, AureliusFamily, AureliusKernel, AureliusPage, AureliusRecord,


### PR DESCRIPTION
## Summary

- compile the Asana users, projects, and audit-events catalog families into closed Rust runtime definitions
- plan bounded origin-restricted requests and normalize typed provider responses without credentials in the kernel
- preserve tenant-scoped identities, cursor/checkpoint behavior, exact event contracts, and provider-local projection facts
- compare all three families with the checked-in Go fixture oracle and reject credential-shaped or untrusted tenant data

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cerebro-source-runtime-next --lib` (463 passed)
- `cargo test -p cerebro-source-runtime-next asana --lib` (5 passed)
- `cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings`
- `go test ./sources/asana -count=1`
- `make source-fixture-check`
- `make check-arch check-structural check-structural-test`
- `./scripts/leak_check.sh staged`

The Go compatibility loader remains in place. Production host integration, promotion receipts, and the configured retirement gate are separate follow-up states.