### PR TITLE
feat(source-runtime): add credential-free JumpCloud Rust kernel

### DIFF
--- a/crates/source-runtime-next/src/jumpcloud.rs
+++ b/crates/source-runtime-next/src/jumpcloud.rs
@@ -1,0 +1,29 @@
+//! Credential-free JumpCloud request, normalization, and projection kernel.
+//!
+//! The trusted host owns credential resolution, authentication, redirects,
+//! deadlines, and bounded network I/O. This module accepts public source
+//! configuration and already-bounded provider response bytes only.
+
+mod catalog;
+mod error;
+mod family;
+mod normalize;
+mod origin;
+mod projection;
+mod request;
+mod response;
+mod types;
+
+pub use catalog::{JumpCloudEventContract, JumpCloudRuntimeDefinition};
+pub use error::JumpCloudError;
+pub use family::JumpCloudFamily;
+pub use projection::{
+    JumpCloudEntityFact, JumpCloudProjectionFacts, JumpCloudRelationFact, project_jumpcloud_records,
+};
+pub use types::{
+    JumpCloudCheckpointCandidate, JumpCloudFilters, JumpCloudKernel, JumpCloudPage,
+    JumpCloudRecord, JumpCloudRequest, JumpCloudResponseMetadata,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/jumpcloud/catalog.rs
+++ b/crates/source-runtime-next/src/jumpcloud/catalog.rs
@@ -1,0 +1,89 @@
+use super::{JumpCloudError, JumpCloudFamily};
+
+/// One exact event contract compiled from `sources/jumpcloud/catalog.yaml`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct JumpCloudEventContract {
+    /// Exact provider event kind.
+    pub kind: &'static str,
+    /// Exact schema reference.
+    pub schema_ref: &'static str,
+    /// Required normalized attributes.
+    pub required_attributes: &'static [&'static str],
+    /// Required normalized payload fields.
+    pub required_payload_fields: &'static [&'static str],
+}
+
+/// Closed runtime definition for one JumpCloud family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct JumpCloudRuntimeDefinition {
+    /// Source identifier.
+    pub source_id: &'static str,
+    /// Selected family.
+    pub family: JumpCloudFamily,
+    /// Exact event contract.
+    pub event_contract: JumpCloudEventContract,
+    /// JumpCloud families are bounded pull operations.
+    pub pull: bool,
+}
+
+impl JumpCloudRuntimeDefinition {
+    /// Compile one catalog family into a closed definition.
+    pub fn compile(family: JumpCloudFamily) -> Result<Self, JumpCloudError> {
+        let event_contract = match family {
+            JumpCloudFamily::Users => contract(
+                family,
+                &["tenant_id", "source_event_id", "user_id"],
+                &["_id"],
+            ),
+            JumpCloudFamily::Groups => contract(
+                family,
+                &["tenant_id", "source_event_id", "group_id"],
+                &["id"],
+            ),
+            JumpCloudFamily::Systems => contract(
+                family,
+                &["tenant_id", "source_event_id", "system_id"],
+                &["_id"],
+            ),
+            JumpCloudFamily::Applications => contract(
+                family,
+                &["tenant_id", "source_event_id", "app_id"],
+                &["_id"],
+            ),
+            JumpCloudFamily::SystemGroups => contract(
+                family,
+                &["tenant_id", "source_event_id", "group_id"],
+                &["id"],
+            ),
+            JumpCloudFamily::GroupMembers => contract(
+                family,
+                &["tenant_id", "source_event_id", "group_id", "member_id"],
+                &["to.id"],
+            ),
+            JumpCloudFamily::AuditEvents => contract(
+                family,
+                &["tenant_id", "source_event_id", "event_type", "actor_id"],
+                &["id"],
+            ),
+        };
+        Ok(Self {
+            source_id: "jumpcloud",
+            family,
+            event_contract,
+            pull: true,
+        })
+    }
+}
+
+const fn contract(
+    family: JumpCloudFamily,
+    required_attributes: &'static [&'static str],
+    required_payload_fields: &'static [&'static str],
+) -> JumpCloudEventContract {
+    JumpCloudEventContract {
+        kind: family.event_kind(),
+        schema_ref: family.schema_ref(),
+        required_attributes,
+        required_payload_fields,
+    }
+}

--- a/crates/source-runtime-next/src/jumpcloud/error.rs
+++ b/crates/source-runtime-next/src/jumpcloud/error.rs
@@ -1,0 +1,163 @@
+use std::{error::Error, fmt};
+
+/// Bounded JumpCloud provider and runtime failure taxonomy.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum JumpCloudError {
+    /// Family is outside the closed catalog.
+    InvalidFamily,
+    /// Required public configuration is missing.
+    MissingConfiguration(&'static str),
+    /// Public configuration is malformed.
+    InvalidConfiguration(&'static str),
+    /// Provider origin is not one of the closed HTTPS JumpCloud origins.
+    InvalidOrigin,
+    /// Authenticated tenant context is missing or malformed.
+    InvalidTenantId,
+    /// Trusted host has no credential reference.
+    MissingCredentialReference,
+    /// Trusted host could not redeem the credential lease.
+    CredentialUnavailable,
+    /// Durable cursor is invalid or cannot round-trip.
+    InvalidCursor,
+    /// Request does not belong to this kernel.
+    RequestScopeMismatch,
+    /// Provider rejected authentication.
+    AuthenticationRejected,
+    /// Credential lacks the required JumpCloud scope.
+    RequiredScopeMissing,
+    /// Trusted host denied provider egress.
+    EgressDenied,
+    /// Provider DNS lookup failed.
+    DnsFailure,
+    /// Provider connection failed.
+    ConnectionFailure,
+    /// Provider operation timed out.
+    ProviderTimeout,
+    /// Provider requested a bounded retry.
+    RateLimited {
+        /// Bounded retry delay supplied by the provider.
+        retry_after_seconds: Option<u64>,
+    },
+    /// Provider returned a retryable server failure.
+    ProviderUnavailable {
+        /// Provider status in the 500-599 range.
+        status: u16,
+    },
+    /// Provider returned an unexpected status.
+    UnexpectedStatus {
+        /// Provider status outside the typed cases.
+        status: u16,
+    },
+    /// Retry delay is outside the persistence bound.
+    InvalidRetryAfter,
+    /// Response exceeds the host-declared byte bound.
+    ResponseTooLarge,
+    /// Response exceeds the planned record count.
+    TooManyRecords,
+    /// Response JSON does not match the selected family.
+    MalformedResponse,
+    /// Provider record violates the family shape.
+    InvalidProviderRecord,
+    /// Provider record has no stable identity.
+    MissingStableIdentity,
+    /// Provider payload attempted to provide tenant context.
+    TenantMismatch,
+    /// Credential-shaped material crossed into the kernel.
+    CredentialMaterial,
+    /// Duplicate provider identity has conflicting content.
+    ConflictingDuplicate,
+    /// Normalized record failed the exact compiled event contract.
+    EventContractRejection,
+    /// Durable append failed.
+    AppendFailure,
+    /// Projection failed.
+    ProjectionFailure,
+    /// Runtime lost its source lease.
+    LeaseLoss,
+    /// Runtime authority or generation is stale.
+    StaleAuthority,
+    /// Internal runtime failure.
+    InternalRuntimeFailure,
+}
+
+impl JumpCloudError {
+    /// Next safe operator action without provider content.
+    pub const fn operator_action(&self) -> &'static str {
+        match self {
+            Self::InvalidFamily
+            | Self::MissingConfiguration(_)
+            | Self::InvalidConfiguration(_)
+            | Self::InvalidOrigin
+            | Self::InvalidTenantId
+            | Self::MissingCredentialReference => "repair source configuration",
+            Self::CredentialUnavailable | Self::AuthenticationRejected => {
+                "repair credential binding"
+            }
+            Self::RequiredScopeMissing => "grant the required provider scope",
+            Self::RateLimited { .. }
+            | Self::ProviderUnavailable { .. }
+            | Self::DnsFailure
+            | Self::ConnectionFailure
+            | Self::ProviderTimeout => "retry the collection later",
+            Self::EgressDenied => "repair trusted-host egress policy",
+            Self::InvalidCursor => "restart from the last committed checkpoint",
+            Self::MalformedResponse
+            | Self::InvalidProviderRecord
+            | Self::MissingStableIdentity
+            | Self::TenantMismatch
+            | Self::CredentialMaterial
+            | Self::ConflictingDuplicate
+            | Self::EventContractRejection => "inspect quarantined provider records",
+            Self::AppendFailure | Self::ProjectionFailure => "repair the durable commit path",
+            Self::LeaseLoss | Self::StaleAuthority => "restart under the current lease",
+            Self::RequestScopeMismatch
+            | Self::InvalidRetryAfter
+            | Self::ResponseTooLarge
+            | Self::TooManyRecords
+            | Self::UnexpectedStatus { .. }
+            | Self::InternalRuntimeFailure => "repair the forward runtime implementation",
+        }
+    }
+}
+
+impl fmt::Display for JumpCloudError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidFamily => "jumpcloud family is invalid",
+            Self::MissingConfiguration(_) => "jumpcloud source configuration is missing",
+            Self::InvalidConfiguration(_) => "jumpcloud source configuration is invalid",
+            Self::InvalidOrigin => "jumpcloud provider origin is invalid",
+            Self::InvalidTenantId => "jumpcloud tenant ID is invalid",
+            Self::MissingCredentialReference => "jumpcloud credential reference is missing",
+            Self::CredentialUnavailable => "jumpcloud credential lease is unavailable",
+            Self::InvalidCursor => "jumpcloud cursor is invalid or not round-trippable",
+            Self::RequestScopeMismatch => "jumpcloud request does not match the kernel",
+            Self::AuthenticationRejected => "jumpcloud rejected authentication",
+            Self::RequiredScopeMissing => "jumpcloud credential lacks required scope",
+            Self::EgressDenied => "jumpcloud egress was denied",
+            Self::DnsFailure => "jumpcloud DNS resolution failed",
+            Self::ConnectionFailure => "jumpcloud connection failed",
+            Self::ProviderTimeout => "jumpcloud operation timed out",
+            Self::RateLimited { .. } => "jumpcloud rate limited the operation",
+            Self::ProviderUnavailable { .. } => "jumpcloud is temporarily unavailable",
+            Self::UnexpectedStatus { .. } => "jumpcloud returned an unexpected status",
+            Self::InvalidRetryAfter => "jumpcloud retry delay exceeds its bound",
+            Self::ResponseTooLarge => "jumpcloud response exceeds its byte bound",
+            Self::TooManyRecords => "jumpcloud response exceeds its record bound",
+            Self::MalformedResponse => "jumpcloud response is malformed",
+            Self::InvalidProviderRecord => "jumpcloud provider record is invalid",
+            Self::MissingStableIdentity => "jumpcloud record has no stable identity",
+            Self::TenantMismatch => "jumpcloud payload attempted to supply tenant context",
+            Self::CredentialMaterial => "jumpcloud payload contains credential-shaped material",
+            Self::ConflictingDuplicate => "jumpcloud duplicate identity has conflicting content",
+            Self::EventContractRejection => "jumpcloud event failed its catalog contract",
+            Self::AppendFailure => "jumpcloud append failed",
+            Self::ProjectionFailure => "jumpcloud projection failed",
+            Self::LeaseLoss => "jumpcloud runtime lost its lease",
+            Self::StaleAuthority => "jumpcloud runtime authority is stale",
+            Self::InternalRuntimeFailure => "jumpcloud runtime failed internally",
+        })
+    }
+}
+
+impl Error for JumpCloudError {}

