### PR TITLE
Add credential-free Abnormal Security Rust kernel

### DIFF
--- a/crates/source-runtime-next/src/abnormal_security.rs
+++ b/crates/source-runtime-next/src/abnormal_security.rs
@@ -1,0 +1,30 @@
+//! Credential-free Abnormal Security request, normalization, and projection kernel.
+//!
+//! The trusted host owns bearer-token resolution and application, redirects,
+//! deadlines, and bounded network I/O. This module receives authenticated
+//! tenant context, a public provider origin, and bounded response bytes only.
+//! The generic Rust catalog connector remains collection authority.
+
+mod catalog;
+mod error;
+mod family;
+mod normalize;
+mod origin;
+mod projection;
+mod request;
+mod response;
+mod types;
+
+pub use catalog::{AbnormalSecurityEventContract, AbnormalSecurityRuntimeDefinition};
+pub use error::AbnormalSecurityError;
+pub use family::AbnormalSecurityFamily;
+pub use projection::{
+    AbnormalSecurityEntityFact, AbnormalSecurityProjectionFacts, project_abnormal_security_records,
+};
+pub use types::{
+    AbnormalSecurityCheckpointCandidate, AbnormalSecurityKernel, AbnormalSecurityPage,
+    AbnormalSecurityRecord, AbnormalSecurityRequest,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/abnormal_security/catalog.rs
+++ b/crates/source-runtime-next/src/abnormal_security/catalog.rs
@@ -1,0 +1,73 @@
+use super::{AbnormalSecurityError, AbnormalSecurityFamily};
+
+/// Exact event contract compiled from the provider catalog.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AbnormalSecurityEventContract {
+    /// Exact event kind.
+    pub kind: &'static str,
+    /// Exact schema reference.
+    pub schema_ref: &'static str,
+    /// Required normalized attributes.
+    pub required_attributes: &'static [&'static str],
+    /// Required normalized payload fields.
+    pub required_payload_fields: &'static [&'static str],
+}
+
+/// Closed runtime definition for one provider family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AbnormalSecurityRuntimeDefinition {
+    /// Source identifier.
+    pub source_id: &'static str,
+    /// Selected family.
+    pub family: AbnormalSecurityFamily,
+    /// Exact event contract.
+    pub event_contract: AbnormalSecurityEventContract,
+    /// Every family is a bounded pull operation.
+    pub pull: bool,
+}
+
+impl AbnormalSecurityRuntimeDefinition {
+    /// Compile one declared family into a closed definition.
+    pub fn compile(family: AbnormalSecurityFamily) -> Result<Self, AbnormalSecurityError> {
+        let required_attributes = match family {
+            AbnormalSecurityFamily::Resources => &[
+                "tenant_id",
+                "source_event_id",
+                "resource_urn",
+                "resource_type",
+                "resource_id",
+            ][..],
+            AbnormalSecurityFamily::Threats | AbnormalSecurityFamily::Cases => &[
+                "tenant_id",
+                "source_event_id",
+                "finding_id",
+                "severity",
+                "status",
+            ][..],
+            AbnormalSecurityFamily::PostureCatalog => {
+                &["tenant_id", "source_event_id", "policy_id", "policy_name"][..]
+            }
+            AbnormalSecurityFamily::AuditEvents => {
+                &["tenant_id", "source_event_id", "event_type", "actor_id"][..]
+            }
+        };
+        let required_payload_fields = match family {
+            AbnormalSecurityFamily::Resources => &["resourceId"][..],
+            AbnormalSecurityFamily::Threats => &["threatId"][..],
+            AbnormalSecurityFamily::Cases => &["caseId"][..],
+            AbnormalSecurityFamily::PostureCatalog => &["id"][..],
+            AbnormalSecurityFamily::AuditEvents => &["timestamp"][..],
+        };
+        Ok(Self {
+            source_id: "abnormal_security",
+            family,
+            event_contract: AbnormalSecurityEventContract {
+                kind: family.event_kind(),
+                schema_ref: family.schema_ref(),
+                required_attributes,
+                required_payload_fields,
+            },
+            pull: true,
+        })
+    }
+}

