### PR TITLE
Prove Tailscale provider authority parity

### DIFF
--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -178,7 +178,7 @@ jobs:
           '
           summary="$(docker run --rm "${CANDIDATE_IMAGE}" catalog-summary)"
           test "$(jq -r .sources <<<"${summary}")" -eq 799
-          test "$(jq -r .families <<<"${summary}")" -eq 3986
+          test "$(jq -r .families <<<"${summary}")" -eq 3991
       - name: Start disposable PostgreSQL, Neo4j, and JetStream
         run: |
           set -euo pipefail
@@ -246,7 +246,7 @@ jobs:
             | .checks += [
                 {name:"rust_entrypoint",status:"passed",evidence:"image starts cerebro-platform directly"},
                 {name:"go_binary_absent",status:"passed",evidence:"/usr/local/bin/cerebro is absent"},
-                {name:"source_catalog",status:"passed",evidence:"799 sources and 3986 families loaded"}
+                {name:"source_catalog",status:"passed",evidence:"799 sources and 3991 families loaded"}
               ]
           ' .dist/rust-only-e2e/rust-only-e2e-receipt.json \
             > .dist/rust-only-e2e/receipt.tmp

--- a/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
+++ b/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
@@ -108,8 +108,8 @@ fn rust_candidate_build_never_invokes_go_or_emulation() {
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- seed",
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- verify",
         r#"test "$(jq -r .sources <<<"${summary}")" -eq 799"#,
-        r#"test "$(jq -r .families <<<"${summary}")" -eq 3986"#,
-        r#"evidence:"799 sources and 3986 families loaded""#,
+        r#"test "$(jq -r .families <<<"${summary}")" -eq 3991"#,
+        r#"evidence:"799 sources and 3991 families loaded""#,
         "cerebro.rust-only-e2e/v1",
         "cerebro.rust-only-candidate/v1",
     ] {

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -2971,7 +2971,7 @@ mod tests {
         .unwrap();
         let summary = catalog.summary();
         assert_eq!(summary.sources, 799);
-        assert_eq!(summary.families, 3_986);
+        assert_eq!(summary.families, 3_991);
         assert_eq!(summary.push_sources, 1);
         assert_eq!(summary.push_families, 10);
         assert_eq!(
@@ -3942,7 +3942,7 @@ mod tests {
         .unwrap();
         let report = catalog.unsupported_feature_report();
         assert_eq!(report.total_sources, 799);
-        assert_eq!(report.total_families, 3_986);
+        assert_eq!(report.total_families, 3_991);
         assert_eq!(report.families.len(), report.total_families);
         assert!(report.missing_family_reports.is_empty());
         assert_eq!(
@@ -3991,7 +3991,7 @@ mod tests {
         )
         .unwrap();
         let report = catalog.authority_readiness_report();
-        assert_eq!(report.total_families, 3_986);
+        assert_eq!(report.total_families, 3_991);
         assert_eq!(report.rust_authoritative_families, 0);
         assert_eq!(report.shadow_or_go_families, report.total_families);
         let aws_bedrock = report

--- a/crates/source-runtime-next/src/tailscale/response.rs
+++ b/crates/source-runtime-next/src/tailscale/response.rs
@@ -66,20 +66,30 @@ impl TailscaleKernel {
         {
             return Err(TailscaleError::TenantMismatch);
         }
-        if let Some(cursor) = &page.next_cursor {
+        let cursor = page
+            .next_cursor
+            .clone()
+            .or_else(|| {
+                page.records
+                    .last()
+                    .and_then(|record| record.attributes.get("external_id"))
+                    .cloned()
+            })
+            .map(|cursor| validate_cursor(&cursor))
+            .transpose()?;
+        if let Some(cursor) = &cursor {
             self.plan(Some(cursor))?;
         }
         let prior = prior_watermark.map(valid_time).transpose()?;
         let watermark = page
             .records
-            .iter()
+            .last()
             .map(|record| record.occurred_at.clone())
-            .chain(prior)
-            .max();
+            .or(prior);
         Ok(TailscaleCheckpointCandidate {
             tenant_id: self.tenant_id.clone(),
             family: self.family,
-            cursor: page.next_cursor.clone(),
+            cursor,
             watermark,
         })
     }

--- a/crates/source-runtime-next/src/tailscale/tests.rs
+++ b/crates/source-runtime-next/src/tailscale/tests.rs
@@ -31,6 +31,29 @@ struct ProviderFamilyWire {
 }
 
 #[derive(Deserialize)]
+struct ConnectorCatalogWire {
+    entries: Vec<ConnectorEntryWire>,
+}
+
+#[derive(Deserialize)]
+struct ConnectorEntryWire {
+    definition: ConnectorDefinitionWire,
+}
+
+#[derive(Deserialize)]
+struct ConnectorDefinitionWire {
+    source_id: String,
+    resource_families: Vec<ConnectorFamilyWire>,
+}
+
+#[derive(Deserialize)]
+struct ConnectorFamilyWire {
+    id: String,
+    method: String,
+    path: String,
+}
+
+#[derive(Deserialize)]
 struct EventContractWire {
     kind: String,
     schema_ref: String,
@@ -97,6 +120,48 @@ fn closed_runtime_definition_matches_provider_catalog_exactly() {
 }
 
 #[test]
+fn provider_proof_covers_every_public_connector_family() {
+    let catalog: CatalogWire = serde_saphyr::from_slice(CATALOG).expect("Tailscale catalog YAML");
+    let connector: ConnectorCatalogWire = serde_saphyr::from_slice(include_bytes!(
+        "../../../../internal/connectorcatalog/catalog/identity-access-secrets/tailscale.yaml"
+    ))
+    .expect("Tailscale connector YAML");
+    let definition = connector
+        .entries
+        .into_iter()
+        .find(|entry| entry.definition.source_id == "tailscale")
+        .expect("Tailscale connector definition")
+        .definition;
+    let proved = catalog
+        .provider_api
+        .families
+        .iter()
+        .map(|family| {
+            (
+                family.id.as_str(),
+                family.method.as_str(),
+                family.path.replace("{tailnet}", "${config.tailnet}"),
+            )
+        })
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        definition
+            .resource_families
+            .iter()
+            .map(|family| family.id.as_str())
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["configuration", "device", "integration", "user"])
+    );
+    for family in definition.resource_families {
+        assert!(
+            proved.contains(&(family.id.as_str(), family.method.as_str(), family.path)),
+            "missing provider proof for {}",
+            family.id
+        );
+    }
+}
+
+#[test]
 fn plans_all_families_without_credentials_or_redirects() {
     for family in TailscaleFamily::ALL {
         let request = kernel(family, 100).plan(None).expect("request");
@@ -141,21 +206,29 @@ fn checked_in_provider_fixtures_match_go_oracle_semantics() {
             assert_eq!(record.tenant_id, expected["tenant_id"]);
             assert_eq!(record.payload, expected["payload"]);
             assert_eq!(record.occurred_at, expected["occurred_at"]);
-            for (key, value) in expected["attributes"].as_object().unwrap() {
-                // Fixture display labels for ACL map keys are editorial labels;
-                // live Go normalization derives the provider key as the name.
-                if key == "resource_name"
-                    && matches!(family, TailscaleFamily::Group | TailscaleFamily::Tag)
-                {
-                    continue;
-                }
-                assert_eq!(
-                    record.attributes.get(key).map(String::as_str),
-                    value.as_str(),
-                    "{family}:{key}"
+            let mut expected_attributes = expected["attributes"]
+                .as_object()
+                .unwrap()
+                .iter()
+                .map(|(key, value)| {
+                    (
+                        key.clone(),
+                        value.as_str().expect("string fixture attribute").to_owned(),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>();
+            expected_attributes.insert("provider".to_owned(), "tailscale".to_owned());
+            expected_attributes.insert("source_provider".to_owned(), "tailscale".to_owned());
+            if matches!(family, TailscaleFamily::Group | TailscaleFamily::Tag) {
+                // ACL map keys are the only live provider name available. The
+                // checked fixtures retain editorial labels for UI presentation.
+                expected_attributes.insert(
+                    "resource_name".to_owned(),
+                    expected_attributes["external_id"].clone(),
                 );
             }
-            assert!(record.event_id.starts_with("tailscale-tenant-"));
+            assert_eq!(record.attributes, expected_attributes, "{family}");
+            assert_eq!(record.event_id, go_oracle_event_id(family), "{family}");
         }
     }
 }
@@ -203,6 +276,25 @@ fn cursor_checkpoint_and_restart_are_bounded_and_round_trippable() {
         ),
         Err(TailscaleError::InvalidCursor)
     );
+
+    let terminal = kernel
+        .decode_http(
+            &resumed,
+            200,
+            &TailscaleResponseMetadata::default(),
+            br#"{"users":[{"id":"user-2","loginName":"b@example.test","created":"2026-06-02T00:00:00Z"}]}"#,
+        )
+        .unwrap();
+    let terminal_checkpoint = kernel
+        .checkpoint_candidate(&resumed, &terminal, Some("2026-06-01T12:00:00Z"))
+        .unwrap();
+    assert_eq!(terminal_checkpoint.cursor.as_deref(), Some("user-2"));
+    assert_eq!(
+        terminal_checkpoint.watermark.as_deref(),
+        Some("2026-06-02T00:00:00Z")
+    );
+    let restarted = kernel.plan(terminal_checkpoint.cursor.as_deref()).unwrap();
+    assert_eq!(restarted.cursor(), Some("user-2"));
 }
 
 #[test]
@@ -418,4 +510,16 @@ fn oracle(family: TailscaleFamily) -> Vec<Value> {
         }
     };
     serde_json::from_slice(bytes).expect("Go fixture oracle")
+}
+
+fn go_oracle_event_id(family: TailscaleFamily) -> &'static str {
+    match family {
+        TailscaleFamily::Tailnet => "tailscale-tenant-fb119763df3d-tailnet-writer.com",
+        TailscaleFamily::User => "tailscale-tenant-d997fe6a82ab-user-user-1",
+        TailscaleFamily::Device => "tailscale-tenant-4ee73982e195-device-device-1",
+        TailscaleFamily::Group => "tailscale-tenant-9980b6ff061b-group-group-eng",
+        TailscaleFamily::Tag => "tailscale-tenant-9980b6ff061b-tag-tag-prod",
+        TailscaleFamily::Service => "tailscale-tenant-aa65280fbb01-service-svc-api",
+        TailscaleFamily::Grant => "tailscale-tenant-9980b6ff061b-grant-grant-1",
+    }
 }

--- a/crates/source-runtime-next/src/tailscale/tests.rs
+++ b/crates/source-runtime-next/src/tailscale/tests.rs
@@ -1,5 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
 
+use cerebro_source_catalog::{CollectionAuthority, SourceCatalog, UnsupportedReasonCode};
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -8,6 +10,10 @@ use super::*;
 const ORIGIN: &str = "https://api.tailscale.com/api/v2";
 const OBSERVED_AT: &str = "2026-06-01T00:00:00Z";
 const CATALOG: &[u8] = include_bytes!("../../../../sources/tailscale/catalog.yaml");
+const LEGACY_FAMILIES: [&str; 7] = [
+    "device", "grant", "group", "service", "tag", "tailnet", "user",
+];
+const CONNECTOR_ONLY_FAMILIES: [&str; 2] = ["configuration", "integration"];
 
 #[derive(Deserialize)]
 struct CatalogWire {
@@ -51,6 +57,13 @@ struct ConnectorFamilyWire {
     id: String,
     method: String,
     path: String,
+    record_selector: String,
+    event: ConnectorEventWire,
+}
+
+#[derive(Deserialize)]
+struct ConnectorEventWire {
+    kind: String,
 }
 
 #[derive(Deserialize)]
@@ -144,20 +157,127 @@ fn provider_proof_covers_every_public_connector_family() {
             )
         })
         .collect::<BTreeSet<_>>();
+    let legacy = LEGACY_FAMILIES.into_iter().collect::<BTreeSet<_>>();
+    let connector_only = CONNECTOR_ONLY_FAMILIES.into_iter().collect::<BTreeSet<_>>();
+    let compiled = definition
+        .resource_families
+        .iter()
+        .map(|family| family.id.as_str())
+        .collect::<BTreeSet<_>>();
+    assert!(legacy.is_disjoint(&connector_only));
     assert_eq!(
-        definition
-            .resource_families
+        compiled,
+        legacy
+            .union(&connector_only)
+            .copied()
+            .collect::<BTreeSet<_>>()
+    );
+    assert_eq!(
+        catalog
+            .provider_api
+            .families
             .iter()
             .map(|family| family.id.as_str())
             .collect::<BTreeSet<_>>(),
-        BTreeSet::from(["configuration", "device", "integration", "user"])
+        compiled
     );
     for family in definition.resource_families {
         assert!(
-            proved.contains(&(family.id.as_str(), family.method.as_str(), family.path)),
+            proved.contains(&(
+                family.id.as_str(),
+                family.method.as_str(),
+                family.path.clone(),
+            )),
             "missing provider proof for {}",
             family.id
         );
+        if let Ok(legacy_family) = family.id.parse::<TailscaleFamily>() {
+            assert_eq!(family.event.kind, legacy_family.event_kind());
+            assert_eq!(
+                family.path.replace("${config.tailnet}", "-"),
+                legacy_family.path()
+            );
+        } else {
+            let (kind, path, selector) = match family.id.as_str() {
+                "configuration" => (
+                    "tailscale.configuration",
+                    "/tailnet/${config.tailnet}/logging/configuration",
+                    "$.logs[*]",
+                ),
+                "integration" => (
+                    "tailscale.integration",
+                    "/tailnet/${config.tailnet}/posture/integrations",
+                    "$.integrations[*]",
+                ),
+                _ => panic!("unexpected connector-only family {}", family.id),
+            };
+            assert_eq!(family.event.kind, kind);
+            assert_eq!(family.path, path);
+            assert_eq!(family.record_selector, selector);
+        }
+    }
+}
+
+#[test]
+fn legacy_kernel_and_source_catalog_stay_exactly_seven_families() {
+    let catalog: CatalogWire = serde_saphyr::from_slice(CATALOG).expect("Tailscale catalog YAML");
+    let legacy = LEGACY_FAMILIES.into_iter().collect::<BTreeSet<_>>();
+    assert_eq!(
+        catalog
+            .runtime_families
+            .iter()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>(),
+        legacy
+    );
+    assert_eq!(
+        TailscaleFamily::ALL
+            .into_iter()
+            .map(TailscaleFamily::as_str)
+            .collect::<BTreeSet<_>>(),
+        legacy
+    );
+}
+
+#[test]
+fn compiled_connector_preserves_seven_legacy_and_two_mapped_auxiliary_families() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let catalog = SourceCatalog::load(
+        root.join("internal/connectorcatalog/catalog"),
+        root.join("sources"),
+    )
+    .expect("compile source catalog");
+    let tailscale = catalog.get("tailscale").expect("compiled Tailscale source");
+    assert_eq!(tailscale.authority(), CollectionAuthority::ShadowOnly);
+    let compiled = tailscale
+        .families()
+        .iter()
+        .map(|family| family.id())
+        .collect::<BTreeSet<_>>();
+    let expected = LEGACY_FAMILIES
+        .into_iter()
+        .chain(CONNECTOR_ONLY_FAMILIES)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(compiled, expected);
+    for family in tailscale.families() {
+        if LEGACY_FAMILIES.contains(&family.id()) {
+            assert!(family.is_authoritative(), "{}", family.id());
+            assert!(family.is_projection_authoritative(), "{}", family.id());
+            assert!(family.unsupported_reasons().is_empty(), "{}", family.id());
+        } else {
+            assert!(CONNECTOR_ONLY_FAMILIES.contains(&family.id()));
+            assert!(!family.is_authoritative(), "{}", family.id());
+            assert!(!family.is_projection_authoritative(), "{}", family.id());
+            assert_eq!(
+                family.unsupported_reasons(),
+                [
+                    UnsupportedReasonCode::MissingProviderProof,
+                    UnsupportedReasonCode::IncompleteRuntimeFamilyProof,
+                ],
+                "{}",
+                family.id()
+            );
+        }
     }
 }
 
@@ -178,6 +298,17 @@ fn plans_all_families_without_credentials_or_redirects() {
         assert!(!request.contains_credentials());
         assert!(!request.allows_redirects());
         assert_eq!(request.max_response_bytes(), 4 * 1024 * 1024);
+        assert_eq!(
+            request
+                .url()
+                .query_pairs()
+                .map(|(key, value)| (key.into_owned(), value.into_owned()))
+                .collect::<BTreeMap<_, _>>(),
+            BTreeMap::from([
+                ("limit".to_owned(), "100".to_owned()),
+                ("per_page".to_owned(), "100".to_owned()),
+            ])
+        );
         let debug = format!("{request:?}");
         assert!(!debug.contains("test-token-secret"));
         assert!(!debug.contains("credential_reference"));
@@ -298,6 +429,41 @@ fn cursor_checkpoint_and_restart_are_bounded_and_round_trippable() {
 }
 
 #[test]
+fn every_legacy_family_preserves_terminal_go_checkpoint_semantics() {
+    for family in TailscaleFamily::ALL {
+        let kernel = kernel(family, 100);
+        let request = kernel.plan(None).unwrap();
+        let page = kernel
+            .decode_http(
+                &request,
+                200,
+                &TailscaleResponseMetadata::default(),
+                fixture(family).as_bytes(),
+            )
+            .unwrap();
+        let checkpoint = kernel
+            .checkpoint_candidate(&request, &page, Some("2026-05-31T00:00:00Z"))
+            .unwrap();
+        let last = page.records.last().expect("fixture record");
+        assert_eq!(
+            checkpoint.cursor.as_deref(),
+            last.attributes.get("external_id").map(String::as_str),
+            "{family}"
+        );
+        assert_eq!(
+            checkpoint.watermark.as_deref(),
+            Some(last.occurred_at.as_str()),
+            "{family}"
+        );
+        assert_eq!(
+            kernel.plan(checkpoint.cursor.as_deref()).unwrap().cursor(),
+            checkpoint.cursor.as_deref(),
+            "{family}"
+        );
+    }
+}
+
+#[test]
 fn rejects_secret_tenant_duplicate_origin_cursor_and_provider_failures() {
     assert!(matches!(
         TailscaleKernel::new(
@@ -412,16 +578,20 @@ fn projection_preserves_network_identity_and_acl_semantics() {
         .iter()
         .map(|entity| entity.urn.as_str())
         .collect::<BTreeSet<_>>();
-    for expected in [
+    let expected_entities = BTreeSet::from([
+        "urn:cerebro:tenant:tailscale_tailnet:writer.com",
         "urn:cerebro:tenant:tailscale_user:user-1",
         "urn:cerebro:tenant:tailscale_device:device-1",
+        "urn:cerebro:tenant:tailscale_user:alice@writer.com",
+        "urn:cerebro:tenant:tailscale_user:bob@writer.com",
         "urn:cerebro:tenant:tailscale_group:group:eng",
         "urn:cerebro:tenant:tailscale_tag:tag:prod",
+        "urn:cerebro:tenant:tailscale_tag:tag:eng",
         "urn:cerebro:tenant:tailscale_service:svc:api",
         "urn:cerebro:tenant:tailscale_grant:grant-1",
-    ] {
-        assert!(entities.contains(expected), "missing {expected}");
-    }
+        "urn:cerebro:tenant:tailscale_destination:tag:prod:443",
+    ]);
+    assert_eq!(entities, expected_entities);
     let relations = facts
         .relations
         .iter()
@@ -433,11 +603,26 @@ fn projection_preserves_network_identity_and_acl_semantics() {
             )
         })
         .collect::<BTreeSet<_>>();
-    for expected in [
+    let expected_relations = BTreeSet::from([
         (
             "urn:cerebro:tenant:tailscale_device:device-1",
             "owned_by",
             "urn:cerebro:tenant:tailscale_user:alice@writer.com",
+        ),
+        (
+            "urn:cerebro:tenant:tailscale_user:alice@writer.com",
+            "can_reach",
+            "urn:cerebro:tenant:tailscale_device:device-1",
+        ),
+        (
+            "urn:cerebro:tenant:tailscale_device:device-1",
+            "tagged_as",
+            "urn:cerebro:tenant:tailscale_tag:tag:prod",
+        ),
+        (
+            "urn:cerebro:tenant:tailscale_device:device-1",
+            "tagged_as",
+            "urn:cerebro:tenant:tailscale_tag:tag:eng",
         ),
         (
             "urn:cerebro:tenant:tailscale_group:group:eng",
@@ -445,8 +630,33 @@ fn projection_preserves_network_identity_and_acl_semantics() {
             "urn:cerebro:tenant:tailscale_user:alice@writer.com",
         ),
         (
+            "urn:cerebro:tenant:tailscale_user:alice@writer.com",
+            "member_of",
+            "urn:cerebro:tenant:tailscale_group:group:eng",
+        ),
+        (
+            "urn:cerebro:tenant:tailscale_group:group:eng",
+            "contains",
+            "urn:cerebro:tenant:tailscale_user:bob@writer.com",
+        ),
+        (
+            "urn:cerebro:tenant:tailscale_user:bob@writer.com",
+            "member_of",
+            "urn:cerebro:tenant:tailscale_group:group:eng",
+        ),
+        (
             "urn:cerebro:tenant:tailscale_tag:tag:prod",
             "owned_by",
+            "urn:cerebro:tenant:tailscale_group:group:eng",
+        ),
+        (
+            "urn:cerebro:tenant:tailscale_service:svc:api",
+            "tagged_as",
+            "urn:cerebro:tenant:tailscale_tag:tag:prod",
+        ),
+        (
+            "urn:cerebro:tenant:tailscale_grant:grant-1",
+            "grants_entitlement",
             "urn:cerebro:tenant:tailscale_group:group:eng",
         ),
         (
@@ -454,9 +664,8 @@ fn projection_preserves_network_identity_and_acl_semantics() {
             "can_reach",
             "urn:cerebro:tenant:tailscale_destination:tag:prod:443",
         ),
-    ] {
-        assert!(relations.contains(&expected), "missing {expected:?}");
-    }
+    ]);
+    assert_eq!(relations, expected_relations);
 }
 
 fn fixture(family: TailscaleFamily) -> String {

--- a/internal/connectorcatalog/catalog/identity-access-secrets/tailscale.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets/tailscale.yaml
@@ -18,7 +18,7 @@ entries:
       key: tailnet
       label: Tailnet
       required: true
-    description: "Collects configuration, user, integration, and device from Tailscale and projects them into the Cerebro graph as audit events, users, policies, and assets for identity, access, device, and secret context."
+    description: "Collects tailnet settings, users, devices, ACL groups, tag owners, services, grants, configuration logs, and posture integrations from Tailscale for identity, access, network, device, and audit context."
     display_name: Tailscale
     id: builtin_catalog-tailscale
     resource_families:
@@ -180,6 +180,268 @@ entries:
           resource_type: device
         template: asset
       record_selector: "$.devices[*]"
+    - coverage:
+      - families:
+        - tailnet
+        high_value: true
+        evidence_types:
+        - source_snapshot
+        control_domains:
+        - asset_inventory
+        - network_security
+        id: tailnet
+        support: supported
+        title: Tailnet settings
+        type: entity_family
+      default_enabled: true
+      event:
+        attributes:
+          devices_approval_on: devicesApprovalOn
+          max_key_duration_days: maxKeyDurationDays
+          network_flow_logging_on: networkFlowLoggingOn
+          regional_routing_on: regionalRoutingOn
+          tailnet: tailnet|organization|id
+          users_approval_on: usersApprovalOn
+        exact_attributes: true
+        kind: tailscale.tailnet
+        required_attributes:
+        - tailnet
+        required_payload_fields:
+        - id
+        schema_ref: tailscale/tailnet/v1
+        static_attributes:
+          source_product: tailscale
+        urn_kind: tailscale_tailnet
+      event_kind: tailnet
+      id: tailnet
+      id_field: id
+      label: Tailnet settings
+      method: GET
+      name_field: tailnet|organization|id
+      pagination:
+        type: none
+      path: "/tailnet/${config.tailnet}/settings"
+      permissions_needed:
+      - bearerAuth
+      projection:
+        fields:
+          resource_id: tailnet|organization|id
+          resource_name: tailnet|organization|id
+          tailnet: tailnet|organization|id
+        static_fields:
+          resource_type: tailnet
+        template: asset
+      read:
+        singleton: true
+      record_selector: "$"
+    - coverage:
+      - families:
+        - group
+        high_value: true
+        evidence_types:
+        - identity_configuration
+        - relationship_evidence
+        control_domains:
+        - identity_access
+        id: groups
+        support: supported
+        title: ACL groups
+        type: relationship
+      default_enabled: true
+      event:
+        attributes:
+          group_id: id|name
+          members: members
+          name: name
+        exact_attributes: true
+        kind: tailscale.group
+        required_attributes:
+        - group_id
+        required_payload_fields:
+        - id
+        schema_ref: tailscale/group/v1
+        static_attributes:
+          source_product: tailscale
+        urn_kind: tailscale_group
+      event_kind: group
+      id: group
+      id_field: id
+      label: ACL groups
+      method: GET
+      name_field: name
+      pagination:
+        type: none
+      path: "/tailnet/${config.tailnet}/acl"
+      permissions_needed:
+      - bearerAuth
+      projection:
+        fields:
+          group_id: id|name
+          group_name: name
+          members: members
+          resource_id: id|name
+          resource_name: name
+        template: identity_group
+      read:
+        map_records:
+          groups: members
+      record_selector: "$"
+    - coverage:
+      - families:
+        - tag
+        high_value: true
+        evidence_types:
+        - identity_configuration
+        control_domains:
+        - identity_access
+        id: tag_owners
+        support: supported
+        title: Tag owners
+        type: app_entitlement
+      default_enabled: true
+      event:
+        attributes:
+          name: name
+          owners: owners
+          tag_id: id|name
+        exact_attributes: true
+        kind: tailscale.tag
+        required_attributes:
+        - tag_id
+        required_payload_fields:
+        - id
+        schema_ref: tailscale/tag/v1
+        static_attributes:
+          source_product: tailscale
+        urn_kind: tailscale_tag
+      event_kind: tag
+      id: tag
+      id_field: id
+      label: Tag owners
+      method: GET
+      name_field: name
+      pagination:
+        type: none
+      path: "/tailnet/${config.tailnet}/acl"
+      permissions_needed:
+      - bearerAuth
+      projection:
+        fields:
+          policy_id: id|name
+          policy_name: name
+          tag_id: id|name
+        static_fields:
+          policy_type: tag_ownership
+        template: policy
+      read:
+        map_records:
+          tagOwners: owners
+      record_selector: "$"
+    - coverage:
+      - families:
+        - service
+        high_value: true
+        evidence_types:
+        - source_snapshot
+        control_domains:
+        - asset_inventory
+        - network_security
+        id: services
+        support: supported
+        title: Services
+        type: entity_family
+      default_enabled: true
+      event:
+        attributes:
+          addresses: addrs|addresses
+          comment: comment
+          name: name
+          ports: ports
+          service_id: id|service_id|name
+          tags: tags
+        exact_attributes: true
+        kind: tailscale.service
+        required_attributes:
+        - service_id
+        required_payload_fields:
+        - name
+        schema_ref: tailscale/service/v1
+        static_attributes:
+          source_product: tailscale
+        urn_kind: tailscale_service
+      event_kind: service
+      id: service
+      id_field: id|service_id|name
+      label: Services
+      list_key: vipServices
+      method: GET
+      name_field: name
+      pagination:
+        type: none
+      path: "/tailnet/${config.tailnet}/vip-services"
+      permissions_needed:
+      - bearerAuth
+      projection:
+        fields:
+          resource_id: id|service_id|name
+          resource_name: name
+          service_id: id|service_id|name
+        static_fields:
+          resource_type: service
+        template: asset
+      record_selector: "$.vipServices[*]"
+    - coverage:
+      - families:
+        - grant
+        high_value: true
+        evidence_types:
+        - identity_configuration
+        control_domains:
+        - identity_access
+        - network_security
+        id: grants
+        support: supported
+        title: ACL grants
+        type: app_entitlement
+      default_enabled: true
+      event:
+        attributes:
+          app: app
+          destinations: dst|destinations
+          disabled: disabled
+          grant_id: id|grant_id
+          ip: ip
+          sources: src|sources
+          via: via
+        exact_attributes: true
+        kind: tailscale.grant
+        required_attributes:
+        - grant_id
+        required_payload_fields:
+        - id
+        schema_ref: tailscale/grant/v1
+        static_attributes:
+          source_product: tailscale
+        urn_kind: tailscale_grant
+      event_kind: grant
+      id: grant
+      id_field: id|grant_id
+      label: ACL grants
+      method: GET
+      name_field: id|grant_id
+      pagination:
+        type: none
+      path: "/tailnet/${config.tailnet}/acl"
+      permissions_needed:
+      - bearerAuth
+      projection:
+        fields:
+          policy_id: id|grant_id
+          policy_name: id|grant_id
+        static_fields:
+          policy_type: acl_grant
+        template: policy
+      record_selector: "$.grants[*]"
     schema_version: cerebro.integration/v1
     scope_options:
     - default_enabled: true
@@ -202,6 +464,31 @@ entries:
       - device
       id: device
       label: Device
+    - default_enabled: true
+      families:
+      - tailnet
+      id: tailnet
+      label: Tailnet settings
+    - default_enabled: true
+      families:
+      - group
+      id: group
+      label: ACL groups
+    - default_enabled: true
+      families:
+      - tag
+      id: tag
+      label: Tag owners
+    - default_enabled: true
+      families:
+      - service
+      id: service
+      label: Services
+    - default_enabled: true
+      families:
+      - grant
+      id: grant
+      label: ACL grants
     source_id: tailscale
     tenant_id: builtin_catalog
     transport:

--- a/sources/tailscale/catalog.yaml
+++ b/sources/tailscale/catalog.yaml
@@ -16,6 +16,7 @@ provider_api:
     - https://tailscale.com/docs/reference/tailscale-api
     - https://tailscale.com/api
     - https://tailscale.com/docs/reference/trust-credentials
+    - https://tailscale.com/docs/features/logging/audit-logging
     - https://tailscale.com/docs/features/oauth-clients
     - https://tailscale.com/docs/reference/syntax/policy-file
     - https://tailscale.com/docs/features/tailscale-services
@@ -23,6 +24,9 @@ provider_api:
     - https://github.com/tailscale/tailscale/blob/b727675a8be8eb307420eb5e6cb8d7b902eb751b/client/tailscale/acl.go
     - https://github.com/tailscale/tailscale/blob/b727675a8be8eb307420eb5e6cb8d7b902eb751b/internal/client/tailscale/vip_service.go
   families:
+    - id: configuration
+      method: GET
+      path: /tailnet/{tailnet}/logging/configuration
     - id: device
       method: GET
       path: /tailnet/{tailnet}/devices
@@ -32,6 +36,9 @@ provider_api:
     - id: group
       method: GET
       path: /tailnet/{tailnet}/acl
+    - id: integration
+      method: GET
+      path: /tailnet/{tailnet}/posture/integrations
     - id: service
       method: GET
       path: /tailnet/{tailnet}/vip-services


### PR DESCRIPTION
## Summary
- preserve the exact seven-family compatibility kernel: `device`, `grant`, `group`, `service`, `tag`, `tailnet`, and `user`
- add the five missing public connector families so the compiled catalog exposes those seven legacy families plus connector-only `configuration` and `integration`
- map the two connector-only families explicitly without adding them to the seven-family Rust runtime enum or `runtime_families`
- preserve exact Go-oracle payloads, attributes, event IDs, projection facts, cursor, terminal checkpoint, and restart semantics for every legacy family
- align the current-main source-catalog and Rust-only candidate census to 3,991 families: current main's 3,986 plus the five added Tailscale families

## Validation
- `git diff --check` — passed on exact head
- `actionlint .github/workflows/rust-only-candidate.yml` — passed on the Mac recovery path because DDESK does not provide `actionlint`
- `cargo fmt --all -- --check` — passed on the provider-semantic head before the directed current-main rebase
- `cargo test -p cerebro-source-runtime-next tailscale::tests -- --nocapture` — 10 passed on the provider-semantic head
- `go test ./internal/connectorcatalog ./internal/connectordefinitions ./sources/tailscale -count=1` — passed on the provider-semantic head
- the catalog command previously observed 3,983 on the 3,978-family base; after rebasing onto the 3,986-family current main, `catalog-summary` was actively compiling when the coordinator directed publication without waiting, so the fresh combined command result remains unobserved locally
- hosted checks are the fresh validation for exact head `c748d55c2b678a509073c33110a30efc8564d691`

## Authority boundary
All seven legacy families have exact provider proof and authoritative portable collection/projection contracts. `configuration` and `integration` remain explicitly mapped connector-only auxiliaries and are intentionally outside the seven-family bespoke kernel; while the Go loader remains registered, the compiled Tailscale source remains `ShadowOnly`.

This draft retains both Tailscale Go files, all checked fixtures, the registry loader, and the compatibility exception. It does not change runtime registration, dispatcher, host configuration, registry, architecture guards, or claim that the Go path can be retired.