--- a/crates/source-runtime-next/src/jumpcloud/family.rs
+++ b/crates/source-runtime-next/src/jumpcloud/family.rs
@@ -1,0 +1,122 @@
+use std::str::FromStr;
+
+use super::JumpCloudError;
+
+/// Closed JumpCloud source-catalog family vocabulary.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum JumpCloudFamily {
+    /// Directory users.
+    Users,
+    /// User groups.
+    Groups,
+    /// Managed systems.
+    Systems,
+    /// SSO applications.
+    Applications,
+    /// Managed-system groups.
+    SystemGroups,
+    /// User-group membership edges.
+    GroupMembers,
+    /// Directory Insights audit events.
+    AuditEvents,
+}
+
+impl JumpCloudFamily {
+    /// Every supported family in catalog order.
+    pub const ALL: [Self; 7] = [
+        Self::Users,
+        Self::Groups,
+        Self::Systems,
+        Self::Applications,
+        Self::SystemGroups,
+        Self::GroupMembers,
+        Self::AuditEvents,
+    ];
+
+    /// Exact catalog family identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Users => "users",
+            Self::Groups => "groups",
+            Self::Systems => "systems",
+            Self::Applications => "applications",
+            Self::SystemGroups => "system_groups",
+            Self::GroupMembers => "group_members",
+            Self::AuditEvents => "audit_events",
+        }
+    }
+
+    /// Exact event kind admitted by the catalog.
+    pub const fn event_kind(self) -> &'static str {
+        match self {
+            Self::Users => "jumpcloud.users",
+            Self::Groups => "jumpcloud.groups",
+            Self::Systems => "jumpcloud.systems",
+            Self::Applications => "jumpcloud.applications",
+            Self::SystemGroups => "jumpcloud.system_groups",
+            Self::GroupMembers => "jumpcloud.group_members",
+            Self::AuditEvents => "jumpcloud.audit_events",
+        }
+    }
+
+    /// Exact event schema admitted by the catalog.
+    pub const fn schema_ref(self) -> &'static str {
+        match self {
+            Self::Users => "jumpcloud/users/v1",
+            Self::Groups => "jumpcloud/groups/v1",
+            Self::Systems => "jumpcloud/systems/v1",
+            Self::Applications => "jumpcloud/applications/v1",
+            Self::SystemGroups => "jumpcloud/system_groups/v1",
+            Self::GroupMembers => "jumpcloud/group_members/v1",
+            Self::AuditEvents => "jumpcloud/audit_events/v1",
+        }
+    }
+
+    /// Provider HTTP method.
+    pub const fn method(self) -> &'static str {
+        if matches!(self, Self::AuditEvents) {
+            "POST"
+        } else {
+            "GET"
+        }
+    }
+
+    /// Provider-relative operation path.
+    pub const fn path(self) -> &'static str {
+        match self {
+            Self::Users => "/systemusers",
+            Self::Groups => "/v2/usergroups",
+            Self::Systems => "/systems",
+            Self::Applications => "/applications",
+            Self::SystemGroups => "/v2/systemgroups",
+            Self::GroupMembers => "/v2/usergroups/{group_id}/members",
+            Self::AuditEvents => "/events",
+        }
+    }
+
+    /// Required provider permission stated without credential material.
+    pub const fn required_scope(self) -> &'static str {
+        match self {
+            Self::AuditEvents => "Directory Insights read access",
+            Self::GroupMembers => "user-group membership read access",
+            Self::Users | Self::Groups => "directory read access",
+            Self::Systems | Self::SystemGroups => "systems read access",
+            Self::Applications => "applications read access",
+        }
+    }
+
+    pub(super) const fn uses_insights_origin(self) -> bool {
+        matches!(self, Self::AuditEvents)
+    }
+}
+
+impl FromStr for JumpCloudFamily {
+    type Err = JumpCloudError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|family| family.as_str() == value.trim())
+            .ok_or(JumpCloudError::InvalidFamily)
+    }
+}

