### PR TITLE
DigitalOcean provider-local Rust parity kernel

### DIFF
--- a/crates/source-runtime-next/src/digitalocean/error.rs
+++ b/crates/source-runtime-next/src/digitalocean/error.rs
@@ -1,0 +1,154 @@
+use std::{error::Error, fmt};
+
+/// Bounded DigitalOcean provider and runtime failure taxonomy.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DigitalOceanError {
+    /// Family is outside droplets, VPCs, and firewalls.
+    InvalidFamily,
+    /// Configured HTTPS provider base is unsafe or malformed.
+    InvalidBaseUrl,
+    /// Authenticated tenant context is malformed.
+    InvalidTenantId,
+    /// Page size is outside the provider bound.
+    InvalidPageSize,
+    /// Cursor is invalid or cannot round-trip.
+    InvalidCursor,
+    /// Request does not belong to this kernel.
+    RequestScopeMismatch,
+    /// Trusted host has no credential reference.
+    MissingCredentialReference,
+    /// Trusted host could not redeem the credential lease.
+    CredentialUnavailable,
+    /// Provider rejected authentication.
+    AuthenticationRejected,
+    /// Credential lacks the selected family permission.
+    RequiredScopeMissing,
+    /// Trusted host denied provider egress.
+    EgressDenied,
+    /// Provider DNS lookup failed.
+    DnsFailure,
+    /// Provider connection failed.
+    ConnectionFailure,
+    /// Provider operation timed out.
+    ProviderTimeout,
+    /// Provider requested a bounded retry.
+    RateLimited {
+        /// Provider-declared retry delay.
+        retry_after_seconds: Option<u64>,
+    },
+    /// Provider returned a retryable server failure.
+    ProviderUnavailable {
+        /// Provider HTTP status.
+        status: u16,
+    },
+    /// Provider returned an unexpected status.
+    UnexpectedStatus {
+        /// Provider HTTP status.
+        status: u16,
+    },
+    /// Provider response exceeds the eight-mebibyte bound.
+    ResponseTooLarge,
+    /// Provider response exceeds the requested page size.
+    TooManyRecords,
+    /// Response JSON does not match the selected family.
+    MalformedResponse,
+    /// Provider record violates the family shape.
+    InvalidProviderRecord,
+    /// Provider record has no stable identity.
+    MissingStableIdentity,
+    /// Duplicate provider identity has conflicting content.
+    ConflictingDuplicate,
+    /// Provider payload attempted to provide tenant context.
+    TenantMismatch,
+    /// Credential-shaped material crossed into the kernel.
+    CredentialMaterial,
+    /// Normalized record failed the exact event contract.
+    EventContractRejection,
+    /// Durable append failed.
+    AppendFailure,
+    /// Projection failed.
+    ProjectionFailure,
+    /// Runtime lost its source lease.
+    LeaseLoss,
+    /// Runtime authority or generation is stale.
+    StaleAuthority,
+    /// Internal runtime failure.
+    InternalRuntimeFailure,
+}
+
+impl DigitalOceanError {
+    /// Next safe operator action without provider content.
+    pub const fn operator_action(&self) -> &'static str {
+        match self {
+            Self::InvalidFamily
+            | Self::InvalidBaseUrl
+            | Self::InvalidTenantId
+            | Self::InvalidPageSize => "repair source configuration",
+            Self::MissingCredentialReference
+            | Self::CredentialUnavailable
+            | Self::AuthenticationRejected => "repair credential binding",
+            Self::RequiredScopeMissing => "grant DigitalOcean read access",
+            Self::RateLimited { .. }
+            | Self::ProviderUnavailable { .. }
+            | Self::DnsFailure
+            | Self::ConnectionFailure
+            | Self::ProviderTimeout => "retry the collection later",
+            Self::EgressDenied => "repair trusted-host egress policy",
+            Self::InvalidCursor => "restart from the last committed checkpoint",
+            Self::MalformedResponse
+            | Self::InvalidProviderRecord
+            | Self::MissingStableIdentity
+            | Self::ConflictingDuplicate
+            | Self::TenantMismatch
+            | Self::CredentialMaterial
+            | Self::EventContractRejection => "inspect quarantined provider records",
+            Self::AppendFailure | Self::ProjectionFailure => "repair the durable commit path",
+            Self::LeaseLoss | Self::StaleAuthority => "restart under the current lease",
+            Self::RequestScopeMismatch
+            | Self::ResponseTooLarge
+            | Self::TooManyRecords
+            | Self::UnexpectedStatus { .. }
+            | Self::InternalRuntimeFailure => "repair the forward runtime implementation",
+        }
+    }
+}
+
+impl fmt::Display for DigitalOceanError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidFamily => "digitalocean family is invalid",
+            Self::InvalidBaseUrl => "digitalocean base URL is invalid",
+            Self::InvalidTenantId => "digitalocean tenant ID is invalid",
+            Self::InvalidPageSize => "digitalocean per_page is invalid",
+            Self::InvalidCursor => "digitalocean page cursor is invalid",
+            Self::RequestScopeMismatch => "digitalocean request does not match the kernel",
+            Self::MissingCredentialReference => "digitalocean credential reference is missing",
+            Self::CredentialUnavailable => "digitalocean credential lease is unavailable",
+            Self::AuthenticationRejected => "digitalocean rejected authentication",
+            Self::RequiredScopeMissing => "digitalocean credential lacks selected family access",
+            Self::EgressDenied => "digitalocean egress was denied",
+            Self::DnsFailure => "digitalocean DNS resolution failed",
+            Self::ConnectionFailure => "digitalocean connection failed",
+            Self::ProviderTimeout => "digitalocean operation timed out",
+            Self::RateLimited { .. } => "digitalocean rate limited the operation",
+            Self::ProviderUnavailable { .. } => "digitalocean is temporarily unavailable",
+            Self::UnexpectedStatus { .. } => "digitalocean returned an unexpected status",
+            Self::ResponseTooLarge => "digitalocean response exceeds its byte bound",
+            Self::TooManyRecords => "digitalocean response exceeds per_page",
+            Self::MalformedResponse => "digitalocean response is malformed",
+            Self::InvalidProviderRecord => "digitalocean provider record is invalid",
+            Self::MissingStableIdentity => "digitalocean record has no stable identity",
+            Self::ConflictingDuplicate => "digitalocean duplicate identity has conflicting content",
+            Self::TenantMismatch => "digitalocean payload attempted to supply tenant context",
+            Self::CredentialMaterial => "digitalocean payload contains credential-shaped material",
+            Self::EventContractRejection => "digitalocean event failed its catalog contract",
+            Self::AppendFailure => "digitalocean append failed",
+            Self::ProjectionFailure => "digitalocean projection failed",
+            Self::LeaseLoss => "digitalocean runtime lost its lease",
+            Self::StaleAuthority => "digitalocean runtime authority is stale",
+            Self::InternalRuntimeFailure => "digitalocean runtime failed internally",
+        })
+    }
+}
+
+impl Error for DigitalOceanError {}

