### PR TITLE
Add credential-free Acunetix Rust kernel

### DIFF
--- a/crates/source-runtime-next/src/acunetix.rs
+++ b/crates/source-runtime-next/src/acunetix.rs
@@ -1,0 +1,28 @@
+//! Credential-free Acunetix request, normalization, and projection kernel.
+//!
+//! The trusted host owns credential-reference resolution, `X-Auth`
+//! authentication, redirects, deadlines, and bounded network I/O. The kernel
+//! accepts only authenticated tenant context, a public provider origin, and
+//! bounded response bytes. The generic Rust catalog connector remains the
+//! authoritative collection path.
+
+mod catalog;
+mod error;
+mod family;
+mod normalize;
+mod origin;
+mod projection;
+mod request;
+mod response;
+mod types;
+
+pub use catalog::{AcunetixEventContract, AcunetixRuntimeDefinition};
+pub use error::AcunetixError;
+pub use family::AcunetixFamily;
+pub use projection::{AcunetixEntityFact, AcunetixProjectionFacts, project_acunetix_records};
+pub use types::{
+    AcunetixCheckpointCandidate, AcunetixKernel, AcunetixPage, AcunetixRecord, AcunetixRequest,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/acunetix/catalog.rs
+++ b/crates/source-runtime-next/src/acunetix/catalog.rs
@@ -1,0 +1,78 @@
+use super::{AcunetixError, AcunetixFamily};
+
+/// Exact event contract compiled from the Acunetix catalog.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AcunetixEventContract {
+    /// Exact event kind.
+    pub kind: &'static str,
+    /// Exact schema reference.
+    pub schema_ref: &'static str,
+    /// Required normalized attributes.
+    pub required_attributes: &'static [&'static str],
+    /// Required normalized payload fields.
+    pub required_payload_fields: &'static [&'static str],
+}
+
+/// Closed runtime definition for one Acunetix family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AcunetixRuntimeDefinition {
+    /// Source identifier.
+    pub source_id: &'static str,
+    /// Selected family.
+    pub family: AcunetixFamily,
+    /// Exact event contract.
+    pub event_contract: AcunetixEventContract,
+    /// Every family is a bounded pull operation.
+    pub pull: bool,
+}
+
+impl AcunetixRuntimeDefinition {
+    /// Compile one declared family into a closed definition.
+    pub fn compile(family: AcunetixFamily) -> Result<Self, AcunetixError> {
+        let required_attributes = match family {
+            AcunetixFamily::Reports | AcunetixFamily::Targets => &[
+                "tenant_id",
+                "source_event_id",
+                "resource_urn",
+                "resource_type",
+                "resource_id",
+            ][..],
+            AcunetixFamily::ScanningProfiles => {
+                &["tenant_id", "source_event_id", "policy_id", "policy_name"][..]
+            }
+            AcunetixFamily::Scans => &[
+                "tenant_id",
+                "source_event_id",
+                "finding_id",
+                "resource_urn",
+                "status",
+            ][..],
+            AcunetixFamily::Vulnerabilities => &[
+                "tenant_id",
+                "source_event_id",
+                "finding_id",
+                "resource_urn",
+                "severity",
+                "status",
+            ][..],
+        };
+        let required_payload_fields = match family {
+            AcunetixFamily::Reports => &["report_id"][..],
+            AcunetixFamily::ScanningProfiles => &["profile_id"][..],
+            AcunetixFamily::Scans => &["scan_id"][..],
+            AcunetixFamily::Targets => &["target_id"][..],
+            AcunetixFamily::Vulnerabilities => &["vuln_id"][..],
+        };
+        Ok(Self {
+            source_id: "acunetix",
+            family,
+            event_contract: AcunetixEventContract {
+                kind: family.event_kind(),
+                schema_ref: family.schema_ref(),
+                required_attributes,
+                required_payload_fields,
+            },
+            pull: true,
+        })
+    }
+}

