### PR TITLE
Add credential-free ActivTrak Rust kernel

### DIFF
--- a/crates/source-runtime-next/src/activtrak.rs
+++ b/crates/source-runtime-next/src/activtrak.rs
@@ -1,0 +1,28 @@
+//! Credential-free ActivTrak request, normalization, and projection kernel.
+//!
+//! The trusted host owns credential-reference resolution, `x-api-key`
+//! authentication, redirects, deadlines, and bounded network I/O. This module
+//! receives only authenticated tenant context, public request configuration,
+//! and bounded provider response bytes. The generic Rust catalog connector
+//! remains the authoritative collection path.
+
+mod catalog;
+mod error;
+mod family;
+mod normalize;
+mod origin;
+mod projection;
+mod request;
+mod response;
+mod types;
+
+pub use catalog::{ActivTrakEventContract, ActivTrakRuntimeDefinition};
+pub use error::ActivTrakError;
+pub use family::ActivTrakFamily;
+pub use projection::{ActivTrakEntityFact, ActivTrakProjectionFacts, project_activtrak_records};
+pub use types::{
+    ActivTrakCheckpointCandidate, ActivTrakKernel, ActivTrakPage, ActivTrakRecord, ActivTrakRequest,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/activtrak/catalog.rs
+++ b/crates/source-runtime-next/src/activtrak/catalog.rs
@@ -1,0 +1,63 @@
+use super::{ActivTrakError, ActivTrakFamily};
+
+/// Exact event contract compiled from the ActivTrak catalog.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ActivTrakEventContract {
+    /// Exact event kind.
+    pub kind: &'static str,
+    /// Exact schema reference.
+    pub schema_ref: &'static str,
+    /// Required normalized attributes.
+    pub required_attributes: &'static [&'static str],
+    /// Required normalized payload fields.
+    pub required_payload_fields: &'static [&'static str],
+}
+
+/// Closed runtime definition for one ActivTrak family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ActivTrakRuntimeDefinition {
+    /// Source identifier.
+    pub source_id: &'static str,
+    /// Selected family.
+    pub family: ActivTrakFamily,
+    /// Exact event contract.
+    pub event_contract: ActivTrakEventContract,
+    /// Every family is a bounded pull operation.
+    pub pull: bool,
+}
+
+impl ActivTrakRuntimeDefinition {
+    /// Compile one declared family into a closed definition.
+    pub fn compile(family: ActivTrakFamily) -> Result<Self, ActivTrakError> {
+        let required_attributes = match family {
+            ActivTrakFamily::ActivityLog => {
+                &["tenant_id", "source_event_id", "event_type", "actor_id"][..]
+            }
+            ActivTrakFamily::Consumers | ActivTrakFamily::Users => {
+                &["tenant_id", "source_event_id", "user_id"][..]
+            }
+            ActivTrakFamily::Clients | ActivTrakFamily::Groups => &[
+                "tenant_id",
+                "source_event_id",
+                "resource_urn",
+                "resource_type",
+                "resource_id",
+            ][..],
+        };
+        let required_payload_fields = match family {
+            ActivTrakFamily::ActivityLog => &["logId"][..],
+            _ => &["id"][..],
+        };
+        Ok(Self {
+            source_id: "activtrak",
+            family,
+            event_contract: ActivTrakEventContract {
+                kind: family.event_kind(),
+                schema_ref: family.schema_ref(),
+                required_attributes,
+                required_payload_fields,
+            },
+            pull: true,
+        })
+    }
+}