--- a/crates/source-runtime-next/src/digitalocean/family.rs
+++ b/crates/source-runtime-next/src/digitalocean/family.rs
@@ -1,0 +1,90 @@
+use std::{fmt, str::FromStr};
+
+use super::DigitalOceanError;
+
+/// Closed legacy DigitalOcean family set.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum DigitalOceanFamily {
+    /// Compute droplets.
+    Droplets,
+    /// Virtual private clouds.
+    Vpcs,
+    /// Cloud firewalls.
+    Firewalls,
+}
+
+impl DigitalOceanFamily {
+    /// Every family implemented by the legacy Go source.
+    pub const ALL: [Self; 3] = [Self::Droplets, Self::Vpcs, Self::Firewalls];
+
+    /// Source catalog identifier.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Droplets => "droplets",
+            Self::Vpcs => "vpcs",
+            Self::Firewalls => "firewalls",
+        }
+    }
+
+    /// Exact DigitalOcean v2 list path.
+    pub const fn path(self) -> &'static str {
+        match self {
+            Self::Droplets => "/v2/droplets",
+            Self::Vpcs => "/v2/vpcs",
+            Self::Firewalls => "/v2/firewalls",
+        }
+    }
+
+    /// Exact append-log event kind.
+    pub const fn event_kind(self) -> &'static str {
+        match self {
+            Self::Droplets => "digitalocean.droplets",
+            Self::Vpcs => "digitalocean.vpcs",
+            Self::Firewalls => "digitalocean.firewalls",
+        }
+    }
+
+    /// Exact event schema reference.
+    pub const fn schema_ref(self) -> &'static str {
+        match self {
+            Self::Droplets => "digitalocean/droplets/v1",
+            Self::Vpcs => "digitalocean/vpcs/v1",
+            Self::Firewalls => "digitalocean/firewalls/v1",
+        }
+    }
+
+    pub(super) const fn resource_type(self) -> &'static str {
+        match self {
+            Self::Droplets => "droplet",
+            Self::Vpcs => "vpc",
+            Self::Firewalls => "firewall",
+        }
+    }
+
+    pub(super) const fn urn_kind(self) -> &'static str {
+        match self {
+            Self::Droplets => "digitalocean_droplets",
+            Self::Vpcs => "digitalocean_vpcs",
+            Self::Firewalls => "digitalocean_firewalls",
+        }
+    }
+}
+
+impl fmt::Display for DigitalOceanFamily {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for DigitalOceanFamily {
+    type Err = DigitalOceanError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim() {
+            "droplets" => Ok(Self::Droplets),
+            "vpcs" => Ok(Self::Vpcs),
+            "firewalls" => Ok(Self::Firewalls),
+            _ => Err(DigitalOceanError::InvalidFamily),
+        }
+    }
+}

