### PR TITLE
test(rust-candidate): align Anthropic family census

### DIFF
--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -178,7 +178,7 @@ jobs:
           '
           summary="$(docker run --rm "${CANDIDATE_IMAGE}" catalog-summary)"
           test "$(jq -r .sources <<<"${summary}")" -eq 799
-          test "$(jq -r .families <<<"${summary}")" -eq 3993
+          test "$(jq -r .families <<<"${summary}")" -eq 4016
       - name: Start disposable PostgreSQL, Neo4j, and JetStream
         run: |
           set -euo pipefail
@@ -246,7 +246,7 @@ jobs:
             | .checks += [
                 {name:"rust_entrypoint",status:"passed",evidence:"image starts cerebro-platform directly"},
                 {name:"go_binary_absent",status:"passed",evidence:"/usr/local/bin/cerebro is absent"},
-                {name:"source_catalog",status:"passed",evidence:"799 sources and 3993 families loaded"}
+                {name:"source_catalog",status:"passed",evidence:"799 sources and 4016 families loaded"}
               ]
           ' .dist/rust-only-e2e/rust-only-e2e-receipt.json \
             > .dist/rust-only-e2e/receipt.tmp

--- a/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
+++ b/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
@@ -108,8 +108,8 @@ fn rust_candidate_build_never_invokes_go_or_emulation() {
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- seed",
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- verify",
         r#"test "$(jq -r .sources <<<"${summary}")" -eq 799"#,
-        r#"test "$(jq -r .families <<<"${summary}")" -eq 3993"#,
-        r#"evidence:"799 sources and 3993 families loaded""#,
+        r#"test "$(jq -r .families <<<"${summary}")" -eq 4016"#,
+        r#"evidence:"799 sources and 4016 families loaded""#,
         "cerebro.rust-only-e2e/v1",
         "cerebro.rust-only-candidate/v1",
     ] {


### PR DESCRIPTION
## Scope

- advance the Rust-only candidate catalog assertion from 3,993 to the merged Anthropic total of 4,016
- keep the checked workflow contract test aligned with the candidate receipt evidence

This is a two-path test/workflow repair. It does not change catalog compilation, source runtime behavior, production registration, credentials, deployment configuration, or provider authority.

## Local validation

Passed:
- rustfmt --edition 2024 --check crates/cerebro-platform/tests/rust_only_runtime_contract.rs
- actionlint .github/workflows/rust-only-candidate.yml
- git diff --check
- make check-arch
- exact assertion scan: both workflow and contract test expect 799 sources and 4,016 families

Not run locally:
- cargo fmt --all -- --check was blocked before execution by the managed Cargo capacity gate (exit 75; short by 26,893,920,870 bytes)
- cargo test --locked -p cerebro-platform --test rust_only_runtime_contract was blocked before execution by the managed Cargo capacity gate (exit 75; short by 26,903,235,174 bytes)
- cargo clippy --locked -p cerebro-platform --test rust_only_runtime_contract -- -D warnings was blocked before execution by the managed Cargo capacity gate (exit 75; short by 26,905,152,102 bytes)

Hosted checks remain required.
