### PR TITLE
source-runtime-next: add Aha provider kernel

### DIFF
--- a/crates/source-runtime-next/src/aha.rs
+++ b/crates/source-runtime-next/src/aha.rs
@@ -1,0 +1,25 @@
+//! Credential-free Aha! request, normalization, and projection kernel.
+//!
+//! The trusted host owns credential-reference resolution, bearer
+//! authentication, redirects, deadlines, and bounded network I/O. The generic
+//! Rust catalog connector remains collection authority until this provider
+//! kernel is wired through the shared credential host.
+
+mod catalog;
+mod error;
+mod family;
+mod normalize;
+mod origin;
+mod projection;
+mod request;
+mod response;
+mod types;
+
+pub use catalog::{AhaEventContract, AhaRuntimeDefinition};
+pub use error::AhaError;
+pub use family::AhaFamily;
+pub use projection::{AhaEntityFact, AhaProjectionFacts, project_aha_records};
+pub use types::{AhaCheckpointCandidate, AhaKernel, AhaPage, AhaRecord, AhaRequest};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/aha/catalog.rs
+++ b/crates/source-runtime-next/src/aha/catalog.rs
@@ -1,0 +1,44 @@
+use super::{AhaError, AhaFamily};
+
+/// Exact event contract compiled from the Aha catalog.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AhaEventContract {
+    /// Exact provider event kind.
+    pub kind: &'static str,
+    /// Exact schema reference.
+    pub schema_ref: &'static str,
+    /// Required normalized attributes.
+    pub required_attributes: &'static [&'static str],
+    /// Required normalized payload fields.
+    pub required_payload_fields: &'static [&'static str],
+}
+
+/// Closed runtime definition for one Aha family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AhaRuntimeDefinition {
+    /// Source identifier.
+    pub source_id: &'static str,
+    /// Selected family.
+    pub family: AhaFamily,
+    /// Exact event contract.
+    pub event_contract: AhaEventContract,
+    /// Every family is a bounded pull operation.
+    pub pull: bool,
+}
+
+impl AhaRuntimeDefinition {
+    /// Compile one declared catalog family into a closed definition.
+    pub fn compile(family: AhaFamily) -> Result<Self, AhaError> {
+        Ok(Self {
+            source_id: "aha",
+            family,
+            event_contract: AhaEventContract {
+                kind: family.event_kind(),
+                schema_ref: family.schema_ref(),
+                required_attributes: family.required_attributes(),
+                required_payload_fields: family.required_payload_fields(),
+            },
+            pull: true,
+        })
+    }
+}

--- a/crates/source-runtime-next/src/aha/error.rs
+++ b/crates/source-runtime-next/src/aha/error.rs
@@ -1,0 +1,170 @@
+use std::{error::Error, fmt};
+
+/// Bounded Aha provider and runtime failure taxonomy.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AhaError {
+    /// Family is outside the closed catalog.
+    InvalidFamily,
+    /// Public configuration is malformed.
+    InvalidConfiguration(&'static str),
+    /// Provider origin is not a valid account-specific HTTPS Aha! origin.
+    InvalidOrigin,
+    /// Authenticated tenant context is malformed.
+    InvalidTenantId,
+    /// The releases family has no configured product identifier.
+    MissingProductId,
+    /// Trusted host has no credential reference.
+    MissingCredentialReference,
+    /// Trusted host could not redeem the credential lease.
+    CredentialUnavailable,
+    /// Cursor is invalid or cannot round-trip.
+    InvalidCursor,
+    /// Request does not belong to this kernel.
+    RequestScopeMismatch,
+    /// Provider rejected authentication.
+    AuthenticationRejected,
+    /// Credential lacks a required provider permission.
+    RequiredScopeMissing,
+    /// Requested provider resource was not found.
+    ProviderResourceNotFound,
+    /// Trusted host denied provider egress.
+    EgressDenied,
+    /// Provider DNS lookup failed.
+    DnsFailure,
+    /// Provider connection failed.
+    ConnectionFailure,
+    /// Provider operation timed out.
+    ProviderTimeout,
+    /// Provider requested a bounded retry.
+    RateLimited {
+        /// Provider-declared retry delay.
+        retry_after_seconds: Option<u64>,
+    },
+    /// Provider returned a retryable server failure.
+    ProviderUnavailable {
+        /// Provider HTTP status.
+        status: u16,
+    },
+    /// Provider returned an unexpected status.
+    UnexpectedStatus {
+        /// Provider HTTP status.
+        status: u16,
+    },
+    /// Retry delay is outside the persistence bound.
+    InvalidRetryAfter,
+    /// Response exceeds the host-declared byte bound.
+    ResponseTooLarge,
+    /// Response exceeds the family record bound.
+    TooManyRecords,
+    /// Response JSON does not match the family.
+    MalformedResponse,
+    /// Provider record violates the family shape.
+    InvalidProviderRecord,
+    /// Provider record has no stable identity.
+    MissingStableIdentity,
+    /// Provider product conflicts with the configured release scope.
+    ProductMismatch,
+    /// Provider payload attempted to provide tenant context.
+    TenantMismatch,
+    /// Credential-shaped material crossed into the kernel.
+    CredentialMaterial,
+    /// Duplicate provider identity has conflicting content.
+    ConflictingDuplicate,
+    /// Normalized record failed the exact event contract.
+    EventContractRejection,
+    /// Durable append failed.
+    AppendFailure,
+    /// Projection failed.
+    ProjectionFailure,
+    /// Runtime lost its source lease.
+    LeaseLoss,
+    /// Runtime authority or generation is stale.
+    StaleAuthority,
+    /// Internal runtime failure.
+    InternalRuntimeFailure,
+}
+
+impl AhaError {
+    /// Next safe operator action without provider content.
+    pub const fn operator_action(&self) -> &'static str {
+        match self {
+            Self::InvalidFamily
+            | Self::InvalidConfiguration(_)
+            | Self::InvalidOrigin
+            | Self::InvalidTenantId
+            | Self::MissingProductId
+            | Self::ProductMismatch
+            | Self::ProviderResourceNotFound => "repair source configuration",
+            Self::MissingCredentialReference
+            | Self::CredentialUnavailable
+            | Self::AuthenticationRejected => "repair credential binding",
+            Self::RequiredScopeMissing => "grant Aha! API read access",
+            Self::RateLimited { .. }
+            | Self::ProviderUnavailable { .. }
+            | Self::DnsFailure
+            | Self::ConnectionFailure
+            | Self::ProviderTimeout => "retry the collection later",
+            Self::EgressDenied => "repair trusted-host egress policy",
+            Self::InvalidCursor => "restart from the last committed checkpoint",
+            Self::MalformedResponse
+            | Self::InvalidProviderRecord
+            | Self::MissingStableIdentity
+            | Self::TenantMismatch
+            | Self::CredentialMaterial
+            | Self::ConflictingDuplicate
+            | Self::EventContractRejection => "inspect quarantined provider records",
+            Self::AppendFailure | Self::ProjectionFailure => "repair the durable commit path",
+            Self::LeaseLoss | Self::StaleAuthority => "restart under the current lease",
+            Self::RequestScopeMismatch
+            | Self::InvalidRetryAfter
+            | Self::ResponseTooLarge
+            | Self::TooManyRecords
+            | Self::UnexpectedStatus { .. }
+            | Self::InternalRuntimeFailure => "repair the forward runtime implementation",
+        }
+    }
+}
+
+impl fmt::Display for AhaError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidFamily => "aha family is invalid",
+            Self::InvalidConfiguration(_) => "aha source configuration is invalid",
+            Self::InvalidOrigin => "aha provider origin is invalid",
+            Self::InvalidTenantId => "aha tenant ID is invalid",
+            Self::MissingProductId => "aha product ID is required",
+            Self::MissingCredentialReference => "aha credential reference is missing",
+            Self::CredentialUnavailable => "aha credential lease is unavailable",
+            Self::InvalidCursor => "aha cursor is invalid or not round-trippable",
+            Self::RequestScopeMismatch => "aha request does not match the kernel",
+            Self::AuthenticationRejected => "aha rejected authentication",
+            Self::RequiredScopeMissing => "aha credential lacks required scope",
+            Self::ProviderResourceNotFound => "aha resource was not found",
+            Self::EgressDenied => "aha egress was denied",
+            Self::DnsFailure => "aha DNS resolution failed",
+            Self::ConnectionFailure => "aha connection failed",
+            Self::ProviderTimeout => "aha operation timed out",
+            Self::RateLimited { .. } => "aha rate limited the operation",
+            Self::ProviderUnavailable { .. } => "aha is temporarily unavailable",
+            Self::UnexpectedStatus { .. } => "aha returned an unexpected status",
+            Self::InvalidRetryAfter => "aha retry delay exceeds its bound",
+            Self::ResponseTooLarge => "aha response exceeds its byte bound",
+            Self::TooManyRecords => "aha response exceeds its record bound",
+            Self::MalformedResponse => "aha response is malformed",
+            Self::InvalidProviderRecord => "aha provider record is invalid",
+            Self::MissingStableIdentity => "aha record has no stable identity",
+            Self::ProductMismatch => "aha record conflicts with the product scope",
+            Self::TenantMismatch => "aha payload attempted to supply tenant context",
+            Self::CredentialMaterial => "aha payload contains credential-shaped material",
+            Self::ConflictingDuplicate => "aha duplicate identity has conflicting content",
+            Self::EventContractRejection => "aha event failed its catalog contract",
+            Self::AppendFailure => "aha append failed",
+            Self::ProjectionFailure => "aha projection failed",
+            Self::LeaseLoss => "aha runtime lost its lease",
+            Self::StaleAuthority => "aha runtime authority is stale",
+            Self::InternalRuntimeFailure => "aha runtime failed internally",
+        })
+    }
+}
+
+impl Error for AhaError {}