--- a/crates/source-runtime-next/src/digitalocean/mod.rs
+++ b/crates/source-runtime-next/src/digitalocean/mod.rs
@@ -1,0 +1,29 @@
+//! Credential-free DigitalOcean request, normalization, and parity kernel.
+//!
+//! The trusted host owns credential-reference resolution, Bearer authentication,
+//! redirects, deadlines, and bounded network I/O. The existing Go source and
+//! projector remain authoritative until shared registration and production
+//! qualification land separately.
+
+mod error;
+mod family;
+mod normalize;
+mod origin;
+mod projection;
+mod request;
+mod response;
+mod types;
+
+pub use error::DigitalOceanError;
+pub use family::DigitalOceanFamily;
+pub use projection::{
+    DigitalOceanEntityFact, DigitalOceanLinkFact, DigitalOceanProjectionFacts,
+    project_digitalocean_records,
+};
+pub use types::{
+    DigitalOceanCheckpointCandidate, DigitalOceanKernel, DigitalOceanOperation, DigitalOceanPage,
+    DigitalOceanRecord, DigitalOceanRequest,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/digitalocean/normalize.rs
+++ b/crates/source-runtime-next/src/digitalocean/normalize.rs
@@ -1,0 +1,269 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    DigitalOceanError, DigitalOceanFamily, DigitalOceanKernel, DigitalOceanRecord, origin,
+};
+
+pub(super) fn normalize_record(
+    kernel: &DigitalOceanKernel,
+    value: &Value,
+) -> Result<DigitalOceanRecord, DigitalOceanError> {
+    reject_untrusted_fields(value)?;
+    let object = value
+        .as_object()
+        .ok_or(DigitalOceanError::InvalidProviderRecord)?;
+    let provider_id = provider_id(kernel.family, object)?;
+    let name = string(object, "name").unwrap_or_default();
+    let created = string(object, "created_at").unwrap_or_default();
+    let occurred_at = timestamp_or_epoch(&created)?;
+    let resource_urn = format!(
+        "urn:cerebro:{}:{}:{}",
+        kernel.tenant_id,
+        kernel.family.urn_kind(),
+        provider_id
+    );
+    let mut attributes = BTreeMap::from([
+        ("record_class".to_owned(), "asset".to_owned()),
+        ("resource_id".to_owned(), provider_id.clone()),
+        ("resource_name".to_owned(), name.clone()),
+        (
+            "resource_type".to_owned(),
+            kernel.family.resource_type().to_owned(),
+        ),
+        ("resource_urn".to_owned(), resource_urn),
+        ("source_event_id".to_owned(), provider_id.clone()),
+        ("tenant_id".to_owned(), kernel.tenant_id.clone()),
+    ]);
+    let payload = match kernel.family {
+        DigitalOceanFamily::Droplets => {
+            let id = integer(object, "id")?;
+            let status = string(object, "status").unwrap_or_default();
+            let region = object
+                .get("region")
+                .and_then(Value::as_object)
+                .and_then(|region| string(region, "slug"))
+                .unwrap_or_default();
+            let vpc_uuid = string(object, "vpc_uuid").unwrap_or_default();
+            attributes.insert("region".to_owned(), region.clone());
+            if !vpc_uuid.is_empty() {
+                attributes.insert("vpc_uuid".to_owned(), vpc_uuid.clone());
+            }
+            json!({
+                "id": id,
+                "name": name,
+                "status": status,
+                "region": region,
+                "vpc_uuid": vpc_uuid,
+                "created_at": created,
+            })
+        }
+        DigitalOceanFamily::Vpcs => {
+            let ip_range = string(object, "ip_range").unwrap_or_default();
+            let region = string(object, "region").unwrap_or_default();
+            let default = object
+                .get("default")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            attributes.insert("region".to_owned(), region.clone());
+            json!({
+                "id": provider_id,
+                "name": name,
+                "ip_range": ip_range,
+                "region": region,
+                "default": default,
+                "created_at": occurred_at,
+            })
+        }
+        DigitalOceanFamily::Firewalls => {
+            let status = string(object, "status").unwrap_or_default();
+            let droplet_ids = droplet_ids(object)?;
+            let public = public_ingress(object)?;
+            attributes.insert("public_ingress".to_owned(), public.to_string());
+            if !droplet_ids.is_empty() {
+                attributes.insert(
+                    "droplet_ids".to_owned(),
+                    droplet_ids
+                        .iter()
+                        .map(i64::to_string)
+                        .collect::<Vec<_>>()
+                        .join(","),
+                );
+            }
+            json!({
+                "id": provider_id,
+                "name": name,
+                "status": status,
+                "droplet_ids": droplet_ids,
+                "public": public,
+                "created_at": created,
+            })
+        }
+    };
+    let record = DigitalOceanRecord {
+        tenant_id: kernel.tenant_id.clone(),
+        event_id: event_id(&kernel.tenant_id, kernel.family, &provider_id),
+        provider_id,
+        family: kernel.family,
+        kind: kernel.family.event_kind().to_owned(),
+        schema_ref: kernel.family.schema_ref().to_owned(),
+        occurred_at,
+        attributes,
+        payload,
+    };
+    admit(&record)?;
+    Ok(record)
+}
+
+fn provider_id(
+    family: DigitalOceanFamily,
+    object: &Map<String, Value>,
+) -> Result<String, DigitalOceanError> {
+    let value = match family {
+        DigitalOceanFamily::Droplets => integer(object, "id")?.to_string(),
+        DigitalOceanFamily::Vpcs | DigitalOceanFamily::Firewalls => {
+            string(object, "id").ok_or(DigitalOceanError::MissingStableIdentity)?
+        }
+    };
+    origin::provider_id(&value).ok_or(DigitalOceanError::MissingStableIdentity)
+}
+
+fn integer(object: &Map<String, Value>, key: &str) -> Result<i64, DigitalOceanError> {
+    object
+        .get(key)
+        .and_then(Value::as_i64)
+        .filter(|value| *value > 0)
+        .ok_or(DigitalOceanError::MissingStableIdentity)
+}
+
+fn string(object: &Map<String, Value>, key: &str) -> Option<String> {
+    object
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn droplet_ids(object: &Map<String, Value>) -> Result<Vec<i64>, DigitalOceanError> {
+    let Some(value) = object.get("droplet_ids") else {
+        return Ok(Vec::new());
+    };
+    let values = value
+        .as_array()
+        .ok_or(DigitalOceanError::InvalidProviderRecord)?;
+    values
+        .iter()
+        .map(|value| {
+            value
+                .as_i64()
+                .filter(|id| *id > 0)
+                .ok_or(DigitalOceanError::InvalidProviderRecord)
+        })
+        .collect()
+}
+
+fn public_ingress(object: &Map<String, Value>) -> Result<bool, DigitalOceanError> {
+    let Some(value) = object.get("inbound_rules") else {
+        return Ok(false);
+    };
+    let rules = value
+        .as_array()
+        .ok_or(DigitalOceanError::InvalidProviderRecord)?;
+    for rule in rules {
+        let Some(addresses) = rule
+            .as_object()
+            .and_then(|rule| rule.get("sources"))
+            .and_then(Value::as_object)
+            .and_then(|sources| sources.get("addresses"))
+        else {
+            continue;
+        };
+        let addresses = addresses
+            .as_array()
+            .ok_or(DigitalOceanError::InvalidProviderRecord)?;
+        if addresses
+            .iter()
+            .any(|address| matches!(address.as_str().map(str::trim), Some("0.0.0.0/0" | "::/0")))
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn timestamp_or_epoch(value: &str) -> Result<String, DigitalOceanError> {
+    if value.is_empty() {
+        return Ok("1970-01-01T00:00:00Z".to_owned());
+    }
+    OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| DigitalOceanError::InvalidProviderRecord)?
+        .format(&Rfc3339)
+        .map_err(|_| DigitalOceanError::InvalidProviderRecord)
+}
+
+fn event_id(tenant_id: &str, family: DigitalOceanFamily, provider_id: &str) -> String {
+    let digest = Sha256::digest(
+        format!(
+            "digitalocean\0{tenant_id}\0{}\0{provider_id}",
+            family.as_str()
+        )
+        .as_bytes(),
+    );
+    format!(
+        "id-{}",
+        digest[..16]
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>()
+    )
+}
+
+fn admit(record: &DigitalOceanRecord) -> Result<(), DigitalOceanError> {
+    if record.kind != record.family.event_kind()
+        || record.schema_ref != record.family.schema_ref()
+        || [
+            "tenant_id",
+            "source_event_id",
+            "resource_urn",
+            "resource_type",
+            "resource_id",
+        ]
+        .iter()
+        .any(|key| record.attributes.get(*key).is_none_or(String::is_empty))
+        || record.payload.get("id").is_none_or(Value::is_null)
+    {
+        return Err(DigitalOceanError::EventContractRejection);
+    }
+    Ok(())
+}
+
+fn reject_untrusted_fields(value: &Value) -> Result<(), DigitalOceanError> {
+    match value {
+        Value::Object(values) => {
+            for (key, nested) in values {
+                let normalized = key.to_ascii_lowercase().replace('-', "_");
+                if matches!(normalized.as_str(), "tenant_id" | "tenantid") {
+                    return Err(DigitalOceanError::TenantMismatch);
+                }
+                if matches!(
+                    normalized.as_str(),
+                    "authorization" | "access_token" | "token" | "password" | "private_key"
+                ) {
+                    return Err(DigitalOceanError::CredentialMaterial);
+                }
+                reject_untrusted_fields(nested)?;
+            }
+        }
+        Value::Array(values) => {
+            for nested in values {
+                reject_untrusted_fields(nested)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}

--- a/crates/source-runtime-next/src/digitalocean/origin.rs
+++ b/crates/source-runtime-next/src/digitalocean/origin.rs
@@ -1,0 +1,43 @@
+use reqwest::Url;
+
+use super::DigitalOceanError;
+
+pub(super) const DEFAULT_BASE_URL: &str = "https://api.digitalocean.com/v2";
+
+pub(super) fn validate(value: Option<&str>) -> Result<Url, DigitalOceanError> {
+    let value = value
+        .unwrap_or(DEFAULT_BASE_URL)
+        .trim()
+        .trim_end_matches('/');
+    let mut url = Url::parse(value).map_err(|_| DigitalOceanError::InvalidBaseUrl)?;
+    if url.scheme() != "https"
+        || url.host_str() != Some("api.digitalocean.com")
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port_or_known_default() != Some(443)
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || !matches!(url.path(), "" | "/" | "/v2")
+    {
+        return Err(DigitalOceanError::InvalidBaseUrl);
+    }
+    url.set_path("/v2");
+    Ok(url)
+}
+
+pub(super) fn tenant(value: &str) -> Option<String> {
+    safe_segment(value, 128)
+}
+
+pub(super) fn provider_id(value: &str) -> Option<String> {
+    safe_segment(value, 512)
+}
+
+fn safe_segment(value: &str, limit: usize) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()
+        && value.len() <= limit
+        && !value.chars().any(char::is_control)
+        && !value.contains([':', '/', '\\']))
+    .then(|| value.to_owned())
+}

--- a/crates/source-runtime-next/src/digitalocean/projection.rs
+++ b/crates/source-runtime-next/src/digitalocean/projection.rs
@@ -1,0 +1,182 @@
+use std::collections::BTreeMap;
+
+use super::{DigitalOceanFamily, DigitalOceanRecord};
+
+/// One deterministic tenant-scoped DigitalOcean projection entity.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct DigitalOceanEntityFact {
+    /// Canonical entity URN.
+    pub urn: String,
+    /// Legacy Go entity type.
+    pub entity_type: String,
+    /// Human-readable label.
+    pub label: String,
+    /// Exact semantic projection attributes.
+    pub attributes: BTreeMap<String, String>,
+}
+
+/// One deterministic DigitalOcean relationship fact.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct DigitalOceanLinkFact {
+    /// Source entity URN.
+    pub from_urn: String,
+    /// Legacy Go relationship name.
+    pub relation: String,
+    /// Target entity URN.
+    pub to_urn: String,
+    /// Relationship attributes.
+    pub attributes: BTreeMap<String, String>,
+}
+
+/// Provider-local semantic projection result used only for parity.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct DigitalOceanProjectionFacts {
+    /// Deduplicated entities in canonical order.
+    pub entities: Vec<DigitalOceanEntityFact>,
+    /// Deduplicated relationships in canonical order.
+    pub links: Vec<DigitalOceanLinkFact>,
+}
+
+/// Project normalized records using the current Go projector semantics.
+pub fn project_digitalocean_records(records: &[DigitalOceanRecord]) -> DigitalOceanProjectionFacts {
+    let mut entities = BTreeMap::<String, DigitalOceanEntityFact>::new();
+    let mut links = BTreeMap::<(String, String, String), DigitalOceanLinkFact>::new();
+    for record in records {
+        let urn = attribute(record, "resource_urn");
+        let resource_id = attribute(record, "resource_id");
+        let label = record
+            .attributes
+            .get("resource_name")
+            .filter(|value| !value.is_empty())
+            .cloned()
+            .unwrap_or_else(|| resource_id.clone());
+        let (entity_type, entity_attributes) = match record.family {
+            DigitalOceanFamily::Droplets => (
+                "runtime.compute.droplet",
+                BTreeMap::from([
+                    ("region".to_owned(), attribute(record, "region")),
+                    ("resource_id".to_owned(), resource_id),
+                    ("resource_type".to_owned(), "droplet".to_owned()),
+                ]),
+            ),
+            DigitalOceanFamily::Vpcs => (
+                "runtime.network.vpc",
+                BTreeMap::from([
+                    ("region".to_owned(), attribute(record, "region")),
+                    ("resource_id".to_owned(), resource_id),
+                    ("resource_type".to_owned(), "vpc".to_owned()),
+                ]),
+            ),
+            DigitalOceanFamily::Firewalls => (
+                "runtime.network.firewall",
+                BTreeMap::from([
+                    (
+                        "public_ingress".to_owned(),
+                        attribute(record, "public_ingress"),
+                    ),
+                    ("resource_id".to_owned(), resource_id),
+                    ("resource_type".to_owned(), "firewall".to_owned()),
+                ]),
+            ),
+        };
+        entities.insert(
+            urn.clone(),
+            DigitalOceanEntityFact {
+                urn: urn.clone(),
+                entity_type: entity_type.to_owned(),
+                label,
+                attributes: entity_attributes,
+            },
+        );
+        match record.family {
+            DigitalOceanFamily::Droplets => {
+                if let Some(vpc) = record.attributes.get("vpc_uuid") {
+                    insert_link(
+                        &mut links,
+                        &urn,
+                        "belongs_to",
+                        &scoped_urn(&record.tenant_id, "digitalocean_vpcs", vpc),
+                        &record.event_id,
+                        None,
+                    );
+                }
+            }
+            DigitalOceanFamily::Firewalls => {
+                let public = record
+                    .attributes
+                    .get("public_ingress")
+                    .is_some_and(|value| value.eq_ignore_ascii_case("true"));
+                for droplet_id in record
+                    .attributes
+                    .get("droplet_ids")
+                    .into_iter()
+                    .flat_map(|ids| ids.split(','))
+                    .map(str::trim)
+                    .filter(|id| !id.is_empty())
+                {
+                    let droplet =
+                        scoped_urn(&record.tenant_id, "digitalocean_droplets", droplet_id);
+                    insert_link(
+                        &mut links,
+                        &urn,
+                        "attached_to",
+                        &droplet,
+                        &record.event_id,
+                        None,
+                    );
+                    if public {
+                        insert_link(
+                            &mut links,
+                            &urn,
+                            "can_reach",
+                            &droplet,
+                            &record.event_id,
+                            Some(("exposure", "public")),
+                        );
+                    }
+                }
+            }
+            DigitalOceanFamily::Vpcs => {}
+        }
+    }
+    DigitalOceanProjectionFacts {
+        entities: entities.into_values().collect(),
+        links: links.into_values().collect(),
+    }
+}
+
+fn insert_link(
+    links: &mut BTreeMap<(String, String, String), DigitalOceanLinkFact>,
+    from_urn: &str,
+    relation: &str,
+    to_urn: &str,
+    event_id: &str,
+    extra: Option<(&str, &str)>,
+) {
+    let mut attributes = BTreeMap::from([("event_id".to_owned(), event_id.to_owned())]);
+    if let Some((key, value)) = extra {
+        attributes.insert(key.to_owned(), value.to_owned());
+    }
+    let fact = DigitalOceanLinkFact {
+        from_urn: from_urn.to_owned(),
+        relation: relation.to_owned(),
+        to_urn: to_urn.to_owned(),
+        attributes,
+    };
+    links.insert(
+        (
+            fact.from_urn.clone(),
+            fact.relation.clone(),
+            fact.to_urn.clone(),
+        ),
+        fact,
+    );
+}
+
+fn scoped_urn(tenant: &str, kind: &str, id: &str) -> String {
+    format!("urn:cerebro:{tenant}:{kind}:{id}")
+}
+
+fn attribute(record: &DigitalOceanRecord, key: &str) -> String {
+    record.attributes.get(key).cloned().unwrap_or_default()
+}

