### PR TITLE
Bind orchestrator syncs to the durable lease fence

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -671,6 +671,24 @@ func runOrchestratorIteration(
 			continue
 		}
 		acquiredCount++
+		runtimeCtx, err = sourceruntime.WithCurrentSourceRuntimeLeaseFence(runtimeCtx, leaser, runtime.GetId(), leaseOwner)
+		if err != nil {
+			runtimeResult.Sync = "failed"
+			runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "lease_fence", err)
+			result.Runtimes = append(result.Runtimes, runtimeResult)
+			runErr = err
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error_stage", "lease_fence")
+			runtimeSpanAttrs = withTelemetryField(runtimeSpanAttrs, "error_kind", telemetry.ErrorKind(err))
+			captureOrchestratorError(runtimeCtx, "orchestrator.runtime.error", iteration, runtime, "lease_fence", err)
+			if releaseErr := releaseOrchestratorRuntimeLease(ctx, leaser, runtime, leaseOwner); releaseErr != nil {
+				runtimeResult.Error = appendRuntimeError(runtimeResult.Error, "release_lease", releaseErr)
+				runErr = errors.Join(runErr, releaseErr)
+			}
+			annotateOrchestratorRuntimeMain(runtimeCtx, runtimeResult, runtimeStatus, runtimeSpanAttrs)
+			emitOrchestratorJobRuntimeEvent(runtimeCtx, "platform.job.runtime.failed", runtimeStatus, iteration, runtime, runtimeResult, runtimeSpanAttrs)
+			telemetry.End(runtimeSpan, runtimeStatus, runtimeSpanAttrs)
+			continue
+		}
 		runtimeCtx, cancelRuntime := context.WithCancel(runtimeCtx)
 		stopLeaseRenewal := startOrchestratorRuntimeLeaseRenewal(ctx, leaser, runtime, leaseOwner, cancelRuntime)
 		syncStartCursorOpaque := orchestratorRuntimeStartCursorOpaque(runtime)

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -523,6 +523,9 @@ func TestRunOrchestratorIterationStopsAfterSyncFailure(t *testing.T) {
 	if store.leaseID != "runtime-1" || store.releaseID != "runtime-1" {
 		t.Fatalf("lease/release = %q/%q, want runtime-1/runtime-1", store.leaseID, store.releaseID)
 	}
+	if store.fenceReadID != "runtime-1" || store.fenceReadOwner != "test-owner" {
+		t.Fatalf("lease fence read = %q/%q, want runtime-1/test-owner", store.fenceReadID, store.fenceReadOwner)
+	}
 }
 
 func TestRunOrchestratorIterationPreservesGraphCountersOnPartialFailure(t *testing.T) {
@@ -1376,13 +1379,15 @@ func (s *leaseRuntimeStore) ReleaseSourceRuntimeLease(ctx context.Context, _ str
 }
 
 type orchestratorRuntimeStore struct {
-	runtime      *cerebrov1.SourceRuntime
-	runtimes     []*cerebrov1.SourceRuntime
-	acquired     bool
-	acquiredByID map[string]bool
-	listFilter   ports.SourceRuntimeFilter
-	leaseID      string
-	releaseID    string
+	runtime        *cerebrov1.SourceRuntime
+	runtimes       []*cerebrov1.SourceRuntime
+	acquired       bool
+	acquiredByID   map[string]bool
+	listFilter     ports.SourceRuntimeFilter
+	leaseID        string
+	releaseID      string
+	fenceReadID    string
+	fenceReadOwner string
 }
 
 func (s *orchestratorRuntimeStore) Ping(context.Context) error { return nil }
@@ -1423,6 +1428,12 @@ func (s *orchestratorRuntimeStore) RenewSourceRuntimeLease(context.Context, stri
 func (s *orchestratorRuntimeStore) ReleaseSourceRuntimeLease(_ context.Context, runtimeID string, _ string) error {
 	s.releaseID = runtimeID
 	return nil
+}
+
+func (s *orchestratorRuntimeStore) ReadSourceRuntimeLeaseFence(_ context.Context, runtimeID string, owner string) (ports.SourceRuntimeLeaseFence, error) {
+	s.fenceReadID = runtimeID
+	s.fenceReadOwner = owner
+	return ports.SourceRuntimeLeaseFence{Owner: owner, Generation: 1, ExpiresAt: time.Now().Add(defaultSourceRuntimeLeaseTTL)}, nil
 }
 
 type orchestratorTestSource struct{}

--- a/internal/sourceruntime/lease.go
+++ b/internal/sourceruntime/lease.go
@@ -63,6 +63,23 @@ func sourceRuntimeLeaseFenceFromContext(ctx context.Context) (ports.SourceRuntim
 	return fence, ok && strings.TrimSpace(fence.Owner) != "" && fence.Generation > 0 && !fence.ExpiresAt.IsZero()
 }
 
+// WithCurrentSourceRuntimeLeaseFence binds the durable owner/generation snapshot
+// for an already acquired lease to source-runtime work. Callers that acquire a
+// lease outside SyncWithLease, such as the orchestrator, must use the returned
+// context before invoking Sync so credential-free source execution can reject
+// stale workers and fenced page commits can use the same generation.
+func WithCurrentSourceRuntimeLeaseFence(ctx context.Context, store ports.SourceRuntimeLeaseStore, runtimeID string, owner string) (context.Context, error) {
+	reader, ok := store.(ports.SourceRuntimeLeaseFenceReader)
+	if !ok {
+		return ctx, nil
+	}
+	fence, err := reader.ReadSourceRuntimeLeaseFence(ctx, strings.TrimSpace(runtimeID), strings.TrimSpace(owner))
+	if err != nil {
+		return ctx, fmt.Errorf("read source runtime lease fence %q: %w", strings.TrimSpace(runtimeID), err)
+	}
+	return context.WithValue(ctx, sourceRuntimeLeaseFenceContextKey{}, sourceRuntimeLeaseAuthority{fence: fence}), nil
+}
+
 // SyncWithLease wraps Sync with a durable, renewable runtime lease so the
 // cursor advance is safe when several API replicas (or the API and the
 // orchestrator) try to sync the same runtime concurrently.
@@ -132,14 +149,11 @@ func (s *Service) SyncWithLease(ctx context.Context, req *cerebrov1.SyncSourceRu
 		return nil, fmt.Errorf("%w: %s", ErrSyncInProgress, runtimeID)
 	}
 	syncCtx, cancelSync := context.WithCancel(ctx)
-	if reader, ok := opts.LeaseStore.(ports.SourceRuntimeLeaseFenceReader); ok {
-		fence, fenceErr := reader.ReadSourceRuntimeLeaseFence(syncCtx, runtimeID, owner)
-		if fenceErr != nil {
-			cancelSync()
-			_ = releaseLease(ctx, opts.LeaseStore, runtimeID, owner)
-			return nil, fmt.Errorf("read source runtime lease fence %q: %w", runtimeID, fenceErr)
-		}
-		syncCtx = context.WithValue(syncCtx, sourceRuntimeLeaseFenceContextKey{}, sourceRuntimeLeaseAuthority{fence: fence})
+	syncCtx, fenceErr := WithCurrentSourceRuntimeLeaseFence(syncCtx, opts.LeaseStore, runtimeID, owner)
+	if fenceErr != nil {
+		cancelSync()
+		_ = releaseLease(ctx, opts.LeaseStore, runtimeID, owner)
+		return nil, fenceErr
 	}
 	stopRenewal := startLeaseRenewal(syncCtx, opts.LeaseStore, runtimeID, owner, ttl, cancelSync)
 	response, syncErr := s.Sync(syncCtx, req)

--- a/internal/sourceruntime/lease_test.go
+++ b/internal/sourceruntime/lease_test.go
@@ -36,6 +36,22 @@ type stubLeaseStore struct {
 	events []leaseEvent
 }
 
+type fencedStubLeaseStore struct {
+	*stubLeaseStore
+	fence ports.SourceRuntimeLeaseFence
+	err   error
+}
+
+func (s *fencedStubLeaseStore) ReadSourceRuntimeLeaseFence(_ context.Context, runtimeID string, owner string) (ports.SourceRuntimeLeaseFence, error) {
+	if s.err != nil {
+		return ports.SourceRuntimeLeaseFence{}, s.err
+	}
+	if strings.TrimSpace(runtimeID) == "" || strings.TrimSpace(owner) == "" {
+		return ports.SourceRuntimeLeaseFence{}, errors.New("runtime ID and owner are required")
+	}
+	return s.fence, nil
+}
+
 func (s *stubLeaseStore) AcquireSourceRuntimeLease(_ context.Context, runtimeID string, owner string, ttl time.Duration) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -102,6 +118,33 @@ func TestSyncWithLeaseFallsThroughWhenLeaseStoreIsNil(t *testing.T) {
 	_, err := service.SyncWithLease(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "runtime-a"}, SyncWithLeaseOptions{})
 	if !errors.Is(err, ErrRuntimeUnavailable) {
 		t.Fatalf("SyncWithLease() err = %v, want %v", err, ErrRuntimeUnavailable)
+	}
+}
+
+func TestWithCurrentSourceRuntimeLeaseFenceBindsDurableFence(t *testing.T) {
+	fence := ports.SourceRuntimeLeaseFence{Owner: "owner-a", Generation: 7, ExpiresAt: time.Now().Add(time.Minute)}
+	store := &fencedStubLeaseStore{stubLeaseStore: &stubLeaseStore{}, fence: fence}
+
+	ctx, err := WithCurrentSourceRuntimeLeaseFence(context.Background(), store, "runtime-a", "owner-a")
+	if err != nil {
+		t.Fatalf("WithCurrentSourceRuntimeLeaseFence() error = %v", err)
+	}
+	got, ok := sourceRuntimeLeaseFenceFromContext(ctx)
+	if !ok {
+		t.Fatal("sourceRuntimeLeaseFenceFromContext() = false, want true")
+	}
+	if got != fence {
+		t.Fatalf("lease fence = %#v, want %#v", got, fence)
+	}
+}
+
+func TestWithCurrentSourceRuntimeLeaseFencePreservesReaderFailure(t *testing.T) {
+	want := errors.New("fence unavailable")
+	store := &fencedStubLeaseStore{stubLeaseStore: &stubLeaseStore{}, err: want}
+
+	_, err := WithCurrentSourceRuntimeLeaseFence(context.Background(), store, "runtime-a", "owner-a")
+	if !errors.Is(err, want) {
+		t.Fatalf("WithCurrentSourceRuntimeLeaseFence() error = %v, want %v", err, want)
 	}
 }
 


### PR DESCRIPTION
## Failure

Candidate Runtime Smoke run 32586165068 reached the exact signed candidate but failed before reading a page: the orchestrator acquired a durable source-runtime lease, then invoked credential-free source execution without attaching the current owner, generation, and expiry to the sync context. The run recorded 0 pages, 0 events, and 0 projections.

## Change

- expose one shared helper that reads and binds an already acquired source-runtime lease fence
- reuse that helper in SyncWithLease
- bind the orchestrator runtime context before source sync
- release the acquired lease if the fence read fails
- add regression coverage for binding, reader failures, and the orchestrator path

## Validation

- go test ./internal/sourceruntime ./cmd/cerebro -count=1
- go test -race ./internal/sourceruntime -run TestWithCurrentSourceRuntimeLeaseFence|TestSyncWithLease -count=1
- go test -race ./cmd/cerebro -run TestRunOrchestratorIterationStopsAfterSyncFailure -count=1
- make check-structural check-structural-test check-arch
- git diff --check

## Release qualification

After merge, the next exact-main Candidate Build must pass before rerunning the bounded Candidate Runtime Smoke. No release is published from the failed smoke.