--- a/crates/source-runtime-next/src/jumpcloud/normalize.rs
+++ b/crates/source-runtime-next/src/jumpcloud/normalize.rs
@@ -1,0 +1,482 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    JumpCloudError, JumpCloudFamily, JumpCloudKernel, JumpCloudRecord, JumpCloudRuntimeDefinition,
+};
+
+pub(super) fn normalize(
+    kernel: &JumpCloudKernel,
+    raw: Value,
+) -> Result<JumpCloudRecord, JumpCloudError> {
+    reject_untrusted(&raw, 0)?;
+    let values = raw
+        .as_object()
+        .ok_or(JumpCloudError::InvalidProviderRecord)?;
+    let external_id = external_id(kernel.family, values)?;
+    let provider_id = if kernel.family == JumpCloudFamily::GroupMembers {
+        let group_id = kernel
+            .filters
+            .group_id
+            .as_deref()
+            .ok_or(JumpCloudError::MissingConfiguration("group_id"))?;
+        format!("{group_id}\0{external_id}")
+    } else {
+        external_id.clone()
+    };
+    let occurred_at = occurred_at(kernel.family, values, &kernel.observed_at)?;
+    let (attributes, payload) = family_values(kernel, values, &external_id)?;
+    validate_contract(kernel.family, &attributes, &payload)?;
+    let digest = Sha256::digest(format!(
+        "{}\0{}\0{}",
+        kernel.tenant_id,
+        kernel.family.as_str(),
+        provider_id
+    ));
+    let suffix = digest[..12]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    Ok(JumpCloudRecord {
+        tenant_id: kernel.tenant_id.clone(),
+        event_id: format!("jumpcloud-{}-{suffix}", kernel.family.as_str()),
+        provider_id,
+        family: kernel.family,
+        kind: kernel.family.event_kind().to_owned(),
+        schema_ref: kernel.family.schema_ref().to_owned(),
+        occurred_at,
+        attributes,
+        payload,
+    })
+}
+
+fn family_values(
+    kernel: &JumpCloudKernel,
+    values: &Map<String, Value>,
+    external_id: &str,
+) -> Result<(BTreeMap<String, String>, Value), JumpCloudError> {
+    let (record_class, schema, resource_type) = match kernel.family {
+        JumpCloudFamily::Users => ("identity_user", "users", "identity_user"),
+        JumpCloudFamily::Groups => ("identity_group", "groups", "user_group"),
+        JumpCloudFamily::Systems => ("asset", "systems", "system"),
+        JumpCloudFamily::Applications => ("identity_application", "applications", "application"),
+        JumpCloudFamily::SystemGroups => ("identity_group", "system_groups", "system_group"),
+        JumpCloudFamily::GroupMembers => (
+            "identity_group_membership",
+            "group_members",
+            "identity_membership",
+        ),
+        JumpCloudFamily::AuditEvents => ("audit_event", "audit_events", "audit_event"),
+    };
+    let mut attributes = BTreeMap::from([
+        ("external_id".to_owned(), external_id.to_owned()),
+        ("family".to_owned(), kernel.family.as_str().to_owned()),
+        ("provider".to_owned(), "jumpcloud".to_owned()),
+        ("record_class".to_owned(), record_class.to_owned()),
+        ("schema".to_owned(), schema.to_owned()),
+        ("source_event_id".to_owned(), external_id.to_owned()),
+        ("source_provider".to_owned(), "jumpcloud".to_owned()),
+        ("source_system".to_owned(), "jumpcloud".to_owned()),
+        ("tenant_id".to_owned(), kernel.tenant_id.clone()),
+    ]);
+    let mut payload = values.clone();
+    match kernel.family {
+        JumpCloudFamily::Users => {
+            copy(&mut attributes, values, &["_id", "id"], "user_id");
+            copy(&mut attributes, values, &["email"], "email");
+            copy(&mut attributes, values, &["email"], "primary_email");
+            copy(&mut attributes, values, &["username", "email"], "login");
+            copy(
+                &mut attributes,
+                values,
+                &["displayname", "displayName", "username", "email"],
+                "display_name",
+            );
+            copy(
+                &mut attributes,
+                values,
+                &["firstname", "firstName"],
+                "first_name",
+            );
+            copy(
+                &mut attributes,
+                values,
+                &["lastname", "lastName"],
+                "last_name",
+            );
+            copy(&mut attributes, values, &["department"], "department");
+            copy(
+                &mut attributes,
+                values,
+                &["jobTitle", "job_title"],
+                "job_title",
+            );
+            copy(
+                &mut attributes,
+                values,
+                &["employeeIdentifier"],
+                "employee_id",
+            );
+            copy(&mut attributes, values, &["state", "status"], "status");
+            copy(&mut attributes, values, &["activated"], "activated");
+            copy(&mut attributes, values, &["suspended"], "suspended");
+            copy(
+                &mut attributes,
+                values,
+                &[
+                    "totp_enabled",
+                    "enable_user_portal_multifactor",
+                    "mfa.configured",
+                ],
+                "mfa_enabled",
+            );
+            copy(&mut attributes, values, &["_id", "id"], "resource_id");
+            copy(
+                &mut attributes,
+                values,
+                &["displayname", "username", "email"],
+                "resource_name",
+            );
+            attributes.insert("resource_type".to_owned(), resource_type.to_owned());
+            attributes.insert(
+                "resource_urn".to_owned(),
+                urn(&kernel.tenant_id, "jumpcloud_users", external_id),
+            );
+        }
+        JumpCloudFamily::Groups => {
+            copy(&mut attributes, values, &["id"], "group_id");
+            copy(&mut attributes, values, &["name"], "group_name");
+            copy(&mut attributes, values, &["type"], "group_type");
+            copy(
+                &mut attributes,
+                values,
+                &["attributes.description", "description"],
+                "description",
+            );
+            copy(&mut attributes, values, &["id"], "resource_id");
+            copy(&mut attributes, values, &["name"], "resource_name");
+            attributes.insert("resource_type".to_owned(), resource_type.to_owned());
+        }
+        JumpCloudFamily::Systems => {
+            copy(&mut attributes, values, &["_id", "id"], "system_id");
+            copy(&mut attributes, values, &["_id", "id"], "resource_id");
+            copy(
+                &mut attributes,
+                values,
+                &["displayName", "hostname"],
+                "resource_name",
+            );
+            attributes.insert("resource_type".to_owned(), resource_type.to_owned());
+            for (paths, target) in [
+                (&["hostname"][..], "hostname"),
+                (&["os"][..], "os"),
+                (&["version"][..], "os_version"),
+                (&["arch"][..], "architecture"),
+                (&["agentVersion"][..], "agent_version"),
+                (&["active"][..], "active"),
+                (&["lastContact"][..], "last_contact_at"),
+                (&["remoteIP"][..], "remote_ip"),
+            ] {
+                copy(&mut attributes, values, paths, target);
+            }
+            attributes.insert(
+                "resource_urn".to_owned(),
+                urn(&kernel.tenant_id, "jumpcloud_systems", external_id),
+            );
+        }
+        JumpCloudFamily::Applications => {
+            copy(&mut attributes, values, &["_id", "id"], "app_id");
+            copy(
+                &mut attributes,
+                values,
+                &["displayName", "displayLabel", "name"],
+                "app_name",
+            );
+            copy(&mut attributes, values, &["ssoUrl", "learnMore"], "app_url");
+            copy(&mut attributes, values, &["_id", "id"], "resource_id");
+            copy(
+                &mut attributes,
+                values,
+                &["displayName", "displayLabel", "name"],
+                "resource_name",
+            );
+            attributes.insert("resource_type".to_owned(), resource_type.to_owned());
+            attributes.insert(
+                "resource_urn".to_owned(),
+                urn(&kernel.tenant_id, "jumpcloud_applications", external_id),
+            );
+        }
+        JumpCloudFamily::SystemGroups => {
+            copy(&mut attributes, values, &["id"], "group_id");
+            copy(&mut attributes, values, &["name"], "group_name");
+            copy(&mut attributes, values, &["type"], "group_type");
+            copy(&mut attributes, values, &["id"], "resource_id");
+            copy(&mut attributes, values, &["name"], "resource_name");
+            attributes.insert("resource_type".to_owned(), resource_type.to_owned());
+        }
+        JumpCloudFamily::GroupMembers => {
+            let group_id = kernel
+                .filters
+                .group_id
+                .as_deref()
+                .ok_or(JumpCloudError::MissingConfiguration("group_id"))?;
+            attributes.insert("group_id".to_owned(), group_id.to_owned());
+            copy(&mut attributes, values, &["to.id", "id"], "member_id");
+            copy(&mut attributes, values, &["to.id", "id"], "member_user_id");
+            copy(&mut attributes, values, &["to.type", "type"], "member_type");
+            copy(&mut attributes, values, &["to.id", "id"], "resource_id");
+            copy(
+                &mut attributes,
+                values,
+                &["to.type", "type"],
+                "resource_type",
+            );
+            payload.insert("group_id".to_owned(), Value::String(group_id.to_owned()));
+        }
+        JumpCloudFamily::AuditEvents => {
+            copy(
+                &mut attributes,
+                values,
+                &["event_type", "type", "action"],
+                "event_type",
+            );
+            copy(
+                &mut attributes,
+                values,
+                &[
+                    "initiated_by.id",
+                    "actor.id",
+                    "admin.id",
+                    "user.id",
+                    "user_id",
+                    "resource.id",
+                    "username",
+                ],
+                "actor_id",
+            );
+            copy(
+                &mut attributes,
+                values,
+                &[
+                    "initiated_by.email",
+                    "actor.email",
+                    "admin.email",
+                    "user.email",
+                    "resource.email",
+                    "email",
+                    "username",
+                ],
+                "actor_email",
+            );
+            copy(
+                &mut attributes,
+                values,
+                &[
+                    "initiated_by.name",
+                    "actor.name",
+                    "admin.name",
+                    "user.name",
+                    "username",
+                ],
+                "actor_name",
+            );
+            copy(
+                &mut attributes,
+                values,
+                &[
+                    "resource.id",
+                    "target.id",
+                    "object.id",
+                    "application.id",
+                    "system.id",
+                ],
+                "resource_id",
+            );
+            copy(
+                &mut attributes,
+                values,
+                &["resource.type", "target.type", "object.type"],
+                "resource_type",
+            );
+            copy(
+                &mut attributes,
+                values,
+                &["resource.email", "target.email", "object.email"],
+                "resource_email",
+            );
+            copy(
+                &mut attributes,
+                values,
+                &[
+                    "resource.name",
+                    "target.name",
+                    "object.name",
+                    "application.name",
+                    "system.hostname",
+                ],
+                "resource_name",
+            );
+            for (paths, target) in [
+                (&["client_ip", "ip", "src_ip"][..], "client_ip"),
+                (&["organization", "org_id"][..], "organization"),
+            ] {
+                copy(&mut attributes, values, paths, target);
+            }
+        }
+    }
+    Ok((attributes, Value::Object(payload)))
+}
+
+fn external_id(
+    family: JumpCloudFamily,
+    values: &Map<String, Value>,
+) -> Result<String, JumpCloudError> {
+    let paths: &[&str] = match family {
+        JumpCloudFamily::Users => &["_id", "id", "email", "username"],
+        JumpCloudFamily::Groups | JumpCloudFamily::SystemGroups => &["id", "name"],
+        JumpCloudFamily::Systems => &["_id", "id", "displayName", "hostname"],
+        JumpCloudFamily::Applications => &["_id", "id", "displayName", "name"],
+        JumpCloudFamily::GroupMembers => &["to.id", "id"],
+        JumpCloudFamily::AuditEvents => &["id", "event_id", "uuid", "request_id"],
+    };
+    provider_component(&string_first(values, paths).ok_or(JumpCloudError::MissingStableIdentity)?)
+}
+
+fn validate_contract(
+    family: JumpCloudFamily,
+    attributes: &BTreeMap<String, String>,
+    payload: &Value,
+) -> Result<(), JumpCloudError> {
+    let definition = JumpCloudRuntimeDefinition::compile(family)?;
+    let contract = definition.event_contract;
+    if contract.kind != family.event_kind()
+        || contract.schema_ref != family.schema_ref()
+        || contract.required_attributes.iter().any(|field| {
+            attributes
+                .get(*field)
+                .is_none_or(|value| value.trim().is_empty())
+        })
+        || contract.required_payload_fields.iter().any(|path| {
+            value_at(payload, path).is_none_or(|value| {
+                value.is_null() || value.as_str().is_some_and(|text| text.trim().is_empty())
+            })
+        })
+    {
+        return Err(JumpCloudError::EventContractRejection);
+    }
+    Ok(())
+}
+
+fn occurred_at(
+    family: JumpCloudFamily,
+    values: &Map<String, Value>,
+    observed_at: &str,
+) -> Result<String, JumpCloudError> {
+    let paths: &[&str] = match family {
+        JumpCloudFamily::Users => &["updated", "created", "lastLogin"],
+        JumpCloudFamily::Groups | JumpCloudFamily::SystemGroups => &["updated", "created"],
+        JumpCloudFamily::Systems => &["lastContact", "updated", "created"],
+        JumpCloudFamily::Applications => &["updated", "created"],
+        JumpCloudFamily::GroupMembers => &[],
+        JumpCloudFamily::AuditEvents => &[
+            "timestamp",
+            "date",
+            "observed_at",
+            "updated_at",
+            "created_at",
+        ],
+    };
+    let candidate = string_first(values, paths).unwrap_or_else(|| observed_at.to_owned());
+    OffsetDateTime::parse(&candidate, &Rfc3339)
+        .map(|time| time.format(&Rfc3339).unwrap_or(candidate))
+        .map_err(|_| JumpCloudError::InvalidProviderRecord)
+}
+
+fn copy(
+    target: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    paths: &[&str],
+    key: &str,
+) {
+    if let Some(value) = string_first(values, paths) {
+        target.insert(key.to_owned(), value);
+    }
+}
+
+fn string_first(values: &Map<String, Value>, paths: &[&str]) -> Option<String> {
+    paths.iter().find_map(|path| {
+        let mut segments = path.split('.');
+        let mut value = values.get(segments.next()?)?;
+        for segment in segments {
+            value = value.get(segment)?;
+        }
+        match value {
+            Value::String(value) => (!value.trim().is_empty()).then(|| value.trim().to_owned()),
+            Value::Number(value) => Some(value.to_string()),
+            Value::Bool(value) => Some(value.to_string()),
+            _ => None,
+        }
+    })
+}
+
+fn value_at<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    path.split('.')
+        .try_fold(value, |value, segment| value.get(segment))
+}
+
+fn provider_component(value: &str) -> Result<String, JumpCloudError> {
+    let value = value.trim();
+    if value.is_empty()
+        || value.len() > 512
+        || value.chars().any(char::is_control)
+        || value.contains([':', '/', '\\'])
+    {
+        return Err(JumpCloudError::MissingStableIdentity);
+    }
+    Ok(value.to_owned())
+}
+
+fn reject_untrusted(value: &Value, depth: usize) -> Result<(), JumpCloudError> {
+    if depth > 32 {
+        return Err(JumpCloudError::InvalidProviderRecord);
+    }
+    match value {
+        Value::Object(values) => {
+            for (key, value) in values {
+                let key = key.to_ascii_lowercase();
+                if key == "tenant_id" {
+                    return Err(JumpCloudError::TenantMismatch);
+                }
+                if matches!(
+                    key.as_str(),
+                    "token"
+                        | "api_key"
+                        | "x-api-key"
+                        | "access_token"
+                        | "refresh_token"
+                        | "client_secret"
+                        | "password"
+                        | "private_key"
+                        | "authorization"
+                ) {
+                    return Err(JumpCloudError::CredentialMaterial);
+                }
+                reject_untrusted(value, depth + 1)?;
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                reject_untrusted(value, depth + 1)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn urn(tenant: &str, kind: &str, provider_id: &str) -> String {
+    format!("urn:cerebro:{tenant}:{kind}:{provider_id}")
+}

--- a/crates/source-runtime-next/src/jumpcloud/origin.rs
+++ b/crates/source-runtime-next/src/jumpcloud/origin.rs
@@ -1,0 +1,48 @@
+use reqwest::Url;
+
+use super::JumpCloudError;
+
+const DIRECTORY_HOST: &str = "console.jumpcloud.com";
+const INSIGHTS_HOSTS: [&str; 3] = [
+    "api.jumpcloud.com",
+    "api.eu.jumpcloud.com",
+    "api.in.jumpcloud.com",
+];
+
+pub(super) fn directory(value: &str) -> Result<Url, JumpCloudError> {
+    validate(value, &[DIRECTORY_HOST], "/api")
+}
+
+pub(super) fn insights(value: &str) -> Result<Url, JumpCloudError> {
+    validate(value, &INSIGHTS_HOSTS, "/insights/directory/v1")
+}
+
+fn validate(value: &str, hosts: &[&str], expected_path: &str) -> Result<Url, JumpCloudError> {
+    let mut url = Url::parse(value.trim().trim_end_matches('/'))
+        .map_err(|_| JumpCloudError::InvalidOrigin)?;
+    let host = url.host_str().unwrap_or_default().trim_end_matches('.');
+    if url.scheme() != "https"
+        || !hosts
+            .iter()
+            .any(|allowed| host.eq_ignore_ascii_case(allowed))
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port_or_known_default() != Some(443)
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || url.path().trim_end_matches('/') != expected_path
+    {
+        return Err(JumpCloudError::InvalidOrigin);
+    }
+    url.set_path(expected_path);
+    Ok(url)
+}
+
+pub(super) fn bounded(value: &str, maximum: usize) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()
+        && value.len() <= maximum
+        && !value.chars().any(char::is_control)
+        && !value.contains(['/', '\\', ':']))
+    .then(|| value.to_owned())
+}

--- a/crates/source-runtime-next/src/jumpcloud/projection.rs
+++ b/crates/source-runtime-next/src/jumpcloud/projection.rs
@@ -1,0 +1,146 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::{JumpCloudFamily, JumpCloudRecord};
+
+/// One deterministic tenant-scoped JumpCloud projection entity.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct JumpCloudEntityFact {
+    /// Canonical entity URN.
+    pub urn: String,
+    /// Closed entity type.
+    pub entity_type: String,
+    /// Human-readable label.
+    pub label: String,
+}
+
+/// One deterministic JumpCloud projection relation.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct JumpCloudRelationFact {
+    /// Source entity URN.
+    pub from_urn: String,
+    /// Closed semantic relation.
+    pub relation: String,
+    /// Target entity URN.
+    pub to_urn: String,
+}
+
+/// Provider-local projection facts used for Go/Rust parity.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct JumpCloudProjectionFacts {
+    /// Deduplicated entities in canonical order.
+    pub entities: Vec<JumpCloudEntityFact>,
+    /// Deduplicated relations in canonical order.
+    pub relations: Vec<JumpCloudRelationFact>,
+}
+
+/// Project normalized JumpCloud records into identity, system, and access context.
+pub fn project_jumpcloud_records(records: &[JumpCloudRecord]) -> JumpCloudProjectionFacts {
+    let mut entities = BTreeMap::<String, JumpCloudEntityFact>::new();
+    let mut relations = BTreeSet::<JumpCloudRelationFact>::new();
+    for record in records {
+        match record.family {
+            JumpCloudFamily::Users => add_entity(
+                &mut entities,
+                record,
+                "jumpcloud_users",
+                "identity_user",
+                "display_name",
+            ),
+            JumpCloudFamily::Groups => add_entity(
+                &mut entities,
+                record,
+                "jumpcloud_groups",
+                "user_group",
+                "group_name",
+            ),
+            JumpCloudFamily::Systems => add_entity(
+                &mut entities,
+                record,
+                "jumpcloud_systems",
+                "system",
+                "resource_name",
+            ),
+            JumpCloudFamily::Applications => add_entity(
+                &mut entities,
+                record,
+                "jumpcloud_applications",
+                "application",
+                "app_name",
+            ),
+            JumpCloudFamily::SystemGroups => add_entity(
+                &mut entities,
+                record,
+                "jumpcloud_system_groups",
+                "system_group",
+                "group_name",
+            ),
+            JumpCloudFamily::GroupMembers => {
+                let group_id = &record.attributes["group_id"];
+                let member_id = &record.attributes["member_id"];
+                let group_urn = format!(
+                    "urn:cerebro:{}:jumpcloud_groups:{group_id}",
+                    record.tenant_id
+                );
+                let member_urn = format!(
+                    "urn:cerebro:{}:jumpcloud_users:{member_id}",
+                    record.tenant_id
+                );
+                entities
+                    .entry(group_urn.clone())
+                    .or_insert(JumpCloudEntityFact {
+                        urn: group_urn.clone(),
+                        entity_type: "user_group".to_owned(),
+                        label: group_id.clone(),
+                    });
+                entities
+                    .entry(member_urn.clone())
+                    .or_insert(JumpCloudEntityFact {
+                        urn: member_urn.clone(),
+                        entity_type: "identity_user".to_owned(),
+                        label: member_id.clone(),
+                    });
+                relations.insert(JumpCloudRelationFact {
+                    from_urn: member_urn,
+                    relation: "member_of".to_owned(),
+                    to_urn: group_urn,
+                });
+            }
+            JumpCloudFamily::AuditEvents => {}
+        }
+    }
+    JumpCloudProjectionFacts {
+        entities: entities.into_values().collect(),
+        relations: relations.into_iter().collect(),
+    }
+}
+
+fn add_entity(
+    entities: &mut BTreeMap<String, JumpCloudEntityFact>,
+    record: &JumpCloudRecord,
+    kind: &str,
+    entity_type: &str,
+    label_key: &str,
+) {
+    let urn = record
+        .attributes
+        .get("resource_urn")
+        .cloned()
+        .unwrap_or_else(|| {
+            format!(
+                "urn:cerebro:{}:{kind}:{}",
+                record.tenant_id, record.provider_id
+            )
+        });
+    entities.insert(
+        urn.clone(),
+        JumpCloudEntityFact {
+            urn,
+            entity_type: entity_type.to_owned(),
+            label: record
+                .attributes
+                .get(label_key)
+                .cloned()
+                .unwrap_or_else(|| record.provider_id.clone()),
+        },
+    );
+}