--- a/crates/source-runtime-next/src/activtrak/error.rs
+++ b/crates/source-runtime-next/src/activtrak/error.rs
@@ -1,0 +1,158 @@
+use std::{error::Error, fmt};
+
+/// Bounded ActivTrak provider and runtime failure taxonomy.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ActivTrakError {
+    /// Family is outside the closed catalog.
+    InvalidFamily,
+    /// Public configuration is malformed.
+    InvalidConfiguration(&'static str),
+    /// Provider origin is not the declared HTTPS origin.
+    InvalidOrigin,
+    /// Authenticated tenant context is malformed.
+    InvalidTenantId,
+    /// Trusted host has no credential reference.
+    MissingCredentialReference,
+    /// Trusted host could not redeem its credential lease.
+    CredentialUnavailable,
+    /// Cursor is invalid or cannot round-trip.
+    InvalidCursor,
+    /// Request does not belong to this kernel.
+    RequestScopeMismatch,
+    /// Provider rejected authentication.
+    AuthenticationRejected,
+    /// Credential lacks required provider permission.
+    RequiredScopeMissing,
+    /// Provider resource was not found.
+    ProviderResourceNotFound,
+    /// Trusted host denied provider egress.
+    EgressDenied,
+    /// Provider DNS lookup failed.
+    DnsFailure,
+    /// Provider connection failed.
+    ConnectionFailure,
+    /// Provider operation timed out.
+    ProviderTimeout,
+    /// Provider requested a bounded retry.
+    RateLimited {
+        /// Provider-declared retry delay.
+        retry_after_seconds: Option<u64>,
+    },
+    /// Provider returned a retryable server failure.
+    ProviderUnavailable {
+        /// Provider HTTP status.
+        status: u16,
+    },
+    /// Provider returned an unexpected status.
+    UnexpectedStatus {
+        /// Provider HTTP status.
+        status: u16,
+    },
+    /// Retry delay is outside its persistence bound.
+    InvalidRetryAfter,
+    /// Response exceeds the host byte bound.
+    ResponseTooLarge,
+    /// Response exceeds the family record bound.
+    TooManyRecords,
+    /// Response JSON does not match the family.
+    MalformedResponse,
+    /// Provider record violates the family shape.
+    InvalidProviderRecord,
+    /// Provider record has no stable identity.
+    MissingStableIdentity,
+    /// Provider payload attempted to supply tenant context.
+    TenantMismatch,
+    /// Credential-shaped material crossed into the kernel.
+    CredentialMaterial,
+    /// Duplicate provider identity has conflicting content.
+    ConflictingDuplicate,
+    /// Normalized record failed the exact event contract.
+    EventContractRejection,
+    /// Durable append failed.
+    AppendFailure,
+    /// Projection failed.
+    ProjectionFailure,
+    /// Runtime lost its source lease.
+    LeaseLoss,
+    /// Runtime authority or generation is stale.
+    StaleAuthority,
+    /// Internal runtime failure.
+    InternalRuntimeFailure,
+}
+
+impl ActivTrakError {
+    /// Next safe operator action without provider content.
+    pub const fn operator_action(&self) -> &'static str {
+        match self {
+            Self::InvalidFamily
+            | Self::InvalidConfiguration(_)
+            | Self::InvalidOrigin
+            | Self::InvalidTenantId
+            | Self::ProviderResourceNotFound => "repair source configuration",
+            Self::MissingCredentialReference
+            | Self::CredentialUnavailable
+            | Self::AuthenticationRejected => "repair credential binding",
+            Self::RequiredScopeMissing => "grant ActivTrak API read access",
+            Self::RateLimited { .. }
+            | Self::ProviderUnavailable { .. }
+            | Self::DnsFailure
+            | Self::ConnectionFailure
+            | Self::ProviderTimeout => "retry the collection later",
+            Self::EgressDenied => "repair trusted-host egress policy",
+            Self::InvalidCursor => "restart from the last committed checkpoint",
+            Self::MalformedResponse
+            | Self::InvalidProviderRecord
+            | Self::MissingStableIdentity
+            | Self::TenantMismatch
+            | Self::CredentialMaterial
+            | Self::ConflictingDuplicate
+            | Self::EventContractRejection => "inspect quarantined provider records",
+            Self::AppendFailure | Self::ProjectionFailure => "repair the durable commit path",
+            Self::LeaseLoss | Self::StaleAuthority => "restart under the current lease",
+            _ => "repair the forward runtime implementation",
+        }
+    }
+}
+
+impl fmt::Display for ActivTrakError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::InvalidFamily => "activtrak family is invalid",
+            Self::InvalidConfiguration(_) => "activtrak source configuration is invalid",
+            Self::InvalidOrigin => "activtrak provider origin is invalid",
+            Self::InvalidTenantId => "activtrak tenant ID is invalid",
+            Self::MissingCredentialReference => "activtrak credential reference is missing",
+            Self::CredentialUnavailable => "activtrak credential lease is unavailable",
+            Self::InvalidCursor => "activtrak cursor is invalid or not round-trippable",
+            Self::RequestScopeMismatch => "activtrak request does not match the kernel",
+            Self::AuthenticationRejected => "activtrak rejected authentication",
+            Self::RequiredScopeMissing => "activtrak credential lacks required scope",
+            Self::ProviderResourceNotFound => "activtrak resource was not found",
+            Self::EgressDenied => "activtrak egress was denied",
+            Self::DnsFailure => "activtrak DNS resolution failed",
+            Self::ConnectionFailure => "activtrak connection failed",
+            Self::ProviderTimeout => "activtrak operation timed out",
+            Self::RateLimited { .. } => "activtrak rate limited the operation",
+            Self::ProviderUnavailable { .. } => "activtrak is temporarily unavailable",
+            Self::UnexpectedStatus { .. } => "activtrak returned an unexpected status",
+            Self::InvalidRetryAfter => "activtrak retry delay exceeds its bound",
+            Self::ResponseTooLarge => "activtrak response exceeds its byte bound",
+            Self::TooManyRecords => "activtrak response exceeds its record bound",
+            Self::MalformedResponse => "activtrak response is malformed",
+            Self::InvalidProviderRecord => "activtrak provider record is invalid",
+            Self::MissingStableIdentity => "activtrak record has no stable identity",
+            Self::TenantMismatch => "activtrak payload attempted to supply tenant context",
+            Self::CredentialMaterial => "activtrak payload contains credential-shaped material",
+            Self::ConflictingDuplicate => "activtrak duplicate identity has conflicting content",
+            Self::EventContractRejection => "activtrak event failed its catalog contract",
+            Self::AppendFailure => "activtrak append failed",
+            Self::ProjectionFailure => "activtrak projection failed",
+            Self::LeaseLoss => "activtrak runtime lost its lease",
+            Self::StaleAuthority => "activtrak runtime authority is stale",
+            Self::InternalRuntimeFailure => "activtrak runtime failed internally",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl Error for ActivTrakError {}

--- a/crates/source-runtime-next/src/activtrak/family.rs
+++ b/crates/source-runtime-next/src/activtrak/family.rs
@@ -1,0 +1,110 @@
+use std::str::FromStr;
+
+use super::ActivTrakError;
+
+/// Closed ActivTrak catalog family vocabulary.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum ActivTrakFamily {
+    /// Activity-log audit events.
+    ActivityLog,
+    /// Administration clients.
+    Clients,
+    /// Administration consumers.
+    Consumers,
+    /// SCIM groups.
+    Groups,
+    /// SCIM users.
+    Users,
+}
+
+impl ActivTrakFamily {
+    /// Every provider-declared family.
+    pub const ALL: [Self; 5] = [
+        Self::ActivityLog,
+        Self::Clients,
+        Self::Consumers,
+        Self::Groups,
+        Self::Users,
+    ];
+
+    /// Exact catalog identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ActivityLog => "activity_log",
+            Self::Clients => "clients",
+            Self::Consumers => "consumers",
+            Self::Groups => "groups",
+            Self::Users => "users",
+        }
+    }
+
+    /// Exact provider path.
+    pub const fn path(self) -> &'static str {
+        match self {
+            Self::ActivityLog => "/reports/v2/activitylog",
+            Self::Clients => "/admin/v1/clients",
+            Self::Consumers => "/admin/v1/consumers",
+            Self::Groups => "/scim/v1/groups",
+            Self::Users => "/scim/v1/users",
+        }
+    }
+
+    /// Provider response-array key.
+    pub const fn response_key(self) -> &'static str {
+        match self {
+            Self::ActivityLog => "activity",
+            Self::Clients => "clients",
+            Self::Consumers => "consumers",
+            Self::Groups | Self::Users => "resources",
+        }
+    }
+
+    /// Maximum provider records admitted per page.
+    pub const fn page_size(self) -> usize {
+        match self {
+            Self::ActivityLog => 150,
+            _ => 100,
+        }
+    }
+
+    /// Exact event kind.
+    pub const fn event_kind(self) -> &'static str {
+        match self {
+            Self::ActivityLog => "activtrak.activity_log",
+            Self::Clients => "activtrak.clients",
+            Self::Consumers => "activtrak.consumers",
+            Self::Groups => "activtrak.groups",
+            Self::Users => "activtrak.users",
+        }
+    }
+
+    /// Exact schema reference.
+    pub const fn schema_ref(self) -> &'static str {
+        match self {
+            Self::ActivityLog => "activtrak/activity_log/v1",
+            Self::Clients => "activtrak/clients/v1",
+            Self::Consumers => "activtrak/consumers/v1",
+            Self::Groups => "activtrak/groups/v1",
+            Self::Users => "activtrak/users/v1",
+        }
+    }
+
+    /// Exact stable provider identity field.
+    pub const fn id_field(self) -> &'static str {
+        match self {
+            Self::ActivityLog => "logId",
+            _ => "id",
+        }
+    }
+}
+
+impl FromStr for ActivTrakFamily {
+    type Err = ActivTrakError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|family| family.as_str() == value.trim())
+            .ok_or(ActivTrakError::InvalidFamily)
+    }
+}