--- a/crates/source-runtime-next/src/abnormal_security/error.rs
+++ b/crates/source-runtime-next/src/abnormal_security/error.rs
@@ -1,0 +1,161 @@
+use std::{error::Error, fmt};
+
+/// Bounded provider and runtime failure taxonomy.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AbnormalSecurityError {
+    /// Family is outside the closed catalog.
+    InvalidFamily,
+    /// Public configuration is malformed.
+    InvalidConfiguration(&'static str),
+    /// Provider origin is not an allowed HTTPS `/v1` base.
+    InvalidOrigin,
+    /// Authenticated tenant context is malformed.
+    InvalidTenantId,
+    /// Trusted host has no credential reference.
+    MissingCredentialReference,
+    /// Trusted host could not redeem its credential lease.
+    CredentialUnavailable,
+    /// Cursor is invalid or cannot round-trip.
+    InvalidCursor,
+    /// Request does not belong to this kernel.
+    RequestScopeMismatch,
+    /// Provider rejected authentication.
+    AuthenticationRejected,
+    /// Credential lacks required provider permission.
+    RequiredScopeMissing,
+    /// Provider resource was not found.
+    ProviderResourceNotFound,
+    /// Trusted host denied provider egress.
+    EgressDenied,
+    /// Provider DNS lookup failed.
+    DnsFailure,
+    /// Provider connection failed.
+    ConnectionFailure,
+    /// Provider operation timed out.
+    ProviderTimeout,
+    /// Provider requested a bounded retry.
+    RateLimited {
+        /// Provider-declared retry delay.
+        retry_after_seconds: Option<u64>,
+    },
+    /// Provider returned a retryable server failure.
+    ProviderUnavailable {
+        /// Provider HTTP status.
+        status: u16,
+    },
+    /// Provider returned an unexpected status.
+    UnexpectedStatus {
+        /// Provider HTTP status.
+        status: u16,
+    },
+    /// Retry delay is outside its persistence bound.
+    InvalidRetryAfter,
+    /// Response exceeds the host byte bound.
+    ResponseTooLarge,
+    /// Response exceeds the family record bound.
+    TooManyRecords,
+    /// Response JSON does not match the family.
+    MalformedResponse,
+    /// Provider record violates the family shape.
+    InvalidProviderRecord,
+    /// Provider record has no stable identity.
+    MissingStableIdentity,
+    /// Provider payload attempted to supply tenant context.
+    TenantMismatch,
+    /// Credential-shaped material crossed into the kernel.
+    CredentialMaterial,
+    /// Duplicate provider identity has conflicting content.
+    ConflictingDuplicate,
+    /// Normalized record failed the exact event contract.
+    EventContractRejection,
+    /// Durable append failed.
+    AppendFailure,
+    /// Projection failed.
+    ProjectionFailure,
+    /// Runtime lost its source lease.
+    LeaseLoss,
+    /// Runtime authority or generation is stale.
+    StaleAuthority,
+    /// Internal runtime failure.
+    InternalRuntimeFailure,
+}
+
+impl AbnormalSecurityError {
+    /// Next safe operator action without provider content.
+    pub const fn operator_action(&self) -> &'static str {
+        match self {
+            Self::InvalidFamily
+            | Self::InvalidConfiguration(_)
+            | Self::InvalidOrigin
+            | Self::InvalidTenantId
+            | Self::ProviderResourceNotFound => "repair source configuration",
+            Self::MissingCredentialReference
+            | Self::CredentialUnavailable
+            | Self::AuthenticationRejected => "repair credential binding",
+            Self::RequiredScopeMissing => "grant Abnormal Security API read access",
+            Self::RateLimited { .. }
+            | Self::ProviderUnavailable { .. }
+            | Self::DnsFailure
+            | Self::ConnectionFailure
+            | Self::ProviderTimeout => "retry the collection later",
+            Self::EgressDenied => "repair trusted-host egress policy",
+            Self::InvalidCursor => "restart from the last committed checkpoint",
+            Self::MalformedResponse
+            | Self::InvalidProviderRecord
+            | Self::MissingStableIdentity
+            | Self::TenantMismatch
+            | Self::CredentialMaterial
+            | Self::ConflictingDuplicate
+            | Self::EventContractRejection => "inspect quarantined provider records",
+            Self::AppendFailure | Self::ProjectionFailure => "repair the durable commit path",
+            Self::LeaseLoss | Self::StaleAuthority => "restart under the current lease",
+            _ => "repair the forward runtime implementation",
+        }
+    }
+}
+
+impl fmt::Display for AbnormalSecurityError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidFamily => "abnormal security family is invalid",
+            Self::InvalidConfiguration(_) => "abnormal security source configuration is invalid",
+            Self::InvalidOrigin => "abnormal security provider origin is invalid",
+            Self::InvalidTenantId => "abnormal security tenant ID is invalid",
+            Self::MissingCredentialReference => "abnormal security credential reference is missing",
+            Self::CredentialUnavailable => "abnormal security credential lease is unavailable",
+            Self::InvalidCursor => "abnormal security cursor is invalid or not round-trippable",
+            Self::RequestScopeMismatch => "abnormal security request does not match the kernel",
+            Self::AuthenticationRejected => "abnormal security rejected authentication",
+            Self::RequiredScopeMissing => "abnormal security credential lacks required scope",
+            Self::ProviderResourceNotFound => "abnormal security resource was not found",
+            Self::EgressDenied => "abnormal security egress was denied",
+            Self::DnsFailure => "abnormal security DNS resolution failed",
+            Self::ConnectionFailure => "abnormal security connection failed",
+            Self::ProviderTimeout => "abnormal security operation timed out",
+            Self::RateLimited { .. } => "abnormal security rate limited the operation",
+            Self::ProviderUnavailable { .. } => "abnormal security is temporarily unavailable",
+            Self::UnexpectedStatus { .. } => "abnormal security returned an unexpected status",
+            Self::InvalidRetryAfter => "abnormal security retry delay exceeds its bound",
+            Self::ResponseTooLarge => "abnormal security response exceeds its byte bound",
+            Self::TooManyRecords => "abnormal security response exceeds its record bound",
+            Self::MalformedResponse => "abnormal security response is malformed",
+            Self::InvalidProviderRecord => "abnormal security provider record is invalid",
+            Self::MissingStableIdentity => "abnormal security record has no stable identity",
+            Self::TenantMismatch => "abnormal security payload attempted to supply tenant context",
+            Self::CredentialMaterial => {
+                "abnormal security payload contains credential-shaped material"
+            }
+            Self::ConflictingDuplicate => {
+                "abnormal security duplicate identity has conflicting content"
+            }
+            Self::EventContractRejection => "abnormal security event failed its catalog contract",
+            Self::AppendFailure => "abnormal security append failed",
+            Self::ProjectionFailure => "abnormal security projection failed",
+            Self::LeaseLoss => "abnormal security runtime lost its lease",
+            Self::StaleAuthority => "abnormal security runtime authority is stale",
+            Self::InternalRuntimeFailure => "abnormal security runtime failed internally",
+        })
+    }
+}
+
+impl Error for AbnormalSecurityError {}

--- a/crates/source-runtime-next/src/abnormal_security/family.rs
+++ b/crates/source-runtime-next/src/abnormal_security/family.rs
@@ -1,0 +1,106 @@
+use std::str::FromStr;
+
+use super::AbnormalSecurityError;
+
+/// Closed Abnormal Security catalog family vocabulary.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum AbnormalSecurityFamily {
+    /// Protected resources.
+    Resources,
+    /// Portal audit events.
+    AuditEvents,
+    /// Security cases.
+    Cases,
+    /// SaaS posture catalog.
+    PostureCatalog,
+    /// Email threats.
+    Threats,
+}
+
+impl AbnormalSecurityFamily {
+    /// Every provider-declared family.
+    pub const ALL: [Self; 5] = [
+        Self::Resources,
+        Self::AuditEvents,
+        Self::Cases,
+        Self::PostureCatalog,
+        Self::Threats,
+    ];
+
+    /// Exact catalog identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Resources => "resources",
+            Self::AuditEvents => "audit_events",
+            Self::Cases => "cases",
+            Self::PostureCatalog => "posture_catalog",
+            Self::Threats => "threats",
+        }
+    }
+
+    /// Exact provider path relative to `/v1`.
+    pub const fn path(self) -> &'static str {
+        match self {
+            Self::Resources => "/resources",
+            Self::AuditEvents => "/auditlogs",
+            Self::Cases => "/cases",
+            Self::PostureCatalog => "/spm-v2/posture-catalog",
+            Self::Threats => "/threats",
+        }
+    }
+
+    /// Provider response-array key.
+    pub const fn response_key(self) -> &'static str {
+        match self {
+            Self::Resources => "resources",
+            Self::AuditEvents => "auditLogs",
+            Self::Cases => "cases",
+            Self::PostureCatalog => "data",
+            Self::Threats => "threats",
+        }
+    }
+
+    /// Stable provider identity field.
+    pub const fn id_field(self) -> &'static str {
+        match self {
+            Self::Resources => "resourceId",
+            Self::AuditEvents => "timestamp",
+            Self::Cases => "caseId",
+            Self::PostureCatalog => "id",
+            Self::Threats => "threatId",
+        }
+    }
+
+    /// Exact event kind.
+    pub const fn event_kind(self) -> &'static str {
+        match self {
+            Self::Resources => "abnormal_security.resources",
+            Self::AuditEvents => "abnormal_security.audit_events",
+            Self::Cases => "abnormal_security.cases",
+            Self::PostureCatalog => "abnormal_security.posture_catalog",
+            Self::Threats => "abnormal_security.threats",
+        }
+    }
+
+    /// Exact schema reference.
+    pub const fn schema_ref(self) -> &'static str {
+        match self {
+            Self::Resources => "abnormal_security/resources/v1",
+            Self::AuditEvents => "abnormal_security/audit_events/v1",
+            Self::Cases => "abnormal_security/cases/v1",
+            Self::PostureCatalog => "abnormal_security/posture_catalog/v1",
+            Self::Threats => "abnormal_security/threats/v1",
+        }
+    }
+}
+
+impl FromStr for AbnormalSecurityFamily {
+    type Err = AbnormalSecurityError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|family| family.as_str() == value.trim())
+            .ok_or(AbnormalSecurityError::InvalidFamily)
+    }
+}

