### PR TITLE
JumpCloud: preserve group fanout and resume parity

### DIFF
--- a/crates/source-runtime-next/src/jumpcloud.rs
+++ b/crates/source-runtime-next/src/jumpcloud.rs
@@ -9,6 +9,7 @@
 #[allow(dead_code)]
 pub(crate) mod adapter;
 mod catalog;
+mod cursor;
 mod error;
 mod family;
 mod identity;
@@ -30,5 +31,7 @@ pub use types::{
     JumpCloudRecord, JumpCloudRequest, JumpCloudResponseMetadata,
 };
 
+#[cfg(test)]
+mod fanout_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/source-runtime-next/src/jumpcloud/adapter.rs
+++ b/crates/source-runtime-next/src/jumpcloud/adapter.rs
@@ -4,6 +4,10 @@
 //! the exact seven registration tuples plus body/header capabilities that the
 //! shared registration follow-up must carry without redefining wire messages.
 
+use std::collections::BTreeSet;
+
+use sha2::{Digest, Sha256};
+
 use super::{
     JumpCloudError, JumpCloudFamily, JumpCloudKernel, JumpCloudPage, JumpCloudRequest,
     JumpCloudResponseMetadata, JumpCloudRuntimeDefinition,
@@ -21,6 +25,9 @@ pub(crate) struct JumpCloudSourceExecutionContract {
     pub(crate) credential_operation: &'static str,
     pub(crate) request_body: bool,
     pub(crate) response_cursor_header: Option<&'static str>,
+    pub(crate) check_scope: &'static str,
+    pub(crate) discover_scope: &'static str,
+    pub(crate) max_fanout_scopes: Option<usize>,
 }
 
 /// Stateless provider-local adapter for one exact JumpCloud family.
@@ -39,6 +46,40 @@ pub(crate) const JUMPCLOUD_SOURCE_EXECUTION_ADAPTERS: [JumpCloudSourceExecutionA
     JumpCloudSourceExecutionAdapter::new(JumpCloudFamily::GroupMembers),
     JumpCloudSourceExecutionAdapter::new(JumpCloudFamily::AuditEvents),
 ];
+
+/// Bounded all-page Discover accumulator for group membership URNs.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct JumpCloudGroupMemberDiscovery {
+    pages: usize,
+    seen: BTreeSet<String>,
+    urns: Vec<String>,
+}
+
+impl JumpCloudGroupMemberDiscovery {
+    pub(crate) const MAX_PAGES: usize = 1_000;
+
+    pub(crate) fn admit_page(
+        &mut self,
+        adapter: JumpCloudSourceExecutionAdapter,
+        page: &JumpCloudPage,
+    ) -> Result<(), JumpCloudError> {
+        self.pages = self
+            .pages
+            .checked_add(1)
+            .filter(|pages| *pages <= Self::MAX_PAGES)
+            .ok_or(JumpCloudError::TooManyRecords)?;
+        for urn in adapter.page_discovery_urns(page)? {
+            if self.seen.insert(urn.clone()) {
+                self.urns.push(urn);
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn urns(&self) -> &[String] {
+        &self.urns
+    }
+}
 
 impl JumpCloudSourceExecutionAdapter {
     pub(crate) const fn new(family: JumpCloudFamily) -> Self {
@@ -70,6 +111,17 @@ impl JumpCloudSourceExecutionAdapter {
             request_body: self.family == JumpCloudFamily::AuditEvents,
             response_cursor_header: (self.family == JumpCloudFamily::AuditEvents)
                 .then_some("X-Search_after"),
+            check_scope: if self.family == JumpCloudFamily::GroupMembers {
+                "first_configured_group"
+            } else {
+                "family_endpoint"
+            },
+            discover_scope: if self.family == JumpCloudFamily::GroupMembers {
+                "all_configured_groups"
+            } else {
+                "family_endpoint"
+            },
+            max_fanout_scopes: (self.family == JumpCloudFamily::GroupMembers).then_some(1_000),
         })
     }
 
@@ -85,6 +137,25 @@ impl JumpCloudSourceExecutionAdapter {
         kernel.plan_with_checkpoint(prior_cursor, prior_watermark)
     }
 
+    /// Plan the bounded Check operation. Group membership checks intentionally
+    /// use only the first ordered configured group, matching the Go source.
+    pub(crate) fn plan_check(
+        self,
+        kernel: &JumpCloudKernel,
+    ) -> Result<JumpCloudRequest, JumpCloudError> {
+        self.plan(kernel, None, None)
+    }
+
+    /// Plan one Discover page. Repeating this with each returned cursor visits
+    /// every configured group and every provider page in deterministic order.
+    pub(crate) fn plan_discover(
+        self,
+        kernel: &JumpCloudKernel,
+        prior_cursor: Option<&str>,
+    ) -> Result<JumpCloudRequest, JumpCloudError> {
+        self.plan(kernel, prior_cursor, None)
+    }
+
     pub(crate) fn decode(
         self,
         kernel: &JumpCloudKernel,
@@ -98,4 +169,52 @@ impl JumpCloudSourceExecutionAdapter {
         }
         kernel.decode(request, status, metadata, response_body)
     }
+
+    /// Convert decoded membership records into the exact Go Discover URNs.
+    fn page_discovery_urns(self, page: &JumpCloudPage) -> Result<Vec<String>, JumpCloudError> {
+        if self.family != JumpCloudFamily::GroupMembers {
+            return Err(JumpCloudError::RequestScopeMismatch);
+        }
+        let mut seen = BTreeSet::new();
+        let mut urns = Vec::new();
+        for record in &page.records {
+            if record.family != self.family {
+                return Err(JumpCloudError::RequestScopeMismatch);
+            }
+            let group_id = record
+                .attributes
+                .get("group_id")
+                .filter(|value| !value.trim().is_empty())
+                .ok_or(JumpCloudError::InvalidProviderRecord)?;
+            let member_id = record
+                .attributes
+                .get("member_id")
+                .filter(|value| !value.trim().is_empty())
+                .ok_or(JumpCloudError::InvalidProviderRecord)?;
+            let digest = Sha256::digest(format!("{}\0{}", group_id.trim(), member_id.trim()));
+            let stable_id = format!("id-{}", hex_prefix(&digest, 16));
+            let urn = format!(
+                "urn:cerebro:{}:jumpcloud_group_members:{stable_id}",
+                record.tenant_id
+            );
+            if seen.insert(urn.clone()) {
+                urns.push(urn);
+            }
+        }
+        Ok(urns)
+    }
+}
+
+fn hex_prefix(bytes: &[u8], count: usize) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    bytes
+        .iter()
+        .take(count)
+        .flat_map(|byte| {
+            [
+                char::from(HEX[usize::from(byte >> 4)]),
+                char::from(HEX[usize::from(byte & 0x0f)]),
+            ]
+        })
+        .collect()
 }

--- a/crates/source-runtime-next/src/jumpcloud/cursor.rs
+++ b/crates/source-runtime-next/src/jumpcloud/cursor.rs
@@ -1,0 +1,112 @@
+//! Go-compatible JumpCloud group-membership fanout continuations.
+
+use serde::{Deserialize, Serialize};
+
+use super::{JumpCloudError, request::validate_offset};
+
+pub(super) const MAX_GROUP_FANOUT: usize = 1_000;
+const MAX_CURSOR_BYTES: usize = 4_096;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) struct FanoutCursorState {
+    pub(super) index: usize,
+    pub(super) offset: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CursorEnvelope {
+    #[serde(default)]
+    version: u8,
+    #[serde(default)]
+    source: String,
+    #[serde(default)]
+    family: String,
+    #[serde(default)]
+    mode: String,
+    #[serde(default)]
+    token: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct FanoutCursor {
+    index: usize,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    cursor: String,
+}
+
+#[derive(Serialize)]
+struct EncodedEnvelope<'a> {
+    version: u8,
+    source: &'a str,
+    mode: &'a str,
+    token: String,
+}
+
+pub(super) fn parse_fanout_cursor(
+    group_count: usize,
+    raw: Option<&str>,
+) -> Result<FanoutCursorState, JumpCloudError> {
+    let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(FanoutCursorState::default());
+    };
+    validate_cursor_text(raw)?;
+    if !raw.starts_with('{') {
+        return Ok(FanoutCursorState {
+            offset: Some(validate_offset(raw)?),
+            ..FanoutCursorState::default()
+        });
+    }
+    let envelope: CursorEnvelope =
+        serde_json::from_str(raw).map_err(|_| JumpCloudError::InvalidCursor)?;
+    if envelope.version != 1
+        || envelope.source != "jumpcloud"
+        || (!envelope.family.is_empty() && envelope.family != "group_members")
+        || envelope.mode != "fanout_path_param"
+        || envelope.token.is_empty()
+    {
+        return Err(JumpCloudError::InvalidCursor);
+    }
+    let inner: FanoutCursor =
+        serde_json::from_str(&envelope.token).map_err(|_| JumpCloudError::InvalidCursor)?;
+    if inner.index >= group_count {
+        return Err(JumpCloudError::InvalidCursor);
+    }
+    Ok(FanoutCursorState {
+        index: inner.index,
+        offset: (!inner.cursor.is_empty())
+            .then(|| validate_offset(&inner.cursor))
+            .transpose()?,
+    })
+}
+
+pub(super) fn encode_fanout_cursor(
+    index: usize,
+    offset: Option<usize>,
+) -> Result<String, JumpCloudError> {
+    let token = serde_json::to_string(&FanoutCursor {
+        index,
+        cursor: offset.map(|value| value.to_string()).unwrap_or_default(),
+    })
+    .map_err(|_| JumpCloudError::InvalidCursor)?;
+    let opaque = serde_json::to_string(&EncodedEnvelope {
+        version: 1,
+        source: "jumpcloud",
+        mode: "fanout_path_param",
+        token,
+    })
+    .map_err(|_| JumpCloudError::InvalidCursor)?;
+    validate_cursor_text(&opaque)?;
+    Ok(opaque)
+}
+
+fn validate_cursor_text(raw: &str) -> Result<(), JumpCloudError> {
+    if raw.is_empty()
+        || raw.len() > MAX_CURSOR_BYTES
+        || raw.chars().any(char::is_control)
+        || raw.starts_with("http://")
+        || raw.starts_with("https://")
+    {
+        return Err(JumpCloudError::InvalidCursor);
+    }
+    Ok(())
+}

