### PR TITLE
fix(sources): complete Go-derived catalog runtime data

### DIFF
--- a/internal/connectorcatalog/catalog/business-data-grc/billbee.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/billbee.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     config_fields:

--- a/internal/connectorcatalog/catalog/business-data-grc/cenit.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/cenit.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     config_fields:

--- a/internal/connectorcatalog/catalog/business-data-grc/clickmeter.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/clickmeter.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     config_fields:

--- a/internal/connectorcatalog/catalog/business-data-grc/files_com.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/files_com.yaml
@@ -10,6 +10,7 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: X-FilesAPI-Key
     categories:
     - saas
     description: Collects external event, api key, group, group user, action notification export result, and permission from Files.com and projects them into the Cerebro graph as alerts, assets, audit events, groups, secrets, and users for inventory, access review, audit, risk, and operational context.

--- a/internal/connectorcatalog/catalog/business-data-grc/gsmtasks.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/gsmtasks.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     config_fields:


### PR DESCRIPTION
## Current scope

- Preserve effective API-key placement from the retired Go runtime for Billbee, Cenit, ClickMeter, Files.com, and GSMtasks.
- Remove 60 family-level `UnsupportedAuthModel` blockers without exposing credentials.
- Continue adding independently verified Go-derived source data in small commits on this draft.

## Validation

- `go test ./internal/connectorcatalog ./internal/connectordefinitions ./internal/sourcegen -count=1`
- `cargo test -p cerebro-source-catalog unsupported_feature_report_classifies_every_family_with_reason_codes -- --nocapture`
- `make sourcegen-check`
- `git diff --check`

All repository build and test commands above ran in the isolated DDESK workspace `cbrsrcdata`. Rust classification remained complete for all 3,938 families; `UnsupportedAuthModel` decreased from 325 to 265.