### PR TITLE
feat(source-runtime): add Docker Hub repository kernel

### DIFF
--- a/crates/source-runtime-next/src/docker_hub.rs
+++ b/crates/source-runtime-next/src/docker_hub.rs
@@ -1,0 +1,27 @@
+//! Credential-free Docker Hub repository request and response kernel.
+//!
+//! The trusted host owns credential-reference resolution, optional bearer
+//! authentication, redirects, deadlines, and bounded network I/O. This module
+//! accepts public scope and bounded provider bytes only. The existing catalog
+//! runtime remains authoritative until repository parity earns promotion.
+
+mod catalog;
+mod error;
+mod family;
+mod normalize;
+mod origin;
+mod projection;
+mod request;
+mod response;
+mod types;
+
+pub use catalog::{DockerHubEventContract, DockerHubRuntimeDefinition};
+pub use error::DockerHubError;
+pub use family::DockerHubFamily;
+pub use projection::{DockerHubEntityFact, DockerHubProjectionFacts, project_docker_hub_records};
+pub use types::{
+    DockerHubCheckpointCandidate, DockerHubKernel, DockerHubPage, DockerHubRecord, DockerHubRequest,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/docker_hub/catalog.rs
+++ b/crates/source-runtime-next/src/docker_hub/catalog.rs
@@ -1,0 +1,53 @@
+use super::{DockerHubError, DockerHubFamily};
+
+/// Exact event contract compiled for Docker Hub repositories.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DockerHubEventContract {
+    /// Exact provider event kind.
+    pub kind: &'static str,
+    /// Exact schema reference.
+    pub schema_ref: &'static str,
+    /// Required normalized attributes.
+    pub required_attributes: &'static [&'static str],
+    /// Required provider payload fields.
+    pub required_payload_fields: &'static [&'static str],
+}
+
+/// Closed runtime definition for one provider-verified Docker Hub family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DockerHubRuntimeDefinition {
+    /// Source identifier.
+    pub source_id: &'static str,
+    /// Selected family.
+    pub family: DockerHubFamily,
+    /// Exact event contract.
+    pub event_contract: DockerHubEventContract,
+    /// Docker Hub repositories are bounded pull operations.
+    pub pull: bool,
+}
+
+impl DockerHubRuntimeDefinition {
+    /// Compile the closed provider-verified family.
+    pub fn compile(family: DockerHubFamily) -> Result<Self, DockerHubError> {
+        let event_contract = match family {
+            DockerHubFamily::Repositories => DockerHubEventContract {
+                kind: "docker_hub.repositories",
+                schema_ref: "docker_hub/repositories/v1",
+                required_attributes: &[
+                    "tenant_id",
+                    "source_event_id",
+                    "resource_urn",
+                    "resource_type",
+                    "resource_id",
+                ],
+                required_payload_fields: &["name"],
+            },
+        };
+        Ok(Self {
+            source_id: "docker_hub",
+            family,
+            event_contract,
+            pull: true,
+        })
+    }
+}