--- a/crates/source-runtime-next/src/jumpcloud/fanout_tests.rs
+++ b/crates/source-runtime-next/src/jumpcloud/fanout_tests.rs
@@ -1,0 +1,190 @@
+use super::*;
+
+#[test]
+fn aliases_are_ordered_deduplicated_bounded_and_path_safe() {
+    let filters = JumpCloudFilters::default().with_group_member_config(
+        Some(" group/a , group-b,group/a"),
+        Some("group-c,group-b"),
+        Some("group-d"),
+        Some("group-e"),
+    );
+    let fanout = JumpCloudKernel::new(
+        "https://console.jumpcloud.com/api",
+        "https://api.jumpcloud.com/insights/directory/v1",
+        "tenant",
+        JumpCloudFamily::GroupMembers,
+        filters,
+        Some(2),
+        "2026-06-01T00:00:00Z",
+    )
+    .unwrap();
+    assert_eq!(
+        fanout.filters.group_ids,
+        ["group/a", "group-b", "group-c", "group-d", "group-e"]
+    );
+    let request = fanout.plan(None).unwrap();
+    assert_eq!(request.group_id(), Some("group/a"));
+    assert!(
+        request
+            .url()
+            .as_str()
+            .contains("/usergroups/group%2Fa/members")
+    );
+
+    let too_many = (0..=cursor::MAX_GROUP_FANOUT)
+        .map(|index| format!("group-{index}"))
+        .collect::<Vec<_>>();
+    assert!(matches!(
+        JumpCloudKernel::new(
+            "https://console.jumpcloud.com/api",
+            "https://api.jumpcloud.com/insights/directory/v1",
+            "tenant",
+            JumpCloudFamily::GroupMembers,
+            JumpCloudFilters {
+                group_ids: too_many,
+                ..JumpCloudFilters::default()
+            },
+            Some(2),
+            "2026-06-01T00:00:00Z",
+        ),
+        Err(JumpCloudError::InvalidConfiguration("group_ids"))
+    ));
+}
+
+#[test]
+fn check_and_discover_match_go_fanout_restart_contract() {
+    let fanout = JumpCloudKernel::new(
+        "https://console.jumpcloud.com/api",
+        "https://api.jumpcloud.com/insights/directory/v1",
+        "tenant",
+        JumpCloudFamily::GroupMembers,
+        JumpCloudFilters::default().with_group_member_config(
+            Some("group-1, group-2, group-1"),
+            Some("group-3"),
+            None,
+            None,
+        ),
+        Some(2),
+        "2026-06-01T00:00:00Z",
+    )
+    .unwrap();
+    let adapter = adapter::JUMPCLOUD_SOURCE_EXECUTION_ADAPTERS[5];
+
+    let check = adapter.plan_check(&fanout).unwrap();
+    assert_eq!(check.group_id(), Some("group-1"));
+    assert_eq!(check.url().path(), "/api/v2/usergroups/group-1/members");
+    assert_eq!(
+        check
+            .url()
+            .query_pairs()
+            .find(|(key, _)| key == "skip")
+            .unwrap()
+            .1,
+        "0"
+    );
+
+    let mut discovery = adapter::JumpCloudGroupMemberDiscovery::default();
+    let first = adapter
+        .decode(
+            &fanout,
+            &check,
+            200,
+            &JumpCloudResponseMetadata::default(),
+            br#"[{"to":{"id":"user-1","type":"user"}},{"to":{"id":"user-2","type":"user"}}]"#,
+        )
+        .unwrap();
+    discovery.admit_page(adapter, &first).unwrap();
+    assert_eq!(
+        first.next_cursor.as_deref(),
+        Some(
+            r#"{"version":1,"source":"jumpcloud","mode":"fanout_path_param","token":"{\"index\":0,\"cursor\":\"2\"}"}"#
+        )
+    );
+
+    let second_request = adapter
+        .plan_discover(&fanout, first.next_cursor.as_deref())
+        .unwrap();
+    assert_eq!(second_request.group_id(), Some("group-1"));
+    assert_eq!(
+        second_request
+            .url()
+            .query_pairs()
+            .find(|(key, _)| key == "skip")
+            .unwrap()
+            .1,
+        "2"
+    );
+    let second = adapter
+        .decode(
+            &fanout,
+            &second_request,
+            200,
+            &JumpCloudResponseMetadata::default(),
+            br#"[{"to":{"id":"user-3","type":"user"}}]"#,
+        )
+        .unwrap();
+    discovery.admit_page(adapter, &second).unwrap();
+    assert_eq!(
+        second.next_cursor.as_deref(),
+        Some(
+            r#"{"version":1,"source":"jumpcloud","mode":"fanout_path_param","token":"{\"index\":1}"}"#
+        )
+    );
+
+    let third_request = adapter
+        .plan_discover(&fanout, second.next_cursor.as_deref())
+        .unwrap();
+    assert_eq!(third_request.group_id(), Some("group-2"));
+    let third = adapter
+        .decode(
+            &fanout,
+            &third_request,
+            200,
+            &JumpCloudResponseMetadata::default(),
+            br#"[]"#,
+        )
+        .unwrap();
+    discovery.admit_page(adapter, &third).unwrap();
+    assert_eq!(
+        third.next_cursor.as_deref(),
+        Some(
+            r#"{"version":1,"source":"jumpcloud","mode":"fanout_path_param","token":"{\"index\":2}"}"#
+        )
+    );
+
+    let fourth_request = adapter
+        .plan_discover(&fanout, third.next_cursor.as_deref())
+        .unwrap();
+    assert_eq!(fourth_request.group_id(), Some("group-3"));
+    let fourth = adapter
+        .decode(
+            &fanout,
+            &fourth_request,
+            200,
+            &JumpCloudResponseMetadata::default(),
+            br#"[{"to":{"id":"user-4","type":"user"}}]"#,
+        )
+        .unwrap();
+    discovery.admit_page(adapter, &fourth).unwrap();
+    assert_eq!(fourth.next_cursor, None);
+    assert_eq!(discovery.urns().len(), 4);
+    assert_eq!(
+        discovery.urns()[0],
+        "urn:cerebro:tenant:jumpcloud_group_members:id-3136bc9e0fb2e9df9ed3b7b56fd78448"
+    );
+
+    assert!(matches!(
+        fanout.plan(Some(
+            r#"{"version":1,"source":"other","mode":"fanout_path_param","token":"{\"index\":0}"}"#
+        )),
+        Err(JumpCloudError::InvalidCursor)
+    ));
+    assert!(matches!(
+        fanout.plan(Some(
+            r#"{"version":1,"source":"jumpcloud","mode":"fanout_path_param","token":"{\"index\":3}"}"#
+        )),
+        Err(JumpCloudError::InvalidCursor)
+    ));
+    let legacy = fanout.plan(Some("2")).unwrap();
+    assert_eq!(legacy.group_id(), Some("group-1"));
+}

