### PR TITLE
fix(sources): close bounded provider request gaps

### DIFF
--- a/crates/source-catalog/tests/okta_contract.rs
+++ b/crates/source-catalog/tests/okta_contract.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+use cerebro_source_catalog::{PathParameterBinding, SourceCatalog};
+
+#[test]
+fn group_membership_binds_the_provider_group_path_parameter() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let catalog = SourceCatalog::load(
+        root.join("internal/connectorcatalog/catalog"),
+        root.join("sources"),
+    )
+    .expect("load source catalog");
+    let family = catalog
+        .get("okta")
+        .expect("Okta source")
+        .families()
+        .iter()
+        .find(|family| family.id() == "group_membership")
+        .expect("Okta group_membership family");
+
+    assert_eq!(family.path(), "/api/v1/groups/{group_id}/users");
+    assert_eq!(
+        family.path_parameters().get("group_id"),
+        Some(&PathParameterBinding::ScalarConfig {
+            field: "group_id".to_owned(),
+        })
+    );
+}

--- a/internal/connectorcatalog/catalog/identity-access-secrets/okta.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets/okta.yaml
@@ -18,6 +18,10 @@ entries:
           key: base_url
           label: API base URL
           required: true
+        - help: Okta group identifier used when collecting the group_membership family.
+          key: group_id
+          label: Group ID
+          required: false
       description: Collects users, groups, roles, applications, and audit events from Okta and projects them into the Cerebro graph as users, groups, policies, assets, and audit events for identity, access, device, and secret context.
       display_name: Okta
       id: builtin-okta

--- a/internal/connectorcatalog/okta_source_contract_test.go
+++ b/internal/connectorcatalog/okta_source_contract_test.go
@@ -1,0 +1,34 @@
+package connectorcatalog
+
+import "testing"
+
+func TestOktaGroupMembershipDeclaresProviderPathScope(t *testing.T) {
+	entry, ok, err := BuiltinEntry("okta")
+	if err != nil {
+		t.Fatalf("BuiltinEntry(okta) error = %v", err)
+	}
+	if !ok {
+		t.Fatal("BuiltinEntry(okta) ok = false, want true")
+	}
+
+	var hasGroupID bool
+	for _, field := range entry.Definition.ConfigFields {
+		if field.Key == "group_id" {
+			hasGroupID = true
+			if field.Required {
+				t.Fatal("group_id is globally required; want family-scoped optional configuration")
+			}
+		}
+	}
+	if !hasGroupID {
+		t.Fatal("Okta config fields omit group_id")
+	}
+
+	family := catalogFamily(t, entry.Definition.ResourceFamilies, "group_membership")
+	if family.Path != "/api/v1/groups/{group_id}/users" {
+		t.Fatalf("group_membership path = %q, want provider path", family.Path)
+	}
+	if family.Read == nil || len(family.Read.PathParams) != 1 || family.Read.PathParams[0] != "group_id" {
+		t.Fatalf("group_membership path params = %#v, want [group_id]", family.Read)
+	}
+}


### PR DESCRIPTION
## Scope

Closes bounded catalog request gaps where the Go source already requires provider scope data but the compiled source definition cannot bind it.

Current slice:
- declares the optional Okta `group_id` source field used only by the `group_membership` family
- binds `/api/v1/groups/{group_id}/users` in the Rust source compiler
- preserves the hand-written Go runtime as the active compatibility path

Provider contract:
- https://raw.githubusercontent.com/okta/okta-management-openapi-spec/master/dist/current/management-minimal.yaml
- https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Group/#tag/Group/operation/listGroupUsers

## Validation

- `go test ./internal/connectorcatalog -run TestOktaGroupMembershipDeclaresProviderPathScope -count=1`
- `cargo test -p cerebro-source-catalog --test okta_contract`
- `git diff --check`

The pull request remains draft while the other independently bounded source-data gaps receive provider citations, fixtures, and parity tests. No runtime authority is promoted by this change.