--- a/crates/source-runtime-next/src/docker_hub/error.rs
+++ b/crates/source-runtime-next/src/docker_hub/error.rs
@@ -1,0 +1,166 @@
+use std::{error::Error, fmt};
+
+/// Bounded Docker Hub provider and runtime failure taxonomy.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DockerHubError {
+    /// Family is outside the closed provider-verified catalog.
+    InvalidFamily,
+    /// Required public configuration is missing.
+    MissingConfiguration(&'static str),
+    /// Public configuration is malformed.
+    InvalidConfiguration(&'static str),
+    /// Base URL is not a credential-free HTTPS origin.
+    InvalidBaseUrl,
+    /// Origin is local, private, or otherwise unsafe.
+    UnsafeOrigin,
+    /// Authenticated tenant context is missing or malformed.
+    InvalidTenantId,
+    /// A private repository requires a host-side credential reference.
+    MissingCredentialReference,
+    /// Trusted host could not redeem the credential lease.
+    CredentialUnavailable,
+    /// Singleton repository reads cannot consume continuation state.
+    InvalidCursor,
+    /// Request does not belong to this kernel.
+    RequestScopeMismatch,
+    /// Provider rejected authentication.
+    AuthenticationRejected,
+    /// Credential lacks repository read scope.
+    RequiredScopeMissing,
+    /// Configured repository does not exist or is not visible.
+    ProviderResourceNotFound,
+    /// Trusted host denied provider egress.
+    EgressDenied,
+    /// Provider DNS lookup failed.
+    DnsFailure,
+    /// Provider connection failed.
+    ConnectionFailure,
+    /// Provider operation timed out.
+    ProviderTimeout,
+    /// Provider requested a bounded retry.
+    RateLimited {
+        /// Bounded retry delay supplied by the provider.
+        retry_after_seconds: Option<u64>,
+    },
+    /// Provider returned a retryable server failure.
+    ProviderUnavailable {
+        /// Provider status in the 500-599 range.
+        status: u16,
+    },
+    /// Provider returned an unexpected status.
+    UnexpectedStatus {
+        /// Provider status outside the typed cases.
+        status: u16,
+    },
+    /// Retry delay is outside the persistence bound.
+    InvalidRetryAfter,
+    /// Response exceeds the host-declared byte bound.
+    ResponseTooLarge,
+    /// Response JSON does not match the repository family.
+    MalformedResponse,
+    /// Provider record violates the repository shape.
+    InvalidProviderRecord,
+    /// Provider record has no stable namespace/name identity.
+    MissingStableIdentity,
+    /// Provider response identifies a different configured repository.
+    ProviderIdentityMismatch,
+    /// Provider payload attempted to provide tenant context.
+    TenantMismatch,
+    /// Credential-shaped material crossed into the kernel.
+    CredentialMaterial,
+    /// Normalized record failed the exact compiled event contract.
+    EventContractRejection,
+    /// Durable append failed.
+    AppendFailure,
+    /// Projection failed.
+    ProjectionFailure,
+    /// Runtime lost its source lease.
+    LeaseLoss,
+    /// Runtime authority or generation is stale.
+    StaleAuthority,
+    /// Internal runtime failure.
+    InternalRuntimeFailure,
+}
+
+impl DockerHubError {
+    /// Next safe operator action without provider content.
+    pub const fn operator_action(&self) -> &'static str {
+        match self {
+            Self::InvalidFamily
+            | Self::MissingConfiguration(_)
+            | Self::InvalidConfiguration(_)
+            | Self::InvalidBaseUrl
+            | Self::UnsafeOrigin
+            | Self::InvalidTenantId
+            | Self::ProviderResourceNotFound => "repair source configuration",
+            Self::MissingCredentialReference
+            | Self::CredentialUnavailable
+            | Self::AuthenticationRejected => "repair credential binding",
+            Self::RequiredScopeMissing => "grant repository read scope",
+            Self::RateLimited { .. }
+            | Self::ProviderUnavailable { .. }
+            | Self::DnsFailure
+            | Self::ConnectionFailure
+            | Self::ProviderTimeout => "retry the collection later",
+            Self::EgressDenied => "repair trusted-host egress policy",
+            Self::InvalidCursor => "restart from the last committed checkpoint",
+            Self::MalformedResponse
+            | Self::InvalidProviderRecord
+            | Self::MissingStableIdentity
+            | Self::ProviderIdentityMismatch
+            | Self::TenantMismatch
+            | Self::CredentialMaterial
+            | Self::EventContractRejection => "inspect quarantined provider records",
+            Self::AppendFailure | Self::ProjectionFailure => "repair the durable commit path",
+            Self::LeaseLoss | Self::StaleAuthority => "restart under the current lease",
+            Self::RequestScopeMismatch
+            | Self::InvalidRetryAfter
+            | Self::ResponseTooLarge
+            | Self::UnexpectedStatus { .. }
+            | Self::InternalRuntimeFailure => "repair the forward runtime implementation",
+        }
+    }
+}
+
+impl fmt::Display for DockerHubError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidFamily => "docker hub family is invalid",
+            Self::MissingConfiguration(_) => "docker hub source configuration is missing",
+            Self::InvalidConfiguration(_) => "docker hub source configuration is invalid",
+            Self::InvalidBaseUrl => "docker hub base URL must be a credential-free HTTPS origin",
+            Self::UnsafeOrigin => "docker hub base URL contains an unsafe origin",
+            Self::InvalidTenantId => "docker hub tenant ID is invalid",
+            Self::MissingCredentialReference => "docker hub credential reference is missing",
+            Self::CredentialUnavailable => "docker hub credential lease is unavailable",
+            Self::InvalidCursor => "docker hub repository cursor must be terminal",
+            Self::RequestScopeMismatch => "docker hub request does not match the kernel",
+            Self::AuthenticationRejected => "docker hub rejected authentication",
+            Self::RequiredScopeMissing => "docker hub credential lacks repository read scope",
+            Self::ProviderResourceNotFound => "docker hub repository was not found",
+            Self::EgressDenied => "docker hub egress was denied",
+            Self::DnsFailure => "docker hub DNS resolution failed",
+            Self::ConnectionFailure => "docker hub connection failed",
+            Self::ProviderTimeout => "docker hub operation timed out",
+            Self::RateLimited { .. } => "docker hub rate limited the operation",
+            Self::ProviderUnavailable { .. } => "docker hub is temporarily unavailable",
+            Self::UnexpectedStatus { .. } => "docker hub returned an unexpected status",
+            Self::InvalidRetryAfter => "docker hub retry delay exceeds its bound",
+            Self::ResponseTooLarge => "docker hub response exceeds its byte bound",
+            Self::MalformedResponse => "docker hub response is malformed",
+            Self::InvalidProviderRecord => "docker hub provider record is invalid",
+            Self::MissingStableIdentity => "docker hub record has no stable identity",
+            Self::ProviderIdentityMismatch => "docker hub response does not match request scope",
+            Self::TenantMismatch => "docker hub payload attempted to supply tenant context",
+            Self::CredentialMaterial => "docker hub payload contains credential-shaped material",
+            Self::EventContractRejection => "docker hub event failed its catalog contract",
+            Self::AppendFailure => "docker hub append failed",
+            Self::ProjectionFailure => "docker hub projection failed",
+            Self::LeaseLoss => "docker hub runtime lost its lease",
+            Self::StaleAuthority => "docker hub runtime authority is stale",
+            Self::InternalRuntimeFailure => "docker hub runtime failed internally",
+        })
+    }
+}
+
+impl Error for DockerHubError {}

--- a/crates/source-runtime-next/src/docker_hub/family.rs
+++ b/crates/source-runtime-next/src/docker_hub/family.rs
@@ -1,0 +1,47 @@
+use std::str::FromStr;
+
+use super::DockerHubError;
+
+/// Closed Docker Hub family vocabulary for the provider-verified Rust slice.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum DockerHubFamily {
+    /// One repository in a configured namespace.
+    Repositories,
+}
+
+impl DockerHubFamily {
+    /// Every provider-verified Docker Hub family.
+    pub const ALL: [Self; 1] = [Self::Repositories];
+
+    /// Exact catalog family identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Repositories => "repositories",
+        }
+    }
+
+    /// Exact admitted event kind.
+    pub const fn event_kind(self) -> &'static str {
+        match self {
+            Self::Repositories => "docker_hub.repositories",
+        }
+    }
+
+    /// Exact admitted event schema.
+    pub const fn schema_ref(self) -> &'static str {
+        match self {
+            Self::Repositories => "docker_hub/repositories/v1",
+        }
+    }
+}
+
+impl FromStr for DockerHubFamily {
+    type Err = DockerHubError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|family| family.as_str() == value.trim())
+            .ok_or(DockerHubError::InvalidFamily)
+    }
+}