--- a/crates/source-runtime-next/src/digitalocean/request.rs
+++ b/crates/source-runtime-next/src/digitalocean/request.rs
@@ -1,0 +1,108 @@
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use super::{
+    DigitalOceanError, DigitalOceanFamily, DigitalOceanKernel, DigitalOceanOperation,
+    DigitalOceanRequest, origin,
+};
+
+const DEFAULT_PAGE_SIZE: usize = 50;
+const MAX_PAGE_SIZE: usize = 200;
+const MAX_PAGE: u32 = 1_000_000;
+
+pub(super) fn new_kernel(
+    base_url: Option<&str>,
+    tenant_id: &str,
+    family: DigitalOceanFamily,
+    page_size: Option<usize>,
+    observed_at: &str,
+) -> Result<DigitalOceanKernel, DigitalOceanError> {
+    let base_url = origin::validate(base_url)?;
+    let tenant_id = origin::tenant(tenant_id).ok_or(DigitalOceanError::InvalidTenantId)?;
+    let page_size = page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+    if !(1..=MAX_PAGE_SIZE).contains(&page_size) {
+        return Err(DigitalOceanError::InvalidPageSize);
+    }
+    let observed = OffsetDateTime::parse(observed_at, &Rfc3339)
+        .map_err(|_| DigitalOceanError::InvalidProviderRecord)?;
+    let observed_at = observed
+        .format(&Rfc3339)
+        .map_err(|_| DigitalOceanError::InvalidProviderRecord)?;
+    Ok(DigitalOceanKernel {
+        base_url,
+        tenant_id,
+        family,
+        page_size,
+        observed_at,
+    })
+}
+
+pub(super) fn plan(
+    kernel: &DigitalOceanKernel,
+    operation: DigitalOceanOperation,
+    cursor: Option<&str>,
+) -> Result<DigitalOceanRequest, DigitalOceanError> {
+    if matches!(
+        operation,
+        DigitalOceanOperation::Check | DigitalOceanOperation::AccountVerification
+    ) && cursor.is_some()
+    {
+        return Err(DigitalOceanError::InvalidCursor);
+    }
+    let page = cursor.map(validate_cursor).transpose()?.unwrap_or(1);
+    let mut url = kernel.base_url.clone();
+    url.set_path(match operation {
+        DigitalOceanOperation::AccountVerification => "/v2/account",
+        DigitalOceanOperation::Check
+        | DigitalOceanOperation::Discover
+        | DigitalOceanOperation::Read => kernel.family.path(),
+    });
+    if url.origin() != kernel.base_url.origin() {
+        return Err(DigitalOceanError::InvalidBaseUrl);
+    }
+    if operation != DigitalOceanOperation::AccountVerification {
+        let mut query = url.query_pairs_mut();
+        query.append_pair("page", &page.to_string());
+        query.append_pair("per_page", &kernel.page_size.to_string());
+    }
+    Ok(DigitalOceanRequest {
+        url,
+        family: kernel.family,
+        operation,
+        cursor: cursor.map(str::to_owned),
+        page,
+        page_size: kernel.page_size,
+    })
+}
+
+pub(super) fn validate_request(
+    kernel: &DigitalOceanKernel,
+    request: &DigitalOceanRequest,
+) -> Result<(), DigitalOceanError> {
+    if request != &plan(kernel, request.operation, request.cursor.as_deref())? {
+        return Err(DigitalOceanError::RequestScopeMismatch);
+    }
+    Ok(())
+}
+
+pub(super) fn validate_cursor(value: &str) -> Result<u32, DigitalOceanError> {
+    let value = value.trim();
+    if value.is_empty()
+        || value.len() > 7
+        || value.starts_with('0')
+        || value.chars().any(char::is_control)
+    {
+        return Err(DigitalOceanError::InvalidCursor);
+    }
+    value
+        .parse::<u32>()
+        .ok()
+        .filter(|page| (1..=MAX_PAGE).contains(page))
+        .ok_or(DigitalOceanError::InvalidCursor)
+}
+
+pub(super) fn next_page(page: u32) -> Result<String, DigitalOceanError> {
+    page.checked_add(1)
+        .filter(|next| *next <= MAX_PAGE)
+        .map(|next| next.to_string())
+        .ok_or(DigitalOceanError::InvalidCursor)
+}