--- a/crates/source-runtime-next/src/jumpcloud/identity.rs
+++ b/crates/source-runtime-next/src/jumpcloud/identity.rs
@@ -1,7 +1,7 @@
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 
-use super::{JumpCloudError, JumpCloudFamily, JumpCloudKernel};
+use super::{JumpCloudError, JumpCloudFamily, JumpCloudKernel, JumpCloudRequest};
 
 pub(super) struct Identity {
     pub(super) external_id: String,
@@ -11,6 +11,7 @@ pub(super) struct Identity {
 
 pub(super) fn material(
     kernel: &JumpCloudKernel,
+    request: &JumpCloudRequest,
     values: &Map<String, Value>,
     raw_bytes: Option<&[u8]>,
 ) -> Result<Identity, JumpCloudError> {
@@ -18,7 +19,7 @@ pub(super) fn material(
     let provider_id = if kernel.family == JumpCloudFamily::AuditEvents {
         external_id.clone()
     } else {
-        record_identity(kernel, values, &external_id)
+        record_identity(kernel, request, values, &external_id)
     };
     let event_id = if kernel.family == JumpCloudFamily::AuditEvents {
         sourcecdk_event_id(&[
@@ -29,7 +30,7 @@ pub(super) fn material(
             &provider_id,
         ])
     } else {
-        let path = resolved_path(kernel)?;
+        let path = resolved_path(kernel, request)?;
         jsonapi_event_id(
             &kernel.tenant_id,
             kernel.directory_origin.as_str().trim_end_matches('/'),
@@ -72,6 +73,7 @@ fn external_id(
 
 fn record_identity(
     kernel: &JumpCloudKernel,
+    request: &JumpCloudRequest,
     values: &Map<String, Value>,
     external_id: &str,
 ) -> String {
@@ -92,7 +94,7 @@ fn record_identity(
         "version",
     ]) {
         let value = if key == "group_id" {
-            kernel.filters.group_id.clone()
+            request.group_id.clone()
         } else {
             string_first(values, &[key])
         };
@@ -107,16 +109,21 @@ fn record_identity(
     format!("{}-{}", parts[0], hex_prefix(&digest, 12))
 }
 
-fn resolved_path(kernel: &JumpCloudKernel) -> Result<String, JumpCloudError> {
+fn resolved_path(
+    kernel: &JumpCloudKernel,
+    request: &JumpCloudRequest,
+) -> Result<String, JumpCloudError> {
     if kernel.family != JumpCloudFamily::GroupMembers {
         return Ok(kernel.family.path().to_owned());
     }
-    let group_id = kernel
-        .filters
-        .group_id
-        .as_deref()
-        .ok_or(JumpCloudError::MissingConfiguration("group_id"))?;
-    Ok(kernel.family.path().replace("{group_id}", group_id))
+    let base_path = kernel.directory_origin.path().trim_end_matches('/');
+    request
+        .url
+        .path()
+        .strip_prefix(base_path)
+        .map(str::to_owned)
+        .filter(|path| path.starts_with('/'))
+        .ok_or(JumpCloudError::RequestScopeMismatch)
 }
 
 fn jsonapi_event_id(

--- a/crates/source-runtime-next/src/jumpcloud/normalize.rs
+++ b/crates/source-runtime-next/src/jumpcloud/normalize.rs
@@ -4,12 +4,13 @@ use serde_json::{Map, Value};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use super::{
-    JumpCloudError, JumpCloudFamily, JumpCloudKernel, JumpCloudRecord, JumpCloudRuntimeDefinition,
-    identity,
+    JumpCloudError, JumpCloudFamily, JumpCloudKernel, JumpCloudRecord, JumpCloudRequest,
+    JumpCloudRuntimeDefinition, identity,
 };
 
 pub(super) fn normalize(
     kernel: &JumpCloudKernel,
+    request: &JumpCloudRequest,
     raw: Value,
     raw_bytes: Option<&[u8]>,
 ) -> Result<JumpCloudRecord, JumpCloudError> {
@@ -17,9 +18,10 @@ pub(super) fn normalize(
     let values = raw
         .as_object()
         .ok_or(JumpCloudError::InvalidProviderRecord)?;
-    let identity = identity::material(kernel, values, raw_bytes)?;
+    let identity = identity::material(kernel, request, values, raw_bytes)?;
     let occurred_at = occurred_at(kernel.family, values, &kernel.observed_at)?;
-    let (attributes, payload) = family_values(kernel, values, &identity.external_id)?;
+    let (attributes, payload) =
+        family_values(kernel, request.group_id(), values, &identity.external_id)?;
     validate_contract(kernel.family, &attributes, &payload)?;
     Ok(JumpCloudRecord {
         tenant_id: kernel.tenant_id.clone(),
@@ -36,6 +38,7 @@ pub(super) fn normalize(
 
 fn family_values(
     kernel: &JumpCloudKernel,
+    request_group_id: Option<&str>,
     values: &Map<String, Value>,
     external_id: &str,
 ) -> Result<(BTreeMap<String, String>, Value), JumpCloudError> {
@@ -199,11 +202,8 @@ fn family_values(
             attributes.insert("resource_type".to_owned(), resource_type.to_owned());
         }
         JumpCloudFamily::GroupMembers => {
-            let group_id = kernel
-                .filters
-                .group_id
-                .as_deref()
-                .ok_or(JumpCloudError::MissingConfiguration("group_id"))?;
+            let group_id =
+                request_group_id.ok_or(JumpCloudError::MissingConfiguration("group_id"))?;
             attributes.insert("group_id".to_owned(), group_id.to_owned());
             copy(&mut attributes, values, &["to.id", "id"], "member_id");
             copy(&mut attributes, values, &["to.id", "id"], "member_user_id");

--- a/crates/source-runtime-next/src/jumpcloud/request.rs
+++ b/crates/source-runtime-next/src/jumpcloud/request.rs
@@ -1,8 +1,12 @@
+use std::collections::BTreeSet;
+
 use serde_json::{Map, Value};
 use time::{Duration, OffsetDateTime, format_description::well_known::Rfc3339};
 
 use super::{
-    JumpCloudError, JumpCloudFamily, JumpCloudFilters, JumpCloudKernel, JumpCloudRequest, origin,
+    JumpCloudError, JumpCloudFamily, JumpCloudFilters, JumpCloudKernel, JumpCloudRequest,
+    cursor::{MAX_GROUP_FANOUT, parse_fanout_cursor},
+    origin,
 };
 
 const MAX_CURSOR_BYTES: usize = 4_096;
@@ -59,35 +63,66 @@ pub(super) fn plan_with_checkpoint(
     } else {
         &kernel.directory_origin
     };
-    let path = if kernel.family == JumpCloudFamily::GroupMembers {
-        let group_id = kernel
-            .filters
-            .group_id
-            .as_deref()
-            .ok_or(JumpCloudError::MissingConfiguration("group_id"))?;
-        kernel.family.path().replace("{group_id}", group_id)
-    } else {
-        kernel.family.path().to_owned()
-    };
+    let input_cursor = cursor.map(str::to_owned);
+    let (fanout_index, group_id, provider_cursor) =
+        if kernel.family == JumpCloudFamily::GroupMembers {
+            let state = parse_fanout_cursor(kernel.filters.group_ids.len(), cursor)?;
+            let group_id = kernel
+                .filters
+                .group_ids
+                .get(state.index)
+                .cloned()
+                .ok_or(JumpCloudError::InvalidCursor)?;
+            (
+                Some(state.index),
+                Some(group_id),
+                state.offset.map(|offset| offset.to_string()),
+            )
+        } else {
+            (None, None, cursor.map(str::to_owned))
+        };
     let mut url = origin.clone();
-    url.set_path(&format!("{}{}", origin.path().trim_end_matches('/'), path));
+    if let Some(group_id) = group_id.as_deref() {
+        let mut segments = url
+            .path_segments_mut()
+            .map_err(|_| JumpCloudError::InvalidOrigin)?;
+        segments
+            .pop_if_empty()
+            .push("v2")
+            .push("usergroups")
+            .push(group_id)
+            .push("members");
+    } else {
+        url.set_path(&format!(
+            "{}{}",
+            origin.path().trim_end_matches('/'),
+            kernel.family.path()
+        ));
+    }
     if url.origin() != origin.origin() {
         return Err(JumpCloudError::InvalidOrigin);
     }
     let (cursor, body) = if kernel.family == JumpCloudFamily::AuditEvents {
-        let cursor = cursor.map(validate_audit_cursor).transpose()?;
+        let cursor = provider_cursor
+            .as_deref()
+            .map(validate_audit_cursor)
+            .transpose()?;
         (
             cursor.clone(),
             Some(audit_body(kernel, cursor.as_deref(), prior_watermark)?),
         )
     } else {
-        let offset = cursor.map(validate_offset).transpose()?.unwrap_or(0);
+        let offset = provider_cursor
+            .as_deref()
+            .map(validate_offset)
+            .transpose()?
+            .unwrap_or(0);
         {
             let mut query = url.query_pairs_mut();
             query.append_pair("limit", &kernel.page_size.to_string());
             query.append_pair("skip", &offset.to_string());
         }
-        (cursor.map(str::to_owned), None)
+        (provider_cursor, None)
     };
     Ok(JumpCloudRequest {
         family: kernel.family,
@@ -95,6 +130,9 @@ pub(super) fn plan_with_checkpoint(
         method: kernel.family.method(),
         page_size: kernel.page_size,
         cursor,
+        input_cursor,
+        fanout_index,
+        group_id,
         body,
         org_id: kernel.filters.org_id.clone(),
         checkpoint_watermark: prior_watermark.map(normalize_watermark).transpose()?,
@@ -108,7 +146,7 @@ pub(super) fn validate_request(
     if request
         != &plan_with_checkpoint(
             kernel,
-            request.cursor.as_deref(),
+            request.input_cursor.as_deref(),
             request.checkpoint_watermark.as_deref(),
         )?
     {
@@ -146,11 +184,39 @@ fn validate_filters(
     family: JumpCloudFamily,
     filters: &mut JumpCloudFilters,
 ) -> Result<(), JumpCloudError> {
-    for value in [&filters.org_id, &filters.group_id].into_iter().flatten() {
+    if let Some(value) = &filters.org_id {
         origin::bounded(value, 256).ok_or(JumpCloudError::InvalidConfiguration("scope"))?;
     }
-    if family == JumpCloudFamily::GroupMembers && filters.group_id.is_none() {
-        return Err(JumpCloudError::MissingConfiguration("group_id"));
+    if family == JumpCloudFamily::GroupMembers {
+        let singular = filters.group_id.iter().map(String::as_str);
+        let mut seen = BTreeSet::new();
+        let mut group_ids = Vec::new();
+        for value in filters
+            .group_ids
+            .iter()
+            .map(String::as_str)
+            .chain(singular)
+            .flat_map(|value| value.split(','))
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            if value.len() > 256 || value.chars().any(char::is_control) {
+                return Err(JumpCloudError::InvalidConfiguration("group_ids"));
+            }
+            if seen.insert(value.to_owned()) {
+                group_ids.push(value.to_owned());
+                if group_ids.len() > MAX_GROUP_FANOUT {
+                    return Err(JumpCloudError::InvalidConfiguration("group_ids"));
+                }
+            }
+        }
+        if group_ids.is_empty() {
+            return Err(JumpCloudError::MissingConfiguration("group_ids"));
+        }
+        filters.group_id = group_ids.first().cloned();
+        filters.group_ids = group_ids;
+    } else if let Some(value) = &filters.group_id {
+        origin::bounded(value, 256).ok_or(JumpCloudError::InvalidConfiguration("scope"))?;
     }
     for value in [&filters.audit_start_time, &filters.audit_end_time]
         .into_iter()

--- a/crates/source-runtime-next/src/jumpcloud/response.rs
+++ b/crates/source-runtime-next/src/jumpcloud/response.rs
@@ -5,7 +5,9 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use super::{
     JumpCloudCheckpointCandidate, JumpCloudError, JumpCloudFamily, JumpCloudKernel, JumpCloudPage,
-    JumpCloudRequest, JumpCloudResponseMetadata, normalize,
+    JumpCloudRequest, JumpCloudResponseMetadata,
+    cursor::encode_fanout_cursor,
+    normalize,
     request::{validate_audit_cursor, validate_offset, validate_request},
 };
 
@@ -44,7 +46,7 @@ pub(super) fn decode(
         let raw_bytes = audit_rows
             .as_ref()
             .and_then(|rows| rows.get(index).copied());
-        let record = normalize::normalize(kernel, raw.clone(), raw_bytes)?;
+        let record = normalize::normalize(kernel, request, raw.clone(), raw_bytes)?;
         let canonical = serde_json::to_vec(&record.payload)
             .map_err(|_| JumpCloudError::InvalidProviderRecord)?;
         match seen.get(&record.event_id) {
@@ -56,7 +58,7 @@ pub(super) fn decode(
             }
         }
     }
-    let next_cursor = next_cursor(kernel.family, request, metadata, &root, items.len())?;
+    let next_cursor = next_cursor(kernel, request, metadata, &root, items.len())?;
     Ok(JumpCloudPage {
         records: normalized,
         next_cursor,
@@ -187,13 +189,14 @@ fn records(family: JumpCloudFamily, root: &Value) -> Result<&[Value], JumpCloudE
 }
 
 fn next_cursor(
-    family: JumpCloudFamily,
+    kernel: &JumpCloudKernel,
     request: &JumpCloudRequest,
     metadata: &JumpCloudResponseMetadata,
     root: &Value,
     raw_count: usize,
 ) -> Result<Option<String>, JumpCloudError> {
-    let next = if family == JumpCloudFamily::AuditEvents {
+    let family = kernel.family;
+    let provider_next = if family == JumpCloudFamily::AuditEvents {
         let limit = metadata.limit.unwrap_or(request.page_size);
         match (metadata.result_count, metadata.search_after.as_deref()) {
             (Some(count), Some(cursor)) if limit > 0 && count >= limit => {
@@ -218,10 +221,23 @@ fn next_cursor(
         let more = total.map_or(raw_count == request.page_size, |total| candidate < total);
         (more && raw_count > 0).then(|| candidate.to_string())
     };
-    if next.is_some() && next == request.cursor {
+    if provider_next.is_some() && provider_next == request.cursor {
         return Err(JumpCloudError::InvalidCursor);
     }
-    Ok(next)
+    if family != JumpCloudFamily::GroupMembers {
+        return Ok(provider_next);
+    }
+    let index = request
+        .fanout_index
+        .ok_or(JumpCloudError::RequestScopeMismatch)?;
+    if let Some(offset) = provider_next {
+        return encode_fanout_cursor(index, Some(validate_offset(&offset)?)).map(Some);
+    }
+    let next_index = index.checked_add(1).ok_or(JumpCloudError::InvalidCursor)?;
+    if next_index < kernel.filters.group_ids.len() {
+        return encode_fanout_cursor(next_index, None).map(Some);
+    }
+    Ok(None)
 }
 
 fn classify_status(status: u16, retry_after_seconds: Option<u64>) -> Result<(), JumpCloudError> {

--- a/crates/source-runtime-next/src/jumpcloud/tests.rs
+++ b/crates/source-runtime-next/src/jumpcloud/tests.rs
@@ -467,6 +467,24 @@ fn provider_local_source_execution_contract_covers_all_seven_families() {
             contract.response_cursor_header,
             audit.then_some("X-Search_after")
         );
+        let fanout = adapter.family() == JumpCloudFamily::GroupMembers;
+        assert_eq!(
+            contract.check_scope,
+            if fanout {
+                "first_configured_group"
+            } else {
+                "family_endpoint"
+            }
+        );
+        assert_eq!(
+            contract.discover_scope,
+            if fanout {
+                "all_configured_groups"
+            } else {
+                "family_endpoint"
+            }
+        );
+        assert_eq!(contract.max_fanout_scopes, fanout.then_some(1_000));
         assert_eq!(
             contract.origin,
             if audit {

--- a/crates/source-runtime-next/src/jumpcloud/types.rs
+++ b/crates/source-runtime-next/src/jumpcloud/types.rs
@@ -12,6 +12,8 @@ pub struct JumpCloudFilters {
     pub org_id: Option<String>,
     /// User group selected for a membership page.
     pub group_id: Option<String>,
+    /// Ordered user-group fanout configured through plural or singular aliases.
+    pub group_ids: Vec<String>,
     /// Directory Insights lower time bound.
     pub audit_start_time: Option<String>,
     /// Optional Directory Insights upper time bound.
@@ -22,6 +24,33 @@ pub struct JumpCloudFilters {
     pub audit_sort: Option<String>,
 }
 
+impl JumpCloudFilters {
+    /// Apply Go-compatible group-member aliases in their production precedence.
+    ///
+    /// Values are normalized, deduplicated, and bounded when the kernel is
+    /// constructed; keeping alias parsing here lets the shared bridge remain
+    /// provider-neutral.
+    #[must_use]
+    pub fn with_group_member_config(
+        mut self,
+        group_ids: Option<&str>,
+        user_group_ids: Option<&str>,
+        group_id: Option<&str>,
+        user_group_id: Option<&str>,
+    ) -> Self {
+        self.group_ids.extend(
+            [group_ids, user_group_ids, group_id, user_group_id]
+                .into_iter()
+                .flatten()
+                .flat_map(|value| value.split(','))
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned),
+        );
+        self
+    }
+}
+
 /// Credential-free request intent for the trusted JumpCloud HTTP host.
 #[derive(Clone, Eq, PartialEq)]
 pub struct JumpCloudRequest {
@@ -30,6 +59,9 @@ pub struct JumpCloudRequest {
     pub(super) method: &'static str,
     pub(super) page_size: usize,
     pub(super) cursor: Option<String>,
+    pub(super) input_cursor: Option<String>,
+    pub(super) fanout_index: Option<usize>,
+    pub(super) group_id: Option<String>,
     pub(super) body: Option<Vec<u8>>,
     pub(super) org_id: Option<String>,
     pub(super) checkpoint_watermark: Option<String>,
@@ -44,6 +76,7 @@ impl fmt::Debug for JumpCloudRequest {
             .field("method", &self.method)
             .field("page_size", &self.page_size)
             .field("has_cursor", &self.cursor.is_some())
+            .field("has_fanout", &self.fanout_index.is_some())
             .field("has_body", &self.body.is_some())
             .field("has_org_id", &self.org_id.is_some())
             .field(
@@ -86,6 +119,10 @@ impl JumpCloudRequest {
     /// Prior terminal audit watermark bound into this request, when present.
     pub fn checkpoint_watermark(&self) -> Option<&str> {
         self.checkpoint_watermark.as_deref()
+    }
+    /// Request-bound group scope for membership fanout.
+    pub fn group_id(&self) -> Option<&str> {
+        self.group_id.as_deref()
     }
     /// Request media type required by the trusted host.
     pub const fn content_type(&self) -> Option<&'static str> {


### PR DESCRIPTION
## Scope

- accept plural and singular group aliases with ordered deduplication and bounded fanout
- preserve nested provider pagination with versioned fanout cursor restart semantics
- bind membership identity and normalization to the request-selected group
- expose provider-local first-group Check and all-group Discover contracts
- keep Go source authority and shared runtime registration unchanged

## Local validation

- cargo fmt --all -- --check
- cargo test -p cerebro-source-runtime-next jumpcloud --lib (12 passed)
- cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings
- cargo test -p cerebro-source-runtime-next --lib (525 passed before the test-only file split; focused suite rerun after split)
- cargo test -p cerebro-source-catalog (24 passed)
- go test ./sources/jumpcloud ./sources/internal/jumpcloudapi ./internal/sourceprojection -count=1
- make fixture-oracle-check source-fixture-check sourcegen-check
- make check-structural check-structural-test check-arch
- scripts/leak_check.sh staged
- scripts/leak_check.sh range origin/main...HEAD

DDESK status was ready, but doctor could not complete the SSH banner exchange after an explicit start. The Rust checks above ran through the repository-managed local Cargo wrapper; hosted checks remain required.

## Remaining boundary

The provider-neutral shared bridge must consume the plural alias and Check/Discover API in a separate non-provider diff. The current Go JumpCloud loader remains authoritative until that integration and production parity gates pass.