--- a/crates/source-runtime-next/src/activtrak/normalize.rs
+++ b/crates/source-runtime-next/src/activtrak/normalize.rs
@@ -1,0 +1,276 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    ActivTrakError, ActivTrakFamily, ActivTrakKernel, ActivTrakRecord, ActivTrakRuntimeDefinition,
+};
+
+pub(super) fn normalize(
+    kernel: &ActivTrakKernel,
+    raw: Value,
+) -> Result<ActivTrakRecord, ActivTrakError> {
+    reject_protected(&raw, 0)?;
+    let values = raw
+        .as_object()
+        .ok_or(ActivTrakError::InvalidProviderRecord)?;
+    let provider_id = scalar(values.get(kernel.family.id_field()))
+        .filter(|value| !value.is_empty() && value.len() <= 512)
+        .ok_or(ActivTrakError::MissingStableIdentity)?;
+    let attributes = attributes(kernel, values, &provider_id)?;
+    let occurred_at = occurred_at(kernel, values)?;
+    let record = ActivTrakRecord {
+        tenant_id: kernel.tenant_id.clone(),
+        event_id: event_id(kernel, &provider_id),
+        provider_id,
+        family: kernel.family,
+        kind: kernel.family.event_kind().to_owned(),
+        schema_ref: kernel.family.schema_ref().to_owned(),
+        occurred_at,
+        attributes,
+        payload: raw,
+    };
+    admit(&record)?;
+    Ok(record)
+}
+
+fn attributes(
+    kernel: &ActivTrakKernel,
+    values: &Map<String, Value>,
+    provider_id: &str,
+) -> Result<BTreeMap<String, String>, ActivTrakError> {
+    let mut output = BTreeMap::from([
+        ("tenant_id".to_owned(), kernel.tenant_id.clone()),
+        ("source_event_id".to_owned(), provider_id.to_owned()),
+        ("source_system".to_owned(), "activtrak".to_owned()),
+        ("schema".to_owned(), kernel.family.as_str().to_owned()),
+    ]);
+    match kernel.family {
+        ActivTrakFamily::Users => {
+            output.insert("record_class".to_owned(), "identity_user".to_owned());
+            output.insert("user_id".to_owned(), provider_id.to_owned());
+            copy(&mut output, values, "displayName", "display_name");
+            nested_email(&mut output, values);
+        }
+        ActivTrakFamily::Consumers => {
+            output.insert("record_class".to_owned(), "identity_user".to_owned());
+            output.insert("user_id".to_owned(), provider_id.to_owned());
+            let name = match (
+                scalar(values.get("firstName")),
+                scalar(values.get("lastName")),
+            ) {
+                (Some(first), Some(last)) => Some(format!("{first} {last}")),
+                _ => scalar(values.get("username")),
+            };
+            if let Some(name) = name {
+                output.insert("display_name".to_owned(), name);
+            }
+            copy(&mut output, values, "email", "email");
+        }
+        ActivTrakFamily::Clients | ActivTrakFamily::Groups => {
+            let (resource_type, name_key) = match kernel.family {
+                ActivTrakFamily::Clients => ("activtrak_client", "alias"),
+                ActivTrakFamily::Groups => ("activtrak_group", "displayName"),
+                _ => return Err(ActivTrakError::InternalRuntimeFailure),
+            };
+            let name = scalar(values.get(name_key)).unwrap_or_else(|| provider_id.to_owned());
+            output.extend(BTreeMap::from([
+                ("record_class".to_owned(), "asset".to_owned()),
+                ("resource_id".to_owned(), provider_id.to_owned()),
+                ("resource_name".to_owned(), name),
+                ("resource_type".to_owned(), resource_type.to_owned()),
+                (
+                    "resource_urn".to_owned(),
+                    format!(
+                        "urn:cerebro:{}:runtime_{}:{}",
+                        encode_segment(&kernel.tenant_id),
+                        resource_type,
+                        encode_segment(provider_id)
+                    ),
+                ),
+            ]));
+        }
+        ActivTrakFamily::ActivityLog => {
+            output.insert("record_class".to_owned(), "audit_event".to_owned());
+            required_copy(&mut output, values, "description", "event_type")?;
+            required_copy(&mut output, values, "user", "actor_id")?;
+            copy(&mut output, values, "user", "actor_name");
+            copy(&mut output, values, "computerId", "resource_id");
+            output.insert("resource_type".to_owned(), "activity_log".to_owned());
+        }
+    }
+    Ok(output)
+}
+
+fn occurred_at(
+    kernel: &ActivTrakKernel,
+    values: &Map<String, Value>,
+) -> Result<String, ActivTrakError> {
+    let value = if kernel.family == ActivTrakFamily::ActivityLog {
+        scalar(values.get("time_utc")).unwrap_or_else(|| kernel.observed_at.clone())
+    } else {
+        kernel.observed_at.clone()
+    };
+    let time = OffsetDateTime::parse(&value, &Rfc3339)
+        .map_err(|_| ActivTrakError::InvalidProviderRecord)?;
+    time.format(&Rfc3339)
+        .map_err(|_| ActivTrakError::InvalidProviderRecord)
+}
+
+fn admit(record: &ActivTrakRecord) -> Result<(), ActivTrakError> {
+    let definition = ActivTrakRuntimeDefinition::compile(record.family)?;
+    if record.kind != definition.event_contract.kind
+        || record.schema_ref != definition.event_contract.schema_ref
+        || definition
+            .event_contract
+            .required_attributes
+            .iter()
+            .any(|key| record.attributes.get(*key).is_none_or(String::is_empty))
+        || definition
+            .event_contract
+            .required_payload_fields
+            .iter()
+            .any(|key| record.payload.get(*key).is_none_or(Value::is_null))
+    {
+        return Err(ActivTrakError::EventContractRejection);
+    }
+    Ok(())
+}
+
+fn event_id(kernel: &ActivTrakKernel, provider_id: &str) -> String {
+    let scope = Sha256::digest(format!(
+        "{}\0{}",
+        kernel.base_url.as_str().trim_end_matches('/'),
+        kernel.family.path()
+    ));
+    let scope = scope[..6]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!(
+        "activtrak-{}-{scope}-{}-{}",
+        normalize_id(&kernel.tenant_id),
+        normalize_id(kernel.family.as_str()),
+        normalize_id(provider_id)
+    )
+}
+
+fn nested_email(output: &mut BTreeMap<String, String>, values: &Map<String, Value>) {
+    let email = values
+        .get("emails")
+        .and_then(Value::as_array)
+        .and_then(|values| values.first())
+        .and_then(|value| value.get("value"))
+        .and_then(|value| scalar(Some(value)));
+    if let Some(email) = email {
+        output.insert("email".to_owned(), email);
+    } else {
+        copy(output, values, "userName", "email");
+    }
+}
+
+fn required_copy(
+    output: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    source: &str,
+    target: &str,
+) -> Result<(), ActivTrakError> {
+    let value = scalar(values.get(source)).filter(|value| !value.is_empty());
+    output.insert(
+        target.to_owned(),
+        value.ok_or(ActivTrakError::InvalidProviderRecord)?,
+    );
+    Ok(())
+}
+
+fn copy(
+    output: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    source: &str,
+    target: &str,
+) {
+    if let Some(value) = scalar(values.get(source)).filter(|value| !value.is_empty()) {
+        output.insert(target.to_owned(), value);
+    }
+}
+
+fn scalar(value: Option<&Value>) -> Option<String> {
+    match value? {
+        Value::String(value) => Some(value.trim().to_owned()),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn reject_protected(value: &Value, depth: usize) -> Result<(), ActivTrakError> {
+    if depth > 32 {
+        return Err(ActivTrakError::InvalidProviderRecord);
+    }
+    match value {
+        Value::Object(values) => {
+            if values.len() > 256 {
+                return Err(ActivTrakError::InvalidProviderRecord);
+            }
+            for (key, value) in values {
+                let key = key.to_ascii_lowercase().replace(['-', '.'], "_");
+                if key == "tenant_id" {
+                    return Err(ActivTrakError::TenantMismatch);
+                }
+                if [
+                    "api_key",
+                    "x_api_key",
+                    "authorization",
+                    "password",
+                    "private_key",
+                ]
+                .contains(&key.as_str())
+                {
+                    return Err(ActivTrakError::CredentialMaterial);
+                }
+                reject_protected(value, depth + 1)?;
+            }
+        }
+        Value::Array(values) => {
+            if values.len() > 512 {
+                return Err(ActivTrakError::InvalidProviderRecord);
+            }
+            for value in values {
+                reject_protected(value, depth + 1)?;
+            }
+        }
+        Value::String(value) if value.len() > 64 * 1024 => {
+            return Err(ActivTrakError::InvalidProviderRecord);
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn normalize_id(value: &str) -> String {
+    let normalized = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_') {
+                character.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    normalized.trim_matches('-').to_owned()
+}
+
+fn encode_segment(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.trim().bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}

--- a/crates/source-runtime-next/src/activtrak/origin.rs
+++ b/crates/source-runtime-next/src/activtrak/origin.rs
@@ -1,0 +1,30 @@
+use reqwest::Url;
+
+use super::ActivTrakError;
+
+pub(super) fn validate(value: &str) -> Result<Url, ActivTrakError> {
+    let mut url = Url::parse(value.trim().trim_end_matches('/'))
+        .map_err(|_| ActivTrakError::InvalidOrigin)?;
+    if url.scheme() != "https"
+        || url.host_str() != Some("api.activtrak.com")
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port_or_known_default() != Some(443)
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || !matches!(url.path(), "" | "/")
+    {
+        return Err(ActivTrakError::InvalidOrigin);
+    }
+    url.set_path("");
+    Ok(url)
+}
+
+pub(super) fn tenant(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()
+        && value.len() <= 128
+        && !value.chars().any(char::is_control)
+        && !value.contains(['/', '\\', ':']))
+    .then(|| value.to_owned())
+}

--- a/crates/source-runtime-next/src/activtrak/projection.rs
+++ b/crates/source-runtime-next/src/activtrak/projection.rs
@@ -1,0 +1,85 @@
+use std::collections::BTreeMap;
+
+use super::{ActivTrakFamily, ActivTrakRecord};
+
+/// One deterministic tenant-scoped ActivTrak projection entity.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ActivTrakEntityFact {
+    /// Canonical entity URN.
+    pub urn: String,
+    /// Closed entity type.
+    pub entity_type: String,
+    /// Human-readable label.
+    pub label: String,
+}
+
+/// Provider-local projection facts used for Go/Rust parity.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ActivTrakProjectionFacts {
+    /// Deduplicated entities in canonical order.
+    pub entities: Vec<ActivTrakEntityFact>,
+}
+
+/// Project normalized records into identity, asset, and audit entities.
+pub fn project_activtrak_records(records: &[ActivTrakRecord]) -> ActivTrakProjectionFacts {
+    let mut entities = BTreeMap::<String, ActivTrakEntityFact>::new();
+    for record in records {
+        let (urn, entity_type, label) = match record.family {
+            ActivTrakFamily::Clients | ActivTrakFamily::Groups => {
+                let (Some(urn), Some(resource_type)) = (
+                    record.attributes.get("resource_urn"),
+                    record.attributes.get("resource_type"),
+                ) else {
+                    continue;
+                };
+                (
+                    urn.clone(),
+                    format!("runtime.{}", resource_type.replace('_', ".")),
+                    record
+                        .attributes
+                        .get("resource_name")
+                        .cloned()
+                        .unwrap_or_else(|| record.provider_id.clone()),
+                )
+            }
+            family => (
+                format!(
+                    "urn:cerebro:{}:activtrak_{}:{}",
+                    encode_segment(&record.tenant_id),
+                    family.as_str(),
+                    encode_segment(&record.provider_id)
+                ),
+                format!("activtrak.{}", family.as_str().replace('_', ".")),
+                record
+                    .attributes
+                    .get("display_name")
+                    .or_else(|| record.attributes.get("event_type"))
+                    .cloned()
+                    .unwrap_or_else(|| record.provider_id.clone()),
+            ),
+        };
+        entities.insert(
+            urn.clone(),
+            ActivTrakEntityFact {
+                urn,
+                entity_type,
+                label,
+            },
+        );
+    }
+    ActivTrakProjectionFacts {
+        entities: entities.into_values().collect(),
+    }
+}
+
+fn encode_segment(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.trim().bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}

--- a/crates/source-runtime-next/src/activtrak/request.rs
+++ b/crates/source-runtime-next/src/activtrak/request.rs
@@ -1,0 +1,99 @@
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{ActivTrakError, ActivTrakFamily, ActivTrakKernel, ActivTrakRequest, origin};
+
+const MAX_OFFSET: usize = 10_000_000;
+const MAX_CURSOR_BYTES: usize = 2_048;
+
+pub(super) fn new_kernel(
+    base_url: &str,
+    tenant_id: &str,
+    family: ActivTrakFamily,
+    observed_at: &str,
+) -> Result<ActivTrakKernel, ActivTrakError> {
+    let base_url = origin::validate(base_url)?;
+    let tenant_id = origin::tenant(tenant_id).ok_or(ActivTrakError::InvalidTenantId)?;
+    let observed = OffsetDateTime::parse(observed_at, &Rfc3339)
+        .map_err(|_| ActivTrakError::InvalidConfiguration("observed_at"))?;
+    let observed_at = observed
+        .format(&Rfc3339)
+        .map_err(|_| ActivTrakError::InvalidConfiguration("observed_at"))?;
+    Ok(ActivTrakKernel {
+        base_url,
+        tenant_id,
+        family,
+        observed_at,
+    })
+}
+
+pub(super) fn plan(
+    kernel: &ActivTrakKernel,
+    cursor: Option<&str>,
+) -> Result<ActivTrakRequest, ActivTrakError> {
+    let mut url = kernel.base_url.clone();
+    url.set_path(kernel.family.path());
+    if url.origin() != kernel.base_url.origin() {
+        return Err(ActivTrakError::InvalidOrigin);
+    }
+    let offset = match kernel.family {
+        ActivTrakFamily::Groups | ActivTrakFamily::Users => {
+            let offset = cursor.map(validate_offset).transpose()?.unwrap_or(1);
+            let mut query = url.query_pairs_mut();
+            query.append_pair("count", &kernel.family.page_size().to_string());
+            query.append_pair("startIndex", &offset.to_string());
+            Some(offset)
+        }
+        ActivTrakFamily::ActivityLog => {
+            let mut query = url.query_pairs_mut();
+            query.append_pair("pageSize", &kernel.family.page_size().to_string());
+            if let Some(cursor) = cursor {
+                query.append_pair("cursor", validate_opaque(cursor)?);
+            }
+            None
+        }
+        ActivTrakFamily::Clients | ActivTrakFamily::Consumers => {
+            if cursor.is_some() {
+                return Err(ActivTrakError::InvalidCursor);
+            }
+            None
+        }
+    };
+    Ok(ActivTrakRequest {
+        url,
+        family: kernel.family,
+        cursor: cursor.map(str::to_owned),
+        offset,
+        page_size: kernel.family.page_size(),
+    })
+}
+
+pub(super) fn validate_request(
+    kernel: &ActivTrakKernel,
+    request: &ActivTrakRequest,
+) -> Result<(), ActivTrakError> {
+    if request != &plan(kernel, request.cursor.as_deref())? {
+        return Err(ActivTrakError::RequestScopeMismatch);
+    }
+    Ok(())
+}
+
+pub(super) fn validate_offset(value: &str) -> Result<usize, ActivTrakError> {
+    value
+        .trim()
+        .parse::<usize>()
+        .ok()
+        .filter(|offset| (1..=MAX_OFFSET).contains(offset))
+        .ok_or(ActivTrakError::InvalidCursor)
+}
+
+pub(super) fn validate_opaque(value: &str) -> Result<&str, ActivTrakError> {
+    let value = value.trim();
+    if value.is_empty()
+        || value.len() > MAX_CURSOR_BYTES
+        || value.chars().any(char::is_control)
+        || value.contains(['/', '\\'])
+    {
+        return Err(ActivTrakError::InvalidCursor);
+    }
+    Ok(value)
+}

--- a/crates/source-runtime-next/src/activtrak/response.rs
+++ b/crates/source-runtime-next/src/activtrak/response.rs
@@ -1,0 +1,150 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    ActivTrakCheckpointCandidate, ActivTrakError, ActivTrakFamily, ActivTrakKernel, ActivTrakPage,
+    ActivTrakRequest, normalize,
+    request::{validate_offset, validate_opaque, validate_request},
+};
+
+pub(super) const MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+pub(super) fn decode(
+    kernel: &ActivTrakKernel,
+    request: &ActivTrakRequest,
+    status: u16,
+    retry_after_seconds: Option<u64>,
+    body: &[u8],
+) -> Result<ActivTrakPage, ActivTrakError> {
+    validate_request(kernel, request)?;
+    classify_status(status, retry_after_seconds)?;
+    if body.len() > MAX_RESPONSE_BYTES {
+        return Err(ActivTrakError::ResponseTooLarge);
+    }
+    let root: Value =
+        serde_json::from_slice(body).map_err(|_| ActivTrakError::MalformedResponse)?;
+    let items = root
+        .get(kernel.family.response_key())
+        .or_else(|| {
+            matches!(
+                kernel.family,
+                ActivTrakFamily::Groups | ActivTrakFamily::Users
+            )
+            .then(|| root.get("Resources"))
+            .flatten()
+        })
+        .and_then(Value::as_array)
+        .ok_or(ActivTrakError::MalformedResponse)?;
+    if items.len() > request.page_size {
+        return Err(ActivTrakError::TooManyRecords);
+    }
+    let mut seen = BTreeMap::<String, Vec<u8>>::new();
+    let mut records = Vec::with_capacity(items.len());
+    for raw in items {
+        let record = normalize::normalize(kernel, raw.clone())?;
+        let canonical = serde_json::to_vec(&record.payload)
+            .map_err(|_| ActivTrakError::InvalidProviderRecord)?;
+        match seen.get(&record.provider_id) {
+            Some(previous) if previous == &canonical => continue,
+            Some(_) => return Err(ActivTrakError::ConflictingDuplicate),
+            None => {
+                seen.insert(record.provider_id.clone(), canonical);
+                records.push(record);
+            }
+        }
+    }
+    let next_cursor = next_cursor(kernel.family, request, &root, items.len())?;
+    if next_cursor.is_some() && next_cursor == request.cursor {
+        return Err(ActivTrakError::InvalidCursor);
+    }
+    Ok(ActivTrakPage {
+        records,
+        next_cursor,
+    })
+}
+
+fn next_cursor(
+    family: ActivTrakFamily,
+    request: &ActivTrakRequest,
+    root: &Value,
+    count: usize,
+) -> Result<Option<String>, ActivTrakError> {
+    match family {
+        ActivTrakFamily::Groups | ActivTrakFamily::Users => {
+            if count < request.page_size {
+                return Ok(None);
+            }
+            let next = request
+                .offset
+                .and_then(|offset| offset.checked_add(count))
+                .ok_or(ActivTrakError::InvalidCursor)?;
+            validate_offset(&next.to_string())?;
+            Ok(Some(next.to_string()))
+        }
+        ActivTrakFamily::ActivityLog => match root.get("cursor") {
+            None | Some(Value::Null) => Ok(None),
+            Some(Value::String(value)) if value.is_empty() => Ok(None),
+            Some(Value::String(value)) => Ok(Some(validate_opaque(value)?.to_owned())),
+            Some(_) => Err(ActivTrakError::InvalidCursor),
+        },
+        ActivTrakFamily::Clients | ActivTrakFamily::Consumers => Ok(None),
+    }
+}
+
+pub(super) fn checkpoint_candidate(
+    kernel: &ActivTrakKernel,
+    request: &ActivTrakRequest,
+    page: &ActivTrakPage,
+    prior_watermark: Option<&str>,
+) -> Result<ActivTrakCheckpointCandidate, ActivTrakError> {
+    validate_request(kernel, request)?;
+    if page
+        .records
+        .iter()
+        .any(|record| record.tenant_id != kernel.tenant_id || record.family != kernel.family)
+    {
+        return Err(ActivTrakError::TenantMismatch);
+    }
+    if let Some(cursor) = &page.next_cursor {
+        kernel.plan(Some(cursor))?;
+    }
+    let mut watermark = valid_time(prior_watermark.unwrap_or(&kernel.observed_at))?;
+    for record in &page.records {
+        let occurred_at = valid_time(&record.occurred_at)?;
+        if occurred_at > watermark {
+            watermark = occurred_at;
+        }
+    }
+    Ok(ActivTrakCheckpointCandidate {
+        tenant_id: kernel.tenant_id.clone(),
+        family: kernel.family,
+        cursor: page.next_cursor.clone(),
+        watermark,
+    })
+}
+
+fn classify_status(status: u16, retry: Option<u64>) -> Result<(), ActivTrakError> {
+    if retry.is_some_and(|seconds| seconds > 3_600) {
+        return Err(ActivTrakError::InvalidRetryAfter);
+    }
+    match status {
+        200..=299 => Ok(()),
+        401 => Err(ActivTrakError::AuthenticationRejected),
+        403 => Err(ActivTrakError::RequiredScopeMissing),
+        404 => Err(ActivTrakError::ProviderResourceNotFound),
+        429 => Err(ActivTrakError::RateLimited {
+            retry_after_seconds: retry,
+        }),
+        500..=599 => Err(ActivTrakError::ProviderUnavailable { status }),
+        _ => Err(ActivTrakError::UnexpectedStatus { status }),
+    }
+}
+
+fn valid_time(value: &str) -> Result<String, ActivTrakError> {
+    let time = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| ActivTrakError::InvalidProviderRecord)?;
+    time.format(&Rfc3339)
+        .map_err(|_| ActivTrakError::InvalidProviderRecord)
+}