--- a/crates/source-runtime-next/src/digitalocean/response.rs
+++ b/crates/source-runtime-next/src/digitalocean/response.rs
@@ -1,0 +1,120 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use super::{
+    DigitalOceanCheckpointCandidate, DigitalOceanError, DigitalOceanKernel, DigitalOceanOperation,
+    DigitalOceanPage, DigitalOceanRecord, DigitalOceanRequest,
+    normalize::normalize_record,
+    request::{next_page, validate_request},
+};
+
+pub(super) const MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+pub(super) fn decode(
+    kernel: &DigitalOceanKernel,
+    request: &DigitalOceanRequest,
+    status: u16,
+    retry_after_seconds: Option<u64>,
+    body: &[u8],
+) -> Result<DigitalOceanPage, DigitalOceanError> {
+    validate_request(kernel, request)?;
+    classify_status(status, retry_after_seconds)?;
+    if body.len() > MAX_RESPONSE_BYTES {
+        return Err(DigitalOceanError::ResponseTooLarge);
+    }
+    let root: Value =
+        serde_json::from_slice(body).map_err(|_| DigitalOceanError::MalformedResponse)?;
+    let object = root
+        .as_object()
+        .ok_or(DigitalOceanError::MalformedResponse)?;
+    let items = object
+        .get(kernel.family.as_str())
+        .and_then(Value::as_array)
+        .ok_or(DigitalOceanError::MalformedResponse)?;
+    if items.len() > request.page_size {
+        return Err(DigitalOceanError::TooManyRecords);
+    }
+    let mut records = Vec::<DigitalOceanRecord>::with_capacity(items.len());
+    let mut seen = BTreeMap::<String, usize>::new();
+    for value in items {
+        let record = normalize_record(kernel, value)?;
+        if let Some(index) = seen.get(&record.provider_id).copied() {
+            if records.get(index) != Some(&record) {
+                return Err(DigitalOceanError::ConflictingDuplicate);
+            }
+            continue;
+        }
+        seen.insert(record.provider_id.clone(), records.len());
+        records.push(record);
+    }
+    let next_cursor = if has_next_link(object)? {
+        Some(next_page(request.page)?)
+    } else {
+        None
+    };
+    Ok(DigitalOceanPage {
+        records,
+        next_cursor,
+    })
+}
+
+pub(super) fn checkpoint_candidate(
+    kernel: &DigitalOceanKernel,
+    request: &DigitalOceanRequest,
+    page: &DigitalOceanPage,
+    prior_watermark: Option<&str>,
+) -> Result<DigitalOceanCheckpointCandidate, DigitalOceanError> {
+    validate_request(kernel, request)?;
+    if request.operation != DigitalOceanOperation::Read {
+        return Err(DigitalOceanError::RequestScopeMismatch);
+    }
+    if let Some(cursor) = page.next_cursor.as_deref() {
+        super::request::validate_cursor(cursor)?;
+    }
+    let watermark = if page.records.is_empty() {
+        prior_watermark.unwrap_or(&kernel.observed_at)
+    } else {
+        &kernel.observed_at
+    };
+    Ok(DigitalOceanCheckpointCandidate {
+        tenant_id: kernel.tenant_id.clone(),
+        family: kernel.family,
+        cursor: page.next_cursor.clone(),
+        watermark: watermark.to_owned(),
+    })
+}
+
+fn has_next_link(object: &serde_json::Map<String, Value>) -> Result<bool, DigitalOceanError> {
+    let Some(links) = object.get("links") else {
+        return Ok(false);
+    };
+    let links = links
+        .as_object()
+        .ok_or(DigitalOceanError::MalformedResponse)?;
+    let Some(pages) = links.get("pages") else {
+        return Ok(false);
+    };
+    let pages = pages
+        .as_object()
+        .ok_or(DigitalOceanError::MalformedResponse)?;
+    let Some(next) = pages.get("next") else {
+        return Ok(false);
+    };
+    next.as_str()
+        .map(|value| !value.is_empty())
+        .ok_or(DigitalOceanError::MalformedResponse)
+}
+
+fn classify_status(status: u16, retry_after_seconds: Option<u64>) -> Result<(), DigitalOceanError> {
+    match status {
+        200 => Ok(()),
+        401 => Err(DigitalOceanError::AuthenticationRejected),
+        403 => Err(DigitalOceanError::RequiredScopeMissing),
+        429 => Err(DigitalOceanError::RateLimited {
+            retry_after_seconds,
+        }),
+        500..=599 => Err(DigitalOceanError::ProviderUnavailable { status }),
+        _ => Err(DigitalOceanError::UnexpectedStatus { status }),
+    }
+}

