### PR TITLE
feat(source-runtime): add credential-free Tailscale Rust kernel

### DIFF
--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -46,6 +46,7 @@ mod security_tooling_map;
 mod sentinelone;
 mod slack;
 pub mod source_execution;
+mod tailscale;
 mod trivy;
 mod twilio;
 mod vulnview;
@@ -207,6 +208,12 @@ pub use sentinelone::{
 pub use slack::{
     SlackCheckpoint, SlackError, SlackFamily, SlackFilters, SlackKernel, SlackPage, SlackRecord,
     SlackRequest,
+};
+pub use tailscale::{
+    TailscaleCheckpointCandidate, TailscaleEntityFact, TailscaleError, TailscaleEventContract,
+    TailscaleFamily, TailscaleKernel, TailscalePage, TailscaleProjectionFacts, TailscaleRecord,
+    TailscaleRelationFact, TailscaleRequest, TailscaleResponseMetadata, TailscaleRuntimeDefinition,
+    project_tailscale_records,
 };
 pub use trivy::{TrivyError, TrivyFamily, TrivyKernel, TrivyPage, TrivyRecord};
 pub use twilio::{

--- a/crates/source-runtime-next/src/tailscale.rs
+++ b/crates/source-runtime-next/src/tailscale.rs
@@ -1,0 +1,31 @@
+//! Credential-free Tailscale request, normalization, and projection kernel.
+//!
+//! The trusted host owns credential-reference resolution, bearer authentication,
+//! redirect policy, deadlines, and bounded network I/O. This module accepts
+//! public source scope and already-bounded provider response bytes only. The Go
+//! source remains authoritative until repository promotion evidence permits a
+//! separate authority change.
+
+mod catalog;
+mod error;
+mod family;
+mod normalize;
+mod origin;
+mod projection;
+mod request;
+mod response;
+mod types;
+
+pub use catalog::{TailscaleEventContract, TailscaleRuntimeDefinition};
+pub use error::TailscaleError;
+pub use family::TailscaleFamily;
+pub use projection::{
+    TailscaleEntityFact, TailscaleProjectionFacts, TailscaleRelationFact, project_tailscale_records,
+};
+pub use types::{
+    TailscaleCheckpointCandidate, TailscaleKernel, TailscalePage, TailscaleRecord,
+    TailscaleRequest, TailscaleResponseMetadata,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/tailscale/catalog.rs
+++ b/crates/source-runtime-next/src/tailscale/catalog.rs
@@ -1,0 +1,67 @@
+use super::{TailscaleError, TailscaleFamily};
+
+/// Exact event contract compiled for one Tailscale family.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TailscaleEventContract {
+    /// Event kind.
+    pub kind: &'static str,
+    /// Schema reference.
+    pub schema_ref: &'static str,
+    /// Attributes required before admission.
+    pub required_attributes: &'static [&'static str],
+    /// Payload fields required before admission.
+    pub required_payload_fields: &'static [&'static str],
+}
+
+/// Closed runtime definition compiled from the provider source catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TailscaleRuntimeDefinition {
+    /// Source identifier.
+    pub source_id: &'static str,
+    /// Provider family.
+    pub family: TailscaleFamily,
+    /// HTTP method.
+    pub method: &'static str,
+    /// Exact provider path.
+    pub path: &'static str,
+    /// Credential model owned by the trusted host.
+    pub auth_model: &'static str,
+    /// Exact admitted event contract.
+    pub contract: TailscaleEventContract,
+}
+
+impl TailscaleRuntimeDefinition {
+    /// Compile one family into a validated closed runtime definition.
+    pub fn compile(family: TailscaleFamily) -> Result<Self, TailscaleError> {
+        let definition = Self {
+            source_id: "tailscale",
+            family,
+            method: "GET",
+            path: family.path(),
+            auth_model: "bearer_token",
+            contract: TailscaleEventContract {
+                kind: family.event_kind(),
+                schema_ref: family.schema_ref(),
+                required_attributes: family.required_attributes(),
+                required_payload_fields: family.required_payload_fields(),
+            },
+        };
+        definition.validate()?;
+        Ok(definition)
+    }
+
+    fn validate(&self) -> Result<(), TailscaleError> {
+        if self.source_id != "tailscale"
+            || self.method != "GET"
+            || self.auth_model != "bearer_token"
+            || self.path != self.family.path()
+            || self.contract.kind != self.family.event_kind()
+            || self.contract.schema_ref != self.family.schema_ref()
+            || self.contract.required_attributes.is_empty()
+            || self.contract.required_payload_fields.is_empty()
+        {
+            return Err(TailscaleError::InvalidCatalogContract);
+        }
+        Ok(())
+    }
+}

--- a/crates/source-runtime-next/src/tailscale/error.rs
+++ b/crates/source-runtime-next/src/tailscale/error.rs
@@ -1,0 +1,167 @@
+use std::fmt;
+
+/// Bounded, provider-specific Tailscale failure taxonomy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TailscaleError {
+    /// Required public configuration is absent.
+    MissingConfiguration(&'static str),
+    /// Public configuration is malformed or outside its bound.
+    InvalidConfiguration(&'static str),
+    /// Base URL is not a credential-free HTTPS origin.
+    InvalidBaseUrl,
+    /// Request escaped the configured provider origin.
+    InvalidOrigin,
+    /// Authenticated tenant scope is missing or malformed.
+    InvalidTenantId,
+    /// Named credential reference is absent in the trusted host.
+    MissingCredentialReference,
+    /// Trusted host could not redeem its credential lease.
+    CredentialUnavailable,
+    /// Provider rejected authentication.
+    AuthenticationRejected,
+    /// Provider rejected the credential's scope.
+    RequiredScopeMissing,
+    /// Trusted host denied provider egress.
+    EgressDenied,
+    /// Provider DNS resolution failed.
+    DnsFailure,
+    /// Provider connection failed.
+    ConnectionFailure,
+    /// Provider deadline expired.
+    ProviderTimeout,
+    /// Provider requested a retry.
+    RateLimited {
+        /// Bounded provider retry delay.
+        retry_after_seconds: Option<u64>,
+    },
+    /// Provider is temporarily unavailable.
+    ProviderUnavailable {
+        /// Provider HTTP status.
+        status: u16,
+    },
+    /// Provider returned an unexpected status.
+    UnexpectedStatus {
+        /// Provider HTTP status.
+        status: u16,
+    },
+    /// Retry-After exceeded the bounded host contract.
+    InvalidRetryAfter,
+    /// Response exceeded the declared byte limit.
+    ResponseTooLarge,
+    /// Response did not match the family envelope.
+    MalformedResponse,
+    /// Response contained more records than allowed.
+    TooManyRecords,
+    /// A provider record was malformed.
+    InvalidProviderRecord,
+    /// Provider record lacked stable identity.
+    MissingStableIdentity,
+    /// Cursor was invalid, repeated, or not round-trippable.
+    InvalidCursor,
+    /// Provider payload tried to supply authenticated tenant scope.
+    TenantMismatch,
+    /// Provider payload contained credential-shaped material.
+    CredentialMaterial,
+    /// Duplicate identity carried conflicting content.
+    ConflictingDuplicate,
+    /// Request did not belong to this kernel instance.
+    RequestScopeMismatch,
+    /// Event failed the exact compiled contract.
+    EventContractRejected,
+    /// Append failed after successful normalization.
+    AppendFailure,
+    /// Projection failed after append.
+    ProjectionFailure,
+    /// Runtime lease was lost.
+    LeaseLoss,
+    /// Runtime generation or authority is stale.
+    StaleAuthority,
+    /// Family is outside the closed catalog.
+    UnknownFamily,
+    /// Checked-in catalog and runtime definition disagree.
+    InvalidCatalogContract,
+    /// Internal bounded runtime failure.
+    InternalRuntimeFailure,
+}
+
+impl TailscaleError {
+    /// Stable error class suitable for bounded receipts.
+    pub const fn class(&self) -> &'static str {
+        match self {
+            Self::MissingConfiguration(_) => "missing_configuration",
+            Self::InvalidConfiguration(_) => "invalid_configuration",
+            Self::InvalidBaseUrl => "invalid_base_url",
+            Self::InvalidOrigin => "egress_denied",
+            Self::InvalidTenantId => "invalid_tenant",
+            Self::MissingCredentialReference => "missing_credential_reference",
+            Self::CredentialUnavailable => "credential_unavailable",
+            Self::AuthenticationRejected => "authentication_rejected",
+            Self::RequiredScopeMissing => "required_scope_missing",
+            Self::EgressDenied => "egress_denied",
+            Self::DnsFailure => "dns_failure",
+            Self::ConnectionFailure => "connection_failure",
+            Self::ProviderTimeout => "provider_timeout",
+            Self::RateLimited { .. } => "provider_rate_limit",
+            Self::ProviderUnavailable { .. } => "provider_unavailable",
+            Self::UnexpectedStatus { .. } => "unexpected_provider_status",
+            Self::InvalidRetryAfter => "invalid_retry_after",
+            Self::ResponseTooLarge => "response_too_large",
+            Self::MalformedResponse => "malformed_response",
+            Self::TooManyRecords => "record_limit_exceeded",
+            Self::InvalidProviderRecord => "invalid_provider_record",
+            Self::MissingStableIdentity => "missing_stable_identity",
+            Self::InvalidCursor => "invalid_cursor",
+            Self::TenantMismatch => "tenant_mismatch",
+            Self::CredentialMaterial => "credential_material",
+            Self::ConflictingDuplicate => "conflicting_duplicate",
+            Self::RequestScopeMismatch => "request_scope_mismatch",
+            Self::EventContractRejected => "event_contract_rejection",
+            Self::AppendFailure => "append_failure",
+            Self::ProjectionFailure => "projection_failure",
+            Self::LeaseLoss => "lease_loss",
+            Self::StaleAuthority => "stale_authority",
+            Self::UnknownFamily => "unknown_family",
+            Self::InvalidCatalogContract => "invalid_catalog_contract",
+            Self::InternalRuntimeFailure => "internal_runtime_failure",
+        }
+    }
+
+    /// Next valid operator action without provider payload or credential data.
+    pub const fn operator_action(&self) -> &'static str {
+        match self {
+            Self::MissingConfiguration(_)
+            | Self::InvalidConfiguration(_)
+            | Self::InvalidBaseUrl => "repair source configuration",
+            Self::MissingCredentialReference | Self::CredentialUnavailable => {
+                "repair credential binding"
+            }
+            Self::AuthenticationRejected => "replace or reauthorize credential",
+            Self::RequiredScopeMissing => "grant required Tailscale read scope",
+            Self::RateLimited { .. } | Self::ProviderUnavailable { .. } | Self::ProviderTimeout => {
+                "retry later"
+            }
+            Self::EgressDenied
+            | Self::InvalidOrigin
+            | Self::DnsFailure
+            | Self::ConnectionFailure => "repair provider egress",
+            Self::MalformedResponse
+            | Self::TooManyRecords
+            | Self::InvalidProviderRecord
+            | Self::MissingStableIdentity
+            | Self::CredentialMaterial
+            | Self::TenantMismatch
+            | Self::EventContractRejected
+            | Self::ConflictingDuplicate => "inspect quarantined records",
+            Self::InvalidCursor => "restart collection from last committed checkpoint",
+            _ => "repair forward runtime implementation",
+        }
+    }
+}
+
+impl fmt::Display for TailscaleError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.class())
+    }
+}
+
+impl std::error::Error for TailscaleError {}

