### PR TITLE
Add credential-free ActiveCampaign Rust kernel

### DIFF
--- a/crates/source-runtime-next/src/activecampaign.rs
+++ b/crates/source-runtime-next/src/activecampaign.rs
@@ -1,0 +1,32 @@
+//! Credential-free ActiveCampaign request, normalization, and projection kernel.
+//!
+//! The trusted host owns credential-reference resolution, `Api-Token` header
+//! authentication, redirects, deadlines, and bounded network I/O. This module
+//! accepts authenticated tenant context, a validated account origin, and
+//! bounded provider response bytes only. The generic Rust catalog connector
+//! remains collection authority until this kernel is integrated through the
+//! shared credential host.
+
+mod catalog;
+mod error;
+mod family;
+mod normalize;
+mod origin;
+mod projection;
+mod request;
+mod response;
+mod types;
+
+pub use catalog::{ActiveCampaignEventContract, ActiveCampaignRuntimeDefinition};
+pub use error::ActiveCampaignError;
+pub use family::ActiveCampaignFamily;
+pub use projection::{
+    ActiveCampaignEntityFact, ActiveCampaignProjectionFacts, project_activecampaign_records,
+};
+pub use types::{
+    ActiveCampaignCheckpointCandidate, ActiveCampaignKernel, ActiveCampaignPage,
+    ActiveCampaignRecord, ActiveCampaignRequest,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/activecampaign/catalog.rs
+++ b/crates/source-runtime-next/src/activecampaign/catalog.rs
@@ -1,0 +1,55 @@
+use super::{ActiveCampaignError, ActiveCampaignFamily};
+
+/// Exact event contract compiled from the ActiveCampaign catalog.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ActiveCampaignEventContract {
+    /// Exact provider event kind.
+    pub kind: &'static str,
+    /// Exact schema reference.
+    pub schema_ref: &'static str,
+    /// Required normalized attributes.
+    pub required_attributes: &'static [&'static str],
+    /// Required normalized payload fields.
+    pub required_payload_fields: &'static [&'static str],
+}
+
+/// Closed runtime definition for one ActiveCampaign family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ActiveCampaignRuntimeDefinition {
+    /// Source identifier.
+    pub source_id: &'static str,
+    /// Selected family.
+    pub family: ActiveCampaignFamily,
+    /// Exact event contract.
+    pub event_contract: ActiveCampaignEventContract,
+    /// Every family is a bounded pull operation.
+    pub pull: bool,
+}
+
+impl ActiveCampaignRuntimeDefinition {
+    /// Compile one declared catalog family into a closed definition.
+    pub fn compile(family: ActiveCampaignFamily) -> Result<Self, ActiveCampaignError> {
+        let required_attributes = if family == ActiveCampaignFamily::Users {
+            &["tenant_id", "source_event_id", "user_id"][..]
+        } else {
+            &[
+                "tenant_id",
+                "source_event_id",
+                "resource_urn",
+                "resource_type",
+                "resource_id",
+            ][..]
+        };
+        Ok(Self {
+            source_id: "activecampaign",
+            family,
+            event_contract: ActiveCampaignEventContract {
+                kind: family.event_kind(),
+                schema_ref: family.schema_ref(),
+                required_attributes,
+                required_payload_fields: &["id"],
+            },
+            pull: true,
+        })
+    }
+}

