### PR TITLE
Close JumpCloud Rust runtime retirement parity gaps

### DIFF
--- a/crates/source-runtime-next/src/jumpcloud.rs
+++ b/crates/source-runtime-next/src/jumpcloud.rs
@@ -4,9 +4,14 @@
 //! deadlines, and bounded network I/O. This module accepts public source
 //! configuration and already-bounded provider response bytes only.
 
+// Shared dispatcher registration lands separately; keep its provider contract
+// callable without requiring this provider branch to edit shared paths.
+#[allow(dead_code)]
+pub(crate) mod adapter;
 mod catalog;
 mod error;
 mod family;
+mod identity;
 mod normalize;
 mod origin;
 mod projection;

--- a/crates/source-runtime-next/src/jumpcloud/adapter.rs
+++ b/crates/source-runtime-next/src/jumpcloud/adapter.rs
@@ -1,0 +1,101 @@
+//! Provider-local source-execution adapter contract.
+//!
+//! The shared dispatcher and wire remain separately owned. This module exposes
+//! the exact seven registration tuples plus body/header capabilities that the
+//! shared registration follow-up must carry without redefining wire messages.
+
+use super::{
+    JumpCloudError, JumpCloudFamily, JumpCloudKernel, JumpCloudPage, JumpCloudRequest,
+    JumpCloudResponseMetadata, JumpCloudRuntimeDefinition,
+};
+
+/// Provider-local contract required by the shared source-execution registry.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct JumpCloudSourceExecutionContract {
+    pub(crate) source_id: &'static str,
+    pub(crate) family_id: &'static str,
+    pub(crate) provider_kernel: &'static str,
+    pub(crate) method: &'static str,
+    pub(crate) origin: &'static str,
+    pub(crate) path: &'static str,
+    pub(crate) credential_operation: &'static str,
+    pub(crate) request_body: bool,
+    pub(crate) response_cursor_header: Option<&'static str>,
+}
+
+/// Stateless provider-local adapter for one exact JumpCloud family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct JumpCloudSourceExecutionAdapter {
+    family: JumpCloudFamily,
+}
+
+/// Exact provider-local adapter set awaiting shared registry registration.
+pub(crate) const JUMPCLOUD_SOURCE_EXECUTION_ADAPTERS: [JumpCloudSourceExecutionAdapter; 7] = [
+    JumpCloudSourceExecutionAdapter::new(JumpCloudFamily::Users),
+    JumpCloudSourceExecutionAdapter::new(JumpCloudFamily::Groups),
+    JumpCloudSourceExecutionAdapter::new(JumpCloudFamily::Systems),
+    JumpCloudSourceExecutionAdapter::new(JumpCloudFamily::Applications),
+    JumpCloudSourceExecutionAdapter::new(JumpCloudFamily::SystemGroups),
+    JumpCloudSourceExecutionAdapter::new(JumpCloudFamily::GroupMembers),
+    JumpCloudSourceExecutionAdapter::new(JumpCloudFamily::AuditEvents),
+];
+
+impl JumpCloudSourceExecutionAdapter {
+    pub(crate) const fn new(family: JumpCloudFamily) -> Self {
+        Self { family }
+    }
+
+    pub(crate) const fn family(self) -> JumpCloudFamily {
+        self.family
+    }
+
+    pub(crate) fn contract(self) -> Result<JumpCloudSourceExecutionContract, JumpCloudError> {
+        let definition = JumpCloudRuntimeDefinition::compile(self.family)?;
+        Ok(JumpCloudSourceExecutionContract {
+            source_id: definition.source_id,
+            family_id: self.family.as_str(),
+            provider_kernel: match self.family {
+                JumpCloudFamily::Users => "jumpcloud.users",
+                JumpCloudFamily::Groups => "jumpcloud.groups",
+                JumpCloudFamily::Systems => "jumpcloud.systems",
+                JumpCloudFamily::Applications => "jumpcloud.applications",
+                JumpCloudFamily::SystemGroups => "jumpcloud.system_groups",
+                JumpCloudFamily::GroupMembers => "jumpcloud.group_members",
+                JumpCloudFamily::AuditEvents => "jumpcloud.audit_events",
+            },
+            method: definition.method,
+            origin: definition.origin,
+            path: definition.path,
+            credential_operation: "jumpcloud.x_api_key",
+            request_body: self.family == JumpCloudFamily::AuditEvents,
+            response_cursor_header: (self.family == JumpCloudFamily::AuditEvents)
+                .then_some("X-Search_after"),
+        })
+    }
+
+    pub(crate) fn plan(
+        self,
+        kernel: &JumpCloudKernel,
+        prior_cursor: Option<&str>,
+        prior_watermark: Option<&str>,
+    ) -> Result<JumpCloudRequest, JumpCloudError> {
+        if kernel.family != self.family {
+            return Err(JumpCloudError::RequestScopeMismatch);
+        }
+        kernel.plan_with_checkpoint(prior_cursor, prior_watermark)
+    }
+
+    pub(crate) fn decode(
+        self,
+        kernel: &JumpCloudKernel,
+        request: &JumpCloudRequest,
+        status: u16,
+        metadata: &JumpCloudResponseMetadata,
+        response_body: &[u8],
+    ) -> Result<JumpCloudPage, JumpCloudError> {
+        if kernel.family != self.family || request.family() != self.family {
+            return Err(JumpCloudError::RequestScopeMismatch);
+        }
+        kernel.decode(request, status, metadata, response_body)
+    }
+}

