### PR TITLE
Add credential-free AbuseIPDB Rust kernel

### DIFF
--- a/crates/source-runtime-next/src/abuseipdb.rs
+++ b/crates/source-runtime-next/src/abuseipdb.rs
@@ -1,0 +1,31 @@
+//! Credential-free AbuseIPDB request, normalization, and projection kernel.
+//!
+//! The trusted host owns credential-reference resolution, `Key` header
+//! authentication, redirects, deadlines, and bounded network I/O. This module
+//! accepts authenticated tenant context, public filters, and bounded provider
+//! response bytes only. The existing generic Rust catalog runtime remains the
+//! collection authority until this kernel is integrated through the shared host.
+
+mod catalog;
+mod error;
+mod family;
+mod normalize;
+mod origin;
+mod projection;
+mod request;
+mod response;
+mod types;
+
+pub use catalog::{AbuseIpDbEventContract, AbuseIpDbRuntimeDefinition};
+pub use error::AbuseIpDbError;
+pub use family::AbuseIpDbFamily;
+pub use projection::{
+    AbuseIpDbEntityFact, AbuseIpDbProjectionFacts, AbuseIpDbRelationFact, project_abuseipdb_records,
+};
+pub use types::{
+    AbuseIpDbCheckpointCandidate, AbuseIpDbFilters, AbuseIpDbKernel, AbuseIpDbPage,
+    AbuseIpDbRecord, AbuseIpDbRequest,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/abuseipdb/catalog.rs
+++ b/crates/source-runtime-next/src/abuseipdb/catalog.rs
@@ -1,0 +1,66 @@
+use super::{AbuseIpDbError, AbuseIpDbFamily};
+
+/// One exact event contract compiled from the AbuseIPDB catalog.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AbuseIpDbEventContract {
+    /// Exact provider event kind.
+    pub kind: &'static str,
+    /// Exact schema reference.
+    pub schema_ref: &'static str,
+    /// Required normalized attributes.
+    pub required_attributes: &'static [&'static str],
+    /// Required normalized payload fields.
+    pub required_payload_fields: &'static [&'static str],
+}
+
+/// Closed runtime definition for one AbuseIPDB family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AbuseIpDbRuntimeDefinition {
+    /// Source identifier.
+    pub source_id: &'static str,
+    /// Selected family.
+    pub family: AbuseIpDbFamily,
+    /// Exact event contract.
+    pub event_contract: AbuseIpDbEventContract,
+    /// Both families are bounded pull operations.
+    pub pull: bool,
+}
+
+impl AbuseIpDbRuntimeDefinition {
+    /// Compile one declared catalog family into a closed definition.
+    pub fn compile(family: AbuseIpDbFamily) -> Result<Self, AbuseIpDbError> {
+        let event_contract = match family {
+            AbuseIpDbFamily::Reports => AbuseIpDbEventContract {
+                kind: family.event_kind(),
+                schema_ref: family.schema_ref(),
+                required_attributes: &[
+                    "tenant_id",
+                    "source_event_id",
+                    "finding_id",
+                    "resource_urn",
+                    "severity",
+                    "status",
+                ],
+                required_payload_fields: &["reportedAt", "reporterId"],
+            },
+            AbuseIpDbFamily::IpAddresses => AbuseIpDbEventContract {
+                kind: family.event_kind(),
+                schema_ref: family.schema_ref(),
+                required_attributes: &[
+                    "tenant_id",
+                    "source_event_id",
+                    "resource_urn",
+                    "resource_type",
+                    "resource_id",
+                ],
+                required_payload_fields: &["ipAddress"],
+            },
+        };
+        Ok(Self {
+            source_id: "abuseipdb",
+            family,
+            event_contract,
+            pull: true,
+        })
+    }
+}

--- a/crates/source-runtime-next/src/abuseipdb/error.rs
+++ b/crates/source-runtime-next/src/abuseipdb/error.rs
@@ -1,0 +1,170 @@
+use std::{error::Error, fmt};
+
+/// Bounded AbuseIPDB provider and runtime failure taxonomy.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AbuseIpDbError {
+    /// Family is outside the closed catalog.
+    InvalidFamily,
+    /// Required public configuration is missing.
+    MissingConfiguration(&'static str),
+    /// Public configuration is malformed.
+    InvalidConfiguration(&'static str),
+    /// Provider origin is not the exact HTTPS AbuseIPDB API root.
+    InvalidOrigin,
+    /// Authenticated tenant context is malformed.
+    InvalidTenantId,
+    /// Trusted host has no credential reference.
+    MissingCredentialReference,
+    /// Trusted host could not redeem the credential lease.
+    CredentialUnavailable,
+    /// Durable cursor is invalid or cannot round-trip.
+    InvalidCursor,
+    /// Request does not belong to this kernel.
+    RequestScopeMismatch,
+    /// Provider rejected authentication.
+    AuthenticationRejected,
+    /// Credential lacks the required provider permission.
+    RequiredScopeMissing,
+    /// Requested provider resource was not found.
+    ProviderResourceNotFound,
+    /// Trusted host denied provider egress.
+    EgressDenied,
+    /// Provider DNS lookup failed.
+    DnsFailure,
+    /// Provider connection failed.
+    ConnectionFailure,
+    /// Provider operation timed out.
+    ProviderTimeout,
+    /// Provider requested a bounded retry.
+    RateLimited {
+        /// Provider-declared retry delay, when present and bounded.
+        retry_after_seconds: Option<u64>,
+    },
+    /// Provider returned a retryable server failure.
+    ProviderUnavailable {
+        /// Provider HTTP status.
+        status: u16,
+    },
+    /// Provider returned an unexpected status.
+    UnexpectedStatus {
+        /// Provider HTTP status.
+        status: u16,
+    },
+    /// Retry delay is outside the persistence bound.
+    InvalidRetryAfter,
+    /// Response exceeds the host-declared byte bound.
+    ResponseTooLarge,
+    /// Response exceeds the selected family record bound.
+    TooManyRecords,
+    /// Response JSON does not match the selected family.
+    MalformedResponse,
+    /// Provider record violates the family shape.
+    InvalidProviderRecord,
+    /// Provider record has no stable identity.
+    MissingStableIdentity,
+    /// Provider response changed the configured IP scope.
+    ProviderIdentityMismatch,
+    /// Provider payload attempted to provide tenant context.
+    TenantMismatch,
+    /// Credential-shaped material crossed into the kernel.
+    CredentialMaterial,
+    /// Duplicate provider identity has conflicting content.
+    ConflictingDuplicate,
+    /// Normalized record failed the exact event contract.
+    EventContractRejection,
+    /// Durable append failed.
+    AppendFailure,
+    /// Projection failed.
+    ProjectionFailure,
+    /// Runtime lost its source lease.
+    LeaseLoss,
+    /// Runtime authority or generation is stale.
+    StaleAuthority,
+    /// Internal runtime failure.
+    InternalRuntimeFailure,
+}
+
+impl AbuseIpDbError {
+    /// Next safe operator action without provider content.
+    pub const fn operator_action(&self) -> &'static str {
+        match self {
+            Self::InvalidFamily
+            | Self::MissingConfiguration(_)
+            | Self::InvalidConfiguration(_)
+            | Self::InvalidOrigin
+            | Self::InvalidTenantId
+            | Self::ProviderResourceNotFound => "repair source configuration",
+            Self::MissingCredentialReference
+            | Self::CredentialUnavailable
+            | Self::AuthenticationRejected => "repair credential binding",
+            Self::RequiredScopeMissing => "grant AbuseIPDB read access",
+            Self::RateLimited { .. }
+            | Self::ProviderUnavailable { .. }
+            | Self::DnsFailure
+            | Self::ConnectionFailure
+            | Self::ProviderTimeout => "retry the collection later",
+            Self::EgressDenied => "repair trusted-host egress policy",
+            Self::InvalidCursor => "restart from the last committed checkpoint",
+            Self::MalformedResponse
+            | Self::InvalidProviderRecord
+            | Self::MissingStableIdentity
+            | Self::ProviderIdentityMismatch
+            | Self::TenantMismatch
+            | Self::CredentialMaterial
+            | Self::ConflictingDuplicate
+            | Self::EventContractRejection => "inspect quarantined provider records",
+            Self::AppendFailure | Self::ProjectionFailure => "repair the durable commit path",
+            Self::LeaseLoss | Self::StaleAuthority => "restart under the current lease",
+            Self::RequestScopeMismatch
+            | Self::InvalidRetryAfter
+            | Self::ResponseTooLarge
+            | Self::TooManyRecords
+            | Self::UnexpectedStatus { .. }
+            | Self::InternalRuntimeFailure => "repair the forward runtime implementation",
+        }
+    }
+}
+
+impl fmt::Display for AbuseIpDbError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidFamily => "abuseipdb family is invalid",
+            Self::MissingConfiguration(_) => "abuseipdb source configuration is missing",
+            Self::InvalidConfiguration(_) => "abuseipdb source configuration is invalid",
+            Self::InvalidOrigin => "abuseipdb provider origin is invalid",
+            Self::InvalidTenantId => "abuseipdb tenant ID is invalid",
+            Self::MissingCredentialReference => "abuseipdb credential reference is missing",
+            Self::CredentialUnavailable => "abuseipdb credential lease is unavailable",
+            Self::InvalidCursor => "abuseipdb cursor is invalid or not round-trippable",
+            Self::RequestScopeMismatch => "abuseipdb request does not match the kernel",
+            Self::AuthenticationRejected => "abuseipdb rejected authentication",
+            Self::RequiredScopeMissing => "abuseipdb credential lacks required scope",
+            Self::ProviderResourceNotFound => "abuseipdb resource was not found",
+            Self::EgressDenied => "abuseipdb egress was denied",
+            Self::DnsFailure => "abuseipdb DNS resolution failed",
+            Self::ConnectionFailure => "abuseipdb connection failed",
+            Self::ProviderTimeout => "abuseipdb operation timed out",
+            Self::RateLimited { .. } => "abuseipdb rate limited the operation",
+            Self::ProviderUnavailable { .. } => "abuseipdb is temporarily unavailable",
+            Self::UnexpectedStatus { .. } => "abuseipdb returned an unexpected status",
+            Self::InvalidRetryAfter => "abuseipdb retry delay exceeds its bound",
+            Self::ResponseTooLarge => "abuseipdb response exceeds its byte bound",
+            Self::TooManyRecords => "abuseipdb response exceeds its record bound",
+            Self::MalformedResponse => "abuseipdb response is malformed",
+            Self::InvalidProviderRecord => "abuseipdb provider record is invalid",
+            Self::MissingStableIdentity => "abuseipdb record has no stable identity",
+            Self::ProviderIdentityMismatch => "abuseipdb response changed request scope",
+            Self::TenantMismatch => "abuseipdb payload attempted to supply tenant context",
+            Self::CredentialMaterial => "abuseipdb payload contains credential-shaped material",
+            Self::ConflictingDuplicate => "abuseipdb duplicate identity has conflicting content",
+            Self::EventContractRejection => "abuseipdb event failed its catalog contract",
+            Self::AppendFailure => "abuseipdb append failed",
+            Self::ProjectionFailure => "abuseipdb projection failed",
+            Self::LeaseLoss => "abuseipdb runtime lost its lease",
+            Self::StaleAuthority => "abuseipdb runtime authority is stale",
+            Self::InternalRuntimeFailure => "abuseipdb runtime failed internally",
+        })
+    }
+}
+
+impl Error for AbuseIpDbError {}