--- a/crates/source-runtime-next/src/activecampaign/error.rs
+++ b/crates/source-runtime-next/src/activecampaign/error.rs
@@ -1,0 +1,166 @@
+use std::{error::Error, fmt};
+
+/// Bounded ActiveCampaign provider and runtime failure taxonomy.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ActiveCampaignError {
+    /// Family is outside the closed catalog.
+    InvalidFamily,
+    /// Public configuration is malformed.
+    InvalidConfiguration(&'static str),
+    /// Provider origin is not an allowed HTTPS ActiveCampaign account origin.
+    InvalidOrigin,
+    /// Authenticated tenant context is malformed.
+    InvalidTenantId,
+    /// Trusted host has no credential reference.
+    MissingCredentialReference,
+    /// Trusted host could not redeem the credential lease.
+    CredentialUnavailable,
+    /// Cursor is invalid or cannot round-trip.
+    InvalidCursor,
+    /// Request does not belong to this kernel.
+    RequestScopeMismatch,
+    /// Provider rejected authentication.
+    AuthenticationRejected,
+    /// Credential lacks the required provider permission.
+    RequiredScopeMissing,
+    /// Requested provider resource was not found.
+    ProviderResourceNotFound,
+    /// Trusted host denied provider egress.
+    EgressDenied,
+    /// Provider DNS lookup failed.
+    DnsFailure,
+    /// Provider connection failed.
+    ConnectionFailure,
+    /// Provider operation timed out.
+    ProviderTimeout,
+    /// Provider requested a bounded retry.
+    RateLimited {
+        /// Provider-declared retry delay.
+        retry_after_seconds: Option<u64>,
+    },
+    /// Provider returned a retryable server failure.
+    ProviderUnavailable {
+        /// Provider HTTP status.
+        status: u16,
+    },
+    /// Provider returned an unexpected status.
+    UnexpectedStatus {
+        /// Provider HTTP status.
+        status: u16,
+    },
+    /// Retry delay is outside the persistence bound.
+    InvalidRetryAfter,
+    /// Response exceeds the host-declared byte bound.
+    ResponseTooLarge,
+    /// Response exceeds the family record bound.
+    TooManyRecords,
+    /// Response JSON does not match the family.
+    MalformedResponse,
+    /// Provider record violates the family shape.
+    InvalidProviderRecord,
+    /// Provider record has no stable identity.
+    MissingStableIdentity,
+    /// Provider payload attempted to provide tenant context.
+    TenantMismatch,
+    /// Credential-shaped material crossed into the kernel.
+    CredentialMaterial,
+    /// Duplicate provider identity has conflicting content.
+    ConflictingDuplicate,
+    /// Normalized record failed the exact event contract.
+    EventContractRejection,
+    /// Durable append failed.
+    AppendFailure,
+    /// Projection failed.
+    ProjectionFailure,
+    /// Runtime lost its source lease.
+    LeaseLoss,
+    /// Runtime authority or generation is stale.
+    StaleAuthority,
+    /// Internal runtime failure.
+    InternalRuntimeFailure,
+}
+
+impl ActiveCampaignError {
+    /// Next safe operator action without provider content.
+    pub const fn operator_action(&self) -> &'static str {
+        match self {
+            Self::InvalidFamily
+            | Self::InvalidConfiguration(_)
+            | Self::InvalidOrigin
+            | Self::InvalidTenantId
+            | Self::ProviderResourceNotFound => "repair source configuration",
+            Self::MissingCredentialReference
+            | Self::CredentialUnavailable
+            | Self::AuthenticationRejected => "repair credential binding",
+            Self::RequiredScopeMissing => "grant ActiveCampaign API read access",
+            Self::RateLimited { .. }
+            | Self::ProviderUnavailable { .. }
+            | Self::DnsFailure
+            | Self::ConnectionFailure
+            | Self::ProviderTimeout => "retry the collection later",
+            Self::EgressDenied => "repair trusted-host egress policy",
+            Self::InvalidCursor => "restart from the last committed checkpoint",
+            Self::MalformedResponse
+            | Self::InvalidProviderRecord
+            | Self::MissingStableIdentity
+            | Self::TenantMismatch
+            | Self::CredentialMaterial
+            | Self::ConflictingDuplicate
+            | Self::EventContractRejection => "inspect quarantined provider records",
+            Self::AppendFailure | Self::ProjectionFailure => "repair the durable commit path",
+            Self::LeaseLoss | Self::StaleAuthority => "restart under the current lease",
+            Self::RequestScopeMismatch
+            | Self::InvalidRetryAfter
+            | Self::ResponseTooLarge
+            | Self::TooManyRecords
+            | Self::UnexpectedStatus { .. }
+            | Self::InternalRuntimeFailure => "repair the forward runtime implementation",
+        }
+    }
+}
+
+impl fmt::Display for ActiveCampaignError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidFamily => "activecampaign family is invalid",
+            Self::InvalidConfiguration(_) => "activecampaign source configuration is invalid",
+            Self::InvalidOrigin => "activecampaign provider origin is invalid",
+            Self::InvalidTenantId => "activecampaign tenant ID is invalid",
+            Self::MissingCredentialReference => "activecampaign credential reference is missing",
+            Self::CredentialUnavailable => "activecampaign credential lease is unavailable",
+            Self::InvalidCursor => "activecampaign cursor is invalid or not round-trippable",
+            Self::RequestScopeMismatch => "activecampaign request does not match the kernel",
+            Self::AuthenticationRejected => "activecampaign rejected authentication",
+            Self::RequiredScopeMissing => "activecampaign credential lacks required scope",
+            Self::ProviderResourceNotFound => "activecampaign resource was not found",
+            Self::EgressDenied => "activecampaign egress was denied",
+            Self::DnsFailure => "activecampaign DNS resolution failed",
+            Self::ConnectionFailure => "activecampaign connection failed",
+            Self::ProviderTimeout => "activecampaign operation timed out",
+            Self::RateLimited { .. } => "activecampaign rate limited the operation",
+            Self::ProviderUnavailable { .. } => "activecampaign is temporarily unavailable",
+            Self::UnexpectedStatus { .. } => "activecampaign returned an unexpected status",
+            Self::InvalidRetryAfter => "activecampaign retry delay exceeds its bound",
+            Self::ResponseTooLarge => "activecampaign response exceeds its byte bound",
+            Self::TooManyRecords => "activecampaign response exceeds its record bound",
+            Self::MalformedResponse => "activecampaign response is malformed",
+            Self::InvalidProviderRecord => "activecampaign provider record is invalid",
+            Self::MissingStableIdentity => "activecampaign record has no stable identity",
+            Self::TenantMismatch => "activecampaign payload attempted to supply tenant context",
+            Self::CredentialMaterial => {
+                "activecampaign payload contains credential-shaped material"
+            }
+            Self::ConflictingDuplicate => {
+                "activecampaign duplicate identity has conflicting content"
+            }
+            Self::EventContractRejection => "activecampaign event failed its catalog contract",
+            Self::AppendFailure => "activecampaign append failed",
+            Self::ProjectionFailure => "activecampaign projection failed",
+            Self::LeaseLoss => "activecampaign runtime lost its lease",
+            Self::StaleAuthority => "activecampaign runtime authority is stale",
+            Self::InternalRuntimeFailure => "activecampaign runtime failed internally",
+        })
+    }
+}
+
+impl Error for ActiveCampaignError {}

--- a/crates/source-runtime-next/src/activecampaign/family.rs
+++ b/crates/source-runtime-next/src/activecampaign/family.rs
@@ -1,0 +1,89 @@
+use std::str::FromStr;
+
+use super::ActiveCampaignError;
+
+/// Closed ActiveCampaign catalog family vocabulary.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum ActiveCampaignFamily {
+    /// CRM accounts.
+    Accounts,
+    /// Marketing automations.
+    Automations,
+    /// Marketing campaigns.
+    Campaigns,
+    /// CRM contacts.
+    Contacts,
+    /// Account users.
+    Users,
+}
+
+impl ActiveCampaignFamily {
+    /// Every provider-declared family in catalog order.
+    pub const ALL: [Self; 5] = [
+        Self::Accounts,
+        Self::Automations,
+        Self::Campaigns,
+        Self::Contacts,
+        Self::Users,
+    ];
+
+    /// Exact catalog identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Accounts => "accounts",
+            Self::Automations => "automations",
+            Self::Campaigns => "campaigns",
+            Self::Contacts => "contacts",
+            Self::Users => "users",
+        }
+    }
+
+    /// Exact provider path.
+    pub const fn path(self) -> &'static str {
+        match self {
+            Self::Accounts => "/api/3/accounts",
+            Self::Automations => "/api/3/automations",
+            Self::Campaigns => "/api/3/campaigns",
+            Self::Contacts => "/api/3/contacts",
+            Self::Users => "/api/3/users",
+        }
+    }
+
+    /// Exact response array key.
+    pub const fn response_key(self) -> &'static str {
+        self.as_str()
+    }
+
+    /// Exact event kind.
+    pub const fn event_kind(self) -> &'static str {
+        match self {
+            Self::Accounts => "activecampaign.accounts",
+            Self::Automations => "activecampaign.automations",
+            Self::Campaigns => "activecampaign.campaigns",
+            Self::Contacts => "activecampaign.contacts",
+            Self::Users => "activecampaign.users",
+        }
+    }
+
+    /// Exact schema reference.
+    pub const fn schema_ref(self) -> &'static str {
+        match self {
+            Self::Accounts => "activecampaign/accounts/v1",
+            Self::Automations => "activecampaign/automations/v1",
+            Self::Campaigns => "activecampaign/campaigns/v1",
+            Self::Contacts => "activecampaign/contacts/v1",
+            Self::Users => "activecampaign/users/v1",
+        }
+    }
+}
+
+impl FromStr for ActiveCampaignFamily {
+    type Err = ActiveCampaignError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|family| family.as_str() == value.trim())
+            .ok_or(ActiveCampaignError::InvalidFamily)
+    }
+}