--- a/crates/source-runtime-next/src/jumpcloud/catalog.rs
+++ b/crates/source-runtime-next/src/jumpcloud/catalog.rs
@@ -20,6 +20,12 @@ pub struct JumpCloudRuntimeDefinition {
     pub source_id: &'static str,
     /// Selected family.
     pub family: JumpCloudFamily,
+    /// Exact provider HTTP method.
+    pub method: &'static str,
+    /// Default credential-free provider origin.
+    pub origin: &'static str,
+    /// Provider operation path, relative to the selected origin.
+    pub path: &'static str,
     /// Exact event contract.
     pub event_contract: JumpCloudEventContract,
     /// JumpCloud families are bounded pull operations.
@@ -63,12 +69,19 @@ impl JumpCloudRuntimeDefinition {
             JumpCloudFamily::AuditEvents => contract(
                 family,
                 &["tenant_id", "source_event_id", "event_type", "actor_id"],
-                &["id"],
+                &[],
             ),
         };
         Ok(Self {
             source_id: "jumpcloud",
             family,
+            method: family.method(),
+            origin: if family.uses_insights_origin() {
+                "https://api.jumpcloud.com/insights/directory/v1"
+            } else {
+                "https://console.jumpcloud.com/api"
+            },
+            path: family.path(),
             event_contract,
             pull: true,
         })

--- a/crates/source-runtime-next/src/jumpcloud/identity.rs
+++ b/crates/source-runtime-next/src/jumpcloud/identity.rs
@@ -1,0 +1,190 @@
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+
+use super::{JumpCloudError, JumpCloudFamily, JumpCloudKernel};
+
+pub(super) struct Identity {
+    pub(super) external_id: String,
+    pub(super) provider_id: String,
+    pub(super) event_id: String,
+}
+
+pub(super) fn material(
+    kernel: &JumpCloudKernel,
+    values: &Map<String, Value>,
+    raw_bytes: Option<&[u8]>,
+) -> Result<Identity, JumpCloudError> {
+    let external_id = external_id(kernel.family, values, raw_bytes)?;
+    let provider_id = if kernel.family == JumpCloudFamily::AuditEvents {
+        external_id.clone()
+    } else {
+        record_identity(kernel, values, &external_id)
+    };
+    let event_id = if kernel.family == JumpCloudFamily::AuditEvents {
+        sourcecdk_event_id(&[
+            "jumpcloud",
+            &kernel.tenant_id,
+            kernel.insights_origin.as_str().trim_end_matches('/'),
+            kernel.family.as_str(),
+            &provider_id,
+        ])
+    } else {
+        let path = resolved_path(kernel)?;
+        jsonapi_event_id(
+            &kernel.tenant_id,
+            kernel.directory_origin.as_str().trim_end_matches('/'),
+            &path,
+            kernel.family.as_str(),
+            &provider_id,
+        )
+    };
+    Ok(Identity {
+        external_id,
+        provider_id,
+        event_id,
+    })
+}
+
+fn external_id(
+    family: JumpCloudFamily,
+    values: &Map<String, Value>,
+    raw_bytes: Option<&[u8]>,
+) -> Result<String, JumpCloudError> {
+    let paths: &[&str] = match family {
+        JumpCloudFamily::Users => &["_id", "id", "email", "username"],
+        JumpCloudFamily::Groups | JumpCloudFamily::SystemGroups => &["id", "name"],
+        JumpCloudFamily::Systems => &["_id", "id", "displayName", "hostname"],
+        JumpCloudFamily::Applications => &["_id", "id", "displayName", "name"],
+        JumpCloudFamily::GroupMembers => &["to.id", "id"],
+        JumpCloudFamily::AuditEvents => &["id", "event_id", "uuid", "request_id"],
+    };
+    match string_first(values, paths) {
+        Some(value) => bounded_provider_id(&value),
+        None if family == JumpCloudFamily::AuditEvents => {
+            let raw = raw_bytes.ok_or(JumpCloudError::InvalidProviderRecord)?;
+            let raw =
+                std::str::from_utf8(raw).map_err(|_| JumpCloudError::InvalidProviderRecord)?;
+            Ok(sourcecdk_event_id(&[raw]))
+        }
+        None => Err(JumpCloudError::MissingStableIdentity),
+    }
+}
+
+fn record_identity(
+    kernel: &JumpCloudKernel,
+    values: &Map<String, Value>,
+    external_id: &str,
+) -> String {
+    let mut parts = vec![external_id.to_owned()];
+    let identity_keys: &[&str] = if kernel.family == JumpCloudFamily::GroupMembers {
+        &["group_id"]
+    } else {
+        &[]
+    };
+    for key in identity_keys.iter().copied().chain([
+        "device_id",
+        "device.id",
+        "serial_number",
+        "agent_id",
+        "agent.uuid",
+        "device_uuid",
+        "installed_version",
+        "version",
+    ]) {
+        let value = if key == "group_id" {
+            kernel.filters.group_id.clone()
+        } else {
+            string_first(values, &[key])
+        };
+        if let Some(value) = value.filter(|value| !value.trim().is_empty()) {
+            parts.push(format!("{key}={}", value.trim()));
+        }
+    }
+    if parts.len() == 1 {
+        return parts.remove(0);
+    }
+    let digest = Sha256::digest(parts.join("\0"));
+    format!("{}-{}", parts[0], hex_prefix(&digest, 12))
+}
+
+fn resolved_path(kernel: &JumpCloudKernel) -> Result<String, JumpCloudError> {
+    if kernel.family != JumpCloudFamily::GroupMembers {
+        return Ok(kernel.family.path().to_owned());
+    }
+    let group_id = kernel
+        .filters
+        .group_id
+        .as_deref()
+        .ok_or(JumpCloudError::MissingConfiguration("group_id"))?;
+    Ok(kernel.family.path().replace("{group_id}", group_id))
+}
+
+fn jsonapi_event_id(
+    tenant_id: &str,
+    base_url: &str,
+    path: &str,
+    family: &str,
+    record_id: &str,
+) -> String {
+    let scope = Sha256::digest(format!("{base_url}\0{path}"));
+    [
+        "jumpcloud".to_owned(),
+        normalize_id(tenant_id),
+        hex_prefix(&scope, 6),
+        normalize_id(family),
+        normalize_id(record_id),
+    ]
+    .join("-")
+}
+
+fn sourcecdk_event_id(parts: &[&str]) -> String {
+    let normalized = parts
+        .iter()
+        .map(|part| part.trim())
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    if normalized.is_empty() {
+        return "id-missing".to_owned();
+    }
+    let digest = Sha256::digest(normalized.join("\0"));
+    format!("id-{}", hex_prefix(&digest, 16))
+}
+
+fn string_first(values: &Map<String, Value>, paths: &[&str]) -> Option<String> {
+    paths.iter().find_map(|path| {
+        let mut segments = path.split('.');
+        let mut value = values.get(segments.next()?)?;
+        for segment in segments {
+            value = value.get(segment)?;
+        }
+        match value {
+            Value::String(value) => (!value.trim().is_empty()).then(|| value.trim().to_owned()),
+            Value::Number(value) => Some(value.to_string()),
+            Value::Bool(value) => Some(value.to_string()),
+            _ => None,
+        }
+    })
+}
+
+fn bounded_provider_id(value: &str) -> Result<String, JumpCloudError> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > 512 {
+        return Err(JumpCloudError::MissingStableIdentity);
+    }
+    Ok(value.to_owned())
+}
+
+fn normalize_id(value: &str) -> String {
+    let value = value.trim();
+    if value.is_empty() {
+        return "unknown".to_owned();
+    }
+    value.replace([' ', '/', ':', '\t', '\n'], "-")
+}
+
+fn hex_prefix(digest: &[u8], bytes: usize) -> String {
+    digest[..bytes]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}