--- a/crates/source-runtime-next/src/acunetix/error.rs
+++ b/crates/source-runtime-next/src/acunetix/error.rs
@@ -1,0 +1,157 @@
+use std::{error::Error, fmt};
+
+/// Bounded Acunetix provider and runtime failure taxonomy.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AcunetixError {
+    /// Family is outside the closed catalog.
+    InvalidFamily,
+    /// Public configuration is malformed.
+    InvalidConfiguration(&'static str),
+    /// Provider origin is not an allowed HTTPS `/api/v1` base.
+    InvalidOrigin,
+    /// Authenticated tenant context is malformed.
+    InvalidTenantId,
+    /// Trusted host has no credential reference.
+    MissingCredentialReference,
+    /// Trusted host could not redeem its credential lease.
+    CredentialUnavailable,
+    /// Cursor is invalid or cannot round-trip.
+    InvalidCursor,
+    /// Request does not belong to this kernel.
+    RequestScopeMismatch,
+    /// Provider rejected authentication.
+    AuthenticationRejected,
+    /// Credential lacks required provider permission.
+    RequiredScopeMissing,
+    /// Provider resource was not found.
+    ProviderResourceNotFound,
+    /// Trusted host denied provider egress.
+    EgressDenied,
+    /// Provider DNS lookup failed.
+    DnsFailure,
+    /// Provider connection failed.
+    ConnectionFailure,
+    /// Provider operation timed out.
+    ProviderTimeout,
+    /// Provider requested a bounded retry.
+    RateLimited {
+        /// Provider-declared retry delay.
+        retry_after_seconds: Option<u64>,
+    },
+    /// Provider returned a retryable server failure.
+    ProviderUnavailable {
+        /// Provider HTTP status.
+        status: u16,
+    },
+    /// Provider returned an unexpected status.
+    UnexpectedStatus {
+        /// Provider HTTP status.
+        status: u16,
+    },
+    /// Retry delay is outside its persistence bound.
+    InvalidRetryAfter,
+    /// Response exceeds the host byte bound.
+    ResponseTooLarge,
+    /// Response exceeds the family record bound.
+    TooManyRecords,
+    /// Response JSON does not match the family.
+    MalformedResponse,
+    /// Provider record violates the family shape.
+    InvalidProviderRecord,
+    /// Provider record has no stable identity.
+    MissingStableIdentity,
+    /// Provider payload attempted to supply tenant context.
+    TenantMismatch,
+    /// Credential-shaped material crossed into the kernel.
+    CredentialMaterial,
+    /// Duplicate provider identity has conflicting content.
+    ConflictingDuplicate,
+    /// Normalized record failed the exact event contract.
+    EventContractRejection,
+    /// Durable append failed.
+    AppendFailure,
+    /// Projection failed.
+    ProjectionFailure,
+    /// Runtime lost its source lease.
+    LeaseLoss,
+    /// Runtime authority or generation is stale.
+    StaleAuthority,
+    /// Internal runtime failure.
+    InternalRuntimeFailure,
+}
+
+impl AcunetixError {
+    /// Next safe operator action without provider content.
+    pub const fn operator_action(&self) -> &'static str {
+        match self {
+            Self::InvalidFamily
+            | Self::InvalidConfiguration(_)
+            | Self::InvalidOrigin
+            | Self::InvalidTenantId
+            | Self::ProviderResourceNotFound => "repair source configuration",
+            Self::MissingCredentialReference
+            | Self::CredentialUnavailable
+            | Self::AuthenticationRejected => "repair credential binding",
+            Self::RequiredScopeMissing => "grant Acunetix API read access",
+            Self::RateLimited { .. }
+            | Self::ProviderUnavailable { .. }
+            | Self::DnsFailure
+            | Self::ConnectionFailure
+            | Self::ProviderTimeout => "retry the collection later",
+            Self::EgressDenied => "repair trusted-host egress policy",
+            Self::InvalidCursor => "restart from the last committed checkpoint",
+            Self::MalformedResponse
+            | Self::InvalidProviderRecord
+            | Self::MissingStableIdentity
+            | Self::TenantMismatch
+            | Self::CredentialMaterial
+            | Self::ConflictingDuplicate
+            | Self::EventContractRejection => "inspect quarantined provider records",
+            Self::AppendFailure | Self::ProjectionFailure => "repair the durable commit path",
+            Self::LeaseLoss | Self::StaleAuthority => "restart under the current lease",
+            _ => "repair the forward runtime implementation",
+        }
+    }
+}
+
+impl fmt::Display for AcunetixError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidFamily => "acunetix family is invalid",
+            Self::InvalidConfiguration(_) => "acunetix source configuration is invalid",
+            Self::InvalidOrigin => "acunetix provider origin is invalid",
+            Self::InvalidTenantId => "acunetix tenant ID is invalid",
+            Self::MissingCredentialReference => "acunetix credential reference is missing",
+            Self::CredentialUnavailable => "acunetix credential lease is unavailable",
+            Self::InvalidCursor => "acunetix cursor is invalid or not round-trippable",
+            Self::RequestScopeMismatch => "acunetix request does not match the kernel",
+            Self::AuthenticationRejected => "acunetix rejected authentication",
+            Self::RequiredScopeMissing => "acunetix credential lacks required scope",
+            Self::ProviderResourceNotFound => "acunetix resource was not found",
+            Self::EgressDenied => "acunetix egress was denied",
+            Self::DnsFailure => "acunetix DNS resolution failed",
+            Self::ConnectionFailure => "acunetix connection failed",
+            Self::ProviderTimeout => "acunetix operation timed out",
+            Self::RateLimited { .. } => "acunetix rate limited the operation",
+            Self::ProviderUnavailable { .. } => "acunetix is temporarily unavailable",
+            Self::UnexpectedStatus { .. } => "acunetix returned an unexpected status",
+            Self::InvalidRetryAfter => "acunetix retry delay exceeds its bound",
+            Self::ResponseTooLarge => "acunetix response exceeds its byte bound",
+            Self::TooManyRecords => "acunetix response exceeds its record bound",
+            Self::MalformedResponse => "acunetix response is malformed",
+            Self::InvalidProviderRecord => "acunetix provider record is invalid",
+            Self::MissingStableIdentity => "acunetix record has no stable identity",
+            Self::TenantMismatch => "acunetix payload attempted to supply tenant context",
+            Self::CredentialMaterial => "acunetix payload contains credential-shaped material",
+            Self::ConflictingDuplicate => "acunetix duplicate identity has conflicting content",
+            Self::EventContractRejection => "acunetix event failed its catalog contract",
+            Self::AppendFailure => "acunetix append failed",
+            Self::ProjectionFailure => "acunetix projection failed",
+            Self::LeaseLoss => "acunetix runtime lost its lease",
+            Self::StaleAuthority => "acunetix runtime authority is stale",
+            Self::InternalRuntimeFailure => "acunetix runtime failed internally",
+        })
+    }
+}
+
+impl Error for AcunetixError {}

--- a/crates/source-runtime-next/src/acunetix/family.rs
+++ b/crates/source-runtime-next/src/acunetix/family.rs
@@ -1,0 +1,100 @@
+use std::str::FromStr;
+
+use super::AcunetixError;
+
+/// Closed Acunetix catalog family vocabulary.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum AcunetixFamily {
+    /// Generated reports.
+    Reports,
+    /// Scanning policy profiles.
+    ScanningProfiles,
+    /// Scan runs.
+    Scans,
+    /// Scan targets.
+    Targets,
+    /// Detected vulnerabilities.
+    Vulnerabilities,
+}
+
+impl AcunetixFamily {
+    /// Every provider-declared family.
+    pub const ALL: [Self; 5] = [
+        Self::Reports,
+        Self::ScanningProfiles,
+        Self::Scans,
+        Self::Targets,
+        Self::Vulnerabilities,
+    ];
+
+    /// Exact catalog identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Reports => "reports",
+            Self::ScanningProfiles => "scanning_profiles",
+            Self::Scans => "scans",
+            Self::Targets => "targets",
+            Self::Vulnerabilities => "vulnerabilities",
+        }
+    }
+
+    /// Exact provider path relative to `/api/v1`.
+    pub const fn path(self) -> &'static str {
+        match self {
+            Self::Reports => "/reports",
+            Self::ScanningProfiles => "/scanning_profiles",
+            Self::Scans => "/scans",
+            Self::Targets => "/targets",
+            Self::Vulnerabilities => "/vulnerabilities",
+        }
+    }
+
+    /// Provider response-array key.
+    pub const fn response_key(self) -> &'static str {
+        self.as_str()
+    }
+
+    /// Stable provider identity field.
+    pub const fn id_field(self) -> &'static str {
+        match self {
+            Self::Reports => "report_id",
+            Self::ScanningProfiles => "profile_id",
+            Self::Scans => "scan_id",
+            Self::Targets => "target_id",
+            Self::Vulnerabilities => "vuln_id",
+        }
+    }
+
+    /// Exact event kind.
+    pub const fn event_kind(self) -> &'static str {
+        match self {
+            Self::Reports => "acunetix.reports",
+            Self::ScanningProfiles => "acunetix.scanning_profiles",
+            Self::Scans => "acunetix.scans",
+            Self::Targets => "acunetix.targets",
+            Self::Vulnerabilities => "acunetix.vulnerabilities",
+        }
+    }
+
+    /// Exact schema reference.
+    pub const fn schema_ref(self) -> &'static str {
+        match self {
+            Self::Reports => "acunetix/reports/v1",
+            Self::ScanningProfiles => "acunetix/scanning_profiles/v1",
+            Self::Scans => "acunetix/scans/v1",
+            Self::Targets => "acunetix/targets/v1",
+            Self::Vulnerabilities => "acunetix/vulnerabilities/v1",
+        }
+    }
+}
+
+impl FromStr for AcunetixFamily {
+    type Err = AcunetixError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|family| family.as_str() == value.trim())
+            .ok_or(AcunetixError::InvalidFamily)
+    }
+}

