### PR TITLE
fix(sources): preserve API key placement for ten catalogs

### DIFF
--- a/internal/connectorcatalog/catalog/business-data-grc/freshservice.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/freshservice.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - itsm
         - support

--- a/internal/connectorcatalog/catalog/business-data-grc/fulfillment_com.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/fulfillment_com.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     description: Collects accounting, inventory, return, and track from Fulfillment.com and projects them into the Cerebro graph as assets and users for inventory, access review, audit, risk, and operational context.

--- a/internal/connectorcatalog/catalog/devops-ci-cd/gitea.yaml
+++ b/internal/connectorcatalog/catalog/devops-ci-cd/gitea.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     config_fields:

--- a/internal/connectorcatalog/catalog/devops-ci-cd/godaddy.yaml
+++ b/internal/connectorcatalog/catalog/devops-ci-cd/godaddy.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     config_fields:

--- a/internal/connectorcatalog/catalog/devops-ci-cd/harness.yaml
+++ b/internal/connectorcatalog/catalog/devops-ci-cd/harness.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - dev
         - ci

--- a/internal/connectorcatalog/catalog/observability-soar-threat-intel/elastic_security.yaml
+++ b/internal/connectorcatalog/catalog/observability-soar-threat-intel/elastic_security.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - siem
         - observability

--- a/internal/connectorcatalog/catalog/observability-soar-threat-intel/elmah.yaml
+++ b/internal/connectorcatalog/catalog/observability-soar-threat-intel/elmah.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     config_fields:

--- a/internal/connectorcatalog/catalog/security-posture-vulnerability/firmalyzer.yaml
+++ b/internal/connectorcatalog/catalog/security-posture-vulnerability/firmalyzer.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     config_fields:

--- a/internal/connectorcatalog/catalog/security-posture-vulnerability/gitguardian.yaml
+++ b/internal/connectorcatalog/catalog/security-posture-vulnerability/gitguardian.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - security
         - code

--- a/internal/connectorcatalog/catalog/security-posture-vulnerability/gitguardian_secrets.yaml
+++ b/internal/connectorcatalog/catalog/security-posture-vulnerability/gitguardian_secrets.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - security
         - secrets


### PR DESCRIPTION
## Scope

Preserve the effective API-key placement from the retired Go runtime for Elastic Security, ELMAH, Firmalyzer, Freshservice, Fulfillment.com, Gitea, GitGuardian, GitGuardian Secrets, GoDaddy, and Harness. For each source, historical Go resolves `AuthModel=api_key`, an empty token header, and `Token` scheme to `Authorization: Token <key>`.

No target already had a token, header-map, or query-map credential placement.

This removes 35 family-level `UnsupportedAuthModel` blockers (`265` to `230`) while leaving all 3,973 families classified on current main.

## Validation

Executed in isolated DDESK workspace `cbrsrcdata` on current `main` plus commit `7da7ca425`:

- `go test ./internal/connectorcatalog ./internal/connectordefinitions ./internal/sourcegen -count=1`
- `cargo test -p cerebro-source-catalog unsupported_feature_report_classifies_every_family_with_reason_codes -- --nocapture`
- `make sourcegen-check`
- `git diff --check`