--- a/crates/source-runtime-next/src/jumpcloud/request.rs
+++ b/crates/source-runtime-next/src/jumpcloud/request.rs
@@ -1,0 +1,229 @@
+use serde_json::{Map, Value};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    JumpCloudError, JumpCloudFamily, JumpCloudFilters, JumpCloudKernel, JumpCloudRequest, origin,
+};
+
+const MAX_CURSOR_BYTES: usize = 4_096;
+const MAX_PAGE_SIZE: usize = 1_000;
+
+pub(super) fn new_kernel(
+    directory_origin: &str,
+    insights_origin: &str,
+    tenant_id: &str,
+    family: JumpCloudFamily,
+    mut filters: JumpCloudFilters,
+    page_size: Option<usize>,
+    observed_at: &str,
+) -> Result<JumpCloudKernel, JumpCloudError> {
+    let directory_origin = origin::directory(directory_origin)?;
+    let insights_origin = origin::insights(insights_origin)?;
+    let tenant_id = origin::bounded(tenant_id, 128).ok_or(JumpCloudError::InvalidTenantId)?;
+    let page_size = page_size.unwrap_or(if family == JumpCloudFamily::AuditEvents {
+        1_000
+    } else {
+        100
+    });
+    if !(1..=MAX_PAGE_SIZE).contains(&page_size) {
+        return Err(JumpCloudError::InvalidConfiguration("page_size"));
+    }
+    OffsetDateTime::parse(observed_at, &Rfc3339)
+        .map_err(|_| JumpCloudError::InvalidConfiguration("observed_at"))?;
+    validate_filters(family, &mut filters)?;
+    Ok(JumpCloudKernel {
+        directory_origin,
+        insights_origin,
+        tenant_id,
+        family,
+        filters,
+        page_size,
+        observed_at: observed_at.to_owned(),
+    })
+}
+
+pub(super) fn plan(
+    kernel: &JumpCloudKernel,
+    cursor: Option<&str>,
+) -> Result<JumpCloudRequest, JumpCloudError> {
+    let origin = if kernel.family.uses_insights_origin() {
+        &kernel.insights_origin
+    } else {
+        &kernel.directory_origin
+    };
+    let path = if kernel.family == JumpCloudFamily::GroupMembers {
+        let group_id = kernel
+            .filters
+            .group_id
+            .as_deref()
+            .ok_or(JumpCloudError::MissingConfiguration("group_id"))?;
+        kernel.family.path().replace("{group_id}", group_id)
+    } else {
+        kernel.family.path().to_owned()
+    };
+    let mut url = origin.clone();
+    url.set_path(&format!("{}{}", origin.path().trim_end_matches('/'), path));
+    if url.origin() != origin.origin() {
+        return Err(JumpCloudError::InvalidOrigin);
+    }
+    let (cursor, body) = if kernel.family == JumpCloudFamily::AuditEvents {
+        let cursor = cursor.map(validate_audit_cursor).transpose()?;
+        (cursor.clone(), Some(audit_body(kernel, cursor.as_deref())?))
+    } else {
+        let offset = cursor.map(validate_offset).transpose()?.unwrap_or(0);
+        {
+            let mut query = url.query_pairs_mut();
+            query.append_pair("limit", &kernel.page_size.to_string());
+            query.append_pair("skip", &offset.to_string());
+        }
+        (cursor.map(str::to_owned), None)
+    };
+    Ok(JumpCloudRequest {
+        family: kernel.family,
+        url,
+        method: kernel.family.method(),
+        page_size: kernel.page_size,
+        cursor,
+        body,
+        org_id: kernel.filters.org_id.clone(),
+    })
+}
+
+pub(super) fn validate_request(
+    kernel: &JumpCloudKernel,
+    request: &JumpCloudRequest,
+) -> Result<(), JumpCloudError> {
+    if request != &plan(kernel, request.cursor.as_deref())? {
+        return Err(JumpCloudError::RequestScopeMismatch);
+    }
+    Ok(())
+}
+
+pub(super) fn validate_offset(value: &str) -> Result<usize, JumpCloudError> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > 16 || value.chars().any(char::is_control) {
+        return Err(JumpCloudError::InvalidCursor);
+    }
+    value
+        .parse::<usize>()
+        .ok()
+        .filter(|offset| *offset <= 10_000_000)
+        .ok_or(JumpCloudError::InvalidCursor)
+}
+
+pub(super) fn validate_audit_cursor(value: &str) -> Result<String, JumpCloudError> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > MAX_CURSOR_BYTES || value.chars().any(char::is_control) {
+        return Err(JumpCloudError::InvalidCursor);
+    }
+    let parsed: Value = serde_json::from_str(value).map_err(|_| JumpCloudError::InvalidCursor)?;
+    if parsed.is_null() {
+        return Err(JumpCloudError::InvalidCursor);
+    }
+    reject_depth(&parsed, 0)?;
+    serde_json::to_string(&parsed).map_err(|_| JumpCloudError::InvalidCursor)
+}
+
+fn validate_filters(
+    family: JumpCloudFamily,
+    filters: &mut JumpCloudFilters,
+) -> Result<(), JumpCloudError> {
+    for value in [&filters.org_id, &filters.group_id].into_iter().flatten() {
+        origin::bounded(value, 256).ok_or(JumpCloudError::InvalidConfiguration("scope"))?;
+    }
+    if family == JumpCloudFamily::GroupMembers && filters.group_id.is_none() {
+        return Err(JumpCloudError::MissingConfiguration("group_id"));
+    }
+    for value in [&filters.audit_start_time, &filters.audit_end_time]
+        .into_iter()
+        .flatten()
+    {
+        OffsetDateTime::parse(value, &Rfc3339)
+            .map_err(|_| JumpCloudError::InvalidConfiguration("audit_time"))?;
+    }
+    if filters.audit_services.is_empty() {
+        filters.audit_services.push("all".to_owned());
+    }
+    if filters.audit_services.len() > 32 {
+        return Err(JumpCloudError::InvalidConfiguration("audit_services"));
+    }
+    for service in &filters.audit_services {
+        origin::bounded(service, 128)
+            .ok_or(JumpCloudError::InvalidConfiguration("audit_services"))?;
+    }
+    let sort = filters.audit_sort.get_or_insert_with(|| "ASC".to_owned());
+    *sort = sort.trim().to_ascii_uppercase();
+    if sort != "ASC" && sort != "DESC" {
+        return Err(JumpCloudError::InvalidConfiguration("audit_sort"));
+    }
+    Ok(())
+}
+
+fn audit_body(kernel: &JumpCloudKernel, cursor: Option<&str>) -> Result<Vec<u8>, JumpCloudError> {
+    let mut body = Map::from_iter([
+        (
+            "service".to_owned(),
+            Value::Array(
+                kernel
+                    .filters
+                    .audit_services
+                    .iter()
+                    .cloned()
+                    .map(Value::String)
+                    .collect(),
+            ),
+        ),
+        (
+            "start_time".to_owned(),
+            Value::String(
+                kernel
+                    .filters
+                    .audit_start_time
+                    .clone()
+                    .unwrap_or_else(|| kernel.observed_at.clone()),
+            ),
+        ),
+        ("limit".to_owned(), Value::from(kernel.page_size)),
+        (
+            "sort".to_owned(),
+            Value::String(
+                kernel
+                    .filters
+                    .audit_sort
+                    .clone()
+                    .unwrap_or_else(|| "ASC".to_owned()),
+            ),
+        ),
+    ]);
+    if let Some(end) = &kernel.filters.audit_end_time {
+        body.insert("end_time".to_owned(), Value::String(end.clone()));
+    }
+    if let Some(cursor) = cursor {
+        let value = serde_json::from_str(cursor).map_err(|_| JumpCloudError::InvalidCursor)?;
+        body.insert("search_after".to_owned(), value);
+    }
+    serde_json::to_vec(&Value::Object(body)).map_err(|_| JumpCloudError::InternalRuntimeFailure)
+}
+
+fn reject_depth(value: &Value, depth: usize) -> Result<(), JumpCloudError> {
+    if depth > 8 {
+        return Err(JumpCloudError::InvalidCursor);
+    }
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                reject_depth(value, depth + 1)?;
+            }
+        }
+        Value::Object(values) => {
+            if values.len() > 32 {
+                return Err(JumpCloudError::InvalidCursor);
+            }
+            for value in values.values() {
+                reject_depth(value, depth + 1)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}

--- a/crates/source-runtime-next/src/jumpcloud/response.rs
+++ b/crates/source-runtime-next/src/jumpcloud/response.rs
@@ -1,0 +1,161 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    JumpCloudCheckpointCandidate, JumpCloudError, JumpCloudFamily, JumpCloudKernel, JumpCloudPage,
+    JumpCloudRequest, JumpCloudResponseMetadata, normalize,
+    request::{validate_audit_cursor, validate_offset, validate_request},
+};
+
+pub(super) const MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+pub(super) fn decode(
+    kernel: &JumpCloudKernel,
+    request: &JumpCloudRequest,
+    status: u16,
+    metadata: &JumpCloudResponseMetadata,
+    body: &[u8],
+) -> Result<JumpCloudPage, JumpCloudError> {
+    validate_request(kernel, request)?;
+    classify_status(status, metadata.retry_after_seconds)?;
+    if body.len() > MAX_RESPONSE_BYTES {
+        return Err(JumpCloudError::ResponseTooLarge);
+    }
+    let root: Value =
+        serde_json::from_slice(body).map_err(|_| JumpCloudError::MalformedResponse)?;
+    let items = records(kernel.family, &root)?;
+    if items.len() > request.page_size {
+        return Err(JumpCloudError::TooManyRecords);
+    }
+    let mut seen = BTreeMap::<String, Vec<u8>>::new();
+    let mut normalized = Vec::with_capacity(items.len());
+    for raw in items {
+        let record = normalize::normalize(kernel, raw.clone())?;
+        let canonical = serde_json::to_vec(&record.payload)
+            .map_err(|_| JumpCloudError::InvalidProviderRecord)?;
+        match seen.get(&record.event_id) {
+            Some(previous) if previous == &canonical => continue,
+            Some(_) => return Err(JumpCloudError::ConflictingDuplicate),
+            None => {
+                seen.insert(record.event_id.clone(), canonical);
+                normalized.push(record);
+            }
+        }
+    }
+    let next_cursor = next_cursor(kernel.family, request, metadata, &root, items.len())?;
+    Ok(JumpCloudPage {
+        records: normalized,
+        next_cursor,
+    })
+}
+
+pub(super) fn checkpoint_candidate(
+    kernel: &JumpCloudKernel,
+    request: &JumpCloudRequest,
+    page: &JumpCloudPage,
+    prior_watermark: Option<&str>,
+) -> Result<JumpCloudCheckpointCandidate, JumpCloudError> {
+    validate_request(kernel, request)?;
+    if page
+        .records
+        .iter()
+        .any(|record| record.tenant_id != kernel.tenant_id || record.family != kernel.family)
+    {
+        return Err(JumpCloudError::TenantMismatch);
+    }
+    if let Some(cursor) = &page.next_cursor {
+        kernel.plan(Some(cursor))?;
+    }
+    let prior = prior_watermark.map(valid_time).transpose()?;
+    let watermark = page
+        .records
+        .iter()
+        .map(|record| record.occurred_at.clone())
+        .chain(prior)
+        .max();
+    Ok(JumpCloudCheckpointCandidate {
+        tenant_id: kernel.tenant_id.clone(),
+        family: kernel.family,
+        cursor: page.next_cursor.clone(),
+        watermark,
+    })
+}
+
+fn records(family: JumpCloudFamily, root: &Value) -> Result<&[Value], JumpCloudError> {
+    match family {
+        JumpCloudFamily::Users | JumpCloudFamily::Systems | JumpCloudFamily::Applications => root
+            .get("results")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .ok_or(JumpCloudError::MalformedResponse),
+        JumpCloudFamily::Groups
+        | JumpCloudFamily::SystemGroups
+        | JumpCloudFamily::GroupMembers
+        | JumpCloudFamily::AuditEvents => root
+            .as_array()
+            .map(Vec::as_slice)
+            .ok_or(JumpCloudError::MalformedResponse),
+    }
+}
+
+fn next_cursor(
+    family: JumpCloudFamily,
+    request: &JumpCloudRequest,
+    metadata: &JumpCloudResponseMetadata,
+    root: &Value,
+    raw_count: usize,
+) -> Result<Option<String>, JumpCloudError> {
+    let next = if family == JumpCloudFamily::AuditEvents {
+        let limit = metadata.limit.unwrap_or(request.page_size);
+        match (metadata.result_count, metadata.search_after.as_deref()) {
+            (Some(count), Some(cursor)) if limit > 0 && count >= limit => {
+                Some(validate_audit_cursor(cursor)?)
+            }
+            _ => None,
+        }
+    } else {
+        let offset = request
+            .cursor
+            .as_deref()
+            .map(validate_offset)
+            .transpose()?
+            .unwrap_or(0);
+        let candidate = offset
+            .checked_add(raw_count)
+            .ok_or(JumpCloudError::InvalidCursor)?;
+        let total = root
+            .get("totalCount")
+            .and_then(Value::as_u64)
+            .and_then(|value| usize::try_from(value).ok());
+        let more = total.map_or(raw_count == request.page_size, |total| candidate < total);
+        (more && raw_count > 0).then(|| candidate.to_string())
+    };
+    if next.is_some() && next == request.cursor {
+        return Err(JumpCloudError::InvalidCursor);
+    }
+    Ok(next)
+}
+
+fn classify_status(status: u16, retry_after_seconds: Option<u64>) -> Result<(), JumpCloudError> {
+    if retry_after_seconds.is_some_and(|seconds| seconds > 3_600) {
+        return Err(JumpCloudError::InvalidRetryAfter);
+    }
+    match status {
+        200..=299 => Ok(()),
+        401 => Err(JumpCloudError::AuthenticationRejected),
+        403 => Err(JumpCloudError::RequiredScopeMissing),
+        429 => Err(JumpCloudError::RateLimited {
+            retry_after_seconds,
+        }),
+        500..=599 => Err(JumpCloudError::ProviderUnavailable { status }),
+        _ => Err(JumpCloudError::UnexpectedStatus { status }),
+    }
+}
+
+fn valid_time(value: &str) -> Result<String, JumpCloudError> {
+    OffsetDateTime::parse(value, &Rfc3339)
+        .map(|time| time.format(&Rfc3339).unwrap_or_else(|_| value.to_owned()))
+        .map_err(|_| JumpCloudError::InvalidProviderRecord)
+}