--- a/crates/source-runtime-next/src/digitalocean/tests.rs
+++ b/crates/source-runtime-next/src/digitalocean/tests.rs
@@ -1,0 +1,363 @@
+use std::{collections::BTreeSet, fs, path::PathBuf, str::FromStr};
+
+use cerebro_source_catalog::{AuthModel, HttpMethod, Pagination, SourceCatalog};
+use serde_json::{Value, json};
+
+use super::*;
+
+const OBSERVED_AT: &str = "2026-06-03T00:00:00Z";
+
+fn root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn kernel(tenant: &str, family: DigitalOceanFamily) -> DigitalOceanKernel {
+    DigitalOceanKernel::new(None, tenant, family, None, OBSERVED_AT).unwrap()
+}
+
+fn fixture(family: DigitalOceanFamily) -> Vec<u8> {
+    fs::read(root().join(format!(
+        "sources/digitalocean/testdata/read_{}.json",
+        family.as_str()
+    )))
+    .unwrap()
+}
+
+fn page(family: DigitalOceanFamily, tenant: &str) -> DigitalOceanPage {
+    let kernel = kernel(tenant, family);
+    let request = kernel.plan(DigitalOceanOperation::Read, None).unwrap();
+    kernel
+        .decode(&request, 200, None, &fixture(family))
+        .unwrap()
+}
+
+#[test]
+fn catalog_and_kernel_close_the_exact_three_legacy_families() {
+    let catalog = SourceCatalog::load(
+        root().join("internal/connectorcatalog/catalog"),
+        root().join("sources"),
+    )
+    .unwrap();
+    let source = catalog.get("digitalocean").unwrap();
+    assert_eq!(source.auth(), &AuthModel::BearerToken);
+    let compiled = source
+        .families()
+        .iter()
+        .map(|family| family.id())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(compiled, BTreeSet::from(["droplets", "firewalls", "vpcs"]));
+    for family in source.families() {
+        assert_eq!(family.method(), HttpMethod::Get);
+        assert_eq!(
+            family.pagination(),
+            &Pagination::Page {
+                parameter: "page".to_owned(),
+                start: 1,
+                page_size_parameter: Some("per_page".to_owned()),
+                page_size: 50,
+            }
+        );
+    }
+    assert_eq!(DigitalOceanFamily::ALL.len(), 3);
+    for family in DigitalOceanFamily::ALL {
+        assert_eq!(DigitalOceanFamily::from_str(family.as_str()), Ok(family));
+    }
+    assert_eq!(
+        DigitalOceanFamily::from_str("unknown"),
+        Err(DigitalOceanError::InvalidFamily)
+    );
+    assert!(root().join("sources/digitalocean/source.go").exists());
+    assert!(root().join("sources/digitalocean/source_test.go").exists());
+}
+
+#[test]
+fn check_uses_the_selected_family_while_catalog_verification_uses_account() {
+    for family in DigitalOceanFamily::ALL {
+        let kernel = kernel("tenant", family);
+        let check = kernel.plan_check().unwrap();
+        assert_eq!(check.operation(), DigitalOceanOperation::Check);
+        assert_eq!(check.family(), family);
+        assert_eq!(check.url().path(), family.path());
+        assert_eq!(check.url().query(), Some("page=1&per_page=50"));
+        assert_ne!(check.url().path(), "/v2/account");
+
+        let verification = kernel.plan_account_verification().unwrap();
+        assert_eq!(
+            verification.operation(),
+            DigitalOceanOperation::AccountVerification
+        );
+        assert_eq!(verification.url().path(), "/v2/account");
+        assert_eq!(verification.url().query(), None);
+    }
+}
+
+#[test]
+fn requests_default_to_fifty_and_keep_bearer_auth_outside_the_kernel() {
+    let default = kernel("tenant", DigitalOceanFamily::Droplets);
+    let request = default.plan(DigitalOceanOperation::Read, None).unwrap();
+    assert_eq!(request.method(), "GET");
+    assert_eq!(
+        request.url().as_str(),
+        "https://api.digitalocean.com/v2/droplets?page=1&per_page=50"
+    );
+    assert_eq!(request.authentication_header(), "Authorization");
+    assert_eq!(request.authentication_scheme(), "Bearer");
+    assert!(request.credential_reference_required());
+    assert!(!request.contains_credentials());
+    assert!(!request.allows_redirects());
+    assert_eq!(request.accept(), "application/json");
+    assert_eq!(request.record_limit(), 50);
+    assert_eq!(request.max_response_bytes(), 8 * 1024 * 1024);
+    assert_eq!(request.required_scope(), "DigitalOcean read access");
+    assert!(!DigitalOceanKernel::requires_credentials());
+
+    let explicit = DigitalOceanKernel::new(
+        Some("https://api.digitalocean.com"),
+        "tenant",
+        DigitalOceanFamily::Vpcs,
+        Some(200),
+        OBSERVED_AT,
+    )
+    .unwrap();
+    assert_eq!(
+        explicit
+            .plan(DigitalOceanOperation::Discover, None)
+            .unwrap()
+            .url()
+            .as_str(),
+        "https://api.digitalocean.com/v2/vpcs?page=1&per_page=200"
+    );
+}
+
+#[test]
+fn origin_tenant_page_size_and_cursor_inputs_fail_closed() {
+    for origin in [
+        "http://api.digitalocean.com/v2",
+        "https://user@api.digitalocean.com/v2",
+        "https://api.digitalocean.com:8443/v2",
+        "https://other.digitalocean.com/v2",
+        "https://api.digitalocean.com/v3",
+        "https://api.digitalocean.com/v2?token=value",
+    ] {
+        assert_eq!(
+            DigitalOceanKernel::new(
+                Some(origin),
+                "tenant",
+                DigitalOceanFamily::Droplets,
+                None,
+                OBSERVED_AT
+            )
+            .unwrap_err(),
+            DigitalOceanError::InvalidBaseUrl
+        );
+    }
+    for tenant in ["", "bad:tenant", "bad/tenant", "bad\ntenant"] {
+        assert!(
+            DigitalOceanKernel::new(
+                None,
+                tenant,
+                DigitalOceanFamily::Droplets,
+                None,
+                OBSERVED_AT
+            )
+            .is_err()
+        );
+    }
+    for page_size in [0, 201, usize::MAX] {
+        assert!(
+            DigitalOceanKernel::new(
+                None,
+                "tenant",
+                DigitalOceanFamily::Droplets,
+                Some(page_size),
+                OBSERVED_AT
+            )
+            .is_err()
+        );
+    }
+    for cursor in ["", "0", "01", "-1", "1000001", "next", "1\n2"] {
+        assert_eq!(
+            kernel("tenant", DigitalOceanFamily::Droplets)
+                .plan(DigitalOceanOperation::Read, Some(cursor)),
+            Err(DigitalOceanError::InvalidCursor)
+        );
+    }
+}
+
+#[test]
+fn checked_provider_fixtures_match_go_event_and_projection_semantics() {
+    let droplets = page(DigitalOceanFamily::Droplets, "tenant");
+    assert_eq!(droplets.records.len(), 2);
+    let droplet = &droplets.records[0];
+    assert_eq!(droplet.provider_id, "3164444");
+    assert_eq!(droplet.kind, "digitalocean.droplets");
+    assert_eq!(droplet.schema_ref, "digitalocean/droplets/v1");
+    assert_eq!(droplet.occurred_at, "2026-06-01T00:00:00Z");
+    assert_eq!(droplet.attributes["region"], "nyc3");
+    assert_eq!(droplet.attributes["vpc_uuid"], "vpc-1111");
+    assert_eq!(
+        droplet.attributes["resource_urn"],
+        "urn:cerebro:tenant:digitalocean_droplets:3164444"
+    );
+    assert_eq!(droplet.payload["region"], "nyc3");
+    assert_eq!(droplet.payload["vpc_uuid"], "vpc-1111");
+
+    let vpcs = page(DigitalOceanFamily::Vpcs, "tenant");
+    let vpc = &vpcs.records[0];
+    assert_eq!(vpc.attributes["region"], "nyc3");
+    assert_eq!(vpc.payload["default"], true);
+    assert_eq!(vpc.payload["ip_range"], "192.0.2.0/24");
+
+    let firewalls = page(DigitalOceanFamily::Firewalls, "tenant");
+    let firewall = &firewalls.records[0];
+    assert_eq!(firewall.attributes["droplet_ids"], "3164444,3164445");
+    assert_eq!(firewall.attributes["public_ingress"], "true");
+    assert_eq!(firewall.payload["droplet_ids"], json!([3164444, 3164445]));
+    assert_eq!(firewall.payload["public"], true);
+    assert!(firewall.payload.get("inbound_rules").is_none());
+
+    let all = droplets
+        .records
+        .into_iter()
+        .chain(vpcs.records)
+        .chain(firewalls.records)
+        .collect::<Vec<_>>();
+    let projection = project_digitalocean_records(&all);
+    assert_eq!(projection.entities.len(), 4);
+    assert_eq!(projection.links.len(), 6);
+    assert!(projection.links.iter().any(|link| {
+        link.from_urn.ends_with(":digitalocean_droplets:3164444")
+            && link.relation == "belongs_to"
+            && link.to_urn.ends_with(":digitalocean_vpcs:vpc-1111")
+    }));
+    assert!(projection.links.iter().any(|link| {
+        link.from_urn.ends_with(":digitalocean_firewalls:fw-2222")
+            && link.relation == "attached_to"
+            && link.to_urn.ends_with(":digitalocean_droplets:3164444")
+    }));
+    assert!(projection.links.iter().any(|link| {
+        link.from_urn.ends_with(":digitalocean_firewalls:fw-2222")
+            && link.relation == "can_reach"
+            && link.to_urn.ends_with(":digitalocean_droplets:3164444")
+            && link.attributes.get("exposure").map(String::as_str) == Some("public")
+    }));
+}
+
+#[test]
+fn godo_links_terminal_behavior_and_restart_checkpoint_round_trip() {
+    let family = DigitalOceanFamily::Droplets;
+    let kernel = kernel("tenant", family);
+    let first_request = kernel.plan(DigitalOceanOperation::Read, None).unwrap();
+    let mut body: Value = serde_json::from_slice(&fixture(family)).unwrap();
+    body["links"] = json!({
+        "pages": {
+            "next": "https://other.invalid/v2/droplets?page=987"
+        }
+    });
+    let first = kernel
+        .decode(
+            &first_request,
+            200,
+            None,
+            &serde_json::to_vec(&body).unwrap(),
+        )
+        .unwrap();
+    assert_eq!(first.next_cursor.as_deref(), Some("2"));
+    let checkpoint = kernel
+        .checkpoint_candidate(&first_request, &first, Some("2026-06-01T00:00:00Z"))
+        .unwrap();
+    assert_eq!(checkpoint.cursor.as_deref(), Some("2"));
+    assert_eq!(checkpoint.watermark, OBSERVED_AT);
+    let resumed = kernel
+        .plan(DigitalOceanOperation::Read, checkpoint.cursor.as_deref())
+        .unwrap();
+    assert_eq!(resumed.url().query(), Some("page=2&per_page=50"));
+
+    body["links"] = json!({});
+    body["droplets"] = json!([]);
+    let terminal = kernel
+        .decode(&resumed, 200, None, &serde_json::to_vec(&body).unwrap())
+        .unwrap();
+    assert_eq!(terminal.next_cursor, None);
+    let terminal_checkpoint = kernel
+        .checkpoint_candidate(&resumed, &terminal, Some(OBSERVED_AT))
+        .unwrap();
+    assert_eq!(terminal_checkpoint.cursor, None);
+    assert_eq!(terminal_checkpoint.watermark, OBSERVED_AT);
+}
+
+#[test]
+fn statuses_bounds_duplicates_scope_and_secret_material_fail_closed() {
+    let family = DigitalOceanFamily::Firewalls;
+    let kernel = kernel("tenant", family);
+    let request = kernel.plan(DigitalOceanOperation::Read, None).unwrap();
+    for (status, expected) in [
+        (401, DigitalOceanError::AuthenticationRejected),
+        (403, DigitalOceanError::RequiredScopeMissing),
+        (
+            429,
+            DigitalOceanError::RateLimited {
+                retry_after_seconds: Some(60),
+            },
+        ),
+        (503, DigitalOceanError::ProviderUnavailable { status: 503 }),
+        (418, DigitalOceanError::UnexpectedStatus { status: 418 }),
+    ] {
+        assert_eq!(
+            kernel.decode(&request, status, Some(60), b"{}"),
+            Err(expected)
+        );
+    }
+    let oversized = vec![b' '; request.max_response_bytes() + 1];
+    assert_eq!(
+        kernel.decode(&request, 200, None, &oversized),
+        Err(DigitalOceanError::ResponseTooLarge)
+    );
+
+    let mut body: Value = serde_json::from_slice(&fixture(family)).unwrap();
+    let record = body["firewalls"][0].clone();
+    body["firewalls"] = json!([record.clone(), record]);
+    assert_eq!(
+        kernel
+            .decode(&request, 200, None, &serde_json::to_vec(&body).unwrap())
+            .unwrap()
+            .records
+            .len(),
+        1
+    );
+    body["firewalls"][1]["name"] = json!("conflict");
+    assert_eq!(
+        kernel.decode(&request, 200, None, &serde_json::to_vec(&body).unwrap()),
+        Err(DigitalOceanError::ConflictingDuplicate)
+    );
+    for (field, expected) in [
+        ("tenant_id", DigitalOceanError::TenantMismatch),
+        ("token", DigitalOceanError::CredentialMaterial),
+        ("authorization", DigitalOceanError::CredentialMaterial),
+        ("private_key", DigitalOceanError::CredentialMaterial),
+    ] {
+        let mut body: Value = serde_json::from_slice(&fixture(family)).unwrap();
+        body["firewalls"][0][field] = json!("sentinel-secret-value");
+        let error = kernel
+            .decode(&request, 200, None, &serde_json::to_vec(&body).unwrap())
+            .unwrap_err();
+        assert_eq!(error, expected);
+        assert!(!error.to_string().contains("sentinel-secret-value"));
+        assert!(!format!("{error:?}").contains("sentinel-secret-value"));
+    }
+}
+
+#[test]
+fn identity_is_deterministic_and_tenant_scoped() {
+    let family = DigitalOceanFamily::Droplets;
+    let first = page(family, "tenant-a");
+    let repeated = page(family, "tenant-a");
+    let other = page(family, "tenant-b");
+    assert_eq!(first, repeated);
+    assert_ne!(first.records[0].event_id, other.records[0].event_id);
+    assert_ne!(
+        first.records[0].attributes["resource_urn"],
+        other.records[0].attributes["resource_urn"]
+    );
+    assert_eq!(first.records[0].provider_id, other.records[0].provider_id);
+}