--- a/crates/source-runtime-next/src/abnormal_security/normalize.rs
+++ b/crates/source-runtime-next/src/abnormal_security/normalize.rs
@@ -1,0 +1,324 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    AbnormalSecurityError, AbnormalSecurityFamily, AbnormalSecurityKernel, AbnormalSecurityRecord,
+    AbnormalSecurityRuntimeDefinition,
+};
+
+pub(super) fn normalize(
+    kernel: &AbnormalSecurityKernel,
+    raw: Value,
+) -> Result<AbnormalSecurityRecord, AbnormalSecurityError> {
+    reject_protected(&raw, 0)?;
+    let values = raw
+        .as_object()
+        .ok_or(AbnormalSecurityError::InvalidProviderRecord)?;
+    let provider_id = required_scalar(values, kernel.family.id_field())?;
+    if provider_id.len() > 512 {
+        return Err(AbnormalSecurityError::MissingStableIdentity);
+    }
+    let occurred_at = occurred_at(kernel, values)?;
+    let record = AbnormalSecurityRecord {
+        tenant_id: kernel.tenant_id.clone(),
+        event_id: event_id(kernel, &provider_id),
+        provider_id: provider_id.clone(),
+        family: kernel.family,
+        kind: kernel.family.event_kind().to_owned(),
+        schema_ref: kernel.family.schema_ref().to_owned(),
+        attributes: attributes(kernel, values, &provider_id, &occurred_at)?,
+        occurred_at,
+        payload: raw,
+    };
+    admit(&record)?;
+    Ok(record)
+}
+
+fn attributes(
+    kernel: &AbnormalSecurityKernel,
+    values: &Map<String, Value>,
+    provider_id: &str,
+    occurred_at: &str,
+) -> Result<BTreeMap<String, String>, AbnormalSecurityError> {
+    let mut output = BTreeMap::from([
+        ("tenant_id".to_owned(), kernel.tenant_id.clone()),
+        ("source_event_id".to_owned(), provider_id.to_owned()),
+        ("source_system".to_owned(), "abnormal_security".to_owned()),
+        ("schema".to_owned(), kernel.family.as_str().to_owned()),
+        ("observed_at".to_owned(), occurred_at.to_owned()),
+    ]);
+    match kernel.family {
+        AbnormalSecurityFamily::Resources => {
+            let name = required_scalar(values, "name")?;
+            output.extend(BTreeMap::from([
+                ("record_class".to_owned(), "asset".to_owned()),
+                ("resource_id".to_owned(), provider_id.to_owned()),
+                ("resource_name".to_owned(), name),
+                ("resource_type".to_owned(), "resource".to_owned()),
+                (
+                    "resource_urn".to_owned(),
+                    format!(
+                        "urn:cerebro:{}:abnormal_security_resources:{}",
+                        encode_segment(&kernel.tenant_id),
+                        encode_segment(provider_id)
+                    ),
+                ),
+            ]));
+        }
+        AbnormalSecurityFamily::Threats => {
+            finding(&mut output, provider_id);
+            output.insert("resource_type".to_owned(), "email_threat".to_owned());
+            required_copy(&mut output, values, "severity", "severity")?;
+            required_copy(&mut output, values, "status", "status")?;
+            required_copy(&mut output, values, "title", "title")?;
+        }
+        AbnormalSecurityFamily::Cases => {
+            finding(&mut output, provider_id);
+            let employee = required_scalar(values, "affectedEmployee")?;
+            output.extend(BTreeMap::from([
+                ("resource_id".to_owned(), employee.clone()),
+                ("resource_name".to_owned(), employee),
+                ("resource_type".to_owned(), "abnormal_case".to_owned()),
+            ]));
+            required_copy(&mut output, values, "severity_level", "severity")?;
+            required_copy(&mut output, values, "case_status", "status")?;
+            required_copy(&mut output, values, "description", "title")?;
+        }
+        AbnormalSecurityFamily::PostureCatalog => {
+            let name = required_scalar(values, "name")?;
+            output.extend(BTreeMap::from([
+                ("record_class".to_owned(), "policy".to_owned()),
+                ("policy_id".to_owned(), provider_id.to_owned()),
+                ("policy_name".to_owned(), name),
+                ("policy_type".to_owned(), "posture_catalog".to_owned()),
+            ]));
+            required_copy(&mut output, values, "description", "policy_description")?;
+            required_copy(&mut output, values, "risk_level", "policy_severity")?;
+        }
+        AbnormalSecurityFamily::AuditEvents => {
+            output.insert("record_class".to_owned(), "audit_event".to_owned());
+            required_copy(&mut output, values, "action", "event_type")?;
+            required_nested(&mut output, values, &["user", "email"], "actor_id")?;
+            required_nested(&mut output, values, &["user", "email"], "actor_email")?;
+            nested(
+                &mut output,
+                values,
+                &["actionDetails", "message_id"],
+                "resource_id",
+            );
+            nested(
+                &mut output,
+                values,
+                &["actionDetails", "request_url"],
+                "resource_name",
+            );
+            copy(&mut output, values, "category", "resource_type");
+        }
+    }
+    Ok(output)
+}
+
+fn finding(output: &mut BTreeMap<String, String>, provider_id: &str) {
+    output.insert("record_class".to_owned(), "finding".to_owned());
+    output.insert("finding_id".to_owned(), provider_id.to_owned());
+}
+
+fn occurred_at(
+    kernel: &AbnormalSecurityKernel,
+    values: &Map<String, Value>,
+) -> Result<String, AbnormalSecurityError> {
+    let key = match kernel.family {
+        AbnormalSecurityFamily::Resources => "updated_at",
+        AbnormalSecurityFamily::AuditEvents => "timestamp",
+        AbnormalSecurityFamily::Cases => "last_modified",
+        AbnormalSecurityFamily::PostureCatalog => "updated_at",
+        AbnormalSecurityFamily::Threats => "receivedTime",
+    };
+    let value = scalar(values.get(key)).unwrap_or_else(|| kernel.observed_at.clone());
+    let time = OffsetDateTime::parse(&value, &Rfc3339)
+        .map_err(|_| AbnormalSecurityError::InvalidProviderRecord)?;
+    time.format(&Rfc3339)
+        .map_err(|_| AbnormalSecurityError::InvalidProviderRecord)
+}
+
+fn admit(record: &AbnormalSecurityRecord) -> Result<(), AbnormalSecurityError> {
+    let contract = AbnormalSecurityRuntimeDefinition::compile(record.family)?.event_contract;
+    if record.kind != contract.kind
+        || record.schema_ref != contract.schema_ref
+        || contract
+            .required_attributes
+            .iter()
+            .any(|key| record.attributes.get(*key).is_none_or(String::is_empty))
+        || contract
+            .required_payload_fields
+            .iter()
+            .any(|key| record.payload.get(*key).is_none_or(Value::is_null))
+    {
+        return Err(AbnormalSecurityError::EventContractRejection);
+    }
+    Ok(())
+}
+
+fn event_id(kernel: &AbnormalSecurityKernel, provider_id: &str) -> String {
+    let scope = Sha256::digest(format!(
+        "{}\0{}",
+        kernel.base_url.as_str(),
+        kernel.family.path()
+    ));
+    let scope = scope[..6]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!(
+        "abnormal-security-{}-{scope}-{}-{}",
+        normalize_id(&kernel.tenant_id),
+        normalize_id(kernel.family.as_str()),
+        normalize_id(provider_id)
+    )
+}
+
+fn required_scalar(
+    values: &Map<String, Value>,
+    key: &str,
+) -> Result<String, AbnormalSecurityError> {
+    scalar(values.get(key))
+        .filter(|value| !value.is_empty())
+        .ok_or(AbnormalSecurityError::MissingStableIdentity)
+}
+
+fn required_copy(
+    output: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    source: &str,
+    target: &str,
+) -> Result<(), AbnormalSecurityError> {
+    let value = scalar(values.get(source))
+        .filter(|value| !value.is_empty())
+        .ok_or(AbnormalSecurityError::InvalidProviderRecord)?;
+    output.insert(target.to_owned(), value);
+    Ok(())
+}
+
+fn required_nested(
+    output: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    path: &[&str],
+    target: &str,
+) -> Result<(), AbnormalSecurityError> {
+    let value = nested_scalar(values, path).ok_or(AbnormalSecurityError::InvalidProviderRecord)?;
+    output.insert(target.to_owned(), value);
+    Ok(())
+}
+
+fn nested(
+    output: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    path: &[&str],
+    target: &str,
+) {
+    if let Some(value) = nested_scalar(values, path) {
+        output.insert(target.to_owned(), value);
+    }
+}
+
+fn nested_scalar(values: &Map<String, Value>, path: &[&str]) -> Option<String> {
+    let mut value = values.get(*path.first()?)?;
+    for key in &path[1..] {
+        value = value.get(*key)?;
+    }
+    scalar(Some(value)).filter(|value| !value.is_empty())
+}
+
+fn copy(
+    output: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    source: &str,
+    target: &str,
+) {
+    if let Some(value) = scalar(values.get(source)).filter(|value| !value.is_empty()) {
+        output.insert(target.to_owned(), value);
+    }
+}
+
+fn scalar(value: Option<&Value>) -> Option<String> {
+    match value? {
+        Value::String(value) => Some(value.trim().to_owned()),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn reject_protected(value: &Value, depth: usize) -> Result<(), AbnormalSecurityError> {
+    if depth > 32 {
+        return Err(AbnormalSecurityError::InvalidProviderRecord);
+    }
+    match value {
+        Value::Object(values) => {
+            if values.len() > 256 {
+                return Err(AbnormalSecurityError::InvalidProviderRecord);
+            }
+            for (key, value) in values {
+                let key = key.to_ascii_lowercase().replace(['-', '.'], "_");
+                if key == "tenant_id" {
+                    return Err(AbnormalSecurityError::TenantMismatch);
+                }
+                if [
+                    "token",
+                    "api_key",
+                    "authorization",
+                    "password",
+                    "private_key",
+                ]
+                .contains(&key.as_str())
+                {
+                    return Err(AbnormalSecurityError::CredentialMaterial);
+                }
+                reject_protected(value, depth + 1)?;
+            }
+        }
+        Value::Array(values) => {
+            if values.len() > 512 {
+                return Err(AbnormalSecurityError::InvalidProviderRecord);
+            }
+            for value in values {
+                reject_protected(value, depth + 1)?;
+            }
+        }
+        Value::String(value) if value.len() > 64 * 1024 => {
+            return Err(AbnormalSecurityError::InvalidProviderRecord);
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn normalize_id(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_') {
+                character.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_owned()
+}
+
+fn encode_segment(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.trim().bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}

--- a/crates/source-runtime-next/src/abnormal_security/origin.rs
+++ b/crates/source-runtime-next/src/abnormal_security/origin.rs
@@ -1,0 +1,32 @@
+use reqwest::Url;
+
+use super::AbnormalSecurityError;
+
+pub(super) fn validate(value: &str) -> Result<Url, AbnormalSecurityError> {
+    let mut url = Url::parse(value.trim().trim_end_matches('/'))
+        .map_err(|_| AbnormalSecurityError::InvalidOrigin)?;
+    let host = url.host_str().unwrap_or_default();
+    if url.scheme() != "https"
+        || host.is_empty()
+        || host.len() > 253
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port_or_known_default() != Some(443)
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || url.path() != "/v1"
+    {
+        return Err(AbnormalSecurityError::InvalidOrigin);
+    }
+    url.set_path("/v1");
+    Ok(url)
+}
+
+pub(super) fn tenant(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()
+        && value.len() <= 128
+        && !value.chars().any(char::is_control)
+        && !value.contains(['/', '\\', ':']))
+    .then(|| value.to_owned())
+}

--- a/crates/source-runtime-next/src/abnormal_security/projection.rs
+++ b/crates/source-runtime-next/src/abnormal_security/projection.rs
@@ -1,0 +1,70 @@
+use std::collections::BTreeMap;
+
+use super::AbnormalSecurityRecord;
+
+/// One deterministic tenant-scoped projection entity.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct AbnormalSecurityEntityFact {
+    /// Canonical entity URN.
+    pub urn: String,
+    /// Closed entity type.
+    pub entity_type: String,
+    /// Human-readable label.
+    pub label: String,
+}
+
+/// Provider-local projection facts used for Go/Rust parity.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AbnormalSecurityProjectionFacts {
+    /// Deduplicated entities in canonical order.
+    pub entities: Vec<AbnormalSecurityEntityFact>,
+}
+
+/// Project normalized records into catalog entities.
+pub fn project_abnormal_security_records(
+    records: &[AbnormalSecurityRecord],
+) -> AbnormalSecurityProjectionFacts {
+    let mut entities = BTreeMap::<String, AbnormalSecurityEntityFact>::new();
+    for record in records {
+        let urn = format!(
+            "urn:cerebro:{}:abnormal_security_{}:{}",
+            encode_segment(&record.tenant_id),
+            record.family.as_str(),
+            encode_segment(&record.provider_id)
+        );
+        let label = record
+            .attributes
+            .get("resource_name")
+            .or_else(|| record.attributes.get("policy_name"))
+            .or_else(|| record.attributes.get("title"))
+            .or_else(|| record.attributes.get("event_type"))
+            .cloned()
+            .unwrap_or_else(|| record.provider_id.clone());
+        entities.insert(
+            urn.clone(),
+            AbnormalSecurityEntityFact {
+                urn,
+                entity_type: format!(
+                    "abnormal_security.{}",
+                    record.family.as_str().replace('_', ".")
+                ),
+                label,
+            },
+        );
+    }
+    AbnormalSecurityProjectionFacts {
+        entities: entities.into_values().collect(),
+    }
+}
+
+fn encode_segment(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.trim().bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~' | b':') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}

--- a/crates/source-runtime-next/src/abnormal_security/request.rs
+++ b/crates/source-runtime-next/src/abnormal_security/request.rs
@@ -1,0 +1,74 @@
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    AbnormalSecurityError, AbnormalSecurityFamily, AbnormalSecurityKernel, AbnormalSecurityRequest,
+    origin,
+};
+
+const PAGE_SIZE: usize = 100;
+const MAX_PAGE_NUMBER: u64 = 10_000_000;
+
+pub(super) fn new_kernel(
+    base_url: &str,
+    tenant_id: &str,
+    family: AbnormalSecurityFamily,
+    observed_at: &str,
+) -> Result<AbnormalSecurityKernel, AbnormalSecurityError> {
+    let base_url = origin::validate(base_url)?;
+    let tenant_id = origin::tenant(tenant_id).ok_or(AbnormalSecurityError::InvalidTenantId)?;
+    let observed = OffsetDateTime::parse(observed_at, &Rfc3339)
+        .map_err(|_| AbnormalSecurityError::InvalidConfiguration("observed_at"))?;
+    let observed_at = observed
+        .format(&Rfc3339)
+        .map_err(|_| AbnormalSecurityError::InvalidConfiguration("observed_at"))?;
+    Ok(AbnormalSecurityKernel {
+        base_url,
+        tenant_id,
+        family,
+        observed_at,
+    })
+}
+
+pub(super) fn plan(
+    kernel: &AbnormalSecurityKernel,
+    cursor: Option<&str>,
+) -> Result<AbnormalSecurityRequest, AbnormalSecurityError> {
+    let mut url = kernel.base_url.clone();
+    url.set_path(&format!("/v1{}", kernel.family.path()));
+    if url.origin() != kernel.base_url.origin() {
+        return Err(AbnormalSecurityError::InvalidOrigin);
+    }
+    {
+        let mut query = url.query_pairs_mut();
+        query.append_pair("pageSize", &PAGE_SIZE.to_string());
+        if let Some(cursor) = cursor {
+            query.append_pair("pageNumber", validate_cursor(cursor)?);
+        }
+    }
+    Ok(AbnormalSecurityRequest {
+        url,
+        family: kernel.family,
+        cursor: cursor.map(str::to_owned),
+        page_size: PAGE_SIZE,
+    })
+}
+
+pub(super) fn validate_request(
+    kernel: &AbnormalSecurityKernel,
+    request: &AbnormalSecurityRequest,
+) -> Result<(), AbnormalSecurityError> {
+    if request != &plan(kernel, request.cursor.as_deref())? {
+        return Err(AbnormalSecurityError::RequestScopeMismatch);
+    }
+    Ok(())
+}
+
+pub(super) fn validate_cursor(value: &str) -> Result<&str, AbnormalSecurityError> {
+    let value = value.trim();
+    value
+        .parse::<u64>()
+        .ok()
+        .filter(|page| (1..=MAX_PAGE_NUMBER).contains(page))
+        .map(|_| value)
+        .ok_or(AbnormalSecurityError::InvalidCursor)
+}

--- a/crates/source-runtime-next/src/abnormal_security/response.rs
+++ b/crates/source-runtime-next/src/abnormal_security/response.rs
@@ -1,0 +1,133 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    AbnormalSecurityCheckpointCandidate, AbnormalSecurityError, AbnormalSecurityFamily,
+    AbnormalSecurityKernel, AbnormalSecurityPage, AbnormalSecurityRequest, normalize,
+    request::{validate_cursor, validate_request},
+};
+
+pub(super) const MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+pub(super) fn decode(
+    kernel: &AbnormalSecurityKernel,
+    request: &AbnormalSecurityRequest,
+    status: u16,
+    retry_after_seconds: Option<u64>,
+    body: &[u8],
+) -> Result<AbnormalSecurityPage, AbnormalSecurityError> {
+    validate_request(kernel, request)?;
+    classify_status(status, retry_after_seconds)?;
+    if body.len() > MAX_RESPONSE_BYTES {
+        return Err(AbnormalSecurityError::ResponseTooLarge);
+    }
+    let root: Value =
+        serde_json::from_slice(body).map_err(|_| AbnormalSecurityError::MalformedResponse)?;
+    let items = root
+        .get(kernel.family.response_key())
+        .and_then(Value::as_array)
+        .ok_or(AbnormalSecurityError::MalformedResponse)?;
+    if items.len() > request.page_size {
+        return Err(AbnormalSecurityError::TooManyRecords);
+    }
+    let mut seen = BTreeMap::<String, Vec<u8>>::new();
+    let mut records = Vec::with_capacity(items.len());
+    for raw in items {
+        let record = normalize::normalize(kernel, raw.clone())?;
+        let canonical = serde_json::to_vec(&record.payload)
+            .map_err(|_| AbnormalSecurityError::InvalidProviderRecord)?;
+        match seen.get(&record.provider_id) {
+            Some(previous) if previous == &canonical => continue,
+            Some(_) => return Err(AbnormalSecurityError::ConflictingDuplicate),
+            None => {
+                seen.insert(record.provider_id.clone(), canonical);
+                records.push(record);
+            }
+        }
+    }
+    let cursor_value = if kernel.family == AbnormalSecurityFamily::PostureCatalog {
+        root.pointer("/metadata/next_page")
+    } else {
+        root.get("nextPageNumber")
+    };
+    let next_cursor = match cursor_value {
+        None | Some(Value::Null) => None,
+        Some(Value::String(value)) if value.is_empty() => None,
+        Some(value) => value_as_cursor(value)?,
+    };
+    if next_cursor.is_some() && next_cursor == request.cursor {
+        return Err(AbnormalSecurityError::InvalidCursor);
+    }
+    Ok(AbnormalSecurityPage {
+        records,
+        next_cursor,
+    })
+}
+
+fn value_as_cursor(value: &Value) -> Result<Option<String>, AbnormalSecurityError> {
+    let cursor = match value {
+        Value::String(value) => value.clone(),
+        Value::Number(value) => value.to_string(),
+        _ => return Err(AbnormalSecurityError::InvalidCursor),
+    };
+    validate_cursor(&cursor)?;
+    Ok(Some(cursor))
+}
+
+pub(super) fn checkpoint_candidate(
+    kernel: &AbnormalSecurityKernel,
+    request: &AbnormalSecurityRequest,
+    page: &AbnormalSecurityPage,
+    prior_watermark: Option<&str>,
+) -> Result<AbnormalSecurityCheckpointCandidate, AbnormalSecurityError> {
+    validate_request(kernel, request)?;
+    if page
+        .records
+        .iter()
+        .any(|record| record.tenant_id != kernel.tenant_id || record.family != kernel.family)
+    {
+        return Err(AbnormalSecurityError::TenantMismatch);
+    }
+    if let Some(cursor) = &page.next_cursor {
+        kernel.plan(Some(cursor))?;
+    }
+    let mut watermark = valid_time(prior_watermark.unwrap_or(&kernel.observed_at))?;
+    for record in &page.records {
+        let occurred_at = valid_time(&record.occurred_at)?;
+        if occurred_at > watermark {
+            watermark = occurred_at;
+        }
+    }
+    Ok(AbnormalSecurityCheckpointCandidate {
+        tenant_id: kernel.tenant_id.clone(),
+        family: kernel.family,
+        cursor: page.next_cursor.clone(),
+        watermark,
+    })
+}
+
+fn classify_status(status: u16, retry: Option<u64>) -> Result<(), AbnormalSecurityError> {
+    if retry.is_some_and(|seconds| seconds > 3_600) {
+        return Err(AbnormalSecurityError::InvalidRetryAfter);
+    }
+    match status {
+        200..=299 => Ok(()),
+        401 => Err(AbnormalSecurityError::AuthenticationRejected),
+        403 => Err(AbnormalSecurityError::RequiredScopeMissing),
+        404 => Err(AbnormalSecurityError::ProviderResourceNotFound),
+        429 => Err(AbnormalSecurityError::RateLimited {
+            retry_after_seconds: retry,
+        }),
+        500..=599 => Err(AbnormalSecurityError::ProviderUnavailable { status }),
+        _ => Err(AbnormalSecurityError::UnexpectedStatus { status }),
+    }
+}
+
+fn valid_time(value: &str) -> Result<String, AbnormalSecurityError> {
+    let time = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| AbnormalSecurityError::InvalidProviderRecord)?;
+    time.format(&Rfc3339)
+        .map_err(|_| AbnormalSecurityError::InvalidProviderRecord)
+}