--- a/crates/source-runtime-next/src/tailscale/family.rs
+++ b/crates/source-runtime-next/src/tailscale/family.rs
@@ -1,0 +1,148 @@
+use std::{fmt, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+
+use super::TailscaleError;
+
+/// Closed set of provider-specific families owned by the Tailscale source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TailscaleFamily {
+    /// Tailnet settings singleton.
+    Tailnet,
+    /// Tailnet users.
+    User,
+    /// Tailnet devices.
+    Device,
+    /// ACL groups.
+    Group,
+    /// ACL tag owners.
+    Tag,
+    /// Tailnet VIP services.
+    Service,
+    /// ACL grants.
+    Grant,
+}
+
+impl TailscaleFamily {
+    /// Exact family set in `sources/tailscale/catalog.yaml`.
+    pub const ALL: [Self; 7] = [
+        Self::Device,
+        Self::Grant,
+        Self::Group,
+        Self::Service,
+        Self::Tag,
+        Self::Tailnet,
+        Self::User,
+    ];
+
+    /// Catalog family identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Tailnet => "tailnet",
+            Self::User => "user",
+            Self::Device => "device",
+            Self::Group => "group",
+            Self::Tag => "tag",
+            Self::Service => "service",
+            Self::Grant => "grant",
+        }
+    }
+
+    /// Exact emitted event kind.
+    pub const fn event_kind(self) -> &'static str {
+        match self {
+            Self::Tailnet => "tailscale.tailnet",
+            Self::User => "tailscale.user",
+            Self::Device => "tailscale.device",
+            Self::Group => "tailscale.group",
+            Self::Tag => "tailscale.tag",
+            Self::Service => "tailscale.service",
+            Self::Grant => "tailscale.grant",
+        }
+    }
+
+    /// Exact emitted schema reference.
+    pub const fn schema_ref(self) -> &'static str {
+        match self {
+            Self::Tailnet => "tailscale/tailnet/v1",
+            Self::User => "tailscale/user/v1",
+            Self::Device => "tailscale/device/v1",
+            Self::Group => "tailscale/group/v1",
+            Self::Tag => "tailscale/tag/v1",
+            Self::Service => "tailscale/service/v1",
+            Self::Grant => "tailscale/grant/v1",
+        }
+    }
+
+    /// Go-oracle request path using Tailscale's authenticated-tailnet alias.
+    pub const fn path(self) -> &'static str {
+        match self {
+            Self::Tailnet => "/tailnet/-/settings",
+            Self::User => "/tailnet/-/users",
+            Self::Device => "/tailnet/-/devices",
+            Self::Group | Self::Tag | Self::Grant => "/tailnet/-/acl",
+            Self::Service => "/tailnet/-/vip-services",
+        }
+    }
+
+    pub(super) const fn urn_kind(self) -> &'static str {
+        match self {
+            Self::Tailnet => "tailscale_tailnet",
+            Self::User => "tailscale_user",
+            Self::Device => "tailscale_device",
+            Self::Group => "tailscale_group",
+            Self::Tag => "tailscale_tag",
+            Self::Service => "tailscale_service",
+            Self::Grant => "tailscale_grant",
+        }
+    }
+
+    pub(super) const fn required_attribute(self) -> &'static str {
+        match self {
+            Self::Tailnet => "tailnet",
+            Self::User => "user_id",
+            Self::Device => "device_id",
+            Self::Group => "group_id",
+            Self::Tag => "tag_id",
+            Self::Service => "service_id",
+            Self::Grant => "grant_id",
+        }
+    }
+
+    pub(super) const fn required_attributes(self) -> &'static [&'static str] {
+        match self {
+            Self::Tailnet => &["tailnet"],
+            Self::User => &["user_id", "login_name"],
+            Self::Device => &["device_id"],
+            Self::Group => &["group_id"],
+            Self::Tag => &["tag_id"],
+            Self::Service => &["service_id"],
+            Self::Grant => &["grant_id"],
+        }
+    }
+
+    pub(super) const fn required_payload_fields(self) -> &'static [&'static str] {
+        match self {
+            Self::Service => &["name"],
+            _ => &["id"],
+        }
+    }
+}
+
+impl fmt::Display for TailscaleFamily {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for TailscaleFamily {
+    type Err = TailscaleError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|family| family.as_str() == value.trim())
+            .ok_or(TailscaleError::UnknownFamily)
+    }
+}

