### PR TITLE
Keep GRC readiness available during graph delays

### DIFF
--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -32,13 +32,13 @@ import (
 )
 
 const (
-	grcDefaultLimit                  = uint32(100)
-	grcMaxLimit                      = uint32(500)
-	grcMaxRuntimeScope               = uint32(500)
-	grcRuntimeScopeFetchLimit        = grcMaxRuntimeScope + 1
-	grcDashboardPreviewLimit         = uint32(25)
-	grcDashboardRuntimeHealthTimeout = 5 * time.Second
-	grcAuditPacketSchema             = grcauditpacket.SchemaVersion
+	grcDefaultLimit                   = uint32(100)
+	grcMaxLimit                       = uint32(500)
+	grcMaxRuntimeScope                = uint32(500)
+	grcRuntimeScopeFetchLimit         = grcMaxRuntimeScope + 1
+	grcDashboardPreviewLimit          = uint32(25)
+	grcRuntimeHealthEnrichmentTimeout = 5 * time.Second
+	grcAuditPacketSchema              = grcauditpacket.SchemaVersion
 )
 
 type grcScope struct {
@@ -193,7 +193,7 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		})
 	})
 	group.Go(func() error {
-		runtimeHealthCtx, cancel := context.WithTimeout(groupCtx, grcDashboardRuntimeHealthTimeout)
+		runtimeHealthCtx, cancel := context.WithTimeout(groupCtx, grcRuntimeHealthEnrichmentTimeout)
 		defer cancel()
 		runtimeHealthErr = operationtelemetry.RunMainPhase(runtimeHealthCtx, "grc.dashboard.runtime_health", telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: len(runtimes)}), func(ctx context.Context) (telemetry.Attributes, error) {
 			var err error

--- a/internal/bootstrap/grc_program_readiness.go
+++ b/internal/bootstrap/grc_program_readiness.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"time"
@@ -46,18 +47,14 @@ func (a *App) handleGRCProgramReadiness(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	generatedAt := time.Now().UTC()
-	sourceSummaries, err := a.grcSourceRuntimeHealthSummaries(r.Context(), runtimes, generatedAt)
-	if err != nil {
-		writeGRCError(w, err)
-		return
-	}
-	coverage, err := a.sourceCoverageRecordsScoped(r.Context(), runtimes, ports.SourceRuntimeFilter{
-		RuntimeID:  scope.RuntimeID,
-		RuntimeIDs: scope.RuntimeIDs,
-		TenantID:   scope.TenantID,
-		SourceID:   scope.SourceID,
-		Limit:      scope.Limit,
-	}, generatedAt, coverageScope)
+	coverage, sourceSummaries, err := grcprogram.RunReadinessEnrichments(r.Context(), grcRuntimeHealthEnrichmentTimeout, func(ctx context.Context) ([]sourcecoverage.Record, error) {
+		return a.sourceCoverageRecordsScoped(ctx, runtimes, ports.SourceRuntimeFilter{
+			RuntimeID: scope.RuntimeID, RuntimeIDs: scope.RuntimeIDs, TenantID: scope.TenantID,
+			SourceID: scope.SourceID, Limit: scope.Limit,
+		}, generatedAt, coverageScope)
+	}, func(ctx context.Context) ([]sourceRuntimeHealthSummary, error) {
+		return a.grcSourceRuntimeHealthSummaries(ctx, runtimes, generatedAt)
+	})
 	if err != nil {
 		writeGRCError(w, err)
 		return

--- a/internal/bootstrap/grc_program_readiness_test.go
+++ b/internal/bootstrap/grc_program_readiness_test.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -95,5 +96,51 @@ func TestGRCProgramReadinessEndpointReturnsProofBundleWorkQueue(t *testing.T) {
 	}
 	if payload.ProductAreas[0].ID != "compliance" || payload.ProductAreas[0].Status == "" {
 		t.Fatalf("first product area = %+v, want compliance area with status", payload.ProductAreas[0])
+	}
+}
+
+func TestGRCProgramReadinessReturnsCoreDataWhenRuntimeHealthUnavailable(t *testing.T) {
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-grc": {
+				Id:       "writer-grc",
+				SourceId: "grc",
+				TenantId: "writer",
+			},
+		},
+		findings:        map[string]*ports.FindingRecord{},
+		findingEvidence: map[string]*cerebrov1.FindingEvidence{},
+	}
+	app := New(
+		config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second},
+		Dependencies{
+			StateStore: store,
+			GraphStore: &stubGraphStore{err: errors.New("runtime health graph read unavailable")},
+		},
+		nil,
+	)
+	server := httptest.NewServer(app.Handler())
+
+	stderr := captureBootstrapStderr(t, func() {
+		defer server.Close()
+		resp, err := server.Client().Get(server.URL + "/grc/program-readiness?tenant_id=writer&limit=1")
+		if err != nil {
+			t.Fatalf("GET /grc/program-readiness error = %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET /grc/program-readiness status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		var payload grcProgramReadinessResponse
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode /grc/program-readiness: %v", err)
+		}
+		if len(payload.SourceSummaries) != 0 {
+			t.Fatalf("source summaries = %#v, want omitted degraded enrichment", payload.SourceSummaries)
+		}
+	})
+
+	if !strings.Contains(stderr, `"name":"sourcehealth.latest_graph_runs"`) {
+		t.Fatalf("runtime health failure telemetry missing: %s", stderr)
 	}
 }