--- a/crates/source-runtime-next/src/abnormal_security/tests.rs
+++ b/crates/source-runtime-next/src/abnormal_security/tests.rs
@@ -1,0 +1,312 @@
+use std::{collections::BTreeMap, fs, path::PathBuf};
+
+use cerebro_source_catalog::{CollectionAuthority, SourceCatalog};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::*;
+
+const ORIGIN: &str = "https://api.abnormalplatform.com/v1";
+const OBSERVED_AT: &str = "2026-06-01T00:00:00Z";
+
+#[derive(Debug, Deserialize)]
+struct GoOracleEvent {
+    id: String,
+    tenant_id: String,
+    source_id: String,
+    kind: String,
+    occurred_at: String,
+    schema_ref: String,
+    payload: Value,
+    attributes: BTreeMap<String, String>,
+}
+
+fn root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn kernel(tenant: &str, family: AbnormalSecurityFamily) -> AbnormalSecurityKernel {
+    AbnormalSecurityKernel::new(ORIGIN, tenant, family, OBSERVED_AT).unwrap()
+}
+
+fn oracle(family: AbnormalSecurityFamily) -> GoOracleEvent {
+    let bytes = fs::read(root().join(format!(
+        "sources/abnormal_security/testdata/read_{}.json",
+        family.as_str()
+    )))
+    .unwrap();
+    serde_json::from_slice::<Vec<GoOracleEvent>>(&bytes)
+        .unwrap()
+        .pop()
+        .unwrap()
+}
+
+fn response(family: AbnormalSecurityFamily, records: Vec<Value>, cursor: Option<u64>) -> Vec<u8> {
+    let mut response = json!({family.response_key(): records});
+    if let Some(cursor) = cursor {
+        if family == AbnormalSecurityFamily::PostureCatalog {
+            response["metadata"] = json!({"next_page": cursor});
+        } else {
+            response["nextPageNumber"] = json!(cursor);
+        }
+    }
+    serde_json::to_vec(&response).unwrap()
+}
+
+#[test]
+fn catalog_closes_the_exact_catalog_runtime_only_family_set() {
+    let catalog = SourceCatalog::load(
+        root().join("internal/connectorcatalog/catalog"),
+        root().join("sources"),
+    )
+    .unwrap();
+    let source = catalog.get("abnormal_security").unwrap();
+    assert_eq!(source.authority(), CollectionAuthority::Authoritative);
+    let mut families = source
+        .families()
+        .iter()
+        .map(|family| family.id())
+        .collect::<Vec<_>>();
+    families.sort_unstable();
+    assert_eq!(
+        families,
+        [
+            "audit_events",
+            "cases",
+            "posture_catalog",
+            "resources",
+            "threats"
+        ]
+    );
+    assert!(!root().join("sources/abnormal_security/source.go").exists());
+    for family in AbnormalSecurityFamily::ALL {
+        let definition = AbnormalSecurityRuntimeDefinition::compile(family).unwrap();
+        assert_eq!(definition.source_id, "abnormal_security");
+        assert!(definition.pull);
+        assert_eq!(definition.event_contract.kind, family.event_kind());
+    }
+}
+
+#[test]
+fn requests_are_origin_locked_bounded_and_credential_free() {
+    for family in AbnormalSecurityFamily::ALL {
+        let request = kernel("tenant", family).plan(None).unwrap();
+        assert_eq!(request.method(), "GET");
+        assert_eq!(request.url().host_str(), Some("api.abnormalplatform.com"));
+        assert_eq!(request.url().path(), format!("/v1{}", family.path()));
+        assert_eq!(request.url().query(), Some("pageSize=100"));
+        assert_eq!(request.authentication_header(), "Authorization");
+        assert_eq!(request.authentication_scheme(), "Bearer");
+        assert!(request.credential_reference_required());
+        assert!(!request.contains_credentials());
+        assert!(!request.allows_redirects());
+        assert_eq!(request.record_limit(), 100);
+        assert_eq!(request.max_response_bytes(), 8 * 1024 * 1024);
+        assert!(!AbnormalSecurityKernel::requires_credentials());
+        assert_eq!(
+            kernel("tenant", family)
+                .plan(Some("2"))
+                .unwrap()
+                .url()
+                .query(),
+            Some("pageSize=100&pageNumber=2")
+        );
+    }
+}
+
+#[test]
+fn go_events_and_projection_fixtures_match_semantically() {
+    for family in AbnormalSecurityFamily::ALL {
+        let oracle = oracle(family);
+        let kernel = kernel("tenant", family);
+        let request = kernel.plan(None).unwrap();
+        let page = kernel
+            .decode(
+                &request,
+                200,
+                None,
+                &response(family, vec![oracle.payload.clone()], None),
+            )
+            .unwrap();
+        let record = &page.records[0];
+        assert_eq!(record.tenant_id, oracle.tenant_id);
+        assert_eq!(oracle.source_id, "abnormal_security");
+        assert_eq!(record.kind, oracle.kind);
+        assert_eq!(record.schema_ref, oracle.schema_ref);
+        assert_eq!(record.occurred_at, oracle.occurred_at);
+        assert_eq!(record.payload, oracle.payload);
+        assert_eq!(record.attributes, oracle.attributes);
+        assert!(oracle.id.starts_with("abnormal-security-"));
+        let projection = project_abnormal_security_records(&page.records);
+        assert_eq!(projection.entities.len(), 1);
+        assert_eq!(
+            projection.entities[0].urn,
+            format!(
+                "urn:cerebro:tenant:abnormal_security_{}:{}",
+                family.as_str(),
+                record.provider_id
+            )
+        );
+    }
+}
+
+#[test]
+fn cursor_checkpoint_and_restart_round_trip_for_both_envelopes() {
+    for family in [
+        AbnormalSecurityFamily::Resources,
+        AbnormalSecurityFamily::PostureCatalog,
+    ] {
+        let kernel = kernel("tenant", family);
+        let request = kernel.plan(None).unwrap();
+        let page = kernel
+            .decode(
+                &request,
+                200,
+                None,
+                &response(family, vec![oracle(family).payload], Some(2)),
+            )
+            .unwrap();
+        assert_eq!(page.next_cursor.as_deref(), Some("2"));
+        let checkpoint = kernel
+            .checkpoint_candidate(&request, &page, Some("2026-05-01T00:00:00Z"))
+            .unwrap();
+        assert_eq!(checkpoint.cursor.as_deref(), Some("2"));
+        assert_eq!(
+            kernel
+                .plan(checkpoint.cursor.as_deref())
+                .unwrap()
+                .url()
+                .query(),
+            Some("pageSize=100&pageNumber=2")
+        );
+    }
+}
+
+#[test]
+fn duplicate_conflict_tenant_secret_and_statuses_fail_closed() {
+    let family = AbnormalSecurityFamily::Resources;
+    let kernel = kernel("tenant", family);
+    let request = kernel.plan(None).unwrap();
+    let raw = oracle(family).payload;
+    let page = kernel
+        .decode(
+            &request,
+            200,
+            None,
+            &response(family, vec![raw.clone(), raw.clone()], None),
+        )
+        .unwrap();
+    assert_eq!(page.records.len(), 1);
+    let mut conflict = raw.clone();
+    conflict["name"] = Value::String("different".to_owned());
+    assert_eq!(
+        kernel.decode(
+            &request,
+            200,
+            None,
+            &response(family, vec![raw, conflict], None)
+        ),
+        Err(AbnormalSecurityError::ConflictingDuplicate)
+    );
+    for (field, expected) in [
+        ("tenant_id", AbnormalSecurityError::TenantMismatch),
+        ("token", AbnormalSecurityError::CredentialMaterial),
+        ("authorization", AbnormalSecurityError::CredentialMaterial),
+    ] {
+        let mut raw = oracle(family).payload;
+        raw[field] = Value::String("sentinel-secret-value".to_owned());
+        let error = kernel
+            .decode(&request, 200, None, &response(family, vec![raw], None))
+            .unwrap_err();
+        assert_eq!(error, expected);
+        assert!(!format!("{error:?}").contains("sentinel-secret-value"));
+    }
+    assert_eq!(
+        kernel.decode(&request, 401, None, b"{}"),
+        Err(AbnormalSecurityError::AuthenticationRejected)
+    );
+    assert_eq!(
+        kernel.decode(&request, 403, None, b"{}"),
+        Err(AbnormalSecurityError::RequiredScopeMissing)
+    );
+    assert_eq!(
+        kernel.decode(&request, 429, Some(60), b"{}"),
+        Err(AbnormalSecurityError::RateLimited {
+            retry_after_seconds: Some(60)
+        })
+    );
+}
+
+#[test]
+fn origin_cursor_and_tenant_inputs_fail_closed() {
+    for origin in [
+        "http://api.abnormalplatform.com/v1",
+        "https://user@api.abnormalplatform.com/v1",
+        "https://api.abnormalplatform.com:8443/v1",
+        "https://api.abnormalplatform.com",
+        "https://api.abnormalplatform.com/v2",
+        "https://api.abnormalplatform.com/v1?token=value",
+    ] {
+        assert!(
+            AbnormalSecurityKernel::new(
+                origin,
+                "tenant",
+                AbnormalSecurityFamily::Resources,
+                OBSERVED_AT
+            )
+            .is_err()
+        );
+    }
+    assert!(
+        AbnormalSecurityKernel::new(
+            ORIGIN,
+            "bad:tenant",
+            AbnormalSecurityFamily::Resources,
+            OBSERVED_AT
+        )
+        .is_err()
+    );
+    assert_eq!(
+        kernel("tenant", AbnormalSecurityFamily::Resources).plan(Some("0")),
+        Err(AbnormalSecurityError::InvalidCursor)
+    );
+    assert_eq!(
+        kernel("tenant", AbnormalSecurityFamily::Resources).plan(Some("10000001")),
+        Err(AbnormalSecurityError::InvalidCursor)
+    );
+}
+
+#[test]
+fn identity_is_deterministic_tenant_and_origin_scoped() {
+    let family = AbnormalSecurityFamily::Threats;
+    let body = response(family, vec![oracle(family).payload], None);
+    let first = kernel("tenant-a", family);
+    let first_request = first.plan(None).unwrap();
+    let first_page = first.decode(&first_request, 200, None, &body).unwrap();
+    assert_eq!(
+        first_page,
+        first.decode(&first_request, 200, None, &body).unwrap()
+    );
+    let other = kernel("tenant-b", family);
+    let other_request = other.plan(None).unwrap();
+    let other_page = other.decode(&other_request, 200, None, &body).unwrap();
+    assert_ne!(
+        first_page.records[0].event_id,
+        other_page.records[0].event_id
+    );
+    let regional = AbnormalSecurityKernel::new(
+        "https://api.eu.abnormalplatform.com/v1",
+        "tenant-a",
+        family,
+        OBSERVED_AT,
+    )
+    .unwrap();
+    let regional_request = regional.plan(None).unwrap();
+    let regional_page = regional
+        .decode(&regional_request, 200, None, &body)
+        .unwrap();
+    assert_ne!(
+        first_page.records[0].event_id,
+        regional_page.records[0].event_id
+    );
+}