--- a/crates/source-runtime-next/src/docker_hub/normalize.rs
+++ b/crates/source-runtime-next/src/docker_hub/normalize.rs
@@ -1,0 +1,202 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    DockerHubError, DockerHubKernel, DockerHubRecord, DockerHubRequest, DockerHubRuntimeDefinition,
+};
+
+pub(super) fn normalize(
+    kernel: &DockerHubKernel,
+    request: &DockerHubRequest,
+    raw: Value,
+    observed_at: &str,
+) -> Result<DockerHubRecord, DockerHubError> {
+    reject_untrusted(&raw, 0)?;
+    let values = raw.as_object().ok_or(DockerHubError::MalformedResponse)?;
+    let namespace = required_component(values, "namespace")?;
+    let name = required_component(values, "name")?;
+    if namespace != kernel.namespace || name != kernel.repository {
+        return Err(DockerHubError::ProviderIdentityMismatch);
+    }
+    let provider_id = format!("{namespace}/{name}");
+    let resource_urn = format!(
+        "urn:cerebro:{}:docker_hub_repositories:{}",
+        kernel.tenant_id,
+        encode_urn_segment(&provider_id)
+    );
+    let occurred_at = occurred_at(values, observed_at)?;
+    let attributes = BTreeMap::from([
+        ("external_id".to_owned(), provider_id.clone()),
+        ("family".to_owned(), "repositories".to_owned()),
+        ("provider".to_owned(), "docker_hub".to_owned()),
+        ("record_class".to_owned(), "asset".to_owned()),
+        ("resource_id".to_owned(), provider_id.clone()),
+        ("resource_name".to_owned(), name),
+        (
+            "resource_type".to_owned(),
+            "container_repository".to_owned(),
+        ),
+        ("resource_urn".to_owned(), resource_urn),
+        ("schema".to_owned(), "repositories".to_owned()),
+        ("source_event_id".to_owned(), provider_id.clone()),
+        ("source_provider".to_owned(), "docker_hub".to_owned()),
+        ("source_system".to_owned(), "docker_hub".to_owned()),
+        ("tenant_id".to_owned(), kernel.tenant_id.clone()),
+    ]);
+    let event_id = go_compatible_event_id(kernel, request, &provider_id);
+    let mut payload = raw;
+    payload
+        .as_object_mut()
+        .ok_or(DockerHubError::MalformedResponse)?
+        .entry("id")
+        .or_insert_with(|| Value::from("repositories"));
+    let record = DockerHubRecord {
+        tenant_id: kernel.tenant_id.clone(),
+        event_id,
+        provider_id,
+        family: kernel.family,
+        kind: kernel.family.event_kind().to_owned(),
+        schema_ref: kernel.family.schema_ref().to_owned(),
+        occurred_at,
+        attributes,
+        payload,
+    };
+    validate_event_contract(&record)?;
+    Ok(record)
+}
+
+fn validate_event_contract(record: &DockerHubRecord) -> Result<(), DockerHubError> {
+    let contract = DockerHubRuntimeDefinition::compile(record.family)?.event_contract;
+    if record.kind != contract.kind || record.schema_ref != contract.schema_ref {
+        return Err(DockerHubError::EventContractRejection);
+    }
+    if contract.required_attributes.iter().any(|key| {
+        record
+            .attributes
+            .get(*key)
+            .is_none_or(|value| value.trim().is_empty())
+    }) || contract.required_payload_fields.iter().any(|key| {
+        record
+            .payload
+            .get(*key)
+            .and_then(Value::as_str)
+            .is_none_or(|value| value.trim().is_empty())
+    }) {
+        return Err(DockerHubError::EventContractRejection);
+    }
+    Ok(())
+}
+
+fn required_component(values: &Map<String, Value>, key: &str) -> Result<String, DockerHubError> {
+    let value = values
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| {
+            !value.is_empty()
+                && value.len() <= 255
+                && !value.chars().any(char::is_control)
+                && value
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+        })
+        .ok_or(DockerHubError::MissingStableIdentity)?;
+    Ok(value.to_owned())
+}
+
+fn occurred_at(values: &Map<String, Value>, observed_at: &str) -> Result<String, DockerHubError> {
+    let candidate = ["last_updated", "last_modified"]
+        .into_iter()
+        .find_map(|key| values.get(key).and_then(Value::as_str))
+        .unwrap_or(observed_at);
+    let parsed = OffsetDateTime::parse(candidate.trim(), &Rfc3339)
+        .map_err(|_| DockerHubError::InvalidProviderRecord)?;
+    parsed
+        .replace_nanosecond(0)
+        .map_err(|_| DockerHubError::InvalidProviderRecord)?
+        .format(&Rfc3339)
+        .map_err(|_| DockerHubError::InvalidProviderRecord)
+}
+
+fn go_compatible_event_id(
+    kernel: &DockerHubKernel,
+    request: &DockerHubRequest,
+    provider_id: &str,
+) -> String {
+    let base_url = kernel.base_url.as_str().trim_end_matches('/');
+    let scope = Sha256::digest(format!("{base_url}\0{}", request.url.path()));
+    let scope = scope[..6]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!(
+        "docker_hub-{}-{scope}-repositories-{}",
+        normalize_id(&kernel.tenant_id),
+        normalize_id(provider_id)
+    )
+}
+
+fn normalize_id(value: &str) -> String {
+    let value = value.trim();
+    if value.is_empty() {
+        return "unknown".to_owned();
+    }
+    value
+        .chars()
+        .map(|character| match character {
+            ' ' | '/' | ':' | '\t' | '\n' => '-',
+            other => other,
+        })
+        .collect()
+}
+
+fn encode_urn_segment(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}
+
+fn reject_untrusted(value: &Value, depth: usize) -> Result<(), DockerHubError> {
+    if depth > 32 {
+        return Err(DockerHubError::InvalidProviderRecord);
+    }
+    match value {
+        Value::Object(values) => {
+            for (key, value) in values {
+                let key = key.to_ascii_lowercase();
+                if key == "tenant_id" {
+                    return Err(DockerHubError::TenantMismatch);
+                }
+                if matches!(
+                    key.as_str(),
+                    "token"
+                        | "access_token"
+                        | "refresh_token"
+                        | "client_secret"
+                        | "password"
+                        | "private_key"
+                        | "authorization"
+                ) {
+                    return Err(DockerHubError::CredentialMaterial);
+                }
+                reject_untrusted(value, depth + 1)?;
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                reject_untrusted(value, depth + 1)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}

--- a/crates/source-runtime-next/src/docker_hub/origin.rs
+++ b/crates/source-runtime-next/src/docker_hub/origin.rs
@@ -1,0 +1,64 @@
+use std::net::IpAddr;
+
+use reqwest::Url;
+
+use super::DockerHubError;
+
+pub(super) fn validate_origin(value: &str) -> Result<Url, DockerHubError> {
+    let mut url = Url::parse(value.trim()).map_err(|_| DockerHubError::InvalidBaseUrl)?;
+    if url.scheme() != "https"
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port_or_known_default() != Some(443)
+        || !matches!(url.path(), "" | "/")
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(DockerHubError::InvalidBaseUrl);
+    }
+    let host = url.host_str().unwrap_or_default().trim_end_matches('.');
+    if host.eq_ignore_ascii_case("localhost")
+        || host.ends_with(".localhost")
+        || host.ends_with(".local")
+        || !host.contains('.')
+        || host.parse::<IpAddr>().is_ok_and(unsafe_ip)
+    {
+        return Err(DockerHubError::UnsafeOrigin);
+    }
+    url.set_path("");
+    Ok(url)
+}
+
+pub(super) fn bounded_scope(value: &str, max: usize) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()
+        && value.len() <= max
+        && !value.chars().any(char::is_control)
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')))
+    .then(|| value.to_owned())
+}
+
+pub(super) fn bounded_tenant(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()
+        && value.len() <= 128
+        && !value.chars().any(char::is_control)
+        && !value.contains(['/', '\\', ':']))
+    .then(|| value.to_owned())
+}
+
+fn unsafe_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => {
+            ip.is_private()
+                || ip.is_loopback()
+                || ip.is_link_local()
+                || ip.is_unspecified()
+                || ip.is_multicast()
+        }
+        IpAddr::V6(ip) => ip.is_loopback() || ip.is_unspecified() || ip.is_multicast(),
+    }
+}