--- a/crates/source-runtime-next/src/activecampaign/normalize.rs
+++ b/crates/source-runtime-next/src/activecampaign/normalize.rs
@@ -1,0 +1,257 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+
+use super::{
+    ActiveCampaignError, ActiveCampaignFamily, ActiveCampaignKernel, ActiveCampaignRecord,
+    ActiveCampaignRuntimeDefinition,
+};
+
+pub(super) fn normalize(
+    kernel: &ActiveCampaignKernel,
+    raw: Value,
+) -> Result<ActiveCampaignRecord, ActiveCampaignError> {
+    reject_untrusted(&raw, 0)?;
+    let values = raw
+        .as_object()
+        .ok_or(ActiveCampaignError::InvalidProviderRecord)?;
+    let provider_id = required_scalar(values, "id")?;
+    let (attributes, payload) = family_values(kernel, values, &provider_id)?;
+    validate_contract(kernel.family, &attributes, &payload)?;
+    Ok(ActiveCampaignRecord {
+        tenant_id: kernel.tenant_id.clone(),
+        event_id: event_id(kernel, &provider_id),
+        provider_id,
+        family: kernel.family,
+        kind: kernel.family.event_kind().to_owned(),
+        schema_ref: kernel.family.schema_ref().to_owned(),
+        occurred_at: kernel.observed_at.clone(),
+        attributes,
+        payload,
+    })
+}
+
+fn family_values(
+    kernel: &ActiveCampaignKernel,
+    values: &Map<String, Value>,
+    provider_id: &str,
+) -> Result<(BTreeMap<String, String>, Value), ActiveCampaignError> {
+    let record_class = if kernel.family == ActiveCampaignFamily::Users {
+        "identity_user"
+    } else {
+        "asset"
+    };
+    let mut attributes = BTreeMap::from([
+        ("tenant_id".to_owned(), kernel.tenant_id.clone()),
+        ("source_event_id".to_owned(), provider_id.to_owned()),
+        ("record_class".to_owned(), record_class.to_owned()),
+        ("schema".to_owned(), kernel.family.as_str().to_owned()),
+        ("source_system".to_owned(), "activecampaign".to_owned()),
+    ]);
+    match kernel.family {
+        ActiveCampaignFamily::Users => {
+            attributes.insert("user_id".to_owned(), provider_id.to_owned());
+            copy(&mut attributes, values, "username", "display_name");
+            copy(&mut attributes, values, "email", "email");
+            copy(&mut attributes, values, "username", "login");
+            copy(&mut attributes, values, "status", "status");
+        }
+        family @ (ActiveCampaignFamily::Accounts
+        | ActiveCampaignFamily::Automations
+        | ActiveCampaignFamily::Campaigns
+        | ActiveCampaignFamily::Contacts) => {
+            let resource_type = match kernel.family {
+                ActiveCampaignFamily::Accounts => "activecampaign_account",
+                ActiveCampaignFamily::Automations => "activecampaign_automation",
+                ActiveCampaignFamily::Campaigns => "activecampaign_campaign",
+                ActiveCampaignFamily::Contacts => "activecampaign_contact",
+                ActiveCampaignFamily::Users => {
+                    return Err(ActiveCampaignError::InternalRuntimeFailure);
+                }
+            };
+            let resource_name_key = if family == ActiveCampaignFamily::Contacts {
+                "email"
+            } else {
+                "name"
+            };
+            let resource_name =
+                scalar(values.get(resource_name_key)).unwrap_or_else(|| provider_id.to_owned());
+            attributes.extend(BTreeMap::from([
+                ("resource_id".to_owned(), provider_id.to_owned()),
+                ("resource_name".to_owned(), resource_name),
+                ("resource_type".to_owned(), resource_type.to_owned()),
+                (
+                    "resource_urn".to_owned(),
+                    format!(
+                        "urn:cerebro:{}:runtime_{}:{}",
+                        encode_segment(&kernel.tenant_id),
+                        resource_type,
+                        encode_segment(provider_id)
+                    ),
+                ),
+            ]));
+            if matches!(
+                family,
+                ActiveCampaignFamily::Automations | ActiveCampaignFamily::Campaigns
+            ) {
+                copy(&mut attributes, values, "status", "status");
+            }
+            if family == ActiveCampaignFamily::Contacts {
+                copy(&mut attributes, values, "email", "email");
+            }
+        }
+    }
+    let mut payload = values.clone();
+    payload.insert(
+        "schema_ref".to_owned(),
+        Value::String(kernel.family.schema_ref().to_owned()),
+    );
+    Ok((attributes, Value::Object(payload)))
+}
+
+fn validate_contract(
+    family: ActiveCampaignFamily,
+    attributes: &BTreeMap<String, String>,
+    payload: &Value,
+) -> Result<(), ActiveCampaignError> {
+    let definition = ActiveCampaignRuntimeDefinition::compile(family)?;
+    if definition.event_contract.kind != family.event_kind()
+        || definition.event_contract.schema_ref != family.schema_ref()
+        || definition
+            .event_contract
+            .required_attributes
+            .iter()
+            .any(|key| {
+                attributes
+                    .get(*key)
+                    .is_none_or(|value| value.trim().is_empty())
+            })
+        || definition
+            .event_contract
+            .required_payload_fields
+            .iter()
+            .any(|key| payload.get(*key).is_none_or(Value::is_null))
+    {
+        return Err(ActiveCampaignError::EventContractRejection);
+    }
+    Ok(())
+}
+
+fn event_id(kernel: &ActiveCampaignKernel, provider_id: &str) -> String {
+    let scope = Sha256::digest(format!(
+        "{}\0{}",
+        kernel.base_url.as_str().trim_end_matches('/'),
+        kernel.family.path()
+    ));
+    let scope = scope[..6]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!(
+        "activecampaign-{}-{scope}-{}-{}",
+        normalize_id(&kernel.tenant_id),
+        normalize_id(kernel.family.as_str()),
+        normalize_id(provider_id)
+    )
+}
+
+fn required_scalar(
+    values: &Map<String, Value>,
+    key: &'static str,
+) -> Result<String, ActiveCampaignError> {
+    scalar(values.get(key)).ok_or(ActiveCampaignError::MissingStableIdentity)
+}
+
+fn scalar(value: Option<&Value>) -> Option<String> {
+    match value? {
+        Value::String(value) => {
+            let value = value.trim();
+            (!value.is_empty()).then(|| value.to_owned())
+        }
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn copy(
+    attributes: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    source: &str,
+    target: &str,
+) {
+    if let Some(value) = scalar(values.get(source)) {
+        attributes.insert(target.to_owned(), value);
+    }
+}
+
+fn encode_segment(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.trim().bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}
+
+fn normalize_id(value: &str) -> String {
+    let value = value.trim();
+    if value.is_empty() {
+        return "unknown".to_owned();
+    }
+    value
+        .chars()
+        .map(|character| match character {
+            ' ' | '/' | ':' | '\t' | '\n' => '-',
+            other => other,
+        })
+        .collect()
+}
+
+fn reject_untrusted(value: &Value, depth: usize) -> Result<(), ActiveCampaignError> {
+    if depth > 16 {
+        return Err(ActiveCampaignError::InvalidProviderRecord);
+    }
+    match value {
+        Value::Object(values) => {
+            if values.len() > 256 {
+                return Err(ActiveCampaignError::InvalidProviderRecord);
+            }
+            for (key, value) in values {
+                let key = key.trim().to_ascii_lowercase().replace('-', "_");
+                if key == "tenant_id" {
+                    return Err(ActiveCampaignError::TenantMismatch);
+                }
+                if matches!(
+                    key.as_str(),
+                    "token"
+                        | "access_token"
+                        | "refresh_token"
+                        | "api_key"
+                        | "api_token"
+                        | "password"
+                        | "private_key"
+                        | "authorization"
+                        | "client_secret"
+                ) {
+                    return Err(ActiveCampaignError::CredentialMaterial);
+                }
+                reject_untrusted(value, depth + 1)?;
+            }
+        }
+        Value::Array(values) => {
+            if values.len() > 10_000 {
+                return Err(ActiveCampaignError::TooManyRecords);
+            }
+            for value in values {
+                reject_untrusted(value, depth + 1)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}

--- a/crates/source-runtime-next/src/activecampaign/origin.rs
+++ b/crates/source-runtime-next/src/activecampaign/origin.rs
@@ -1,0 +1,41 @@
+use reqwest::Url;
+
+use super::ActiveCampaignError;
+
+const HOST_SUFFIX: &str = ".api-us1.com";
+
+pub(super) fn validate(value: &str) -> Result<Url, ActiveCampaignError> {
+    let mut url = Url::parse(value.trim().trim_end_matches('/'))
+        .map_err(|_| ActiveCampaignError::InvalidOrigin)?;
+    let host = url.host_str().unwrap_or_default().trim_end_matches('.');
+    let account = host.strip_suffix(HOST_SUFFIX).unwrap_or_default();
+    if url.scheme() != "https"
+        || account.is_empty()
+        || account.len() > 63
+        || account.contains('.')
+        || account.starts_with('-')
+        || account.ends_with('-')
+        || account
+            .bytes()
+            .any(|byte| !byte.is_ascii_alphanumeric() && byte != b'-')
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port_or_known_default() != Some(443)
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || !matches!(url.path(), "" | "/")
+    {
+        return Err(ActiveCampaignError::InvalidOrigin);
+    }
+    url.set_path("");
+    Ok(url)
+}
+
+pub(super) fn tenant(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()
+        && value.len() <= 128
+        && !value.chars().any(char::is_control)
+        && !value.contains(['/', '\\', ':']))
+    .then(|| value.to_owned())
+}

--- a/crates/source-runtime-next/src/activecampaign/projection.rs
+++ b/crates/source-runtime-next/src/activecampaign/projection.rs
@@ -1,0 +1,85 @@
+use std::collections::BTreeMap;
+
+use super::{ActiveCampaignFamily, ActiveCampaignRecord};
+
+/// One deterministic tenant-scoped ActiveCampaign projection entity.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ActiveCampaignEntityFact {
+    /// Canonical entity URN.
+    pub urn: String,
+    /// Closed entity type.
+    pub entity_type: String,
+    /// Human-readable label.
+    pub label: String,
+}
+
+/// Provider-local projection facts used for Go/Rust parity.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ActiveCampaignProjectionFacts {
+    /// Deduplicated entities in canonical order.
+    pub entities: Vec<ActiveCampaignEntityFact>,
+}
+
+/// Project normalized ActiveCampaign records into users and business assets.
+pub fn project_activecampaign_records(
+    records: &[ActiveCampaignRecord],
+) -> ActiveCampaignProjectionFacts {
+    let mut entities = BTreeMap::<String, ActiveCampaignEntityFact>::new();
+    for record in records {
+        let (urn, entity_type, label) = if record.family == ActiveCampaignFamily::Users {
+            (
+                format!(
+                    "urn:cerebro:{}:activecampaign_user:{}",
+                    encode_segment(&record.tenant_id),
+                    encode_segment(&record.provider_id)
+                ),
+                "activecampaign.user".to_owned(),
+                record
+                    .attributes
+                    .get("display_name")
+                    .or_else(|| record.attributes.get("email"))
+                    .cloned()
+                    .unwrap_or_else(|| record.provider_id.clone()),
+            )
+        } else {
+            let Some(urn) = record.attributes.get("resource_urn") else {
+                continue;
+            };
+            let Some(resource_type) = record.attributes.get("resource_type") else {
+                continue;
+            };
+            (
+                urn.clone(),
+                format!("runtime.{}", resource_type.replace('_', ".")),
+                record
+                    .attributes
+                    .get("resource_name")
+                    .cloned()
+                    .unwrap_or_else(|| record.provider_id.clone()),
+            )
+        };
+        entities.insert(
+            urn.clone(),
+            ActiveCampaignEntityFact {
+                urn,
+                entity_type,
+                label,
+            },
+        );
+    }
+    ActiveCampaignProjectionFacts {
+        entities: entities.into_values().collect(),
+    }
+}
+
+fn encode_segment(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.trim().bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}

--- a/crates/source-runtime-next/src/activecampaign/request.rs
+++ b/crates/source-runtime-next/src/activecampaign/request.rs
@@ -1,0 +1,75 @@
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    ActiveCampaignError, ActiveCampaignFamily, ActiveCampaignKernel, ActiveCampaignRequest, origin,
+};
+
+const PAGE_SIZE: usize = 100;
+const MAX_OFFSET: usize = 10_000_000;
+
+pub(super) fn new_kernel(
+    base_url: &str,
+    tenant_id: &str,
+    family: ActiveCampaignFamily,
+    observed_at: &str,
+) -> Result<ActiveCampaignKernel, ActiveCampaignError> {
+    let base_url = origin::validate(base_url)?;
+    let tenant_id = origin::tenant(tenant_id).ok_or(ActiveCampaignError::InvalidTenantId)?;
+    let observed = OffsetDateTime::parse(observed_at, &Rfc3339)
+        .map_err(|_| ActiveCampaignError::InvalidConfiguration("observed_at"))?;
+    let observed_at = observed
+        .format(&Rfc3339)
+        .map_err(|_| ActiveCampaignError::InvalidConfiguration("observed_at"))?;
+    Ok(ActiveCampaignKernel {
+        base_url,
+        tenant_id,
+        family,
+        observed_at,
+    })
+}
+
+pub(super) fn plan(
+    kernel: &ActiveCampaignKernel,
+    cursor: Option<&str>,
+) -> Result<ActiveCampaignRequest, ActiveCampaignError> {
+    let offset = cursor.map(validate_cursor).transpose()?.unwrap_or(0);
+    let mut url = kernel.base_url.clone();
+    url.set_path(kernel.family.path());
+    if url.origin() != kernel.base_url.origin() {
+        return Err(ActiveCampaignError::InvalidOrigin);
+    }
+    {
+        let mut query = url.query_pairs_mut();
+        query.append_pair("limit", &PAGE_SIZE.to_string());
+        query.append_pair("offset", &offset.to_string());
+    }
+    Ok(ActiveCampaignRequest {
+        url,
+        family: kernel.family,
+        offset,
+        cursor: cursor.map(str::to_owned),
+        page_size: PAGE_SIZE,
+    })
+}
+
+pub(super) fn validate_request(
+    kernel: &ActiveCampaignKernel,
+    request: &ActiveCampaignRequest,
+) -> Result<(), ActiveCampaignError> {
+    if request != &plan(kernel, request.cursor.as_deref())? {
+        return Err(ActiveCampaignError::RequestScopeMismatch);
+    }
+    Ok(())
+}
+
+pub(super) fn validate_cursor(value: &str) -> Result<usize, ActiveCampaignError> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > 16 || value.chars().any(char::is_control) {
+        return Err(ActiveCampaignError::InvalidCursor);
+    }
+    value
+        .parse::<usize>()
+        .ok()
+        .filter(|offset| *offset <= MAX_OFFSET)
+        .ok_or(ActiveCampaignError::InvalidCursor)
+}