--- a/crates/source-runtime-next/src/activtrak/tests.rs
+++ b/crates/source-runtime-next/src/activtrak/tests.rs
@@ -1,0 +1,290 @@
+use std::{collections::BTreeMap, fs, path::PathBuf};
+
+use cerebro_source_catalog::{CollectionAuthority, SourceCatalog};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::*;
+
+const ORIGIN: &str = "https://api.activtrak.com";
+const OBSERVED_AT: &str = "2026-06-01T00:00:00Z";
+
+#[derive(Debug, Deserialize)]
+struct GoOracleEvent {
+    id: String,
+    tenant_id: String,
+    source_id: String,
+    kind: String,
+    occurred_at: String,
+    schema_ref: String,
+    payload: Value,
+    attributes: BTreeMap<String, String>,
+}
+
+fn root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn kernel(tenant: &str, family: ActivTrakFamily) -> ActivTrakKernel {
+    ActivTrakKernel::new(ORIGIN, tenant, family, OBSERVED_AT).unwrap()
+}
+
+fn oracle(family: ActivTrakFamily) -> GoOracleEvent {
+    let bytes = fs::read(root().join(format!(
+        "sources/activtrak/testdata/read_{}.json",
+        family.as_str()
+    )))
+    .unwrap();
+    serde_json::from_slice::<Vec<GoOracleEvent>>(&bytes)
+        .unwrap()
+        .pop()
+        .unwrap()
+}
+
+fn response(family: ActivTrakFamily, records: Vec<Value>, cursor: Option<&str>) -> Vec<u8> {
+    let mut response = json!({family.response_key(): records});
+    if let Some(cursor) = cursor {
+        response["cursor"] = Value::String(cursor.to_owned());
+    }
+    serde_json::to_vec(&response).unwrap()
+}
+
+#[test]
+fn catalog_closes_the_exact_authoritative_family_set() {
+    let catalog = SourceCatalog::load(
+        root().join("internal/connectorcatalog/catalog"),
+        root().join("sources"),
+    )
+    .unwrap();
+    let source = catalog.get("activtrak").unwrap();
+    assert_eq!(source.authority(), CollectionAuthority::Authoritative);
+    let mut families = source
+        .families()
+        .iter()
+        .map(|family| family.id())
+        .collect::<Vec<_>>();
+    families.sort_unstable();
+    assert_eq!(
+        families,
+        ["activity_log", "clients", "consumers", "groups", "users"]
+    );
+    assert!(
+        source
+            .families()
+            .iter()
+            .all(|family| family.is_authoritative())
+    );
+    for family in ActivTrakFamily::ALL {
+        let definition = ActivTrakRuntimeDefinition::compile(family).unwrap();
+        assert_eq!(definition.source_id, "activtrak");
+        assert_eq!(definition.event_contract.kind, family.event_kind());
+    }
+}
+
+#[test]
+fn requests_are_origin_locked_bounded_and_credential_free() {
+    for family in ActivTrakFamily::ALL {
+        let request = kernel("tenant", family).plan(None).unwrap();
+        assert_eq!(request.method(), "GET");
+        assert_eq!(request.url().host_str(), Some("api.activtrak.com"));
+        assert_eq!(request.url().path(), family.path());
+        assert_eq!(request.authentication_header(), "x-api-key");
+        assert!(request.credential_reference_required());
+        assert!(!request.contains_credentials());
+        assert!(!request.allows_redirects());
+        assert_eq!(request.record_limit(), family.page_size());
+    }
+    assert_eq!(
+        kernel("tenant", ActivTrakFamily::Users)
+            .plan(Some("101"))
+            .unwrap()
+            .url()
+            .query(),
+        Some("count=100&startIndex=101")
+    );
+    assert_eq!(
+        kernel("tenant", ActivTrakFamily::ActivityLog)
+            .plan(Some("next-token"))
+            .unwrap()
+            .url()
+            .query(),
+        Some("pageSize=150&cursor=next-token")
+    );
+}
+
+#[test]
+fn go_event_and_projection_fixtures_match_semantically() {
+    for family in ActivTrakFamily::ALL {
+        let oracle = oracle(family);
+        let request = kernel("tenant", family).plan(None).unwrap();
+        let page = kernel("tenant", family)
+            .decode(
+                &request,
+                200,
+                None,
+                &response(family, vec![oracle.payload.clone()], None),
+            )
+            .unwrap();
+        let record = &page.records[0];
+        assert_eq!(record.tenant_id, oracle.tenant_id);
+        assert_eq!(oracle.source_id, "activtrak");
+        assert_eq!(record.kind, oracle.kind);
+        assert_eq!(record.schema_ref, oracle.schema_ref);
+        assert_eq!(record.occurred_at, oracle.occurred_at);
+        assert_eq!(record.payload, oracle.payload);
+        assert_eq!(record.attributes, oracle.attributes);
+        assert_eq!(
+            oracle.id,
+            format!("source-activtrak-{}-event-1", family.as_str())
+        );
+        assert_eq!(project_activtrak_records(&page.records).entities.len(), 1);
+    }
+}
+
+#[test]
+fn cursors_checkpoint_and_restart_round_trip() {
+    let family = ActivTrakFamily::Users;
+    let scim_kernel = kernel("tenant", family);
+    let request = scim_kernel.plan(None).unwrap();
+    let records = (1..=100)
+        .map(|id| json!({"id": id.to_string(), "displayName": format!("user-{id}")}))
+        .collect::<Vec<_>>();
+    let page = scim_kernel
+        .decode(&request, 200, None, &response(family, records, None))
+        .unwrap();
+    assert_eq!(page.next_cursor.as_deref(), Some("101"));
+    let checkpoint = scim_kernel
+        .checkpoint_candidate(&request, &page, Some("2026-05-01T00:00:00Z"))
+        .unwrap();
+    assert_eq!(checkpoint.cursor.as_deref(), Some("101"));
+    assert_eq!(
+        scim_kernel
+            .plan(checkpoint.cursor.as_deref())
+            .unwrap()
+            .url()
+            .query(),
+        Some("count=100&startIndex=101")
+    );
+
+    let activity = ActivTrakFamily::ActivityLog;
+    let kernel = kernel("tenant", activity);
+    let request = kernel.plan(None).unwrap();
+    let page = kernel
+        .decode(
+            &request,
+            200,
+            None,
+            &response(activity, vec![oracle(activity).payload], Some("next-token")),
+        )
+        .unwrap();
+    assert_eq!(page.next_cursor.as_deref(), Some("next-token"));
+}
+
+#[test]
+fn duplicate_conflict_tenant_secret_and_statuses_fail_closed() {
+    let family = ActivTrakFamily::Clients;
+    let kernel = kernel("tenant", family);
+    let request = kernel.plan(None).unwrap();
+    let raw = oracle(family).payload;
+    let page = kernel
+        .decode(
+            &request,
+            200,
+            None,
+            &response(family, vec![raw.clone(), raw.clone()], None),
+        )
+        .unwrap();
+    assert_eq!(page.records.len(), 1);
+    let mut conflict = raw.clone();
+    conflict["alias"] = Value::String("different".to_owned());
+    assert_eq!(
+        kernel.decode(
+            &request,
+            200,
+            None,
+            &response(family, vec![raw, conflict], None)
+        ),
+        Err(ActivTrakError::ConflictingDuplicate)
+    );
+    for (field, expected) in [
+        ("tenant_id", ActivTrakError::TenantMismatch),
+        ("api_key", ActivTrakError::CredentialMaterial),
+        ("authorization", ActivTrakError::CredentialMaterial),
+    ] {
+        let mut raw = oracle(family).payload;
+        raw[field] = Value::String("sentinel-secret-value".to_owned());
+        let error = kernel
+            .decode(&request, 200, None, &response(family, vec![raw], None))
+            .unwrap_err();
+        assert_eq!(error, expected);
+        assert!(!format!("{error:?}").contains("sentinel-secret-value"));
+    }
+    assert_eq!(
+        kernel.decode(&request, 401, None, b"{}"),
+        Err(ActivTrakError::AuthenticationRejected)
+    );
+    assert_eq!(
+        kernel.decode(&request, 403, None, b"{}"),
+        Err(ActivTrakError::RequiredScopeMissing)
+    );
+    assert_eq!(
+        kernel.decode(&request, 429, Some(60), b"{}"),
+        Err(ActivTrakError::RateLimited {
+            retry_after_seconds: Some(60)
+        })
+    );
+}
+
+#[test]
+fn origin_cursor_and_tenant_inputs_fail_closed() {
+    for origin in [
+        "http://api.activtrak.com",
+        "https://other.activtrak.com",
+        "https://user@api.activtrak.com",
+        "https://api.activtrak.com:8443",
+        "https://api.activtrak.com/path",
+        "https://api.activtrak.com?api_key=value",
+    ] {
+        assert!(
+            ActivTrakKernel::new(origin, "tenant", ActivTrakFamily::Users, OBSERVED_AT).is_err()
+        );
+    }
+    assert!(
+        ActivTrakKernel::new(ORIGIN, "bad:tenant", ActivTrakFamily::Users, OBSERVED_AT).is_err()
+    );
+    assert_eq!(
+        kernel("tenant", ActivTrakFamily::Users).plan(Some("0")),
+        Err(ActivTrakError::InvalidCursor)
+    );
+    assert_eq!(
+        kernel("tenant", ActivTrakFamily::Clients).plan(Some("1")),
+        Err(ActivTrakError::InvalidCursor)
+    );
+    assert_eq!(
+        kernel("tenant", ActivTrakFamily::ActivityLog).plan(Some("../escape")),
+        Err(ActivTrakError::InvalidCursor)
+    );
+}
+
+#[test]
+fn identity_is_deterministic_and_tenant_scoped() {
+    let family = ActivTrakFamily::Consumers;
+    let body = response(family, vec![oracle(family).payload], None);
+    let first_kernel = kernel("tenant-a", family);
+    let first_request = first_kernel.plan(None).unwrap();
+    let first = first_kernel
+        .decode(&first_request, 200, None, &body)
+        .unwrap();
+    assert_eq!(
+        first,
+        first_kernel
+            .decode(&first_request, 200, None, &body)
+            .unwrap()
+    );
+    let second_kernel = kernel("tenant-b", family);
+    let second_request = second_kernel.plan(None).unwrap();
+    let second = second_kernel
+        .decode(&second_request, 200, None, &body)
+        .unwrap();
+    assert_ne!(first.records[0].event_id, second.records[0].event_id);
+}

