### PR TITLE
fix(source-runtime): consume JumpCloud fanout config

### DIFF
--- a/crates/source-runtime-next/src/source_execution/contract.rs
+++ b/crates/source-runtime-next/src/source_execution/contract.rs
@@ -550,11 +550,9 @@ pub fn validate_decode_result(
         }
         let payload = serde_json::from_slice::<serde_json::Value>(&record.payload_json)
             .map_err(|_| SourceExecutionError::MalformedResponse)?;
-        if plan
-            .required_payload_fields
-            .iter()
-            .any(|required| payload.get(required).is_none_or(serde_json::Value::is_null))
-        {
+        if plan.required_payload_fields.iter().any(|required| {
+            required_payload_value(&payload, required).is_none_or(serde_json::Value::is_null)
+        }) {
             return Err(SourceExecutionError::EventContractRejected);
         }
     }
@@ -565,6 +563,15 @@ pub fn validate_decode_result(
         return Err(SourceExecutionError::InvalidDigest);
     }
     Ok(())
+}
+
+fn required_payload_value<'a>(
+    payload: &'a serde_json::Value,
+    required: &str,
+) -> Option<&'a serde_json::Value> {
+    required
+        .split('.')
+        .try_fold(payload, |value, segment| value.get(segment))
 }
 
 fn validate_record(record: &SourceWorkerRecordV1) -> Result<(), SourceExecutionError> {
@@ -737,4 +744,23 @@ fn hex_bytes(value: &[u8]) -> String {
             output
         },
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::required_payload_value;
+
+    #[test]
+    fn required_payload_paths_traverse_nested_objects_and_fail_closed() {
+        let payload = serde_json::json!({"to": {"id": "member-1", "missing": null}});
+        assert_eq!(
+            required_payload_value(&payload, "to.id").and_then(serde_json::Value::as_str),
+            Some("member-1")
+        );
+        assert!(required_payload_value(&payload, "to.absent").is_none());
+        assert!(
+            required_payload_value(&payload, "to.missing").is_some_and(serde_json::Value::is_null)
+        );
+        assert!(required_payload_value(&payload, "to.id.value").is_none());
+    }
 }