--- a/crates/source-runtime-next/src/activecampaign/response.rs
+++ b/crates/source-runtime-next/src/activecampaign/response.rs
@@ -1,0 +1,136 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    ActiveCampaignCheckpointCandidate, ActiveCampaignError, ActiveCampaignKernel,
+    ActiveCampaignPage, ActiveCampaignRequest, normalize,
+    request::{validate_cursor, validate_request},
+};
+
+pub(super) const MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+pub(super) fn decode(
+    kernel: &ActiveCampaignKernel,
+    request: &ActiveCampaignRequest,
+    status: u16,
+    retry_after_seconds: Option<u64>,
+    body: &[u8],
+) -> Result<ActiveCampaignPage, ActiveCampaignError> {
+    validate_request(kernel, request)?;
+    classify_status(status, retry_after_seconds)?;
+    if body.len() > MAX_RESPONSE_BYTES {
+        return Err(ActiveCampaignError::ResponseTooLarge);
+    }
+    let root: Value =
+        serde_json::from_slice(body).map_err(|_| ActiveCampaignError::MalformedResponse)?;
+    let items = root
+        .get(kernel.family.response_key())
+        .and_then(Value::as_array)
+        .ok_or(ActiveCampaignError::MalformedResponse)?;
+    if items.len() > request.page_size {
+        return Err(ActiveCampaignError::TooManyRecords);
+    }
+    let mut seen = BTreeMap::<String, Vec<u8>>::new();
+    let mut normalized = Vec::with_capacity(items.len());
+    for raw in items {
+        let record = normalize::normalize(kernel, raw.clone())?;
+        let canonical = serde_json::to_vec(&record.payload)
+            .map_err(|_| ActiveCampaignError::InvalidProviderRecord)?;
+        match seen.get(&record.provider_id) {
+            Some(previous) if previous == &canonical => continue,
+            Some(_) => return Err(ActiveCampaignError::ConflictingDuplicate),
+            None => {
+                seen.insert(record.provider_id.clone(), canonical);
+                normalized.push(record);
+            }
+        }
+    }
+    let candidate = request
+        .offset
+        .checked_add(items.len())
+        .ok_or(ActiveCampaignError::InvalidCursor)?;
+    let total = root
+        .get("meta")
+        .and_then(|value| value.get("total"))
+        .and_then(integer)
+        .and_then(|value| usize::try_from(value).ok());
+    let has_more = total.map_or(items.len() == request.page_size, |total| candidate < total);
+    let next_cursor = (has_more && !items.is_empty()).then(|| candidate.to_string());
+    if let Some(cursor) = &next_cursor {
+        validate_cursor(cursor)?;
+    }
+    if next_cursor.is_some() && next_cursor == request.cursor {
+        return Err(ActiveCampaignError::InvalidCursor);
+    }
+    Ok(ActiveCampaignPage {
+        records: normalized,
+        next_cursor,
+    })
+}
+
+pub(super) fn checkpoint_candidate(
+    kernel: &ActiveCampaignKernel,
+    request: &ActiveCampaignRequest,
+    page: &ActiveCampaignPage,
+    prior_watermark: Option<&str>,
+) -> Result<ActiveCampaignCheckpointCandidate, ActiveCampaignError> {
+    validate_request(kernel, request)?;
+    if page
+        .records
+        .iter()
+        .any(|record| record.tenant_id != kernel.tenant_id || record.family != kernel.family)
+    {
+        return Err(ActiveCampaignError::TenantMismatch);
+    }
+    if let Some(cursor) = &page.next_cursor {
+        kernel.plan(Some(cursor))?;
+    }
+    let mut watermark = valid_time(prior_watermark.unwrap_or(&kernel.observed_at))?;
+    for record in &page.records {
+        let occurred_at = valid_time(&record.occurred_at)?;
+        if occurred_at > watermark {
+            watermark = occurred_at;
+        }
+    }
+    Ok(ActiveCampaignCheckpointCandidate {
+        tenant_id: kernel.tenant_id.clone(),
+        family: kernel.family,
+        cursor: page.next_cursor.clone(),
+        watermark,
+    })
+}
+
+fn classify_status(
+    status: u16,
+    retry_after_seconds: Option<u64>,
+) -> Result<(), ActiveCampaignError> {
+    if retry_after_seconds.is_some_and(|seconds| seconds > 3_600) {
+        return Err(ActiveCampaignError::InvalidRetryAfter);
+    }
+    match status {
+        200..=299 => Ok(()),
+        401 => Err(ActiveCampaignError::AuthenticationRejected),
+        403 => Err(ActiveCampaignError::RequiredScopeMissing),
+        404 => Err(ActiveCampaignError::ProviderResourceNotFound),
+        429 => Err(ActiveCampaignError::RateLimited {
+            retry_after_seconds,
+        }),
+        500..=599 => Err(ActiveCampaignError::ProviderUnavailable { status }),
+        _ => Err(ActiveCampaignError::UnexpectedStatus { status }),
+    }
+}
+
+fn integer(value: &Value) -> Option<u64> {
+    value
+        .as_u64()
+        .or_else(|| value.as_str()?.trim().parse::<u64>().ok())
+}
+
+fn valid_time(value: &str) -> Result<String, ActiveCampaignError> {
+    let time = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| ActiveCampaignError::InvalidProviderRecord)?;
+    time.format(&Rfc3339)
+        .map_err(|_| ActiveCampaignError::InvalidProviderRecord)
+}