--- a/crates/source-runtime-next/src/abnormal_security/types.rs
+++ b/crates/source-runtime-next/src/abnormal_security/types.rs
@@ -1,0 +1,170 @@
+use std::{collections::BTreeMap, fmt};
+
+use reqwest::Url;
+use serde_json::Value;
+
+use super::{AbnormalSecurityError, AbnormalSecurityFamily, request, response};
+
+/// Credential-free request intent for the trusted provider HTTP host.
+#[derive(Clone, Eq, PartialEq)]
+pub struct AbnormalSecurityRequest {
+    pub(super) url: Url,
+    pub(super) family: AbnormalSecurityFamily,
+    pub(super) cursor: Option<String>,
+    pub(super) page_size: usize,
+}
+
+impl fmt::Debug for AbnormalSecurityRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AbnormalSecurityRequest")
+            .field("url", &self.url)
+            .field("family", &self.family)
+            .field("has_cursor", &self.cursor.is_some())
+            .field("page_size", &self.page_size)
+            .finish()
+    }
+}
+
+impl AbnormalSecurityRequest {
+    /// Fully planned provider URL.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+    /// Provider HTTP method.
+    pub const fn method(&self) -> &'static str {
+        "GET"
+    }
+    /// Family owning this request.
+    pub const fn family(&self) -> AbnormalSecurityFamily {
+        self.family
+    }
+    /// Authentication header applied by the trusted host.
+    pub const fn authentication_header(&self) -> &'static str {
+        "Authorization"
+    }
+    /// Bearer prefix applied outside the kernel.
+    pub const fn authentication_scheme(&self) -> &'static str {
+        "Bearer"
+    }
+    /// Host must redeem a credential reference before execution.
+    pub const fn credential_reference_required(&self) -> bool {
+        true
+    }
+    /// Portable plan contains no credential bytes or references.
+    pub const fn contains_credentials(&self) -> bool {
+        false
+    }
+    /// Redirects are disabled by the trusted host.
+    pub const fn allows_redirects(&self) -> bool {
+        false
+    }
+    /// Maximum admitted response bytes.
+    pub const fn max_response_bytes(&self) -> usize {
+        response::MAX_RESPONSE_BYTES
+    }
+    /// Maximum admitted records.
+    pub const fn record_limit(&self) -> usize {
+        self.page_size
+    }
+    /// Provider permission required by every family.
+    pub const fn required_scope(&self) -> &'static str {
+        "Abnormal Security API read access"
+    }
+}
+
+/// One normalized tenant-scoped event candidate.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AbnormalSecurityRecord {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Stable tenant-, origin-, family-, and provider-scoped identity.
+    pub event_id: String,
+    /// Stable provider object identity.
+    pub provider_id: String,
+    /// Exact family.
+    pub family: AbnormalSecurityFamily,
+    /// Exact event kind.
+    pub kind: String,
+    /// Exact schema reference.
+    pub schema_ref: String,
+    /// Normalized RFC3339 occurrence time.
+    pub occurred_at: String,
+    /// Deterministic projection attributes.
+    pub attributes: BTreeMap<String, String>,
+    /// Credential-free provider payload.
+    pub payload: Value,
+}
+
+/// One bounded normalized provider page.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AbnormalSecurityPage {
+    /// Accepted records after deterministic deduplication.
+    pub records: Vec<AbnormalSecurityRecord>,
+    /// Validated continuation, or terminal state.
+    pub next_cursor: Option<String>,
+}
+
+/// Checkpoint candidate for post-append/projection persistence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AbnormalSecurityCheckpointCandidate {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Selected family.
+    pub family: AbnormalSecurityFamily,
+    /// Validated continuation state.
+    pub cursor: Option<String>,
+    /// Provider observation watermark.
+    pub watermark: String,
+}
+
+/// Closed provider kernel for one tenant, origin, and family.
+#[derive(Clone, Debug)]
+pub struct AbnormalSecurityKernel {
+    pub(super) base_url: Url,
+    pub(super) tenant_id: String,
+    pub(super) family: AbnormalSecurityFamily,
+    pub(super) observed_at: String,
+}
+
+impl AbnormalSecurityKernel {
+    /// Construct one family kernel from public execution context.
+    pub fn new(
+        base_url: &str,
+        tenant_id: &str,
+        family: AbnormalSecurityFamily,
+        observed_at: &str,
+    ) -> Result<Self, AbnormalSecurityError> {
+        request::new_kernel(base_url, tenant_id, family, observed_at)
+    }
+    /// Kernel protocol never accepts credential material.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+    /// Plan one bounded origin-restricted request.
+    pub fn plan(
+        &self,
+        cursor: Option<&str>,
+    ) -> Result<AbnormalSecurityRequest, AbnormalSecurityError> {
+        request::plan(self, cursor)
+    }
+    /// Decode one bounded provider response.
+    pub fn decode(
+        &self,
+        request: &AbnormalSecurityRequest,
+        status: u16,
+        retry_after_seconds: Option<u64>,
+        body: &[u8],
+    ) -> Result<AbnormalSecurityPage, AbnormalSecurityError> {
+        response::decode(self, request, status, retry_after_seconds, body)
+    }
+    /// Validate a checkpoint candidate for post-commit persistence.
+    pub fn checkpoint_candidate(
+        &self,
+        request: &AbnormalSecurityRequest,
+        page: &AbnormalSecurityPage,
+        prior_watermark: Option<&str>,
+    ) -> Result<AbnormalSecurityCheckpointCandidate, AbnormalSecurityError> {
+        response::checkpoint_candidate(self, request, page, prior_watermark)
+    }
+}

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! Rust-native source collection and graph admission boundary.
 