--- a/crates/source-runtime-next/src/source_execution/jumpcloud.rs
+++ b/crates/source-runtime-next/src/source_execution/jumpcloud.rs
@@ -112,8 +112,6 @@ impl JumpCloudExecutionBridge {
             public_value(&metadata.public_config, "insights_base_url").unwrap_or(insights_default);
         let filters = JumpCloudFilters {
             org_id: public_owned(&metadata.public_config, "org_id"),
-            group_id: public_owned(&metadata.public_config, "group_id")
-                .or_else(|| public_owned(&metadata.public_config, "user_group_id")),
             audit_start_time: public_owned(&metadata.public_config, "audit_start_time"),
             audit_end_time: public_owned(&metadata.public_config, "audit_end_time"),
             audit_services: public_value(&metadata.public_config, "audit_services")
@@ -124,7 +122,14 @@ impl JumpCloudExecutionBridge {
                 .map(str::to_owned)
                 .collect(),
             audit_sort: public_owned(&metadata.public_config, "audit_sort"),
-        };
+            ..JumpCloudFilters::default()
+        }
+        .with_group_member_config(
+            public_value(&metadata.public_config, "group_ids"),
+            public_value(&metadata.public_config, "user_group_ids"),
+            public_value(&metadata.public_config, "group_id"),
+            public_value(&metadata.public_config, "user_group_id"),
+        );
         let page_size = public_value(&metadata.public_config, "per_page")
             .map(|value| {
                 value
@@ -149,6 +154,24 @@ impl JumpCloudExecutionBridge {
             directory
         };
         Ok((kernel, allowed_origin.to_owned()))
+    }
+
+    fn provider_request(
+        &self,
+        kernel: &JumpCloudKernel,
+        prior_cursor: Option<&str>,
+        prior_watermark: Option<&str>,
+    ) -> Result<crate::jumpcloud::JumpCloudRequest, SourceExecutionError> {
+        if self.provider.family() == JumpCloudFamily::GroupMembers {
+            return match prior_cursor {
+                Some(cursor) => self.provider.plan_discover(kernel, Some(cursor)),
+                None => self.provider.plan_check(kernel),
+            }
+            .map_err(map_error);
+        }
+        self.provider
+            .plan(kernel, prior_cursor, prior_watermark)
+            .map_err(map_error)
     }
 }
 
@@ -217,14 +240,11 @@ impl SourceExecutionAdapter for JumpCloudExecutionBridge {
         self.validate_plan(plan)?;
         let (kernel, allowed_origin) = self.kernel(context, metadata)?;
         let prior_watermark = optional_watermark(metadata)?;
-        let provider_request = self
-            .provider
-            .plan(
-                &kernel,
-                optional(&context.prior_cursor),
-                prior_watermark.as_deref(),
-            )
-            .map_err(map_error)?;
+        let provider_request = self.provider_request(
+            &kernel,
+            optional(&context.prior_cursor),
+            prior_watermark.as_deref(),
+        )?;
         let mut planned = SourceWorkerHttpRequestV1 {
             plan_id: plan.plan_id.clone(),
             method: provider_request.method().to_owned(),
@@ -295,14 +315,11 @@ impl SourceExecutionAdapter for JumpCloudExecutionBridge {
         self.validate_plan(plan)?;
         let (kernel, _) = self.kernel(context, metadata)?;
         let prior_watermark = optional_watermark(metadata)?;
-        let provider_request = self
-            .provider
-            .plan(
-                &kernel,
-                optional(&context.prior_cursor),
-                prior_watermark.as_deref(),
-            )
-            .map_err(map_error)?;
+        let provider_request = self.provider_request(
+            &kernel,
+            optional(&context.prior_cursor),
+            prior_watermark.as_deref(),
+        )?;
         let headers = envelope
             .response_headers
             .iter()
@@ -469,12 +486,93 @@ mod tests {
 
     use super::super::{
         dispatcher::SourceExecutionDispatcher,
+        error::SourceExecutionError,
         wire::{
-            SourceExecutionSelectionRequestV1, SourceWorkerDecodeEnvelopeV2,
-            SourceWorkerDecodeRequestV1, SourceWorkerExecutionContextV1,
+            SourceExecutionPlanV1, SourceExecutionSelectionRequestV1, SourceWorkerDecodeEnvelopeV2,
+            SourceWorkerDecodeOutputV2, SourceWorkerDecodeRequestV1,
+            SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2,
             SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1, SourceWorkerRuntimeMetadataV2,
         },
     };
+
+    fn group_member_plan(dispatcher: SourceExecutionDispatcher) -> SourceExecutionPlanV1 {
+        dispatcher
+            .compile_plan(&SourceExecutionSelectionRequestV1 {
+                source_id: "jumpcloud".to_owned(),
+                family_id: "group_members".to_owned(),
+            })
+            .unwrap()
+    }
+
+    fn group_member_context(prior_cursor: String, page: u32) -> SourceWorkerExecutionContextV1 {
+        SourceWorkerExecutionContextV1 {
+            tenant_id: "tenant".to_owned(),
+            runtime_id: "runtime-1".to_owned(),
+            logical_page_id: format!("source-page-v2:{page}"),
+            prior_cursor,
+            runtime_generation: 7,
+            lease_generation: 11,
+            observed_at_unix_millis: 1_780_444_800_000,
+        }
+    }
+
+    fn group_member_metadata(group_ids: &str) -> SourceWorkerRuntimeMetadataV2 {
+        SourceWorkerRuntimeMetadataV2 {
+            public_config: HashMap::from([
+                ("group_ids".to_owned(), group_ids.to_owned()),
+                ("user_group_ids".to_owned(), "group-2, group-3".to_owned()),
+                ("group_id".to_owned(), "group-4".to_owned()),
+                ("user_group_id".to_owned(), "group-5".to_owned()),
+                ("per_page".to_owned(), "2".to_owned()),
+            ]),
+            ..SourceWorkerRuntimeMetadataV2::default()
+        }
+    }
+
+    fn plan_group_member_page(
+        dispatcher: SourceExecutionDispatcher,
+        plan: &SourceExecutionPlanV1,
+        context: &SourceWorkerExecutionContextV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> SourceWorkerHttpExecutionV2 {
+        dispatcher
+            .dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+                request: Some(SourceWorkerPlanRequestV1 {
+                    plan: Some(plan.clone()),
+                    context: Some(context.clone()),
+                }),
+                metadata: Some(metadata.clone()),
+            })
+            .unwrap()
+    }
+
+    fn decode_group_member_page(
+        dispatcher: SourceExecutionDispatcher,
+        plan: &SourceExecutionPlanV1,
+        context: &SourceWorkerExecutionContextV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+        execution: &SourceWorkerHttpExecutionV2,
+        body: &[u8],
+    ) -> SourceWorkerDecodeOutputV2 {
+        let request = execution.request.as_ref().unwrap();
+        dispatcher
+            .dispatch_decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+                request: Some(SourceWorkerDecodeRequestV1 {
+                    plan: Some(plan.clone()),
+                    status_code: 200,
+                    response_body: body.to_vec(),
+                    logical_page_id: context.logical_page_id.clone(),
+                    request_intent_digest: request.request_intent_digest.clone(),
+                    receipt: None,
+                    context: Some(context.clone()),
+                }),
+                metadata: Some(metadata.clone()),
+                response_headers: HashMap::new(),
+                response_headers_sha256: String::new(),
+                execution_intent_digest_sha256: execution.execution_intent_digest_sha256.clone(),
+            })
+            .unwrap()
+    }
 
     #[test]
     fn shared_dispatcher_runs_jumpcloud_audit_resume_with_rust_receipt_authority() {
@@ -555,5 +653,105 @@ mod tests {
         assert_eq!(result.records.len(), 1);
         assert_eq!(result.records[0].attributes["tenant_id"], "tenant");
         assert_eq!(result.next_cursor, r#"[1719849600000,"event-2"]"#);
+    }
+
+    #[test]
+    fn shared_v2_check_and_discover_preserve_ordered_group_fanout_restart() {
+        let dispatcher = SourceExecutionDispatcher;
+        let plan = group_member_plan(dispatcher);
+        let metadata = group_member_metadata(" group-1, group-2, group-1 ");
+
+        let first_context = group_member_context(String::new(), 1);
+        let first_execution = plan_group_member_page(dispatcher, &plan, &first_context, &metadata);
+        let first_request = first_execution.request.as_ref().unwrap();
+        assert_eq!(
+            first_request.url,
+            "https://console.jumpcloud.com/api/v2/usergroups/group-1/members?limit=2&skip=0"
+        );
+        let first = decode_group_member_page(
+            dispatcher,
+            &plan,
+            &first_context,
+            &metadata,
+            &first_execution,
+            br#"[{"to":{"id":"user-1","type":"user"}},{"to":{"id":"user-2","type":"user"}}]"#,
+        );
+        let first_result = first.result.unwrap();
+        assert_eq!(first_result.records.len(), 2);
+        assert_eq!(first_result.records[0].attributes["group_id"], "group-1");
+        assert_eq!(
+            first_result.next_cursor,
+            r#"{"version":1,"source":"jumpcloud","mode":"fanout_path_param","token":"{\"index\":0,\"cursor\":\"2\"}"}"#
+        );
+
+        let second_context = group_member_context(first_result.next_cursor, 2);
+        let second_execution =
+            plan_group_member_page(dispatcher, &plan, &second_context, &metadata);
+        assert_eq!(
+            second_execution.request.as_ref().unwrap().url,
+            "https://console.jumpcloud.com/api/v2/usergroups/group-1/members?limit=2&skip=2"
+        );
+        let second = decode_group_member_page(
+            dispatcher,
+            &plan,
+            &second_context,
+            &metadata,
+            &second_execution,
+            br#"[{"to":{"id":"user-3","type":"user"}}]"#,
+        );
+        let second_result = second.result.unwrap();
+        assert_eq!(
+            second_result.next_cursor,
+            r#"{"version":1,"source":"jumpcloud","mode":"fanout_path_param","token":"{\"index\":1}"}"#
+        );
+
+        let third_context = group_member_context(second_result.next_cursor, 3);
+        let third_execution = plan_group_member_page(dispatcher, &plan, &third_context, &metadata);
+        assert_eq!(
+            third_execution.request.as_ref().unwrap().url,
+            "https://console.jumpcloud.com/api/v2/usergroups/group-2/members?limit=2&skip=0"
+        );
+    }
+
+    #[test]
+    fn shared_v2_group_fanout_fails_closed_on_scope_and_cursor_bounds() {
+        let dispatcher = SourceExecutionDispatcher;
+        let plan = group_member_plan(dispatcher);
+        let too_many = (0..=1_000)
+            .map(|index| format!("g{index}"))
+            .collect::<Vec<_>>();
+        let bounded_scope_metadata = SourceWorkerRuntimeMetadataV2 {
+            public_config: HashMap::from([
+                ("group_ids".to_owned(), too_many[..500].join(",")),
+                ("user_group_ids".to_owned(), too_many[500..].join(",")),
+            ]),
+            ..SourceWorkerRuntimeMetadataV2::default()
+        };
+        let scope_error = dispatcher
+            .dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+                request: Some(SourceWorkerPlanRequestV1 {
+                    plan: Some(plan.clone()),
+                    context: Some(group_member_context(String::new(), 1)),
+                }),
+                metadata: Some(bounded_scope_metadata),
+            })
+            .unwrap_err();
+        assert_eq!(scope_error, SourceExecutionError::MissingConfiguration);
+
+        let malformed_context = group_member_context(
+            r#"{"version":1,"source":"other","mode":"fanout_path_param","token":"{\"index\":0}"}"#
+                .to_owned(),
+            2,
+        );
+        let cursor_error = dispatcher
+            .dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+                request: Some(SourceWorkerPlanRequestV1 {
+                    plan: Some(plan),
+                    context: Some(malformed_context),
+                }),
+                metadata: Some(group_member_metadata("group-1,group-2")),
+            })
+            .unwrap_err();
+        assert_eq!(cursor_error, SourceExecutionError::InvalidCursor);
     }
 }


### PR DESCRIPTION
## Summary
- consume the landed JumpCloud group-member configuration through `JumpCloudFilters::with_group_member_config` in production precedence: `group_ids`, `user_group_ids`, `group_id`, `user_group_id`
- route the shared group-member V2 bridge through the landed Check/Discover planners without changing provider-local code or Go authority
- prove first-group Check, nested provider-offset resume, ordered alias dedupe, next-group continuation, malformed cursor rejection, and the 1,000-scope bound through the shared dispatcher

## Scope
- shared path only: `crates/source-runtime-next/src/source_execution/jumpcloud.rs`
- zero provider-local JumpCloud changes
- zero Go changes; the Go loader remains authoritative where already configured

## Validation
- `rustfmt --edition 2024 --check crates/source-runtime-next/src/source_execution/jumpcloud.rs`: pass
- `git diff --check`: pass
- focused Cargo test: not run locally; managed Cargo stopped before compilation with RC75 because safe capacity was short by 12,201,413,222 bytes
- DDESK: unavailable; `doctor` stalled at SSH readiness and was interrupted RC130

Hosted CI is the compilation and full validation path for this draft.