### PR TITLE
JumpCloud: probe plural runtime bridge configuration

### DIFF
--- a/crates/source-runtime-next/src/jumpcloud/fanout_tests.rs
+++ b/crates/source-runtime-next/src/jumpcloud/fanout_tests.rs
@@ -1,4 +1,52 @@
 use super::*;
+use std::collections::HashMap;
+
+#[test]
+fn public_runtime_metadata_consumes_all_group_aliases_without_credentials() {
+    let public_config = HashMap::from([
+        (
+            "group_ids".to_owned(),
+            "group-1, group-2, group-1".to_owned(),
+        ),
+        ("user_group_ids".to_owned(), "group-3".to_owned()),
+        ("group_id".to_owned(), "group-4".to_owned()),
+        ("user_group_id".to_owned(), "group-5".to_owned()),
+    ]);
+    let kernel = JumpCloudKernel::new(
+        "https://console.jumpcloud.com/api",
+        "https://api.jumpcloud.com/insights/directory/v1",
+        "tenant",
+        JumpCloudFamily::GroupMembers,
+        JumpCloudFilters::default().with_group_member_public_config(&public_config),
+        Some(2),
+        "2026-06-01T00:00:00Z",
+    )
+    .unwrap();
+    assert_eq!(
+        kernel.filters.group_ids,
+        ["group-1", "group-2", "group-3", "group-4", "group-5"]
+    );
+
+    let adapter = adapter::JUMPCLOUD_SOURCE_EXECUTION_ADAPTERS[5];
+    let check = adapter.plan_check(&kernel).unwrap();
+    assert_eq!(check.group_id(), Some("group-1"));
+    assert!(!check.contains_credentials());
+
+    let terminal_first_group = adapter
+        .decode(
+            &kernel,
+            &check,
+            200,
+            &JumpCloudResponseMetadata::default(),
+            br#"[]"#,
+        )
+        .unwrap();
+    let second_group = adapter
+        .plan_discover(&kernel, terminal_first_group.next_cursor.as_deref())
+        .unwrap();
+    assert_eq!(second_group.group_id(), Some("group-2"));
+    assert!(!second_group.contains_credentials());
+}
 
 #[test]
 fn aliases_are_ordered_deduplicated_bounded_and_path_safe() {

--- a/crates/source-runtime-next/src/jumpcloud/types.rs
+++ b/crates/source-runtime-next/src/jumpcloud/types.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeMap, fmt};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt,
+};
 
 use reqwest::Url;
 use serde_json::Value;
@@ -25,6 +28,20 @@ pub struct JumpCloudFilters {
 }
 
 impl JumpCloudFilters {
+    /// Apply the public runtime metadata keys accepted by the trusted bridge.
+    ///
+    /// This keeps alias precedence provider-owned while allowing a shared host
+    /// to pass its credential-free public configuration through unchanged.
+    #[must_use]
+    pub fn with_group_member_public_config(self, public_config: &HashMap<String, String>) -> Self {
+        self.with_group_member_config(
+            public_config.get("group_ids").map(String::as_str),
+            public_config.get("user_group_ids").map(String::as_str),
+            public_config.get("group_id").map(String::as_str),
+            public_config.get("user_group_id").map(String::as_str),
+        )
+    }
+
     /// Apply Go-compatible group-member aliases in their production precedence.
     ///
     /// Values are normalized, deduplicated, and bounded when the kernel is


### PR DESCRIPTION
## Scope

- expose a provider-local adapter from credential-free public runtime metadata to the four supported group aliases
- prove ordered deduplication, first-group Check, next-group Discover, and credential-free request plans
- leave shared source-execution paths and Go authority unchanged

## Available local validation

- rustfmt --edition 2024 --check on both changed Rust files
- git diff --check
- scripts/leak_check.sh staged
- scripts/leak_check.sh range origin/main...HEAD

## Unrun validation

The managed Cargo wrapper blocked before compilation with RC75 because safe build capacity was short by 4,036,696,678 bytes. DDESK status is ready, but doctor did not return and was interrupted with RC130. The focused Rust test and Clippy are not claimed as passing. Current main also has a separately owned shared compile defect: source_execution/jumpcloud.rs omits the landed group_ids field. The shared-runtime owner has that exact forward repair; hosted checks on this draft are expected to remain red until it lands.

This PR does not delete the Go JumpCloud loader or claim production Check/Discover authority.