--- a/crates/source-runtime-next/src/acunetix/normalize.rs
+++ b/crates/source-runtime-next/src/acunetix/normalize.rs
@@ -1,0 +1,351 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    AcunetixError, AcunetixFamily, AcunetixKernel, AcunetixRecord, AcunetixRuntimeDefinition,
+};
+
+pub(super) fn normalize(
+    kernel: &AcunetixKernel,
+    raw: Value,
+) -> Result<AcunetixRecord, AcunetixError> {
+    reject_protected(&raw, 0)?;
+    let values = raw
+        .as_object()
+        .ok_or(AcunetixError::InvalidProviderRecord)?;
+    let provider_id = scalar(values.get(kernel.family.id_field()))
+        .filter(|value| !value.is_empty() && value.len() <= 512)
+        .ok_or(AcunetixError::MissingStableIdentity)?;
+    let record = AcunetixRecord {
+        tenant_id: kernel.tenant_id.clone(),
+        event_id: event_id(kernel, &provider_id),
+        provider_id: provider_id.clone(),
+        family: kernel.family,
+        kind: kernel.family.event_kind().to_owned(),
+        schema_ref: kernel.family.schema_ref().to_owned(),
+        occurred_at: occurred_at(kernel, values)?,
+        attributes: attributes(kernel, values, &provider_id)?,
+        payload: raw,
+    };
+    admit(&record)?;
+    Ok(record)
+}
+
+fn attributes(
+    kernel: &AcunetixKernel,
+    values: &Map<String, Value>,
+    provider_id: &str,
+) -> Result<BTreeMap<String, String>, AcunetixError> {
+    let mut output = BTreeMap::from([
+        ("tenant_id".to_owned(), kernel.tenant_id.clone()),
+        ("source_event_id".to_owned(), provider_id.to_owned()),
+        ("source_system".to_owned(), "acunetix".to_owned()),
+        ("schema".to_owned(), kernel.family.as_str().to_owned()),
+    ]);
+    match kernel.family {
+        AcunetixFamily::Reports => {
+            asset(
+                &mut output,
+                &kernel.tenant_id,
+                provider_id,
+                scalar(values.get("template_name")).unwrap_or_else(|| provider_id.to_owned()),
+                "report",
+                "acunetix_reports",
+            );
+            copy(&mut output, values, "report_id", "id");
+            copy(&mut output, values, "template_name", "name");
+            copy(&mut output, values, "status", "status");
+        }
+        AcunetixFamily::Targets => {
+            asset(
+                &mut output,
+                &kernel.tenant_id,
+                provider_id,
+                scalar(values.get("address")).unwrap_or_else(|| provider_id.to_owned()),
+                "target",
+                "acunetix_targets",
+            );
+            copy(&mut output, values, "target_id", "id");
+            copy(&mut output, values, "target_id", "target_id");
+            copy(&mut output, values, "address", "name");
+            copy(&mut output, values, "criticality", "criticality");
+            copy(&mut output, values, "description", "description");
+        }
+        AcunetixFamily::ScanningProfiles => {
+            let name = required_scalar(values, "name")?;
+            output.extend(BTreeMap::from([
+                ("record_class".to_owned(), "policy".to_owned()),
+                ("policy_id".to_owned(), provider_id.to_owned()),
+                ("policy_name".to_owned(), name.clone()),
+                ("policy_description".to_owned(), name.clone()),
+                ("policy_type".to_owned(), "scanning_profile".to_owned()),
+                ("resource_id".to_owned(), provider_id.to_owned()),
+                ("resource_name".to_owned(), name),
+                ("resource_type".to_owned(), "scanning_profile".to_owned()),
+            ]));
+            copy(&mut output, values, "sort_order", "policy_severity");
+        }
+        AcunetixFamily::Scans => {
+            finding_base(&mut output, &kernel.tenant_id, values, provider_id)?;
+            let title = required_scalar(values, "profile_name")?;
+            output.insert("scan_id".to_owned(), provider_id.to_owned());
+            output.insert("title".to_owned(), title.clone());
+            output.insert("description".to_owned(), title);
+            required_nested(
+                &mut output,
+                values,
+                &["current_session", "status"],
+                "status",
+            )?;
+            nested(&mut output, values, &["target", "address"], "resource_name");
+        }
+        AcunetixFamily::Vulnerabilities => {
+            finding_base(&mut output, &kernel.tenant_id, values, provider_id)?;
+            let title = required_scalar(values, "vt_name")?;
+            output.insert("title".to_owned(), title.clone());
+            output.insert("description".to_owned(), title);
+            required_copy(&mut output, values, "severity", "severity")?;
+            required_copy(&mut output, values, "status", "status")?;
+            copy(&mut output, values, "affects_url", "affects_url");
+            copy(&mut output, values, "affects_url", "resource_name");
+        }
+    }
+    Ok(output)
+}
+
+fn asset(
+    output: &mut BTreeMap<String, String>,
+    tenant: &str,
+    id: &str,
+    name: String,
+    resource_type: &str,
+    urn_kind: &str,
+) {
+    output.extend(BTreeMap::from([
+        ("record_class".to_owned(), "asset".to_owned()),
+        ("resource_id".to_owned(), id.to_owned()),
+        ("resource_name".to_owned(), name),
+        ("resource_type".to_owned(), resource_type.to_owned()),
+        (
+            "resource_urn".to_owned(),
+            format!(
+                "urn:cerebro:{}:{}:{}",
+                encode_segment(tenant),
+                urn_kind,
+                encode_segment(id)
+            ),
+        ),
+    ]));
+}
+
+fn finding_base(
+    output: &mut BTreeMap<String, String>,
+    tenant: &str,
+    values: &Map<String, Value>,
+    id: &str,
+) -> Result<(), AcunetixError> {
+    let target_id = required_scalar(values, "target_id")?;
+    output.extend(BTreeMap::from([
+        ("record_class".to_owned(), "finding".to_owned()),
+        ("finding_id".to_owned(), id.to_owned()),
+        ("resource_id".to_owned(), target_id.clone()),
+        ("resource_type".to_owned(), "target".to_owned()),
+        (
+            "resource_urn".to_owned(),
+            format!(
+                "urn:cerebro:{}:acunetix_targets:{}",
+                encode_segment(tenant),
+                encode_segment(&target_id)
+            ),
+        ),
+    ]));
+    Ok(())
+}
+
+fn occurred_at(
+    kernel: &AcunetixKernel,
+    values: &Map<String, Value>,
+) -> Result<String, AcunetixError> {
+    let value = scalar(values.get("generation_date")).unwrap_or_else(|| kernel.observed_at.clone());
+    let time = OffsetDateTime::parse(&value, &Rfc3339)
+        .map_err(|_| AcunetixError::InvalidProviderRecord)?;
+    time.format(&Rfc3339)
+        .map_err(|_| AcunetixError::InvalidProviderRecord)
+}
+
+fn admit(record: &AcunetixRecord) -> Result<(), AcunetixError> {
+    let contract = AcunetixRuntimeDefinition::compile(record.family)?.event_contract;
+    if record.kind != contract.kind
+        || record.schema_ref != contract.schema_ref
+        || contract
+            .required_attributes
+            .iter()
+            .any(|key| record.attributes.get(*key).is_none_or(String::is_empty))
+        || contract
+            .required_payload_fields
+            .iter()
+            .any(|key| record.payload.get(*key).is_none_or(Value::is_null))
+    {
+        return Err(AcunetixError::EventContractRejection);
+    }
+    Ok(())
+}
+
+fn event_id(kernel: &AcunetixKernel, provider_id: &str) -> String {
+    let scope = Sha256::digest(format!(
+        "{}\0{}",
+        kernel.base_url.as_str(),
+        kernel.family.path()
+    ));
+    let scope = scope[..6]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!(
+        "acunetix-{}-{scope}-{}-{}",
+        normalize_id(&kernel.tenant_id),
+        normalize_id(kernel.family.as_str()),
+        normalize_id(provider_id)
+    )
+}
+
+fn required_scalar(values: &Map<String, Value>, key: &str) -> Result<String, AcunetixError> {
+    scalar(values.get(key))
+        .filter(|value| !value.is_empty())
+        .ok_or(AcunetixError::InvalidProviderRecord)
+}
+
+fn required_copy(
+    output: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    source: &str,
+    target: &str,
+) -> Result<(), AcunetixError> {
+    output.insert(target.to_owned(), required_scalar(values, source)?);
+    Ok(())
+}
+
+fn required_nested(
+    output: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    path: &[&str],
+    target: &str,
+) -> Result<(), AcunetixError> {
+    let value = nested_scalar(values, path).ok_or(AcunetixError::InvalidProviderRecord)?;
+    output.insert(target.to_owned(), value);
+    Ok(())
+}
+
+fn nested(
+    output: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    path: &[&str],
+    target: &str,
+) {
+    if let Some(value) = nested_scalar(values, path) {
+        output.insert(target.to_owned(), value);
+    }
+}
+
+fn nested_scalar(values: &Map<String, Value>, path: &[&str]) -> Option<String> {
+    let mut value = values.get(*path.first()?)?;
+    for key in &path[1..] {
+        value = value.get(*key)?;
+    }
+    scalar(Some(value)).filter(|value| !value.is_empty())
+}
+
+fn copy(
+    output: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    source: &str,
+    target: &str,
+) {
+    if let Some(value) = scalar(values.get(source)).filter(|value| !value.is_empty()) {
+        output.insert(target.to_owned(), value);
+    }
+}
+
+fn scalar(value: Option<&Value>) -> Option<String> {
+    match value? {
+        Value::String(value) => Some(value.trim().to_owned()),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn reject_protected(value: &Value, depth: usize) -> Result<(), AcunetixError> {
+    if depth > 32 {
+        return Err(AcunetixError::InvalidProviderRecord);
+    }
+    match value {
+        Value::Object(values) => {
+            if values.len() > 256 {
+                return Err(AcunetixError::InvalidProviderRecord);
+            }
+            for (key, value) in values {
+                let key = key.to_ascii_lowercase().replace(['-', '.'], "_");
+                if key == "tenant_id" {
+                    return Err(AcunetixError::TenantMismatch);
+                }
+                if [
+                    "x_auth",
+                    "api_key",
+                    "token",
+                    "authorization",
+                    "password",
+                    "private_key",
+                ]
+                .contains(&key.as_str())
+                {
+                    return Err(AcunetixError::CredentialMaterial);
+                }
+                reject_protected(value, depth + 1)?;
+            }
+        }
+        Value::Array(values) => {
+            if values.len() > 512 {
+                return Err(AcunetixError::InvalidProviderRecord);
+            }
+            for value in values {
+                reject_protected(value, depth + 1)?;
+            }
+        }
+        Value::String(value) if value.len() > 64 * 1024 => {
+            return Err(AcunetixError::InvalidProviderRecord);
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn normalize_id(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_') {
+                character.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_owned()
+}
+
+fn encode_segment(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.trim().bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}

--- a/crates/source-runtime-next/src/acunetix/origin.rs
+++ b/crates/source-runtime-next/src/acunetix/origin.rs
@@ -1,0 +1,32 @@
+use reqwest::Url;
+
+use super::AcunetixError;
+
+pub(super) fn validate(value: &str) -> Result<Url, AcunetixError> {
+    let mut url =
+        Url::parse(value.trim().trim_end_matches('/')).map_err(|_| AcunetixError::InvalidOrigin)?;
+    let host = url.host_str().unwrap_or_default();
+    if url.scheme() != "https"
+        || host.is_empty()
+        || host.len() > 253
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port_or_known_default() != Some(443)
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || url.path() != "/api/v1"
+    {
+        return Err(AcunetixError::InvalidOrigin);
+    }
+    url.set_path("/api/v1");
+    Ok(url)
+}
+
+pub(super) fn tenant(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()
+        && value.len() <= 128
+        && !value.chars().any(char::is_control)
+        && !value.contains(['/', '\\', ':']))
+    .then(|| value.to_owned())
+}

--- a/crates/source-runtime-next/src/acunetix/projection.rs
+++ b/crates/source-runtime-next/src/acunetix/projection.rs
@@ -1,0 +1,64 @@
+use std::collections::BTreeMap;
+
+use super::AcunetixRecord;
+
+/// One deterministic tenant-scoped Acunetix projection entity.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct AcunetixEntityFact {
+    /// Canonical entity URN.
+    pub urn: String,
+    /// Closed entity type.
+    pub entity_type: String,
+    /// Human-readable label.
+    pub label: String,
+}
+
+/// Provider-local projection facts used for Go/Rust parity.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AcunetixProjectionFacts {
+    /// Deduplicated entities in canonical order.
+    pub entities: Vec<AcunetixEntityFact>,
+}
+
+/// Project normalized Acunetix records into catalog entities.
+pub fn project_acunetix_records(records: &[AcunetixRecord]) -> AcunetixProjectionFacts {
+    let mut entities = BTreeMap::<String, AcunetixEntityFact>::new();
+    for record in records {
+        let urn = format!(
+            "urn:cerebro:{}:acunetix_{}:{}",
+            encode_segment(&record.tenant_id),
+            record.family.as_str(),
+            encode_segment(&record.provider_id)
+        );
+        let label = record
+            .attributes
+            .get("resource_name")
+            .or_else(|| record.attributes.get("policy_name"))
+            .or_else(|| record.attributes.get("title"))
+            .cloned()
+            .unwrap_or_else(|| record.provider_id.clone());
+        entities.insert(
+            urn.clone(),
+            AcunetixEntityFact {
+                urn,
+                entity_type: format!("acunetix.{}", record.family.as_str().replace('_', ".")),
+                label,
+            },
+        );
+    }
+    AcunetixProjectionFacts {
+        entities: entities.into_values().collect(),
+    }
+}
+
+fn encode_segment(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.trim().bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}

--- a/crates/source-runtime-next/src/acunetix/request.rs
+++ b/crates/source-runtime-next/src/acunetix/request.rs
@@ -1,0 +1,73 @@
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{AcunetixError, AcunetixFamily, AcunetixKernel, AcunetixRequest, origin};
+
+const PAGE_SIZE: usize = 100;
+const MAX_CURSOR_BYTES: usize = 2_048;
+
+pub(super) fn new_kernel(
+    base_url: &str,
+    tenant_id: &str,
+    family: AcunetixFamily,
+    observed_at: &str,
+) -> Result<AcunetixKernel, AcunetixError> {
+    let base_url = origin::validate(base_url)?;
+    let tenant_id = origin::tenant(tenant_id).ok_or(AcunetixError::InvalidTenantId)?;
+    let observed = OffsetDateTime::parse(observed_at, &Rfc3339)
+        .map_err(|_| AcunetixError::InvalidConfiguration("observed_at"))?;
+    let observed_at = observed
+        .format(&Rfc3339)
+        .map_err(|_| AcunetixError::InvalidConfiguration("observed_at"))?;
+    Ok(AcunetixKernel {
+        base_url,
+        tenant_id,
+        family,
+        observed_at,
+    })
+}
+
+pub(super) fn plan(
+    kernel: &AcunetixKernel,
+    cursor: Option<&str>,
+) -> Result<AcunetixRequest, AcunetixError> {
+    let mut url = kernel.base_url.clone();
+    url.set_path(&format!("/api/v1{}", kernel.family.path()));
+    if url.origin() != kernel.base_url.origin() {
+        return Err(AcunetixError::InvalidOrigin);
+    }
+    {
+        let mut query = url.query_pairs_mut();
+        query.append_pair("l", &PAGE_SIZE.to_string());
+        if let Some(cursor) = cursor {
+            query.append_pair("c", validate_cursor(cursor)?);
+        }
+    }
+    Ok(AcunetixRequest {
+        url,
+        family: kernel.family,
+        cursor: cursor.map(str::to_owned),
+        page_size: PAGE_SIZE,
+    })
+}
+
+pub(super) fn validate_request(
+    kernel: &AcunetixKernel,
+    request: &AcunetixRequest,
+) -> Result<(), AcunetixError> {
+    if request != &plan(kernel, request.cursor.as_deref())? {
+        return Err(AcunetixError::RequestScopeMismatch);
+    }
+    Ok(())
+}
+
+pub(super) fn validate_cursor(value: &str) -> Result<&str, AcunetixError> {
+    let value = value.trim();
+    if value.is_empty()
+        || value.len() > MAX_CURSOR_BYTES
+        || value.chars().any(char::is_control)
+        || value.contains(['/', '\\'])
+    {
+        return Err(AcunetixError::InvalidCursor);
+    }
+    Ok(value)
+}

--- a/crates/source-runtime-next/src/acunetix/response.rs
+++ b/crates/source-runtime-next/src/acunetix/response.rs
@@ -1,0 +1,118 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    AcunetixCheckpointCandidate, AcunetixError, AcunetixKernel, AcunetixPage, AcunetixRequest,
+    normalize,
+    request::{validate_cursor, validate_request},
+};
+
+pub(super) const MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+pub(super) fn decode(
+    kernel: &AcunetixKernel,
+    request: &AcunetixRequest,
+    status: u16,
+    retry_after_seconds: Option<u64>,
+    body: &[u8],
+) -> Result<AcunetixPage, AcunetixError> {
+    validate_request(kernel, request)?;
+    classify_status(status, retry_after_seconds)?;
+    if body.len() > MAX_RESPONSE_BYTES {
+        return Err(AcunetixError::ResponseTooLarge);
+    }
+    let root: Value = serde_json::from_slice(body).map_err(|_| AcunetixError::MalformedResponse)?;
+    let items = root
+        .get(kernel.family.response_key())
+        .and_then(Value::as_array)
+        .ok_or(AcunetixError::MalformedResponse)?;
+    if items.len() > request.page_size {
+        return Err(AcunetixError::TooManyRecords);
+    }
+    let mut seen = BTreeMap::<String, Vec<u8>>::new();
+    let mut records = Vec::with_capacity(items.len());
+    for raw in items {
+        let record = normalize::normalize(kernel, raw.clone())?;
+        let canonical = serde_json::to_vec(&record.payload)
+            .map_err(|_| AcunetixError::InvalidProviderRecord)?;
+        match seen.get(&record.provider_id) {
+            Some(previous) if previous == &canonical => continue,
+            Some(_) => return Err(AcunetixError::ConflictingDuplicate),
+            None => {
+                seen.insert(record.provider_id.clone(), canonical);
+                records.push(record);
+            }
+        }
+    }
+    let next_cursor = match root.pointer("/pagination/next_cursor") {
+        None | Some(Value::Null) => None,
+        Some(Value::String(value)) if value.is_empty() => None,
+        Some(Value::String(value)) => Some(validate_cursor(value)?.to_owned()),
+        Some(_) => return Err(AcunetixError::InvalidCursor),
+    };
+    if next_cursor.is_some() && next_cursor == request.cursor {
+        return Err(AcunetixError::InvalidCursor);
+    }
+    Ok(AcunetixPage {
+        records,
+        next_cursor,
+    })
+}
+
+pub(super) fn checkpoint_candidate(
+    kernel: &AcunetixKernel,
+    request: &AcunetixRequest,
+    page: &AcunetixPage,
+    prior_watermark: Option<&str>,
+) -> Result<AcunetixCheckpointCandidate, AcunetixError> {
+    validate_request(kernel, request)?;
+    if page
+        .records
+        .iter()
+        .any(|record| record.tenant_id != kernel.tenant_id || record.family != kernel.family)
+    {
+        return Err(AcunetixError::TenantMismatch);
+    }
+    if let Some(cursor) = &page.next_cursor {
+        kernel.plan(Some(cursor))?;
+    }
+    let mut watermark = valid_time(prior_watermark.unwrap_or(&kernel.observed_at))?;
+    for record in &page.records {
+        let occurred_at = valid_time(&record.occurred_at)?;
+        if occurred_at > watermark {
+            watermark = occurred_at;
+        }
+    }
+    Ok(AcunetixCheckpointCandidate {
+        tenant_id: kernel.tenant_id.clone(),
+        family: kernel.family,
+        cursor: page.next_cursor.clone(),
+        watermark,
+    })
+}
+
+fn classify_status(status: u16, retry: Option<u64>) -> Result<(), AcunetixError> {
+    if retry.is_some_and(|seconds| seconds > 3_600) {
+        return Err(AcunetixError::InvalidRetryAfter);
+    }
+    match status {
+        200..=299 => Ok(()),
+        401 => Err(AcunetixError::AuthenticationRejected),
+        403 => Err(AcunetixError::RequiredScopeMissing),
+        404 => Err(AcunetixError::ProviderResourceNotFound),
+        429 => Err(AcunetixError::RateLimited {
+            retry_after_seconds: retry,
+        }),
+        500..=599 => Err(AcunetixError::ProviderUnavailable { status }),
+        _ => Err(AcunetixError::UnexpectedStatus { status }),
+    }
+}
+
+fn valid_time(value: &str) -> Result<String, AcunetixError> {
+    let time =
+        OffsetDateTime::parse(value, &Rfc3339).map_err(|_| AcunetixError::InvalidProviderRecord)?;
+    time.format(&Rfc3339)
+        .map_err(|_| AcunetixError::InvalidProviderRecord)
+}

--- a/crates/source-runtime-next/src/acunetix/tests.rs
+++ b/crates/source-runtime-next/src/acunetix/tests.rs
@@ -1,0 +1,304 @@
+use std::{collections::BTreeMap, fs, path::PathBuf};
+
+use cerebro_source_catalog::{CollectionAuthority, SourceCatalog};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::*;
+
+const ORIGIN: &str = "https://online.acunetix.com/api/v1";
+const OBSERVED_AT: &str = "2026-06-01T00:00:00Z";
+
+#[derive(Debug, Deserialize)]
+struct GoOracleEvent {
+    id: String,
+    tenant_id: String,
+    source_id: String,
+    kind: String,
+    occurred_at: String,
+    schema_ref: String,
+    payload: Value,
+    attributes: BTreeMap<String, String>,
+}
+
+fn root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn kernel(tenant: &str, family: AcunetixFamily) -> AcunetixKernel {
+    AcunetixKernel::new(ORIGIN, tenant, family, OBSERVED_AT).unwrap()
+}
+
+fn oracle(family: AcunetixFamily) -> GoOracleEvent {
+    let bytes = fs::read(root().join(format!(
+        "sources/acunetix/testdata/read_{}.json",
+        family.as_str()
+    )))
+    .unwrap();
+    serde_json::from_slice::<Vec<GoOracleEvent>>(&bytes)
+        .unwrap()
+        .pop()
+        .unwrap()
+}
+
+fn response(family: AcunetixFamily, records: Vec<Value>, cursor: Option<&str>) -> Vec<u8> {
+    let mut response = json!({family.response_key(): records});
+    if let Some(cursor) = cursor {
+        response["pagination"] = json!({"next_cursor": cursor});
+    }
+    serde_json::to_vec(&response).unwrap()
+}
+
+#[test]
+fn catalog_closes_the_exact_catalog_runtime_only_family_set() {
+    let catalog = SourceCatalog::load(
+        root().join("internal/connectorcatalog/catalog"),
+        root().join("sources"),
+    )
+    .unwrap();
+    let source = catalog.get("acunetix").unwrap();
+    assert_eq!(source.authority(), CollectionAuthority::Authoritative);
+    let mut families = source
+        .families()
+        .iter()
+        .map(|family| family.id())
+        .collect::<Vec<_>>();
+    families.sort_unstable();
+    assert_eq!(
+        families,
+        [
+            "reports",
+            "scanning_profiles",
+            "scans",
+            "targets",
+            "vulnerabilities"
+        ]
+    );
+    assert!(!root().join("sources/acunetix/source.go").exists());
+    for family in AcunetixFamily::ALL {
+        let definition = AcunetixRuntimeDefinition::compile(family).unwrap();
+        assert_eq!(definition.source_id, "acunetix");
+        assert!(definition.pull);
+        assert_eq!(definition.event_contract.kind, family.event_kind());
+    }
+}
+
+#[test]
+fn requests_are_origin_locked_bounded_and_credential_free() {
+    for family in AcunetixFamily::ALL {
+        let request = kernel("tenant", family).plan(None).unwrap();
+        assert_eq!(request.method(), "GET");
+        assert_eq!(request.url().host_str(), Some("online.acunetix.com"));
+        assert_eq!(request.url().path(), format!("/api/v1{}", family.path()));
+        assert_eq!(request.url().query(), Some("l=100"));
+        assert_eq!(request.authentication_header(), "X-Auth");
+        assert!(request.credential_reference_required());
+        assert!(!request.contains_credentials());
+        assert!(!request.allows_redirects());
+        assert_eq!(request.record_limit(), 100);
+        assert_eq!(request.max_response_bytes(), 8 * 1024 * 1024);
+        assert!(!AcunetixKernel::requires_credentials());
+        assert_eq!(
+            kernel("tenant", family)
+                .plan(Some("next-token"))
+                .unwrap()
+                .url()
+                .query(),
+            Some("l=100&c=next-token")
+        );
+    }
+}
+
+#[test]
+fn go_events_and_projection_fixtures_match_semantically() {
+    for family in AcunetixFamily::ALL {
+        let oracle = oracle(family);
+        let kernel = kernel("tenant", family);
+        let request = kernel.plan(None).unwrap();
+        let page = kernel
+            .decode(
+                &request,
+                200,
+                None,
+                &response(family, vec![oracle.payload.clone()], None),
+            )
+            .unwrap();
+        let record = &page.records[0];
+        assert_eq!(record.tenant_id, oracle.tenant_id);
+        assert_eq!(oracle.source_id, "acunetix");
+        assert_eq!(record.kind, oracle.kind);
+        assert_eq!(record.schema_ref, oracle.schema_ref);
+        assert_eq!(record.occurred_at, oracle.occurred_at);
+        assert_eq!(record.payload, oracle.payload);
+        assert_eq!(record.attributes, oracle.attributes);
+        assert!(
+            oracle
+                .id
+                .starts_with(&format!("acunetix-{}", family.as_str().replace('_', "-")))
+        );
+        let projection = project_acunetix_records(&page.records);
+        assert_eq!(projection.entities.len(), 1);
+        assert_eq!(
+            projection.entities[0].urn,
+            format!(
+                "urn:cerebro:tenant:acunetix_{}:{}",
+                family.as_str(),
+                record.provider_id
+            )
+        );
+    }
+}
+
+#[test]
+fn cursor_checkpoint_and_restart_round_trip() {
+    let family = AcunetixFamily::Targets;
+    let kernel = kernel("tenant", family);
+    let request = kernel.plan(None).unwrap();
+    let page = kernel
+        .decode(
+            &request,
+            200,
+            None,
+            &response(family, vec![oracle(family).payload], Some("next-token")),
+        )
+        .unwrap();
+    assert_eq!(page.next_cursor.as_deref(), Some("next-token"));
+    let checkpoint = kernel
+        .checkpoint_candidate(&request, &page, Some("2026-05-01T00:00:00Z"))
+        .unwrap();
+    assert_eq!(checkpoint.cursor.as_deref(), Some("next-token"));
+    assert_eq!(checkpoint.watermark, OBSERVED_AT);
+    assert_eq!(
+        kernel
+            .plan(checkpoint.cursor.as_deref())
+            .unwrap()
+            .url()
+            .query(),
+        Some("l=100&c=next-token")
+    );
+    let terminal_request = kernel.plan(Some("next-token")).unwrap();
+    let terminal = kernel
+        .decode(
+            &terminal_request,
+            200,
+            None,
+            &response(family, Vec::new(), None),
+        )
+        .unwrap();
+    assert_eq!(terminal.next_cursor, None);
+}
+
+#[test]
+fn duplicate_conflict_tenant_secret_and_statuses_fail_closed() {
+    let family = AcunetixFamily::Targets;
+    let kernel = kernel("tenant", family);
+    let request = kernel.plan(None).unwrap();
+    let raw = oracle(family).payload;
+    let page = kernel
+        .decode(
+            &request,
+            200,
+            None,
+            &response(family, vec![raw.clone(), raw.clone()], None),
+        )
+        .unwrap();
+    assert_eq!(page.records.len(), 1);
+    let mut conflict = raw.clone();
+    conflict["address"] = Value::String("https://different.example.test".to_owned());
+    assert_eq!(
+        kernel.decode(
+            &request,
+            200,
+            None,
+            &response(family, vec![raw, conflict], None)
+        ),
+        Err(AcunetixError::ConflictingDuplicate)
+    );
+    for (field, expected) in [
+        ("tenant_id", AcunetixError::TenantMismatch),
+        ("x_auth", AcunetixError::CredentialMaterial),
+        ("token", AcunetixError::CredentialMaterial),
+    ] {
+        let mut raw = oracle(family).payload;
+        raw[field] = Value::String("sentinel-secret-value".to_owned());
+        let error = kernel
+            .decode(&request, 200, None, &response(family, vec![raw], None))
+            .unwrap_err();
+        assert_eq!(error, expected);
+        assert!(!format!("{error:?}").contains("sentinel-secret-value"));
+    }
+    assert_eq!(
+        kernel.decode(&request, 401, None, b"{}"),
+        Err(AcunetixError::AuthenticationRejected)
+    );
+    assert_eq!(
+        kernel.decode(&request, 403, None, b"{}"),
+        Err(AcunetixError::RequiredScopeMissing)
+    );
+    assert_eq!(
+        kernel.decode(&request, 429, Some(60), b"{}"),
+        Err(AcunetixError::RateLimited {
+            retry_after_seconds: Some(60)
+        })
+    );
+}
+
+#[test]
+fn origin_cursor_and_tenant_inputs_fail_closed() {
+    for origin in [
+        "http://online.acunetix.com/api/v1",
+        "https://user@online.acunetix.com/api/v1",
+        "https://online.acunetix.com:8443/api/v1",
+        "https://online.acunetix.com",
+        "https://online.acunetix.com/api/v2",
+        "https://online.acunetix.com/api/v1?token=value",
+    ] {
+        assert!(
+            AcunetixKernel::new(origin, "tenant", AcunetixFamily::Targets, OBSERVED_AT).is_err()
+        );
+    }
+    assert!(
+        AcunetixKernel::new(ORIGIN, "bad:tenant", AcunetixFamily::Targets, OBSERVED_AT).is_err()
+    );
+    assert_eq!(
+        kernel("tenant", AcunetixFamily::Targets).plan(Some("../escape")),
+        Err(AcunetixError::InvalidCursor)
+    );
+}
+
+#[test]
+fn identity_is_deterministic_tenant_and_origin_scoped() {
+    let family = AcunetixFamily::Reports;
+    let body = response(family, vec![oracle(family).payload], None);
+    let first = kernel("tenant-a", family);
+    let first_request = first.plan(None).unwrap();
+    let first_page = first.decode(&first_request, 200, None, &body).unwrap();
+    assert_eq!(
+        first_page,
+        first.decode(&first_request, 200, None, &body).unwrap()
+    );
+    let other_tenant = kernel("tenant-b", family);
+    let other_request = other_tenant.plan(None).unwrap();
+    let other_page = other_tenant
+        .decode(&other_request, 200, None, &body)
+        .unwrap();
+    assert_ne!(
+        first_page.records[0].event_id,
+        other_page.records[0].event_id
+    );
+    let other_origin = AcunetixKernel::new(
+        "https://scanner.example.test/api/v1",
+        "tenant-a",
+        family,
+        OBSERVED_AT,
+    )
+    .unwrap();
+    let other_origin_request = other_origin.plan(None).unwrap();
+    let other_origin_page = other_origin
+        .decode(&other_origin_request, 200, None, &body)
+        .unwrap();
+    assert_ne!(
+        first_page.records[0].event_id,
+        other_origin_page.records[0].event_id
+    );
+}

--- a/crates/source-runtime-next/src/acunetix/types.rs
+++ b/crates/source-runtime-next/src/acunetix/types.rs
@@ -1,0 +1,167 @@
+use std::{collections::BTreeMap, fmt};
+
+use reqwest::Url;
+use serde_json::Value;
+
+use super::{AcunetixError, AcunetixFamily, request, response};
+
+/// Credential-free request intent for the trusted Acunetix HTTP host.
+#[derive(Clone, Eq, PartialEq)]
+pub struct AcunetixRequest {
+    pub(super) url: Url,
+    pub(super) family: AcunetixFamily,
+    pub(super) cursor: Option<String>,
+    pub(super) page_size: usize,
+}
+
+impl fmt::Debug for AcunetixRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AcunetixRequest")
+            .field("url", &self.url)
+            .field("family", &self.family)
+            .field("has_cursor", &self.cursor.is_some())
+            .field("page_size", &self.page_size)
+            .finish()
+    }
+}
+
+impl AcunetixRequest {
+    /// Fully planned provider URL.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+    /// Provider HTTP method.
+    pub const fn method(&self) -> &'static str {
+        "GET"
+    }
+    /// Family owning this request.
+    pub const fn family(&self) -> AcunetixFamily {
+        self.family
+    }
+    /// Authentication header applied by the trusted host.
+    pub const fn authentication_header(&self) -> &'static str {
+        "X-Auth"
+    }
+    /// API keys have no prefix scheme.
+    pub const fn authentication_scheme(&self) -> &'static str {
+        ""
+    }
+    /// Host must redeem a credential reference before execution.
+    pub const fn credential_reference_required(&self) -> bool {
+        true
+    }
+    /// Portable plan contains no credential bytes or references.
+    pub const fn contains_credentials(&self) -> bool {
+        false
+    }
+    /// Redirects are disabled by the trusted host.
+    pub const fn allows_redirects(&self) -> bool {
+        false
+    }
+    /// Maximum admitted response bytes.
+    pub const fn max_response_bytes(&self) -> usize {
+        response::MAX_RESPONSE_BYTES
+    }
+    /// Maximum admitted records.
+    pub const fn record_limit(&self) -> usize {
+        self.page_size
+    }
+    /// Provider permission required by every family.
+    pub const fn required_scope(&self) -> &'static str {
+        "Acunetix API read access"
+    }
+}
+
+/// One normalized tenant-scoped Acunetix event candidate.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AcunetixRecord {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Stable tenant-, origin-, family-, and provider-scoped identity.
+    pub event_id: String,
+    /// Stable provider object identity.
+    pub provider_id: String,
+    /// Exact family.
+    pub family: AcunetixFamily,
+    /// Exact event kind.
+    pub kind: String,
+    /// Exact schema reference.
+    pub schema_ref: String,
+    /// Normalized RFC3339 occurrence time.
+    pub occurred_at: String,
+    /// Deterministic projection attributes.
+    pub attributes: BTreeMap<String, String>,
+    /// Credential-free provider payload.
+    pub payload: Value,
+}
+
+/// One bounded normalized Acunetix page.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AcunetixPage {
+    /// Accepted records after deterministic deduplication.
+    pub records: Vec<AcunetixRecord>,
+    /// Validated continuation, or terminal state.
+    pub next_cursor: Option<String>,
+}
+
+/// Checkpoint candidate for post-append/projection persistence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcunetixCheckpointCandidate {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Selected family.
+    pub family: AcunetixFamily,
+    /// Validated continuation state.
+    pub cursor: Option<String>,
+    /// Provider observation watermark.
+    pub watermark: String,
+}
+
+/// Closed Acunetix kernel for one tenant, origin, and family.
+#[derive(Clone, Debug)]
+pub struct AcunetixKernel {
+    pub(super) base_url: Url,
+    pub(super) tenant_id: String,
+    pub(super) family: AcunetixFamily,
+    pub(super) observed_at: String,
+}
+
+impl AcunetixKernel {
+    /// Construct one family kernel from public execution context.
+    pub fn new(
+        base_url: &str,
+        tenant_id: &str,
+        family: AcunetixFamily,
+        observed_at: &str,
+    ) -> Result<Self, AcunetixError> {
+        request::new_kernel(base_url, tenant_id, family, observed_at)
+    }
+    /// Kernel protocol never accepts credential material.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+    /// Plan one bounded origin-restricted request.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<AcunetixRequest, AcunetixError> {
+        request::plan(self, cursor)
+    }
+    /// Decode one bounded provider response.
+    pub fn decode(
+        &self,
+        request: &AcunetixRequest,
+        status: u16,
+        retry_after_seconds: Option<u64>,
+        body: &[u8],
+    ) -> Result<AcunetixPage, AcunetixError> {
+        response::decode(self, request, status, retry_after_seconds, body)
+    }
+    /// Validate a checkpoint candidate for post-commit persistence.
+    pub fn checkpoint_candidate(
+        &self,
+        request: &AcunetixRequest,
+        page: &AcunetixPage,
+        prior_watermark: Option<&str>,
+    ) -> Result<AcunetixCheckpointCandidate, AcunetixError> {
+        response::checkpoint_candidate(self, request, page, prior_watermark)
+    }
+}

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -6,6 +6,7 @@
 mod abuseipdb;
 mod activecampaign;
 mod activtrak;