--- a/crates/source-runtime-next/src/tailscale/normalize.rs
+++ b/crates/source-runtime-next/src/tailscale/normalize.rs
@@ -1,0 +1,433 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{TailscaleError, TailscaleFamily, TailscaleKernel, TailscaleRecord};
+
+pub(super) fn records(
+    family: TailscaleFamily,
+    root: &Value,
+    tailnet: &str,
+) -> Result<Vec<Value>, TailscaleError> {
+    match family {
+        TailscaleFamily::Tailnet => {
+            let mut object = root
+                .as_object()
+                .cloned()
+                .ok_or(TailscaleError::MalformedResponse)?;
+            object
+                .entry("id".to_owned())
+                .or_insert_with(|| Value::String(tailnet.to_owned()));
+            object
+                .entry("tailnet".to_owned())
+                .or_insert_with(|| Value::String(tailnet.to_owned()));
+            Ok(vec![Value::Object(object)])
+        }
+        TailscaleFamily::User => list(root, &["users", "data", "items", "results"]),
+        TailscaleFamily::Device => list(root, &["devices", "data", "items", "results"]),
+        TailscaleFamily::Service => list(
+            root,
+            &["vipServices", "services", "data", "items", "results"],
+        ),
+        TailscaleFamily::Grant => list(root, &["grants", "data", "items", "results"]),
+        TailscaleFamily::Group => object_map(root, "groups", "members"),
+        TailscaleFamily::Tag => object_map(root, "tagOwners", "owners"),
+    }
+}
+
+pub(super) fn normalize(
+    kernel: &TailscaleKernel,
+    mut payload: Value,
+) -> Result<TailscaleRecord, TailscaleError> {
+    reject_untrusted_material(&payload, 0)?;
+    let provider_id = provider_id(
+        kernel.family,
+        payload
+            .as_object()
+            .ok_or(TailscaleError::InvalidProviderRecord)?,
+        &payload,
+    )?;
+    if kernel.family == TailscaleFamily::Tailnet {
+        let object = payload
+            .as_object_mut()
+            .ok_or(TailscaleError::InvalidProviderRecord)?;
+        object.insert("id".to_owned(), Value::String(kernel.tailnet.clone()));
+        object.insert("tailnet".to_owned(), Value::String(kernel.tailnet.clone()));
+    }
+    let object = payload
+        .as_object()
+        .ok_or(TailscaleError::InvalidProviderRecord)?;
+    let mut attributes = BTreeMap::from([
+        ("external_id".to_owned(), provider_id.clone()),
+        ("family".to_owned(), kernel.family.as_str().to_owned()),
+        ("provider".to_owned(), "tailscale".to_owned()),
+        ("source_product".to_owned(), "tailscale".to_owned()),
+        ("source_provider".to_owned(), "tailscale".to_owned()),
+        ("tenant_id".to_owned(), kernel.tenant_id.clone()),
+    ]);
+    for (name, paths) in mappings(kernel.family) {
+        if let Some(value) = first_value(object, paths) {
+            attributes.insert((*name).to_owned(), value);
+        }
+    }
+    if kernel.family == TailscaleFamily::Tailnet {
+        attributes.insert("tailnet".to_owned(), kernel.tailnet.clone());
+    }
+    attributes.insert("resource_id".to_owned(), provider_id.clone());
+    attributes.insert(
+        "resource_type".to_owned(),
+        kernel.family.as_str().to_owned(),
+    );
+    attributes.insert(
+        "resource_name".to_owned(),
+        resource_name(kernel.family, object, &provider_id),
+    );
+    attributes.insert(
+        "resource_urn".to_owned(),
+        format!(
+            "urn:cerebro:{}:{}:{}",
+            kernel.tenant_id,
+            kernel.family.urn_kind(),
+            provider_id
+        ),
+    );
+    validate_contract(kernel.family, &attributes, &payload)?;
+    let occurred_at = occurred_at(kernel, object)?;
+    let event_id = event_id(kernel, &provider_id);
+    Ok(TailscaleRecord {
+        tenant_id: kernel.tenant_id.clone(),
+        family: kernel.family,
+        event_id,
+        kind: kernel.family.event_kind().to_owned(),
+        schema_ref: kernel.family.schema_ref().to_owned(),
+        occurred_at,
+        attributes,
+        payload,
+    })
+}
+
+pub(super) fn canonical_bytes(value: &Value) -> Result<Vec<u8>, TailscaleError> {
+    serde_json::to_vec(&canonical(value)).map_err(|_| TailscaleError::InternalRuntimeFailure)
+}
+
+fn list(root: &Value, keys: &[&str]) -> Result<Vec<Value>, TailscaleError> {
+    if let Some(values) = root.as_array() {
+        return Ok(values.clone());
+    }
+    let object = root.as_object().ok_or(TailscaleError::MalformedResponse)?;
+    keys.iter()
+        .find_map(|key| object.get(*key).and_then(Value::as_array))
+        .cloned()
+        .ok_or(TailscaleError::MalformedResponse)
+}
+
+fn object_map(root: &Value, key: &str, value_key: &str) -> Result<Vec<Value>, TailscaleError> {
+    let values = root
+        .get(key)
+        .and_then(Value::as_object)
+        .ok_or(TailscaleError::MalformedResponse)?;
+    let mut keys = values.keys().collect::<Vec<_>>();
+    keys.sort_unstable();
+    Ok(keys
+        .into_iter()
+        .map(|id| {
+            Value::Object(Map::from_iter([
+                ("id".to_owned(), Value::String(id.clone())),
+                ("name".to_owned(), Value::String(id.clone())),
+                (value_key.to_owned(), values[id].clone()),
+            ]))
+        })
+        .collect())
+}
+
+fn provider_id(
+    family: TailscaleFamily,
+    object: &Map<String, Value>,
+    payload: &Value,
+) -> Result<String, TailscaleError> {
+    let keys: &[&str] = match family {
+        TailscaleFamily::Tailnet => &["id", "tailnet", "organization"],
+        TailscaleFamily::User => &["id", "user_id", "loginName"],
+        TailscaleFamily::Device => &["id", "nodeId", "device_id"],
+        TailscaleFamily::Group | TailscaleFamily::Tag => &["id", "name"],
+        TailscaleFamily::Service => &["id", "service_id", "name"],
+        TailscaleFamily::Grant => &["id", "grant_id"],
+    };
+    if let Some(id) = first_value(object, keys) {
+        return Ok(id);
+    }
+    if family == TailscaleFamily::Grant {
+        let digest = Sha256::digest(canonical_bytes(payload)?);
+        return Ok(hex_prefix(&digest, 24));
+    }
+    Err(TailscaleError::MissingStableIdentity)
+}
+
+fn mappings(family: TailscaleFamily) -> &'static [(&'static str, &'static [&'static str])] {
+    match family {
+        TailscaleFamily::Tailnet => &[
+            ("tailnet", &["id", "tailnet", "organization"]),
+            ("devices_approval_on", &["devicesApprovalOn"]),
+            ("users_approval_on", &["usersApprovalOn"]),
+            ("network_flow_logging_on", &["networkFlowLoggingOn"]),
+            ("regional_routing_on", &["regionalRoutingOn"]),
+            ("max_key_duration_days", &["maxKeyDurationDays"]),
+        ],
+        TailscaleFamily::User => &[
+            ("user_id", &["id", "user_id"]),
+            ("login_name", &["loginName", "login_name", "email"]),
+            ("email", &["email", "loginName"]),
+            ("display_name", &["displayName", "display_name"]),
+            ("role", &["role"]),
+            ("status", &["status"]),
+            ("type", &["type"]),
+            ("last_seen_at", &["lastSeen", "last_seen"]),
+        ],
+        TailscaleFamily::Device => &[
+            ("device_id", &["id", "nodeId", "device_id"]),
+            ("node_id", &["nodeId", "id"]),
+            ("name", &["name"]),
+            ("hostname", &["hostname"]),
+            ("os", &["os"]),
+            ("user_id", &["user"]),
+            ("owner_email", &["user"]),
+            ("authorized", &["authorized"]),
+            ("is_external", &["isExternal", "is_external"]),
+            (
+                "key_expiry_disabled",
+                &["keyExpiryDisabled", "key_expiry_disabled"],
+            ),
+            ("update_available", &["updateAvailable", "update_available"]),
+            (
+                "blocks_incoming_connections",
+                &["blocksIncomingConnections", "blocks_incoming_connections"],
+            ),
+            ("tags", &["tags"]),
+            ("last_seen_at", &["lastSeen", "last_seen"]),
+            ("client_version", &["clientVersion", "client_version"]),
+        ],
+        TailscaleFamily::Group => &[
+            ("group_id", &["id", "name"]),
+            ("name", &["name"]),
+            ("members", &["members"]),
+        ],
+        TailscaleFamily::Tag => &[
+            ("tag_id", &["id", "name"]),
+            ("name", &["name"]),
+            ("owners", &["owners"]),
+        ],
+        TailscaleFamily::Service => &[
+            ("service_id", &["id", "service_id", "name"]),
+            ("name", &["name"]),
+            ("addresses", &["addrs", "addresses"]),
+            ("ports", &["ports"]),
+            ("tags", &["tags"]),
+            ("comment", &["comment"]),
+        ],
+        TailscaleFamily::Grant => &[
+            ("grant_id", &["id", "grant_id"]),
+            ("sources", &["src", "sources"]),
+            ("destinations", &["dst", "destinations"]),
+            ("via", &["via"]),
+            ("ip", &["ip"]),
+            ("app", &["app"]),
+            ("disabled", &["disabled"]),
+        ],
+    }
+}
+
+fn first_value(object: &Map<String, Value>, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| object.get(*key).and_then(value_string))
+}
+
+fn value_string(value: &Value) -> Option<String> {
+    let value = match value {
+        Value::Null => return None,
+        Value::String(value) => value.trim().to_owned(),
+        Value::Bool(value) => value.to_string(),
+        Value::Number(value) => value.to_string(),
+        Value::Array(values) => values
+            .iter()
+            .filter_map(value_string)
+            .collect::<Vec<_>>()
+            .join(","),
+        Value::Object(_) => serde_json::to_string(value).ok()?,
+    };
+    (!value.is_empty()).then_some(value)
+}
+
+fn occurred_at(
+    kernel: &TailscaleKernel,
+    object: &Map<String, Value>,
+) -> Result<String, TailscaleError> {
+    let preferred: &[&str] = match kernel.family {
+        TailscaleFamily::User => &["created", "lastSeen"],
+        TailscaleFamily::Device => &["lastSeen", "created"],
+        _ => &[],
+    };
+    for key in preferred.iter().chain(
+        [
+            "updated_at",
+            "updatedAt",
+            "last_seen_at",
+            "lastSeenAt",
+            "created_at",
+            "createdAt",
+            "timestamp",
+        ]
+        .iter(),
+    ) {
+        if let Some(value) = object.get(*key).and_then(value_string)
+            && let Ok(parsed) = OffsetDateTime::parse(&value, &Rfc3339)
+        {
+            return parsed
+                .format(&Rfc3339)
+                .map_err(|_| TailscaleError::InvalidProviderRecord);
+        }
+    }
+    Ok(kernel.observed_at.clone())
+}
+
+fn event_id(kernel: &TailscaleKernel, provider_id: &str) -> String {
+    let mut scope = Sha256::new();
+    scope.update(kernel.base_url.as_str().as_bytes());
+    scope.update([0]);
+    scope.update(kernel.family.path().as_bytes());
+    let scope = scope.finalize();
+    format!(
+        "tailscale-{}-{}-{}-{}",
+        normalize_id(&kernel.tenant_id),
+        hex_prefix(&scope, 12),
+        normalize_id(kernel.family.as_str()),
+        normalize_id(provider_id)
+    )
+}
+
+fn normalize_id(value: &str) -> String {
+    let value = value.trim();
+    if value.is_empty() {
+        return "unknown".to_owned();
+    }
+    value
+        .chars()
+        .map(|character| match character {
+            ' ' | '/' | ':' | '\t' | '\n' => '-',
+            other => other,
+        })
+        .collect()
+}
+
+fn resource_name(family: TailscaleFamily, object: &Map<String, Value>, fallback: &str) -> String {
+    if family == TailscaleFamily::Grant {
+        let sources = first_value(object, &["src", "sources"]);
+        let destinations = first_value(object, &["dst", "destinations"]);
+        if let (Some(sources), Some(destinations)) = (sources, destinations) {
+            return format!("{sources} to {destinations}");
+        }
+    }
+    let keys: &[&str] = match family {
+        TailscaleFamily::User => &["displayName", "loginName", "email"],
+        TailscaleFamily::Device | TailscaleFamily::Service => &["name", "hostname"],
+        TailscaleFamily::Group | TailscaleFamily::Tag => &["name"],
+        TailscaleFamily::Grant => &["name"],
+        TailscaleFamily::Tailnet => &["tailnet", "organization", "id"],
+    };
+    first_value(object, keys).unwrap_or_else(|| fallback.to_owned())
+}
+
+fn validate_contract(
+    family: TailscaleFamily,
+    attributes: &BTreeMap<String, String>,
+    payload: &Value,
+) -> Result<(), TailscaleError> {
+    if family.required_attributes().iter().any(|key| {
+        attributes
+            .get(*key)
+            .is_none_or(|value| value.trim().is_empty())
+    }) || payload.as_object().is_none_or(|payload| {
+        family
+            .required_payload_fields()
+            .iter()
+            .any(|field| payload.get(*field).is_none_or(Value::is_null))
+    }) {
+        return Err(TailscaleError::EventContractRejected);
+    }
+    Ok(())
+}
+
+fn reject_untrusted_material(value: &Value, depth: usize) -> Result<(), TailscaleError> {
+    if depth > 16 {
+        return Err(TailscaleError::InvalidProviderRecord);
+    }
+    match value {
+        Value::Object(object) => {
+            if object.len() > 512 {
+                return Err(TailscaleError::InvalidProviderRecord);
+            }
+            for (key, value) in object {
+                let normalized = key.trim().to_ascii_lowercase().replace('-', "_");
+                if normalized == "tenant_id" || normalized == "tenant" {
+                    return Err(TailscaleError::TenantMismatch);
+                }
+                if matches!(
+                    normalized.as_str(),
+                    "token"
+                        | "access_token"
+                        | "api_key"
+                        | "client_secret"
+                        | "clientsecret"
+                        | "password"
+                        | "private_key"
+                        | "authorization"
+                        | "cookie"
+                ) {
+                    return Err(TailscaleError::CredentialMaterial);
+                }
+                reject_untrusted_material(value, depth + 1)?;
+            }
+        }
+        Value::Array(values) => {
+            if values.len() > 10_000 {
+                return Err(TailscaleError::InvalidProviderRecord);
+            }
+            for value in values {
+                reject_untrusted_material(value, depth + 1)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn canonical(value: &Value) -> Value {
+    match value {
+        Value::Object(object) => {
+            let mut entries = object.iter().collect::<Vec<_>>();
+            entries.sort_unstable_by(|left, right| left.0.cmp(right.0));
+            Value::Object(Map::from_iter(
+                entries
+                    .into_iter()
+                    .map(|(key, value)| (key.clone(), canonical(value))),
+            ))
+        }
+        Value::Array(values) => Value::Array(values.iter().map(canonical).collect()),
+        other => other.clone(),
+    }
+}
+
+fn hex_prefix(bytes: &[u8], length: usize) -> String {
+    bytes
+        .iter()
+        .flat_map(|byte| {
+            [
+                char::from_digit((byte >> 4) as u32, 16),
+                char::from_digit((byte & 15) as u32, 16),
+            ]
+        })
+        .flatten()
+        .take(length)
+        .collect()
+}

--- a/crates/source-runtime-next/src/tailscale/origin.rs
+++ b/crates/source-runtime-next/src/tailscale/origin.rs
@@ -1,0 +1,59 @@
+use std::net::IpAddr;
+
+use super::TailscaleError;
+
+pub(super) fn validate_origin(value: &str) -> Result<reqwest::Url, TailscaleError> {
+    let mut url = reqwest::Url::parse(value.trim()).map_err(|_| TailscaleError::InvalidBaseUrl)?;
+    if url.scheme() != "https"
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || url.host_str().is_none()
+        || url.port_or_known_default() != Some(443)
+    {
+        return Err(TailscaleError::InvalidBaseUrl);
+    }
+    let host = url.host_str().ok_or(TailscaleError::InvalidBaseUrl)?;
+    if host.eq_ignore_ascii_case("localhost")
+        || host.ends_with(".localhost")
+        || host.parse::<IpAddr>().is_ok_and(|ip| !is_public(ip))
+    {
+        return Err(TailscaleError::InvalidBaseUrl);
+    }
+    let path = url.path().trim_end_matches('/');
+    if path.is_empty() {
+        url.set_path("");
+    } else if path != "/api/v2" {
+        return Err(TailscaleError::InvalidBaseUrl);
+    }
+    Ok(url)
+}
+
+pub(super) fn bounded(value: &str, max: usize) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()
+        && value.len() <= max
+        && !value.chars().any(char::is_control)
+        && !value.contains(['\0', '\r', '\n']))
+    .then(|| value.to_owned())
+}
+
+fn is_public(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => {
+            !(ip.is_private()
+                || ip.is_loopback()
+                || ip.is_link_local()
+                || ip.is_broadcast()
+                || ip.is_documentation()
+                || ip.is_unspecified())
+        }
+        IpAddr::V6(ip) => {
+            !(ip.is_loopback()
+                || ip.is_unspecified()
+                || ip.is_unique_local()
+                || ip.is_unicast_link_local())
+        }
+    }
+}

--- a/crates/source-runtime-next/src/tailscale/projection.rs
+++ b/crates/source-runtime-next/src/tailscale/projection.rs
@@ -1,0 +1,290 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::{TailscaleError, TailscaleFamily, TailscaleRecord};
+
+/// Deterministic tenant-scoped Tailscale projection entity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TailscaleEntityFact {
+    /// Entity URN.
+    pub urn: String,
+    /// Provider-specific entity type.
+    pub entity_type: String,
+    /// Human-readable label.
+    pub label: String,
+    /// Provider attributes safe for graph persistence.
+    pub attributes: BTreeMap<String, String>,
+}
+
+/// Deterministic tenant-scoped Tailscale projection relation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TailscaleRelationFact {
+    /// Source entity URN.
+    pub from: String,
+    /// Stable relation kind.
+    pub relation: String,
+    /// Target entity URN.
+    pub to: String,
+    /// Relation evidence attributes.
+    pub attributes: BTreeMap<String, String>,
+}
+
+/// Projection facts emitted from normalized Tailscale records.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TailscaleProjectionFacts {
+    /// Deterministically ordered entities.
+    pub entities: Vec<TailscaleEntityFact>,
+    /// Deterministically ordered relations.
+    pub relations: Vec<TailscaleRelationFact>,
+}
+
+/// Project exact provider semantics without using the narrower generic catalog.
+pub fn project_tailscale_records(
+    records: &[TailscaleRecord],
+) -> Result<TailscaleProjectionFacts, TailscaleError> {
+    let mut entities = BTreeMap::<String, TailscaleEntityFact>::new();
+    let mut relations = BTreeMap::<(String, String, String), TailscaleRelationFact>::new();
+    for record in records {
+        let id = record
+            .attributes
+            .get(record.family.required_attribute())
+            .filter(|value| !value.trim().is_empty())
+            .ok_or(TailscaleError::ProjectionFailure)?;
+        let primary = urn(&record.tenant_id, record.family.urn_kind(), id);
+        add_entity(
+            &mut entities,
+            &primary,
+            record.family.event_kind(),
+            record
+                .attributes
+                .get("resource_name")
+                .map_or(id.as_str(), String::as_str),
+            record.attributes.clone(),
+        );
+        match record.family {
+            TailscaleFamily::Tailnet | TailscaleFamily::User => {}
+            TailscaleFamily::Device => {
+                project_device(record, &primary, &mut entities, &mut relations)
+            }
+            TailscaleFamily::Group => {
+                project_group(record, &primary, &mut entities, &mut relations)
+            }
+            TailscaleFamily::Tag => project_tag(record, &primary, &mut entities, &mut relations),
+            TailscaleFamily::Service => {
+                project_service(record, &primary, &mut entities, &mut relations)
+            }
+            TailscaleFamily::Grant => {
+                project_grant(record, &primary, &mut entities, &mut relations)
+            }
+        }
+    }
+    Ok(TailscaleProjectionFacts {
+        entities: entities.into_values().collect(),
+        relations: relations.into_values().collect(),
+    })
+}
+
+fn project_device(
+    record: &TailscaleRecord,
+    device: &str,
+    entities: &mut BTreeMap<String, TailscaleEntityFact>,
+    relations: &mut BTreeMap<(String, String, String), TailscaleRelationFact>,
+) {
+    if let Some(owner) = first(record, &["user_id", "owner_email"]) {
+        let owner_urn = urn(&record.tenant_id, "tailscale_user", owner);
+        add_entity(
+            entities,
+            &owner_urn,
+            "tailscale.user",
+            owner,
+            BTreeMap::from([("login_name".to_owned(), owner.to_owned())]),
+        );
+        add_relation(record, relations, device, "owned_by", &owner_urn, None);
+        if truthy(record.attributes.get("authorized"))
+            && !truthy(record.attributes.get("blocks_incoming_connections"))
+        {
+            add_relation(record, relations, &owner_urn, "can_reach", device, None);
+        }
+    }
+    for tag in list(record.attributes.get("tags")) {
+        let tag_urn = urn(&record.tenant_id, "tailscale_tag", tag);
+        add_entity(
+            entities,
+            &tag_urn,
+            "tailscale.tag",
+            tag,
+            BTreeMap::from([("tag_id".to_owned(), tag.to_owned())]),
+        );
+        add_relation(record, relations, device, "tagged_as", &tag_urn, None);
+    }
+}
+
+fn project_group(
+    record: &TailscaleRecord,
+    group: &str,
+    entities: &mut BTreeMap<String, TailscaleEntityFact>,
+    relations: &mut BTreeMap<(String, String, String), TailscaleRelationFact>,
+) {
+    for member in list(record.attributes.get("members")) {
+        let (kind, entity_type) = principal_kind(member);
+        let member_urn = urn(&record.tenant_id, kind, member);
+        add_entity(
+            entities,
+            &member_urn,
+            entity_type,
+            member,
+            BTreeMap::from([("login_name".to_owned(), member.to_owned())]),
+        );
+        add_relation(record, relations, group, "contains", &member_urn, None);
+        add_relation(record, relations, &member_urn, "member_of", group, None);
+    }
+}
+
+fn project_tag(
+    record: &TailscaleRecord,
+    tag: &str,
+    entities: &mut BTreeMap<String, TailscaleEntityFact>,
+    relations: &mut BTreeMap<(String, String, String), TailscaleRelationFact>,
+) {
+    for owner in list(record.attributes.get("owners")) {
+        let (kind, entity_type) = principal_kind(owner);
+        let owner_urn = urn(&record.tenant_id, kind, owner);
+        add_entity(entities, &owner_urn, entity_type, owner, BTreeMap::new());
+        add_relation(record, relations, tag, "owned_by", &owner_urn, None);
+    }
+}
+
+fn project_service(
+    record: &TailscaleRecord,
+    service: &str,
+    entities: &mut BTreeMap<String, TailscaleEntityFact>,
+    relations: &mut BTreeMap<(String, String, String), TailscaleRelationFact>,
+) {
+    for tag in list(record.attributes.get("tags")) {
+        let tag_urn = urn(&record.tenant_id, "tailscale_tag", tag);
+        add_entity(entities, &tag_urn, "tailscale.tag", tag, BTreeMap::new());
+        add_relation(record, relations, service, "tagged_as", &tag_urn, None);
+    }
+}
+
+fn project_grant(
+    record: &TailscaleRecord,
+    grant: &str,
+    entities: &mut BTreeMap<String, TailscaleEntityFact>,
+    relations: &mut BTreeMap<(String, String, String), TailscaleRelationFact>,
+) {
+    let disabled = truthy(record.attributes.get("disabled"));
+    for source in list(record.attributes.get("sources")) {
+        let (kind, entity_type) = principal_kind(source);
+        let source_urn = urn(&record.tenant_id, kind, source);
+        add_entity(entities, &source_urn, entity_type, source, BTreeMap::new());
+        add_relation(
+            record,
+            relations,
+            grant,
+            "grants_entitlement",
+            &source_urn,
+            disabled.then_some("tailscale_grant_disabled"),
+        );
+    }
+    for destination in list(record.attributes.get("destinations")) {
+        let destination_urn = urn(&record.tenant_id, "tailscale_destination", destination);
+        add_entity(
+            entities,
+            &destination_urn,
+            "tailscale.destination",
+            destination,
+            BTreeMap::new(),
+        );
+        add_relation(
+            record,
+            relations,
+            grant,
+            "can_reach",
+            &destination_urn,
+            disabled.then_some("tailscale_grant_disabled"),
+        );
+    }
+}
+
+fn add_entity(
+    entities: &mut BTreeMap<String, TailscaleEntityFact>,
+    urn: &str,
+    entity_type: &str,
+    label: &str,
+    attributes: BTreeMap<String, String>,
+) {
+    entities
+        .entry(urn.to_owned())
+        .and_modify(|entity| entity.attributes.extend(attributes.clone()))
+        .or_insert_with(|| TailscaleEntityFact {
+            urn: urn.to_owned(),
+            entity_type: entity_type.to_owned(),
+            label: label.to_owned(),
+            attributes,
+        });
+}
+
+fn add_relation(
+    record: &TailscaleRecord,
+    relations: &mut BTreeMap<(String, String, String), TailscaleRelationFact>,
+    from: &str,
+    relation: &str,
+    to: &str,
+    retraction: Option<&str>,
+) {
+    let mut attributes = BTreeMap::from([
+        ("event_id".to_owned(), record.event_id.clone()),
+        ("at".to_owned(), record.occurred_at.clone()),
+    ]);
+    if let Some(retraction) = retraction {
+        attributes.insert("retraction".to_owned(), retraction.to_owned());
+    }
+    let key = (from.to_owned(), relation.to_owned(), to.to_owned());
+    relations.insert(
+        key,
+        TailscaleRelationFact {
+            from: from.to_owned(),
+            relation: relation.to_owned(),
+            to: to.to_owned(),
+            attributes,
+        },
+    );
+}
+
+fn first<'a>(record: &'a TailscaleRecord, keys: &[&str]) -> Option<&'a str> {
+    keys.iter().find_map(|key| {
+        record
+            .attributes
+            .get(*key)
+            .map(String::as_str)
+            .filter(|value| !value.trim().is_empty())
+    })
+}
+
+fn list(value: Option<&String>) -> Vec<&str> {
+    let mut seen = BTreeSet::new();
+    value
+        .into_iter()
+        .flat_map(|value| value.split(','))
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && seen.insert((*value).to_owned()))
+        .collect()
+}
+
+fn principal_kind(value: &str) -> (&'static str, &'static str) {
+    if value.starts_with("group:") {
+        ("tailscale_group", "tailscale.group")
+    } else if value.starts_with("tag:") {
+        ("tailscale_tag", "tailscale.tag")
+    } else {
+        ("tailscale_user", "tailscale.user")
+    }
+}
+
+fn truthy(value: Option<&String>) -> bool {
+    value.is_some_and(|value| value.eq_ignore_ascii_case("true"))
+}
+
+fn urn(tenant: &str, kind: &str, id: &str) -> String {
+    format!("urn:cerebro:{tenant}:{kind}:{}", id.trim())
+}

