### PR TITLE
fix(sources): align Kubernetes catalog with runtime

### DIFF
--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -178,7 +178,7 @@ jobs:
           '
           summary="$(docker run --rm "${CANDIDATE_IMAGE}" catalog-summary)"
           test "$(jq -r .sources <<<"${summary}")" -eq 799
-          test "$(jq -r .families <<<"${summary}")" -eq 3978
+          test "$(jq -r .families <<<"${summary}")" -eq 3986
       - name: Start disposable PostgreSQL, Neo4j, and JetStream
         run: |
           set -euo pipefail
@@ -246,7 +246,7 @@ jobs:
             | .checks += [
                 {name:"rust_entrypoint",status:"passed",evidence:"image starts cerebro-platform directly"},
                 {name:"go_binary_absent",status:"passed",evidence:"/usr/local/bin/cerebro is absent"},
-                {name:"source_catalog",status:"passed",evidence:"799 sources and 3978 families loaded"}
+                {name:"source_catalog",status:"passed",evidence:"799 sources and 3986 families loaded"}
               ]
           ' .dist/rust-only-e2e/rust-only-e2e-receipt.json \
             > .dist/rust-only-e2e/receipt.tmp

--- a/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
+++ b/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
@@ -108,8 +108,8 @@ fn rust_candidate_build_never_invokes_go_or_emulation() {
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- seed",
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- verify",
         r#"test "$(jq -r .sources <<<"${summary}")" -eq 799"#,
-        r#"test "$(jq -r .families <<<"${summary}")" -eq 3978"#,
-        r#"evidence:"799 sources and 3978 families loaded""#,
+        r#"test "$(jq -r .families <<<"${summary}")" -eq 3986"#,
+        r#"evidence:"799 sources and 3986 families loaded""#,
         "cerebro.rust-only-e2e/v1",
         "cerebro.rust-only-candidate/v1",
     ] {

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -1308,15 +1308,15 @@ fn compile_source(
             "model_config_key requires more than one configurable auth model",
         );
     }
-    let generic_runtime_supported = classifier_supported
-        && configurable_auth_models
-            .iter()
-            .all(AuthModel::supports_generic_runtime)
+    let auth_runtime_supported = configurable_auth_models
+        .iter()
+        .all(AuthModel::supports_generic_runtime)
         && (auth != AuthModel::ApiKey
             || !token_header.is_empty()
             || !auth_header_parameters.is_empty()
             || !auth_query_parameters.is_empty()
             || !auth_json_body_parameters.is_empty());
+    let generic_runtime_supported = classifier_supported && auth_runtime_supported;
     let verified_families = verified_families(proofs.get(&id));
     let mut family_ids = BTreeSet::new();
     let mut families = Vec::with_capacity(entry.definition.resource_families.len());
@@ -1329,6 +1329,8 @@ fn compile_source(
             family,
             &verified_families,
             generic_runtime_supported,
+            classifier_supported,
+            auth_runtime_supported,
             &config_fields,
         )?);
     }
