### PR TITLE
Prove Tailscale terminal checkpoint lifecycle

### DIFF
--- a/crates/source-runtime-next/src/source_execution/tailscale.rs
+++ b/crates/source-runtime-next/src/source_execution/tailscale.rs
@@ -577,6 +577,99 @@ mod tests {
     }
 
     #[test]
+    fn combined_provider_and_dispatcher_seal_terminal_progress_for_all_seven_families() {
+        let dispatcher = SourceExecutionDispatcher;
+        let cases = [
+            ("device", br#"{"devices":[{"id":"device-1"}]}"#.as_slice()),
+            ("grant", br#"{"grants":[{"id":"grant-1"}]}"#.as_slice()),
+            (
+                "group",
+                br#"{"groups":{"group:eng":["alice@example.test"]}}"#.as_slice(),
+            ),
+            (
+                "service",
+                br#"{"vipServices":[{"name":"svc:api"}]}"#.as_slice(),
+            ),
+            (
+                "tag",
+                br#"{"tagOwners":{"tag:prod":["group:eng"]}}"#.as_slice(),
+            ),
+            ("tailnet", br#"{}"#.as_slice()),
+            (
+                "user",
+                br#"{"users":[{"id":"user-1","loginName":"alice@example.test"}]}"#.as_slice(),
+            ),
+        ];
+
+        for (family, body) in cases {
+            let plan = plan(dispatcher, family);
+            let first_context = context("", 1);
+            let mut metadata = metadata();
+            metadata.prior_terminal_watermark_unix_millis = OBSERVED_AT_MILLIS - 1_000;
+            let execution = plan_page(dispatcher, &plan, &first_context, &metadata);
+            let mut output = decode_page(
+                dispatcher,
+                &plan,
+                &first_context,
+                &metadata,
+                &execution,
+                body,
+            );
+            let receipt = output.receipt.take().unwrap();
+            let result = output.result.take().unwrap();
+            let last = result.records.last().expect("terminal provider record");
+            let terminal_cursor = last.provider_id.clone();
+            let terminal_watermark = last.occurred_at_unix_millis;
+
+            assert_eq!(result.next_cursor, terminal_cursor, "{family}");
+            let program = seal_page_program_v2(&SourceExecutionLifecycleEnvelopeV2 {
+                request: Some(SourceExecutionLifecycleRequestV1 {
+                    plan: Some(plan.clone()),
+                    context: Some(first_context),
+                    receipt: Some(receipt),
+                    result: Some(result),
+                    current_lease_generation: 11,
+                }),
+                metadata: Some(metadata.clone()),
+            })
+            .unwrap();
+            assert_eq!(program.checkpoint_cursor, terminal_cursor, "{family}");
+            assert_eq!(
+                program.checkpoint_watermark_unix_millis, terminal_watermark,
+                "{family}"
+            );
+
+            let restarted = plan_page(
+                dispatcher,
+                &plan,
+                &context(&program.checkpoint_cursor, 2),
+                &metadata,
+            );
+            let restarted_url = reqwest::Url::parse(&restarted.request.unwrap().url).unwrap();
+            assert_eq!(
+                restarted_url
+                    .query_pairs()
+                    .find(|(key, _)| key == "cursor")
+                    .map(|(_, value)| value.into_owned())
+                    .as_deref(),
+                Some(program.checkpoint_cursor.as_str()),
+                "{family}"
+            );
+
+            let error = dispatcher
+                .dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+                    request: Some(SourceWorkerPlanRequestV1 {
+                        plan: Some(plan),
+                        context: Some(context("https://other.example/page", 2)),
+                    }),
+                    metadata: Some(metadata),
+                })
+                .unwrap_err();
+            assert_eq!(error, SourceExecutionError::InvalidCursor, "{family}");
+        }
+    }
+
+    #[test]
     fn cursor_checkpoint_and_restart_are_rust_sealed_and_fail_closed() {
         let dispatcher = SourceExecutionDispatcher;
         let plan = plan(dispatcher, "user");


### PR DESCRIPTION
## State

This narrow forward qualification follows the provider/shared ordering repair. Exact base `0e9cdfbfb8542e2106ce2170ea703ecc95434ae7` contains both Tailscale authority merges and the combined Aha/orchestrator repair. Exact head `ad674a200e75a8f6676e9a3bd7baa79d0e507322` adds only terminal checkpoint lifecycle proof. This PR does not alter provider-local Tailscale code or delete the Go loader.

## Proof

The combined provider kernel and shared dispatcher have an explicit lifecycle test for all seven registered families:

- `device`
- `grant`
- `group`
- `service`
- `tag`
- `tailnet`
- `user`

For each family the test proves:

- a terminal provider page without a continuation falls back to the last admitted record's provider identity;
- Rust seals that exact cursor only after admission into the append/projection/checkpoint program;
- the checkpoint watermark equals the last admitted record timestamp and does not regress the prior watermark;
- restart sends the sealed opaque cursor back through the credential-free request plan;
- a malformed cross-origin cursor fails closed.

## Scope

One shared test path only:

- `crates/source-runtime-next/src/source_execution/tailscale.rs`

Zero diff under provider-local `crates/source-runtime-next/src/tailscale/**`, `sources/tailscale/**`, or Go source runtime paths.

## Validation

DDESK v1.12.16, workspace `ctailterm`, session `session_d634ea1dc56fb026`, rebased file state matching exact head:

- terminal lifecycle test: 1 passed
- `cargo test --locked -p cerebro-source-runtime-next source_execution -- --nocapture`: 38 passed
- `cargo test --locked -p cerebro-source-runtime-next tailscale::tests -- --nocapture`: 13 passed
- `cargo test --locked -p cerebro-source-runtime-next`: 601 library, 8 DigitalOcean integration, 7 Linode integration, and 10 PagerDuty integration tests passed; binary and doc tests clean
- `cargo fmt --all -- --check`: passed
- `cargo clippy --locked -p cerebro-source-runtime-next --all-targets -- -D warnings`: passed
- `go test ./sources/tailscale -count=1`: passed
- `go test ./internal/sourceruntime/... -count=1`: four packages passed

A fresh hosted matrix is running for exact head `ad674a200e75a8f6676e9a3bd7baa79d0e507322`. The PR remains draft until that matrix is terminal green.