--- a/crates/source-runtime-next/src/jumpcloud/tests.rs
+++ b/crates/source-runtime-next/src/jumpcloud/tests.rs
@@ -1,0 +1,420 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Value, json};
+
+use super::*;
+
+const CATALOG: &[u8] = include_bytes!("../../../../sources/jumpcloud/catalog.yaml");
+const USERS_ORACLE: &[u8] =
+    include_bytes!("../../../../sources/jumpcloud/testdata/read_users.json");
+const GROUPS_ORACLE: &[u8] =
+    include_bytes!("../../../../sources/jumpcloud/testdata/read_groups.json");
+const SYSTEMS_ORACLE: &[u8] =
+    include_bytes!("../../../../sources/jumpcloud/testdata/read_systems.json");
+const APPLICATIONS_ORACLE: &[u8] =
+    include_bytes!("../../../../sources/jumpcloud/testdata/read_applications.json");
+const SYSTEM_GROUPS_ORACLE: &[u8] =
+    include_bytes!("../../../../sources/jumpcloud/testdata/read_system_groups.json");
+const GROUP_MEMBERS_ORACLE: &[u8] =
+    include_bytes!("../../../../sources/jumpcloud/testdata/read_group_members.json");
+const AUDIT_ORACLE: &[u8] =
+    include_bytes!("../../../../sources/jumpcloud/testdata/read_audit_events.json");
+
+#[derive(serde::Deserialize)]
+struct CatalogWire {
+    runtime_families: Vec<String>,
+    event_contracts: Vec<EventContractWire>,
+}
+
+#[derive(serde::Deserialize)]
+struct EventContractWire {
+    kind: String,
+    schema_ref: String,
+    required_attributes: Vec<String>,
+    required_payload_fields: Vec<String>,
+}
+
+fn kernel(tenant: &str, family: JumpCloudFamily) -> JumpCloudKernel {
+    let mut filters = JumpCloudFilters {
+        org_id: Some("org-1".to_owned()),
+        ..JumpCloudFilters::default()
+    };
+    if family == JumpCloudFamily::GroupMembers {
+        filters.group_id = Some("group-1".to_owned());
+    }
+    if family == JumpCloudFamily::AuditEvents {
+        filters.audit_start_time = Some("2026-06-01T00:00:00Z".to_owned());
+    }
+    JumpCloudKernel::new(
+        "https://console.jumpcloud.com/api",
+        "https://api.jumpcloud.com/insights/directory/v1",
+        tenant,
+        family,
+        filters,
+        Some(100),
+        "2026-06-01T00:00:00Z",
+    )
+    .expect("valid JumpCloud kernel")
+}
+
+#[test]
+fn closed_runtime_definition_matches_catalog_exactly() {
+    let catalog: CatalogWire = serde_saphyr::from_slice(CATALOG).expect("JumpCloud catalog YAML");
+    assert_eq!(
+        catalog.runtime_families,
+        [
+            "users",
+            "groups",
+            "systems",
+            "applications",
+            "system_groups",
+            "group_members",
+            "audit_events",
+        ]
+    );
+    let definitions = JumpCloudFamily::ALL
+        .into_iter()
+        .map(|family| JumpCloudRuntimeDefinition::compile(family).expect("compiled family"))
+        .collect::<Vec<_>>();
+    assert!(definitions.iter().all(|definition| definition.pull));
+    assert_eq!(catalog.event_contracts.len(), definitions.len());
+    for expected in catalog.event_contracts {
+        let actual = definitions
+            .iter()
+            .map(|definition| definition.event_contract)
+            .find(|contract| contract.kind == expected.kind)
+            .expect("catalog contract compiled");
+        assert_eq!(actual.schema_ref, expected.schema_ref);
+        assert!(
+            actual
+                .required_attributes
+                .iter()
+                .copied()
+                .eq(expected.required_attributes.iter().map(String::as_str))
+        );
+        assert!(
+            actual
+                .required_payload_fields
+                .iter()
+                .copied()
+                .eq(expected.required_payload_fields.iter().map(String::as_str))
+        );
+    }
+    assert_eq!(
+        "roles".parse::<JumpCloudFamily>(),
+        Err(JumpCloudError::InvalidFamily)
+    );
+}
+
+#[test]
+fn plans_all_families_without_credentials_or_redirects() {
+    for (family, method, path) in [
+        (JumpCloudFamily::Users, "GET", "/api/systemusers"),
+        (JumpCloudFamily::Groups, "GET", "/api/v2/usergroups"),
+        (JumpCloudFamily::Systems, "GET", "/api/systems"),
+        (JumpCloudFamily::Applications, "GET", "/api/applications"),
+        (JumpCloudFamily::SystemGroups, "GET", "/api/v2/systemgroups"),
+        (
+            JumpCloudFamily::GroupMembers,
+            "GET",
+            "/api/v2/usergroups/group-1/members",
+        ),
+        (
+            JumpCloudFamily::AuditEvents,
+            "POST",
+            "/insights/directory/v1/events",
+        ),
+    ] {
+        let request = kernel("tenant-a", family).plan(None).expect("request");
+        assert_eq!(request.method(), method);
+        assert_eq!(request.url().path(), path);
+        assert_eq!(request.authentication_header(), "x-api-key");
+        assert_eq!(request.authentication_scheme(), "");
+        assert_eq!(request.organization_id(), Some("org-1"));
+        assert!(!request.contains_credentials());
+        assert!(!request.allows_redirects());
+        assert_eq!(request.max_response_bytes(), 8 * 1024 * 1024);
+        if family == JumpCloudFamily::AuditEvents {
+            let body: Value = serde_json::from_slice(request.body().expect("audit body")).unwrap();
+            assert_eq!(body["service"], json!(["all"]));
+            assert_eq!(body["start_time"], "2026-06-01T00:00:00Z");
+            assert_eq!(body["sort"], "ASC");
+        } else {
+            assert_eq!(
+                request
+                    .url()
+                    .query_pairs()
+                    .find(|(key, _)| key == "skip")
+                    .map(|(_, value)| value.into_owned()),
+                Some("0".to_owned())
+            );
+        }
+        let debug = format!("{request:?}").to_ascii_lowercase();
+        for forbidden in [
+            "test-key",
+            "api_key",
+            "access_token",
+            "private_key",
+            "org-1",
+        ] {
+            assert!(!debug.contains(forbidden));
+        }
+    }
+    assert!(!JumpCloudKernel::requires_credentials());
+}
+
+#[test]
+fn checked_in_go_oracles_match_all_rust_families() {
+    for (family, oracle) in [
+        (JumpCloudFamily::Users, USERS_ORACLE),
+        (JumpCloudFamily::Groups, GROUPS_ORACLE),
+        (JumpCloudFamily::Systems, SYSTEMS_ORACLE),
+        (JumpCloudFamily::Applications, APPLICATIONS_ORACLE),
+        (JumpCloudFamily::SystemGroups, SYSTEM_GROUPS_ORACLE),
+        (JumpCloudFamily::GroupMembers, GROUP_MEMBERS_ORACLE),
+        (JumpCloudFamily::AuditEvents, AUDIT_ORACLE),
+    ] {
+        let expected = oracle_event(oracle);
+        let raw = expected["payload"].clone();
+        let response = match family {
+            JumpCloudFamily::Users | JumpCloudFamily::Systems | JumpCloudFamily::Applications => {
+                json!({
+                    "results": [raw], "skip": 0, "limit": 100, "totalCount": 1
+                })
+            }
+            _ => json!([raw]),
+        };
+        let kernel = kernel("tenant", family);
+        let page = kernel
+            .decode(
+                &kernel.plan(None).unwrap(),
+                200,
+                &JumpCloudResponseMetadata::default(),
+                &serde_json::to_vec(&response).unwrap(),
+            )
+            .expect("fixture page");
+        assert_eq!(page.records.len(), 1, "family {family:?}");
+        assert_oracle(&page.records[0], &expected);
+    }
+}
+
+#[test]
+fn offset_and_search_after_checkpoints_round_trip_after_restart() {
+    let users = kernel("tenant", JumpCloudFamily::Users);
+    let request = users.plan(None).unwrap();
+    let page = users
+        .decode(
+            &request,
+            200,
+            &JumpCloudResponseMetadata::default(),
+            br#"{"results":[{"_id":"user-1"},{"_id":"user-2"}],"skip":0,"limit":2,"totalCount":3}"#,
+        )
+        .unwrap();
+    assert_eq!(page.next_cursor.as_deref(), Some("2"));
+    let checkpoint = users
+        .checkpoint_candidate(&request, &page, Some("2026-05-01T00:00:00Z"))
+        .unwrap();
+    let resumed = users.plan(checkpoint.cursor.as_deref()).unwrap();
+    assert_eq!(
+        resumed
+            .url()
+            .query_pairs()
+            .find(|(key, _)| key == "skip")
+            .map(|(_, value)| value.into_owned()),
+        Some("2".to_owned())
+    );
+
+    let audit = kernel("tenant", JumpCloudFamily::AuditEvents);
+    let audit_request = audit.plan(None).unwrap();
+    let metadata = JumpCloudResponseMetadata {
+        result_count: Some(100),
+        limit: Some(100),
+        search_after: Some(r#"[1719849600000,"event-2"]"#.to_owned()),
+        retry_after_seconds: None,
+    };
+    let audit_page = audit
+        .decode(
+            &audit_request,
+            200,
+            &metadata,
+            br#"[{"id":"event-1","event_type":"login","resource":{"id":"user-1"},"timestamp":"2026-06-01T00:00:00Z"}]"#,
+        )
+        .unwrap();
+    assert_eq!(
+        audit_page.next_cursor.as_deref(),
+        Some(r#"[1719849600000,"event-2"]"#)
+    );
+    let resumed = audit.plan(audit_page.next_cursor.as_deref()).unwrap();
+    let body: Value = serde_json::from_slice(resumed.body().unwrap()).unwrap();
+    assert_eq!(body["search_after"], json!([1719849600000_u64, "event-2"]));
+    assert_eq!(
+        audit.plan(Some("not-json")),
+        Err(JumpCloudError::InvalidCursor)
+    );
+}
+
+#[test]
+fn failures_tenants_duplicates_and_origins_fail_closed_without_leaks() {
+    assert!(matches!(
+        JumpCloudKernel::new(
+            "https://attacker.example/api",
+            "https://api.jumpcloud.com/insights/directory/v1",
+            "tenant",
+            JumpCloudFamily::Users,
+            JumpCloudFilters::default(),
+            None,
+            "2026-06-01T00:00:00Z",
+        ),
+        Err(JumpCloudError::InvalidOrigin)
+    ));
+    let users = kernel("tenant", JumpCloudFamily::Users);
+    let request = users.plan(None).unwrap();
+    for body in [
+        br#"{"results":[{"_id":"user-1","tenant_id":"attacker"}]}"#.as_slice(),
+        br#"{"results":[{"_id":"user-1","profile":{"api_key":"secret-sentinel"}}]}"#.as_slice(),
+    ] {
+        assert!(matches!(
+            users.decode(&request, 200, &JumpCloudResponseMetadata::default(), body),
+            Err(JumpCloudError::TenantMismatch | JumpCloudError::CredentialMaterial)
+        ));
+    }
+    assert_eq!(
+        users.decode(
+            &request,
+            200,
+            &JumpCloudResponseMetadata::default(),
+            br#"{"results":[{"_id":"user-1","displayname":"One"},{"_id":"user-1","displayname":"Two"}]}"#,
+        ),
+        Err(JumpCloudError::ConflictingDuplicate)
+    );
+    for (status, expected) in [
+        (401, JumpCloudError::AuthenticationRejected),
+        (403, JumpCloudError::RequiredScopeMissing),
+        (503, JumpCloudError::ProviderUnavailable { status: 503 }),
+    ] {
+        assert_eq!(
+            users.decode(&request, status, &JumpCloudResponseMetadata::default(), b""),
+            Err(expected)
+        );
+    }
+    assert_eq!(
+        users.decode(
+            &request,
+            429,
+            &JumpCloudResponseMetadata {
+                retry_after_seconds: Some(30),
+                ..JumpCloudResponseMetadata::default()
+            },
+            b""
+        ),
+        Err(JumpCloudError::RateLimited {
+            retry_after_seconds: Some(30)
+        })
+    );
+    let other = kernel("tenant-b", JumpCloudFamily::Users)
+        .decode(
+            &kernel("tenant-b", JumpCloudFamily::Users)
+                .plan(None)
+                .unwrap(),
+            200,
+            &JumpCloudResponseMetadata::default(),
+            br#"{"results":[{"_id":"user-1"}]}"#,
+        )
+        .unwrap();
+    let first = users
+        .decode(
+            &request,
+            200,
+            &JumpCloudResponseMetadata::default(),
+            br#"{"results":[{"_id":"user-1"}]}"#,
+        )
+        .unwrap();
+    assert_ne!(first.records[0].event_id, other.records[0].event_id);
+    let diagnostic = format!(
+        "{:?}",
+        users.decode(
+            &request,
+            200,
+            &JumpCloudResponseMetadata::default(),
+            br#"{"results":[{"_id":"user-1","password":"secret-sentinel"}]}"#,
+        )
+    );
+    assert!(!diagnostic.contains("secret-sentinel"));
+}
+
+#[test]
+fn projection_preserves_users_systems_and_memberships() {
+    let user = decode_payload(
+        JumpCloudFamily::Users,
+        json!({"_id":"user-1","displayname":"User One"}),
+    );
+    let system = decode_payload(
+        JumpCloudFamily::Systems,
+        json!({"_id":"system-1","displayName":"Mac 1"}),
+    );
+    let member = decode_payload(
+        JumpCloudFamily::GroupMembers,
+        json!({"to":{"id":"user-1","type":"user"}}),
+    );
+    let facts = project_jumpcloud_records(&[user, system, member]);
+    assert!(facts.entities.iter().any(|entity| entity.urn
+        == "urn:cerebro:tenant:jumpcloud_users:user-1"
+        && entity.entity_type == "identity_user"));
+    assert!(facts.entities.iter().any(|entity| entity.urn
+        == "urn:cerebro:tenant:jumpcloud_systems:system-1"
+        && entity.entity_type == "system"));
+    assert!(facts.relations.iter().any(|relation| relation.from_urn
+        == "urn:cerebro:tenant:jumpcloud_users:user-1"
+        && relation.relation == "member_of"
+        && relation.to_urn == "urn:cerebro:tenant:jumpcloud_groups:group-1"));
+}
+
+fn decode_payload(family: JumpCloudFamily, payload: Value) -> JumpCloudRecord {
+    let response = match family {
+        JumpCloudFamily::Users | JumpCloudFamily::Systems | JumpCloudFamily::Applications => {
+            json!({"results":[payload],"totalCount":1})
+        }
+        _ => json!([payload]),
+    };
+    let kernel = kernel("tenant", family);
+    kernel
+        .decode(
+            &kernel.plan(None).unwrap(),
+            200,
+            &JumpCloudResponseMetadata::default(),
+            &serde_json::to_vec(&response).unwrap(),
+        )
+        .unwrap()
+        .records
+        .remove(0)
+}
+
+fn oracle_event(bytes: &[u8]) -> Value {
+    serde_json::from_slice::<Vec<Value>>(bytes)
+        .expect("Go oracle JSON")
+        .remove(0)
+}
+
+fn assert_oracle(record: &JumpCloudRecord, expected: &Value) {
+    assert_eq!(record.tenant_id, expected["tenant_id"]);
+    assert_eq!(record.kind, expected["kind"]);
+    assert_eq!(record.schema_ref, expected["schema_ref"]);
+    assert_eq!(record.occurred_at, expected["occurred_at"]);
+    assert_eq!(record.attributes, attributes(&expected["attributes"]));
+    assert_eq!(record.payload, expected["payload"]);
+    assert!(!record.event_id.is_empty());
+}
+
+fn attributes(value: &Value) -> BTreeMap<String, String> {
+    value
+        .as_object()
+        .expect("oracle attributes")
+        .iter()
+        .map(|(key, value)| {
+            (
+                key.clone(),
+                value.as_str().expect("string attribute").to_owned(),
+            )
+        })
+        .collect()
+}

--- a/crates/source-runtime-next/src/jumpcloud/types.rs
+++ b/crates/source-runtime-next/src/jumpcloud/types.rs
@@ -1,0 +1,225 @@
+use std::{collections::BTreeMap, fmt};
+
+use reqwest::Url;
+use serde_json::Value;
+
+use super::{JumpCloudError, JumpCloudFamily, request, response};
+
+/// Public, non-secret selectors for one JumpCloud family request.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct JumpCloudFilters {
+    /// Optional organization header applied by the trusted host.
+    pub org_id: Option<String>,
+    /// User group selected for a membership page.
+    pub group_id: Option<String>,
+    /// Directory Insights lower time bound.
+    pub audit_start_time: Option<String>,
+    /// Optional Directory Insights upper time bound.
+    pub audit_end_time: Option<String>,
+    /// Directory Insights services, or `all` when empty.
+    pub audit_services: Vec<String>,
+    /// Directory Insights sort direction, defaulting to `ASC`.
+    pub audit_sort: Option<String>,
+}
+
+/// Credential-free request intent for the trusted JumpCloud HTTP host.
+#[derive(Clone, Eq, PartialEq)]
+pub struct JumpCloudRequest {
+    pub(super) family: JumpCloudFamily,
+    pub(super) url: Url,
+    pub(super) method: &'static str,
+    pub(super) page_size: usize,
+    pub(super) cursor: Option<String>,
+    pub(super) body: Option<Vec<u8>>,
+    pub(super) org_id: Option<String>,
+}
+
+impl fmt::Debug for JumpCloudRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("JumpCloudRequest")
+            .field("family", &self.family)
+            .field("url", &self.url)
+            .field("method", &self.method)
+            .field("page_size", &self.page_size)
+            .field("has_cursor", &self.cursor.is_some())
+            .field("has_body", &self.body.is_some())
+            .field("has_org_id", &self.org_id.is_some())
+            .finish()
+    }
+}
+
+impl JumpCloudRequest {
+    /// Fully planned provider URL.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+    /// Provider HTTP method.
+    pub const fn method(&self) -> &'static str {
+        self.method
+    }
+    /// Family owning this request.
+    pub const fn family(&self) -> JumpCloudFamily {
+        self.family
+    }
+    /// Authentication header applied outside this kernel.
+    pub const fn authentication_header(&self) -> &'static str {
+        "x-api-key"
+    }
+    /// JumpCloud API keys have no prefix scheme.
+    pub const fn authentication_scheme(&self) -> &'static str {
+        ""
+    }
+    /// Optional public organization header value.
+    pub fn organization_id(&self) -> Option<&str> {
+        self.org_id.as_deref()
+    }
+    /// Canonical credential-free request body for Directory Insights.
+    pub fn body(&self) -> Option<&[u8]> {
+        self.body.as_deref()
+    }
+    /// Expected response media type.
+    pub const fn accept(&self) -> &'static str {
+        "application/json"
+    }
+    /// Portable request plans contain no credential bytes or references.
+    pub const fn contains_credentials(&self) -> bool {
+        false
+    }
+    /// Redirects are disabled by the trusted host.
+    pub const fn allows_redirects(&self) -> bool {
+        false
+    }
+    /// Maximum admitted response bytes.
+    pub const fn max_response_bytes(&self) -> usize {
+        response::MAX_RESPONSE_BYTES
+    }
+    /// Provider permission required for this family.
+    pub const fn required_scope(&self) -> &'static str {
+        self.family.required_scope()
+    }
+}
+
+/// Bounded response headers captured by the trusted host.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct JumpCloudResponseMetadata {
+    /// Directory Insights `X-Result-Count` value.
+    pub result_count: Option<usize>,
+    /// Directory Insights `X-Limit` value.
+    pub limit: Option<usize>,
+    /// Directory Insights `X-Search_after` value.
+    pub search_after: Option<String>,
+    /// Bounded retry delay.
+    pub retry_after_seconds: Option<u64>,
+}
+
+/// One normalized tenant-scoped JumpCloud event candidate.
+#[derive(Clone, Debug, PartialEq)]
+pub struct JumpCloudRecord {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Stable tenant- and provider-scoped event identity.
+    pub event_id: String,
+    /// Stable provider object identity.
+    pub provider_id: String,
+    /// Exact family.
+    pub family: JumpCloudFamily,
+    /// Exact event kind.
+    pub kind: String,
+    /// Exact schema reference.
+    pub schema_ref: String,
+    /// Normalized RFC3339 occurrence time.
+    pub occurred_at: String,
+    /// Deterministic projection attributes.
+    pub attributes: BTreeMap<String, String>,
+    /// Credential-free normalized provider payload.
+    pub payload: Value,
+}
+
+/// One bounded normalized JumpCloud page.
+#[derive(Clone, Debug, PartialEq)]
+pub struct JumpCloudPage {
+    /// Accepted records in provider order.
+    pub records: Vec<JumpCloudRecord>,
+    /// Validated continuation persisted only after durable commit.
+    pub next_cursor: Option<String>,
+}
+
+/// Validated checkpoint candidate for post-append/project persistence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct JumpCloudCheckpointCandidate {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Selected family.
+    pub family: JumpCloudFamily,
+    /// Validated next cursor.
+    pub cursor: Option<String>,
+    /// Highest normalized occurrence time.
+    pub watermark: Option<String>,
+}
+
+/// Closed JumpCloud kernel for one tenant and family.
+#[derive(Clone, Debug)]
+pub struct JumpCloudKernel {
+    pub(super) directory_origin: Url,
+    pub(super) insights_origin: Url,
+    pub(super) tenant_id: String,
+    pub(super) family: JumpCloudFamily,
+    pub(super) filters: JumpCloudFilters,
+    pub(super) page_size: usize,
+    pub(super) observed_at: String,
+}
+
+impl JumpCloudKernel {
+    /// Construct one family kernel from public execution context only.
+    pub fn new(
+        directory_origin: &str,
+        insights_origin: &str,
+        tenant_id: &str,
+        family: JumpCloudFamily,
+        filters: JumpCloudFilters,
+        page_size: Option<usize>,
+        observed_at: &str,
+    ) -> Result<Self, JumpCloudError> {
+        request::new_kernel(
+            directory_origin,
+            insights_origin,
+            tenant_id,
+            family,
+            filters,
+            page_size,
+            observed_at,
+        )
+    }
+
+    /// Kernel protocol never accepts credential material.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+
+    /// Plan one bounded origin-restricted provider request.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<JumpCloudRequest, JumpCloudError> {
+        request::plan(self, cursor)
+    }
+
+    /// Decode one provider response under the exact planned request.
+    pub fn decode(
+        &self,
+        request: &JumpCloudRequest,
+        status: u16,
+        metadata: &JumpCloudResponseMetadata,
+        body: &[u8],
+    ) -> Result<JumpCloudPage, JumpCloudError> {
+        response::decode(self, request, status, metadata, body)
+    }
+
+    /// Validate a checkpoint candidate for durable host persistence.
+    pub fn checkpoint_candidate(
+        &self,
+        request: &JumpCloudRequest,
+        page: &JumpCloudPage,
+        prior_watermark: Option<&str>,
+    ) -> Result<JumpCloudCheckpointCandidate, JumpCloudError> {
+        response::checkpoint_candidate(self, request, page, prior_watermark)
+    }
+}

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -30,6 +30,7 @@ mod github;
 mod google_workspace;
 mod grc;
 mod http;
