### PR TITLE
fix(sources): preserve API key placement for another ten catalogs

### DIFF
--- a/internal/connectorcatalog/catalog/business-data-grc/redirection_io.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/redirection_io.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     description: "Collects aggregate log, user, agent rule, notification, smart list, and log from redirection.io and projects them into the Cerebro graph as audit events, users, policies, alerts, and assets for owner, account, evidence, and compliance context."

--- a/internal/connectorcatalog/catalog/business-data-grc/shipengine.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/shipengine.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     config_fields:

--- a/internal/connectorcatalog/catalog/business-data-grc/statuspage.yaml
+++ b/internal/connectorcatalog/catalog/business-data-grc/statuspage.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - itsm
         - incident

--- a/internal/connectorcatalog/catalog/collaboration-productivity/sendgrid.yaml
+++ b/internal/connectorcatalog/catalog/collaboration-productivity/sendgrid.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     description: "Collects activity, API key, group, and invalid email from SendGrid and projects them into the Cerebro graph as audit events, secrets, groups, and users for workspace, document, message, and collaboration context."

--- a/internal/connectorcatalog/catalog/devops-ci-cd/stream_io_api.yaml
+++ b/internal/connectorcatalog/catalog/devops-ci-cd/stream_io_api.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     description: "Collects member, role, device, and query banned user from Stream and projects them into the Cerebro graph as users, groups, and assets for repository, build, deployment, and release context."

--- a/internal/connectorcatalog/catalog/identity-access-secrets/strongdm.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets/strongdm.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - identity
         - access

--- a/internal/connectorcatalog/catalog/observability-soar-threat-intel/recorded_future.yaml
+++ b/internal/connectorcatalog/catalog/observability-soar-threat-intel/recorded_future.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - security
         - threat_intel

--- a/internal/connectorcatalog/catalog/observability-soar-threat-intel/resend.yaml
+++ b/internal/connectorcatalog/catalog/observability-soar-threat-intel/resend.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - observability
         - email

--- a/internal/connectorcatalog/catalog/security-posture-vulnerability/rapid7_insightvm.yaml
+++ b/internal/connectorcatalog/catalog/security-posture-vulnerability/rapid7_insightvm.yaml
@@ -7,6 +7,8 @@ entries:
             reference_only: true
             secret: true
         model: api_key
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - security
         - vulnerability

--- a/internal/connectorcatalog/catalog/security-posture-vulnerability/redhat.yaml
+++ b/internal/connectorcatalog/catalog/security-posture-vulnerability/redhat.yaml
@@ -10,6 +10,8 @@ entries:
         secret: true
       model: api_key
       requires_references: true
+      token_header: Authorization
+      token_scheme: Token
     categories:
     - saas
     config_fields:


### PR DESCRIPTION
## Scope

Preserve retired-Go `Authorization: Token <key>` placement for Rapid7 InsightVM, Recorded Future, Red Hat, redirection.io, Resend, SendGrid, ShipEngine, Statuspage, Stream, and StrongDM. All ten are source-proved from commit `360665cea`; none had another credential placement.

This removes 43 family-level `UnsupportedAuthModel` blockers and brings the cumulative current-main count from 325 to 66 while leaving all 3,973 families classified.

## Validation

Executed in isolated DDESK workspace `cbrsrcdata` on current `main` plus commit `4e8d1f203`:

- `go test ./internal/connectorcatalog ./internal/connectordefinitions ./internal/sourcegen -count=1`
- `cargo test -p cerebro-source-catalog unsupported_feature_report_classifies_every_family_with_reason_codes -- --nocapture`
- `make sourcegen-check`
- `git diff --check`