--- a/crates/source-runtime-next/src/activecampaign/tests.rs
+++ b/crates/source-runtime-next/src/activecampaign/tests.rs
@@ -1,0 +1,335 @@
+use std::{collections::BTreeMap, fs, path::PathBuf};
+
+use cerebro_source_catalog::{CollectionAuthority, SourceCatalog};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::*;
+
+const ORIGIN: &str = "https://example-account.api-us1.com";
+const OBSERVED_AT: &str = "2026-06-01T00:00:00Z";
+
+#[derive(Debug, Deserialize)]
+struct GoOracleEvent {
+    id: String,
+    tenant_id: String,
+    source_id: String,
+    kind: String,
+    occurred_at: String,
+    schema_ref: String,
+    payload: Value,
+    attributes: BTreeMap<String, String>,
+}
+
+fn repository_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn kernel(tenant: &str, family: ActiveCampaignFamily) -> ActiveCampaignKernel {
+    ActiveCampaignKernel::new(ORIGIN, tenant, family, OBSERVED_AT).unwrap()
+}
+
+fn oracle(family: ActiveCampaignFamily) -> GoOracleEvent {
+    let bytes = fs::read(repository_root().join(format!(
+        "sources/activecampaign/testdata/read_{}.json",
+        family.as_str()
+    )))
+    .unwrap();
+    serde_json::from_slice::<Vec<GoOracleEvent>>(&bytes)
+        .unwrap()
+        .pop()
+        .unwrap()
+}
+
+fn provider_raw(family: ActiveCampaignFamily) -> Value {
+    let mut payload = oracle(family).payload;
+    payload.as_object_mut().unwrap().remove("schema_ref");
+    payload
+}
+
+fn response(family: ActiveCampaignFamily, records: Vec<Value>) -> Vec<u8> {
+    serde_json::to_vec(&json!({family.response_key(): records})).unwrap()
+}
+
+#[test]
+fn catalog_and_kernel_close_the_exact_authoritative_family_set() {
+    let root = repository_root();
+    let catalog = SourceCatalog::load(
+        root.join("internal/connectorcatalog/catalog"),
+        root.join("sources"),
+    )
+    .unwrap();
+    let source = catalog.get("activecampaign").unwrap();
+    assert_eq!(source.authority(), CollectionAuthority::Authoritative);
+    let mut families = source
+        .families()
+        .iter()
+        .map(|family| family.id())
+        .collect::<Vec<_>>();
+    families.sort_unstable();
+    assert_eq!(
+        families,
+        ["accounts", "automations", "campaigns", "contacts", "users"]
+    );
+    assert!(
+        source
+            .families()
+            .iter()
+            .all(|family| family.is_authoritative())
+    );
+    for family in ActiveCampaignFamily::ALL {
+        let definition = ActiveCampaignRuntimeDefinition::compile(family).unwrap();
+        assert_eq!(definition.source_id, "activecampaign");
+        assert!(definition.pull);
+        assert_eq!(definition.event_contract.kind, family.event_kind());
+        assert_eq!(definition.event_contract.schema_ref, family.schema_ref());
+    }
+}
+
+#[test]
+fn every_family_plans_a_bounded_origin_locked_credential_free_request() {
+    for family in ActiveCampaignFamily::ALL {
+        let kernel = kernel("tenant", family);
+        let request = kernel.plan(None).unwrap();
+        assert_eq!(request.method(), "GET");
+        assert_eq!(request.family(), family);
+        assert_eq!(request.url().scheme(), "https");
+        assert_eq!(
+            request.url().host_str(),
+            Some("example-account.api-us1.com")
+        );
+        assert_eq!(request.url().path(), family.path());
+        assert_eq!(request.url().query(), Some("limit=100&offset=0"));
+        assert_eq!(request.authentication_header(), "Api-Token");
+        assert_eq!(request.authentication_scheme(), "");
+        assert!(request.credential_reference_required());
+        assert!(!request.contains_credentials());
+        assert!(!request.allows_redirects());
+        assert_eq!(request.record_limit(), 100);
+        assert_eq!(request.max_response_bytes(), 8 * 1024 * 1024);
+        assert_eq!(request.required_scope(), "ActiveCampaign API read access");
+        assert!(!ActiveCampaignKernel::requires_credentials());
+        assert_eq!(
+            kernel.plan(Some("100")).unwrap().url().query(),
+            Some("limit=100&offset=100")
+        );
+    }
+}
+
+#[test]
+fn origin_tenant_and_cursor_inputs_fail_closed() {
+    for origin in [
+        "http://example-account.api-us1.com",
+        "https://api-us1.com",
+        "https://other.example-account.api-us1.com",
+        "https://user@example-account.api-us1.com",
+        "https://example-account.api-us1.com:8443",
+        "https://example-account.api-us1.com/api/3",
+        "https://example-account.api-us1.com?token=value",
+    ] {
+        assert!(
+            ActiveCampaignKernel::new(origin, "tenant", ActiveCampaignFamily::Users, OBSERVED_AT,)
+                .is_err()
+        );
+    }
+    assert!(
+        ActiveCampaignKernel::new(
+            ORIGIN,
+            "bad:tenant",
+            ActiveCampaignFamily::Users,
+            OBSERVED_AT
+        )
+        .is_err()
+    );
+    assert_eq!(
+        kernel("tenant", ActiveCampaignFamily::Users).plan(Some("-1")),
+        Err(ActiveCampaignError::InvalidCursor)
+    );
+    assert_eq!(
+        kernel("tenant", ActiveCampaignFamily::Users).plan(Some("10000001")),
+        Err(ActiveCampaignError::InvalidCursor)
+    );
+}
+
+#[test]
+fn every_family_matches_the_checked_go_event_fixture_semantically() {
+    for family in ActiveCampaignFamily::ALL {
+        let kernel = kernel("tenant", family);
+        let request = kernel.plan(None).unwrap();
+        let page = kernel
+            .decode(
+                &request,
+                200,
+                None,
+                &response(family, vec![provider_raw(family)]),
+            )
+            .unwrap();
+        assert_eq!(page.records.len(), 1);
+        assert_eq!(page.next_cursor, None);
+        let record = &page.records[0];
+        let oracle = oracle(family);
+        assert_eq!(record.tenant_id, oracle.tenant_id);
+        assert_eq!(oracle.source_id, "activecampaign");
+        assert_eq!(record.kind, oracle.kind);
+        assert_eq!(record.schema_ref, oracle.schema_ref);
+        assert_eq!(record.occurred_at, oracle.occurred_at);
+        assert_eq!(record.payload, oracle.payload);
+        assert_eq!(record.attributes, oracle.attributes);
+        assert_eq!(
+            oracle.id,
+            format!("activecampaign-{}-{}", family.as_str(), record.provider_id)
+        );
+        assert!(record.event_id.starts_with("activecampaign-tenant-"));
+
+        let projection = project_activecampaign_records(&page.records);
+        assert_eq!(projection.entities.len(), 1);
+        if family == ActiveCampaignFamily::Users {
+            assert_eq!(projection.entities[0].entity_type, "activecampaign.user");
+        } else {
+            assert!(
+                projection.entities[0]
+                    .entity_type
+                    .starts_with("runtime.activecampaign.")
+            );
+        }
+    }
+}
+
+#[test]
+fn offset_pagination_checkpoint_and_restart_are_round_trippable() {
+    let family = ActiveCampaignFamily::Accounts;
+    let kernel = kernel("tenant", family);
+    let request = kernel.plan(None).unwrap();
+    let records: Vec<_> = (1..=100)
+        .map(|id| json!({"id": id.to_string(), "name": format!("account-{id}")}))
+        .collect();
+    let page = kernel
+        .decode(
+            &request,
+            200,
+            None,
+            &serde_json::to_vec(&json!({"accounts": records, "meta": {"total": "101"}})).unwrap(),
+        )
+        .unwrap();
+    assert_eq!(page.next_cursor.as_deref(), Some("100"));
+    let checkpoint = kernel
+        .checkpoint_candidate(&request, &page, Some("2026-05-01T00:00:00Z"))
+        .unwrap();
+    assert_eq!(checkpoint.cursor.as_deref(), Some("100"));
+    assert_eq!(checkpoint.watermark, OBSERVED_AT);
+    let resumed = kernel.plan(checkpoint.cursor.as_deref()).unwrap();
+    assert_eq!(resumed.url().query(), Some("limit=100&offset=100"));
+    let terminal = kernel
+        .decode(
+            &resumed,
+            200,
+            None,
+            &response(family, vec![json!({"id":"101","name":"last"})]),
+        )
+        .unwrap();
+    assert_eq!(terminal.next_cursor, None);
+}
+
+#[test]
+fn duplicate_identity_is_idempotent_but_conflicting_content_fails() {
+    let family = ActiveCampaignFamily::Accounts;
+    let kernel = kernel("tenant", family);
+    let request = kernel.plan(None).unwrap();
+    let raw = provider_raw(family);
+    let identical = kernel
+        .decode(
+            &request,
+            200,
+            None,
+            &response(family, vec![raw.clone(), raw.clone()]),
+        )
+        .unwrap();
+    assert_eq!(identical.records.len(), 1);
+    let mut conflict = raw.clone();
+    conflict["name"] = Value::String("different".to_owned());
+    assert_eq!(
+        kernel.decode(&request, 200, None, &response(family, vec![raw, conflict])),
+        Err(ActiveCampaignError::ConflictingDuplicate)
+    );
+}
+
+#[test]
+fn provider_failures_size_tenant_and_secret_material_remain_typed() {
+    let family = ActiveCampaignFamily::Users;
+    let kernel = kernel("tenant", family);
+    let request = kernel.plan(None).unwrap();
+    for (status, expected) in [
+        (401, ActiveCampaignError::AuthenticationRejected),
+        (403, ActiveCampaignError::RequiredScopeMissing),
+        (404, ActiveCampaignError::ProviderResourceNotFound),
+        (
+            429,
+            ActiveCampaignError::RateLimited {
+                retry_after_seconds: Some(60),
+            },
+        ),
+        (
+            503,
+            ActiveCampaignError::ProviderUnavailable { status: 503 },
+        ),
+        (418, ActiveCampaignError::UnexpectedStatus { status: 418 }),
+    ] {
+        assert_eq!(
+            kernel.decode(&request, status, Some(60), b"{}"),
+            Err(expected)
+        );
+    }
+    assert_eq!(
+        kernel.decode(&request, 429, Some(3_601), b"{}"),
+        Err(ActiveCampaignError::InvalidRetryAfter)
+    );
+    let oversized = vec![b' '; request.max_response_bytes() + 1];
+    assert_eq!(
+        kernel.decode(&request, 200, None, &oversized),
+        Err(ActiveCampaignError::ResponseTooLarge)
+    );
+
+    for (field, expected) in [
+        ("tenant_id", ActiveCampaignError::TenantMismatch),
+        ("api_token", ActiveCampaignError::CredentialMaterial),
+        ("authorization", ActiveCampaignError::CredentialMaterial),
+        ("private_key", ActiveCampaignError::CredentialMaterial),
+    ] {
+        let mut raw = provider_raw(family);
+        raw[field] = Value::String("sentinel-secret-value".to_owned());
+        let error = kernel
+            .decode(&request, 200, None, &response(family, vec![raw]))
+            .unwrap_err();
+        assert_eq!(error, expected);
+        assert!(!error.to_string().contains("sentinel-secret-value"));
+        assert!(!format!("{error:?}").contains("sentinel-secret-value"));
+    }
+}
+
+#[test]
+fn identity_is_deterministic_and_tenant_scoped() {
+    let family = ActiveCampaignFamily::Contacts;
+    let body = response(family, vec![provider_raw(family)]);
+    let first_kernel = kernel("tenant-a", family);
+    let first_request = first_kernel.plan(None).unwrap();
+    let first = first_kernel
+        .decode(&first_request, 200, None, &body)
+        .unwrap();
+    assert_eq!(
+        first,
+        first_kernel
+            .decode(&first_request, 200, None, &body)
+            .unwrap()
+    );
+    let other_kernel = kernel("tenant-b", family);
+    let other_request = other_kernel.plan(None).unwrap();
+    let other = other_kernel
+        .decode(&other_request, 200, None, &body)
+        .unwrap();
+    assert_eq!(first.records[0].provider_id, other.records[0].provider_id);
+    assert_ne!(first.records[0].event_id, other.records[0].event_id);
+    assert_ne!(
+        first.records[0].attributes["resource_urn"],
+        other.records[0].attributes["resource_urn"]
+    );
+}