--- a/crates/source-runtime-next/src/abuseipdb/family.rs
+++ b/crates/source-runtime-next/src/abuseipdb/family.rs
@@ -1,0 +1,60 @@
+use std::str::FromStr;
+
+use super::AbuseIpDbError;
+
+/// Closed AbuseIPDB source-catalog family vocabulary.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum AbuseIpDbFamily {
+    /// Paginated report history for one configured IP address.
+    Reports,
+    /// One bounded blacklist snapshot.
+    IpAddresses,
+}
+
+impl AbuseIpDbFamily {
+    /// Every provider-declared family in catalog order.
+    pub const ALL: [Self; 2] = [Self::Reports, Self::IpAddresses];
+
+    /// Exact catalog family identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Reports => "reports",
+            Self::IpAddresses => "ip_addresses",
+        }
+    }
+
+    /// Exact admitted event kind.
+    pub const fn event_kind(self) -> &'static str {
+        match self {
+            Self::Reports => "abuseipdb.reports",
+            Self::IpAddresses => "abuseipdb.ip_addresses",
+        }
+    }
+
+    /// Exact admitted event schema.
+    pub const fn schema_ref(self) -> &'static str {
+        match self {
+            Self::Reports => "abuseipdb/reports/v1",
+            Self::IpAddresses => "abuseipdb/ip_addresses/v1",
+        }
+    }
+
+    /// Provider-relative operation path.
+    pub const fn path(self) -> &'static str {
+        match self {
+            Self::Reports => "/reports",
+            Self::IpAddresses => "/blacklist",
+        }
+    }
+}
+
+impl FromStr for AbuseIpDbFamily {
+    type Err = AbuseIpDbError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|family| family.as_str() == value.trim())
+            .ok_or(AbuseIpDbError::InvalidFamily)
+    }
+}