--- a/crates/source-runtime-next/src/docker_hub/projection.rs
+++ b/crates/source-runtime-next/src/docker_hub/projection.rs
@@ -1,0 +1,45 @@
+use std::collections::BTreeMap;
+
+use super::DockerHubRecord;
+
+/// One deterministic tenant-scoped Docker Hub projection entity.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct DockerHubEntityFact {
+    /// Canonical entity URN.
+    pub urn: String,
+    /// Closed entity type.
+    pub entity_type: String,
+    /// Human-readable repository label.
+    pub label: String,
+}
+
+/// Provider-local projection facts used for Go/Rust parity.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct DockerHubProjectionFacts {
+    /// Deduplicated entities in canonical order.
+    pub entities: Vec<DockerHubEntityFact>,
+}
+
+/// Project normalized repositories into the existing Go semantic shape.
+pub fn project_docker_hub_records(records: &[DockerHubRecord]) -> DockerHubProjectionFacts {
+    let mut entities = BTreeMap::<String, DockerHubEntityFact>::new();
+    for record in records {
+        if let Some(urn) = record.attributes.get("resource_urn") {
+            entities.insert(
+                urn.clone(),
+                DockerHubEntityFact {
+                    urn: urn.clone(),
+                    entity_type: "runtime.container.repository".to_owned(),
+                    label: record
+                        .attributes
+                        .get("resource_name")
+                        .cloned()
+                        .unwrap_or_else(|| record.provider_id.clone()),
+                },
+            );
+        }
+    }
+    DockerHubProjectionFacts {
+        entities: entities.into_values().collect(),
+    }
+}