--- a/crates/source-runtime-next/src/activecampaign/types.rs
+++ b/crates/source-runtime-next/src/activecampaign/types.rs
@@ -1,0 +1,188 @@
+use std::{collections::BTreeMap, fmt};
+
+use reqwest::Url;
+use serde_json::Value;
+
+use super::{ActiveCampaignError, ActiveCampaignFamily, request, response};
+
+/// Credential-free request intent for the trusted ActiveCampaign HTTP host.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ActiveCampaignRequest {
+    pub(super) url: Url,
+    pub(super) family: ActiveCampaignFamily,
+    pub(super) offset: usize,
+    pub(super) cursor: Option<String>,
+    pub(super) page_size: usize,
+}
+
+impl fmt::Debug for ActiveCampaignRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ActiveCampaignRequest")
+            .field("url", &self.url)
+            .field("family", &self.family)
+            .field("offset", &self.offset)
+            .field("has_cursor", &self.cursor.is_some())
+            .field("page_size", &self.page_size)
+            .finish()
+    }
+}
+
+impl ActiveCampaignRequest {
+    /// Fully planned provider URL.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Provider HTTP method.
+    pub const fn method(&self) -> &'static str {
+        "GET"
+    }
+
+    /// Family owning this request.
+    pub const fn family(&self) -> ActiveCampaignFamily {
+        self.family
+    }
+
+    /// Authentication header applied by the trusted host.
+    pub const fn authentication_header(&self) -> &'static str {
+        "Api-Token"
+    }
+
+    /// ActiveCampaign API tokens have no prefix scheme.
+    pub const fn authentication_scheme(&self) -> &'static str {
+        ""
+    }
+
+    /// The trusted host must redeem a credential reference before execution.
+    pub const fn credential_reference_required(&self) -> bool {
+        true
+    }
+
+    /// Expected response media type.
+    pub const fn accept(&self) -> &'static str {
+        "application/json"
+    }
+
+    /// Portable plans contain no credential bytes or references.
+    pub const fn contains_credentials(&self) -> bool {
+        false
+    }
+
+    /// Redirects are disabled by the trusted host.
+    pub const fn allows_redirects(&self) -> bool {
+        false
+    }
+
+    /// Maximum admitted response bytes.
+    pub const fn max_response_bytes(&self) -> usize {
+        response::MAX_RESPONSE_BYTES
+    }
+
+    /// Provider permission required for every list operation.
+    pub const fn required_scope(&self) -> &'static str {
+        "ActiveCampaign API read access"
+    }
+
+    /// Maximum records admitted from this response.
+    pub const fn record_limit(&self) -> usize {
+        self.page_size
+    }
+}
+
+/// One normalized tenant-scoped ActiveCampaign event candidate.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ActiveCampaignRecord {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Stable tenant-, origin-, family-, and provider-scoped event identity.
+    pub event_id: String,
+    /// Stable provider object identity.
+    pub provider_id: String,
+    /// Exact family.
+    pub family: ActiveCampaignFamily,
+    /// Exact event kind.
+    pub kind: String,
+    /// Exact schema reference.
+    pub schema_ref: String,
+    /// Normalized RFC3339 occurrence time.
+    pub occurred_at: String,
+    /// Deterministic projection attributes.
+    pub attributes: BTreeMap<String, String>,
+    /// Credential-free provider payload admitted by the event contract.
+    pub payload: Value,
+}
+
+/// One bounded normalized ActiveCampaign page.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ActiveCampaignPage {
+    /// Accepted records after deterministic deduplication.
+    pub records: Vec<ActiveCampaignRecord>,
+    /// Validated offset continuation, or terminal state.
+    pub next_cursor: Option<String>,
+}
+
+/// Validated checkpoint candidate for post-append/projection persistence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ActiveCampaignCheckpointCandidate {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Selected family.
+    pub family: ActiveCampaignFamily,
+    /// Validated continuation state.
+    pub cursor: Option<String>,
+    /// Provider observation watermark.
+    pub watermark: String,
+}
+
+/// Closed ActiveCampaign kernel for one tenant, origin, and family.
+#[derive(Clone, Debug)]
+pub struct ActiveCampaignKernel {
+    pub(super) base_url: Url,
+    pub(super) tenant_id: String,
+    pub(super) family: ActiveCampaignFamily,
+    pub(super) observed_at: String,
+}
+
+impl ActiveCampaignKernel {
+    /// Construct one family kernel from public execution context only.
+    pub fn new(
+        base_url: &str,
+        tenant_id: &str,
+        family: ActiveCampaignFamily,
+        observed_at: &str,
+    ) -> Result<Self, ActiveCampaignError> {
+        request::new_kernel(base_url, tenant_id, family, observed_at)
+    }
+
+    /// Kernel protocol never accepts credential material.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+
+    /// Plan one bounded origin-restricted provider request.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<ActiveCampaignRequest, ActiveCampaignError> {
+        request::plan(self, cursor)
+    }
+
+    /// Decode one bounded provider response under the exact request plan.
+    pub fn decode(
+        &self,
+        request: &ActiveCampaignRequest,
+        status: u16,
+        retry_after_seconds: Option<u64>,
+        body: &[u8],
+    ) -> Result<ActiveCampaignPage, ActiveCampaignError> {
+        response::decode(self, request, status, retry_after_seconds, body)
+    }
+
+    /// Validate a checkpoint candidate for post-commit host persistence.
+    pub fn checkpoint_candidate(
+        &self,
+        request: &ActiveCampaignRequest,
+        page: &ActiveCampaignPage,
+        prior_watermark: Option<&str>,
+    ) -> Result<ActiveCampaignCheckpointCandidate, ActiveCampaignError> {
+        response::checkpoint_candidate(self, request, page, prior_watermark)
+    }
+}

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -4,6 +4,7 @@
 //! Rust-native source collection and graph admission boundary.
 
 mod abuseipdb;