--- a/crates/source-runtime-next/src/activtrak/types.rs
+++ b/crates/source-runtime-next/src/activtrak/types.rs
@@ -1,0 +1,172 @@
+use std::{collections::BTreeMap, fmt};
+
+use reqwest::Url;
+use serde_json::Value;
+
+use super::{ActivTrakError, ActivTrakFamily, request, response};
+
+/// Credential-free request intent for the trusted ActivTrak HTTP host.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ActivTrakRequest {
+    pub(super) url: Url,
+    pub(super) family: ActivTrakFamily,
+    pub(super) cursor: Option<String>,
+    pub(super) offset: Option<usize>,
+    pub(super) page_size: usize,
+}
+
+impl fmt::Debug for ActivTrakRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ActivTrakRequest")
+            .field("url", &self.url)
+            .field("family", &self.family)
+            .field("has_cursor", &self.cursor.is_some())
+            .field("page_size", &self.page_size)
+            .finish()
+    }
+}
+
+impl ActivTrakRequest {
+    /// Fully planned provider URL.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+    /// Provider HTTP method.
+    pub const fn method(&self) -> &'static str {
+        "GET"
+    }
+    /// Family owning this request.
+    pub const fn family(&self) -> ActivTrakFamily {
+        self.family
+    }
+    /// Authentication header applied by the trusted host.
+    pub const fn authentication_header(&self) -> &'static str {
+        "x-api-key"
+    }
+    /// API keys have no prefix scheme.
+    pub const fn authentication_scheme(&self) -> &'static str {
+        ""
+    }
+    /// Host must redeem a credential reference before execution.
+    pub const fn credential_reference_required(&self) -> bool {
+        true
+    }
+    /// Expected response media type.
+    pub const fn accept(&self) -> &'static str {
+        "application/json"
+    }
+    /// Portable plan contains no credential bytes or references.
+    pub const fn contains_credentials(&self) -> bool {
+        false
+    }
+    /// Redirects are disabled by the trusted host.
+    pub const fn allows_redirects(&self) -> bool {
+        false
+    }
+    /// Maximum admitted response bytes.
+    pub const fn max_response_bytes(&self) -> usize {
+        response::MAX_RESPONSE_BYTES
+    }
+    /// Provider permission required for list operations.
+    pub const fn required_scope(&self) -> &'static str {
+        "ActivTrak API read access"
+    }
+    /// Maximum records admitted from this response.
+    pub const fn record_limit(&self) -> usize {
+        self.page_size
+    }
+}
+
+/// One normalized tenant-scoped ActivTrak event candidate.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ActivTrakRecord {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Stable tenant-, family-, and provider-scoped identity.
+    pub event_id: String,
+    /// Stable provider object identity.
+    pub provider_id: String,
+    /// Exact family.
+    pub family: ActivTrakFamily,
+    /// Exact event kind.
+    pub kind: String,
+    /// Exact schema reference.
+    pub schema_ref: String,
+    /// Normalized RFC3339 occurrence time.
+    pub occurred_at: String,
+    /// Deterministic projection attributes.
+    pub attributes: BTreeMap<String, String>,
+    /// Credential-free provider payload.
+    pub payload: Value,
+}
+
+/// One bounded normalized ActivTrak page.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ActivTrakPage {
+    /// Accepted records after deterministic deduplication.
+    pub records: Vec<ActivTrakRecord>,
+    /// Validated continuation, or terminal state.
+    pub next_cursor: Option<String>,
+}
+
+/// Checkpoint candidate for post-append/projection persistence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ActivTrakCheckpointCandidate {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Selected family.
+    pub family: ActivTrakFamily,
+    /// Validated continuation state.
+    pub cursor: Option<String>,
+    /// Provider observation watermark.
+    pub watermark: String,
+}
+
+/// Closed ActivTrak kernel for one tenant and family.
+#[derive(Clone, Debug)]
+pub struct ActivTrakKernel {
+    pub(super) base_url: Url,
+    pub(super) tenant_id: String,
+    pub(super) family: ActivTrakFamily,
+    pub(super) observed_at: String,
+}
+
+impl ActivTrakKernel {
+    /// Construct one family kernel from public execution context.
+    pub fn new(
+        base_url: &str,
+        tenant_id: &str,
+        family: ActivTrakFamily,
+        observed_at: &str,
+    ) -> Result<Self, ActivTrakError> {
+        request::new_kernel(base_url, tenant_id, family, observed_at)
+    }
+    /// Kernel protocol never accepts credential material.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+    /// Plan one bounded origin-restricted request.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<ActivTrakRequest, ActivTrakError> {
+        request::plan(self, cursor)
+    }
+    /// Decode one bounded provider response.
+    pub fn decode(
+        &self,
+        request: &ActivTrakRequest,
+        status: u16,
+        retry_after_seconds: Option<u64>,
+        body: &[u8],
+    ) -> Result<ActivTrakPage, ActivTrakError> {
+        response::decode(self, request, status, retry_after_seconds, body)
+    }
+    /// Validate a checkpoint candidate for post-commit persistence.
+    pub fn checkpoint_candidate(
+        &self,
+        request: &ActivTrakRequest,
+        page: &ActivTrakPage,
+        prior_watermark: Option<&str>,
+    ) -> Result<ActivTrakCheckpointCandidate, ActivTrakError> {
+        response::checkpoint_candidate(self, request, page, prior_watermark)
+    }
+}

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod abuseipdb;
 mod activecampaign;