--- a/crates/source-runtime-next/src/docker_hub/request.rs
+++ b/crates/source-runtime-next/src/docker_hub/request.rs
@@ -1,0 +1,127 @@
+use super::{
+    DockerHubError, DockerHubFamily, DockerHubKernel, DockerHubRequest,
+    origin::{bounded_scope, bounded_tenant, validate_origin},
+};
+
+pub(super) const MAX_RESPONSE_BYTES: usize = 1024 * 1024;
+
+impl DockerHubRequest {
+    /// HTTP method.
+    pub const fn method(&self) -> &'static str {
+        "GET"
+    }
+
+    /// Exact origin-restricted provider URL.
+    pub fn url(&self) -> &reqwest::Url {
+        &self.url
+    }
+
+    /// Family owning this request.
+    pub const fn family(&self) -> DockerHubFamily {
+        self.family
+    }
+
+    /// Optional header populated by the trusted host for private repositories.
+    pub const fn authorization_header(&self) -> &'static str {
+        "Authorization"
+    }
+
+    /// Scheme applied outside this kernel.
+    pub const fn authorization_scheme(&self) -> &'static str {
+        "Bearer"
+    }
+
+    /// Public repository reads do not require a credential lease.
+    pub const fn credential_reference_required(&self) -> bool {
+        false
+    }
+
+    /// Required provider response media type.
+    pub const fn accept(&self) -> &'static str {
+        "application/json"
+    }
+
+    /// Portable requests contain no credential bytes or references.
+    pub const fn contains_credentials(&self) -> bool {
+        false
+    }
+
+    /// Redirects are disabled by the trusted host.
+    pub const fn allows_redirects(&self) -> bool {
+        false
+    }
+
+    /// Host response byte limit.
+    pub const fn max_response_bytes(&self) -> usize {
+        MAX_RESPONSE_BYTES
+    }
+
+    /// Provider permission required for private repository reads.
+    pub const fn required_scope(&self) -> &'static str {
+        "repository read access"
+    }
+}
+
+impl DockerHubKernel {
+    /// Construct a closed credential-free repository kernel.
+    pub fn new(
+        base_url: &str,
+        tenant_id: &str,
+        namespace: &str,
+        repository: &str,
+    ) -> Result<Self, DockerHubError> {
+        let base_url = validate_origin(base_url)?;
+        let tenant_id = bounded_tenant(tenant_id).ok_or(DockerHubError::InvalidTenantId)?;
+        let namespace = bounded_scope(namespace, 255)
+            .ok_or(DockerHubError::MissingConfiguration("namespace"))?;
+        let repository = bounded_scope(repository, 255)
+            .ok_or(DockerHubError::MissingConfiguration("repository"))?;
+        Ok(Self {
+            base_url,
+            tenant_id,
+            namespace,
+            repository,
+            family: DockerHubFamily::Repositories,
+        })
+    }
+
+    /// Kernel protocol never accepts credential material.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+
+    /// Plan the singleton repository detail request.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<DockerHubRequest, DockerHubError> {
+        if cursor.is_some_and(|value| !value.trim().is_empty()) {
+            return Err(DockerHubError::InvalidCursor);
+        }
+        let mut url = self.base_url.clone();
+        {
+            let mut segments = url
+                .path_segments_mut()
+                .map_err(|_| DockerHubError::InvalidBaseUrl)?;
+            segments.pop_if_empty();
+            segments.extend([
+                "v2",
+                "namespaces",
+                &self.namespace,
+                "repositories",
+                &self.repository,
+            ]);
+        }
+        Ok(DockerHubRequest {
+            url,
+            family: self.family,
+        })
+    }
+
+    pub(super) fn validate_request(
+        &self,
+        request: &DockerHubRequest,
+    ) -> Result<(), DockerHubError> {
+        if request != &self.plan(None)? {
+            return Err(DockerHubError::RequestScopeMismatch);
+        }
+        Ok(())
+    }
+}

--- a/crates/source-runtime-next/src/docker_hub/response.rs
+++ b/crates/source-runtime-next/src/docker_hub/response.rs
@@ -1,0 +1,66 @@
+use serde_json::Value;
+
+use super::{
+    DockerHubCheckpointCandidate, DockerHubError, DockerHubKernel, DockerHubPage, DockerHubRequest,
+    normalize::normalize, request::MAX_RESPONSE_BYTES,
+};
+
+impl DockerHubKernel {
+    /// Classify status and normalize one bounded provider response.
+    pub fn decode_http(
+        &self,
+        request: &DockerHubRequest,
+        status: u16,
+        retry_after_seconds: Option<u64>,
+        body: &[u8],
+        observed_at: &str,
+    ) -> Result<DockerHubPage, DockerHubError> {
+        self.validate_request(request)?;
+        if body.len() > MAX_RESPONSE_BYTES {
+            return Err(DockerHubError::ResponseTooLarge);
+        }
+        if retry_after_seconds.is_some_and(|seconds| seconds > 3_600) {
+            return Err(DockerHubError::InvalidRetryAfter);
+        }
+        match status {
+            200 => {}
+            401 => return Err(DockerHubError::AuthenticationRejected),
+            403 => return Err(DockerHubError::RequiredScopeMissing),
+            404 => return Err(DockerHubError::ProviderResourceNotFound),
+            429 => {
+                return Err(DockerHubError::RateLimited {
+                    retry_after_seconds,
+                });
+            }
+            500..=599 => return Err(DockerHubError::ProviderUnavailable { status }),
+            _ => return Err(DockerHubError::UnexpectedStatus { status }),
+        }
+        let raw: Value =
+            serde_json::from_slice(body).map_err(|_| DockerHubError::MalformedResponse)?;
+        let record = normalize(self, request, raw, observed_at)?;
+        Ok(DockerHubPage {
+            records: vec![record],
+            next_cursor: None,
+        })
+    }
+
+    /// Validate terminal progress for persistence after append and projection.
+    pub fn checkpoint_candidate(
+        &self,
+        page: &DockerHubPage,
+    ) -> Result<DockerHubCheckpointCandidate, DockerHubError> {
+        if page.next_cursor.is_some() || page.records.len() != 1 {
+            return Err(DockerHubError::InvalidCursor);
+        }
+        let record = &page.records[0];
+        if record.tenant_id != self.tenant_id || record.family != self.family {
+            return Err(DockerHubError::TenantMismatch);
+        }
+        Ok(DockerHubCheckpointCandidate {
+            tenant_id: self.tenant_id.clone(),
+            family: self.family,
+            cursor: None,
+            watermark: record.occurred_at.clone(),
+        })
+    }
+}