--- a/crates/source-runtime-next/src/aha/family.rs
+++ b/crates/source-runtime-next/src/aha/family.rs
@@ -1,0 +1,121 @@
+use std::str::FromStr;
+
+use super::AhaError;
+
+/// Closed Aha! catalog family vocabulary.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum AhaFamily {
+    /// Account audit records.
+    AuditEvents,
+    /// Product features.
+    Features,
+    /// Products and development teams.
+    Products,
+    /// Product-scoped releases.
+    Releases,
+    /// Account users.
+    Users,
+}
+
+impl AhaFamily {
+    /// Every provider-declared family in catalog order.
+    pub const ALL: [Self; 5] = [
+        Self::AuditEvents,
+        Self::Features,
+        Self::Products,
+        Self::Releases,
+        Self::Users,
+    ];
+
+    /// Exact catalog identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::AuditEvents => "audit_events",
+            Self::Features => "features",
+            Self::Products => "products",
+            Self::Releases => "releases",
+            Self::Users => "users",
+        }
+    }
+
+    /// Provider path relative to the account API v1 origin.
+    pub fn path(self, product_id: Option<&str>) -> Result<String, AhaError> {
+        Ok(match self {
+            Self::AuditEvents => "/audits".to_owned(),
+            Self::Features => "/features".to_owned(),
+            Self::Products => "/products".to_owned(),
+            Self::Releases => format!(
+                "/products/{}/releases",
+                product_id.ok_or(AhaError::MissingProductId)?
+            ),
+            Self::Users => "/users".to_owned(),
+        })
+    }
+
+    /// JSON response collection field.
+    pub const fn response_key(self) -> &'static str {
+        match self {
+            Self::AuditEvents => "audits",
+            Self::Features => "features",
+            Self::Products => "products",
+            Self::Releases => "releases",
+            Self::Users => "users",
+        }
+    }
+
+    /// Stable provider identity field.
+    pub const fn id_field(self) -> &'static str {
+        "id"
+    }
+
+    /// Exact event kind.
+    pub const fn event_kind(self) -> &'static str {
+        match self {
+            Self::AuditEvents => "aha.audit_events",
+            Self::Features => "aha.features",
+            Self::Products => "aha.products",
+            Self::Releases => "aha.releases",
+            Self::Users => "aha.users",
+        }
+    }
+
+    /// Exact schema reference.
+    pub const fn schema_ref(self) -> &'static str {
+        match self {
+            Self::AuditEvents => "aha/audit_events/v1",
+            Self::Features => "aha/features/v1",
+            Self::Products => "aha/products/v1",
+            Self::Releases => "aha/releases/v1",
+            Self::Users => "aha/users/v1",
+        }
+    }
+
+    pub(super) const fn required_attributes(self) -> &'static [&'static str] {
+        match self {
+            Self::AuditEvents => &["tenant_id", "source_event_id", "event_type", "actor_id"],
+            Self::Features | Self::Products | Self::Releases => &[
+                "tenant_id",
+                "source_event_id",
+                "resource_urn",
+                "resource_type",
+                "resource_id",
+            ],
+            Self::Users => &["tenant_id", "source_event_id", "user_id"],
+        }
+    }
+
+    pub(super) const fn required_payload_fields(self) -> &'static [&'static str] {
+        &["id"]
+    }
+}
+
+impl FromStr for AhaFamily {
+    type Err = AhaError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::ALL
+            .into_iter()
+            .find(|family| family.as_str() == value.trim())
+            .ok_or(AhaError::InvalidFamily)
+    }
+}

