### PR TITLE
Fix Rust-only catalog family count

### DIFF
--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -178,7 +178,7 @@ jobs:
           '
           summary="$(docker run --rm "${CANDIDATE_IMAGE}" catalog-summary)"
           test "$(jq -r .sources <<<"${summary}")" -eq 799
-          test "$(jq -r .families <<<"${summary}")" -eq 3973
+          test "$(jq -r .families <<<"${summary}")" -eq 3978
       - name: Start disposable PostgreSQL, Neo4j, and JetStream
         run: |
           set -euo pipefail
@@ -246,7 +246,7 @@ jobs:
             | .checks += [
                 {name:"rust_entrypoint",status:"passed",evidence:"image starts cerebro-platform directly"},
                 {name:"go_binary_absent",status:"passed",evidence:"/usr/local/bin/cerebro is absent"},
-                {name:"source_catalog",status:"passed",evidence:"799 sources and 3973 families loaded"}
+                {name:"source_catalog",status:"passed",evidence:"799 sources and 3978 families loaded"}
               ]
           ' .dist/rust-only-e2e/rust-only-e2e-receipt.json \
             > .dist/rust-only-e2e/receipt.tmp

--- a/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
+++ b/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
@@ -108,8 +108,8 @@ fn rust_candidate_build_never_invokes_go_or_emulation() {
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- seed",
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- verify",
         r#"test "$(jq -r .sources <<<"${summary}")" -eq 799"#,
-        r#"test "$(jq -r .families <<<"${summary}")" -eq 3973"#,
-        r#"evidence:"799 sources and 3973 families loaded""#,
+        r#"test "$(jq -r .families <<<"${summary}")" -eq 3978"#,
+        r#"evidence:"799 sources and 3978 families loaded""#,
         "cerebro.rust-only-e2e/v1",
         "cerebro.rust-only-candidate/v1",
     ] {


### PR DESCRIPTION
## Failure

Current-main Rust-only Candidate run 32566824498, job 97019002964 failed its catalog assertion after both platform images and the signed manifest succeeded. The compiled catalog on exact current base b8890964e1f5bb91f967d946f8beec9a0812f9c4 reports 799 sources and 3978 families; the workflow and its structural test still expected 3973 families.

## Change

- update the Rust-only candidate family assertion to 3978
- update the signed receipt evidence text to the same count
- update the workflow contract test to require the current assertion and evidence

This remains a synchronized generated-count assertion in two contract locations. A broader single-source refactor would enlarge the release-workflow change; this repair keeps the failed qualification path narrow and source-proven.

## Validation

- `CARGO_INCREMENTAL=0 cargo run -p cerebro-platform -- catalog-summary` -> 799 sources, 3978 families on exact base b8890964e1f5bb91f967d946f8beec9a0812f9c4
- `CARGO_INCREMENTAL=0 cargo test -p cerebro-platform --test rust_only_runtime_contract -- --nocapture` -> 6 passed
- `actionlint .github/workflows/rust-only-candidate.yml` -> pass
- `cargo fmt --all -- --check` -> pass
- `git diff --check` -> pass

DDESK was degraded without command access, so these focused checks ran through the managed local Cargo cache.