+mod acunetix;
 mod amplitude;
 mod anthropic;
 mod append_log;
@@ -71,6 +72,11 @@ pub use activtrak::{
     ActivTrakCheckpointCandidate, ActivTrakEntityFact, ActivTrakError, ActivTrakEventContract,
     ActivTrakFamily, ActivTrakKernel, ActivTrakPage, ActivTrakProjectionFacts, ActivTrakRecord,
     ActivTrakRequest, ActivTrakRuntimeDefinition, project_activtrak_records,
+};
+pub use acunetix::{
+    AcunetixCheckpointCandidate, AcunetixEntityFact, AcunetixError, AcunetixEventContract,
+    AcunetixFamily, AcunetixKernel, AcunetixPage, AcunetixProjectionFacts, AcunetixRecord,
+    AcunetixRequest, AcunetixRuntimeDefinition, project_acunetix_records,
 };
 pub use amplitude::{
     AmplitudeError, AmplitudeFamily, AmplitudeKernel, AmplitudePage, AmplitudeRecord,


### PR DESCRIPTION
## Scope

Adds an additive credential-free Rust kernel for the catalog-runtime-only Acunetix families: reports, scanning_profiles, scans, targets, and vulnerabilities.

The kernel compiles the closed family set, plans bounded HTTPS requests restricted to the configured Acunetix /api/v1 origin, leaves X-Auth credential application to the trusted host, validates bounded provider responses, normalizes deterministic tenant- and origin-scoped identities, validates opaque cursor checkpoints, admits exact event contracts, preserves asset/policy/finding projection semantics, and compares semantic output with the checked Go fixture oracle.

Acunetix already has no provider-local Go source loader and is in the repository grandfathered catalog-runtime-only set. This PR does not change collection authority, shared runtime hosting, Go fixtures/oracles, private configuration, or deployment topology.

## Validation

- cargo fmt --all -- --check
- cargo test -p cerebro-source-runtime-next acunetix --no-fail-fast: 7 passed
- cargo test -p cerebro-source-runtime-next --no-fail-fast: 530 unit, 7 Linode integration, 10 PagerDuty integration passed
- cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings
- go test ./internal/sourceprojection ./internal/sourcefixture ./internal/connectorcatalog ./internal/connectordefinitions ./internal/sourcegen ./internal/sourceregistry ./sources/catalogruntime ./sources/internal/catalogruntime
- make catalog-check source-fixture-check fixture-oracle-check projection-parity-test
- make check-structural check-structural-test check-arch
- ./scripts/leak_check.sh staged

## Evidence boundaries

No live Acunetix credential or provider operation was used. No repository-owned deployment applies to this additive crate-only change. Live-provider collection and authenticated product-path proof remain unproven.