--- a/crates/source-runtime-next/src/tailscale/request.rs
+++ b/crates/source-runtime-next/src/tailscale/request.rs
@@ -1,0 +1,153 @@
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    TailscaleError, TailscaleFamily, TailscaleKernel, TailscaleRequest,
+    origin::{bounded, validate_origin},
+};
+
+pub(super) const MAX_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
+const MAX_CURSOR_BYTES: usize = 4_096;
+const MAX_PAGE_SIZE: usize = 500;
+
+impl TailscaleRequest {
+    /// HTTP method.
+    pub const fn method(&self) -> &'static str {
+        "GET"
+    }
+
+    /// Exact origin-restricted URL.
+    pub fn url(&self) -> &reqwest::Url {
+        &self.url
+    }
+
+    /// Family owning the request.
+    pub const fn family(&self) -> TailscaleFamily {
+        self.family
+    }
+
+    /// Optional continuation included in the request.
+    pub fn cursor(&self) -> Option<&str> {
+        self.cursor.as_deref()
+    }
+
+    /// Header populated by the trusted host.
+    pub const fn authorization_header(&self) -> &'static str {
+        "Authorization"
+    }
+
+    /// Provider authentication scheme applied outside this kernel.
+    pub const fn authorization_scheme(&self) -> &'static str {
+        "Bearer"
+    }
+
+    /// Portable request plans never contain credential bytes or references.
+    pub const fn contains_credentials(&self) -> bool {
+        false
+    }
+
+    /// Redirects are disabled by the trusted host.
+    pub const fn allows_redirects(&self) -> bool {
+        false
+    }
+
+    /// Host response byte limit.
+    pub const fn max_response_bytes(&self) -> usize {
+        MAX_RESPONSE_BYTES
+    }
+
+    /// Provider permission required for this read-only operation.
+    pub const fn required_scope(&self) -> &'static str {
+        "Tailscale tailnet read access"
+    }
+}
+
+impl TailscaleKernel {
+    /// Construct a closed credential-free provider kernel.
+    pub fn new(
+        base_url: &str,
+        tenant_id: &str,
+        tailnet: &str,
+        family: TailscaleFamily,
+        page_size: Option<usize>,
+        observed_at: &str,
+    ) -> Result<Self, TailscaleError> {
+        let base_url = validate_origin(base_url)?;
+        let tenant_id = bounded(tenant_id, 128).ok_or(TailscaleError::InvalidTenantId)?;
+        let tailnet =
+            bounded(tailnet, 256).ok_or(TailscaleError::MissingConfiguration("tailnet"))?;
+        if tailnet.contains(['/', '?', '#']) {
+            return Err(TailscaleError::InvalidConfiguration("tailnet"));
+        }
+        let page_size = page_size.unwrap_or(100);
+        if !(1..=MAX_PAGE_SIZE).contains(&page_size) {
+            return Err(TailscaleError::InvalidConfiguration("page_size"));
+        }
+        OffsetDateTime::parse(observed_at, &Rfc3339)
+            .map_err(|_| TailscaleError::InvalidConfiguration("observed_at"))?;
+        Ok(Self {
+            base_url,
+            tenant_id,
+            tailnet,
+            family,
+            page_size,
+            observed_at: observed_at.to_owned(),
+        })
+    }
+
+    /// Kernel protocol never accepts credential material.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+
+    /// Plan one bounded, origin-restricted request.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<TailscaleRequest, TailscaleError> {
+        let cursor = cursor.map(validate_cursor).transpose()?;
+        let mut url = self.base_url.clone();
+        let path = format!(
+            "{}{}",
+            self.base_url.path().trim_end_matches('/'),
+            self.family.path()
+        );
+        url.set_path(&path);
+        {
+            let mut query = url.query_pairs_mut();
+            query.append_pair("limit", &self.page_size.to_string());
+            query.append_pair("per_page", &self.page_size.to_string());
+            if let Some(cursor) = &cursor {
+                query.append_pair("cursor", cursor);
+            }
+        }
+        if url.origin() != self.base_url.origin() {
+            return Err(TailscaleError::InvalidOrigin);
+        }
+        Ok(TailscaleRequest {
+            family: self.family,
+            url,
+            cursor,
+            page_size: self.page_size,
+        })
+    }
+
+    pub(super) fn validate_request(
+        &self,
+        request: &TailscaleRequest,
+    ) -> Result<(), TailscaleError> {
+        if request != &self.plan(request.cursor.as_deref())? {
+            return Err(TailscaleError::RequestScopeMismatch);
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn validate_cursor(value: &str) -> Result<String, TailscaleError> {
+    let value = value.trim();
+    if value.is_empty()
+        || value.len() > MAX_CURSOR_BYTES
+        || value.chars().any(char::is_control)
+        || value.starts_with("http://")
+        || value.starts_with("https://")
+    {
+        return Err(TailscaleError::InvalidCursor);
+    }
+    Ok(value.to_owned())
+}

--- a/crates/source-runtime-next/src/tailscale/response.rs
+++ b/crates/source-runtime-next/src/tailscale/response.rs
@@ -1,0 +1,129 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    TailscaleCheckpointCandidate, TailscaleError, TailscaleKernel, TailscalePage, TailscaleRequest,
+    TailscaleResponseMetadata,
+    normalize::{canonical_bytes, normalize, records},
+    request::{MAX_RESPONSE_BYTES, validate_cursor},
+};
+
+impl TailscaleKernel {
+    /// Classify one status and normalize a bounded provider response.
+    pub fn decode_http(
+        &self,
+        request: &TailscaleRequest,
+        status: u16,
+        metadata: &TailscaleResponseMetadata,
+        body: &[u8],
+    ) -> Result<TailscalePage, TailscaleError> {
+        self.validate_request(request)?;
+        classify_status(status, metadata.retry_after_seconds)?;
+        if body.len() > MAX_RESPONSE_BYTES {
+            return Err(TailscaleError::ResponseTooLarge);
+        }
+        let root: Value =
+            serde_json::from_slice(body).map_err(|_| TailscaleError::MalformedResponse)?;
+        let raw_records = records(self.family, &root, &self.tailnet)?;
+        if raw_records.len() > request.page_size {
+            return Err(TailscaleError::TooManyRecords);
+        }
+        let mut seen = BTreeMap::<String, Vec<u8>>::new();
+        let mut normalized = Vec::with_capacity(raw_records.len());
+        for raw in raw_records {
+            let record = normalize(self, raw)?;
+            let canonical = canonical_bytes(&record.payload)?;
+            match seen.get(&record.event_id) {
+                Some(previous) if previous == &canonical => continue,
+                Some(_) => return Err(TailscaleError::ConflictingDuplicate),
+                None => {
+                    seen.insert(record.event_id.clone(), canonical);
+                    normalized.push(record);
+                }
+            }
+        }
+        let next_cursor = next_cursor(request, metadata, &root)?;
+        Ok(TailscalePage {
+            records: normalized,
+            next_cursor,
+        })
+    }
+
+    /// Validate a checkpoint proposal for persistence after append and projection.
+    pub fn checkpoint_candidate(
+        &self,
+        request: &TailscaleRequest,
+        page: &TailscalePage,
+        prior_watermark: Option<&str>,
+    ) -> Result<TailscaleCheckpointCandidate, TailscaleError> {
+        self.validate_request(request)?;
+        if page
+            .records
+            .iter()
+            .any(|record| record.tenant_id != self.tenant_id || record.family != self.family)
+        {
+            return Err(TailscaleError::TenantMismatch);
+        }
+        if let Some(cursor) = &page.next_cursor {
+            self.plan(Some(cursor))?;
+        }
+        let prior = prior_watermark.map(valid_time).transpose()?;
+        let watermark = page
+            .records
+            .iter()
+            .map(|record| record.occurred_at.clone())
+            .chain(prior)
+            .max();
+        Ok(TailscaleCheckpointCandidate {
+            tenant_id: self.tenant_id.clone(),
+            family: self.family,
+            cursor: page.next_cursor.clone(),
+            watermark,
+        })
+    }
+}
+
+fn next_cursor(
+    request: &TailscaleRequest,
+    metadata: &TailscaleResponseMetadata,
+    root: &Value,
+) -> Result<Option<String>, TailscaleError> {
+    let body_cursor = ["nextCursor", "next_cursor", "cursor", "next"]
+        .into_iter()
+        .find_map(|key| root.get(key).and_then(Value::as_str));
+    let next = metadata
+        .next_cursor
+        .as_deref()
+        .or(body_cursor)
+        .map(validate_cursor)
+        .transpose()?;
+    if next.is_some() && next == request.cursor {
+        return Err(TailscaleError::InvalidCursor);
+    }
+    Ok(next)
+}
+
+fn classify_status(status: u16, retry_after_seconds: Option<u64>) -> Result<(), TailscaleError> {
+    if retry_after_seconds.is_some_and(|seconds| seconds > 3_600) {
+        return Err(TailscaleError::InvalidRetryAfter);
+    }
+    match status {
+        200..=299 => Ok(()),
+        401 => Err(TailscaleError::AuthenticationRejected),
+        403 => Err(TailscaleError::RequiredScopeMissing),
+        429 => Err(TailscaleError::RateLimited {
+            retry_after_seconds,
+        }),
+        500..=599 => Err(TailscaleError::ProviderUnavailable { status }),
+        _ => Err(TailscaleError::UnexpectedStatus { status }),
+    }
+}
+
+fn valid_time(value: &str) -> Result<String, TailscaleError> {
+    let time = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| TailscaleError::InvalidProviderRecord)?;
+    time.format(&Rfc3339)
+        .map_err(|_| TailscaleError::InvalidProviderRecord)
+}