--- a/crates/source-runtime-next/src/aha/normalize.rs
+++ b/crates/source-runtime-next/src/aha/normalize.rs
@@ -1,0 +1,359 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{AhaError, AhaFamily, AhaKernel, AhaRecord, AhaRuntimeDefinition};
+
+pub(super) fn normalize(kernel: &AhaKernel, raw: Value) -> Result<AhaRecord, AhaError> {
+    reject_protected(&raw, 0)?;
+    let values = raw.as_object().ok_or(AhaError::InvalidProviderRecord)?;
+    let provider_id = required_scalar(values, kernel.family.id_field())
+        .map_err(|_| AhaError::MissingStableIdentity)?;
+    if kernel.family == AhaFamily::Releases {
+        let product_id =
+            nested_scalar(values, &["product", "id"]).ok_or(AhaError::InvalidProviderRecord)?;
+        if Some(product_id.as_str()) != kernel.product_id.as_deref() {
+            return Err(AhaError::ProductMismatch);
+        }
+    }
+    let record = AhaRecord {
+        tenant_id: kernel.tenant_id.clone(),
+        event_id: event_id(kernel, &provider_id),
+        provider_id: provider_id.clone(),
+        family: kernel.family,
+        kind: kernel.family.event_kind().to_owned(),
+        schema_ref: kernel.family.schema_ref().to_owned(),
+        occurred_at: occurred_at(kernel, values)?,
+        attributes: attributes(kernel, values, &provider_id)?,
+        payload: raw,
+    };
+    admit(&record)?;
+    Ok(record)
+}
+
+fn attributes(
+    kernel: &AhaKernel,
+    values: &Map<String, Value>,
+    provider_id: &str,
+) -> Result<BTreeMap<String, String>, AhaError> {
+    let mut output = BTreeMap::from([
+        ("external_id".to_owned(), provider_id.to_owned()),
+        ("family".to_owned(), kernel.family.as_str().to_owned()),
+        ("observed_at".to_owned(), kernel.observed_at.clone()),
+        ("provider".to_owned(), "aha".to_owned()),
+        ("schema".to_owned(), kernel.family.as_str().to_owned()),
+        ("source_event_id".to_owned(), provider_id.to_owned()),
+        ("source_provider".to_owned(), "aha".to_owned()),
+        ("source_system".to_owned(), "aha".to_owned()),
+        ("tenant_id".to_owned(), kernel.tenant_id.clone()),
+    ]);
+    match kernel.family {
+        AhaFamily::AuditEvents => audit_attributes(&mut output, values, provider_id)?,
+        AhaFamily::Features => feature_attributes(&mut output, values, provider_id)?,
+        AhaFamily::Products => product_attributes(&mut output, values, provider_id)?,
+        AhaFamily::Releases => release_attributes(&mut output, values, provider_id)?,
+        AhaFamily::Users => user_attributes(&mut output, values, provider_id)?,
+    }
+    Ok(output)
+}
+
+fn user_attributes(
+    output: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    provider_id: &str,
+) -> Result<(), AhaError> {
+    let name = required_scalar(values, "name")?;
+    output.extend(BTreeMap::from([
+        ("display_name".to_owned(), name.clone()),
+        ("record_class".to_owned(), "identity_user".to_owned()),
+        ("resource_id".to_owned(), provider_id.to_owned()),
+        ("resource_name".to_owned(), name),
+        ("resource_type".to_owned(), "user".to_owned()),
+        ("user_id".to_owned(), provider_id.to_owned()),
+    ]));
+    if let Some(email) = scalar(values.get("email")).filter(|value| !value.is_empty()) {
+        output.insert("email".to_owned(), email.clone());
+        output.insert("primary_email".to_owned(), email);
+    }
+    Ok(())
+}
+
+fn product_attributes(
+    output: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    provider_id: &str,
+) -> Result<(), AhaError> {
+    let name = required_scalar(values, "name")?;
+    let tenant = output
+        .get("tenant_id")
+        .cloned()
+        .ok_or(AhaError::InternalRuntimeFailure)?;
+    common_resource_for_tenant(output, &tenant, "products", provider_id, name, "product");
+    output.insert("product_id".to_owned(), provider_id.to_owned());
+    copy(output, values, "reference_prefix", "product_key");
+    Ok(())
+}
+
+fn feature_attributes(
+    output: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    provider_id: &str,
+) -> Result<(), AhaError> {
+    let name = required_scalar(values, "name")?;
+    let tenant = output
+        .get("tenant_id")
+        .cloned()
+        .ok_or(AhaError::InternalRuntimeFailure)?;
+    common_resource_for_tenant(output, &tenant, "features", provider_id, name, "feature");
+    output.insert("feature_id".to_owned(), provider_id.to_owned());
+    copy(output, values, "reference_num", "reference_num");
+    nested_copy(output, values, &["product", "id"], "product_id");
+    nested_copy(output, values, &["release", "id"], "release_id");
+    Ok(())
+}
+
+fn release_attributes(
+    output: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    provider_id: &str,
+) -> Result<(), AhaError> {
+    let name = required_scalar(values, "name")?;
+    let tenant = output
+        .get("tenant_id")
+        .cloned()
+        .ok_or(AhaError::InternalRuntimeFailure)?;
+    common_resource_for_tenant(output, &tenant, "releases", provider_id, name, "release");
+    output.insert("release_id".to_owned(), provider_id.to_owned());
+    copy(output, values, "reference_num", "reference_num");
+    copy(output, values, "release_date", "release_date");
+    nested_copy(output, values, &["product", "id"], "product_id");
+    Ok(())
+}
+
+fn audit_attributes(
+    output: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    provider_id: &str,
+) -> Result<(), AhaError> {
+    let actor_id = nested_scalar(values, &["user", "id"]).ok_or(AhaError::InvalidProviderRecord)?;
+    let action = required_scalar(values, "action")?;
+    let resource_id = required_scalar(values, "auditable_id")?;
+    let resource_type = required_scalar(values, "auditable_type")?;
+    let tenant = output
+        .get("tenant_id")
+        .cloned()
+        .ok_or(AhaError::InternalRuntimeFailure)?;
+    let resource_urn = format!(
+        "urn:cerebro:{}:aha_audit_events:{}",
+        encode_segment(&tenant),
+        encode_segment(provider_id)
+    );
+    output.extend(BTreeMap::from([
+        ("actor_id".to_owned(), actor_id),
+        ("event_type".to_owned(), action),
+        ("record_class".to_owned(), "audit_event".to_owned()),
+        ("resource_id".to_owned(), resource_id),
+        ("resource_name".to_owned(), provider_id.to_owned()),
+        ("resource_type".to_owned(), resource_type),
+        ("resource_urn".to_owned(), resource_urn),
+    ]));
+    nested_copy(output, values, &["user", "name"], "actor_name");
+    nested_copy(output, values, &["user", "email"], "actor_email");
+    Ok(())
+}
+
+fn common_resource_for_tenant(
+    output: &mut BTreeMap<String, String>,
+    tenant: &str,
+    family: &str,
+    provider_id: &str,
+    name: String,
+    resource_type: &str,
+) {
+    output.extend(BTreeMap::from([
+        ("record_class".to_owned(), "asset".to_owned()),
+        ("resource_id".to_owned(), provider_id.to_owned()),
+        ("resource_name".to_owned(), name),
+        ("resource_type".to_owned(), resource_type.to_owned()),
+        (
+            "resource_urn".to_owned(),
+            format!(
+                "urn:cerebro:{}:aha_{}:{}",
+                encode_segment(tenant),
+                family,
+                encode_segment(provider_id)
+            ),
+        ),
+    ]));
+}
+
+fn occurred_at(kernel: &AhaKernel, values: &Map<String, Value>) -> Result<String, AhaError> {
+    for key in ["updated_at", "created_at"] {
+        if let Some(value) = scalar(values.get(key)).filter(|value| !value.is_empty()) {
+            return valid_time(&value);
+        }
+    }
+    Ok(kernel.observed_at.clone())
+}
+
+fn valid_time(value: &str) -> Result<String, AhaError> {
+    let time =
+        OffsetDateTime::parse(value, &Rfc3339).map_err(|_| AhaError::InvalidProviderRecord)?;
+    time.format(&Rfc3339)
+        .map_err(|_| AhaError::InvalidProviderRecord)
+}
+
+fn admit(record: &AhaRecord) -> Result<(), AhaError> {
+    let contract = AhaRuntimeDefinition::compile(record.family)?.event_contract;
+    if record.kind != contract.kind
+        || record.schema_ref != contract.schema_ref
+        || contract
+            .required_attributes
+            .iter()
+            .any(|key| record.attributes.get(*key).is_none_or(String::is_empty))
+        || contract
+            .required_payload_fields
+            .iter()
+            .any(|key| record.payload.get(*key).is_none_or(Value::is_null))
+    {
+        return Err(AhaError::EventContractRejection);
+    }
+    Ok(())
+}
+
+fn event_id(kernel: &AhaKernel, provider_id: &str) -> String {
+    let scope = Sha256::digest(format!(
+        "{}\0{}\0{}",
+        kernel.base_url.as_str(),
+        kernel.family.as_str(),
+        kernel.product_id.as_deref().unwrap_or("")
+    ));
+    let scope = scope[..6]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!(
+        "aha-{}-{scope}-{}-{}",
+        normalize_id(&kernel.tenant_id),
+        normalize_id(kernel.family.as_str()),
+        normalize_id(provider_id)
+    )
+}
+
+fn required_scalar(values: &Map<String, Value>, key: &str) -> Result<String, AhaError> {
+    scalar(values.get(key))
+        .filter(|value| !value.is_empty() && value.len() <= 512)
+        .ok_or(AhaError::InvalidProviderRecord)
+}
+
+fn copy(
+    output: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    source: &str,
+    target: &str,
+) {
+    if let Some(value) = scalar(values.get(source)).filter(|value| !value.is_empty()) {
+        output.insert(target.to_owned(), value);
+    }
+}
+
+fn nested_copy(
+    output: &mut BTreeMap<String, String>,
+    values: &Map<String, Value>,
+    path: &[&str],
+    target: &str,
+) {
+    if let Some(value) = nested_scalar(values, path) {
+        output.insert(target.to_owned(), value);
+    }
+}
+
+fn nested_scalar(values: &Map<String, Value>, path: &[&str]) -> Option<String> {
+    let mut value = values.get(*path.first()?)?;
+    for key in &path[1..] {
+        value = value.as_object()?.get(*key)?;
+    }
+    scalar(Some(value)).filter(|value| !value.is_empty() && value.len() <= 512)
+}
+
+fn scalar(value: Option<&Value>) -> Option<String> {
+    match value? {
+        Value::String(value) => Some(value.trim().to_owned()),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn encode_segment(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.trim().bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}
+
+fn normalize_id(value: &str) -> String {
+    let value = value.trim();
+    if value.is_empty() {
+        return "unknown".to_owned();
+    }
+    value
+        .chars()
+        .map(|character| match character {
+            ' ' | '/' | ':' | '\t' | '\n' => '-',
+            other => other,
+        })
+        .collect()
+}
+
+fn reject_protected(value: &Value, depth: usize) -> Result<(), AhaError> {
+    if depth > 16 {
+        return Err(AhaError::InvalidProviderRecord);
+    }
+    match value {
+        Value::Object(values) => {
+            if values.len() > 256 {
+                return Err(AhaError::InvalidProviderRecord);
+            }
+            for (key, value) in values {
+                let key = key.trim().to_ascii_lowercase().replace('-', "_");
+                if key == "tenant_id" {
+                    return Err(AhaError::TenantMismatch);
+                }
+                if matches!(
+                    key.as_str(),
+                    "token"
+                        | "access_token"
+                        | "refresh_token"
+                        | "api_key"
+                        | "api_token"
+                        | "password"
+                        | "private_key"
+                        | "authorization"
+                        | "client_secret"
+                        | "cookie"
+                ) {
+                    return Err(AhaError::CredentialMaterial);
+                }
+                reject_protected(value, depth + 1)?;
+            }
+        }
+        Value::Array(values) => {
+            if values.len() > 10_000 {
+                return Err(AhaError::TooManyRecords);
+            }
+            for value in values {
+                reject_protected(value, depth + 1)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}

--- a/crates/source-runtime-next/src/aha/origin.rs
+++ b/crates/source-runtime-next/src/aha/origin.rs
@@ -1,0 +1,51 @@
+use reqwest::Url;
+
+use super::AhaError;
+
+const HOST_SUFFIX: &str = ".aha.io";
+
+pub(super) fn validate(value: &str) -> Result<Url, AhaError> {
+    let mut url =
+        Url::parse(value.trim().trim_end_matches('/')).map_err(|_| AhaError::InvalidOrigin)?;
+    let host = url.host_str().unwrap_or_default().trim_end_matches('.');
+    let account = host.strip_suffix(HOST_SUFFIX).unwrap_or_default();
+    if url.scheme() != "https"
+        || account.is_empty()
+        || account.len() > 63
+        || account.contains('.')
+        || account.starts_with('-')
+        || account.ends_with('-')
+        || account
+            .bytes()
+            .any(|byte| !byte.is_ascii_alphanumeric() && byte != b'-')
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port_or_known_default() != Some(443)
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || !matches!(url.path(), "" | "/")
+    {
+        return Err(AhaError::InvalidOrigin);
+    }
+    url.set_path("");
+    Ok(url)
+}
+
+pub(super) fn tenant(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()
+        && value.len() <= 128
+        && !value.chars().any(char::is_control)
+        && !value.contains(['/', '\\', ':']))
+    .then(|| value.to_owned())
+}
+
+pub(super) fn product(value: Option<&str>) -> Option<String> {
+    let value = value?.trim();
+    (!value.is_empty()
+        && value.len() <= 128
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_')))
+    .then(|| value.to_owned())
+}

--- a/crates/source-runtime-next/src/aha/projection.rs
+++ b/crates/source-runtime-next/src/aha/projection.rs
@@ -1,0 +1,114 @@
+use std::collections::BTreeMap;
+
+use super::{AhaFamily, AhaRecord};
+
+/// One deterministic tenant-scoped Aha projection entity.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct AhaEntityFact {
+    /// Canonical entity URN.
+    pub urn: String,
+    /// Closed entity type.
+    pub entity_type: String,
+    /// Human-readable label.
+    pub label: String,
+}
+
+/// Provider-local projection facts used for Go/Rust parity.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AhaProjectionFacts {
+    /// Deduplicated entities in canonical order.
+    pub entities: Vec<AhaEntityFact>,
+}
+
+/// Project normalized Aha! records into identities, assets, and audit resources.
+pub fn project_aha_records(records: &[AhaRecord]) -> AhaProjectionFacts {
+    let mut entities = BTreeMap::<String, AhaEntityFact>::new();
+    for record in records {
+        let (urn, entity_type, label) = match record.family {
+            AhaFamily::Features | AhaFamily::Products | AhaFamily::Releases => {
+                let Some(urn) = record.attributes.get("resource_urn") else {
+                    continue;
+                };
+                (
+                    urn.clone(),
+                    format!(
+                        "runtime.{}",
+                        record
+                            .attributes
+                            .get("resource_type")
+                            .map(String::as_str)
+                            .unwrap_or("asset")
+                    ),
+                    attribute(record, "resource_name"),
+                )
+            }
+            AhaFamily::Users => (
+                scoped_urn(record, "aha_user"),
+                "aha.user".to_owned(),
+                attribute(record, "display_name"),
+            ),
+            AhaFamily::AuditEvents => (
+                format!(
+                    "urn:cerebro:{}:runtime_{}:{}",
+                    encode_segment(&record.tenant_id),
+                    encode_segment(
+                        record
+                            .attributes
+                            .get("resource_type")
+                            .map(String::as_str)
+                            .unwrap_or("resource")
+                    ),
+                    encode_segment(
+                        record
+                            .attributes
+                            .get("resource_id")
+                            .map(String::as_str)
+                            .unwrap_or(&record.provider_id)
+                    )
+                ),
+                "aha.audit_resource".to_owned(),
+                attribute(record, "resource_name"),
+            ),
+        };
+        entities.insert(
+            urn.clone(),
+            AhaEntityFact {
+                urn,
+                entity_type,
+                label,
+            },
+        );
+    }
+    AhaProjectionFacts {
+        entities: entities.into_values().collect(),
+    }
+}
+
+fn scoped_urn(record: &AhaRecord, kind: &str) -> String {
+    format!(
+        "urn:cerebro:{}:{}:{}",
+        encode_segment(&record.tenant_id),
+        kind,
+        encode_segment(&record.provider_id)
+    )
+}
+
+fn attribute(record: &AhaRecord, key: &str) -> String {
+    record
+        .attributes
+        .get(key)
+        .cloned()
+        .unwrap_or_else(|| record.provider_id.clone())
+}
+
+fn encode_segment(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.trim().bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}

--- a/crates/source-runtime-next/src/aha/request.rs
+++ b/crates/source-runtime-next/src/aha/request.rs
@@ -1,0 +1,75 @@
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{AhaError, AhaFamily, AhaKernel, AhaRequest, origin};
+
+const PAGE_SIZE: usize = 100;
+const MAX_PAGE: u32 = 1_000_000;
+
+pub(super) fn new_kernel(
+    base_url: &str,
+    tenant_id: &str,
+    family: AhaFamily,
+    product_id: Option<&str>,
+    observed_at: &str,
+) -> Result<AhaKernel, AhaError> {
+    let base_url = origin::validate(base_url)?;
+    let tenant_id = origin::tenant(tenant_id).ok_or(AhaError::InvalidTenantId)?;
+    let product_id = if family == AhaFamily::Releases {
+        Some(origin::product(product_id).ok_or(AhaError::MissingProductId)?)
+    } else {
+        None
+    };
+    let observed = OffsetDateTime::parse(observed_at, &Rfc3339)
+        .map_err(|_| AhaError::InvalidConfiguration("observed_at"))?;
+    let observed_at = observed
+        .format(&Rfc3339)
+        .map_err(|_| AhaError::InvalidConfiguration("observed_at"))?;
+    Ok(AhaKernel {
+        base_url,
+        tenant_id,
+        family,
+        product_id,
+        observed_at,
+    })
+}
+
+pub(super) fn plan(kernel: &AhaKernel, cursor: Option<&str>) -> Result<AhaRequest, AhaError> {
+    let page = cursor.map(validate_cursor).transpose()?.unwrap_or(1);
+    let path = kernel.family.path(kernel.product_id.as_deref())?;
+    let mut url = kernel.base_url.clone();
+    url.set_path(&format!("/api/v1{path}"));
+    if url.origin() != kernel.base_url.origin() {
+        return Err(AhaError::InvalidOrigin);
+    }
+    {
+        let mut query = url.query_pairs_mut();
+        query.append_pair("per_page", &PAGE_SIZE.to_string());
+        query.append_pair("page", &page.to_string());
+    }
+    Ok(AhaRequest {
+        url,
+        family: kernel.family,
+        cursor: cursor.map(str::to_owned),
+        page,
+        page_size: PAGE_SIZE,
+    })
+}
+
+pub(super) fn validate_request(kernel: &AhaKernel, request: &AhaRequest) -> Result<(), AhaError> {
+    if request != &plan(kernel, request.cursor.as_deref())? {
+        return Err(AhaError::RequestScopeMismatch);
+    }
+    Ok(())
+}
+
+pub(super) fn validate_cursor(value: &str) -> Result<u32, AhaError> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > 7 || value.chars().any(char::is_control) {
+        return Err(AhaError::InvalidCursor);
+    }
+    value
+        .parse::<u32>()
+        .ok()
+        .filter(|page| (1..=MAX_PAGE).contains(page))
+        .ok_or(AhaError::InvalidCursor)
+}

--- a/crates/source-runtime-next/src/aha/response.rs
+++ b/crates/source-runtime-next/src/aha/response.rs
@@ -1,0 +1,121 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    AhaCheckpointCandidate, AhaError, AhaKernel, AhaPage, AhaRequest, normalize,
+    request::{validate_cursor, validate_request},
+};
+
+pub(super) const MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+pub(super) fn decode(
+    kernel: &AhaKernel,
+    request: &AhaRequest,
+    status: u16,
+    retry_after_seconds: Option<u64>,
+    body: &[u8],
+) -> Result<AhaPage, AhaError> {
+    validate_request(kernel, request)?;
+    classify_status(status, retry_after_seconds)?;
+    if body.len() > MAX_RESPONSE_BYTES {
+        return Err(AhaError::ResponseTooLarge);
+    }
+    let root: Value = serde_json::from_slice(body).map_err(|_| AhaError::MalformedResponse)?;
+    let items = root
+        .get(kernel.family.response_key())
+        .and_then(Value::as_array)
+        .ok_or(AhaError::MalformedResponse)?;
+    if items.len() > request.page_size {
+        return Err(AhaError::TooManyRecords);
+    }
+
+    let mut seen = BTreeMap::<String, Vec<u8>>::new();
+    let mut records = Vec::with_capacity(items.len());
+    for raw in items {
+        let record = normalize::normalize(kernel, raw.clone())?;
+        let canonical =
+            serde_json::to_vec(&record.payload).map_err(|_| AhaError::InvalidProviderRecord)?;
+        match seen.get(&record.provider_id) {
+            Some(previous) if previous == &canonical => continue,
+            Some(_) => return Err(AhaError::ConflictingDuplicate),
+            None => {
+                seen.insert(record.provider_id.clone(), canonical);
+                records.push(record);
+            }
+        }
+    }
+
+    let next_cursor = if items.len() == request.page_size {
+        let next = request
+            .page
+            .checked_add(1)
+            .ok_or(AhaError::InvalidCursor)?
+            .to_string();
+        validate_cursor(&next)?;
+        Some(next)
+    } else {
+        None
+    };
+    Ok(AhaPage {
+        records,
+        next_cursor,
+    })
+}
+
+pub(super) fn checkpoint_candidate(
+    kernel: &AhaKernel,
+    request: &AhaRequest,
+    page: &AhaPage,
+    prior_watermark: Option<&str>,
+) -> Result<AhaCheckpointCandidate, AhaError> {
+    validate_request(kernel, request)?;
+    if page
+        .records
+        .iter()
+        .any(|record| record.tenant_id != kernel.tenant_id || record.family != kernel.family)
+    {
+        return Err(AhaError::TenantMismatch);
+    }
+    if let Some(cursor) = &page.next_cursor {
+        kernel.plan(Some(cursor))?;
+    }
+    let mut watermark = valid_time(prior_watermark.unwrap_or(&kernel.observed_at))?;
+    for record in &page.records {
+        let occurred_at = valid_time(&record.occurred_at)?;
+        if occurred_at > watermark {
+            watermark = occurred_at;
+        }
+    }
+    Ok(AhaCheckpointCandidate {
+        tenant_id: kernel.tenant_id.clone(),
+        family: kernel.family,
+        cursor: page.next_cursor.clone(),
+        watermark,
+    })
+}
+
+fn classify_status(status: u16, retry_after_seconds: Option<u64>) -> Result<(), AhaError> {
+    if retry_after_seconds.is_some_and(|seconds| seconds > 3_600) {
+        return Err(AhaError::InvalidRetryAfter);
+    }
+    match status {
+        200..=299 => Ok(()),
+        401 => Err(AhaError::AuthenticationRejected),
+        403 => Err(AhaError::RequiredScopeMissing),
+        404 => Err(AhaError::ProviderResourceNotFound),
+        429 => Err(AhaError::RateLimited {
+            retry_after_seconds,
+        }),
+        500..=599 => Err(AhaError::ProviderUnavailable { status }),
+        _ => Err(AhaError::UnexpectedStatus { status }),
+    }
+}
+
+fn valid_time(value: &str) -> Result<String, AhaError> {
+    let time =
+        OffsetDateTime::parse(value, &Rfc3339).map_err(|_| AhaError::InvalidProviderRecord)?;
+    time.format(&Rfc3339)
+        .map_err(|_| AhaError::InvalidProviderRecord)
+}

--- a/crates/source-runtime-next/src/aha/tests.rs
+++ b/crates/source-runtime-next/src/aha/tests.rs
@@ -1,0 +1,327 @@
+use std::{collections::BTreeMap, fs, path::PathBuf};
+
+use cerebro_source_catalog::{CollectionAuthority, SourceCatalog};
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+
+use super::*;
+
+const ORIGIN: &str = "https://example.aha.io";
+const OBSERVED_AT: &str = "2026-06-01T00:00:00Z";
+
+#[derive(Debug, Deserialize)]
+struct GoOracleEvent {
+    id: String,
+    tenant_id: String,
+    source_id: String,
+    kind: String,
+    occurred_at: String,
+    schema_ref: String,
+    payload: Value,
+    attributes: BTreeMap<String, String>,
+}
+
+fn root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn kernel(tenant: &str, family: AhaFamily) -> AhaKernel {
+    AhaKernel::new(
+        ORIGIN,
+        tenant,
+        family,
+        (family == AhaFamily::Releases).then_some("product-1"),
+        OBSERVED_AT,
+    )
+    .unwrap()
+}
+
+fn oracle(family: AhaFamily) -> GoOracleEvent {
+    let bytes = fs::read(root().join(format!(
+        "sources/aha/testdata/read_{}.json",
+        family.as_str()
+    )))
+    .unwrap();
+    serde_json::from_slice::<Vec<GoOracleEvent>>(&bytes)
+        .unwrap()
+        .pop()
+        .unwrap()
+}
+
+fn response(family: AhaFamily, records: Vec<Value>) -> Vec<u8> {
+    let mut root = Map::new();
+    root.insert(family.response_key().to_owned(), Value::Array(records));
+    serde_json::to_vec(&Value::Object(root)).unwrap()
+}
+
+#[test]
+fn catalog_closes_the_exact_compatibility_authoritative_family_set() {
+    let catalog = SourceCatalog::load(
+        root().join("internal/connectorcatalog/catalog"),
+        root().join("sources"),
+    )
+    .unwrap();
+    let source = catalog.get("aha").unwrap();
+    assert_eq!(source.authority(), CollectionAuthority::Authoritative);
+    let mut families = source
+        .families()
+        .iter()
+        .map(|family| family.id())
+        .collect::<Vec<_>>();
+    families.sort_unstable();
+    assert_eq!(
+        families,
+        ["audit_events", "features", "products", "releases", "users"]
+    );
+    assert!(!root().join("sources/aha/source.go").exists());
+    for family in AhaFamily::ALL {
+        let definition = AhaRuntimeDefinition::compile(family).unwrap();
+        assert_eq!(definition.source_id, "aha");
+        assert!(definition.pull);
+        assert_eq!(definition.event_contract.kind, family.event_kind());
+        assert_eq!(definition.event_contract.schema_ref, family.schema_ref());
+    }
+}
+
+#[test]
+fn requests_are_origin_locked_bounded_and_credential_free() {
+    for family in AhaFamily::ALL {
+        let request = kernel("tenant", family).plan(None).unwrap();
+        assert_eq!(request.method(), "GET");
+        assert_eq!(request.url().scheme(), "https");
+        assert_eq!(request.url().host_str(), Some("example.aha.io"));
+        assert_eq!(
+            request.url().path(),
+            format!(
+                "/api/v1{}",
+                family
+                    .path((family == AhaFamily::Releases).then_some("product-1"))
+                    .unwrap()
+            )
+        );
+        assert_eq!(request.url().query(), Some("per_page=100&page=1"));
+        assert_eq!(request.authentication_header(), "Authorization");
+        assert_eq!(request.authentication_scheme(), "Bearer");
+        assert!(request.credential_reference_required());
+        assert!(!request.contains_credentials());
+        assert!(!request.allows_redirects());
+        assert_eq!(request.record_limit(), 100);
+        assert_eq!(request.max_response_bytes(), 8 * 1024 * 1024);
+        assert_eq!(request.required_scope(), "Aha! API read access");
+        assert!(!AhaKernel::requires_credentials());
+    }
+}
+
+#[test]
+fn origin_product_tenant_and_cursor_inputs_fail_closed() {
+    for origin in [
+        "http://example.aha.io",
+        "https://user@example.aha.io",
+        "https://example.aha.io:8443",
+        "https://aha.io",
+        "https://nested.example.aha.io",
+        "https://example.aha.io/api/v1",
+        "https://example.aha.io?token=value",
+    ] {
+        assert!(AhaKernel::new(origin, "tenant", AhaFamily::Products, None, OBSERVED_AT).is_err());
+    }
+    assert!(matches!(
+        AhaKernel::new(ORIGIN, "tenant", AhaFamily::Releases, None, OBSERVED_AT),
+        Err(AhaError::MissingProductId)
+    ));
+    assert!(
+        AhaKernel::new(
+            ORIGIN,
+            "tenant",
+            AhaFamily::Releases,
+            Some("../escape"),
+            OBSERVED_AT
+        )
+        .is_err()
+    );
+    assert!(AhaKernel::new(ORIGIN, "bad:tenant", AhaFamily::Products, None, OBSERVED_AT).is_err());
+    for cursor in ["0", "-1", "1000001", "next"] {
+        assert_eq!(
+            kernel("tenant", AhaFamily::Products).plan(Some(cursor)),
+            Err(AhaError::InvalidCursor)
+        );
+    }
+}
+
+#[test]
+fn every_family_matches_the_checked_go_event_and_projection_fixture() {
+    for family in AhaFamily::ALL {
+        let kernel = kernel("tenant", family);
+        let request = kernel.plan(None).unwrap();
+        let oracle = oracle(family);
+        let page = kernel
+            .decode(
+                &request,
+                200,
+                None,
+                &response(family, vec![oracle.payload.clone()]),
+            )
+            .unwrap();
+        assert_eq!(page.records.len(), 1);
+        assert_eq!(page.next_cursor, None);
+        let record = &page.records[0];
+        assert_eq!(record.tenant_id, oracle.tenant_id);
+        assert_eq!(oracle.source_id, "aha");
+        assert_eq!(record.kind, oracle.kind);
+        assert_eq!(record.schema_ref, oracle.schema_ref);
+        assert_eq!(record.occurred_at, oracle.occurred_at);
+        assert_eq!(record.payload, oracle.payload);
+        assert_eq!(record.attributes, oracle.attributes);
+        assert!(oracle.id.starts_with("aha-"));
+        assert!(record.event_id.starts_with("aha-tenant-"));
+        assert_eq!(project_aha_records(&page.records).entities.len(), 1);
+    }
+}
+
+#[test]
+fn page_checkpoint_and_restart_are_round_trippable() {
+    let family = AhaFamily::Features;
+    let kernel = kernel("tenant", family);
+    let request = kernel.plan(None).unwrap();
+    let records = (1..=100)
+        .map(|number| {
+            json!({
+                "id": format!("feature-{number}"),
+                "name": format!("Feature {number}"),
+                "updated_at": OBSERVED_AT
+            })
+        })
+        .collect();
+    let page = kernel
+        .decode(&request, 200, None, &response(family, records))
+        .unwrap();
+    assert_eq!(page.next_cursor.as_deref(), Some("2"));
+    let checkpoint = kernel
+        .checkpoint_candidate(&request, &page, Some("2026-05-01T00:00:00Z"))
+        .unwrap();
+    assert_eq!(checkpoint.cursor.as_deref(), Some("2"));
+    assert_eq!(checkpoint.watermark, OBSERVED_AT);
+    let resumed = kernel.plan(checkpoint.cursor.as_deref()).unwrap();
+    assert_eq!(resumed.url().query(), Some("per_page=100&page=2"));
+    let terminal = kernel
+        .decode(&resumed, 200, None, &response(family, Vec::new()))
+        .unwrap();
+    assert_eq!(terminal.next_cursor, None);
+}
+
+#[test]
+fn duplicates_statuses_bounds_scope_and_secret_material_fail_closed() {
+    let family = AhaFamily::Products;
+    let kernel = kernel("tenant", family);
+    let request = kernel.plan(None).unwrap();
+    let raw = oracle(family).payload;
+    let page = kernel
+        .decode(
+            &request,
+            200,
+            None,
+            &response(family, vec![raw.clone(), raw.clone()]),
+        )
+        .unwrap();
+    assert_eq!(page.records.len(), 1);
+    let mut conflict = raw.clone();
+    conflict["updated_at"] = Value::String("2026-06-03T00:00:00Z".to_owned());
+    assert_eq!(
+        kernel.decode(&request, 200, None, &response(family, vec![raw, conflict])),
+        Err(AhaError::ConflictingDuplicate)
+    );
+    for (status, expected) in [
+        (401, AhaError::AuthenticationRejected),
+        (403, AhaError::RequiredScopeMissing),
+        (404, AhaError::ProviderResourceNotFound),
+        (
+            429,
+            AhaError::RateLimited {
+                retry_after_seconds: Some(60),
+            },
+        ),
+        (503, AhaError::ProviderUnavailable { status: 503 }),
+        (418, AhaError::UnexpectedStatus { status: 418 }),
+    ] {
+        assert_eq!(
+            kernel.decode(&request, status, Some(60), b"{}"),
+            Err(expected)
+        );
+    }
+    let oversized = vec![b' '; request.max_response_bytes() + 1];
+    assert_eq!(
+        kernel.decode(&request, 200, None, &oversized),
+        Err(AhaError::ResponseTooLarge)
+    );
+
+    let releases = kernel("tenant", AhaFamily::Releases);
+    let releases_request = releases.plan(None).unwrap();
+    let mut wrong_scope = oracle(AhaFamily::Releases).payload;
+    wrong_scope["product"]["id"] = Value::String("other-product".to_owned());
+    assert_eq!(
+        releases.decode(
+            &releases_request,
+            200,
+            None,
+            &response(AhaFamily::Releases, vec![wrong_scope])
+        ),
+        Err(AhaError::ProductMismatch)
+    );
+    for (field, expected) in [
+        ("tenant_id", AhaError::TenantMismatch),
+        ("authorization", AhaError::CredentialMaterial),
+        ("token", AhaError::CredentialMaterial),
+        ("private_key", AhaError::CredentialMaterial),
+    ] {
+        let mut raw = oracle(family).payload;
+        raw[field] = Value::String("sentinel-secret-value".to_owned());
+        let error = kernel
+            .decode(&request, 200, None, &response(family, vec![raw]))
+            .unwrap_err();
+        assert_eq!(error, expected);
+        assert!(!error.to_string().contains("sentinel-secret-value"));
+        assert!(!format!("{error:?}").contains("sentinel-secret-value"));
+    }
+}
+
+#[test]
+fn identity_is_deterministic_and_tenant_and_account_scoped() {
+    let family = AhaFamily::Users;
+    let body = response(family, vec![oracle(family).payload]);
+    let first_kernel = kernel("tenant-a", family);
+    let first_request = first_kernel.plan(None).unwrap();
+    let first = first_kernel
+        .decode(&first_request, 200, None, &body)
+        .unwrap();
+    assert_eq!(
+        first,
+        first_kernel
+            .decode(&first_request, 200, None, &body)
+            .unwrap()
+    );
+    let other_tenant = kernel("tenant-b", family);
+    let other_tenant_request = other_tenant.plan(None).unwrap();
+    let other_tenant_page = other_tenant
+        .decode(&other_tenant_request, 200, None, &body)
+        .unwrap();
+    assert_ne!(
+        first.records[0].event_id,
+        other_tenant_page.records[0].event_id
+    );
+    let other_account = AhaKernel::new(
+        "https://other.aha.io",
+        "tenant-a",
+        family,
+        None,
+        OBSERVED_AT,
+    )
+    .unwrap();
+    let other_account_request = other_account.plan(None).unwrap();
+    let other_account_page = other_account
+        .decode(&other_account_request, 200, None, &body)
+        .unwrap();
+    assert_ne!(
+        first.records[0].event_id,
+        other_account_page.records[0].event_id
+    );
+}

--- a/crates/source-runtime-next/src/aha/tests.rs
+++ b/crates/source-runtime-next/src/aha/tests.rs
@@ -212,10 +212,10 @@ fn page_checkpoint_and_restart_are_round_trippable() {
 #[test]
 fn duplicates_statuses_bounds_scope_and_secret_material_fail_closed() {
     let family = AhaFamily::Products;
-    let kernel = kernel("tenant", family);
-    let request = kernel.plan(None).unwrap();
+    let product_kernel = kernel("tenant", family);
+    let request = product_kernel.plan(None).unwrap();
     let raw = oracle(family).payload;
-    let page = kernel
+    let page = product_kernel
         .decode(
             &request,
             200,
@@ -227,7 +227,7 @@ fn duplicates_statuses_bounds_scope_and_secret_material_fail_closed() {
     let mut conflict = raw.clone();
     conflict["updated_at"] = Value::String("2026-06-03T00:00:00Z".to_owned());
     assert_eq!(
-        kernel.decode(&request, 200, None, &response(family, vec![raw, conflict])),
+        product_kernel.decode(&request, 200, None, &response(family, vec![raw, conflict])),
         Err(AhaError::ConflictingDuplicate)
     );
     for (status, expected) in [
@@ -244,13 +244,13 @@ fn duplicates_statuses_bounds_scope_and_secret_material_fail_closed() {
         (418, AhaError::UnexpectedStatus { status: 418 }),
     ] {
         assert_eq!(
-            kernel.decode(&request, status, Some(60), b"{}"),
+            product_kernel.decode(&request, status, Some(60), b"{}"),
             Err(expected)
         );
     }
     let oversized = vec![b' '; request.max_response_bytes() + 1];
     assert_eq!(
-        kernel.decode(&request, 200, None, &oversized),
+        product_kernel.decode(&request, 200, None, &oversized),
         Err(AhaError::ResponseTooLarge)
     );
 
@@ -275,7 +275,7 @@ fn duplicates_statuses_bounds_scope_and_secret_material_fail_closed() {
     ] {
         let mut raw = oracle(family).payload;
         raw[field] = Value::String("sentinel-secret-value".to_owned());
-        let error = kernel
+        let error = product_kernel
             .decode(&request, 200, None, &response(family, vec![raw]))
             .unwrap_err();
         assert_eq!(error, expected);

--- a/crates/source-runtime-next/src/aha/types.rs
+++ b/crates/source-runtime-next/src/aha/types.rs
@@ -1,0 +1,190 @@
+use std::{collections::BTreeMap, fmt};
+
+use reqwest::Url;
+use serde_json::Value;
+
+use super::{AhaError, AhaFamily, request, response};
+
+/// Credential-free request intent for the trusted Aha! HTTP host.
+#[derive(Clone, Eq, PartialEq)]
+pub struct AhaRequest {
+    pub(super) url: Url,
+    pub(super) family: AhaFamily,
+    pub(super) cursor: Option<String>,
+    pub(super) page: u32,
+    pub(super) page_size: usize,
+}
+
+impl fmt::Debug for AhaRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AhaRequest")
+            .field("url", &self.url)
+            .field("family", &self.family)
+            .field("has_cursor", &self.cursor.is_some())
+            .field("page", &self.page)
+            .field("page_size", &self.page_size)
+            .finish()
+    }
+}
+
+impl AhaRequest {
+    /// Fully planned provider URL.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Provider HTTP method.
+    pub const fn method(&self) -> &'static str {
+        "GET"
+    }
+
+    /// Family owning this request.
+    pub const fn family(&self) -> AhaFamily {
+        self.family
+    }
+
+    /// Authentication header applied by the trusted host.
+    pub const fn authentication_header(&self) -> &'static str {
+        "Authorization"
+    }
+
+    /// Authentication scheme applied by the trusted host.
+    pub const fn authentication_scheme(&self) -> &'static str {
+        "Bearer"
+    }
+
+    /// The trusted host must redeem a credential reference before execution.
+    pub const fn credential_reference_required(&self) -> bool {
+        true
+    }
+
+    /// Expected response media type.
+    pub const fn accept(&self) -> &'static str {
+        "application/json"
+    }
+
+    /// Portable plans contain no credential bytes or references.
+    pub const fn contains_credentials(&self) -> bool {
+        false
+    }
+
+    /// Redirects are disabled by the trusted host.
+    pub const fn allows_redirects(&self) -> bool {
+        false
+    }
+
+    /// Maximum admitted response bytes.
+    pub const fn max_response_bytes(&self) -> usize {
+        response::MAX_RESPONSE_BYTES
+    }
+
+    /// Provider permission required for every list operation.
+    pub const fn required_scope(&self) -> &'static str {
+        "Aha! API read access"
+    }
+
+    /// Maximum records admitted from this response.
+    pub const fn record_limit(&self) -> usize {
+        self.page_size
+    }
+}
+
+/// One normalized tenant-scoped Aha! event candidate.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AhaRecord {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Stable tenant-, origin-, family-, and provider-scoped event identity.
+    pub event_id: String,
+    /// Stable provider object identity.
+    pub provider_id: String,
+    /// Exact family.
+    pub family: AhaFamily,
+    /// Exact event kind.
+    pub kind: String,
+    /// Exact schema reference.
+    pub schema_ref: String,
+    /// Normalized RFC3339 occurrence time.
+    pub occurred_at: String,
+    /// Deterministic projection attributes.
+    pub attributes: BTreeMap<String, String>,
+    /// Credential-free provider payload admitted by the event contract.
+    pub payload: Value,
+}
+
+/// One bounded normalized Aha! page.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AhaPage {
+    /// Accepted records after deterministic deduplication.
+    pub records: Vec<AhaRecord>,
+    /// Validated page continuation, or terminal state.
+    pub next_cursor: Option<String>,
+}
+
+/// Validated checkpoint candidate for post-append/projection persistence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AhaCheckpointCandidate {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Selected family.
+    pub family: AhaFamily,
+    /// Validated continuation state.
+    pub cursor: Option<String>,
+    /// Provider observation watermark.
+    pub watermark: String,
+}
+
+/// Closed Aha! kernel for one tenant, account origin, and family.
+#[derive(Clone, Debug)]
+pub struct AhaKernel {
+    pub(super) base_url: Url,
+    pub(super) tenant_id: String,
+    pub(super) family: AhaFamily,
+    pub(super) product_id: Option<String>,
+    pub(super) observed_at: String,
+}
+
+impl AhaKernel {
+    /// Construct one family kernel from public execution context only.
+    pub fn new(
+        base_url: &str,
+        tenant_id: &str,
+        family: AhaFamily,
+        product_id: Option<&str>,
+        observed_at: &str,
+    ) -> Result<Self, AhaError> {
+        request::new_kernel(base_url, tenant_id, family, product_id, observed_at)
+    }
+
+    /// Kernel protocol never accepts credential material.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+
+    /// Plan one bounded origin-restricted provider request.
+    pub fn plan(&self, cursor: Option<&str>) -> Result<AhaRequest, AhaError> {
+        request::plan(self, cursor)
+    }
+
+    /// Decode one bounded provider response under the exact request plan.
+    pub fn decode(
+        &self,
+        request: &AhaRequest,
+        status: u16,
+        retry_after_seconds: Option<u64>,
+        body: &[u8],
+    ) -> Result<AhaPage, AhaError> {
+        response::decode(self, request, status, retry_after_seconds, body)
+    }
+
+    /// Validate a checkpoint candidate for post-commit host persistence.
+    pub fn checkpoint_candidate(
+        &self,
+        request: &AhaRequest,
+        page: &AhaPage,
+        prior_watermark: Option<&str>,
+    ) -> Result<AhaCheckpointCandidate, AhaError> {
+        response::checkpoint_candidate(self, request, page, prior_watermark)
+    }
+}

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -11,6 +11,7 @@ mod acunetix;
 mod ada_support;
 mod addigy;
 mod adp_workforce_now;