--- a/crates/source-runtime-next/src/digitalocean/types.rs
+++ b/crates/source-runtime-next/src/digitalocean/types.rs
@@ -1,0 +1,224 @@
+use std::{collections::BTreeMap, fmt};
+
+use reqwest::Url;
+use serde_json::Value;
+
+use super::{DigitalOceanError, DigitalOceanFamily, request, response};
+
+/// Provider operation using one selected legacy family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DigitalOceanOperation {
+    /// Catalog transport verification through DigitalOcean's account endpoint.
+    AccountVerification,
+    /// Credential and connectivity check through the selected family list.
+    Check,
+    /// Provider identity discovery through the selected family list.
+    Discover,
+    /// Event collection through the selected family list.
+    Read,
+}
+
+/// Credential-free request intent for the trusted DigitalOcean HTTP host.
+#[derive(Clone, Eq, PartialEq)]
+pub struct DigitalOceanRequest {
+    pub(super) url: Url,
+    pub(super) family: DigitalOceanFamily,
+    pub(super) operation: DigitalOceanOperation,
+    pub(super) cursor: Option<String>,
+    pub(super) page: u32,
+    pub(super) page_size: usize,
+}
+
+impl fmt::Debug for DigitalOceanRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DigitalOceanRequest")
+            .field("url", &self.url)
+            .field("family", &self.family)
+            .field("operation", &self.operation)
+            .field("has_cursor", &self.cursor.is_some())
+            .field("page", &self.page)
+            .field("page_size", &self.page_size)
+            .finish()
+    }
+}
+
+impl DigitalOceanRequest {
+    /// Fully planned provider URL.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Provider HTTP method.
+    pub const fn method(&self) -> &'static str {
+        "GET"
+    }
+
+    /// Selected family.
+    pub const fn family(&self) -> DigitalOceanFamily {
+        self.family
+    }
+
+    /// Selected source operation.
+    pub const fn operation(&self) -> DigitalOceanOperation {
+        self.operation
+    }
+
+    /// Authentication header applied by the trusted host.
+    pub const fn authentication_header(&self) -> &'static str {
+        "Authorization"
+    }
+
+    /// Authentication scheme applied outside this kernel.
+    pub const fn authentication_scheme(&self) -> &'static str {
+        "Bearer"
+    }
+
+    /// The trusted host must redeem a credential reference before execution.
+    pub const fn credential_reference_required(&self) -> bool {
+        true
+    }
+
+    /// Portable plans contain neither credential values nor references.
+    pub const fn contains_credentials(&self) -> bool {
+        false
+    }
+
+    /// Redirects are disabled by the trusted host.
+    pub const fn allows_redirects(&self) -> bool {
+        false
+    }
+
+    /// Expected response media type.
+    pub const fn accept(&self) -> &'static str {
+        "application/json"
+    }
+
+    /// Maximum admitted response bytes.
+    pub const fn max_response_bytes(&self) -> usize {
+        response::MAX_RESPONSE_BYTES
+    }
+
+    /// Maximum admitted records from this response.
+    pub const fn record_limit(&self) -> usize {
+        self.page_size
+    }
+
+    /// Provider permission needed for the selected read operation.
+    pub const fn required_scope(&self) -> &'static str {
+        "DigitalOcean read access"
+    }
+}
+
+/// One normalized tenant-scoped DigitalOcean event candidate.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DigitalOceanRecord {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Stable tenant-scoped event identity.
+    pub event_id: String,
+    /// Stable provider object identity.
+    pub provider_id: String,
+    /// Exact family.
+    pub family: DigitalOceanFamily,
+    /// Exact event kind.
+    pub kind: String,
+    /// Exact schema reference.
+    pub schema_ref: String,
+    /// Normalized RFC3339 occurrence time.
+    pub occurred_at: String,
+    /// Exact Go-compatible event attributes.
+    pub attributes: BTreeMap<String, String>,
+    /// Credential-free provider payload admitted by the event contract.
+    pub payload: Value,
+}
+
+/// One bounded normalized DigitalOcean page.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DigitalOceanPage {
+    /// Accepted records after deterministic deduplication.
+    pub records: Vec<DigitalOceanRecord>,
+    /// Validated next numeric page, or terminal state.
+    pub next_cursor: Option<String>,
+}
+
+/// Validated checkpoint candidate for post-append/projection persistence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DigitalOceanCheckpointCandidate {
+    /// Authenticated tenant scope.
+    pub tenant_id: String,
+    /// Selected family.
+    pub family: DigitalOceanFamily,
+    /// Validated continuation state.
+    pub cursor: Option<String>,
+    /// Provider observation watermark.
+    pub watermark: String,
+}
+
+/// Closed DigitalOcean kernel for one tenant and one legacy family.
+#[derive(Clone, Debug)]
+pub struct DigitalOceanKernel {
+    pub(super) base_url: Url,
+    pub(super) tenant_id: String,
+    pub(super) family: DigitalOceanFamily,
+    pub(super) page_size: usize,
+    pub(super) observed_at: String,
+}
+
+impl DigitalOceanKernel {
+    /// Construct one family kernel from public execution context only.
+    pub fn new(
+        base_url: Option<&str>,
+        tenant_id: &str,
+        family: DigitalOceanFamily,
+        page_size: Option<usize>,
+        observed_at: &str,
+    ) -> Result<Self, DigitalOceanError> {
+        request::new_kernel(base_url, tenant_id, family, page_size, observed_at)
+    }
+
+    /// Kernel protocol never accepts credential material.
+    pub const fn requires_credentials() -> bool {
+        false
+    }
+
+    /// Plan Check against the configured family, matching the legacy Go source.
+    pub fn plan_check(&self) -> Result<DigitalOceanRequest, DigitalOceanError> {
+        request::plan(self, DigitalOceanOperation::Check, None)
+    }
+
+    /// Plan the declarative catalog's separate `/account` verification probe.
+    pub fn plan_account_verification(&self) -> Result<DigitalOceanRequest, DigitalOceanError> {
+        request::plan(self, DigitalOceanOperation::AccountVerification, None)
+    }
+
+    /// Plan one bounded origin-restricted provider request.
+    pub fn plan(
+        &self,
+        operation: DigitalOceanOperation,
+        cursor: Option<&str>,
+    ) -> Result<DigitalOceanRequest, DigitalOceanError> {
+        request::plan(self, operation, cursor)
+    }
+
+    /// Decode one bounded provider response under the exact request plan.
+    pub fn decode(
+        &self,
+        request: &DigitalOceanRequest,
+        status: u16,
+        retry_after_seconds: Option<u64>,
+        body: &[u8],
+    ) -> Result<DigitalOceanPage, DigitalOceanError> {
+        response::decode(self, request, status, retry_after_seconds, body)
+    }
+
+    /// Validate a checkpoint candidate for post-commit host persistence.
+    pub fn checkpoint_candidate(
+        &self,
+        request: &DigitalOceanRequest,
+        page: &DigitalOceanPage,
+        prior_watermark: Option<&str>,
+    ) -> Result<DigitalOceanCheckpointCandidate, DigitalOceanError> {
+        response::checkpoint_candidate(self, request, page, prior_watermark)
+    }
+}