+mod abnormal_security;
 mod abuseipdb;
 mod amplitude;
 mod anthropic;
@@ -53,6 +54,12 @@ mod trivy;
 mod twilio;
 mod vulnview;
 
+pub use abnormal_security::{
+    AbnormalSecurityCheckpointCandidate, AbnormalSecurityEntityFact, AbnormalSecurityError,
+    AbnormalSecurityEventContract, AbnormalSecurityFamily, AbnormalSecurityKernel,
+    AbnormalSecurityPage, AbnormalSecurityProjectionFacts, AbnormalSecurityRecord,
+    AbnormalSecurityRequest, AbnormalSecurityRuntimeDefinition, project_abnormal_security_records,
+};
 pub use abuseipdb::{
     AbuseIpDbCheckpointCandidate, AbuseIpDbEntityFact, AbuseIpDbError, AbuseIpDbEventContract,
     AbuseIpDbFamily, AbuseIpDbFilters, AbuseIpDbKernel, AbuseIpDbPage, AbuseIpDbProjectionFacts,


### PR DESCRIPTION
## Scope

Adds an additive credential-free Rust kernel for the catalog-runtime-only Abnormal Security families: resources, threats, cases, posture_catalog, and audit_events.

The kernel compiles the closed family set, plans bounded HTTPS requests restricted to the configured /v1 provider origin, leaves bearer-token application to the trusted host, validates bounded provider responses, normalizes deterministic tenant- and origin-scoped identities, validates page-number checkpoints for both provider envelope shapes, admits exact event contracts, preserves asset/finding/policy/audit projection semantics, and compares semantic output with the checked Go fixture oracle.

Abnormal Security already has no provider-local Go source loader and is listed in the repository catalog-runtime retirement inventory. This PR does not change collection authority, shared runtime hosting, Go fixtures/oracles, private configuration, or deployment topology.

## Validation

- cargo fmt --all -- --check
- cargo test -p cerebro-source-runtime-next abnormal_security --no-fail-fast: 7 passed
- cargo test -p cerebro-source-runtime-next --no-fail-fast: 530 unit, 7 Linode integration, 10 PagerDuty integration passed
- cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings
- go test ./internal/sourceprojection ./internal/sourcefixture ./internal/connectorcatalog ./internal/connectordefinitions ./internal/sourcegen ./internal/sourceregistry ./sources/catalogruntime ./sources/internal/catalogruntime
- make catalog-check source-fixture-check fixture-oracle-check projection-parity-test
- make check-structural check-structural-test check-arch
- ./scripts/leak_check.sh staged

## Evidence boundaries

No live Abnormal Security credential or provider operation was used. No repository-owned deployment applies to this additive crate-only change. Live-provider collection and authenticated product-path proof remain unproven.