--- a/crates/source-runtime-next/src/docker_hub/tests.rs
+++ b/crates/source-runtime-next/src/docker_hub/tests.rs
@@ -1,0 +1,357 @@
+use std::{collections::BTreeMap, fs, path::PathBuf};
+
+use cerebro_source_catalog::{CollectionAuthority, SourceCatalog, UnsupportedReasonCode};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::*;
+
+const OBSERVED_AT: &str = "2026-07-18T08:18:36Z";
+
+#[derive(Debug, Deserialize)]
+struct GoOracleEvent {
+    id: String,
+    tenant_id: String,
+    source_id: String,
+    kind: String,
+    occurred_at: String,
+    schema_ref: String,
+    payload: Value,
+    attributes: BTreeMap<String, String>,
+}
+
+fn repository_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn kernel(tenant: &str) -> DockerHubKernel {
+    DockerHubKernel::new("https://hub.docker.com", tenant, "library", "ubuntu").unwrap()
+}
+
+fn provider_fixture() -> Vec<u8> {
+    fs::read(
+        repository_root()
+            .join("sources/docker_hub/testdata/api/repositories/ubuntu_repository/response.json"),
+    )
+    .unwrap()
+}
+
+fn go_event_fixture() -> GoOracleEvent {
+    let bytes =
+        fs::read(repository_root().join("sources/docker_hub/testdata/read_repositories.json"))
+            .unwrap();
+    serde_json::from_slice::<Vec<GoOracleEvent>>(&bytes)
+        .unwrap()
+        .pop()
+        .unwrap()
+}
+
+#[test]
+fn catalog_closes_only_the_provider_verified_repository_family() {
+    let root = repository_root();
+    let catalog = SourceCatalog::load(
+        root.join("internal/connectorcatalog/catalog"),
+        root.join("sources"),
+    )
+    .unwrap();
+    let source = catalog.get("docker_hub").unwrap();
+    assert_eq!(source.authority(), CollectionAuthority::ShadowOnly);
+    let repository = source
+        .families()
+        .iter()
+        .find(|family| family.id() == "repositories")
+        .unwrap();
+    assert!(!repository.is_authoritative());
+    assert!(!repository.is_projection_authoritative());
+    assert!(
+        repository
+            .unsupported_reasons()
+            .contains(&UnsupportedReasonCode::MissingProviderProof)
+    );
+    assert!(
+        !repository
+            .unsupported_reasons()
+            .contains(&UnsupportedReasonCode::UnboundPathConfigParameter)
+    );
+    assert_eq!(
+        repository.path_parameters()["namespace"].field(),
+        "namespace"
+    );
+    assert_eq!(
+        repository.path_parameters()["repository"].field(),
+        "repository"
+    );
+
+    for compatibility_family in ["users", "audit_events"] {
+        let family = source
+            .families()
+            .iter()
+            .find(|family| family.id() == compatibility_family)
+            .unwrap();
+        assert!(!family.is_authoritative());
+        assert!(
+            family
+                .unsupported_reasons()
+                .contains(&UnsupportedReasonCode::MissingProviderProof)
+        );
+    }
+
+    let runtime = DockerHubRuntimeDefinition::compile(DockerHubFamily::Repositories).unwrap();
+    assert_eq!(runtime.source_id, "docker_hub");
+    assert!(runtime.pull);
+    assert_eq!(runtime.event_contract.kind, "docker_hub.repositories");
+    assert_eq!(runtime.event_contract.required_payload_fields, &["name"]);
+}
+
+#[test]
+fn request_is_origin_restricted_terminal_and_credential_free() {
+    let kernel = kernel("tenant");
+    let request = kernel.plan(None).unwrap();
+    assert_eq!(request.method(), "GET");
+    assert_eq!(
+        request.url().as_str(),
+        "https://hub.docker.com/v2/namespaces/library/repositories/ubuntu"
+    );
+    assert_eq!(request.authorization_header(), "Authorization");
+    assert_eq!(request.authorization_scheme(), "Bearer");
+    assert!(!request.credential_reference_required());
+    assert!(!request.contains_credentials());
+    assert!(!request.allows_redirects());
+    assert_eq!(request.max_response_bytes(), 1024 * 1024);
+    assert_eq!(request.required_scope(), "repository read access");
+    assert!(!DockerHubKernel::requires_credentials());
+    assert_eq!(
+        kernel.plan(Some("next")),
+        Err(DockerHubError::InvalidCursor)
+    );
+
+    let debug = format!("{kernel:?}{request:?}");
+    for secret in ["sentinel-token-value", "Bearer sentinel", "credential:"] {
+        assert!(!debug.contains(secret));
+    }
+}
+
+#[test]
+fn origin_and_public_scope_fail_closed() {
+    for origin in [
+        "http://hub.docker.com",
+        "https://localhost",
+        "https://127.0.0.1",
+        "https://user@hub.docker.com",
+        "https://hub.docker.com:8443",
+        "https://hub.docker.com/other-api",
+        "https://hub.docker.com?token=value",
+    ] {
+        assert!(DockerHubKernel::new(origin, "tenant", "library", "ubuntu").is_err());
+    }
+    assert_eq!(
+        DockerHubKernel::new("https://hub.docker.com", "tenant", "../library", "ubuntu")
+            .unwrap_err(),
+        DockerHubError::MissingConfiguration("namespace")
+    );
+    assert_eq!(
+        DockerHubKernel::new("https://hub.docker.com", "tenant", "library", "a/b").unwrap_err(),
+        DockerHubError::MissingConfiguration("repository")
+    );
+}
+
+#[test]
+fn captured_provider_response_matches_the_existing_go_oracle_semantically() {
+    let kernel = kernel("tenant");
+    let request = kernel.plan(None).unwrap();
+    let page = kernel
+        .decode_http(&request, 200, None, &provider_fixture(), OBSERVED_AT)
+        .unwrap();
+    assert_eq!(page.records.len(), 1);
+    assert_eq!(page.next_cursor, None);
+    let record = &page.records[0];
+    let oracle = go_event_fixture();
+
+    assert_eq!(record.tenant_id, oracle.tenant_id);
+    assert_eq!(oracle.source_id, "docker_hub");
+    assert_eq!(record.kind, oracle.kind);
+    assert_eq!(record.schema_ref, oracle.schema_ref);
+    assert_eq!(record.occurred_at, oracle.occurred_at);
+    assert_eq!(record.payload, oracle.payload);
+    assert_eq!(record.attributes, oracle.attributes);
+    assert_eq!(record.provider_id, "library/ubuntu");
+    assert_eq!(
+        record.event_id,
+        "docker_hub-tenant-e4f4db18300a-repositories-library-ubuntu"
+    );
+
+    // The checked Go fixture intentionally replaces the live event ID with a
+    // content address over Go's exact payload bytes so loopback replay is
+    // stable. Keep that oracle identity explicit while production identity is
+    // provider-object-stable above.
+    assert_eq!(oracle.id, "docker_hub-tenant-repositories-37642678684e8b22");
+
+    let checkpoint = kernel.checkpoint_candidate(&page).unwrap();
+    assert_eq!(checkpoint.tenant_id, "tenant");
+    assert_eq!(checkpoint.family, DockerHubFamily::Repositories);
+    assert_eq!(checkpoint.cursor, None);
+    assert_eq!(checkpoint.watermark, "2026-07-16T22:04:47Z");
+
+    let projection = project_docker_hub_records(&page.records);
+    assert_eq!(projection.entities.len(), 1);
+    assert_eq!(
+        projection.entities[0],
+        DockerHubEntityFact {
+            urn: "urn:cerebro:tenant:docker_hub_repositories:library%2Fubuntu".to_owned(),
+            entity_type: "runtime.container.repository".to_owned(),
+            label: "ubuntu".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn go_fixture_parity_corpus_contains_all_repository_operations() {
+    let bytes = fs::read(
+        repository_root().join("crates/source-runtime-next/testdata/go_fixture_oracle.json"),
+    )
+    .unwrap();
+    let oracle: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(oracle["schema_version"], "cerebro.source-fixture-parity.v2");
+    let cases = oracle["cases"].as_array().unwrap();
+    let docker_cases = cases
+        .iter()
+        .filter(|case| {
+            case["source_id"] == "docker_hub"
+                && case["family_id"] == "repositories"
+                && case["case_id"] == "ubuntu_repository"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(docker_cases.len(), 3);
+    assert_eq!(
+        docker_cases
+            .iter()
+            .map(|case| case["operation"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        ["check", "discover", "read-page"]
+    );
+    assert!(docker_cases.iter().all(|case| {
+        case["payload_sha256"] == "a5300b497f4d172c91d24eb7d5946ca253e92377591cbe164ce69db9c3c7d8c5"
+            && case["provider_network_egress"] == false
+            && case["offline_proof"] == "fixture_only_no_provider_network"
+    }));
+}
+
+#[test]
+fn typed_provider_statuses_remain_distinct_and_bounded() {
+    let kernel = kernel("tenant");
+    let request = kernel.plan(None).unwrap();
+    let body = b"{}";
+    for (status, expected) in [
+        (401, DockerHubError::AuthenticationRejected),
+        (403, DockerHubError::RequiredScopeMissing),
+        (404, DockerHubError::ProviderResourceNotFound),
+        (
+            429,
+            DockerHubError::RateLimited {
+                retry_after_seconds: Some(60),
+            },
+        ),
+        (503, DockerHubError::ProviderUnavailable { status: 503 }),
+        (418, DockerHubError::UnexpectedStatus { status: 418 }),
+    ] {
+        assert_eq!(
+            kernel.decode_http(&request, status, Some(60), body, OBSERVED_AT),
+            Err(expected)
+        );
+    }
+    assert_eq!(
+        kernel.decode_http(&request, 429, Some(3_601), body, OBSERVED_AT),
+        Err(DockerHubError::InvalidRetryAfter)
+    );
+    let oversized = vec![b' '; request.max_response_bytes() + 1];
+    assert_eq!(
+        kernel.decode_http(&request, 200, None, &oversized, OBSERVED_AT),
+        Err(DockerHubError::ResponseTooLarge)
+    );
+}
+
+#[test]
+fn provider_scope_tenant_and_secret_material_cannot_cross_the_kernel() {
+    let kernel = kernel("tenant");
+    let request = kernel.plan(None).unwrap();
+    for (field, expected) in [
+        ("tenant_id", DockerHubError::TenantMismatch),
+        ("access_token", DockerHubError::CredentialMaterial),
+        ("authorization", DockerHubError::CredentialMaterial),
+        ("private_key", DockerHubError::CredentialMaterial),
+    ] {
+        let body = serde_json::to_vec(&json!({
+            "namespace": "library",
+            "name": "ubuntu",
+            (field): "sentinel-secret-value",
+            "last_updated": "2026-07-16T22:04:47Z"
+        }))
+        .unwrap();
+        let error = kernel
+            .decode_http(&request, 200, None, &body, OBSERVED_AT)
+            .unwrap_err();
+        assert_eq!(error, expected);
+        assert!(!error.to_string().contains("sentinel-secret-value"));
+        assert!(!format!("{error:?}").contains("sentinel-secret-value"));
+    }
+
+    let wrong_scope = serde_json::to_vec(&json!({
+        "namespace": "library",
+        "name": "debian",
+        "last_updated": "2026-07-16T22:04:47Z"
+    }))
+    .unwrap();
+    assert_eq!(
+        kernel.decode_http(&request, 200, None, &wrong_scope, OBSERVED_AT),
+        Err(DockerHubError::ProviderIdentityMismatch)
+    );
+}
+
+#[test]
+fn identity_is_deterministic_and_tenant_scoped() {
+    let fixture = provider_fixture();
+    let first_kernel = kernel("tenant-a");
+    let first_request = first_kernel.plan(None).unwrap();
+    let first = first_kernel
+        .decode_http(&first_request, 200, None, &fixture, OBSERVED_AT)
+        .unwrap();
+    let replay = first_kernel
+        .decode_http(&first_request, 200, None, &fixture, OBSERVED_AT)
+        .unwrap();
+    assert_eq!(first, replay);
+
+    let other_kernel = kernel("tenant-b");
+    let other_request = other_kernel.plan(None).unwrap();
+    let other = other_kernel
+        .decode_http(&other_request, 200, None, &fixture, OBSERVED_AT)
+        .unwrap();
+    assert_eq!(first.records[0].provider_id, other.records[0].provider_id);
+    assert_ne!(first.records[0].event_id, other.records[0].event_id);
+    assert_ne!(
+        first.records[0].attributes["resource_urn"],
+        other.records[0].attributes["resource_urn"]
+    );
+}
+
+#[test]
+fn errors_expose_operator_actions_without_provider_content() {
+    assert_eq!(
+        DockerHubError::AuthenticationRejected.operator_action(),
+        "repair credential binding"
+    );
+    assert_eq!(
+        DockerHubError::RequiredScopeMissing.operator_action(),
+        "grant repository read scope"
+    );
+    assert_eq!(
+        DockerHubError::RateLimited {
+            retry_after_seconds: Some(30)
+        }
+        .operator_action(),
+        "retry the collection later"
+    );
+    assert_eq!(
+        DockerHubError::InvalidCursor.operator_action(),
+        "restart from the last committed checkpoint"
+    );
+}

--- a/crates/source-runtime-next/src/docker_hub/types.rs
+++ b/crates/source-runtime-next/src/docker_hub/types.rs
@@ -1,0 +1,68 @@
+use std::collections::BTreeMap;
+
+use reqwest::Url;
+use serde_json::Value;
+
+use super::DockerHubFamily;
+
+/// One credential-free Docker Hub request plan.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DockerHubRequest {
+    pub(super) url: Url,
+    pub(super) family: DockerHubFamily,
+}
+
+/// One normalized tenant-scoped Docker Hub event candidate.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DockerHubRecord {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Stable Go-compatible tenant- and provider-scoped event identity.
+    pub event_id: String,
+    /// Stable provider namespace/name identity.
+    pub provider_id: String,
+    /// Exact family.
+    pub family: DockerHubFamily,
+    /// Exact event kind.
+    pub kind: String,
+    /// Exact schema reference.
+    pub schema_ref: String,
+    /// Normalized RFC3339 occurrence time.
+    pub occurred_at: String,
+    /// Deterministic projection attributes.
+    pub attributes: BTreeMap<String, String>,
+    /// Credential-free normalized provider payload.
+    pub payload: Value,
+}
+
+/// One bounded normalized Docker Hub page.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DockerHubPage {
+    /// The accepted repository record.
+    pub records: Vec<DockerHubRecord>,
+    /// Repository detail reads are terminal and never emit a cursor.
+    pub next_cursor: Option<String>,
+}
+
+/// Validated checkpoint candidate for post-append/project persistence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DockerHubCheckpointCandidate {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Selected family.
+    pub family: DockerHubFamily,
+    /// Terminal continuation state.
+    pub cursor: Option<String>,
+    /// Provider observation watermark.
+    pub watermark: String,
+}
+
+/// Closed Docker Hub kernel for one tenant and repository.
+#[derive(Clone, Debug)]
+pub struct DockerHubKernel {
+    pub(super) base_url: Url,
+    pub(super) tenant_id: String,
+    pub(super) namespace: String,
+    pub(super) repository: String,
+    pub(super) family: DockerHubFamily,
+}

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -21,6 +21,7 @@ mod cosmo;
 mod credential_lease;
 mod deposit;
 mod discord;
+mod docker_hub;
 mod egress;
 mod email_domain_health;
 mod evidence_cas;
@@ -112,6 +113,11 @@ pub use deposit::{
 };
 pub use discord::{
     DiscordError, DiscordFamily, DiscordKernel, DiscordPage, DiscordRecord, DiscordRequest,
+};
+pub use docker_hub::{
+    DockerHubCheckpointCandidate, DockerHubEntityFact, DockerHubError, DockerHubEventContract,
+    DockerHubFamily, DockerHubKernel, DockerHubPage, DockerHubProjectionFacts, DockerHubRecord,
+    DockerHubRequest, DockerHubRuntimeDefinition, project_docker_hub_records,
 };
 pub use egress::{
     EgressDecision, EgressDecisionKind, EgressMode, EgressPolicy, EgressPolicyError,

--- a/internal/connectorcatalog/catalog/devops-ci-cd/docker_hub.yaml
+++ b/internal/connectorcatalog/catalog/devops-ci-cd/docker_hub.yaml
@@ -10,6 +10,15 @@ entries:
       categories:
         - dev
         - artifacts
+      config_fields:
+        - help: Docker Hub namespace containing the repository.
+          key: namespace
+          label: Namespace
+          required: true
+        - help: Repository name within the Docker Hub namespace.
+          key: repository
+          label: Repository
+          required: true
       description: Collects repositories, users, and audit events from Docker Hub and projects them into the Cerebro graph as repositories, users, and audit events for repository, build, deployment, and release context.
       display_name: Docker Hub
       id: builtin-docker_hub


### PR DESCRIPTION
## Scope

- Add a credential-free Rust request/response kernel for the provider-verified `docker_hub.repositories` family.
- Compile an exact closed catalog definition, enforce the Docker Hub root origin and bounded terminal request, normalize tenant-scoped identities, classify typed provider failures, and emit a post-append/projection checkpoint candidate.
- Compare the captured provider response semantically with the existing Go oracle and preserve the existing projection shape.
- Bind the required `namespace` and `repository` catalog configuration explicitly.

## Authority

This is additive shadow-only coverage. Docker Hub proof is captured rather than declared, so this change does not promote Rust authority. Go catalog compatibility remains the authority/oracle. The synthetic `users` and `audit_events` families remain outside this Rust runtime definition.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cerebro-source-runtime-next docker_hub -- --nocapture`
- `cargo test -p cerebro-source-runtime-next`
- `cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings`
- `cargo test -p cerebro-source-catalog unsupported_feature_report_classifies_every_family_with_reason_codes -- --nocapture`
- `go test ./internal/sourcefixture ./internal/sourceprojection ./internal/connectorcatalog ./internal/connectordefinitions ./internal/sourcegen ./internal/sourceregistry ./tools/archtests -count=1`
- `make source-fixture-check projection-parity-test catalog-check sourcegen-check check-structural check-structural-test check-arch`
- `git diff --check origin/main...HEAD`
- `./scripts/leak_check.sh range origin/main...HEAD`