+mod jumpcloud;
 mod kubernetes;
 mod linode;
 mod mapper;
@@ -147,6 +148,12 @@ pub use google_workspace::{
 };
 pub use grc::{GrcError, GrcFamily, GrcKernel, GrcPage, GrcRecord, GrcRequest};
 pub use http::{HttpConnectorError, HttpProviderAccess, HttpSourceConnector, ResolvedAuth};
+pub use jumpcloud::{
+    JumpCloudCheckpointCandidate, JumpCloudEntityFact, JumpCloudError, JumpCloudEventContract,
+    JumpCloudFamily, JumpCloudFilters, JumpCloudKernel, JumpCloudPage, JumpCloudProjectionFacts,
+    JumpCloudRecord, JumpCloudRelationFact, JumpCloudRequest, JumpCloudResponseMetadata,
+    JumpCloudRuntimeDefinition, project_jumpcloud_records,
+};
 pub use kubernetes::{
     KubernetesConfig, KubernetesError, KubernetesFamily, KubernetesKernel, KubernetesPage,
     KubernetesProjection, KubernetesProjectionEntity, KubernetesProjectionLink, KubernetesRecord,


### PR DESCRIPTION
## Summary
- compile all seven JumpCloud families into a closed credential-free Rust request and response kernel
- preserve tenant-scoped identities, bounded offset and Directory Insights continuations, typed provider failures, exact event contracts, and checked-in Go fixture parity
- project users, groups, systems, applications, system groups, and membership relationships while retaining audit events as bounded activity context

## Security and durability invariants
- request plans carry no API key values or credential references; the trusted host owns `x-api-key` application
- directory and regional Directory Insights requests are restricted to closed HTTPS JumpCloud origins with redirects disabled
- provider payloads cannot supply tenant identity or credential-shaped material
- cursors, response bytes, record counts, request scopes, duplicate identities, and checkpoint candidates are bounded and validated

## Local validation
- `cargo fmt --all -- --check`
- `cargo test -p cerebro-source-runtime-next jumpcloud --no-fail-fast`
- `cargo test -p cerebro-source-catalog --no-fail-fast`
- `cargo clippy -p cerebro-source-runtime-next -p cerebro-source-catalog --all-targets --all-features -- -D warnings`
- `go test ./sources/jumpcloud ./internal/connectorcatalog ./internal/sourceprojection ./internal/sourceregistry -count=1`
- `go test -race ./sources/jumpcloud -count=1`
- `make fixture-oracle-check source-fixture-check catalog-check sourcegen-check`
- `make check-structural check-structural-test check-arch`
- `./scripts/leak_check.sh`

## Delivery boundary
- the hand-written Go source remains the runtime and fixture oracle; its compile-time loader is retained until the repository retirement gate permits removal
- live-provider and authenticated product-path proof require an authorized read-only JumpCloud identity and a deployed merged revision; no credentials or private deployment configuration are included here