--- a/crates/source-runtime-next/tests/digitalocean_provider_local.rs
+++ b/crates/source-runtime-next/tests/digitalocean_provider_local.rs
@@ -1,0 +1,6 @@
+#![allow(dead_code, unused_imports)]
+
+// Provider-local compile/test seam. Shared crate registration is intentionally
+// deferred to its separately owned integration gate.
+#[path = "../src/digitalocean/mod.rs"]
+mod digitalocean;


### PR DESCRIPTION
## Summary

- add a credential-free DigitalOcean kernel for droplets, VPCs, and firewalls
- keep legacy selected-family checks distinct from the catalog account verification request
- preserve page-one and `per_page=50` defaults, bounded numeric continuation, and terminal `links.pages.next` behavior
- compare normalized region, VPC, droplet attachment, public-ingress, and projection semantics against checked provider fixtures

## Authority boundary

This draft adds provider-local planning, normalization, checkpoint, and parity code only. It does not register a production dispatcher or host path, change collection or projection authority, modify shared catalogs, or delete the existing Go source and projector. The current 503-line Go compatibility target remains intact for a later production-authority gate.

## Validation

- `rustfmt --edition 2024 --check crates/source-runtime-next/src/digitalocean/*.rs crates/source-runtime-next/tests/digitalocean_provider_local.rs`
- `go test ./sources/digitalocean ./internal/sourceprojection -count=1`
- `./scripts/leak_check.sh staged`
- Rust compile, test, and Clippy are pending hosted checks because managed local build capacity was unavailable