--- a/crates/source-runtime-next/src/tailscale/tests.rs
+++ b/crates/source-runtime-next/src/tailscale/tests.rs
@@ -1,0 +1,421 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::*;
+
+const ORIGIN: &str = "https://api.tailscale.com/api/v2";
+const OBSERVED_AT: &str = "2026-06-01T00:00:00Z";
+const CATALOG: &[u8] = include_bytes!("../../../../sources/tailscale/catalog.yaml");
+
+#[derive(Deserialize)]
+struct CatalogWire {
+    runtime_families: Vec<String>,
+    provider_api: ProviderApiWire,
+    event_contracts: Vec<EventContractWire>,
+}
+
+#[derive(Deserialize)]
+struct ProviderApiWire {
+    auth: String,
+    base_url: String,
+    families: Vec<ProviderFamilyWire>,
+}
+
+#[derive(Deserialize)]
+struct ProviderFamilyWire {
+    id: String,
+    method: String,
+    path: String,
+}
+
+#[derive(Deserialize)]
+struct EventContractWire {
+    kind: String,
+    schema_ref: String,
+    required_attributes: Vec<String>,
+    required_payload_fields: Vec<String>,
+}
+
+fn kernel(family: TailscaleFamily, page_size: usize) -> TailscaleKernel {
+    TailscaleKernel::new(
+        ORIGIN,
+        "tenant",
+        "writer.com",
+        family,
+        Some(page_size),
+        OBSERVED_AT,
+    )
+    .expect("valid kernel")
+}
+
+#[test]
+fn closed_runtime_definition_matches_provider_catalog_exactly() {
+    let catalog: CatalogWire = serde_saphyr::from_slice(CATALOG).expect("Tailscale catalog YAML");
+    let runtime = TailscaleFamily::ALL
+        .into_iter()
+        .map(|family| TailscaleRuntimeDefinition::compile(family).expect("compiled family"))
+        .collect::<Vec<_>>();
+    let expected_families = catalog
+        .runtime_families
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        runtime
+            .iter()
+            .map(|definition| definition.family.as_str().to_owned())
+            .collect::<BTreeSet<_>>(),
+        expected_families
+    );
+    assert_eq!(catalog.provider_api.auth, "bearer_token");
+    assert_eq!(catalog.provider_api.base_url, ORIGIN);
+    for definition in runtime {
+        let provider = catalog
+            .provider_api
+            .families
+            .iter()
+            .find(|family| family.id == definition.family.as_str())
+            .expect("provider family");
+        assert_eq!(provider.method, definition.method);
+        assert_eq!(provider.path.replace("{tailnet}", "-"), definition.path);
+        let contract = catalog
+            .event_contracts
+            .iter()
+            .find(|contract| contract.kind == definition.contract.kind)
+            .expect("event contract");
+        assert_eq!(contract.schema_ref, definition.contract.schema_ref);
+        assert_eq!(
+            contract.required_attributes,
+            definition.contract.required_attributes
+        );
+        assert_eq!(
+            contract.required_payload_fields,
+            definition.contract.required_payload_fields
+        );
+    }
+}
+
+#[test]
+fn plans_all_families_without_credentials_or_redirects() {
+    for family in TailscaleFamily::ALL {
+        let request = kernel(family, 100).plan(None).expect("request");
+        assert_eq!(request.method(), "GET");
+        assert_eq!(request.family(), family);
+        assert_eq!(
+            request.url().origin().ascii_serialization(),
+            "https://api.tailscale.com"
+        );
+        assert_eq!(request.url().path(), format!("/api/v2{}", family.path()));
+        assert_eq!(request.authorization_header(), "Authorization");
+        assert_eq!(request.authorization_scheme(), "Bearer");
+        assert_eq!(request.required_scope(), "Tailscale tailnet read access");
+        assert!(!request.contains_credentials());
+        assert!(!request.allows_redirects());
+        assert_eq!(request.max_response_bytes(), 4 * 1024 * 1024);
+        let debug = format!("{request:?}");
+        assert!(!debug.contains("test-token-secret"));
+        assert!(!debug.contains("credential_reference"));
+    }
+    assert!(!TailscaleKernel::requires_credentials());
+}
+
+#[test]
+fn checked_in_provider_fixtures_match_go_oracle_semantics() {
+    for family in TailscaleFamily::ALL {
+        let fixture = fixture(family);
+        let oracle = oracle(family);
+        let request = kernel(family, 100).plan(None).unwrap();
+        let page = kernel(family, 100)
+            .decode_http(
+                &request,
+                200,
+                &TailscaleResponseMetadata::default(),
+                fixture.as_bytes(),
+            )
+            .unwrap();
+        assert_eq!(page.records.len(), oracle.len(), "{family}");
+        for (record, expected) in page.records.iter().zip(oracle) {
+            assert_eq!(record.kind, expected["kind"]);
+            assert_eq!(record.schema_ref, expected["schema_ref"]);
+            assert_eq!(record.tenant_id, expected["tenant_id"]);
+            assert_eq!(record.payload, expected["payload"]);
+            assert_eq!(record.occurred_at, expected["occurred_at"]);
+            for (key, value) in expected["attributes"].as_object().unwrap() {
+                // Fixture display labels for ACL map keys are editorial labels;
+                // live Go normalization derives the provider key as the name.
+                if key == "resource_name"
+                    && matches!(family, TailscaleFamily::Group | TailscaleFamily::Tag)
+                {
+                    continue;
+                }
+                assert_eq!(
+                    record.attributes.get(key).map(String::as_str),
+                    value.as_str(),
+                    "{family}:{key}"
+                );
+            }
+            assert!(record.event_id.starts_with("tailscale-tenant-"));
+        }
+    }
+}
+
+#[test]
+fn cursor_checkpoint_and_restart_are_bounded_and_round_trippable() {
+    let kernel = kernel(TailscaleFamily::User, 2);
+    let first_request = kernel.plan(None).unwrap();
+    let first = kernel
+        .decode_http(
+            &first_request,
+            200,
+            &TailscaleResponseMetadata {
+                next_cursor: Some("page-2".to_owned()),
+                retry_after_seconds: None,
+            },
+            br#"{"users":[{"id":"user-1","loginName":"a@example.test"}]}"#,
+        )
+        .unwrap();
+    assert_eq!(first.next_cursor.as_deref(), Some("page-2"));
+    let checkpoint = kernel
+        .checkpoint_candidate(&first_request, &first, None)
+        .unwrap();
+    assert_eq!(checkpoint.cursor.as_deref(), Some("page-2"));
+    assert_eq!(checkpoint.watermark.as_deref(), Some(OBSERVED_AT));
+    let resumed = kernel.plan(checkpoint.cursor.as_deref()).unwrap();
+    assert_eq!(resumed.cursor(), Some("page-2"));
+    assert_eq!(
+        resumed
+            .url()
+            .query_pairs()
+            .find(|(key, _)| key == "cursor")
+            .map(|(_, value)| value.into_owned()),
+        Some("page-2".to_owned())
+    );
+    assert_eq!(
+        kernel.decode_http(
+            &resumed,
+            200,
+            &TailscaleResponseMetadata {
+                next_cursor: Some("page-2".to_owned()),
+                retry_after_seconds: None,
+            },
+            br#"{"users":[]}"#,
+        ),
+        Err(TailscaleError::InvalidCursor)
+    );
+}
+
+#[test]
+fn rejects_secret_tenant_duplicate_origin_cursor_and_provider_failures() {
+    assert!(matches!(
+        TailscaleKernel::new(
+            "https://127.0.0.1/api/v2",
+            "tenant",
+            "writer.com",
+            TailscaleFamily::User,
+            None,
+            OBSERVED_AT,
+        ),
+        Err(TailscaleError::InvalidBaseUrl)
+    ));
+    let kernel = kernel(TailscaleFamily::User, 100);
+    let request = kernel.plan(None).unwrap();
+    assert_eq!(
+        kernel.decode_http(
+            &request,
+            200,
+            &TailscaleResponseMetadata::default(),
+            br#"{"users":[{"id":"user-1","loginName":"a@example.test","tenant_id":"attacker"}]}"#,
+        ),
+        Err(TailscaleError::TenantMismatch)
+    );
+    assert_eq!(
+        kernel.decode_http(
+            &request,
+            200,
+            &TailscaleResponseMetadata::default(),
+            br#"{"users":[{"id":"user-1","loginName":"a@example.test","access_token":"secret-sentinel"}]}"#,
+        ),
+        Err(TailscaleError::CredentialMaterial)
+    );
+    assert_eq!(
+        kernel.decode_http(
+            &request,
+            200,
+            &TailscaleResponseMetadata::default(),
+            br#"{"users":[{"id":"user-1","loginName":"a@example.test"},{"id":"user-1","loginName":"b@example.test"}]}"#,
+        ),
+        Err(TailscaleError::ConflictingDuplicate)
+    );
+    assert_eq!(
+        kernel.plan(Some("https://evil.example/page")),
+        Err(TailscaleError::InvalidCursor)
+    );
+    assert_eq!(
+        kernel.decode_http(
+            &request,
+            401,
+            &TailscaleResponseMetadata::default(),
+            b"secret response body",
+        ),
+        Err(TailscaleError::AuthenticationRejected)
+    );
+    assert_eq!(
+        kernel.decode_http(
+            &request,
+            403,
+            &TailscaleResponseMetadata::default(),
+            b"scope body",
+        ),
+        Err(TailscaleError::RequiredScopeMissing)
+    );
+    assert_eq!(
+        kernel.decode_http(
+            &request,
+            429,
+            &TailscaleResponseMetadata {
+                next_cursor: None,
+                retry_after_seconds: Some(30),
+            },
+            b"rate body",
+        ),
+        Err(TailscaleError::RateLimited {
+            retry_after_seconds: Some(30)
+        })
+    );
+    for error in [
+        TailscaleError::CredentialUnavailable,
+        TailscaleError::DnsFailure,
+        TailscaleError::ConnectionFailure,
+        TailscaleError::ProviderTimeout,
+        TailscaleError::AppendFailure,
+        TailscaleError::ProjectionFailure,
+        TailscaleError::LeaseLoss,
+        TailscaleError::StaleAuthority,
+    ] {
+        let diagnostic = format!("{error}: {}", error.operator_action());
+        assert!(!diagnostic.contains("secret-sentinel"));
+        assert!(!diagnostic.contains("response body"));
+    }
+}
+
+#[test]
+fn projection_preserves_network_identity_and_acl_semantics() {
+    let mut records = Vec::new();
+    for family in TailscaleFamily::ALL {
+        let request = kernel(family, 100).plan(None).unwrap();
+        let page = kernel(family, 100)
+            .decode_http(
+                &request,
+                200,
+                &TailscaleResponseMetadata::default(),
+                fixture(family).as_bytes(),
+            )
+            .unwrap();
+        records.extend(page.records);
+    }
+    let facts = project_tailscale_records(&records).unwrap();
+    let entities = facts
+        .entities
+        .iter()
+        .map(|entity| entity.urn.as_str())
+        .collect::<BTreeSet<_>>();
+    for expected in [
+        "urn:cerebro:tenant:tailscale_user:user-1",
+        "urn:cerebro:tenant:tailscale_device:device-1",
+        "urn:cerebro:tenant:tailscale_group:group:eng",
+        "urn:cerebro:tenant:tailscale_tag:tag:prod",
+        "urn:cerebro:tenant:tailscale_service:svc:api",
+        "urn:cerebro:tenant:tailscale_grant:grant-1",
+    ] {
+        assert!(entities.contains(expected), "missing {expected}");
+    }
+    let relations = facts
+        .relations
+        .iter()
+        .map(|relation| {
+            (
+                relation.from.as_str(),
+                relation.relation.as_str(),
+                relation.to.as_str(),
+            )
+        })
+        .collect::<BTreeSet<_>>();
+    for expected in [
+        (
+            "urn:cerebro:tenant:tailscale_device:device-1",
+            "owned_by",
+            "urn:cerebro:tenant:tailscale_user:alice@writer.com",
+        ),
+        (
+            "urn:cerebro:tenant:tailscale_group:group:eng",
+            "contains",
+            "urn:cerebro:tenant:tailscale_user:alice@writer.com",
+        ),
+        (
+            "urn:cerebro:tenant:tailscale_tag:tag:prod",
+            "owned_by",
+            "urn:cerebro:tenant:tailscale_group:group:eng",
+        ),
+        (
+            "urn:cerebro:tenant:tailscale_grant:grant-1",
+            "can_reach",
+            "urn:cerebro:tenant:tailscale_destination:tag:prod:443",
+        ),
+    ] {
+        assert!(relations.contains(&expected), "missing {expected:?}");
+    }
+}
+
+fn fixture(family: TailscaleFamily) -> String {
+    let oracle = oracle(family);
+    let payloads = oracle
+        .iter()
+        .map(|event| event["payload"].clone())
+        .collect::<Vec<_>>();
+    let value = match family {
+        TailscaleFamily::Tailnet => payloads[0].clone(),
+        TailscaleFamily::User => serde_json::json!({"users": payloads}),
+        TailscaleFamily::Device => serde_json::json!({"devices": payloads}),
+        TailscaleFamily::Service => serde_json::json!({"vipServices": payloads}),
+        TailscaleFamily::Grant => serde_json::json!({"grants": payloads}),
+        TailscaleFamily::Group => serde_json::json!({
+            "groups": payloads.into_iter().map(|payload| {
+                (payload["id"].as_str().unwrap().to_owned(), payload["members"].clone())
+            }).collect::<BTreeMap<_, _>>()
+        }),
+        TailscaleFamily::Tag => serde_json::json!({
+            "tagOwners": payloads.into_iter().map(|payload| {
+                (payload["id"].as_str().unwrap().to_owned(), payload["owners"].clone())
+            }).collect::<BTreeMap<_, _>>()
+        }),
+    };
+    serde_json::to_string(&value).unwrap()
+}
+
+fn oracle(family: TailscaleFamily) -> Vec<Value> {
+    let bytes: &[u8] = match family {
+        TailscaleFamily::Tailnet => {
+            include_bytes!("../../../../sources/tailscale/testdata/read_tailnet.json")
+        }
+        TailscaleFamily::User => {
+            include_bytes!("../../../../sources/tailscale/testdata/read_user.json")
+        }
+        TailscaleFamily::Device => {
+            include_bytes!("../../../../sources/tailscale/testdata/read_device.json")
+        }
+        TailscaleFamily::Group => {
+            include_bytes!("../../../../sources/tailscale/testdata/read_group.json")
+        }
+        TailscaleFamily::Tag => {
+            include_bytes!("../../../../sources/tailscale/testdata/read_tag.json")
+        }
+        TailscaleFamily::Service => {
+            include_bytes!("../../../../sources/tailscale/testdata/read_service.json")
+        }
+        TailscaleFamily::Grant => {
+            include_bytes!("../../../../sources/tailscale/testdata/read_grant.json")
+        }
+    };
+    serde_json::from_slice(bytes).expect("Go fixture oracle")
+}