+mod activtrak;
 mod amplitude;
 mod anthropic;
 mod append_log;
@@ -65,6 +66,11 @@ pub use activecampaign::{
     ActiveCampaignEventContract, ActiveCampaignFamily, ActiveCampaignKernel, ActiveCampaignPage,
     ActiveCampaignProjectionFacts, ActiveCampaignRecord, ActiveCampaignRequest,
     ActiveCampaignRuntimeDefinition, project_activecampaign_records,
+};
+pub use activtrak::{
+    ActivTrakCheckpointCandidate, ActivTrakEntityFact, ActivTrakError, ActivTrakEventContract,
+    ActivTrakFamily, ActivTrakKernel, ActivTrakPage, ActivTrakProjectionFacts, ActivTrakRecord,
+    ActivTrakRequest, ActivTrakRuntimeDefinition, project_activtrak_records,
 };
 pub use amplitude::{
     AmplitudeError, AmplitudeFamily, AmplitudeKernel, AmplitudePage, AmplitudeRecord,


### PR DESCRIPTION
## Scope

Adds an additive credential-free Rust kernel for the authoritative ActivTrak families: activity_log, clients, consumers, groups, and users.

The kernel compiles the closed catalog family set, plans bounded HTTPS requests restricted to api.activtrak.com, leaves x-api-key credential application to the trusted host, validates bounded provider responses, normalizes deterministic tenant-scoped identities, proposes SCIM offset and activity-log cursor checkpoints, admits exact event contracts, preserves identity/asset/audit projection semantics, and compares semantic output with the checked Go fixture oracle.

ActivTrak is already listed in the repository Go-retirement authority guard. This PR does not change collection authority, shared runtime hosting, Go fixtures/oracles, private configuration, or deployment topology.

## Validation

- cargo fmt --all -- --check
- cargo test -p cerebro-source-runtime-next activtrak --no-fail-fast: 7 passed
- cargo test -p cerebro-source-runtime-next --no-fail-fast: 526 unit, 7 Linode integration, 10 PagerDuty integration passed
- cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings
- go test ./internal/sourceprojection ./internal/sourcefixture ./internal/connectorcatalog ./internal/connectordefinitions ./internal/sourcegen ./internal/sourceregistry ./sources/catalogruntime ./sources/internal/catalogruntime
- make catalog-check source-fixture-check fixture-oracle-check projection-parity-test
- make check-structural check-structural-test check-arch
- ./scripts/leak_check.sh staged

The focused Rust tests and Clippy were rerun after rebasing onto current main. The full Rust and Go/fixture/architecture matrices passed immediately before that conflict-free rebase and are delegated to hosted checks for the exact head.

## Evidence boundaries

No live ActivTrak credential or provider operation was used. No repository-owned deployment applies to this additive crate-only change. Live-provider collection and authenticated product-path proof remain unproven.