@@ -1530,6 +1532,8 @@ fn compile_family(
     family: FamilyWire,
     verified: &BTreeSet<(String, String, String)>,
     generic_runtime_supported: bool,
+    classifier_supported: bool,
+    auth_runtime_supported: bool,
     config_fields: &BTreeMap<&str, bool>,
 ) -> Result<CompiledFamily, CatalogError> {
     let method = match family.method.trim() {
@@ -1857,8 +1861,11 @@ fn compile_family(
     let projection_authoritative =
         provider_contract_verified && projection_class.can_be_authoritative();
     let mut unsupported_reasons = Vec::new();
-    if !generic_runtime_supported {
+    if !auth_runtime_supported {
         unsupported_reasons.push(UnsupportedReasonCode::UnsupportedAuthModel);
+    }
+    if !classifier_supported {
+        unsupported_reasons.push(UnsupportedReasonCode::BespokeRuntime);
     }
     if !provider_contract_verified {
         unsupported_reasons.push(UnsupportedReasonCode::MissingProviderProof);
@@ -2964,7 +2971,7 @@ mod tests {
         .unwrap();
         let summary = catalog.summary();
         assert_eq!(summary.sources, 799);
-        assert_eq!(summary.families, 3_978);
+        assert_eq!(summary.families, 3_986);
         assert_eq!(summary.push_sources, 1);
         assert_eq!(summary.push_families, 10);
         assert_eq!(
@@ -3700,6 +3707,33 @@ mod tests {
     }
 
     #[test]
+    fn bespoke_classifier_is_not_reported_as_an_auth_failure() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+
+        for source_id in ["auth0", "kubernetes"] {
+            let source = catalog.get(source_id).unwrap();
+            assert!(source.auth().supports_generic_runtime());
+            for family in source.families() {
+                assert!(
+                    !family
+                        .unsupported_reasons()
+                        .contains(&UnsupportedReasonCode::UnsupportedAuthModel)
+                );
+                assert!(
+                    family
+                        .unsupported_reasons()
+                        .contains(&UnsupportedReasonCode::BespokeRuntime)
+                );
+            }
+        }
+    }
+
+    #[test]
     fn composite_id_templates_are_closed_and_bounded() {
         for valid in [
             "${reportedAt}:${reporterId}",
@@ -3908,7 +3942,7 @@ mod tests {
         .unwrap();
         let report = catalog.unsupported_feature_report();
         assert_eq!(report.total_sources, 799);
-        assert_eq!(report.total_families, 3_978);
+        assert_eq!(report.total_families, 3_986);
         assert_eq!(report.families.len(), report.total_families);
         assert!(report.missing_family_reports.is_empty());
         assert_eq!(
@@ -3957,7 +3991,7 @@ mod tests {
         )
         .unwrap();
         let report = catalog.authority_readiness_report();
-        assert_eq!(report.total_families, 3_978);
+        assert_eq!(report.total_families, 3_986);
         assert_eq!(report.rust_authoritative_families, 0);
         assert_eq!(report.shadow_or_go_families, report.total_families);
         let aws_bedrock = report

--- a/internal/connectorcatalog/catalog/devops-ci-cd/kubernetes.yaml
+++ b/internal/connectorcatalog/catalog/devops-ci-cd/kubernetes.yaml
@@ -1,213 +1,780 @@
 entries:
-- classifier_output: supported
+- classifier_output: bespoke_required
   definition:
     auth:
-      credential_fields:
-      - key: api_key
-        label: API key
-        reference_only: true
-        required: true
-        secret: true
-      model: api_key
-      requires_references: true
+      model: none
     categories:
-    - saas
-    description: "Collects event, clusterrole, secret, and serviceaccount from Kubernetes and projects them into the Cerebro graph as audit events, groups, secrets, and users for repository, build, deployment, and release context."
+    - cloud
+    - infrastructure
+    config_fields:
+    - help: HTTPS origin of the Kubernetes API server selected by the trusted runtime
+        host.
+      key: api_server
+      label: API server
+      required: true
+    - help: Stable cluster identity. The runtime falls back to external_id, cloud
+        account plus cluster name, or cluster_name.
+      key: cluster_id
+      label: Cluster ID
+    - help: Operator-facing cluster name.
+      key: cluster_name
+      label: Cluster name
+    - help: Optional provider-owned external cluster identity.
+      key: external_id
+      label: External ID
+    - help: Normalized cloud provider identifier when the cluster is cloud-hosted.
+      key: cloud_provider
+      label: Cloud provider
+    - help: Cloud account, project, or subscription identity.
+      key: cloud_account_id
+      label: Cloud account ID
+    - help: Host-local kubeconfig path. Required by the Go compatibility runtime unless
+        in_cluster is true.
+      key: kubeconfig_path
+      label: Kubeconfig path
+    - help: Optional kubeconfig context override.
+      key: context
+      label: Kubeconfig context
+    - help: Use the runtime host's in-cluster Kubernetes identity.
+      key: in_cluster
+      label: In-cluster authentication
+    - help: Provider page size from 1 through 500. Defaults to 100.
+      key: per_page
+      label: Page size
+    description: Collects Kubernetes clusters, namespaces, nodes, pods, workloads,
+      containers, services, ingresses, service accounts, RBAC roles and bindings,
+      and workload identity bindings for asset, identity, and access context.
     display_name: Kubernetes
     id: builtin_catalog-kubernetes
     resource_families:
     - coverage:
-      - families:
-        - event
-        high_value: true
-        evidence_types:
-        - logging_configuration
-        control_domains:
-        - logging_monitoring
-        id: audit_events
-        support: partial
-        title: Event
-        type: audit_event
-      default_enabled: true
-      event:
-        kind: kubernetes.event
-        required_payload_fields:
-        - action
-        schema_ref: kubernetes/event/v1
-        urn_kind: kubernetes_event
-      event_kind: event
-      id: event
-      id_field: action
-      label: Event
-      list_key: items
-      method: GET
-      name_field: action
-      pagination:
-        page_size: 100
-        page_size_param: limit
-        type: page
-      path: "/api/v1/events"
-      permissions_needed:
-      - BearerToken
-      projection:
-        fields:
-          id: action
-          name: action
-          provider_id: action
-        template: audit_event
-      record_selector: "$.items[*]"
-    - coverage:
-      - families:
-        - clusterrole
+      - id: clusters
+        type: entity_family
+        title: Kubernetes clusters
+        families:
+        - cluster
+        support: supported
         high_value: true
         evidence_types:
         - source_snapshot
         control_domains:
         - asset_inventory
-        id: clusterrole
-        support: partial
-        title: Clusterrole
-        type: entity_family
       default_enabled: true
       event:
-        kind: kubernetes.clusterrole
+        kind: kubernetes.cluster
+        required_attributes:
+        - cluster_id
+        - cluster_name
         required_payload_fields:
-        - aggregationRule
-        schema_ref: kubernetes/clusterrole/v1
-        urn_kind: kubernetes_clusterrole
-      event_kind: clusterrole
-      id: clusterrole
-      id_field: aggregationRule
-      label: Clusterrole
-      list_key: items
+        - cluster_id
+        - cluster_name
+        schema_ref: kubernetes/cluster/v1
+        urn_kind: kubernetes_cluster
+      id: cluster
+      id_field: cluster_id
+      label: Cluster
       method: GET
-      name_field: aggregationRule
-      pagination:
-        page_size: 100
-        page_size_param: limit
-        type: page
-      path: "/apis/rbac.authorization.k8s.io/v1/clusterroles"
-      permissions_needed:
-      - BearerToken
+      name_field: cluster_name
+      path: "/version"
       projection:
+        entity:
+          entity_type: kubernetes.cluster
+          id_attributes:
+          - cluster_id
+          label_attribute: cluster_name
+          urn_kind: kubernetes_cluster
         fields:
-          id: aggregationRule
-          name: aggregationRule
-          provider_id: aggregationRule
-        template: identity_group
-      record_selector: "$.items[*]"
+          id: cluster_name
+          name: cluster_name
+          provider_id: cluster_name
+        static_fields:
+          source_product: kubernetes
+        template: asset
+      record_selector: "$"
+      pagination:
+        type: none
+      singleton: true
     - coverage:
-      - families:
-        - secret
+      - id: namespaces
+        type: entity_family
+        title: Kubernetes namespaces
+        families:
+        - namespace
+        support: supported
         high_value: true
         evidence_types:
         - source_snapshot
         control_domains:
         - asset_inventory
-        id: secrets
-        support: partial
-        title: Secret
-        type: entity_family
       default_enabled: true
       event:
-        kind: kubernetes.secret
+        kind: kubernetes.namespace
+        required_attributes:
+        - cluster_id
+        - namespace
         required_payload_fields:
-        - apiVersion
-        schema_ref: kubernetes/secret/v1
-        urn_kind: kubernetes_secret
-      event_kind: secret
-      id: secret
-      id_field: apiVersion
-      label: Secret
-      list_key: items
+        - name
+        - uid
+        schema_ref: kubernetes/namespace/v1
+        urn_kind: kubernetes_namespace
+      id: namespace
+      id_field: metadata.uid
+      label: Namespaces
       method: GET
-      name_field: apiVersion
+      name_field: metadata.name
+      path: "/api/v1/namespaces"
+      projection:
+        entity:
+          entity_type: kubernetes.namespace
+          id_attributes:
+          - cluster_id
+          - namespace
+          label_attribute: namespace
+          urn_kind: kubernetes_namespace
+        fields:
+          id: namespace
+          name: namespace
+          provider_id: namespace
+        static_fields:
+          source_product: kubernetes
+        template: asset
+      record_selector: "$.items[*]"
+      list_key: items
       pagination:
+        cursor_json_path: "$.metadata.continue"
+        cursor_param: continue
         page_size: 100
         page_size_param: limit
-        type: page
-      path: "/api/v1/secrets"
-      permissions_needed:
-      - BearerToken
-      projection:
-        fields:
-          id: apiVersion
-          name: apiVersion
-          secret_id: apiVersion
-          secret_name: apiVersion
-          secret_type: secret
-        template: secret
-      record_selector: "$.items[*]"
+        type: cursor
     - coverage:
-      - families:
-        - serviceaccount
+      - id: nodes
+        type: entity_family
+        title: Kubernetes nodes
+        families:
+        - node
+        support: supported
         high_value: true
         evidence_types:
         - source_snapshot
         control_domains:
         - asset_inventory
-        id: serviceaccount
-        support: partial
-        title: Serviceaccount
-        type: entity_family
       default_enabled: true
       event:
-        kind: kubernetes.serviceaccount
+        kind: kubernetes.node
+        required_attributes:
+        - cluster_id
+        - node_name
+        - ready
         required_payload_fields:
-        - apiVersion
-        schema_ref: kubernetes/serviceaccount/v1
-        urn_kind: kubernetes_serviceaccount
-      event_kind: serviceaccount
-      id: serviceaccount
-      id_field: apiVersion
-      label: Serviceaccount
-      list_key: items
+        - name
+        - node_info
+        - ready
+        schema_ref: kubernetes/node/v1
+        urn_kind: kubernetes_node
+      id: node
+      id_field: metadata.uid
+      label: Nodes
       method: GET
-      name_field: apiVersion
+      name_field: metadata.name
+      path: "/api/v1/nodes"
+      projection:
+        entity:
+          entity_type: kubernetes.node
+          id_attributes:
+          - cluster_id
+          - node_name
+          label_attribute: node_name
+          urn_kind: kubernetes_node
+        fields:
+          id: node_name
+          name: node_name
+          provider_id: node_name
+        static_fields:
+          source_product: kubernetes
+        template: asset
+      record_selector: "$.items[*]"
+      list_key: items
       pagination:
+        cursor_json_path: "$.metadata.continue"
+        cursor_param: continue
         page_size: 100
         page_size_param: limit
-        type: page
+        type: cursor
+    - coverage:
+      - id: pods
+        type: entity_family
+        title: Kubernetes pods
+        families:
+        - pod
+        - container
+        support: supported
+        high_value: true
+        evidence_types:
+        - source_snapshot
+        control_domains:
+        - asset_inventory
+      default_enabled: true
+      event:
+        kind: kubernetes.pod
+        required_attributes:
+        - cluster_id
+        - namespace
+        - workload_uid
+        required_payload_fields:
+        - name
+        - namespace
+        - uid
+        schema_ref: kubernetes/pod/v1
+        urn_kind: kubernetes_pod
+      id: pod
+      id_field: metadata.uid
+      label: Pods
+      method: GET
+      name_field: metadata.name
+      path: "/api/v1/pods"
+      projection:
+        entity:
+          entity_type: kubernetes.pod
+          id_attributes:
+          - cluster_id
+          - namespace
+          - workload_uid
+          label_attribute: resource_name
+          urn_kind: kubernetes_pod
+        fields:
+          id: resource_name
+          name: resource_name
+          provider_id: resource_name
+        static_fields:
+          source_product: kubernetes
+        template: asset
+      record_selector: "$.items[*]"
+      list_key: items
+      pagination:
+        cursor_json_path: "$.metadata.continue"
+        cursor_param: continue
+        page_size: 100
+        page_size_param: limit
+        type: cursor
+    - coverage:
+      - id: workloads
+        type: entity_family
+        title: Kubernetes workloads
+        families:
+        - workload
+        support: supported
+        high_value: true
+        evidence_types:
+        - source_snapshot
+        control_domains:
+        - asset_inventory
+      default_enabled: true
+      event:
+        kind: kubernetes.workload
+        required_attributes:
+        - cluster_id
+        - namespace
+        - workload_uid
+        required_payload_fields:
+        - workload_kind
+        - workload_name
+        - workload_uid
+        schema_ref: kubernetes/workload/v1
+        urn_kind: kubernetes_workload
+      id: workload
+      id_field: metadata.uid
+      label: Workloads
+      method: GET
+      name_field: metadata.name
+      path: "/api/v1/pods"
+      projection:
+        entity:
+          entity_type: kubernetes.workload
+          id_attributes:
+          - cluster_id
+          - namespace
+          - workload_uid
+          label_attribute: workload_name
+          urn_kind: kubernetes_workload
+        fields:
+          id: workload_name
+          name: workload_name
+          provider_id: workload_name
+        static_fields:
+          source_product: kubernetes
+        template: asset
+      record_selector: "$.items[*]"
+      list_key: items
+      pagination:
+        cursor_json_path: "$.metadata.continue"
+        cursor_param: continue
+        page_size: 100
+        page_size_param: limit
+        type: cursor
+    - coverage:
+      - id: pods
+        type: entity_family
+        title: Kubernetes pods
+        families:
+        - pod
+        - container
+        support: supported
+        high_value: true
+        evidence_types:
+        - source_snapshot
+        control_domains:
+        - asset_inventory
+      default_enabled: true
+      event:
+        kind: kubernetes.container
+        required_attributes:
+        - cluster_id
+        - container_name
+        - namespace
+        required_payload_fields:
+        - container_name
+        - pod_uid
+        schema_ref: kubernetes/container/v1
+        urn_kind: kubernetes_container
+      id: container
+      id_field: metadata.uid
+      label: Containers
+      method: GET
+      name_field: metadata.name
+      path: "/api/v1/pods"
+      projection:
+        entity:
+          entity_type: kubernetes.container
+          id_attributes:
+          - cluster_id
+          - namespace
+          - resource_id
+          - container_name
+          label_attribute: container_name
+          urn_kind: kubernetes_container
+        fields:
+          id: container_name
+          name: container_name
+          provider_id: container_name
+        static_fields:
+          source_product: kubernetes
+        template: asset
+      record_selector: "$.items[*]"
+      list_key: items
+      pagination:
+        cursor_json_path: "$.metadata.continue"
+        cursor_param: continue
+        page_size: 100
+        page_size_param: limit
+        type: cursor
+    - coverage:
+      - id: services
+        type: entity_family
+        title: Kubernetes services
+        families:
+        - service
+        support: supported
+        high_value: true
+        evidence_types:
+        - source_snapshot
+        control_domains:
+        - asset_inventory
+      default_enabled: true
+      event:
+        kind: kubernetes.service
+        required_attributes:
+        - cluster_id
+        - namespace
+        - service_name
+        - service_type
+        required_payload_fields:
+        - name
+        - namespace
+        - ports
+        - type
+        schema_ref: kubernetes/service/v1
+        urn_kind: kubernetes_service
+      id: service
+      id_field: metadata.uid
+      label: Services
+      method: GET
+      name_field: metadata.name
+      path: "/api/v1/services"
+      projection:
+        entity:
+          entity_type: kubernetes.service
+          id_attributes:
+          - cluster_id
+          - namespace
+          - service_name
+          label_attribute: service_name
+          urn_kind: kubernetes_service
+        fields:
+          id: service_name
+          name: service_name
+          provider_id: service_name
+        static_fields:
+          source_product: kubernetes
+        template: asset
+      record_selector: "$.items[*]"
+      list_key: items
+      pagination:
+        cursor_json_path: "$.metadata.continue"
+        cursor_param: continue
+        page_size: 100
+        page_size_param: limit
+        type: cursor
+    - coverage:
+      - id: ingresses
+        type: entity_family
+        title: Kubernetes ingresses
+        families:
+        - ingress
+        support: supported
+        high_value: true
+        evidence_types:
+        - source_snapshot
+        control_domains:
+        - asset_inventory
+      default_enabled: true
+      event:
+        kind: kubernetes.ingress
+        required_attributes:
+        - cluster_id
+        - ingress_name
+        - namespace
+        required_payload_fields:
+        - name
+        - namespace
+        - rules
+        schema_ref: kubernetes/ingress/v1
+        urn_kind: kubernetes_ingress
+      id: ingress
+      id_field: metadata.uid
+      label: Ingresses
+      method: GET
+      name_field: metadata.name
+      path: "/apis/networking.k8s.io/v1/ingresses"
+      projection:
+        entity:
+          entity_type: kubernetes.ingress
+          id_attributes:
+          - cluster_id
+          - namespace
+          - ingress_name
+          label_attribute: ingress_name
+          urn_kind: kubernetes_ingress
+        fields:
+          id: ingress_name
+          name: ingress_name
+          provider_id: ingress_name
+        static_fields:
+          source_product: kubernetes
+        template: asset
+      record_selector: "$.items[*]"
+      list_key: items
+      pagination:
+        cursor_json_path: "$.metadata.continue"
+        cursor_param: continue
+        page_size: 100
+        page_size_param: limit
+        type: cursor
+    - coverage:
+      - id: service_accounts
+        type: entity_family
+        title: Kubernetes service accounts
+        families:
+        - service_account
+        support: supported
+        high_value: true
+        evidence_types:
+        - source_snapshot
+        control_domains:
+        - asset_inventory
+      default_enabled: true
+      event:
+        kind: kubernetes.service_account
+        required_attributes:
+        - cluster_id
+        - namespace
+        - service_account_name
+        required_payload_fields:
+        - name
+        - namespace
+        schema_ref: kubernetes/service_account/v1
+        urn_kind: kubernetes_service_account
+      id: service_account
+      id_field: metadata.uid
+      label: Service accounts
+      method: GET
+      name_field: metadata.name
       path: "/api/v1/serviceaccounts"
-      permissions_needed:
-      - BearerToken
       projection:
+        entity:
+          entity_type: kubernetes.service_account
+          id_attributes:
+          - cluster_id
+          - namespace
+          - service_account_name
+          label_attribute: service_account_name
+          urn_kind: kubernetes_service_account
         fields:
-          id: apiVersion
-          name: apiVersion
-          provider_id: apiVersion
+          user_id: service_account_name
+          login: service_account_name
+          display_name: service_account_name
+        static_fields:
+          source_product: kubernetes
         template: identity_user
       record_selector: "$.items[*]"
+      list_key: items
+      pagination:
+        cursor_json_path: "$.metadata.continue"
+        cursor_param: continue
+        page_size: 100
+        page_size_param: limit
+        type: cursor
       sensitive_payload_paths:
       - automountServiceAccountToken
       - imagePullSecrets
       - secrets
+    - coverage:
+      - id: rbac_roles
+        type: app_entitlement
+        title: Kubernetes RBAC roles
+        families:
+        - rbac_role
+        support: supported
+        high_value: true
+        evidence_types:
+        - identity_configuration
+        control_domains:
+        - identity_access
+      default_enabled: true
+      event:
+        kind: kubernetes.rbac_role
+        required_attributes:
+        - cluster_id
+        - role_kind
+        - role_name
+        required_payload_fields:
+        - name
+        - role_kind
+        - rules
+        schema_ref: kubernetes/rbac_role/v1
+        urn_kind: kubernetes_rbac_role
+      id: rbac_role
+      id_field: metadata.uid
+      label: RBAC roles
+      method: GET
+      name_field: metadata.name
+      path: "/apis/rbac.authorization.k8s.io/v1/roles"
+      projection:
+        entity:
+          entity_type: kubernetes.rbac_role
+          id_attributes:
+          - cluster_id
+          - role_kind
+          - role_scope
+          - role_name
+          label_attribute: role_name
+          urn_kind: kubernetes_rbac_role
+        fields:
+          group_id: role_name
+          group_name: role_name
+          display_name: role_name
+        static_fields:
+          source_product: kubernetes
+        template: identity_group
+      record_selector: "$.items[*]"
+      list_key: items
+      pagination:
+        cursor_json_path: "$.metadata.continue"
+        cursor_param: continue
+        page_size: 100
+        page_size_param: limit
+        type: cursor
+    - coverage:
+      - id: rbac_bindings
+        type: relationship
+        title: Kubernetes RBAC bindings
+        families:
+        - rbac_binding
+        support: supported
+        high_value: true
+        evidence_types:
+        - relationship_evidence
+        control_domains:
+        - asset_inventory
+      default_enabled: true
+      event:
+        kind: kubernetes.rbac_binding
+        required_attributes:
+        - binding_kind
+        - binding_name
+        - cluster_id
+        - role_name
+        required_payload_fields:
+        - binding_kind
+        - name
+        - role_ref
+        schema_ref: kubernetes/rbac_binding/v1
+        urn_kind: kubernetes_rbac_binding
+      id: rbac_binding
+      id_field: metadata.uid
+      label: RBAC bindings
+      method: GET
+      name_field: metadata.name
+      path: "/apis/rbac.authorization.k8s.io/v1/rolebindings"
+      projection:
+        entity:
+          entity_type: kubernetes.rbac_binding
+          id_attributes:
+          - cluster_id
+          - binding_kind
+          - binding_scope
+          - binding_name
+          label_attribute: binding_name
+          urn_kind: kubernetes_rbac_binding
+        fields:
+          id: binding_name
+          name: binding_name
+          provider_id: binding_name
+        static_fields:
+          source_product: kubernetes
+        template: asset
+      record_selector: "$.items[*]"
+      list_key: items
+      pagination:
+        cursor_json_path: "$.metadata.continue"
+        cursor_param: continue
+        page_size: 100
+        page_size_param: limit
+        type: cursor
+    - coverage:
+      - id: workload_identity_bindings
+        type: relationship
+        title: Kubernetes workload identity bindings
+        families:
+        - workload_identity_binding
+        support: supported
+        high_value: true
+        evidence_types:
+        - relationship_evidence
+        control_domains:
+        - asset_inventory
+      default_enabled: true
+      event:
+        kind: kubernetes.workload_identity_binding
+        required_attributes:
+        - cloud_provider
+        - cluster_id
+        - namespace
+        - service_account_name
+        - target_id
+        required_payload_fields:
+        - cloud_provider
+        - service_account_name
+        - target_id
+        schema_ref: kubernetes/workload_identity_binding/v1
+        urn_kind: kubernetes_service_account
+      id: workload_identity_binding
+      id_field: metadata.uid
+      label: Workload identity bindings
+      method: GET
+      name_field: metadata.name
+      path: "/api/v1/serviceaccounts"
+      projection:
+        entity:
+          entity_type: kubernetes.workload_identity_binding
+          id_attributes:
+          - cluster_id
+          - namespace
+          - service_account_name
+          - cloud_provider
+          - target_id
+          label_attribute: service_account_name
+          urn_kind: kubernetes_service_account
+        fields:
+          user_id: service_account_name
+          login: service_account_name
+          display_name: service_account_name
+        static_fields:
+          source_product: kubernetes
+        template: identity_user
+      record_selector: "$.items[*]"
+      list_key: items
+      pagination:
+        cursor_json_path: "$.metadata.continue"
+        cursor_param: continue
+        page_size: 100
+        page_size_param: limit
+        type: cursor
     schema_version: cerebro.integration/v1
     scope_options:
     - default_enabled: true
       families:
-      - event
-      id: event
-      label: Event
+      - cluster
+      id: cluster
+      label: Cluster
     - default_enabled: true
       families:
-      - clusterrole
-      id: clusterrole
-      label: Clusterrole
+      - namespace
+      id: namespace
+      label: Namespaces
     - default_enabled: true
       families:
-      - secret
-      id: secret
-      label: Secret
+      - node
+      id: node
+      label: Nodes
     - default_enabled: true
       families:
-      - serviceaccount
-      id: serviceaccount
-      label: Serviceaccount
+      - pod
+      id: pod
+      label: Pods
+    - default_enabled: true
+      families:
+      - workload
+      id: workload
+      label: Workloads
+    - default_enabled: true
+      families:
+      - container
+      id: container
+      label: Containers
+    - default_enabled: true
+      families:
+      - service
+      id: service
+      label: Services
+    - default_enabled: true
+      families:
+      - ingress
+      id: ingress
+      label: Ingresses
+    - default_enabled: true
+      families:
+      - service_account
+      id: service_account
+      label: Service accounts
+    - default_enabled: true
+      families:
+      - rbac_role
+      id: rbac_role
+      label: RBAC roles
+    - default_enabled: true
+      families:
+      - rbac_binding
+      id: rbac_binding
+      label: RBAC bindings
+    - default_enabled: true
+      families:
+      - workload_identity_binding
+      id: workload_identity_binding
+      label: Workload identity bindings
     source_id: kubernetes
     tenant_id: builtin_catalog
     transport:
-      base_url: https://kubernetes.local
+      base_url: "${config.api_server}"
       retry:
         backoff: exponential
         max_attempts: 3
@@ -222,4 +789,4 @@ entries:
         expect_status:
         - 200
         method: GET
-        path: "/api/v1/events"
+        path: "/version"

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const wantBuiltinCatalogEntries = 799
-const wantBuiltinCatalogBespokeRuntimeEntries = 1
+const wantBuiltinCatalogBespokeRuntimeEntries = 2
 
 func TestAnalyzeDirAcceptsGenerateableCatalogEntry(t *testing.T) {
 	root := t.TempDir()
@@ -244,7 +244,7 @@ func TestBuiltinCatalogSeedSummary(t *testing.T) {
 		t.Fatalf("summary = %#v, want no auth-extension entries", analysis.Summary)
 	}
 	if analysis.Summary.NeedsBespokeRuntime != wantBuiltinCatalogBespokeRuntimeEntries {
-		t.Fatalf("summary = %#v, want one bespoke-runtime entry", analysis.Summary)
+		t.Fatalf("summary = %#v, want %d bespoke-runtime entries", analysis.Summary, wantBuiltinCatalogBespokeRuntimeEntries)
 	}
 	counted := analysis.Summary.CatalogReady + analysis.Summary.Generateable + analysis.Summary.NeedsAuthExtension + analysis.Summary.NeedsBespokeRuntime
 	if counted != analysis.Summary.Total {
@@ -452,11 +452,11 @@ func TestBuiltinRuntimeSkipsSourcegenDryRun(t *testing.T) {
 		t.Fatalf("runtime catalog size = total %d entries %d, want %d", analysis.Summary.Total, len(analysis.Entries), wantBuiltinCatalogEntries)
 	}
 	if analysis.Summary.CatalogReady != wantBuiltinCatalogEntries-wantBuiltinCatalogBespokeRuntimeEntries || analysis.Summary.Generateable != 0 || analysis.Summary.NeedsBespokeRuntime != wantBuiltinCatalogBespokeRuntimeEntries {
-		t.Fatalf("runtime summary = %#v, want catalog-ready supported entries and one bespoke runtime entry", analysis.Summary)
+		t.Fatalf("runtime summary = %#v, want catalog-ready supported entries and %d bespoke runtime entries", analysis.Summary, wantBuiltinCatalogBespokeRuntimeEntries)
 	}
 	for _, entry := range analysis.Entries {
 		wantStatus := StatusCatalogReady
-		if entry.Definition.SourceID == "auth0" {
+		if entry.Definition.SourceID == "auth0" || entry.Definition.SourceID == "kubernetes" {
 			wantStatus = StatusNeedsBespokeRuntime
 		}
 		if entry.SourcegenDryRun || entry.Generateable || entry.Status != wantStatus {
@@ -538,6 +538,81 @@ func TestBuiltinCloudflareCatalogClosesTheProviderFamilyAndCredentialContracts(t
 		}
 		if family.Projection == nil || strings.TrimSpace(family.Projection.Template) == "" {
 			t.Fatalf("%s projection is not compiled", family.ID)
+		}
+		delete(want, family.ID)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing families = %#v", want)
+	}
+}
+
+func TestBuiltinKubernetesCatalogMatchesRuntimeContract(t *testing.T) {
+	entry, ok, err := BuiltinEntry("kubernetes")
+	if err != nil {
+		t.Fatalf("BuiltinEntry(kubernetes) error = %v", err)
+	}
+	if !ok {
+		t.Fatal("BuiltinEntry(kubernetes) ok = false")
+	}
+	definition := entry.Definition
+	if definition.Auth.Model != "none" || len(definition.Auth.CredentialFields) != 0 || definition.Auth.RequiresReferences {
+		t.Fatalf("auth = %#v, want host-managed credentials outside the connector contract", definition.Auth)
+	}
+	if entry.Status != StatusNeedsBespokeRuntime {
+		t.Fatalf("status = %q, want %q", entry.Status, StatusNeedsBespokeRuntime)
+	}
+	if definition.Transport == nil || definition.Transport.BaseURL != "${config.api_server}" || definition.Transport.Verification == nil || definition.Transport.Verification.Path != "/version" {
+		t.Fatalf("transport = %#v, want configured API-server origin and /version verification", definition.Transport)
+	}
+	configFields := map[string]connectordefinitions.Field{}
+	for _, field := range definition.ConfigFields {
+		configFields[field.Key] = field
+	}
+	if !configFields["api_server"].Required {
+		t.Fatalf("config fields = %#v, want required api_server", definition.ConfigFields)
+	}
+
+	type familyContract struct {
+		path               string
+		requiredAttributes []string
+	}
+	want := map[string]familyContract{
+		"cluster":                   {path: "/version", requiredAttributes: []string{"cluster_id", "cluster_name"}},
+		"namespace":                 {path: "/api/v1/namespaces", requiredAttributes: []string{"cluster_id", "namespace"}},
+		"node":                      {path: "/api/v1/nodes", requiredAttributes: []string{"cluster_id", "node_name", "ready"}},
+		"pod":                       {path: "/api/v1/pods", requiredAttributes: []string{"cluster_id", "namespace", "workload_uid"}},
+		"workload":                  {path: "/api/v1/pods", requiredAttributes: []string{"cluster_id", "namespace", "workload_uid"}},
+		"container":                 {path: "/api/v1/pods", requiredAttributes: []string{"cluster_id", "container_name", "namespace"}},
+		"service":                   {path: "/api/v1/services", requiredAttributes: []string{"cluster_id", "namespace", "service_name", "service_type"}},
+		"ingress":                   {path: "/apis/networking.k8s.io/v1/ingresses", requiredAttributes: []string{"cluster_id", "ingress_name", "namespace"}},
+		"service_account":           {path: "/api/v1/serviceaccounts", requiredAttributes: []string{"cluster_id", "namespace", "service_account_name"}},
+		"rbac_role":                 {path: "/apis/rbac.authorization.k8s.io/v1/roles", requiredAttributes: []string{"cluster_id", "role_kind", "role_name"}},
+		"rbac_binding":              {path: "/apis/rbac.authorization.k8s.io/v1/rolebindings", requiredAttributes: []string{"binding_kind", "binding_name", "cluster_id", "role_name"}},
+		"workload_identity_binding": {path: "/api/v1/serviceaccounts", requiredAttributes: []string{"cloud_provider", "cluster_id", "namespace", "service_account_name", "target_id"}},
+	}
+	if len(definition.ResourceFamilies) != len(want) || len(definition.ScopeOptions) != len(want) {
+		t.Fatalf("families/scopes = %d/%d, want %d/%d", len(definition.ResourceFamilies), len(definition.ScopeOptions), len(want), len(want))
+	}
+	for _, family := range definition.ResourceFamilies {
+		contract, ok := want[family.ID]
+		if !ok {
+			t.Fatalf("unexpected family %q", family.ID)
+		}
+		if family.Path != contract.path || family.Event.Kind != "kubernetes."+family.ID || family.Event.SchemaRef != "kubernetes/"+family.ID+"/v1" {
+			t.Fatalf("%s path/event = %q/%#v", family.ID, family.Path, family.Event)
+		}
+		if strings.Join(family.Event.RequiredAttributes, ",") != strings.Join(contract.requiredAttributes, ",") {
+			t.Fatalf("%s required attributes = %#v, want %#v", family.ID, family.Event.RequiredAttributes, contract.requiredAttributes)
+		}
+		if family.Projection == nil || strings.TrimSpace(family.Projection.Template) == "" || len(family.Coverage) == 0 {
+			t.Fatalf("%s projection/coverage = %#v/%#v", family.ID, family.Projection, family.Coverage)
+		}
+		if family.ID == "cluster" {
+			if !family.Singleton || family.Pagination == nil || family.Pagination.Type != "none" {
+				t.Fatalf("cluster singleton/pagination = %v/%#v", family.Singleton, family.Pagination)
+			}
+		} else if family.Pagination == nil || family.Pagination.Type != "cursor" || family.Pagination.CursorParam != "continue" || family.Pagination.CursorJSONPath != "$.metadata.continue" || family.Pagination.PageSizeParam != "limit" {
+			t.Fatalf("%s pagination = %#v", family.ID, family.Pagination)
 		}
 		delete(want, family.ID)
 	}

--- a/internal/sourceregistry/registry_test.go
+++ b/internal/sourceregistry/registry_test.go
@@ -318,14 +318,16 @@ func TestBuiltinKeepsOnlyCatalogCompatibilityExceptionsAsStaticLoaders(t *testin
 	seenExceptions := make(map[string]bool, len(compatibilityExceptions))
 	for _, loader := range builtinSourceLoaders {
 		entry, ok := entries[loader.name]
-		if !ok || entry.Report.Verdict != connectordefinitions.SupportVerdictSupported {
+		if !ok {
 			continue
 		}
-		if !compatibilityExceptions[loader.name] {
+		if compatibilityExceptions[loader.name] {
+			seenExceptions[loader.name] = true
+			continue
+		}
+		if entry.Report.Verdict == connectordefinitions.SupportVerdictSupported {
 			t.Errorf("catalog-supported source %q has a redundant compile-time loader", loader.name)
-			continue
 		}
-		seenExceptions[loader.name] = true
 	}
 	for sourceID := range compatibilityExceptions {
 		if !seenExceptions[sourceID] {


### PR DESCRIPTION
## Scope

- replace four phantom Kubernetes catalog families with the 12 families implemented by the Go source and credential-free Rust kernel
- model Kubernetes authentication as trusted-host managed and keep credential material outside the portable catalog contract
- pin API paths, continuation-token pagination, event contracts, scopes, projections, sensitive service-account fields, and the configured API-server origin
- distinguish a supported auth grammar from a source that intentionally requires a bespoke runtime
- update the Rust-only candidate's exact catalog-family evidence from 3,978 to 3,986

## Source contracts

- `sources/internal/kubernetes/catalog.internal.yaml`
- `sources/internal/kubernetes/*.go`
- `sources/kubernetes/catalog.yaml`
- `crates/source-runtime-next/src/kubernetes/**`

## Validation

- `go test ./internal/connectorcatalog ./internal/connectordefinitions ./internal/sourcegen ./sources/internal/kubernetes ./sources/kubernetes -count=1`
- `make sourcegen-check`
- `make connector-catalog-fidelity-check`
- `make catalog-check`
- `cargo fmt --all -- --check`
- `cargo test -p cerebro-source-catalog` — 26 passed
- focused Kubernetes Rust kernel tests before the latest main merge — 9 passed
- `cargo test -p cerebro-platform --test rust_only_runtime_contract` before the latest main merge — 6 passed
- `cargo clippy -p cerebro-source-catalog -p cerebro-source-runtime-next --all-targets -- -D warnings` before the latest main merge
- all-catalog raw YAML AST and semantic-ID scan — 799 files, 799 entries, 3,986 families, zero parse or duplicate-key/family/coverage/scope problems
- tenant/secret leak check on the published range

## Current external gate

The latest `main` cannot compile `cerebro-source-runtime-next` because the newly added `JumpCloudFilters.group_ids` field is missing from a constructor. PR #2490 owns the forward repair and already has the relevant build/test/lint/security checks passing. After that repair reaches `main`, this branch must merge forward and rerun the focused Kubernetes kernel, Rust-only platform contract, and Clippy on the exact new head.

This PR does not claim provider-authority completeness for all catalog families. The current classifier still reports thousands of families without provider-authority evidence; those require separate source-backed runtime and fixture work.
