### PR TITLE
Keep the orchestrator lease-fence test reader fallible

### DIFF
--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -1388,6 +1388,7 @@ type orchestratorRuntimeStore struct {
 	releaseID      string
 	fenceReadID    string
 	fenceReadOwner string
+	fenceReadErr   error
 }
 
 func (s *orchestratorRuntimeStore) Ping(context.Context) error { return nil }
@@ -1433,7 +1434,7 @@ func (s *orchestratorRuntimeStore) ReleaseSourceRuntimeLease(_ context.Context, 
 func (s *orchestratorRuntimeStore) ReadSourceRuntimeLeaseFence(_ context.Context, runtimeID string, owner string) (ports.SourceRuntimeLeaseFence, error) {
 	s.fenceReadID = runtimeID
 	s.fenceReadOwner = owner
-	return ports.SourceRuntimeLeaseFence{Owner: owner, Generation: 1, ExpiresAt: time.Now().Add(defaultSourceRuntimeLeaseTTL)}, nil
+	return ports.SourceRuntimeLeaseFence{Owner: owner, Generation: 1, ExpiresAt: time.Now().Add(defaultSourceRuntimeLeaseTTL)}, s.fenceReadErr
 }
 
 type orchestratorTestSource struct{}


### PR DESCRIPTION
## Failure

PR #2507 merged before its lint shard completed. The later lint result flagged the orchestrator test fence reader because its error return was statically always nil.

## Change

The test store now carries an injectable fence-read error and returns it from ReadSourceRuntimeLeaseFence. Production behavior is unchanged.

## Validation

- go test ./cmd/cerebro -run TestRunOrchestratorIterationStopsAfterSyncFailure -count=1
- make lint-api-cmd
- git diff --check

The exact lint command reports 0 issues on current main.