--- a/crates/source-runtime-next/src/tailscale/types.rs
+++ b/crates/source-runtime-next/src/tailscale/types.rs
@@ -1,0 +1,77 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use super::TailscaleFamily;
+
+/// One credential-free Tailscale request plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TailscaleRequest {
+    pub(super) family: TailscaleFamily,
+    pub(super) url: reqwest::Url,
+    pub(super) cursor: Option<String>,
+    pub(super) page_size: usize,
+}
+
+/// One normalized tenant-scoped Tailscale event candidate.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TailscaleRecord {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Provider family.
+    pub family: TailscaleFamily,
+    /// Stable tenant-, request-, family-, and provider-scoped identity.
+    pub event_id: String,
+    /// Exact event kind.
+    pub kind: String,
+    /// Exact schema reference.
+    pub schema_ref: String,
+    /// Normalized observation time.
+    pub occurred_at: String,
+    /// Canonical Go-compatible attributes.
+    pub attributes: BTreeMap<String, String>,
+    /// Canonical provider payload with no credential or tenant material.
+    pub payload: Value,
+}
+
+/// Bounded normalized response page.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TailscalePage {
+    /// Accepted records after deterministic deduplication.
+    pub records: Vec<TailscaleRecord>,
+    /// Validated continuation proposed to the durable host.
+    pub next_cursor: Option<String>,
+}
+
+/// Non-secret response metadata supplied by the trusted host.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TailscaleResponseMetadata {
+    /// Provider continuation extracted from a response header, when present.
+    pub next_cursor: Option<String>,
+    /// Parsed Retry-After seconds.
+    pub retry_after_seconds: Option<u64>,
+}
+
+/// Candidate checkpoint; the durable host persists it only after append and projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TailscaleCheckpointCandidate {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Family whose progress is advancing.
+    pub family: TailscaleFamily,
+    /// Validated continuation.
+    pub cursor: Option<String>,
+    /// Greatest accepted observation time, preserving a prior watermark.
+    pub watermark: Option<String>,
+}
+
+/// Closed Tailscale kernel for one tenant, tailnet, and family.
+#[derive(Debug, Clone)]
+pub struct TailscaleKernel {
+    pub(super) base_url: reqwest::Url,
+    pub(super) tenant_id: String,
+    pub(super) tailnet: String,
+    pub(super) family: TailscaleFamily,
+    pub(super) page_size: usize,
+    pub(super) observed_at: String,
+}


