### PR TITLE
fix(sources): preserve API key placement for nine catalogs

### DIFF
--- a/internal/connectorcatalog/catalog/business-data-grc/billingo.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/billingo.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     description: "Collects bank account, document, document block, and partner from Billingo and projects them into the Cerebro graph as users and assets for owner, account, evidence, and compliance context."

--- a/internal/connectorcatalog/catalog/business-data-grc/braintree.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/braintree.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - business
         - billing

--- a/internal/connectorcatalog/catalog/business-data-grc/checkr.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/checkr.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - background_checks
         - hr

--- a/internal/connectorcatalog/catalog/devops-ci-cd/appveyor.yaml
+++ b/internal/connectorcatalog/catalog/devops-ci-cd/appveyor.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     config_fields:

--- a/internal/connectorcatalog/catalog/devops-ci-cd/codefresh.yaml
+++ b/internal/connectorcatalog/catalog/devops-ci-cd/codefresh.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - devops
         - ci

--- a/internal/connectorcatalog/catalog/identity-access-secrets/bitwarden_enterprise.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets/bitwarden_enterprise.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - identity
         - secrets

--- a/internal/connectorcatalog/catalog/observability-soar-threat-intel/bugsnag.yaml
+++ b/internal/connectorcatalog/catalog/observability-soar-threat-intel/bugsnag.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - observability
         - security

--- a/internal/connectorcatalog/catalog/observability-soar-threat-intel/cortex_xdr.yaml
+++ b/internal/connectorcatalog/catalog/observability-soar-threat-intel/cortex_xdr.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - security
         - endpoint

--- a/internal/connectorcatalog/catalog/observability-soar-threat-intel/cortex_xsoar.yaml
+++ b/internal/connectorcatalog/catalog/observability-soar-threat-intel/cortex_xsoar.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - soar
         - security


### PR DESCRIPTION
## Scope

Preserve the effective API-key placement from the retired Go runtime for Billingo, Braintree, Checkr, AppVeyor, Codefresh, Bitwarden Enterprise, Bugsnag, Cortex XDR, and Cortex XSOAR. Each historical Go source resolves to `Authorization: Token <key>`.

API2Cart was intentionally excluded after the Rust classifier proved its existing `header_parameters` already provide its single credential placement.

This removes 29 family-level `UnsupportedAuthModel` blockers (`265` to `236`) while leaving all 3,938 families classified.

## Validation

Executed in isolated DDESK workspace `cbrsrcdata` on current `main` plus commit `7f130aaf8`:

- `go test ./internal/connectorcatalog ./internal/connectordefinitions ./internal/sourcegen -count=1`
- `cargo test -p cerebro-source-catalog unsupported_feature_report_classifies_every_family_with_reason_codes -- --nocapture`
- `make sourcegen-check`
- `git diff --check`