### PR TITLE
feat(source-runtime): reconcile PagerDuty public families

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -2971,7 +2971,7 @@ mod tests {
         .unwrap();
         let summary = catalog.summary();
         assert_eq!(summary.sources, 799);
-        assert_eq!(summary.families, 3_991);
+        assert_eq!(summary.families, 3_993);
         assert_eq!(summary.push_sources, 1);
         assert_eq!(summary.push_families, 10);
         assert_eq!(
@@ -3942,7 +3942,7 @@ mod tests {
         .unwrap();
         let report = catalog.unsupported_feature_report();
         assert_eq!(report.total_sources, 799);
-        assert_eq!(report.total_families, 3_991);
+        assert_eq!(report.total_families, 3_993);
         assert_eq!(report.families.len(), report.total_families);
         assert!(report.missing_family_reports.is_empty());
         assert_eq!(
@@ -3991,7 +3991,7 @@ mod tests {
         )
         .unwrap();
         let report = catalog.authority_readiness_report();
-        assert_eq!(report.total_families, 3_991);
+        assert_eq!(report.total_families, 3_993);
         assert_eq!(report.rust_authoritative_families, 0);
         assert_eq!(report.shadow_or_go_families, report.total_families);
         let aws_bedrock = report

--- a/crates/source-runtime-next/src/pagerduty/model.rs
+++ b/crates/source-runtime-next/src/pagerduty/model.rs
@@ -162,6 +162,10 @@ pub struct PagerDutyPlan {
     pub family_id: &'static str,
     /// HTTP method.
     pub method: &'static str,
+    /// Authentication header applied only by the trusted host.
+    pub auth_header: &'static str,
+    /// Exact PagerDuty authentication scheme metadata without credential bytes.
+    pub auth_scheme: &'static str,
     /// Allowed provider origin.
     pub origin: String,
     /// Closed request path template.
@@ -170,6 +174,14 @@ pub struct PagerDutyPlan {
     pub record_selector: String,
     /// Stable provider identity field.
     pub id_field: &'static str,
+    /// Provider offset parameter.
+    pub offset_param: &'static str,
+    /// Provider page-size parameter.
+    pub page_size_param: &'static str,
+    /// Provider continuation flag.
+    pub has_more_key: &'static str,
+    /// Optional plural config field that drives bounded path fan-out.
+    pub fanout_config_key: Option<&'static str>,
     /// Event kind.
     pub event_kind: &'static str,
     /// Event schema reference.

--- a/crates/source-runtime-next/src/pagerduty/request.rs
+++ b/crates/source-runtime-next/src/pagerduty/request.rs
@@ -23,6 +23,11 @@ pub struct PagerDutyRequest {
 }
 
 impl PagerDutyRequest {
+    /// Exact HTTP method.
+    pub const fn method(&self) -> &'static str {
+        "GET"
+    }
+
     /// Exact origin-restricted provider URL. A trusted host applies credentials before I/O.
     pub fn url(&self) -> &Url {
         &self.url
@@ -33,9 +38,29 @@ impl PagerDutyRequest {
         "Token token="
     }
 
+    /// Authentication header applied only by the trusted host.
+    pub const fn authorization_header(&self) -> &'static str {
+        "Authorization"
+    }
+
     /// Required response media type.
     pub const fn accept(&self) -> &'static str {
         "application/json"
+    }
+
+    /// Requests never carry credential material across the kernel boundary.
+    pub const fn contains_credentials(&self) -> bool {
+        false
+    }
+
+    /// Redirects are not part of the closed request contract.
+    pub const fn allows_redirects(&self) -> bool {
+        false
+    }
+
+    /// Maximum response bytes accepted by the decoder.
+    pub const fn max_response_bytes(&self) -> usize {
+        MAX_RESPONSE_BYTES
     }
 }
 
@@ -101,10 +126,17 @@ impl PagerDutyKernel {
             source_id: "pagerduty",
             family_id: self.family.as_str(),
             method: "GET",
+            auth_header: "Authorization",
+            auth_scheme: "Token token=",
             origin: self.origin.clone(),
             path_template: self.family.path_template(),
             record_selector: format!("$.{}[*]", self.family.response_key()),
             id_field: "id",
+            offset_param: "offset",
+            page_size_param: "limit",
+            has_more_key: "more",
+            fanout_config_key: (self.family == PagerDutyFamily::Integration)
+                .then_some("service_ids"),
             event_kind: self.family.event_kind(),
             schema_ref: self.family.schema_ref(),
             required_attributes: vec![

--- a/crates/source-runtime-next/src/pagerduty/tests.rs
+++ b/crates/source-runtime-next/src/pagerduty/tests.rs
@@ -257,6 +257,7 @@ fn public_connector_matches_go_contract_but_remains_non_authoritative() {
         assert_eq!(public.id_field, plan.id_field);
         assert_eq!(public.event.kind, plan.event_kind);
         assert_eq!(public.event.schema_ref, plan.schema_ref);
+        assert_eq!(contract.schema_ref, plan.schema_ref);
         assert_eq!(
             public.event.required_attributes,
             contract.required_attributes

--- a/crates/source-runtime-next/src/pagerduty/tests.rs
+++ b/crates/source-runtime-next/src/pagerduty/tests.rs
@@ -1,5 +1,13 @@
-use std::collections::BTreeMap;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
+};
 
+use cerebro_source_catalog::{
+    AuthModel, CollectionAuthority, Pagination, PathParameterBinding, SourceCatalog,
+    UnsupportedReasonCode,
+};
+use serde::Deserialize;
 use serde_json::{Value, json};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
@@ -7,9 +15,120 @@ use super::*;
 
 const OBSERVED_AT: &str = "2026-06-01T00:00:00Z";
 const SECRET_CANARY: &str = "pagerduty-secret-test-value";
+const SOURCE_CATALOG: &[u8] = include_bytes!("../../../../sources/pagerduty/catalog.yaml");
+const CONNECTOR_CATALOG: &[u8] = include_bytes!(
+    "../../../../internal/connectorcatalog/catalog/observability-soar-threat-intel/pagerduty.yaml"
+);
+
+#[derive(Deserialize)]
+struct SourceCatalogWire {
+    runtime_families: Vec<String>,
+    provider_api: ProviderApiWire,
+    event_contracts: Vec<EventContractWire>,
+}
+
+#[derive(Deserialize)]
+struct ProviderApiWire {
+    auth: String,
+    base_url: String,
+    families: Vec<ProviderFamilyWire>,
+}
+
+#[derive(Deserialize)]
+struct ProviderFamilyWire {
+    id: String,
+    method: String,
+    path: String,
+}
+
+#[derive(Deserialize)]
+struct EventContractWire {
+    kind: String,
+    schema_ref: String,
+    required_attributes: Vec<String>,
+    required_payload_fields: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct ConnectorCatalogWire {
+    entries: Vec<ConnectorEntryWire>,
+}
+
+#[derive(Deserialize)]
+struct ConnectorEntryWire {
+    classifier_output: String,
+    definition: ConnectorDefinitionWire,
+}
+
+#[derive(Deserialize)]
+struct ConnectorDefinitionWire {
+    source_id: String,
+    auth: ConnectorAuthWire,
+    resource_families: Vec<ConnectorFamilyWire>,
+    scope_options: Vec<ScopeOptionWire>,
+}
+
+#[derive(Deserialize)]
+struct ConnectorAuthWire {
+    model: String,
+    token_header: String,
+    token_scheme: String,
+}
+
+#[derive(Deserialize)]
+struct ConnectorFamilyWire {
+    id: String,
+    method: String,
+    path: String,
+    record_selector: String,
+    id_field: String,
+    event: ConnectorEventWire,
+    pagination: ConnectorPaginationWire,
+    #[serde(default)]
+    read: Option<ConnectorReadWire>,
+}
+
+#[derive(Deserialize)]
+struct ConnectorEventWire {
+    kind: String,
+    schema_ref: String,
+    required_attributes: Vec<String>,
+    required_payload_fields: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct ConnectorPaginationWire {
+    #[serde(rename = "type")]
+    kind: String,
+    offset_param: String,
+    limit_param: String,
+    has_more_key: String,
+    page_size: usize,
+}
+
+#[derive(Deserialize)]
+struct ConnectorReadWire {
+    path_params: Vec<String>,
+    path_param_fanout: BTreeMap<String, String>,
+}
+
+#[derive(Deserialize)]
+struct ScopeOptionWire {
+    id: String,
+    families: Vec<String>,
+}
 
 #[test]
 fn closed_definition_covers_exact_pagerduty_families() {
+    let source: SourceCatalogWire =
+        serde_saphyr::from_slice(SOURCE_CATALOG).expect("PagerDuty source catalog YAML");
+    let connector: ConnectorCatalogWire =
+        serde_saphyr::from_slice(CONNECTOR_CATALOG).expect("PagerDuty connector catalog YAML");
+    let connector = connector
+        .entries
+        .into_iter()
+        .next()
+        .expect("PagerDuty entry");
     let got = PagerDutyFamily::ALL
         .into_iter()
         .map(|family| {
@@ -18,6 +137,8 @@ fn closed_definition_covers_exact_pagerduty_families() {
             assert_eq!(plan.source_id, "pagerduty");
             assert_eq!(plan.family_id, family.as_str());
             assert_eq!(plan.method, "GET");
+            assert_eq!(plan.auth_header, "Authorization");
+            assert_eq!(plan.auth_scheme, "Token token=");
             assert_eq!(plan.origin, "https://api.pagerduty.com");
             assert_eq!(plan.path_template, family.path_template());
             assert_eq!(
@@ -25,6 +146,13 @@ fn closed_definition_covers_exact_pagerduty_families() {
                 format!("$.{}[*]", family.response_key())
             );
             assert_eq!(plan.id_field, "id");
+            assert_eq!(plan.offset_param, "offset");
+            assert_eq!(plan.page_size_param, "limit");
+            assert_eq!(plan.has_more_key, "more");
+            assert_eq!(
+                plan.fanout_config_key,
+                (family == PagerDutyFamily::Integration).then_some("service_ids")
+            );
             assert_eq!(plan.event_kind, family.event_kind());
             assert_eq!(plan.schema_ref, family.schema_ref());
             assert_eq!(plan.required_payload_fields, ["id"]);
@@ -46,6 +174,156 @@ fn closed_definition_covers_exact_pagerduty_families() {
             "integration",
             "vendor",
         ]
+    );
+    let expected = got.into_iter().collect::<BTreeSet<_>>();
+    assert_eq!(
+        source
+            .runtime_families
+            .iter()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>(),
+        expected
+    );
+    assert_eq!(
+        connector
+            .definition
+            .resource_families
+            .iter()
+            .map(|family| family.id.as_str())
+            .collect::<BTreeSet<_>>(),
+        expected
+    );
+    assert_eq!(
+        connector
+            .definition
+            .scope_options
+            .iter()
+            .map(|scope| scope.id.as_str())
+            .collect::<BTreeSet<_>>(),
+        expected
+    );
+    assert!(
+        connector
+            .definition
+            .scope_options
+            .iter()
+            .all(|scope| scope.families.len() == 1 && scope.families[0] == scope.id)
+    );
+}
+
+#[test]
+fn public_connector_matches_go_contract_but_remains_non_authoritative() {
+    let source: SourceCatalogWire =
+        serde_saphyr::from_slice(SOURCE_CATALOG).expect("PagerDuty source catalog YAML");
+    let connector: ConnectorCatalogWire =
+        serde_saphyr::from_slice(CONNECTOR_CATALOG).expect("PagerDuty connector catalog YAML");
+    let connector = connector
+        .entries
+        .into_iter()
+        .next()
+        .expect("PagerDuty entry");
+    assert_eq!(connector.classifier_output, "bespoke_required");
+    assert_eq!(connector.definition.source_id, "pagerduty");
+    assert_eq!(connector.definition.auth.model, "api_key");
+    assert_eq!(connector.definition.auth.token_header, "Authorization");
+    assert_eq!(connector.definition.auth.token_scheme, "Token");
+    assert_eq!(source.provider_api.auth, "pagerduty_api_token");
+    assert_eq!(source.provider_api.base_url, "https://api.pagerduty.com");
+
+    for family in PagerDutyFamily::ALL {
+        let plan = kernel(family, "tenant", None).definition();
+        let provider = source
+            .provider_api
+            .families
+            .iter()
+            .find(|candidate| candidate.id == family.as_str())
+            .expect("provider proof family");
+        let public = connector
+            .definition
+            .resource_families
+            .iter()
+            .find(|candidate| candidate.id == family.as_str())
+            .expect("public connector family");
+        let contract = source
+            .event_contracts
+            .iter()
+            .find(|candidate| candidate.kind == family.event_kind())
+            .expect("source event contract");
+        assert_eq!(provider.method, plan.method);
+        assert_eq!(provider.path, plan.path_template);
+        assert_eq!(public.method, plan.method);
+        assert_eq!(public.path, plan.path_template);
+        assert_eq!(public.record_selector, plan.record_selector);
+        assert_eq!(public.id_field, plan.id_field);
+        assert_eq!(public.event.kind, plan.event_kind);
+        assert_eq!(public.event.schema_ref, plan.schema_ref);
+        assert_eq!(
+            public.event.required_attributes,
+            contract.required_attributes
+        );
+        assert_eq!(
+            public.event.required_payload_fields,
+            contract.required_payload_fields
+        );
+        assert_eq!(public.pagination.kind, "offset");
+        assert_eq!(public.pagination.offset_param, plan.offset_param);
+        assert_eq!(public.pagination.limit_param, plan.page_size_param);
+        assert_eq!(public.pagination.has_more_key, plan.has_more_key);
+        assert_eq!(public.pagination.page_size, plan.max_records_per_page);
+        if family == PagerDutyFamily::Integration {
+            let read = public.read.as_ref().expect("integration fanout");
+            assert_eq!(read.path_params, ["service_id"]);
+            assert_eq!(
+                read.path_param_fanout,
+                BTreeMap::from([("service_id".to_owned(), "service_ids".to_owned())])
+            );
+        } else {
+            assert!(public.read.is_none());
+        }
+    }
+
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let compiled = SourceCatalog::load(
+        root.join("internal/connectorcatalog/catalog"),
+        root.join("sources"),
+    )
+    .expect("compile source catalog");
+    let pagerduty = compiled
+        .get("pagerduty")
+        .expect("compiled PagerDuty source");
+    assert_eq!(pagerduty.authority(), CollectionAuthority::ShadowOnly);
+    assert_eq!(pagerduty.auth(), &AuthModel::ApiKey);
+    assert_eq!(pagerduty.token_header(), "Authorization");
+    assert_eq!(pagerduty.token_scheme(), "Token");
+    assert_eq!(pagerduty.families().len(), PagerDutyFamily::ALL.len());
+    for family in pagerduty.families() {
+        assert!(!family.is_authoritative(), "{}", family.id());
+        assert!(family.is_projection_authoritative(), "{}", family.id());
+        assert_eq!(
+            family.unsupported_reasons(),
+            [UnsupportedReasonCode::BespokeRuntime],
+            "{}",
+            family.id()
+        );
+        assert_eq!(
+            family.pagination(),
+            &Pagination::Offset {
+                parameter: "offset".to_owned(),
+                limit_parameter: "limit".to_owned(),
+                page_size: 100,
+            }
+        );
+    }
+    let integration = pagerduty
+        .families()
+        .iter()
+        .find(|family| family.id() == "integration")
+        .expect("integration family");
+    assert_eq!(
+        integration.path_parameters().get("service_id"),
+        Some(&PathParameterBinding::CsvFanout {
+            field: "service_ids".to_owned(),
+        })
     );
 }
 
@@ -70,7 +348,12 @@ fn requests_are_bounded_origin_locked_and_credential_free() {
         );
         assert!(request.url().query_pairs().all(|(key, _)| key != "offset"));
         assert_eq!(request.authorization_scheme(), "Token token=");
+        assert_eq!(request.authorization_header(), "Authorization");
+        assert_eq!(request.method(), "GET");
         assert_eq!(request.accept(), "application/json");
+        assert!(!request.contains_credentials());
+        assert!(!request.allows_redirects());
+        assert_eq!(request.max_response_bytes(), request::MAX_RESPONSE_BYTES);
         let debug = format!("{kernel:?}{request:?}");
         assert!(!debug.contains(SECRET_CANARY));
         assert!(!debug.contains("Authorization"));

--- a/internal/connectorcatalog/catalog/observability-soar-threat-intel/pagerduty.yaml
+++ b/internal/connectorcatalog/catalog/observability-soar-threat-intel/pagerduty.yaml
@@ -1,237 +1,494 @@
 entries:
-  - classifier_output: supported
+  - classifier_output: bespoke_required
     definition:
       auth:
         credential_fields:
           - key: token
-            label: Bearer token
+            label: PagerDuty API token
             reference_only: true
             required: true
             secret: true
-        model: bearer_token
+        model: api_key
         requires_references: true
+        token_header: Authorization
+        token_scheme: Token
       categories:
         - saas
         - observability_soar_threat_intel
       config_fields:
-        - help: Tenant or regional API base URL.
+        - help: PagerDuty REST API origin. Use the US or EU PagerDuty API origin.
           key: base_url
           label: API base URL
           required: true
-      description: Collects alerts, incidents, monitors, dashboards, and audit events from Pagerduty and projects them into the Cerebro graph as alerts, findings, assets, and audit events for alert, incident, service health, and response context.
-      display_name: Pagerduty
+        - help: Comma-separated PagerDuty service IDs used to collect service integrations.
+          key: service_ids
+          label: Service IDs
+      description: Collects PagerDuty users, teams, services, schedules, escalation policies, service integrations, and vendors for responder identity, escalation coverage, and incident-routing topology.
+      display_name: PagerDuty
       id: builtin-pagerduty
       ingest:
         mode: pull
       resource_families:
         - coverage:
-            - control_domains:
-                - logging_monitoring
-              evidence_types:
-                - security_monitoring
-              families:
-                - alerts
+            - control_domains: [asset_inventory, identity_access]
+              evidence_types: [source_snapshot]
+              families: [user]
               high_value: true
-              id: alerts
-              support: partial
-              title: Alerts
-              type: alert_state
+              id: users
+              support: supported
+              title: Users
+              type: entity_family
           default_enabled: true
           event:
-            kind: pagerduty.alerts
-            required_payload_fields:
-              - id
-            schema_ref: pagerduty/alerts/v1
-            urn_kind: pagerduty_alerts
-          id: alerts
+            attributes:
+              email: email
+              job_title: job_title
+              name: name
+              role: role
+              time_zone: time_zone
+              user_id: id
+            exact_attributes: true
+            kind: pagerduty.user
+            required_attributes:
+              - external_id
+              - family
+              - source_provider
+              - source_product
+              - user_id
+            required_payload_fields: [id]
+            schema_ref: pagerduty/user/v1
+            static_attributes:
+              source_product: pagerduty
+            urn_kind: pagerduty_user
+          id: user
           id_field: id
-          label: Alerts
+          label: Users
           method: GET
           name_field: name
           pagination:
-            cursor_json_path: $.next_cursor
-            cursor_param: cursor
+            has_more_key: more
+            limit_param: limit
+            offset_param: offset
             page_size: 100
-            page_size_param: limit
-            type: cursor
-          path: /v1/alerts
+            type: offset
+          path: /users
           projection:
+            entity:
+              entity_type: pagerduty.user
+              id_attributes: [user_id]
+              label_attribute: name
+              urn_kind: pagerduty_user
             fields:
-              alert_id: id
-              alert_name: name
-              alert_severity: severity
-              alert_status: status
-            template: alert
-          record_selector: $.data[*]
+              display_name: name
+              email: email
+              job_title: job_title
+              role: role
+              source_event_id: id
+              time_zone: time_zone
+              user_id: id
+            template: identity_user
+          record_selector: $.users[*]
         - coverage:
-            - control_domains:
-                - incident_response
-              evidence_types:
-                - finding_snapshot
-              families:
-                - incidents
+            - control_domains: [asset_inventory, identity_access]
+              evidence_types: [source_snapshot]
+              families: [team]
               high_value: true
-              id: incidents
-              support: partial
-              title: Incidents
-              type: finding
+              id: teams
+              support: supported
+              title: Teams
+              type: entity_family
           default_enabled: true
           event:
-            kind: pagerduty.incidents
-            required_payload_fields:
-              - id
-            schema_ref: pagerduty/incidents/v1
-            urn_kind: pagerduty_incidents
-          id: incidents
+            attributes:
+              description: description
+              name: name
+              team_id: id
+            exact_attributes: true
+            kind: pagerduty.team
+            required_attributes:
+              - external_id
+              - family
+              - source_provider
+              - source_product
+              - team_id
+            required_payload_fields: [id]
+            schema_ref: pagerduty/team/v1
+            static_attributes:
+              source_product: pagerduty
+            urn_kind: pagerduty_team
+          id: team
           id_field: id
-          label: Incidents
+          label: Teams
           method: GET
           name_field: name
           pagination:
-            cursor_json_path: $.next_cursor
-            cursor_param: cursor
+            has_more_key: more
+            limit_param: limit
+            offset_param: offset
             page_size: 100
-            page_size_param: limit
-            type: cursor
-          path: /v1/incidents
+            type: offset
+          path: /teams
           projection:
+            entity:
+              entity_type: pagerduty.team
+              id_attributes: [team_id]
+              label_attribute: name
+              urn_kind: pagerduty_team
             fields:
-              finding_id: id
-              resource_id: resource_id
-              resource_type: resource_type
-              severity: severity
+              description: description
+              group_id: id
+              group_name: name
+              source_event_id: id
+              team_id: id
+            template: identity_group
+          record_selector: $.teams[*]
+        - coverage:
+            - control_domains: [asset_inventory, incident_response]
+              evidence_types: [source_snapshot, relationship_evidence]
+              families: [service]
+              high_value: true
+              id: services
+              support: supported
+              title: Services
+              type: entity_family
+          default_enabled: true
+          event:
+            attributes:
+              escalation_policy_id: escalation_policy.id
+              escalation_policy_name: escalation_policy.summary|escalation_policy.name
+              html_url: html_url
+              name: name
+              service_id: id
               status: status
-              title: title
-            template: finding
-          record_selector: $.data[*]
+              summary: summary
+            exact_attributes: true
+            kind: pagerduty.service
+            required_attributes:
+              - external_id
+              - family
+              - source_provider
+              - source_product
+              - service_id
+            required_payload_fields: [id]
+            schema_ref: pagerduty/service/v1
+            static_attributes:
+              source_product: pagerduty
+            urn_kind: pagerduty_service
+          id: service
+          id_field: id
+          label: Services
+          method: GET
+          name_field: name
+          pagination:
+            has_more_key: more
+            limit_param: limit
+            offset_param: offset
+            page_size: 100
+            type: offset
+          path: /services
+          projection:
+            entity:
+              entity_type: pagerduty.service
+              id_attributes: [service_id]
+              label_attribute: name
+              urn_kind: pagerduty_service
+            fields:
+              escalation_policy_id: escalation_policy.id
+              escalation_policy_name: escalation_policy.summary|escalation_policy.name
+              resource_id: id
+              resource_name: name
+              service_id: id
+              source_event_id: id
+              status: status
+            static_fields:
+              resource_type: pagerduty_service
+            template: asset
+          record_selector: $.services[*]
+          updated_at_field: created_at
         - coverage:
-            - control_domains:
-                - asset_inventory
-              evidence_types:
-                - source_snapshot
-              families:
-                - monitors
+            - control_domains: [asset_inventory, incident_response]
+              evidence_types: [source_snapshot]
+              families: [schedule]
               high_value: true
-              id: monitors
-              support: partial
-              title: Monitors
+              id: schedules
+              support: supported
+              title: Schedules
               type: entity_family
           default_enabled: true
           event:
-            kind: pagerduty.monitors
-            required_payload_fields:
-              - id
-            schema_ref: pagerduty/monitors/v1
-            urn_kind: pagerduty_monitors
-          id: monitors
+            attributes:
+              html_url: html_url
+              name: name
+              schedule_id: id
+              summary: summary
+              time_zone: time_zone
+            exact_attributes: true
+            kind: pagerduty.schedule
+            required_attributes:
+              - external_id
+              - family
+              - source_provider
+              - source_product
+              - schedule_id
+            required_payload_fields: [id]
+            schema_ref: pagerduty/schedule/v1
+            static_attributes:
+              source_product: pagerduty
+            urn_kind: pagerduty_schedule
+          id: schedule
           id_field: id
-          label: Monitors
+          label: Schedules
           method: GET
           name_field: name
           pagination:
-            cursor_json_path: $.next_cursor
-            cursor_param: cursor
+            has_more_key: more
+            limit_param: limit
+            offset_param: offset
             page_size: 100
-            page_size_param: limit
-            type: cursor
-          path: /v1/monitors
+            type: offset
+          path: /schedules
           projection:
+            entity:
+              entity_type: pagerduty.schedule
+              id_attributes: [schedule_id]
+              label_attribute: name
+              urn_kind: pagerduty_schedule
             fields:
-              id: id
-              name: name
               resource_id: id
               resource_name: name
-              resource_type: monitor
+              schedule_id: id
+              source_event_id: id
+              time_zone: time_zone
+            static_fields:
+              resource_type: pagerduty_schedule
             template: asset
-          record_selector: $.data[*]
+          record_selector: $.schedules[*]
         - coverage:
-            - control_domains:
-                - asset_inventory
-              evidence_types:
-                - source_snapshot
-              families:
-                - dashboards
+            - control_domains: [incident_response, security_operations]
+              evidence_types: [configuration_state, relationship_evidence]
+              families: [escalation_policy]
               high_value: true
-              id: dashboards
-              support: partial
-              title: Dashboards
+              id: escalation_policies
+              support: supported
+              title: Escalation policies
+              type: lifecycle_state
+          default_enabled: true
+          event:
+            attributes:
+              escalation_policy_id: id
+              html_url: html_url
+              name: name
+              num_loops: num_loops
+              summary: summary
+            exact_attributes: true
+            kind: pagerduty.escalation_policy
+            required_attributes:
+              - external_id
+              - family
+              - source_provider
+              - source_product
+              - escalation_policy_id
+            required_payload_fields: [id]
+            schema_ref: pagerduty/escalation_policy/v1
+            static_attributes:
+              source_product: pagerduty
+            urn_kind: pagerduty_escalation_policy
+          id: escalation_policy
+          id_field: id
+          label: Escalation policies
+          list_key: escalation_policies
+          method: GET
+          name_field: name
+          pagination:
+            has_more_key: more
+            limit_param: limit
+            offset_param: offset
+            page_size: 100
+            type: offset
+          path: /escalation_policies
+          projection:
+            entity:
+              entity_type: pagerduty.escalation_policy
+              id_attributes: [escalation_policy_id]
+              label_attribute: name
+              urn_kind: pagerduty_escalation_policy
+            fields:
+              escalation_policy_id: id
+              policy_id: id
+              policy_name: name
+              source_event_id: id
+            static_fields:
+              policy_type: escalation_policy
+            template: policy
+          record_selector: $.escalation_policies[*]
+        - coverage:
+            - control_domains: [asset_inventory, incident_response]
+              evidence_types: [source_snapshot, relationship_evidence]
+              families: [integration]
+              high_value: true
+              id: integrations
+              support: supported
+              title: Service integrations
+              type: relationship
+          default_enabled: true
+          event:
+            attributes:
+              integration_id: id
+              name: name
+              service_id: service.id|service_id
+              service_name: service.summary|service.name
+              summary: summary
+              vendor_id: vendor.id
+              vendor_name: vendor.summary|vendor.name
+            exact_attributes: true
+            kind: pagerduty.integration
+            required_attributes:
+              - external_id
+              - family
+              - integration_id
+              - service_id
+              - source_provider
+              - source_product
+            required_payload_fields: [id]
+            schema_ref: pagerduty/integration/v1
+            static_attributes:
+              source_product: pagerduty
+            urn_kind: pagerduty_integration
+          id: integration
+          id_field: id
+          label: Service integrations
+          method: GET
+          name_field: name|summary
+          pagination:
+            has_more_key: more
+            limit_param: limit
+            offset_param: offset
+            page_size: 100
+            type: offset
+          path: /services/{service_id}/integrations
+          projection:
+            entity:
+              entity_type: pagerduty.integration
+              id_attributes: [integration_id]
+              label_attribute: name
+              urn_kind: pagerduty_integration
+            fields:
+              integration_id: id
+              resource_id: id
+              resource_name: name|summary
+              service_id: service.id|service_id
+              service_name: service.summary|service.name
+              source_event_id: id
+              vendor_id: vendor.id
+            relationships:
+              - match_type: integration_service
+                relation: belongs_to
+                required_attributes: [service_id]
+                to:
+                  entity_type: pagerduty.service
+                  id_attributes: [service_id]
+                  label_attribute: service_name
+                  urn_kind: pagerduty_service
+            static_fields:
+              resource_type: pagerduty_integration
+            template: asset
+          read:
+            path_param_fanout:
+              service_id: service_ids
+            path_params: [service_id]
+          record_selector: $.integrations[*]
+        - coverage:
+            - control_domains: [asset_inventory, vendor_management]
+              evidence_types: [source_snapshot]
+              families: [vendor]
+              high_value: true
+              id: vendors
+              support: supported
+              title: Vendors
               type: entity_family
           default_enabled: true
           event:
-            kind: pagerduty.dashboards
-            required_payload_fields:
-              - id
-            schema_ref: pagerduty/dashboards/v1
-            urn_kind: pagerduty_dashboards
-          id: dashboards
-          id_field: id
-          label: Dashboards
-          method: GET
-          name_field: name
-          pagination:
-            cursor_json_path: $.next_cursor
-            cursor_param: cursor
-            page_size: 100
-            page_size_param: limit
-            type: cursor
-          path: /v1/dashboards
-          projection:
-            fields:
-              id: id
+            attributes:
               name: name
-              resource_id: id
-              resource_name: name
-              resource_type: dashboard
-            template: asset
-          record_selector: $.data[*]
-        - coverage:
-            - control_domains:
-                - logging_monitoring
-              evidence_types:
-                - logging_configuration
-              families:
-                - audit_events
-              high_value: true
-              id: audit_events
-              support: partial
-              title: Audit events
-              type: audit_event
-          default_enabled: true
-          event:
-            kind: pagerduty.audit_events
-            required_payload_fields:
-              - id
-            schema_ref: pagerduty/audit_events/v1
-            urn_kind: pagerduty_audit_events
-          id: audit_events
+              summary: summary
+              vendor_id: id
+              website_url: website_url
+            exact_attributes: true
+            kind: pagerduty.vendor
+            required_attributes:
+              - external_id
+              - family
+              - source_provider
+              - source_product
+              - vendor_id
+            required_payload_fields: [id]
+            schema_ref: pagerduty/vendor/v1
+            static_attributes:
+              source_product: pagerduty
+            urn_kind: pagerduty_vendor
+          id: vendor
           id_field: id
-          label: Audit events
+          label: Vendors
           method: GET
-          name_field: name
+          name_field: name|summary
           pagination:
-            cursor_json_path: $.next_cursor
-            cursor_param: cursor
+            has_more_key: more
+            limit_param: limit
+            offset_param: offset
             page_size: 100
-            page_size_param: limit
-            type: cursor
-          path: /v1/audit_events
+            type: offset
+          path: /vendors
           projection:
+            entity:
+              entity_type: pagerduty.vendor
+              id_attributes: [vendor_id]
+              label_attribute: name
+              urn_kind: pagerduty_vendor
             fields:
-              actor_email: actor_email
-              actor_id: actor_id
-              event_type: event_type
-              id: id
-              resource_id: resource_id
-              resource_type: resource_type
-            template: audit_event
-          record_selector: $.data[*]
+              resource_id: id
+              resource_name: name|summary
+              source_event_id: id
+              vendor_id: id
+              website_url: website_url
+            static_fields:
+              resource_type: pagerduty_vendor
+            template: asset
+          record_selector: $.vendors[*]
       schema_version: cerebro.integration/v1
+      scope_options:
+        - default_enabled: true
+          families: [user]
+          id: user
+          label: Users
+        - default_enabled: true
+          families: [team]
+          id: team
+          label: Teams
+        - default_enabled: true
+          families: [service]
+          id: service
+          label: Services
+        - default_enabled: true
+          families: [schedule]
+          id: schedule
+          label: Schedules
+        - default_enabled: true
+          families: [escalation_policy]
+          id: escalation_policy
+          label: Escalation policies
+        - default_enabled: true
+          families: [integration]
+          id: integration
+          label: Service integrations
+        - default_enabled: true
+          families: [vendor]
+          id: vendor
+          label: Vendors
       source_id: pagerduty
       tenant_id: builtin_catalog
       transport:
         base_url: ${config.base_url}
         verification:
-          expect_status:
-            - 200
+          expect_status: [200]
           method: GET
-          path: /v1/me
+          path: /users

--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const wantBuiltinCatalogEntries = 799
-const wantBuiltinCatalogBespokeRuntimeEntries = 2
+const wantBuiltinCatalogBespokeRuntimeEntries = 3
 
 func TestAnalyzeDirAcceptsGenerateableCatalogEntry(t *testing.T) {
 	root := t.TempDir()
@@ -456,7 +456,7 @@ func TestBuiltinRuntimeSkipsSourcegenDryRun(t *testing.T) {
 	}
 	for _, entry := range analysis.Entries {
 		wantStatus := StatusCatalogReady
-		if entry.Definition.SourceID == "auth0" || entry.Definition.SourceID == "kubernetes" {
+		if entry.Definition.SourceID == "auth0" || entry.Definition.SourceID == "kubernetes" || entry.Definition.SourceID == "pagerduty" {
 			wantStatus = StatusNeedsBespokeRuntime
 		}
 		if entry.SourcegenDryRun || entry.Generateable || entry.Status != wantStatus {


### PR DESCRIPTION
## Summary

- replace the stale PagerDuty public connector families with users, teams, services, schedules, escalation policies, integrations, and vendors
- preserve the provider-local `Token token=` request contract, offset pagination, bounded `service_ids` integration fanout, and responder-topology projection parity
- keep the compiled connector shadow-only; this change does not register PagerDuty for production Rust execution or remove the Go compatibility oracle

## Validation

- `make catalog-check`
- `go test ./sources/pagerduty -count=1`
- `go test ./internal/sourceprojection -run PagerDuty -count=1`
- `make connector-catalog-fidelity-check`
- `make sourcegen-check`
- `make source-fixture-check`
- `cargo fmt --all -- --check`
- `cargo test --locked -p cerebro-source-runtime-next --test pagerduty_provider -- --nocapture`
- `cargo clippy --locked -p cerebro-source-runtime-next --all-targets --all-features -- -D warnings`
- `make projection-parity-test`

The Rust and mixed parity commands ran against the exact published source tree in the repository development environment.