### PR TITLE
fix(sources): preserve API key placement for ten additional catalogs

### DIFF
--- a/internal/connectorcatalog/catalog/business-data-grc/opendatasoft.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/opendatasoft.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     config_fields:

--- a/internal/connectorcatalog/catalog/business-data-grc/opsgenie.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/opsgenie.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - itsm
         - incident

--- a/internal/connectorcatalog/catalog/business-data-grc/pendo.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/pendo.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     description: "Collects account, feature, user, and search from Pendo and projects them into the Cerebro graph as users and assets for owner, account, evidence, and compliance context."

--- a/internal/connectorcatalog/catalog/devops-ci-cd/netboxdemo.yaml
+++ b/internal/connectorcatalog/catalog/devops-ci-cd/netboxdemo.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     description: "Collects cluster group, secret, connected device, and device role from NetBox and projects them into the Cerebro graph as groups, secrets, and assets for repository, build, deployment, and release context."

--- a/internal/connectorcatalog/catalog/devops-ci-cd/postman.yaml
+++ b/internal/connectorcatalog/catalog/devops-ci-cd/postman.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - dev
         - api

--- a/internal/connectorcatalog/catalog/devops-ci-cd/pulumi_cloud.yaml
+++ b/internal/connectorcatalog/catalog/devops-ci-cd/pulumi_cloud.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - dev
         - iac

--- a/internal/connectorcatalog/catalog/identity-access-secrets/n_auth.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets/n_auth.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     config_fields:

--- a/internal/connectorcatalog/catalog/observability-soar-threat-intel/neutrinoapi.yaml
+++ b/internal/connectorcatalog/catalog/observability-soar-threat-intel/neutrinoapi.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     description: "Collects IP blocklist, host reputation, bin lookup, and geocode address from Neutrino API and projects them into the Cerebro graph as assets for alert, incident, service health, and response context."

--- a/internal/connectorcatalog/catalog/observability-soar-threat-intel/postmark.yaml
+++ b/internal/connectorcatalog/catalog/observability-soar-threat-intel/postmark.yaml
@@ -7,6 +7,7 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: X-Postmark-Account-Token
       categories:
         - observability
         - email

--- a/internal/connectorcatalog/catalog/security-posture-vulnerability/orca.yaml
+++ b/internal/connectorcatalog/catalog/security-posture-vulnerability/orca.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - security
         - cloud


### PR DESCRIPTION
## Scope

Preserve retired-Go API-key placement for n_auth, NetBox Demo, Neutrino API, OpenDataSoft, Opsgenie, Orca, Pendo, Postman, Postmark, and Pulumi Cloud.

Postmark uses the source-proved raw `X-Postmark-Account-Token` header. The other nine resolve to `Authorization: Token <key>`. None had another credential placement.

This independently removes 43 family-level `UnsupportedAuthModel` blockers (`201` to `158`) while leaving all 3,973 families classified.

## Validation

Executed in isolated DDESK workspace `cbrsrcdata` on current `main` plus commit `ecc150747`:

- `go test ./internal/connectorcatalog ./internal/connectordefinitions ./internal/sourcegen -count=1`
- `cargo test -p cerebro-source-catalog unsupported_feature_report_classifies_every_family_with_reason_codes -- --nocapture`
- `make sourcegen-check`
- `git diff --check`