### PR TITLE
test(rust-candidate): update combined family census

### DIFF
--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -178,7 +178,7 @@ jobs:
           '
           summary="$(docker run --rm "${CANDIDATE_IMAGE}" catalog-summary)"
           test "$(jq -r .sources <<<"${summary}")" -eq 799
-          test "$(jq -r .families <<<"${summary}")" -eq 3993
+          test "$(jq -r .families <<<"${summary}")" -eq 4016
       - name: Start disposable PostgreSQL, Neo4j, and JetStream
         run: |
           set -euo pipefail
@@ -246,7 +246,7 @@ jobs:
             | .checks += [
                 {name:"rust_entrypoint",status:"passed",evidence:"image starts cerebro-platform directly"},
                 {name:"go_binary_absent",status:"passed",evidence:"/usr/local/bin/cerebro is absent"},
-                {name:"source_catalog",status:"passed",evidence:"799 sources and 3993 families loaded"}
+                {name:"source_catalog",status:"passed",evidence:"799 sources and 4016 families loaded"}
               ]
           ' .dist/rust-only-e2e/rust-only-e2e-receipt.json \
             > .dist/rust-only-e2e/receipt.tmp

--- a/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
+++ b/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
@@ -108,8 +108,8 @@ fn rust_candidate_build_never_invokes_go_or_emulation() {
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- seed",
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- verify",
         r#"test "$(jq -r .sources <<<"${summary}")" -eq 799"#,
-        r#"test "$(jq -r .families <<<"${summary}")" -eq 3993"#,
-        r#"evidence:"799 sources and 3993 families loaded""#,
+        r#"test "$(jq -r .families <<<"${summary}")" -eq 4016"#,
+        r#"evidence:"799 sources and 4016 families loaded""#,
         "cerebro.rust-only-e2e/v1",
         "cerebro.rust-only-candidate/v1",
     ] {


### PR DESCRIPTION
## Summary
- update the Rust-only candidate family assertion from 3,993 to the compiled 4,016-family current-main catalog
- keep the executable workflow assertion, emitted evidence, and workflow contract test aligned
- repair the stale combined census after PagerDuty, Mailchimp, Anthropic, Airbrake, and dependency updates landed

## Scope
Exactly two candidate-contract files. This changes no provider runtime behavior, production authority, credentials, deployment configuration, or live-provider behavior.

## Validation
- cargo fmt --all -- --check
- cargo run --locked -p cerebro-platform -- catalog-summary (799 sources, 4,016 families)
- cargo test --locked -p cerebro-platform --test rust_only_runtime_contract (6 passed)
- cargo test --locked -p cerebro-source-catalog --lib (26 passed)
- cargo clippy --locked -p cerebro-platform --test rust_only_runtime_contract -- -D warnings
- actionlint .github/workflows/rust-only-candidate.yml

DDESK ran the Rust checks and catalog census. Workflow lint ran successfully on the local control plane because actionlint is not installed on the desk.