+mod activecampaign;
 mod amplitude;
 mod anthropic;
 mod append_log;
@@ -58,6 +59,12 @@ pub use abuseipdb::{
     AbuseIpDbFamily, AbuseIpDbFilters, AbuseIpDbKernel, AbuseIpDbPage, AbuseIpDbProjectionFacts,
     AbuseIpDbRecord, AbuseIpDbRelationFact, AbuseIpDbRequest, AbuseIpDbRuntimeDefinition,
     project_abuseipdb_records,
+};
+pub use activecampaign::{
+    ActiveCampaignCheckpointCandidate, ActiveCampaignEntityFact, ActiveCampaignError,
+    ActiveCampaignEventContract, ActiveCampaignFamily, ActiveCampaignKernel, ActiveCampaignPage,
+    ActiveCampaignProjectionFacts, ActiveCampaignRecord, ActiveCampaignRequest,
+    ActiveCampaignRuntimeDefinition, project_activecampaign_records,
 };
 pub use amplitude::{
     AmplitudeError, AmplitudeFamily, AmplitudeKernel, AmplitudePage, AmplitudeRecord,


### PR DESCRIPTION
## Scope

Adds an additive credential-free Rust kernel for the authoritative ActiveCampaign source families: accounts, automations, campaigns, contacts, and users.

The kernel compiles the closed catalog family set, plans bounded HTTPS requests restricted to one ActiveCampaign account origin, leaves Api-Token credential application to the trusted host, validates bounded provider responses, normalizes tenant-scoped deterministic identities, proposes offset checkpoints, admits exact event contracts, preserves projection semantics, and checks semantic parity against the existing Go fixture oracle.

ActiveCampaign is already listed in the repository Go-retirement authority guard. This PR does not change collection authority, the shared runtime host, the Go fixtures/oracle, private configuration, or deployment topology.

## Validation

- cargo fmt --all -- --check
- cargo test -p cerebro-source-runtime-next activecampaign --no-fail-fast: 8 passed
- cargo test -p cerebro-source-runtime-next --no-fail-fast: 527 unit, 7 Linode integration, 10 PagerDuty integration passed
- cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings
- go test ./internal/sourceprojection ./internal/sourcefixture ./internal/connectorcatalog ./internal/connectordefinitions ./internal/sourcegen ./internal/sourceregistry
- go test ./sources/catalogruntime ./sources/internal/catalogruntime
- make catalog-check source-fixture-check fixture-oracle-check projection-parity-test
- make check-structural check-structural-test check-arch
- ./scripts/leak_check.sh staged

## Evidence boundaries

No live ActiveCampaign credential or provider operation was used. No repository-owned deployment applies to this additive crate-only change. Live-provider collection and authenticated product-path proof remain unproven.