--- a/internal/grcprogram/enrichment.go
+++ b/internal/grcprogram/enrichment.go
@@ -1,0 +1,33 @@
+package grcprogram
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// RunReadinessEnrichments runs required enrichment alongside bounded optional
+// enrichment. Optional failure degrades the response; required failure stops it.
+func RunReadinessEnrichments[Required, Optional any](ctx context.Context, optionalTimeout time.Duration, required func(context.Context) (Required, error), optional func(context.Context) (Optional, error)) (Required, Optional, error) {
+	var requiredResult Required
+	var optionalResult Optional
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.Go(func() error {
+		var err error
+		requiredResult, err = required(groupCtx)
+		return err
+	})
+	group.Go(func() error {
+		optionalCtx, cancel := context.WithTimeout(groupCtx, optionalTimeout)
+		defer cancel()
+		var err error
+		optionalResult, err = optional(optionalCtx)
+		if err != nil {
+			var zero Optional
+			optionalResult = zero
+		}
+		return nil
+	})
+	return requiredResult, optionalResult, group.Wait()
+}

--- a/internal/grcprogram/enrichment_test.go
+++ b/internal/grcprogram/enrichment_test.go
@@ -1,0 +1,41 @@
+package grcprogram
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRunReadinessEnrichmentsIgnoresOptionalFailure(t *testing.T) {
+	optionalErr := errors.New("optional enrichment unavailable")
+	required, optional, err := RunReadinessEnrichments(t.Context(), time.Second, func(context.Context) (string, error) { return "required", nil }, func(context.Context) (string, error) { return "partial", optionalErr })
+	if err != nil {
+		t.Fatalf("RunReadinessEnrichments() error = %v, want nil", err)
+	}
+	if required != "required" || optional != "" {
+		t.Fatalf("RunReadinessEnrichments() = %q, %q, want required result and omitted optional result", required, optional)
+	}
+}
+
+func TestRunReadinessEnrichmentsReturnsRequiredFailure(t *testing.T) {
+	requiredErr := errors.New("required enrichment unavailable")
+	_, _, err := RunReadinessEnrichments(t.Context(), time.Second, func(context.Context) (string, error) { return "", requiredErr }, func(context.Context) (string, error) { return "optional", nil })
+	if !errors.Is(err, requiredErr) {
+		t.Fatalf("RunReadinessEnrichments() error = %v, want %v", err, requiredErr)
+	}
+}
+
+func TestRunReadinessEnrichmentsBoundsOptionalWork(t *testing.T) {
+	startedAt := time.Now()
+	_, _, err := RunReadinessEnrichments(t.Context(), time.Millisecond, func(context.Context) (string, error) { return "required", nil }, func(ctx context.Context) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	})
+	if err != nil {
+		t.Fatalf("RunReadinessEnrichments() error = %v, want nil", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("RunReadinessEnrichments() elapsed = %s, want bounded optional work", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

- run required coverage and bounded runtime-health enrichment concurrently for program readiness
- omit optional source summaries when graph-backed runtime health is slow or unavailable
- preserve required-enrichment failures and add domain and endpoint regression coverage

## Validation

- `go test ./internal/grcprogram ./internal/bootstrap -count=1`
- `go test -race ./internal/grcprogram ./internal/bootstrap -run 'Test(RunReadinessEnrichments|GRCProgramReadiness)' -count=1`\n- `go vet ./internal/bootstrap ./internal/grcprogram`\n- `golangci-lint run -j 4 --timeout 20m ./internal/bootstrap ./internal/grcprogram`\n- `make check-structural check-structural-test check-arch`