--- a/crates/source-runtime-next/src/jumpcloud/normalize.rs
+++ b/crates/source-runtime-next/src/jumpcloud/normalize.rs
@@ -1,49 +1,30 @@
 use std::collections::BTreeMap;
 
 use serde_json::{Map, Value};
-use sha2::{Digest, Sha256};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use super::{
     JumpCloudError, JumpCloudFamily, JumpCloudKernel, JumpCloudRecord, JumpCloudRuntimeDefinition,
+    identity,
 };
 
 pub(super) fn normalize(
     kernel: &JumpCloudKernel,
     raw: Value,
+    raw_bytes: Option<&[u8]>,
 ) -> Result<JumpCloudRecord, JumpCloudError> {
     reject_untrusted(&raw, 0)?;
     let values = raw
         .as_object()
         .ok_or(JumpCloudError::InvalidProviderRecord)?;
-    let external_id = external_id(kernel.family, values)?;
-    let provider_id = if kernel.family == JumpCloudFamily::GroupMembers {
-        let group_id = kernel
-            .filters
-            .group_id
-            .as_deref()
-            .ok_or(JumpCloudError::MissingConfiguration("group_id"))?;
-        format!("{group_id}\0{external_id}")
-    } else {
-        external_id.clone()
-    };
+    let identity = identity::material(kernel, values, raw_bytes)?;
     let occurred_at = occurred_at(kernel.family, values, &kernel.observed_at)?;
-    let (attributes, payload) = family_values(kernel, values, &external_id)?;
+    let (attributes, payload) = family_values(kernel, values, &identity.external_id)?;
     validate_contract(kernel.family, &attributes, &payload)?;
-    let digest = Sha256::digest(format!(
-        "{}\0{}\0{}",
-        kernel.tenant_id,
-        kernel.family.as_str(),
-        provider_id
-    ));
-    let suffix = digest[..12]
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect::<String>();
     Ok(JumpCloudRecord {
         tenant_id: kernel.tenant_id.clone(),
-        event_id: format!("jumpcloud-{}-{suffix}", kernel.family.as_str()),
-        provider_id,
+        event_id: identity.event_id,
+        provider_id: identity.provider_id,
         family: kernel.family,
         kind: kernel.family.event_kind().to_owned(),
         schema_ref: kernel.family.schema_ref().to_owned(),
@@ -330,21 +311,6 @@ fn family_values(
     Ok((attributes, Value::Object(payload)))
 }
 
-fn external_id(
-    family: JumpCloudFamily,
-    values: &Map<String, Value>,
-) -> Result<String, JumpCloudError> {
-    let paths: &[&str] = match family {
-        JumpCloudFamily::Users => &["_id", "id", "email", "username"],
-        JumpCloudFamily::Groups | JumpCloudFamily::SystemGroups => &["id", "name"],
-        JumpCloudFamily::Systems => &["_id", "id", "displayName", "hostname"],
-        JumpCloudFamily::Applications => &["_id", "id", "displayName", "name"],
-        JumpCloudFamily::GroupMembers => &["to.id", "id"],
-        JumpCloudFamily::AuditEvents => &["id", "event_id", "uuid", "request_id"],
-    };
-    provider_component(&string_first(values, paths).ok_or(JumpCloudError::MissingStableIdentity)?)
-}
-
 fn validate_contract(
     family: JumpCloudFamily,
     attributes: &BTreeMap<String, String>,
@@ -425,18 +391,6 @@ fn string_first(values: &Map<String, Value>, paths: &[&str]) -> Option<String> {
 fn value_at<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
     path.split('.')
         .try_fold(value, |value, segment| value.get(segment))
-}
-
-fn provider_component(value: &str) -> Result<String, JumpCloudError> {
-    let value = value.trim();
-    if value.is_empty()
-        || value.len() > 512
-        || value.chars().any(char::is_control)
-        || value.contains([':', '/', '\\'])
-    {
-        return Err(JumpCloudError::MissingStableIdentity);
-    }
-    Ok(value.to_owned())
 }
 
 fn reject_untrusted(value: &Value, depth: usize) -> Result<(), JumpCloudError> {

--- a/crates/source-runtime-next/src/jumpcloud/request.rs
+++ b/crates/source-runtime-next/src/jumpcloud/request.rs
@@ -1,5 +1,5 @@
 use serde_json::{Map, Value};
-use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+use time::{Duration, OffsetDateTime, format_description::well_known::Rfc3339};
 
 use super::{
     JumpCloudError, JumpCloudFamily, JumpCloudFilters, JumpCloudKernel, JumpCloudRequest, origin,
@@ -46,6 +46,14 @@ pub(super) fn plan(
     kernel: &JumpCloudKernel,
     cursor: Option<&str>,
 ) -> Result<JumpCloudRequest, JumpCloudError> {
+    plan_with_checkpoint(kernel, cursor, None)
+}
+
+pub(super) fn plan_with_checkpoint(
+    kernel: &JumpCloudKernel,
+    cursor: Option<&str>,
+    prior_watermark: Option<&str>,
+) -> Result<JumpCloudRequest, JumpCloudError> {
     let origin = if kernel.family.uses_insights_origin() {
         &kernel.insights_origin
     } else {
@@ -68,7 +76,10 @@ pub(super) fn plan(
     }
     let (cursor, body) = if kernel.family == JumpCloudFamily::AuditEvents {
         let cursor = cursor.map(validate_audit_cursor).transpose()?;
-        (cursor.clone(), Some(audit_body(kernel, cursor.as_deref())?))
+        (
+            cursor.clone(),
+            Some(audit_body(kernel, cursor.as_deref(), prior_watermark)?),
+        )
     } else {
         let offset = cursor.map(validate_offset).transpose()?.unwrap_or(0);
         {
@@ -86,6 +97,7 @@ pub(super) fn plan(
         cursor,
         body,
         org_id: kernel.filters.org_id.clone(),
+        checkpoint_watermark: prior_watermark.map(normalize_watermark).transpose()?,
     })
 }
 
@@ -93,7 +105,13 @@ pub(super) fn validate_request(
     kernel: &JumpCloudKernel,
     request: &JumpCloudRequest,
 ) -> Result<(), JumpCloudError> {
-    if request != &plan(kernel, request.cursor.as_deref())? {
+    if request
+        != &plan_with_checkpoint(
+            kernel,
+            request.cursor.as_deref(),
+            request.checkpoint_watermark.as_deref(),
+        )?
+    {
         return Err(JumpCloudError::RequestScopeMismatch);
     }
     Ok(())
@@ -159,7 +177,24 @@ fn validate_filters(
     Ok(())
 }
 
-fn audit_body(kernel: &JumpCloudKernel, cursor: Option<&str>) -> Result<Vec<u8>, JumpCloudError> {
+fn audit_body(
+    kernel: &JumpCloudKernel,
+    cursor: Option<&str>,
+    prior_watermark: Option<&str>,
+) -> Result<Vec<u8>, JumpCloudError> {
+    let start_time = match &kernel.filters.audit_start_time {
+        Some(configured) => configured.clone(),
+        None => match prior_watermark {
+            Some(watermark) => normalize_watermark(watermark)?,
+            None => (OffsetDateTime::parse(&kernel.observed_at, &Rfc3339)
+                .map_err(|_| JumpCloudError::InvalidConfiguration("observed_at"))?
+                - Duration::days(1))
+            .replace_nanosecond(0)
+            .map_err(|_| JumpCloudError::InvalidConfiguration("observed_at"))?
+            .format(&Rfc3339)
+            .map_err(|_| JumpCloudError::InternalRuntimeFailure)?,
+        },
+    };
     let mut body = Map::from_iter([
         (
             "service".to_owned(),
@@ -173,16 +208,7 @@ fn audit_body(kernel: &JumpCloudKernel, cursor: Option<&str>) -> Result<Vec<u8>,
                     .collect(),
             ),
         ),
-        (
-            "start_time".to_owned(),
-            Value::String(
-                kernel
-                    .filters
-                    .audit_start_time
-                    .clone()
-                    .unwrap_or_else(|| kernel.observed_at.clone()),
-            ),
-        ),
+        ("start_time".to_owned(), Value::String(start_time)),
         ("limit".to_owned(), Value::from(kernel.page_size)),
         (
             "sort".to_owned(),
@@ -203,6 +229,15 @@ fn audit_body(kernel: &JumpCloudKernel, cursor: Option<&str>) -> Result<Vec<u8>,
         body.insert("search_after".to_owned(), value);
     }
     serde_json::to_vec(&Value::Object(body)).map_err(|_| JumpCloudError::InternalRuntimeFailure)
+}
+
+fn normalize_watermark(value: &str) -> Result<String, JumpCloudError> {
+    OffsetDateTime::parse(value.trim(), &Rfc3339)
+        .map_err(|_| JumpCloudError::InvalidConfiguration("checkpoint_watermark"))?
+        .replace_nanosecond(0)
+        .map_err(|_| JumpCloudError::InvalidConfiguration("checkpoint_watermark"))?
+        .format(&Rfc3339)
+        .map_err(|_| JumpCloudError::InternalRuntimeFailure)
 }
 
 fn reject_depth(value: &Value, depth: usize) -> Result<(), JumpCloudError> {

--- a/crates/source-runtime-next/src/jumpcloud/response.rs
+++ b/crates/source-runtime-next/src/jumpcloud/response.rs
@@ -26,13 +26,25 @@ pub(super) fn decode(
     let root: Value =
         serde_json::from_slice(body).map_err(|_| JumpCloudError::MalformedResponse)?;
     let items = records(kernel.family, &root)?;
+    let audit_rows = (kernel.family == JumpCloudFamily::AuditEvents)
+        .then(|| raw_array_elements(body))
+        .transpose()?;
+    if audit_rows
+        .as_ref()
+        .is_some_and(|rows| rows.len() != items.len())
+    {
+        return Err(JumpCloudError::MalformedResponse);
+    }
     if items.len() > request.page_size {
         return Err(JumpCloudError::TooManyRecords);
     }
     let mut seen = BTreeMap::<String, Vec<u8>>::new();
     let mut normalized = Vec::with_capacity(items.len());
-    for raw in items {
-        let record = normalize::normalize(kernel, raw.clone())?;
+    for (index, raw) in items.iter().enumerate() {
+        let raw_bytes = audit_rows
+            .as_ref()
+            .and_then(|rows| rows.get(index).copied());
+        let record = normalize::normalize(kernel, raw.clone(), raw_bytes)?;
         let canonical = serde_json::to_vec(&record.payload)
             .map_err(|_| JumpCloudError::InvalidProviderRecord)?;
         match seen.get(&record.event_id) {
@@ -49,6 +61,80 @@ pub(super) fn decode(
         records: normalized,
         next_cursor,
     })
+}
+
+/// Preserve exact provider bytes for idless audit-row identity parity with Go.
+fn raw_array_elements(body: &[u8]) -> Result<Vec<&[u8]>, JumpCloudError> {
+    let mut index = skip_space(body, 0);
+    if body.get(index) != Some(&b'[') {
+        return Err(JumpCloudError::MalformedResponse);
+    }
+    index += 1;
+    let mut elements = Vec::new();
+    loop {
+        index = skip_space(body, index);
+        if body.get(index) == Some(&b']') {
+            index = skip_space(body, index + 1);
+            return (index == body.len())
+                .then_some(elements)
+                .ok_or(JumpCloudError::MalformedResponse);
+        }
+        if body.get(index) != Some(&b'{') {
+            return Err(JumpCloudError::MalformedResponse);
+        }
+        let start = index;
+        let mut depth = 0_usize;
+        let mut in_string = false;
+        let mut escaped = false;
+        while index < body.len() {
+            let byte = body[index];
+            if in_string {
+                if escaped {
+                    escaped = false;
+                } else if byte == b'\\' {
+                    escaped = true;
+                } else if byte == b'"' {
+                    in_string = false;
+                }
+            } else {
+                match byte {
+                    b'"' => in_string = true,
+                    b'{' | b'[' => depth = depth.saturating_add(1),
+                    b'}' | b']' => {
+                        depth = depth
+                            .checked_sub(1)
+                            .ok_or(JumpCloudError::MalformedResponse)?;
+                        if depth == 0 {
+                            index += 1;
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            index += 1;
+        }
+        if depth != 0 || in_string {
+            return Err(JumpCloudError::MalformedResponse);
+        }
+        elements.push(&body[start..index]);
+        index = skip_space(body, index);
+        match body.get(index) {
+            Some(b',') => index += 1,
+            Some(b']') => {}
+            _ => return Err(JumpCloudError::MalformedResponse),
+        }
+    }
+}
+
+fn skip_space(body: &[u8], mut index: usize) -> usize {
+    while body
+        .get(index)
+        .is_some_and(|byte| matches!(byte, b' ' | b'\n' | b'\r' | b'\t'))
+    {
+        index += 1;
+    }
+    index
 }
 
 pub(super) fn checkpoint_candidate(

--- a/crates/source-runtime-next/src/jumpcloud/tests.rs
+++ b/crates/source-runtime-next/src/jumpcloud/tests.rs
@@ -19,6 +19,8 @@ const GROUP_MEMBERS_ORACLE: &[u8] =
     include_bytes!("../../../../sources/jumpcloud/testdata/read_group_members.json");
 const AUDIT_ORACLE: &[u8] =
     include_bytes!("../../../../sources/jumpcloud/testdata/read_audit_events.json");
+const IDLESS_AUDIT_ORACLE: &[u8] =
+    include_bytes!("../../../../sources/jumpcloud/testdata/idless_audit_events.json");
 
 #[derive(serde::Deserialize)]
 struct CatalogWire {
@@ -165,14 +167,42 @@ fn plans_all_families_without_credentials_or_redirects() {
 
 #[test]
 fn checked_in_go_oracles_match_all_rust_families() {
-    for (family, oracle) in [
-        (JumpCloudFamily::Users, USERS_ORACLE),
-        (JumpCloudFamily::Groups, GROUPS_ORACLE),
-        (JumpCloudFamily::Systems, SYSTEMS_ORACLE),
-        (JumpCloudFamily::Applications, APPLICATIONS_ORACLE),
-        (JumpCloudFamily::SystemGroups, SYSTEM_GROUPS_ORACLE),
-        (JumpCloudFamily::GroupMembers, GROUP_MEMBERS_ORACLE),
-        (JumpCloudFamily::AuditEvents, AUDIT_ORACLE),
+    for (family, oracle, event_id) in [
+        (
+            JumpCloudFamily::Users,
+            USERS_ORACLE,
+            "jumpcloud-tenant-7b2f83dc868b-users-user-1",
+        ),
+        (
+            JumpCloudFamily::Groups,
+            GROUPS_ORACLE,
+            "jumpcloud-tenant-101a38d129e6-groups-group-1",
+        ),
+        (
+            JumpCloudFamily::Systems,
+            SYSTEMS_ORACLE,
+            "jumpcloud-tenant-2922a216fe1a-systems-system-1",
+        ),
+        (
+            JumpCloudFamily::Applications,
+            APPLICATIONS_ORACLE,
+            "jumpcloud-tenant-52cd854825d7-applications-app-1",
+        ),
+        (
+            JumpCloudFamily::SystemGroups,
+            SYSTEM_GROUPS_ORACLE,
+            "jumpcloud-tenant-93d3aa9d2bf0-system_groups-system-group-1",
+        ),
+        (
+            JumpCloudFamily::GroupMembers,
+            GROUP_MEMBERS_ORACLE,
+            "jumpcloud-tenant-3436a8f4ca37-group_members-user-1-0e0c6c2b62ad1daf6ed6f4b9",
+        ),
+        (
+            JumpCloudFamily::AuditEvents,
+            AUDIT_ORACLE,
+            "id-110a0d85f5ff3756b59221395dcc5752",
+        ),
     ] {
         let expected = oracle_event(oracle);
         let raw = expected["payload"].clone();
@@ -194,8 +224,45 @@ fn checked_in_go_oracles_match_all_rust_families() {
             )
             .expect("fixture page");
         assert_eq!(page.records.len(), 1, "family {family:?}");
-        assert_oracle(&page.records[0], &expected);
+        assert_oracle(&page.records[0], &expected, event_id);
     }
+}
+
+#[test]
+fn idless_audit_identity_hashes_exact_provider_row_bytes_like_go() {
+    let audit = kernel("tenant", JumpCloudFamily::AuditEvents);
+    let page = audit
+        .decode(
+            &audit.plan(None).unwrap(),
+            200,
+            &JumpCloudResponseMetadata::default(),
+            IDLESS_AUDIT_ORACLE,
+        )
+        .expect("idless audit row");
+    assert_eq!(page.records.len(), 1);
+    assert_eq!(
+        page.records[0].provider_id,
+        "id-5bded99005439a1abf0d1e0fbee3f84b"
+    );
+    assert_eq!(
+        page.records[0].event_id,
+        "id-e7af2eebff7e584819c58bd1b5c3970c"
+    );
+    assert_eq!(
+        page.records[0].attributes["source_event_id"],
+        "id-5bded99005439a1abf0d1e0fbee3f84b"
+    );
+
+    let reordered = br#"[{"timestamp":"2026-06-02T03:04:05Z","initiated_by":{"id":"actor-1"},"event_type":"login"}]"#;
+    let other = audit
+        .decode(
+            &audit.plan(None).unwrap(),
+            200,
+            &JumpCloudResponseMetadata::default(),
+            reordered,
+        )
+        .unwrap();
+    assert_ne!(page.records[0].provider_id, other.records[0].provider_id);
 }
 
 #[test]
@@ -251,6 +318,189 @@ fn offset_and_search_after_checkpoints_round_trip_after_restart() {
         audit.plan(Some("not-json")),
         Err(JumpCloudError::InvalidCursor)
     );
+}
+
+#[test]
+fn terminal_audit_watermark_drives_the_next_request_after_restart() {
+    let filters = JumpCloudFilters {
+        org_id: Some("org-1".to_owned()),
+        ..JumpCloudFilters::default()
+    };
+    let audit = JumpCloudKernel::new(
+        "https://console.jumpcloud.com/api",
+        "https://api.jumpcloud.com/insights/directory/v1",
+        "tenant",
+        JumpCloudFamily::AuditEvents,
+        filters.clone(),
+        Some(100),
+        "2026-06-03T00:00:00Z",
+    )
+    .unwrap();
+    let request = audit.plan(None).unwrap();
+    let body: Value = serde_json::from_slice(request.body().unwrap()).unwrap();
+    assert_eq!(body["start_time"], "2026-06-02T00:00:00Z");
+    let page = audit
+        .decode(
+            &request,
+            200,
+            &JumpCloudResponseMetadata {
+                result_count: Some(1),
+                limit: Some(100),
+                ..JumpCloudResponseMetadata::default()
+            },
+            br#"[{"id":"event-1","event_type":"login","initiated_by":{"id":"actor-1"},"timestamp":"2026-06-02T03:04:05Z"}]"#,
+        )
+        .unwrap();
+    assert_eq!(page.next_cursor, None);
+    let checkpoint = audit
+        .checkpoint_candidate(&request, &page, None)
+        .expect("terminal checkpoint");
+    assert_eq!(
+        checkpoint.watermark.as_deref(),
+        Some("2026-06-02T03:04:05Z")
+    );
+
+    let restarted = JumpCloudKernel::new(
+        "https://console.jumpcloud.com/api",
+        "https://api.jumpcloud.com/insights/directory/v1",
+        "tenant",
+        JumpCloudFamily::AuditEvents,
+        filters,
+        Some(100),
+        "2026-06-04T00:00:00Z",
+    )
+    .unwrap();
+    let resumed = restarted
+        .plan_with_checkpoint(None, checkpoint.watermark.as_deref())
+        .unwrap();
+    assert_eq!(resumed.checkpoint_watermark(), Some("2026-06-02T03:04:05Z"));
+    let body: Value = serde_json::from_slice(resumed.body().unwrap()).unwrap();
+    assert_eq!(body["start_time"], "2026-06-02T03:04:05Z");
+
+    let configured = kernel("tenant", JumpCloudFamily::AuditEvents)
+        .plan_with_checkpoint(None, Some("2026-05-01T00:00:00Z"))
+        .unwrap();
+    let body: Value = serde_json::from_slice(configured.body().unwrap()).unwrap();
+    assert_eq!(body["start_time"], "2026-06-01T00:00:00Z");
+}
+
+#[test]
+fn audit_dynamic_body_safe_headers_and_alternate_origins_are_exact() {
+    let filters = JumpCloudFilters {
+        org_id: Some("org-1".to_owned()),
+        audit_start_time: Some("2026-06-01T00:00:00Z".to_owned()),
+        audit_end_time: Some("2026-06-02T00:00:00Z".to_owned()),
+        audit_services: vec!["sso".to_owned(), "directory".to_owned()],
+        audit_sort: Some("desc".to_owned()),
+        ..JumpCloudFilters::default()
+    };
+    for origin in [
+        "https://api.eu.jumpcloud.com/insights/directory/v1",
+        "https://api.in.jumpcloud.com/insights/directory/v1",
+    ] {
+        let audit = JumpCloudKernel::new(
+            "https://console.jumpcloud.com/api",
+            origin,
+            "tenant",
+            JumpCloudFamily::AuditEvents,
+            filters.clone(),
+            Some(250),
+            "2026-06-03T00:00:00Z",
+        )
+        .unwrap();
+        let request = audit.plan(Some(r#"[1719849600000,"event-2"]"#)).unwrap();
+        assert_eq!(request.url().as_str(), format!("{origin}/events"));
+        assert_eq!(request.content_type(), Some("application/json"));
+        let body: Value = serde_json::from_slice(request.body().unwrap()).unwrap();
+        assert_eq!(body["service"], json!(["sso", "directory"]));
+        assert_eq!(body["start_time"], "2026-06-01T00:00:00Z");
+        assert_eq!(body["end_time"], "2026-06-02T00:00:00Z");
+        assert_eq!(body["limit"], 250);
+        assert_eq!(body["sort"], "DESC");
+        assert_eq!(body["search_after"], json!([1719849600000_u64, "event-2"]));
+    }
+
+    let headers = BTreeMap::from([
+        ("X-Result-Count".to_owned(), "250".to_owned()),
+        ("X-Limit".to_owned(), "250".to_owned()),
+        (
+            "X-Search_after".to_owned(),
+            r#"[1719849600000,"event-2"]"#.to_owned(),
+        ),
+        ("Retry-After".to_owned(), "30".to_owned()),
+    ]);
+    assert_eq!(
+        JumpCloudResponseMetadata::from_headers(&headers).unwrap(),
+        JumpCloudResponseMetadata {
+            result_count: Some(250),
+            limit: Some(250),
+            search_after: Some(r#"[1719849600000,"event-2"]"#.to_owned()),
+            retry_after_seconds: Some(30),
+        }
+    );
+    assert_eq!(
+        JumpCloudResponseMetadata::from_headers(&BTreeMap::from([(
+            "X-Result-Count".to_owned(),
+            "not-an-integer".to_owned(),
+        )])),
+        Err(JumpCloudError::MalformedResponse)
+    );
+}
+
+#[test]
+fn provider_local_source_execution_contract_covers_all_seven_families() {
+    assert_eq!(adapter::JUMPCLOUD_SOURCE_EXECUTION_ADAPTERS.len(), 7);
+    for adapter in adapter::JUMPCLOUD_SOURCE_EXECUTION_ADAPTERS {
+        let contract = adapter.contract().unwrap();
+        assert_eq!(contract.source_id, "jumpcloud");
+        assert_eq!(contract.family_id, adapter.family().as_str());
+        assert_eq!(contract.method, adapter.family().method());
+        assert_eq!(contract.path, adapter.family().path());
+        assert_eq!(contract.credential_operation, "jumpcloud.x_api_key");
+        assert_eq!(
+            contract.provider_kernel,
+            format!("jumpcloud.{}", adapter.family().as_str())
+        );
+        let audit = adapter.family() == JumpCloudFamily::AuditEvents;
+        assert_eq!(contract.request_body, audit);
+        assert_eq!(
+            contract.response_cursor_header,
+            audit.then_some("X-Search_after")
+        );
+        assert_eq!(
+            contract.origin,
+            if audit {
+                "https://api.jumpcloud.com/insights/directory/v1"
+            } else {
+                "https://console.jumpcloud.com/api"
+            }
+        );
+        let planned = adapter
+            .plan(&kernel("tenant", adapter.family()), None, None)
+            .unwrap();
+        assert_eq!(planned.family(), adapter.family());
+        let response = if adapter.family() == JumpCloudFamily::AuditEvents {
+            br#"[{"id":"event-1","event_type":"login","initiated_by":{"id":"actor-1"},"timestamp":"2026-06-02T03:04:05Z"}]"#.as_slice()
+        } else if matches!(
+            adapter.family(),
+            JumpCloudFamily::Users | JumpCloudFamily::Systems | JumpCloudFamily::Applications
+        ) {
+            br#"{"results":[]}"#.as_slice()
+        } else {
+            br#"[]"#.as_slice()
+        };
+        assert!(
+            adapter
+                .decode(
+                    &kernel("tenant", adapter.family()),
+                    &planned,
+                    200,
+                    &JumpCloudResponseMetadata::default(),
+                    response,
+                )
+                .is_ok()
+        );
+    }
 }
 
 #[test]
@@ -395,14 +645,14 @@ fn oracle_event(bytes: &[u8]) -> Value {
         .remove(0)
 }
 
-fn assert_oracle(record: &JumpCloudRecord, expected: &Value) {
+fn assert_oracle(record: &JumpCloudRecord, expected: &Value, event_id: &str) {
     assert_eq!(record.tenant_id, expected["tenant_id"]);
     assert_eq!(record.kind, expected["kind"]);
     assert_eq!(record.schema_ref, expected["schema_ref"]);
     assert_eq!(record.occurred_at, expected["occurred_at"]);
     assert_eq!(record.attributes, attributes(&expected["attributes"]));
     assert_eq!(record.payload, expected["payload"]);
-    assert!(!record.event_id.is_empty());
+    assert_eq!(record.event_id, event_id);
 }
 
 fn attributes(value: &Value) -> BTreeMap<String, String> {

--- a/crates/source-runtime-next/src/jumpcloud/types.rs
+++ b/crates/source-runtime-next/src/jumpcloud/types.rs
@@ -32,6 +32,7 @@ pub struct JumpCloudRequest {
     pub(super) cursor: Option<String>,
     pub(super) body: Option<Vec<u8>>,
     pub(super) org_id: Option<String>,
+    pub(super) checkpoint_watermark: Option<String>,
 }
 
 impl fmt::Debug for JumpCloudRequest {
@@ -45,6 +46,10 @@ impl fmt::Debug for JumpCloudRequest {
             .field("has_cursor", &self.cursor.is_some())
             .field("has_body", &self.body.is_some())
             .field("has_org_id", &self.org_id.is_some())
+            .field(
+                "has_checkpoint_watermark",
+                &self.checkpoint_watermark.is_some(),
+            )
             .finish()
     }
 }
@@ -77,6 +82,18 @@ impl JumpCloudRequest {
     /// Canonical credential-free request body for Directory Insights.
     pub fn body(&self) -> Option<&[u8]> {
         self.body.as_deref()
+    }
+    /// Prior terminal audit watermark bound into this request, when present.
+    pub fn checkpoint_watermark(&self) -> Option<&str> {
+        self.checkpoint_watermark.as_deref()
+    }
+    /// Request media type required by the trusted host.
+    pub const fn content_type(&self) -> Option<&'static str> {
+        if matches!(self.family, JumpCloudFamily::AuditEvents) {
+            Some("application/json")
+        } else {
+            None
+        }
     }
     /// Expected response media type.
     pub const fn accept(&self) -> &'static str {
@@ -111,6 +128,63 @@ pub struct JumpCloudResponseMetadata {
     pub search_after: Option<String>,
     /// Bounded retry delay.
     pub retry_after_seconds: Option<u64>,
+}
+
+impl JumpCloudResponseMetadata {
+    /// Parse only the bounded, public response headers required by JumpCloud.
+    pub fn from_headers(headers: &BTreeMap<String, String>) -> Result<Self, JumpCloudError> {
+        let result_count = bounded_usize(header(headers, "x-result-count")?, 1_000_000)?;
+        let limit = bounded_usize(header(headers, "x-limit")?, 1_000)?;
+        let search_after = header(headers, "x-search_after")?
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(request::validate_audit_cursor)
+            .transpose()?;
+        let retry_after_seconds = header(headers, "retry-after")?
+            .map(str::trim)
+            .map(|value| {
+                value
+                    .parse::<u64>()
+                    .ok()
+                    .filter(|seconds| *seconds <= 3_600)
+                    .ok_or(JumpCloudError::InvalidRetryAfter)
+            })
+            .transpose()?;
+        Ok(Self {
+            result_count,
+            limit,
+            search_after,
+            retry_after_seconds,
+        })
+    }
+}
+
+fn header<'a>(
+    headers: &'a BTreeMap<String, String>,
+    expected: &str,
+) -> Result<Option<&'a str>, JumpCloudError> {
+    let mut matches = headers
+        .iter()
+        .filter(|(name, _)| name.eq_ignore_ascii_case(expected))
+        .map(|(_, value)| value.as_str());
+    let first = matches.next();
+    if matches.next().is_some() {
+        return Err(JumpCloudError::MalformedResponse);
+    }
+    Ok(first)
+}
+
+fn bounded_usize(value: Option<&str>, maximum: usize) -> Result<Option<usize>, JumpCloudError> {
+    value
+        .map(str::trim)
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .ok()
+                .filter(|value| *value <= maximum)
+                .ok_or(JumpCloudError::MalformedResponse)
+        })
+        .transpose()
 }
 
 /// One normalized tenant-scoped JumpCloud event candidate.
@@ -200,6 +274,18 @@ impl JumpCloudKernel {
     /// Plan one bounded origin-restricted provider request.
     pub fn plan(&self, cursor: Option<&str>) -> Result<JumpCloudRequest, JumpCloudError> {
         request::plan(self, cursor)
+    }
+
+    /// Plan a request with the last terminal durable watermark.
+    ///
+    /// For Directory Insights this matches Go `ReadWithCheckpoint`: explicit
+    /// configuration wins, otherwise the prior watermark becomes `start_time`.
+    pub fn plan_with_checkpoint(
+        &self,
+        cursor: Option<&str>,
+        prior_watermark: Option<&str>,
+    ) -> Result<JumpCloudRequest, JumpCloudError> {
+        request::plan_with_checkpoint(self, cursor, prior_watermark)
     }
 
     /// Decode one provider response under the exact planned request.

--- a/sources/jumpcloud/catalog.yaml
+++ b/sources/jumpcloud/catalog.yaml
@@ -459,5 +459,4 @@ event_contracts:
       - source_event_id
       - event_type
       - actor_id
-    required_payload_fields:
-      - id
+    required_payload_fields: []

--- a/sources/jumpcloud/testdata/idless_audit_events.json
+++ b/sources/jumpcloud/testdata/idless_audit_events.json
@@ -1,0 +1,1 @@
+[{"event_type":"login","initiated_by":{"id":"actor-1"},"timestamp":"2026-06-02T03:04:05Z"}]


### PR DESCRIPTION
## Scope

- preserve all seven JumpCloud families and compile their exact provider-local request/event contracts
- plan Directory Insights requests on the alternate JumpCloud origin with dynamic JSON bodies and prior-watermark resume
- parse bounded `X-Result-Count`, `X-Limit`, `X-Search_after`, and `Retry-After` response metadata
- match Go event identity for generic families and exact raw-row hash fallback for idless audit events
- expose the provider-local seven-family adapter tuple for the separately owned shared registry integration
- keep credentials outside the kernel and retain current Go runtime authority

## Local validation

- `cargo fmt --all -- --check`
- `cargo test -p cerebro-source-runtime-next jumpcloud --lib` (10 passed)
- `cargo clippy -p cerebro-source-runtime-next --lib --tests -- -D warnings`
- `cargo test -p cerebro-source-runtime-next --lib` (506 passed)
- `cargo test -p cerebro-source-catalog --lib` (24 passed)
- `go test ./sources/jumpcloud ./sources/internal/jumpcloudapi ./internal/sourceprojection`
- `make fixture-oracle-check`
- `make source-fixture-check`
- `make sourcegen-test`
- `make catalog-check`
- `make check-structural`
- `make check-structural-test`
- `make check-arch`
- `./scripts/leak_check.sh range 1a816dde1df081249870f0f86272633b26234406..HEAD`

## Remaining boundaries

- Shared source-execution wire/host registration is owned by a separate non-colliding change and is not modified here.
- Go collection authority remains enabled pending the production-host and promotion gate.
- No live-provider collection or authenticated product-path verification was run because this public provider-local slice does not receive provider credentials or deployment authority.
- Full repository `make verify` was not run locally; required hosted checks are the remaining repository-wide validation.