--- a/crates/source-runtime-next/src/abuseipdb/normalize.rs
+++ b/crates/source-runtime-next/src/abuseipdb/normalize.rs
@@ -1,0 +1,369 @@
+use std::{collections::BTreeMap, net::IpAddr};
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    AbuseIpDbError, AbuseIpDbFamily, AbuseIpDbKernel, AbuseIpDbRecord, AbuseIpDbRuntimeDefinition,
+};
+
+pub(super) fn normalize(
+    kernel: &AbuseIpDbKernel,
+    raw: Value,
+) -> Result<AbuseIpDbRecord, AbuseIpDbError> {
+    reject_untrusted(&raw, 0)?;
+    let values = raw
+        .as_object()
+        .ok_or(AbuseIpDbError::InvalidProviderRecord)?;
+    let (provider_id, occurred_at, attributes, payload) = match kernel.family {
+        AbuseIpDbFamily::Reports => normalize_report(kernel, values)?,
+        AbuseIpDbFamily::IpAddresses => normalize_ip_address(kernel, values)?,
+    };
+    validate_contract(kernel.family, &attributes, &payload)?;
+    Ok(AbuseIpDbRecord {
+        tenant_id: kernel.tenant_id.clone(),
+        event_id: event_id(kernel, &provider_id),
+        provider_id,
+        family: kernel.family,
+        kind: kernel.family.event_kind().to_owned(),
+        schema_ref: kernel.family.schema_ref().to_owned(),
+        occurred_at,
+        attributes,
+        payload,
+    })
+}
+
+fn normalize_report(
+    kernel: &AbuseIpDbKernel,
+    values: &Map<String, Value>,
+) -> Result<(String, String, BTreeMap<String, String>, Value), AbuseIpDbError> {
+    let reported_at = required_time(values, "reportedAt")?;
+    let reporter_id = positive_integer(values.get("reporterId"))?;
+    let provider_id = format!("{reported_at}:{reporter_id}");
+    let configured_ip = kernel
+        .filters
+        .ip_address
+        .as_deref()
+        .ok_or(AbuseIpDbError::MissingConfiguration("ip_address"))?;
+    if let Some(provider_ip) = values.get("ipAddress").and_then(Value::as_str) {
+        let provider_ip = provider_ip
+            .trim()
+            .parse::<IpAddr>()
+            .map_err(|_| AbuseIpDbError::InvalidProviderRecord)?
+            .to_string();
+        if provider_ip != configured_ip {
+            return Err(AbuseIpDbError::ProviderIdentityMismatch);
+        }
+    }
+    let resource_urn = resource_urn(&kernel.tenant_id, configured_ip);
+    let mut attributes = common_attributes(kernel, &provider_id, "finding", "reports");
+    attributes.extend(BTreeMap::from([
+        ("finding_id".to_owned(), provider_id.clone()),
+        ("resource_id".to_owned(), configured_ip.to_owned()),
+        ("resource_name".to_owned(), configured_ip.to_owned()),
+        ("resource_type".to_owned(), "abuseipdb_report".to_owned()),
+        ("resource_urn".to_owned(), resource_urn.clone()),
+        ("severity".to_owned(), "reported".to_owned()),
+        ("status".to_owned(), "observed".to_owned()),
+    ]));
+    if let Some(comment) = nonempty_string(values.get("comment")) {
+        attributes.insert("description".to_owned(), comment.to_owned());
+        attributes.insert("title".to_owned(), comment.to_owned());
+    }
+    let mut payload = values.clone();
+    payload.insert(
+        "ipAddress".to_owned(),
+        Value::String(configured_ip.to_owned()),
+    );
+    add_payload_metadata(
+        kernel,
+        &mut payload,
+        &provider_id,
+        "finding",
+        configured_ip,
+        "abuseipdb_report",
+        &resource_urn,
+    );
+    Ok((provider_id, reported_at, attributes, Value::Object(payload)))
+}
+
+fn normalize_ip_address(
+    kernel: &AbuseIpDbKernel,
+    values: &Map<String, Value>,
+) -> Result<(String, String, BTreeMap<String, String>, Value), AbuseIpDbError> {
+    let ip = values
+        .get("ipAddress")
+        .and_then(Value::as_str)
+        .ok_or(AbuseIpDbError::MissingStableIdentity)?
+        .trim()
+        .parse::<IpAddr>()
+        .map_err(|_| AbuseIpDbError::InvalidProviderRecord)?
+        .to_string();
+    let occurred_at = values
+        .get("lastReportedAt")
+        .and_then(Value::as_str)
+        .map(normalized_time)
+        .transpose()?
+        .unwrap_or_else(|| kernel.observed_at.clone());
+    let resource_urn = resource_urn(&kernel.tenant_id, &ip);
+    let mut attributes = common_attributes(kernel, &ip, "asset", "ip_addresses");
+    attributes.extend(BTreeMap::from([
+        ("resource_id".to_owned(), ip.clone()),
+        ("resource_name".to_owned(), ip.clone()),
+        ("resource_type".to_owned(), "ip_address".to_owned()),
+        ("resource_urn".to_owned(), resource_urn.clone()),
+    ]));
+    if let Some(score) = scalar(values.get("abuseConfidenceScore")) {
+        attributes.insert("abuse_confidence_score".to_owned(), score);
+    }
+    if let Some(country) = scalar(values.get("countryCode")) {
+        attributes.insert("country_code".to_owned(), country);
+    }
+    let mut payload = values.clone();
+    payload.insert("ipAddress".to_owned(), Value::String(ip.clone()));
+    add_payload_metadata(
+        kernel,
+        &mut payload,
+        &ip,
+        "asset",
+        &ip,
+        "ip_address",
+        &resource_urn,
+    );
+    Ok((ip, occurred_at, attributes, Value::Object(payload)))
+}
+
+fn common_attributes(
+    kernel: &AbuseIpDbKernel,
+    provider_id: &str,
+    record_class: &str,
+    schema: &str,
+) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        ("api_method".to_owned(), "GET".to_owned()),
+        ("api_path".to_owned(), kernel.family.path().to_owned()),
+        ("external_id".to_owned(), provider_id.to_owned()),
+        ("family".to_owned(), kernel.family.as_str().to_owned()),
+        ("observed_at".to_owned(), kernel.observed_at.clone()),
+        ("provider".to_owned(), "abuseipdb".to_owned()),
+        ("record_class".to_owned(), record_class.to_owned()),
+        (
+            "record_selector".to_owned(),
+            match kernel.family {
+                AbuseIpDbFamily::Reports => "$.data.results[*]",
+                AbuseIpDbFamily::IpAddresses => "$.data[*]",
+            }
+            .to_owned(),
+        ),
+        ("schema".to_owned(), schema.to_owned()),
+        ("source_event_id".to_owned(), provider_id.to_owned()),
+        ("source_provider".to_owned(), "abuseipdb".to_owned()),
+        ("source_system".to_owned(), "abuseipdb".to_owned()),
+        ("tenant_id".to_owned(), kernel.tenant_id.clone()),
+    ])
+}
+
+fn add_payload_metadata(
+    kernel: &AbuseIpDbKernel,
+    payload: &mut Map<String, Value>,
+    provider_id: &str,
+    record_class: &str,
+    resource_id: &str,
+    resource_type: &str,
+    resource_urn: &str,
+) {
+    for (key, value) in [
+        ("api_method", "GET"),
+        ("api_path", kernel.family.path()),
+        ("event_id", provider_id),
+        ("family", kernel.family.as_str()),
+        ("record_class", record_class),
+        (
+            "record_selector",
+            match kernel.family {
+                AbuseIpDbFamily::Reports => "$.data.results[*]",
+                AbuseIpDbFamily::IpAddresses => "$.data[*]",
+            },
+        ),
+        ("resource_id", resource_id),
+        ("resource_type", resource_type),
+        ("resource_urn", resource_urn),
+        ("schema_ref", kernel.family.schema_ref()),
+        ("source_id", "abuseipdb"),
+        ("tenant_id", &kernel.tenant_id),
+    ] {
+        payload.insert(key.to_owned(), Value::String(value.to_owned()));
+    }
+    if kernel.family == AbuseIpDbFamily::Reports {
+        payload.insert("status".to_owned(), Value::String("observed".to_owned()));
+    }
+}
+
+fn validate_contract(
+    family: AbuseIpDbFamily,
+    attributes: &BTreeMap<String, String>,
+    payload: &Value,
+) -> Result<(), AbuseIpDbError> {
+    let definition = AbuseIpDbRuntimeDefinition::compile(family)?;
+    if definition.event_contract.kind != family.event_kind()
+        || definition.event_contract.schema_ref != family.schema_ref()
+        || definition
+            .event_contract
+            .required_attributes
+            .iter()
+            .any(|key| {
+                attributes
+                    .get(*key)
+                    .is_none_or(|value| value.trim().is_empty())
+            })
+        || definition
+            .event_contract
+            .required_payload_fields
+            .iter()
+            .any(|key| payload.get(*key).is_none_or(Value::is_null))
+    {
+        return Err(AbuseIpDbError::EventContractRejection);
+    }
+    Ok(())
+}
+
+fn event_id(kernel: &AbuseIpDbKernel, provider_id: &str) -> String {
+    let scope = Sha256::digest(format!(
+        "{}\0{}",
+        kernel.base_url.as_str(),
+        kernel.family.path()
+    ));
+    let scope = scope[..6]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!(
+        "abuseipdb-{}-{scope}-{}-{}",
+        normalize_id(&kernel.tenant_id),
+        normalize_id(kernel.family.as_str()),
+        normalize_id(provider_id)
+    )
+}
+
+fn resource_urn(tenant: &str, ip: &str) -> String {
+    format!(
+        "urn:cerebro:{}:abuseipdb_ip_address:{}",
+        encode_segment(tenant),
+        encode_segment(ip)
+    )
+}
+
+fn encode_segment(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.trim().bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}
+
+fn normalize_id(value: &str) -> String {
+    let value = value.trim();
+    if value.is_empty() {
+        return "unknown".to_owned();
+    }
+    value
+        .chars()
+        .map(|character| match character {
+            ' ' | '/' | ':' | '\t' | '\n' => '-',
+            other => other,
+        })
+        .collect()
+}
+
+fn positive_integer(value: Option<&Value>) -> Result<String, AbuseIpDbError> {
+    let value = value.ok_or(AbuseIpDbError::MissingStableIdentity)?;
+    let parsed = value
+        .as_u64()
+        .or_else(|| value.as_str()?.trim().parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .ok_or(AbuseIpDbError::MissingStableIdentity)?;
+    Ok(parsed.to_string())
+}
+
+fn required_time(values: &Map<String, Value>, key: &'static str) -> Result<String, AbuseIpDbError> {
+    let value = values
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or(AbuseIpDbError::MissingStableIdentity)?;
+    normalized_time(value)
+}
+
+fn normalized_time(value: &str) -> Result<String, AbuseIpDbError> {
+    let time = OffsetDateTime::parse(value.trim(), &Rfc3339)
+        .map_err(|_| AbuseIpDbError::InvalidProviderRecord)?;
+    time.format(&Rfc3339)
+        .map_err(|_| AbuseIpDbError::InvalidProviderRecord)
+}
+
+fn scalar(value: Option<&Value>) -> Option<String> {
+    match value? {
+        Value::String(value) => {
+            let value = value.trim();
+            (!value.is_empty()).then(|| value.to_owned())
+        }
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn nonempty_string(value: Option<&Value>) -> Option<&str> {
+    value?
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn reject_untrusted(value: &Value, depth: usize) -> Result<(), AbuseIpDbError> {
+    if depth > 16 {
+        return Err(AbuseIpDbError::InvalidProviderRecord);
+    }
+    match value {
+        Value::Object(values) => {
+            if values.len() > 256 {
+                return Err(AbuseIpDbError::InvalidProviderRecord);
+            }
+            for (key, value) in values {
+                let key = key.trim().to_ascii_lowercase().replace('-', "_");
+                if key == "tenant_id" {
+                    return Err(AbuseIpDbError::TenantMismatch);
+                }
+                if matches!(
+                    key.as_str(),
+                    "token"
+                        | "access_token"
+                        | "refresh_token"
+                        | "api_key"
+                        | "key"
+                        | "password"
+                        | "private_key"
+                        | "authorization"
+                        | "client_secret"
+                ) {
+                    return Err(AbuseIpDbError::CredentialMaterial);
+                }
+                reject_untrusted(value, depth + 1)?;
+            }
+        }
+        Value::Array(values) => {
+            if values.len() > 10_000 {
+                return Err(AbuseIpDbError::TooManyRecords);
+            }
+            for value in values {
+                reject_untrusted(value, depth + 1)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}

--- a/crates/source-runtime-next/src/abuseipdb/origin.rs
+++ b/crates/source-runtime-next/src/abuseipdb/origin.rs
@@ -1,0 +1,34 @@
+use reqwest::Url;
+
+use super::AbuseIpDbError;
+
+const HOST: &str = "api.abuseipdb.com";
+const BASE_PATH: &str = "/api/v2";
+
+pub(super) fn validate(value: &str) -> Result<Url, AbuseIpDbError> {
+    let mut url = Url::parse(value.trim().trim_end_matches('/'))
+        .map_err(|_| AbuseIpDbError::InvalidOrigin)?;
+    let host = url.host_str().unwrap_or_default().trim_end_matches('.');
+    if url.scheme() != "https"
+        || !host.eq_ignore_ascii_case(HOST)
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port_or_known_default() != Some(443)
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || url.path().trim_end_matches('/') != BASE_PATH
+    {
+        return Err(AbuseIpDbError::InvalidOrigin);
+    }
+    url.set_path(BASE_PATH);
+    Ok(url)
+}
+
+pub(super) fn tenant(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()
+        && value.len() <= 128
+        && !value.chars().any(char::is_control)
+        && !value.contains(['/', '\\', ':']))
+    .then(|| value.to_owned())
+}

--- a/crates/source-runtime-next/src/abuseipdb/projection.rs
+++ b/crates/source-runtime-next/src/abuseipdb/projection.rs
@@ -1,0 +1,106 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::{AbuseIpDbFamily, AbuseIpDbRecord};
+
+/// One deterministic tenant-scoped AbuseIPDB projection entity.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct AbuseIpDbEntityFact {
+    /// Canonical entity URN.
+    pub urn: String,
+    /// Closed entity type.
+    pub entity_type: String,
+    /// Human-readable label.
+    pub label: String,
+}
+
+/// One deterministic AbuseIPDB projection relation.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct AbuseIpDbRelationFact {
+    /// Source entity URN.
+    pub from_urn: String,
+    /// Closed semantic relation.
+    pub relation: String,
+    /// Target entity URN.
+    pub to_urn: String,
+}
+
+/// Provider-local projection facts used for Go/Rust parity.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AbuseIpDbProjectionFacts {
+    /// Deduplicated entities in canonical order.
+    pub entities: Vec<AbuseIpDbEntityFact>,
+    /// Deduplicated relations in canonical order.
+    pub relations: Vec<AbuseIpDbRelationFact>,
+}
+
+/// Project normalized AbuseIPDB records into IP assets and findings.
+pub fn project_abuseipdb_records(records: &[AbuseIpDbRecord]) -> AbuseIpDbProjectionFacts {
+    let mut entities = BTreeMap::<String, AbuseIpDbEntityFact>::new();
+    let mut relations = BTreeSet::<AbuseIpDbRelationFact>::new();
+    for record in records {
+        match record.family {
+            AbuseIpDbFamily::IpAddresses => {
+                let Some(resource_urn) = record.attributes.get("resource_urn") else {
+                    continue;
+                };
+                entities.insert(
+                    resource_urn.clone(),
+                    AbuseIpDbEntityFact {
+                        urn: resource_urn.clone(),
+                        entity_type: "runtime.ip.address".to_owned(),
+                        label: record
+                            .attributes
+                            .get("resource_name")
+                            .cloned()
+                            .unwrap_or_else(|| record.provider_id.clone()),
+                    },
+                );
+            }
+            AbuseIpDbFamily::Reports => {
+                let Some(finding_id) = record.attributes.get("finding_id") else {
+                    continue;
+                };
+                let finding_urn = format!(
+                    "urn:cerebro:{}:finding:{}",
+                    encode_segment(&record.tenant_id),
+                    encode_segment(finding_id)
+                );
+                entities.insert(
+                    finding_urn.clone(),
+                    AbuseIpDbEntityFact {
+                        urn: finding_urn.clone(),
+                        entity_type: "finding".to_owned(),
+                        label: record
+                            .attributes
+                            .get("title")
+                            .cloned()
+                            .unwrap_or_else(|| finding_id.clone()),
+                    },
+                );
+                if let Some(resource_urn) = record.attributes.get("resource_urn") {
+                    relations.insert(AbuseIpDbRelationFact {
+                        from_urn: finding_urn,
+                        relation: "affects".to_owned(),
+                        to_urn: resource_urn.clone(),
+                    });
+                }
+            }
+        }
+    }
+    AbuseIpDbProjectionFacts {
+        entities: entities.into_values().collect(),
+        relations: relations.into_iter().collect(),
+    }
+}
+
+fn encode_segment(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.trim().bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}

--- a/crates/source-runtime-next/src/abuseipdb/request.rs
+++ b/crates/source-runtime-next/src/abuseipdb/request.rs
@@ -1,0 +1,157 @@
+use std::net::IpAddr;
+
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    AbuseIpDbError, AbuseIpDbFamily, AbuseIpDbFilters, AbuseIpDbKernel, AbuseIpDbRequest, origin,
+};
+
+const MAX_PAGE: usize = 10_000;
+const REPORTS_PAGE_SIZE: usize = 100;
+const BLACKLIST_LIMIT: usize = 10_000;
+
+pub(super) fn new_kernel(
+    base_url: &str,
+    tenant_id: &str,
+    family: AbuseIpDbFamily,
+    mut filters: AbuseIpDbFilters,
+    observed_at: &str,
+) -> Result<AbuseIpDbKernel, AbuseIpDbError> {
+    let base_url = origin::validate(base_url)?;
+    let tenant_id = origin::tenant(tenant_id).ok_or(AbuseIpDbError::InvalidTenantId)?;
+    let observed = OffsetDateTime::parse(observed_at, &Rfc3339)
+        .map_err(|_| AbuseIpDbError::InvalidConfiguration("observed_at"))?;
+    let observed_at = observed
+        .format(&Rfc3339)
+        .map_err(|_| AbuseIpDbError::InvalidConfiguration("observed_at"))?;
+    validate_filters(family, &mut filters)?;
+    Ok(AbuseIpDbKernel {
+        base_url,
+        tenant_id,
+        family,
+        filters,
+        observed_at,
+    })
+}
+
+pub(super) fn plan(
+    kernel: &AbuseIpDbKernel,
+    cursor: Option<&str>,
+) -> Result<AbuseIpDbRequest, AbuseIpDbError> {
+    let mut url = kernel.base_url.clone();
+    url.set_path(&format!(
+        "{}{}",
+        kernel.base_url.path().trim_end_matches('/'),
+        kernel.family.path()
+    ));
+    if url.origin() != kernel.base_url.origin() {
+        return Err(AbuseIpDbError::InvalidOrigin);
+    }
+    let (page, cursor, record_limit) = match kernel.family {
+        AbuseIpDbFamily::Reports => {
+            let page = cursor.map(validate_cursor).transpose()?.unwrap_or(1);
+            let ip_address = kernel
+                .filters
+                .ip_address
+                .as_deref()
+                .ok_or(AbuseIpDbError::MissingConfiguration("ip_address"))?;
+            let mut query = url.query_pairs_mut();
+            query.append_pair("ipAddress", ip_address);
+            if let Some(days) = kernel.filters.max_age_in_days {
+                query.append_pair("maxAgeInDays", &days.to_string());
+            }
+            query.append_pair("perPage", &REPORTS_PAGE_SIZE.to_string());
+            query.append_pair("page", &page.to_string());
+            (page, cursor.map(str::to_owned), REPORTS_PAGE_SIZE)
+        }
+        AbuseIpDbFamily::IpAddresses => {
+            if cursor.is_some() {
+                return Err(AbuseIpDbError::InvalidCursor);
+            }
+            let mut query = url.query_pairs_mut();
+            query.append_pair(
+                "confidenceMinimum",
+                &kernel.filters.confidence_minimum.unwrap_or(90).to_string(),
+            );
+            if let Some(version) = kernel.filters.ip_version {
+                query.append_pair("ipVersion", &version.to_string());
+            }
+            query.append_pair("limit", &BLACKLIST_LIMIT.to_string());
+            (1, None, BLACKLIST_LIMIT)
+        }
+    };
+    Ok(AbuseIpDbRequest {
+        url,
+        family: kernel.family,
+        page,
+        cursor,
+        record_limit,
+    })
+}
+
+pub(super) fn validate_request(
+    kernel: &AbuseIpDbKernel,
+    request: &AbuseIpDbRequest,
+) -> Result<(), AbuseIpDbError> {
+    if request != &plan(kernel, request.cursor.as_deref())? {
+        return Err(AbuseIpDbError::RequestScopeMismatch);
+    }
+    Ok(())
+}
+
+pub(super) fn validate_cursor(value: &str) -> Result<usize, AbuseIpDbError> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > 5 || value.chars().any(char::is_control) {
+        return Err(AbuseIpDbError::InvalidCursor);
+    }
+    value
+        .parse::<usize>()
+        .ok()
+        .filter(|page| (1..=MAX_PAGE).contains(page))
+        .ok_or(AbuseIpDbError::InvalidCursor)
+}
+
+fn validate_filters(
+    family: AbuseIpDbFamily,
+    filters: &mut AbuseIpDbFilters,
+) -> Result<(), AbuseIpDbError> {
+    match family {
+        AbuseIpDbFamily::Reports => {
+            let ip = filters
+                .ip_address
+                .as_deref()
+                .ok_or(AbuseIpDbError::MissingConfiguration("ip_address"))?
+                .trim()
+                .parse::<IpAddr>()
+                .map_err(|_| AbuseIpDbError::InvalidConfiguration("ip_address"))?;
+            filters.ip_address = Some(ip.to_string());
+            if filters
+                .max_age_in_days
+                .is_some_and(|days| !(1..=365).contains(&days))
+            {
+                return Err(AbuseIpDbError::InvalidConfiguration("max_age_in_days"));
+            }
+            if filters.confidence_minimum.is_some() || filters.ip_version.is_some() {
+                return Err(AbuseIpDbError::InvalidConfiguration("blacklist_filter"));
+            }
+        }
+        AbuseIpDbFamily::IpAddresses => {
+            if filters.ip_address.is_some() || filters.max_age_in_days.is_some() {
+                return Err(AbuseIpDbError::InvalidConfiguration("reports_filter"));
+            }
+            if filters
+                .confidence_minimum
+                .is_some_and(|value| !(25..=100).contains(&value))
+            {
+                return Err(AbuseIpDbError::InvalidConfiguration("confidence_minimum"));
+            }
+            if filters
+                .ip_version
+                .is_some_and(|value| value != 4 && value != 6)
+            {
+                return Err(AbuseIpDbError::InvalidConfiguration("ip_version"));
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/source-runtime-next/src/abuseipdb/response.rs
+++ b/crates/source-runtime-next/src/abuseipdb/response.rs
@@ -1,0 +1,164 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    AbuseIpDbCheckpointCandidate, AbuseIpDbError, AbuseIpDbFamily, AbuseIpDbKernel, AbuseIpDbPage,
+    AbuseIpDbRequest, normalize,
+    request::{validate_cursor, validate_request},
+};
+
+pub(super) const MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+pub(super) fn decode(
+    kernel: &AbuseIpDbKernel,
+    request: &AbuseIpDbRequest,
+    status: u16,
+    retry_after_seconds: Option<u64>,
+    body: &[u8],
+) -> Result<AbuseIpDbPage, AbuseIpDbError> {
+    validate_request(kernel, request)?;
+    classify_status(status, retry_after_seconds)?;
+    if body.len() > MAX_RESPONSE_BYTES {
+        return Err(AbuseIpDbError::ResponseTooLarge);
+    }
+    let root: Value =
+        serde_json::from_slice(body).map_err(|_| AbuseIpDbError::MalformedResponse)?;
+    let items = records(kernel.family, &root)?;
+    if items.len() > request.record_limit {
+        return Err(AbuseIpDbError::TooManyRecords);
+    }
+    let mut seen = BTreeMap::<String, Vec<u8>>::new();
+    let mut normalized = Vec::with_capacity(items.len());
+    for raw in items {
+        let record = normalize::normalize(kernel, raw.clone())?;
+        let canonical = serde_json::to_vec(&record.payload)
+            .map_err(|_| AbuseIpDbError::InvalidProviderRecord)?;
+        match seen.get(&record.provider_id) {
+            Some(previous) if previous == &canonical => continue,
+            Some(_) => return Err(AbuseIpDbError::ConflictingDuplicate),
+            None => {
+                seen.insert(record.provider_id.clone(), canonical);
+                normalized.push(record);
+            }
+        }
+    }
+    Ok(AbuseIpDbPage {
+        records: normalized,
+        next_cursor: next_cursor(kernel.family, request, &root, items.len())?,
+    })
+}
+
+pub(super) fn checkpoint_candidate(
+    kernel: &AbuseIpDbKernel,
+    request: &AbuseIpDbRequest,
+    page: &AbuseIpDbPage,
+    prior_watermark: Option<&str>,
+) -> Result<AbuseIpDbCheckpointCandidate, AbuseIpDbError> {
+    validate_request(kernel, request)?;
+    if page
+        .records
+        .iter()
+        .any(|record| record.tenant_id != kernel.tenant_id || record.family != kernel.family)
+    {
+        return Err(AbuseIpDbError::TenantMismatch);
+    }
+    if let Some(cursor) = &page.next_cursor {
+        kernel.plan(Some(cursor))?;
+    }
+    let mut watermark = valid_time(prior_watermark.unwrap_or(&kernel.observed_at))?;
+    for record in &page.records {
+        let occurred_at = valid_time(&record.occurred_at)?;
+        if occurred_at > watermark {
+            watermark = occurred_at;
+        }
+    }
+    Ok(AbuseIpDbCheckpointCandidate {
+        tenant_id: kernel.tenant_id.clone(),
+        family: kernel.family,
+        cursor: page.next_cursor.clone(),
+        watermark,
+    })
+}
+
+fn records(family: AbuseIpDbFamily, root: &Value) -> Result<&[Value], AbuseIpDbError> {
+    match family {
+        AbuseIpDbFamily::Reports => root
+            .get("data")
+            .and_then(|value| value.get("results"))
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .ok_or(AbuseIpDbError::MalformedResponse),
+        AbuseIpDbFamily::IpAddresses => root
+            .get("data")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .ok_or(AbuseIpDbError::MalformedResponse),
+    }
+}
+
+fn next_cursor(
+    family: AbuseIpDbFamily,
+    request: &AbuseIpDbRequest,
+    root: &Value,
+    raw_count: usize,
+) -> Result<Option<String>, AbuseIpDbError> {
+    if family == AbuseIpDbFamily::IpAddresses {
+        return Ok(None);
+    }
+    let data = root.get("data").ok_or(AbuseIpDbError::MalformedResponse)?;
+    if let Some(page) = data.get("page").and_then(Value::as_u64)
+        && usize::try_from(page).ok() != Some(request.page)
+    {
+        return Err(AbuseIpDbError::InvalidCursor);
+    }
+    if let Some(per_page) = data.get("perPage").and_then(Value::as_u64)
+        && usize::try_from(per_page).ok() != Some(request.record_limit)
+    {
+        return Err(AbuseIpDbError::MalformedResponse);
+    }
+    let has_more = match data.get("lastPage").and_then(Value::as_u64) {
+        Some(last) => usize::try_from(last)
+            .ok()
+            .is_some_and(|last| request.page < last),
+        None => raw_count == request.record_limit,
+    };
+    if !has_more || raw_count == 0 {
+        return Ok(None);
+    }
+    let next = request
+        .page
+        .checked_add(1)
+        .ok_or(AbuseIpDbError::InvalidCursor)?
+        .to_string();
+    validate_cursor(&next)?;
+    if request.cursor.as_deref() == Some(next.as_str()) {
+        return Err(AbuseIpDbError::InvalidCursor);
+    }
+    Ok(Some(next))
+}
+
+fn classify_status(status: u16, retry_after_seconds: Option<u64>) -> Result<(), AbuseIpDbError> {
+    if retry_after_seconds.is_some_and(|seconds| seconds > 3_600) {
+        return Err(AbuseIpDbError::InvalidRetryAfter);
+    }
+    match status {
+        200..=299 => Ok(()),
+        401 => Err(AbuseIpDbError::AuthenticationRejected),
+        403 => Err(AbuseIpDbError::RequiredScopeMissing),
+        404 => Err(AbuseIpDbError::ProviderResourceNotFound),
+        429 => Err(AbuseIpDbError::RateLimited {
+            retry_after_seconds,
+        }),
+        500..=599 => Err(AbuseIpDbError::ProviderUnavailable { status }),
+        _ => Err(AbuseIpDbError::UnexpectedStatus { status }),
+    }
+}
+
+fn valid_time(value: &str) -> Result<String, AbuseIpDbError> {
+    let time = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| AbuseIpDbError::InvalidProviderRecord)?;
+    time.format(&Rfc3339)
+        .map_err(|_| AbuseIpDbError::InvalidProviderRecord)
+}

--- a/crates/source-runtime-next/src/abuseipdb/tests.rs
+++ b/crates/source-runtime-next/src/abuseipdb/tests.rs
@@ -1,0 +1,510 @@
+use std::{collections::BTreeMap, fs, path::PathBuf};
+
+use cerebro_source_catalog::{CollectionAuthority, SourceCatalog};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::*;
+
+const OBSERVED_AT: &str = "2026-06-01T00:00:00Z";
+
+#[derive(Debug, Deserialize)]
+struct GoOracleEvent {
+    id: String,
+    tenant_id: String,
+    source_id: String,
+    kind: String,
+    occurred_at: String,
+    schema_ref: String,
+    payload: Value,
+    attributes: BTreeMap<String, String>,
+}
+
+fn repository_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn reports_kernel(tenant: &str) -> AbuseIpDbKernel {
+    AbuseIpDbKernel::new(
+        "https://api.abuseipdb.com/api/v2",
+        tenant,
+        AbuseIpDbFamily::Reports,
+        AbuseIpDbFilters {
+            ip_address: Some("192.0.2.10".to_owned()),
+            max_age_in_days: Some(30),
+            ..AbuseIpDbFilters::default()
+        },
+        OBSERVED_AT,
+    )
+    .unwrap()
+}
+
+fn ip_kernel(tenant: &str) -> AbuseIpDbKernel {
+    AbuseIpDbKernel::new(
+        "https://api.abuseipdb.com/api/v2",
+        tenant,
+        AbuseIpDbFamily::IpAddresses,
+        AbuseIpDbFilters {
+            confidence_minimum: Some(90),
+            ip_version: Some(4),
+            ..AbuseIpDbFilters::default()
+        },
+        OBSERVED_AT,
+    )
+    .unwrap()
+}
+
+fn report_raw() -> Value {
+    json!({
+        "reportedAt": "2026-06-01T00:00:00Z",
+        "reporterId": 43121,
+        "comment": "SSH login attempts",
+        "categories": [18, 22],
+        "reporterCountryCode": "US"
+    })
+}
+
+fn ip_raw() -> Value {
+    json!({
+        "ipAddress": "192.0.2.10",
+        "abuseConfidenceScore": 100,
+        "countryCode": "US",
+        "lastReportedAt": "2026-06-01T00:00:00Z"
+    })
+}
+
+fn response(family: AbuseIpDbFamily, records: Vec<Value>) -> Vec<u8> {
+    serde_json::to_vec(&match family {
+        AbuseIpDbFamily::Reports => json!({"data": {"results": records}}),
+        AbuseIpDbFamily::IpAddresses => json!({"data": records}),
+    })
+    .unwrap()
+}
+
+fn go_event_fixture(family: AbuseIpDbFamily) -> GoOracleEvent {
+    let file = match family {
+        AbuseIpDbFamily::Reports => "read_reports.json",
+        AbuseIpDbFamily::IpAddresses => "read_ip_addresses.json",
+    };
+    let bytes = fs::read(
+        repository_root()
+            .join("sources/abuseipdb/testdata")
+            .join(file),
+    )
+    .unwrap();
+    serde_json::from_slice::<Vec<GoOracleEvent>>(&bytes)
+        .unwrap()
+        .pop()
+        .unwrap()
+}
+
+#[test]
+fn catalog_and_kernel_close_the_exact_authoritative_family_set() {
+    let root = repository_root();
+    let catalog = SourceCatalog::load(
+        root.join("internal/connectorcatalog/catalog"),
+        root.join("sources"),
+    )
+    .unwrap();
+    let source = catalog.get("abuseipdb").unwrap();
+    assert_eq!(source.authority(), CollectionAuthority::Authoritative);
+    assert_eq!(
+        source
+            .families()
+            .iter()
+            .map(|family| family.id())
+            .collect::<Vec<_>>(),
+        ["reports", "ip_addresses"]
+    );
+    assert!(
+        source
+            .families()
+            .iter()
+            .all(|family| family.is_authoritative())
+    );
+    assert_eq!(
+        AbuseIpDbFamily::ALL.map(AbuseIpDbFamily::as_str),
+        ["reports", "ip_addresses"]
+    );
+    for family in AbuseIpDbFamily::ALL {
+        let definition = AbuseIpDbRuntimeDefinition::compile(family).unwrap();
+        assert_eq!(definition.source_id, "abuseipdb");
+        assert!(definition.pull);
+        assert_eq!(definition.event_contract.kind, family.event_kind());
+        assert_eq!(definition.event_contract.schema_ref, family.schema_ref());
+    }
+}
+
+#[test]
+fn requests_are_bounded_origin_restricted_and_credential_free() {
+    let reports = reports_kernel("tenant");
+    let first = reports.plan(None).unwrap();
+    assert_eq!(first.method(), "GET");
+    assert_eq!(
+        first.url().as_str(),
+        "https://api.abuseipdb.com/api/v2/reports?ipAddress=192.0.2.10&maxAgeInDays=30&perPage=100&page=1"
+    );
+    assert_eq!(first.authentication_header(), "Key");
+    assert_eq!(first.authentication_scheme(), "");
+    assert!(first.credential_reference_required());
+    assert_eq!(first.accept(), "application/json");
+    assert_eq!(first.record_limit(), 100);
+    assert_eq!(first.max_response_bytes(), 8 * 1024 * 1024);
+    assert_eq!(first.required_scope(), "AbuseIPDB API read access");
+    assert!(!first.contains_credentials());
+    assert!(!first.allows_redirects());
+    assert!(!AbuseIpDbKernel::requires_credentials());
+    assert_eq!(
+        reports
+            .plan(Some("2"))
+            .unwrap()
+            .url()
+            .query_pairs()
+            .last()
+            .unwrap()
+            .1,
+        "2"
+    );
+
+    let blacklist = ip_kernel("tenant").plan(None).unwrap();
+    assert_eq!(
+        blacklist.url().as_str(),
+        "https://api.abuseipdb.com/api/v2/blacklist?confidenceMinimum=90&ipVersion=4&limit=10000"
+    );
+    assert_eq!(blacklist.record_limit(), 10_000);
+    assert_eq!(
+        ip_kernel("tenant").plan(Some("2")),
+        Err(AbuseIpDbError::InvalidCursor)
+    );
+
+    let debug = format!("{reports:?}{first:?}{blacklist:?}");
+    for secret in ["sentinel-token-value", "Key: sentinel", "credential:"] {
+        assert!(!debug.contains(secret));
+    }
+}
+
+#[test]
+fn origins_cursors_and_family_configuration_fail_closed() {
+    for origin in [
+        "http://api.abuseipdb.com/api/v2",
+        "https://localhost/api/v2",
+        "https://127.0.0.1/api/v2",
+        "https://user@api.abuseipdb.com/api/v2",
+        "https://api.abuseipdb.com:8443/api/v2",
+        "https://api.abuseipdb.com/api/v1",
+        "https://api.abuseipdb.com/api/v2?token=value",
+    ] {
+        assert!(
+            AbuseIpDbKernel::new(
+                origin,
+                "tenant",
+                AbuseIpDbFamily::Reports,
+                AbuseIpDbFilters {
+                    ip_address: Some("192.0.2.10".to_owned()),
+                    ..AbuseIpDbFilters::default()
+                },
+                OBSERVED_AT,
+            )
+            .is_err()
+        );
+    }
+    assert_eq!(
+        reports_kernel("tenant").plan(Some("0")),
+        Err(AbuseIpDbError::InvalidCursor)
+    );
+    assert_eq!(
+        reports_kernel("tenant").plan(Some("10001")),
+        Err(AbuseIpDbError::InvalidCursor)
+    );
+    assert_eq!(
+        AbuseIpDbKernel::new(
+            "https://api.abuseipdb.com/api/v2",
+            "tenant",
+            AbuseIpDbFamily::Reports,
+            AbuseIpDbFilters::default(),
+            OBSERVED_AT,
+        )
+        .unwrap_err(),
+        AbuseIpDbError::MissingConfiguration("ip_address")
+    );
+}
+
+#[test]
+fn reports_response_matches_the_existing_go_oracle_semantically() {
+    let kernel = reports_kernel("tenant");
+    let request = kernel.plan(None).unwrap();
+    let page = kernel
+        .decode(
+            &request,
+            200,
+            None,
+            &response(AbuseIpDbFamily::Reports, vec![report_raw()]),
+        )
+        .unwrap();
+    assert_eq!(page.records.len(), 1);
+    assert_eq!(page.next_cursor, None);
+    let record = &page.records[0];
+    let oracle = go_event_fixture(AbuseIpDbFamily::Reports);
+    assert_eq!(record.tenant_id, oracle.tenant_id);
+    assert_eq!(oracle.source_id, "abuseipdb");
+    assert_eq!(record.kind, oracle.kind);
+    assert_eq!(record.schema_ref, oracle.schema_ref);
+    assert_eq!(record.occurred_at, oracle.occurred_at);
+    assert_eq!(record.payload, oracle.payload);
+    assert_eq!(record.attributes, oracle.attributes);
+    assert_eq!(record.provider_id, "2026-06-01T00:00:00Z:43121");
+    assert_eq!(
+        record.event_id,
+        "abuseipdb-tenant-cc8ad95318cd-reports-2026-06-01T00-00-00Z-43121"
+    );
+    assert_eq!(
+        oracle.id,
+        "abuseipdb-tenant-reports-2026-06-01t00-00-00z-43121"
+    );
+
+    let projection = project_abuseipdb_records(&page.records);
+    assert_eq!(projection.entities.len(), 1);
+    assert_eq!(projection.relations.len(), 1);
+    assert_eq!(projection.entities[0].entity_type, "finding");
+    assert_eq!(projection.entities[0].label, "SSH login attempts");
+    assert_eq!(projection.relations[0].relation, "affects");
+    assert_eq!(
+        projection.relations[0].to_urn,
+        "urn:cerebro:tenant:abuseipdb_ip_address:192.0.2.10"
+    );
+}
+
+#[test]
+fn blacklist_response_matches_the_existing_go_oracle_semantically() {
+    let kernel = ip_kernel("tenant");
+    let request = kernel.plan(None).unwrap();
+    let page = kernel
+        .decode(
+            &request,
+            200,
+            None,
+            &response(AbuseIpDbFamily::IpAddresses, vec![ip_raw()]),
+        )
+        .unwrap();
+    let record = &page.records[0];
+    let oracle = go_event_fixture(AbuseIpDbFamily::IpAddresses);
+    assert_eq!(record.tenant_id, oracle.tenant_id);
+    assert_eq!(oracle.source_id, "abuseipdb");
+    assert_eq!(record.kind, oracle.kind);
+    assert_eq!(record.schema_ref, oracle.schema_ref);
+    assert_eq!(record.occurred_at, oracle.occurred_at);
+    assert_eq!(record.payload, oracle.payload);
+    assert_eq!(record.attributes, oracle.attributes);
+    assert_eq!(record.provider_id, "192.0.2.10");
+    assert_eq!(
+        record.event_id,
+        "abuseipdb-tenant-d9cb64b1547c-ip_addresses-192.0.2.10"
+    );
+    assert_eq!(oracle.id, "abuseipdb-tenant-blacklist-192-0-2-10");
+
+    let projection = project_abuseipdb_records(&page.records);
+    assert_eq!(
+        projection.entities,
+        vec![AbuseIpDbEntityFact {
+            urn: "urn:cerebro:tenant:abuseipdb_ip_address:192.0.2.10".to_owned(),
+            entity_type: "runtime.ip.address".to_owned(),
+            label: "192.0.2.10".to_owned(),
+        }]
+    );
+    assert!(projection.relations.is_empty());
+}
+
+#[test]
+fn reports_pagination_and_checkpoint_are_round_trippable() {
+    let kernel = reports_kernel("tenant");
+    let request = kernel.plan(None).unwrap();
+    let records = (1..=100)
+        .map(|reporter| {
+            json!({
+                "reportedAt": "2026-06-01T00:00:00Z",
+                "reporterId": reporter,
+                "comment": format!("report-{reporter}")
+            })
+        })
+        .collect();
+    let page = kernel
+        .decode(
+            &request,
+            200,
+            None,
+            &response(AbuseIpDbFamily::Reports, records),
+        )
+        .unwrap();
+    assert_eq!(page.records.len(), 100);
+    assert_eq!(page.next_cursor.as_deref(), Some("2"));
+    assert!(kernel.plan(page.next_cursor.as_deref()).is_ok());
+    let checkpoint = kernel
+        .checkpoint_candidate(&request, &page, Some("2026-05-01T00:00:00Z"))
+        .unwrap();
+    assert_eq!(checkpoint.cursor.as_deref(), Some("2"));
+    assert_eq!(checkpoint.watermark, OBSERVED_AT);
+
+    let second = kernel.plan(Some("2")).unwrap();
+    let terminal = kernel
+        .decode(
+            &second,
+            200,
+            None,
+            &response(AbuseIpDbFamily::Reports, Vec::new()),
+        )
+        .unwrap();
+    assert_eq!(terminal.next_cursor, None);
+    assert_eq!(
+        kernel
+            .checkpoint_candidate(&second, &terminal, None)
+            .unwrap()
+            .watermark,
+        OBSERVED_AT
+    );
+}
+
+#[test]
+fn duplicate_identity_is_idempotent_but_conflicting_content_fails() {
+    let kernel = reports_kernel("tenant");
+    let request = kernel.plan(None).unwrap();
+    let identical = kernel
+        .decode(
+            &request,
+            200,
+            None,
+            &response(AbuseIpDbFamily::Reports, vec![report_raw(), report_raw()]),
+        )
+        .unwrap();
+    assert_eq!(identical.records.len(), 1);
+    let mut conflicting = report_raw();
+    conflicting["comment"] = Value::String("different".to_owned());
+    assert_eq!(
+        kernel.decode(
+            &request,
+            200,
+            None,
+            &response(AbuseIpDbFamily::Reports, vec![report_raw(), conflicting]),
+        ),
+        Err(AbuseIpDbError::ConflictingDuplicate)
+    );
+}
+
+#[test]
+fn typed_provider_statuses_remain_distinct_and_bounded() {
+    let kernel = reports_kernel("tenant");
+    let request = kernel.plan(None).unwrap();
+    for (status, expected) in [
+        (401, AbuseIpDbError::AuthenticationRejected),
+        (403, AbuseIpDbError::RequiredScopeMissing),
+        (404, AbuseIpDbError::ProviderResourceNotFound),
+        (
+            429,
+            AbuseIpDbError::RateLimited {
+                retry_after_seconds: Some(60),
+            },
+        ),
+        (503, AbuseIpDbError::ProviderUnavailable { status: 503 }),
+        (418, AbuseIpDbError::UnexpectedStatus { status: 418 }),
+    ] {
+        assert_eq!(
+            kernel.decode(&request, status, Some(60), b"{}"),
+            Err(expected)
+        );
+    }
+    assert_eq!(
+        kernel.decode(&request, 429, Some(3_601), b"{}"),
+        Err(AbuseIpDbError::InvalidRetryAfter)
+    );
+    let oversized = vec![b' '; request.max_response_bytes() + 1];
+    assert_eq!(
+        kernel.decode(&request, 200, None, &oversized),
+        Err(AbuseIpDbError::ResponseTooLarge)
+    );
+}
+
+#[test]
+fn tenant_provider_scope_and_secret_material_cannot_cross_the_kernel() {
+    let kernel = reports_kernel("tenant");
+    let request = kernel.plan(None).unwrap();
+    for (field, expected) in [
+        ("tenant_id", AbuseIpDbError::TenantMismatch),
+        ("access_token", AbuseIpDbError::CredentialMaterial),
+        ("authorization", AbuseIpDbError::CredentialMaterial),
+        ("private_key", AbuseIpDbError::CredentialMaterial),
+    ] {
+        let mut raw = report_raw();
+        raw[field] = Value::String("sentinel-secret-value".to_owned());
+        let error = kernel
+            .decode(
+                &request,
+                200,
+                None,
+                &response(AbuseIpDbFamily::Reports, vec![raw]),
+            )
+            .unwrap_err();
+        assert_eq!(error, expected);
+        assert!(!error.to_string().contains("sentinel-secret-value"));
+        assert!(!format!("{error:?}").contains("sentinel-secret-value"));
+    }
+
+    let mut wrong_ip = report_raw();
+    wrong_ip["ipAddress"] = Value::String("192.0.2.11".to_owned());
+    assert_eq!(
+        kernel.decode(
+            &request,
+            200,
+            None,
+            &response(AbuseIpDbFamily::Reports, vec![wrong_ip])
+        ),
+        Err(AbuseIpDbError::ProviderIdentityMismatch)
+    );
+}
+
+#[test]
+fn identity_is_deterministic_and_tenant_scoped() {
+    let body = response(AbuseIpDbFamily::IpAddresses, vec![ip_raw()]);
+    let first_kernel = ip_kernel("tenant-a");
+    let first_request = first_kernel.plan(None).unwrap();
+    let first = first_kernel
+        .decode(&first_request, 200, None, &body)
+        .unwrap();
+    let replay = first_kernel
+        .decode(&first_request, 200, None, &body)
+        .unwrap();
+    assert_eq!(first, replay);
+
+    let other_kernel = ip_kernel("tenant-b");
+    let other_request = other_kernel.plan(None).unwrap();
+    let other = other_kernel
+        .decode(&other_request, 200, None, &body)
+        .unwrap();
+    assert_eq!(first.records[0].provider_id, other.records[0].provider_id);
+    assert_ne!(first.records[0].event_id, other.records[0].event_id);
+    assert_ne!(
+        first.records[0].attributes["resource_urn"],
+        other.records[0].attributes["resource_urn"]
+    );
+}
+
+#[test]
+fn errors_expose_bounded_operator_actions() {
+    assert_eq!(
+        AbuseIpDbError::AuthenticationRejected.operator_action(),
+        "repair credential binding"
+    );
+    assert_eq!(
+        AbuseIpDbError::RequiredScopeMissing.operator_action(),
+        "grant AbuseIPDB read access"
+    );
+    assert_eq!(
+        AbuseIpDbError::RateLimited {
+            retry_after_seconds: Some(30)
+        }
+        .operator_action(),
+        "retry the collection later"
+    );
+    assert_eq!(
+        AbuseIpDbError::InvalidCursor.operator_action(),
+        "restart from the last committed checkpoint"
+    );
+}

--- a/crates/source-runtime-next/src/abuseipdb/types.rs
+++ b/crates/source-runtime-next/src/abuseipdb/types.rs
@@ -1,0 +1,203 @@
+use std::{collections::BTreeMap, fmt};
+
+use reqwest::Url;
+use serde_json::Value;
+
+use super::{AbuseIpDbError, AbuseIpDbFamily, request, response};
+
+/// Public, credential-free filters compiled for one AbuseIPDB operation.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AbuseIpDbFilters {
+    /// Required report-history IP address.
+    pub ip_address: Option<String>,
+    /// Optional report lookback from 1 through 365 days.
+    pub max_age_in_days: Option<u16>,
+    /// Optional blacklist confidence threshold from 25 through 100.
+    pub confidence_minimum: Option<u8>,
+    /// Optional blacklist IP version, either 4 or 6.
+    pub ip_version: Option<u8>,
+}
+
+/// One credential-free AbuseIPDB request plan.
+#[derive(Clone, Eq, PartialEq)]
+pub struct AbuseIpDbRequest {
+    pub(super) url: Url,
+    pub(super) family: AbuseIpDbFamily,
+    pub(super) page: usize,
+    pub(super) cursor: Option<String>,
+    pub(super) record_limit: usize,
+}
+
+impl fmt::Debug for AbuseIpDbRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AbuseIpDbRequest")
+            .field("url", &self.url)
+            .field("family", &self.family)
+            .field("page", &self.page)
+            .field("has_cursor", &self.cursor.is_some())
+            .field("record_limit", &self.record_limit)
+            .finish()
+    }
+}
+
+impl AbuseIpDbRequest {
+    /// Fully planned provider URL.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Provider HTTP method.
+    pub const fn method(&self) -> &'static str {
+        "GET"
+    }
+
+    /// Family owning this request.
+    pub const fn family(&self) -> AbuseIpDbFamily {
+        self.family
+    }
+
+    /// Authentication header applied by the trusted host.
+    pub const fn authentication_header(&self) -> &'static str {
+        "Key"
+    }
+
+    /// AbuseIPDB API keys have no prefix scheme.
+    pub const fn authentication_scheme(&self) -> &'static str {
+        ""
+    }
+
+    /// The trusted host must redeem a credential reference before execution.
+    pub const fn credential_reference_required(&self) -> bool {
+        true
+    }
+
+    /// Expected response media type.
+    pub const fn accept(&self) -> &'static str {
+        "application/json"
+    }
+
+    /// Portable request plans contain no credential bytes or references.
+    pub const fn contains_credentials(&self) -> bool {
+        false
+    }
+
+    /// Redirects are disabled by the trusted host.
+    pub const fn allows_redirects(&self) -> bool {
+        false
+    }
+
+    /// Maximum admitted response bytes.
+    pub const fn max_response_bytes(&self) -> usize {
+        response::MAX_RESPONSE_BYTES
+    }
+
+    /// Provider permission required for both read operations.
+    pub const fn required_scope(&self) -> &'static str {
+        "AbuseIPDB API read access"
+    }
+
+    /// Maximum records admitted from this response.
+    pub const fn record_limit(&self) -> usize {
+        self.record_limit
+    }
+}
+
+/// One normalized tenant-scoped AbuseIPDB event candidate.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AbuseIpDbRecord {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Stable Go-compatible tenant- and provider-scoped event identity.
+    pub event_id: String,
+    /// Stable provider identity.
+    pub provider_id: String,
+    /// Exact family.
+    pub family: AbuseIpDbFamily,
+    /// Exact event kind.
+    pub kind: String,
+    /// Exact schema reference.
+    pub schema_ref: String,
+    /// Normalized RFC3339 occurrence time.
+    pub occurred_at: String,
+    /// Deterministic projection attributes.
+    pub attributes: BTreeMap<String, String>,
+    /// Credential-free normalized provider payload.
+    pub payload: Value,
+}
+
+/// One bounded normalized AbuseIPDB page.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AbuseIpDbPage {
+    /// Accepted records after deterministic deduplication.
+    pub records: Vec<AbuseIpDbRecord>,
+    /// Validated numbered-page continuation, or terminal state.
+    pub next_cursor: Option<String>,
+}
+
+/// Validated checkpoint candidate for post-append/projection persistence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AbuseIpDbCheckpointCandidate {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Selected family.
+    pub family: AbuseIpDbFamily,
+    /// Validated continuation state.
+    pub cursor: Option<String>,
+    /// Provider observation watermark.
+    pub watermark: String,
+}
+
+/// Closed AbuseIPDB kernel for one tenant and family.
+#[derive(Clone, Debug)]
+pub struct AbuseIpDbKernel {
+    pub(super) base_url: Url,
+    pub(super) tenant_id: String,
+    pub(super) family: AbuseIpDbFamily,
+    pub(super) filters: AbuseIpDbFilters,
+    pub(super) observed_at: String,
+}
+
+impl AbuseIpDbKernel {
+    /// Construct one family kernel from public execution context only.
+    pub fn new(
+        base_url: &str,
+        tenant_id: &str,
+        family: AbuseIpDbFamily,
+        filters: AbuseIpDbFilters,
+        observed_at: &str,
+    ) -> Result<Self, AbuseIpDbError> {
+        request::new_kernel(base_url, tenant_id, family, filters, observed_at)
+    }
+
+    /// Kernel protocol never accepts credential material.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+
+    /// Plan one bounded origin-restricted provider request.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<AbuseIpDbRequest, AbuseIpDbError> {
+        request::plan(self, cursor)
+    }
+
+    /// Decode one bounded provider response under the exact request plan.
+    pub fn decode(
+        &self,
+        request: &AbuseIpDbRequest,
+        status: u16,
+        retry_after_seconds: Option<u64>,
+        body: &[u8],
+    ) -> Result<AbuseIpDbPage, AbuseIpDbError> {
+        response::decode(self, request, status, retry_after_seconds, body)
+    }
+
+    /// Validate a checkpoint candidate for post-commit host persistence.
+    pub fn checkpoint_candidate(
+        &self,
+        request: &AbuseIpDbRequest,
+        page: &AbuseIpDbPage,
+        prior_watermark: Option<&str>,
+    ) -> Result<AbuseIpDbCheckpointCandidate, AbuseIpDbError> {
+        response::checkpoint_candidate(self, request, page, prior_watermark)
+    }
+}

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! Rust-native source collection and graph admission boundary.
 
