### PR TITLE
fix(sources): preserve API key placement for ten more catalogs

### DIFF
--- a/internal/connectorcatalog/catalog/business-data-grc/hitrust_mycsf.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/hitrust_mycsf.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - grc
         - audit

--- a/internal/connectorcatalog/catalog/business-data-grc/illumidesk.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/illumidesk.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     config_fields:

--- a/internal/connectorcatalog/catalog/business-data-grc/iqualify.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/iqualify.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     config_fields:

--- a/internal/connectorcatalog/catalog/devops-ci-cd/launchdarkly.yaml
+++ b/internal/connectorcatalog/catalog/devops-ci-cd/launchdarkly.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - dev
         - feature_flags

--- a/internal/connectorcatalog/catalog/devops-ci-cd/mist.yaml
+++ b/internal/connectorcatalog/catalog/devops-ci-cd/mist.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     config_fields:

--- a/internal/connectorcatalog/catalog/identity-access-secrets/lastpass_business.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets/lastpass_business.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - identity
         - secrets

--- a/internal/connectorcatalog/catalog/observability-soar-threat-intel/haveibeenpwned.yaml
+++ b/internal/connectorcatalog/catalog/observability-soar-threat-intel/haveibeenpwned.yaml
@@ -7,6 +7,7 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: hibp-api-key
       categories:
         - threat_intel
         - identity

--- a/internal/connectorcatalog/catalog/observability-soar-threat-intel/hudsonrock.yaml
+++ b/internal/connectorcatalog/catalog/observability-soar-threat-intel/hudsonrock.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - threat_intel
         - security

--- a/internal/connectorcatalog/catalog/security-posture-vulnerability/lacework.yaml
+++ b/internal/connectorcatalog/catalog/security-posture-vulnerability/lacework.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - security
         - cloud

--- a/internal/connectorcatalog/catalog/security-posture-vulnerability/mend_io.yaml
+++ b/internal/connectorcatalog/catalog/security-posture-vulnerability/mend_io.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - security
         - sca


### PR DESCRIPTION
## Scope

Preserve retired-Go API-key placement for Have I Been Pwned, HITRUST MyCSF, Hudson Rock, IllumiDesk, iQualify, Lacework, LastPass Business, LaunchDarkly, Mend.io, and Juniper Mist.

Have I Been Pwned uses the source-proved raw `hibp-api-key` header. The other nine resolve to `Authorization: Token <key>`. None had another credential placement.

This removes 49 family-level `UnsupportedAuthModel` blockers and brings the cumulative current-main count from 325 to 152 while leaving all 3,973 families classified.

## Validation

Executed in isolated DDESK workspace `cbrsrcdata` on current `main` plus commit `9f8ee2c35`:

- `go test ./internal/connectorcatalog ./internal/connectordefinitions ./internal/sourcegen -count=1`
- `cargo test -p cerebro-source-catalog unsupported_feature_report_classifies_every_family_with_reason_codes -- --nocapture`
- `make sourcegen-check`
- `git diff --check`