+mod aha;
 mod amplitude;
 mod anthropic;
 mod append_log;
@@ -101,6 +102,10 @@ pub use addigy::{
 pub use adp_workforce_now::{
     AdpCheckpointCandidate, AdpEntityFact, AdpError, AdpEventContract, AdpFamily, AdpKernel,
     AdpPage, AdpProjectionFacts, AdpRecord, AdpRequest, AdpRuntimeDefinition, project_adp_records,
+};
+pub use aha::{
+    AhaCheckpointCandidate, AhaEntityFact, AhaError, AhaEventContract, AhaFamily, AhaKernel,
+    AhaPage, AhaProjectionFacts, AhaRecord, AhaRequest, AhaRuntimeDefinition, project_aha_records,
 };
 pub use amplitude::{
     AmplitudeError, AmplitudeFamily, AmplitudeKernel, AmplitudePage, AmplitudeRecord,


### PR DESCRIPTION
## Scope

Adds a credential-free Aha! request/response kernel for `audit_events`, `features`, `products`, `releases`, and `users`.

- compiles the checked five-family catalog into closed runtime definitions
- plans bounded account-origin requests without credential values
- keeps bearer credential redemption and authentication in the trusted host
- validates family-specific response collections and deterministic page cursors
- emits tenant-, account-, family-, and provider-scoped identities
- validates product-scoped releases against configured `product_id`
- admits exact event contracts and compares every family with checked Go fixtures
- projects identity, asset, release, and audit-resource facts
- rejects tenant or credential-shaped provider fields and preserves typed provider/runtime failures

## Authority

This is an additive provider-local kernel and does not promote Aha! collection authority. The Go compatibility runtime and existing catalog execution path remain authoritative until hosted parity, production integration, and authority receipts prove the cutover. No compatibility loader or Go fixture oracle is removed.

## Local validation

Passed:

- direct `rustfmt --edition 2024 --check` over the Aha! module
- repository staged-diff leak check and `git diff --check`
- `make check-structural check-arch`
- `make catalog-check source-fixture-check`
- `make fixture-oracle-check`
- focused Go connector catalog, source fixture, source projection, source runtime, source generation, catalog runtime, and Source CDK packages except the event-admission package noted below

Incomplete locally:

- Rust unit tests and Clippy were not started because the managed Cargo wrapper stopped before build while its safe-capacity reserve was short
- `make projection-parity-test` reached the Cargo boundary and stopped for the same reserve gate
- `internal/sourceruntime/eventadmission` repeatedly failed its unrelated worker restart timing test with `context deadline exceeded`; hosted checks must determine whether this persists on the exact PR head
- no live-provider collection, deployment, authority promotion, or authenticated product-path proof is claimed

Hosted required checks are the exact-head validation path.