+mod abuseipdb;
 mod amplitude;
 mod anthropic;
 mod append_log;
@@ -51,6 +52,12 @@ mod trivy;
 mod twilio;
 mod vulnview;
 
+pub use abuseipdb::{
+    AbuseIpDbCheckpointCandidate, AbuseIpDbEntityFact, AbuseIpDbError, AbuseIpDbEventContract,
+    AbuseIpDbFamily, AbuseIpDbFilters, AbuseIpDbKernel, AbuseIpDbPage, AbuseIpDbProjectionFacts,
+    AbuseIpDbRecord, AbuseIpDbRelationFact, AbuseIpDbRequest, AbuseIpDbRuntimeDefinition,
+    project_abuseipdb_records,
+};
 pub use amplitude::{
     AmplitudeError, AmplitudeFamily, AmplitudeKernel, AmplitudePage, AmplitudeRecord,
     AmplitudeRequest,


### PR DESCRIPTION
## Scope

Add a provider-local credential-free AbuseIPDB kernel for the catalog's two declared families:

- `reports`: required IP scope, bounded numbered pagination, composite report identity, finding projection
- `ip_addresses`: bounded blacklist snapshot, IP asset projection

The kernel compiles exact event contracts, plans only the declared HTTPS origin, admits bounded provider responses, preserves typed provider failures, emits deterministic tenant-scoped identities, proposes round-trippable checkpoint state, and rejects tenant or credential-shaped provider data.

The existing generic Rust catalog connector remains collection authority. This PR does not add a second writer or change authority. The checked Go fixtures and projection behavior remain compatibility/parity oracles; no Go loader or oracle code is removed.

## Local validation

- `cargo fmt --all -- --check`
- `cargo test -p cerebro-source-runtime-next abuseipdb --no-fail-fast` — 13 passed
- `cargo test -p cerebro-source-runtime-next --no-fail-fast` — 513 unit tests, 7 Linode integration tests, and 10 PagerDuty integration tests passed
- `cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings`
- `go test ./internal/sourceprojection ./internal/sourcefixture ./internal/connectorcatalog ./internal/connectordefinitions ./internal/sourcegen ./sources/internal/catalogruntime ./internal/sourceregistry -count=1`
- `make catalog-check source-fixture-check fixture-oracle-check projection-parity-test`
- `make check-structural check-structural-test check-arch`
- `./scripts/leak_check.sh staged`

## Evidence boundaries

- Provider proof: checked catalog contract and checked synthetic Go fixture parity only; no live AbuseIPDB credentials or provider request used.
- Product path: projection semantics are covered locally; no deployed or authenticated product-path claim.
- Deployment: not owned or triggered by this additive crate change.
