### PR TITLE
ci: centralize JavaScript workspace setup

### DIFF
--- a/.github/actions/setup-javascript-workspaces/action.yml
+++ b/.github/actions/setup-javascript-workspaces/action.yml
@@ -1,0 +1,21 @@
+name: Set up JavaScript workspaces
+description: Install the repository Node.js toolchain and optionally restore workspace dependencies.
+
+inputs:
+  install:
+    description: Run the repository workspace install target.
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: 22
+        cache: npm
+
+    - name: Install JavaScript workspaces
+      if: inputs.install == 'true'
+      shell: bash
+      run: make workspace-install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,13 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install JavaScript workspaces
-        run: npm ci
+      - uses: ./.github/actions/setup-javascript-workspaces
 
       - name: Check web workspace
         run: npm run check --workspace @writer/cerebro-web
@@ -109,13 +103,7 @@ jobs:
       - name: Set up Rust
         run: rustup toolchain install 1.93.1 --profile minimal
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install JavaScript workspaces
-        run: npm ci
+      - uses: ./.github/actions/setup-javascript-workspaces
 
       - name: Install Chromium for real-service validation
         run: npm exec --workspace @writer/cerebro-web -- playwright install --with-deps chromium
@@ -157,13 +145,7 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-rust-v1-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml', '**/Cargo.toml') }}-
             ${{ runner.os }}-${{ runner.arch }}-rust-v1-
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install JavaScript workspaces
-        run: npm ci
+      - uses: ./.github/actions/setup-javascript-workspaces
 
       - name: Install Chromium for Rust authority validation
         run: npm exec --workspace @writer/cerebro-web -- playwright install --with-deps chromium
@@ -199,13 +181,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install JavaScript workspaces
-        run: npm ci
+      - uses: ./.github/actions/setup-javascript-workspaces
 
       - name: Check Slack companion workspace
         run: |
@@ -236,13 +212,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install JavaScript workspaces
-        run: npm ci
+      - uses: ./.github/actions/setup-javascript-workspaces
 
       - name: Check TypeScript SDK workspace
         run: npm run check --workspace @writer/cerebro-sdk
@@ -254,10 +224,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: ./.github/actions/setup-javascript-workspaces
         with:
-          node-version: 22
-          cache: npm
+          install: "false"
 
       - name: Audit JavaScript workspace dependencies
         run: npm audit --omit=dev --audit-level=moderate

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -663,14 +663,10 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "22"
-          cache: npm
+      - uses: ./.github/actions/setup-javascript-workspaces
       - name: Build portable Slack companion and SDK archives
         run: |
           set -euo pipefail
-          npm ci
           make openapi-check openapi-ts-check agent-service-lifecycle-check
           npm run check --workspace @writer/cerebro-sdk
           npm run check --workspace @writer/cerebro-slack-companion

--- a/.github/workflows/portable-consumer-chain.yml
+++ b/.github/workflows/portable-consumer-chain.yml
@@ -57,10 +57,9 @@ jobs:
           go-version-file: go.mod
           cache: false
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: ./.github/actions/setup-javascript-workspaces
         with:
-          node-version: 22
-          cache: npm
+          install: "false"
 
       - name: Verify portable contract consumers and release inputs
         run: scripts/release/verify_portable_consumer_chain.sh

--- a/tools/archtests/javascript_workflow_setup_test.go
+++ b/tools/archtests/javascript_workflow_setup_test.go
@@ -1,0 +1,41 @@
+package archtests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWorkflowsUseSharedJavaScriptSetup(t *testing.T) {
+	root := repoRoot(t)
+	actionPath := filepath.Join(root, ".github", "actions", "setup-javascript-workspaces", "action.yml")
+	actionBytes, err := os.ReadFile(actionPath)
+	if err != nil {
+		t.Fatalf("read shared JavaScript setup action: %v", err)
+	}
+	action := string(actionBytes)
+	for _, required := range []string{
+		"actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
+		"node-version: 22",
+		"run: make workspace-install",
+	} {
+		if !strings.Contains(action, required) {
+			t.Errorf("%s must contain %q", actionPath, required)
+		}
+	}
+
+	workflows, err := filepath.Glob(filepath.Join(root, ".github", "workflows", "*.yml"))
+	if err != nil {
+		t.Fatalf("list GitHub workflows: %v", err)
+	}
+	for _, path := range workflows {
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if strings.Contains(string(contents), "actions/setup-node@") {
+			t.Errorf("%s configures Node.js directly; use ./.github/actions/setup-javascript-workspaces", path)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- define one JavaScript workspace bootstrap for Node.js, npm caching, and the repository install target
- use it across CI, release, and portable-consumer workflows
- keep the portable-consumer script responsible for its own standalone install
- prevent workflows from reintroducing direct Node.js setup

## Validation

- `make workspace-install`
- `actionlint .github/workflows/ci.yml .github/workflows/portable-consumer-chain.yml`
- parsed the shared action and all changed workflows as YAML
- `go test ./tools/archtests -count=1`
- `git diff --check`

The release workflow retains three pre-existing actionlint diagnostics outside this diff; the changed YAML parses cleanly.