### PR DESCRIPTION
## Scope

- compile the exact seven-family Tailscale catalog contract into a closed Rust runtime definition
- plan origin-restricted bearer requests without credential bytes or references in the kernel
- normalize tailnet, user, device, ACL group, ACL tag, service, and ACL grant responses with deterministic tenant-scoped identities
- validate cursor and checkpoint proposals, exact event contracts, duplicate conflicts, provider failures, secret-shaped payloads, and tenant injection
- preserve dedicated Tailscale owner, reachability, membership, tag, service, and grant projection semantics
- keep the existing Go loader and runtime authority unchanged pending production-host and promotion evidence

## Local validation

- cargo fmt --all -- --check
- cargo test -p cerebro-source-runtime-next tailscale --lib (6 passed)
- cargo clippy -p cerebro-source-runtime-next --lib --tests -- -D warnings
- cargo test -p cerebro-source-runtime-next --lib (501 passed)
- cargo llvm-cov -p cerebro-source-runtime-next --lib --summary-only (89.57% crate line coverage)
- go test ./sources/tailscale ./internal/sourceprojection
- make fixture-oracle-check
- go run ./tools/sourcefixture verify -root . (138 bundles, 34 sources, 126 families)
- make sourcegen-test
- make catalog-check
- make check-structural check-structural-test check-arch
- cargo test -p cerebro-source-catalog --lib (23 passed)
- RUSTDOCFLAGS=-D warnings cargo doc -p cerebro-source-runtime-next --no-deps
- ./scripts/leak_check.sh range origin/main...HEAD

Local gitleaks was not run because the binary is unavailable; hosted Secret Scan is required. No live Tailscale credential, collection, deployment, promotion, or product-path claim is made.