### PR TITLE
Route Tailscale source operations through Rust authority

### DIFF
--- a/cmd/cerebro/graph.go
+++ b/cmd/cerebro/graph.go
@@ -276,7 +276,12 @@ func runGraph(args []string) error {
 		if projector == nil {
 			return fmt.Errorf("projection graph store is required")
 		}
-		result, err := ingestGraph(ctx, sourceops.New(registry), projector, deps.GraphStore, options)
+		cfg, err := config.Load()
+		if err != nil {
+			return fmt.Errorf("load config: %w", err)
+		}
+		sourceService := sourceops.New(registry).WithSourceExecutionWorkerPath(cfg.SourceRuntime.SourceWorkerPath)
+		result, err := ingestGraph(ctx, sourceService, projector, deps.GraphStore, options)
 		if err != nil {
 			return err
 		}

--- a/cmd/cerebro/main.go
+++ b/cmd/cerebro/main.go
@@ -410,6 +410,13 @@ func runSource(args []string) error {
 		return fmt.Errorf("open source registry: %w", err)
 	}
 	service := sourceops.New(registry)
+	if args[0] != "list" {
+		cfg, loadErr := appconfig.Load()
+		if loadErr != nil {
+			return fmt.Errorf("load config: %w", loadErr)
+		}
+		service.WithSourceExecutionWorkerPath(cfg.SourceRuntime.SourceWorkerPath)
+	}
 
 	switch args[0] {
 	case "list":

--- a/crates/source-runtime-next/src/source_execution/runtime.rs
+++ b/crates/source-runtime-next/src/source_execution/runtime.rs
@@ -100,10 +100,16 @@ fn seal_page_program_inner(
             |watermark| watermark.max(prior_watermark),
         );
 
+    let checkpoint_cursor = if plan.source_id == "tailscale" {
+        super::tailscale::durable_checkpoint_cursor(plan, result).unwrap_or_default()
+    } else {
+        result.next_cursor.clone()
+    };
+
     Ok(SourceExecutionLifecycleDecisionV1 {
         transition_digest_sha256: page_program_digest(plan, context, result, metadata),
         admitted_records: records,
-        checkpoint_cursor: result.next_cursor.clone(),
+        checkpoint_cursor,
         checkpoint_watermark_unix_millis,
     })
 }

--- a/crates/source-runtime-next/src/source_execution/tailscale.rs
+++ b/crates/source-runtime-next/src/source_execution/tailscale.rs
@@ -264,6 +264,7 @@ impl SourceExecutionAdapter for TailscaleExecutionBridge {
                 optional_watermark(metadata)?.as_deref(),
             )
             .map_err(map_error)?;
+        let next_cursor = page.next_cursor.clone().unwrap_or_default();
         let records = page
             .records
             .into_iter()
@@ -291,7 +292,10 @@ impl SourceExecutionAdapter for TailscaleExecutionBridge {
             })
             .collect::<Result<Vec<_>, _>>()?;
         let records = validate_and_deduplicate_records(records)?;
-        let next_cursor = checkpoint.cursor.unwrap_or_default();
+        // A provider continuation controls only the current collection loop.
+        // The last-record fallback from `checkpoint_candidate` is durable
+        // restart state and is sealed separately by the Rust lifecycle.
+        let _validated_checkpoint = checkpoint.cursor;
         let result_digest_sha256 = canonical_result_digest(receipt, &next_cursor, &records)?;
         Ok(SourceWorkerDecodeResultV1 {
             plan_id: plan.plan_id.clone(),
@@ -308,6 +312,29 @@ impl SourceExecutionAdapter for TailscaleExecutionBridge {
             observed_at_unix_millis: context.observed_at_unix_millis,
         })
     }
+}
+
+pub(super) fn durable_checkpoint_cursor(
+    plan: &SourceExecutionPlanV1,
+    result: &SourceWorkerDecodeResultV1,
+) -> Option<String> {
+    if plan.source_id != "tailscale"
+        || !TAILSCALE_ADAPTERS
+            .iter()
+            .any(|adapter| adapter.family_id() == plan.family_id)
+    {
+        return None;
+    }
+    if !result.next_cursor.is_empty() {
+        return Some(result.next_cursor.clone());
+    }
+    Some(
+        result
+            .records
+            .last()
+            .map(|record| record.provider_id.clone())
+            .unwrap_or_default(),
+    )
 }
 
 fn public_value<'a>(config: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
@@ -621,7 +648,7 @@ mod tests {
             let terminal_cursor = last.provider_id.clone();
             let terminal_watermark = last.occurred_at_unix_millis;
 
-            assert_eq!(result.next_cursor, terminal_cursor, "{family}");
+            assert!(result.next_cursor.is_empty(), "{family}");
             let program = seal_page_program_v2(&SourceExecutionLifecycleEnvelopeV2 {
                 request: Some(SourceExecutionLifecycleRequestV1 {
                     plan: Some(plan.clone()),

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -283,7 +283,7 @@ func newWithOptions(cfg config.Config, deps Dependencies, sources *sourcecdk.Reg
 		}
 		app.mcpOAuthService = service
 	}
-	app.services.sourceOps = newSourceService(app.sources)
+	app.services.sourceOps = newSourceService(app.cfg, app.sources)
 	app.services.reports = app.newReportService()
 	app.services.runtimeOps = newRuntimeService(app.cfg, app.deps, app.sources)
 	if cfg.SourceRuntime.EventAdmissionWorkerPath != "" {
@@ -731,11 +731,11 @@ func (s *bootstrapService) GetReportRun(ctx context.Context, req *connect.Reques
 }
 
 func (s *bootstrapService) ListSources(_ context.Context, _ *connect.Request[cerebrov1.ListSourcesRequest]) (*connect.Response[cerebrov1.ListSourcesResponse], error) {
-	return connect.NewResponse(newSourceService(s.sources).List()), nil
+	return connect.NewResponse(newSourceService(s.cfg, s.sources).List()), nil
 }
 
 func (s *bootstrapService) CheckSource(ctx context.Context, req *connect.Request[cerebrov1.CheckSourceRequest]) (*connect.Response[cerebrov1.CheckSourceResponse], error) {
-	response, err := newSourceService(s.sources).Check(ctx, req.Msg)
+	response, err := newSourceService(s.cfg, s.sources).Check(ctx, req.Msg)
 	if err != nil {
 		return nil, sourceConnectError(err)
 	}
@@ -743,7 +743,7 @@ func (s *bootstrapService) CheckSource(ctx context.Context, req *connect.Request
 }
 
 func (s *bootstrapService) DiscoverSource(ctx context.Context, req *connect.Request[cerebrov1.DiscoverSourceRequest]) (*connect.Response[cerebrov1.DiscoverSourceResponse], error) {
-	response, err := newSourceService(s.sources).Discover(ctx, req.Msg)
+	response, err := newSourceService(s.cfg, s.sources).Discover(ctx, req.Msg)
 	if err != nil {
 		return nil, sourceConnectError(err)
 	}
@@ -751,7 +751,7 @@ func (s *bootstrapService) DiscoverSource(ctx context.Context, req *connect.Requ
 }
 
 func (s *bootstrapService) ReadSource(ctx context.Context, req *connect.Request[cerebrov1.ReadSourceRequest]) (*connect.Response[cerebrov1.ReadSourceResponse], error) {
-	response, err := newSourceService(s.sources).Read(ctx, req.Msg)
+	response, err := newSourceService(s.cfg, s.sources).Read(ctx, req.Msg)
 	if err != nil {
 		return nil, sourceConnectError(err)
 	}
@@ -1491,7 +1491,7 @@ func (a *App) sourceService() *sourceops.Service {
 	if a != nil && a.services.sourceOps != nil {
 		return a.services.sourceOps
 	}
-	return newSourceService(a.sources)
+	return newSourceService(a.cfg, a.sources)
 }
 
 func (a *App) reportService() *reports.Service {
@@ -1512,8 +1512,8 @@ func (a *App) runtimeService() *sourceruntime.Service {
 	return newRuntimeService(a.cfg, a.deps, a.sources)
 }
 
-func newSourceService(sources *sourcecdk.Registry) *sourceops.Service {
-	return newSourceFeatureService(newSourceFeatureDeps(sources))
+func newSourceService(cfg config.Config, sources *sourcecdk.Registry) *sourceops.Service {
+	return newSourceFeatureService(newSourceFeatureDeps(cfg, sources))
 }
 
 func newRuntimeService(cfg config.Config, deps Dependencies, sources *sourcecdk.Registry) *sourceruntime.Service {

--- a/internal/bootstrap/feature_dependencies.go
+++ b/internal/bootstrap/feature_dependencies.go
@@ -23,15 +23,16 @@ import (
 )
 
 type sourceFeatureDeps struct {
-	Sources *sourcecdk.Registry
+	Sources          *sourcecdk.Registry
+	SourceWorkerPath string
 }
 
-func newSourceFeatureDeps(sources *sourcecdk.Registry) sourceFeatureDeps {
-	return sourceFeatureDeps{Sources: sources}
+func newSourceFeatureDeps(cfg config.Config, sources *sourcecdk.Registry) sourceFeatureDeps {
+	return sourceFeatureDeps{Sources: sources, SourceWorkerPath: cfg.SourceRuntime.SourceWorkerPath}
 }
 
 func newSourceFeatureService(deps sourceFeatureDeps) *sourceops.Service {
-	return sourceops.New(deps.Sources)
+	return sourceops.New(deps.Sources).WithSourceExecutionWorkerPath(deps.SourceWorkerPath)
 }
 
 type reportFeatureDeps struct {

--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -12,6 +12,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
+	"github.com/writer/cerebro/internal/sourceruntime/sourceworker"
 	"github.com/writer/cerebro/internal/telemetry"
 )
 
@@ -24,6 +25,8 @@ var (
 type Service struct {
 	registry            *sourcecdk.Registry
 	allowInternalConfig bool
+	sourceWorker        sourceworker.Worker
+	runSourceExecution  sourceExecutionRunner
 }
 
 // New constructs a source operations service.
@@ -70,7 +73,11 @@ func (s *Service) Check(ctx context.Context, req *cerebrov1.CheckSourceRequest) 
 	if err != nil {
 		return nil, err
 	}
-	if err := source.Check(ctx, sourcecdk.NewConfig(config)); err != nil {
+	if tailscaleSource(req.GetSourceId()) {
+		if _, err := s.executeTailscale(ctx, config, nil); err != nil {
+			return nil, sourceOperationError(err)
+		}
+	} else if err := source.Check(ctx, sourcecdk.NewConfig(config)); err != nil {
 		return nil, sourceOperationError(err)
 	}
 	return &cerebrov1.CheckSourceResponse{
@@ -100,7 +107,16 @@ func (s *Service) Discover(ctx context.Context, req *cerebrov1.DiscoverSourceReq
 	if err != nil {
 		return nil, err
 	}
-	urns, err := source.Discover(ctx, sourcecdk.NewConfig(config))
+	var urns []sourcecdk.URN
+	if tailscaleSource(req.GetSourceId()) {
+		pull, executeErr := s.executeTailscale(ctx, config, nil)
+		if executeErr != nil {
+			return nil, sourceOperationError(executeErr)
+		}
+		urns, err = discoverURNs(pull)
+	} else {
+		urns, err = source.Discover(ctx, sourcecdk.NewConfig(config))
+	}
 	if err != nil {
 		return nil, sourceOperationError(err)
 	}
@@ -136,7 +152,12 @@ func (s *Service) Read(ctx context.Context, req *cerebrov1.ReadSourceRequest) (_
 	if err != nil {
 		return nil, err
 	}
-	pull, err := source.Read(ctx, sourcecdk.NewConfig(config), req.GetCursor())
+	var pull sourcecdk.Pull
+	if tailscaleSource(req.GetSourceId()) {
+		pull, err = s.executeTailscale(ctx, config, req.GetCursor())
+	} else {
+		pull, err = source.Read(ctx, sourcecdk.NewConfig(config), req.GetCursor())
+	}
 	if err != nil {
 		return nil, sourceOperationError(err)
 	}

--- a/internal/sourceops/source_execution.go
+++ b/internal/sourceops/source_execution.go
@@ -1,0 +1,128 @@
+package sourceops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceruntime/sourceworker"
+)
+
+const (
+	tailscaleSourceID                 = "tailscale"
+	previewCredentialReference        = "credential:source-preview:token" // #nosec G101 -- opaque credential-reference label.
+	previewLeaseOwner                 = "source-preview"
+	previewRuntimeGeneration   uint64 = 1
+	previewLeaseGeneration     uint64 = 1
+)
+
+type sourceExecutionRunner func(context.Context, sourceworker.Worker, string, []byte, time.Time, sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error)
+
+func runSourceExecution(ctx context.Context, worker sourceworker.Worker, reference string, credential []byte, expiresAt time.Time, input sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+	return sourceworker.NewHost(worker, reference, credential, expiresAt).Execute(ctx, input)
+}
+
+// WithSourceExecutionWorkerPath enables the closed Rust execution path for
+// source preview operations owned by the dispatcher.
+func (s *Service) WithSourceExecutionWorkerPath(path string) *Service {
+	if s == nil {
+		return nil
+	}
+	if path = strings.TrimSpace(path); path != "" {
+		s.sourceWorker = sourceworker.NewProcessWorker(path)
+		s.runSourceExecution = runSourceExecution
+	}
+	return s
+}
+
+func tailscaleSource(sourceID string) bool {
+	return strings.TrimSpace(sourceID) == tailscaleSourceID
+}
+
+func (s *Service) executeTailscale(ctx context.Context, config map[string]string, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	if s == nil || s.sourceWorker == nil || s.runSourceExecution == nil {
+		return sourcecdk.Pull{}, sourceExecutionError("", sourceworker.ErrWorkerUnsupported)
+	}
+	family := strings.TrimSpace(config["family"])
+	if family == "" {
+		family = "device"
+	}
+	if !sourceworker.RustAuthoritativeTailscale(tailscaleSourceID, family) {
+		return sourcecdk.Pull{}, sourceExecutionError(family, sourceworker.ErrWorkerUnsupported)
+	}
+	tenantID := strings.TrimSpace(config["tenant_id"])
+	credential := []byte(strings.TrimSpace(config["token"]))
+	if tenantID == "" || len(credential) == 0 {
+		clear(credential)
+		return sourcecdk.Pull{}, sourceExecutionError(family, sourceworker.ErrSourceConfiguration)
+	}
+	providerCursor, priorWatermark, err := sourceworker.ProviderResume(cursor, tailscaleSourceID, family)
+	if err != nil {
+		clear(credential)
+		return sourcecdk.Pull{}, sourceExecutionError(family, err)
+	}
+	publicConfig := sourceworker.PublicExecutionConfig(config)
+	publicConfig["family"] = family
+	now := time.Now().UTC()
+	input := sourceworker.ExecutionInput{
+		SourceID: tailscaleSourceID, FamilyID: family, CredentialReference: previewCredentialReference, PageNumber: 1,
+		Scope: sourceworker.CredentialScope{
+			TenantID: tenantID, RuntimeID: "source-preview-tailscale-" + family,
+			PriorCursor: providerCursor, PublicConfig: publicConfig,
+			PriorTerminalWatermarkUnixMillis: priorWatermark, PriorCheckpoint: strings.TrimSpace(cursor.GetOpaque()),
+			LeaseOwner: previewLeaseOwner, RuntimeGeneration: previewRuntimeGeneration,
+			LeaseGeneration: previewLeaseGeneration, LeaseExpiresAt: now.Add(time.Minute),
+		},
+	}
+	output, err := s.runSourceExecution(ctx, s.sourceWorker, previewCredentialReference, credential, now.Add(time.Minute), input)
+	clear(credential)
+	if err != nil {
+		return sourcecdk.Pull{}, sourceExecutionError(family, err)
+	}
+	pull, err := sourceworker.PullFromExecutionOutput(output, tenantID)
+	if err != nil {
+		return sourcecdk.Pull{}, sourceExecutionError(family, err)
+	}
+	return pull, nil
+}
+
+func discoverURNs(pull sourcecdk.Pull) ([]sourcecdk.URN, error) {
+	seen := make(map[string]struct{}, len(pull.Events))
+	urns := make([]sourcecdk.URN, 0, len(pull.Events))
+	for _, event := range pull.Events {
+		raw := strings.TrimSpace(event.GetAttributes()["resource_urn"])
+		urn, err := sourcecdk.ParseURN(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%w: Rust record resource URN is invalid", sourceworker.ErrWorkerContract)
+		}
+		if _, ok := seen[urn.String()]; ok {
+			continue
+		}
+		seen[urn.String()] = struct{}{}
+		urns = append(urns, urn)
+	}
+	return urns, nil
+}
+
+func sourceExecutionError(family string, err error) error {
+	kind := sourcecdk.ErrorKindProvider
+	switch {
+	case errors.Is(err, sourceworker.ErrSourceConfiguration), errors.Is(err, sourceworker.ErrCredentialReferenceMissing), errors.Is(err, sourceworker.ErrWorkerUnsupported):
+		kind = sourcecdk.ErrorKindInvalidConfig
+	case errors.Is(err, sourceworker.ErrProviderAuthentication), errors.Is(err, sourceworker.ErrCredentialUnavailable):
+		kind = sourcecdk.ErrorKindAuth
+	case errors.Is(err, sourceworker.ErrProviderPermission):
+		kind = sourcecdk.ErrorKindPermission
+	case errors.Is(err, sourceworker.ErrProviderRateLimited):
+		kind = sourcecdk.ErrorKindRateLimited
+	case errors.Is(err, sourceworker.ErrProviderTimeout), errors.Is(err, sourceworker.ErrProviderEgress):
+		kind = sourcecdk.ErrorKindTransient
+	case errors.Is(err, sourceworker.ErrProviderMalformedResponse), errors.Is(err, sourceworker.ErrWorkerContract), errors.Is(err, sourceworker.ErrInvalidExecution):
+		kind = sourcecdk.ErrorKindDecode
+	}
+	return sourcecdk.WrapSourceError(kind, tailscaleSourceID, family, err)
+}

--- a/internal/sourceops/source_execution_test.go
+++ b/internal/sourceops/source_execution_test.go
@@ -1,0 +1,202 @@
+package sourceops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceruntime/sourceworker"
+)
+
+func TestTailscaleCheckDiscoverAndReadUseOnlyClosedRustAuthority(t *testing.T) {
+	for _, family := range []string{"device", "grant", "group", "service", "tag", "tailnet", "user"} {
+		t.Run(family, func(t *testing.T) {
+			legacy := &authorityProbeSource{}
+			registry, err := sourcecdk.NewRegistry(legacy)
+			if err != nil {
+				t.Fatal(err)
+			}
+			service := New(registry)
+			service.sourceWorker = previewWorkerStub{}
+			calls := 0
+			service.runSourceExecution = func(_ context.Context, _ sourceworker.Worker, reference string, credential []byte, _ time.Time, input sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+				calls++
+				if reference != previewCredentialReference || string(credential) != "host-only-secret" {
+					t.Fatal("credential was not confined to the trusted runner boundary")
+				}
+				encoded, marshalErr := json.Marshal(input)
+				if marshalErr != nil || strings.Contains(string(encoded), "host-only-secret") || input.Scope.PublicConfig["token"] != "" {
+					t.Fatalf("credential crossed the worker protocol: %s, %v", encoded, marshalErr)
+				}
+				return previewOutput(family, "", family+"-1", input.Scope.PriorTerminalWatermarkUnixMillis), nil
+			}
+			config := map[string]string{"family": family, "tailnet": "example.com", "tenant_id": "tenant-1", "token": "host-only-secret"}
+			if _, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{SourceId: "tailscale", Config: config}); err != nil {
+				t.Fatal(err)
+			}
+			discovered, err := service.Discover(context.Background(), &cerebrov1.DiscoverSourceRequest{SourceId: "tailscale", Config: config})
+			if err != nil || len(discovered.GetUrns()) != 1 {
+				t.Fatalf("Discover() = %#v, %v", discovered, err)
+			}
+			read, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{SourceId: "tailscale", Config: config})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if read.GetNextCursor() != nil || len(read.GetEvents()) != 1 || read.GetCheckpoint().GetCursorOpaque() == "" {
+				t.Fatalf("terminal Read() = %#v", read)
+			}
+			if calls != 3 || legacy.checkCalls != 0 || legacy.discoverCalls != 0 || legacy.readCalls != 0 {
+				t.Fatalf("calls = Rust %d, Go check/discover/read %d/%d/%d", calls, legacy.checkCalls, legacy.discoverCalls, legacy.readCalls)
+			}
+		})
+	}
+}
+
+func TestTailscaleReadPersistsTerminalRestartWithoutContinuingCurrentRun(t *testing.T) {
+	service := tailscaleAuthorityService(t)
+	var inputs []sourceworker.ExecutionInput
+	service.runSourceExecution = func(_ context.Context, _ sourceworker.Worker, _ string, _ []byte, _ time.Time, input sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+		inputs = append(inputs, input)
+		return previewOutput("user", "", "user-terminal", max(input.Scope.PriorTerminalWatermarkUnixMillis, 1_725_000_000_000)), nil
+	}
+	config := tailscalePreviewConfig("user")
+	first, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{SourceId: "tailscale", Config: config})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.GetNextCursor() != nil {
+		t.Fatalf("terminal page scheduled another page: %#v", first.GetNextCursor())
+	}
+	second, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{
+		SourceId: "tailscale", Config: config, Cursor: &cerebrov1.SourceCursor{Opaque: first.GetCheckpoint().GetCursorOpaque()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inputs) != 2 || inputs[1].Scope.PriorCursor != "user-terminal" || inputs[1].Scope.PriorTerminalWatermarkUnixMillis != 1_725_000_000_000 {
+		t.Fatalf("restart input = %#v", inputs)
+	}
+	if second.GetNextCursor() != nil {
+		t.Fatal("restarted terminal page scheduled another page")
+	}
+}
+
+func TestTailscaleReadContinuesOnlyForProviderCursorAndFailsClosed(t *testing.T) {
+	service := tailscaleAuthorityService(t)
+	service.runSourceExecution = func(_ context.Context, _ sourceworker.Worker, _ string, _ []byte, _ time.Time, input sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+		return previewOutput("device", "provider-page-2", "provider-page-2", 1_725_000_000_000), nil
+	}
+	response, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{SourceId: "tailscale", Config: tailscalePreviewConfig("device")})
+	if err != nil || response.GetNextCursor().GetOpaque() != "provider-page-2" {
+		t.Fatalf("Read() continuation = %#v, %v", response, err)
+	}
+
+	for name, cursor := range map[string]string{
+		"malformed": `{"version":1`,
+		"cross family": `{"version":1,"source":"tailscale","family":"user","mode":"rust_provider_checkpoint",` +
+			`"resumable_checkpoint":true,"token":"user-1"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{
+				SourceId: "tailscale", Config: tailscalePreviewConfig("device"), Cursor: &cerebrov1.SourceCursor{Opaque: cursor},
+			})
+			if sourcecdk.SourceErrorKind(err) != sourcecdk.ErrorKindDecode || !errors.Is(err, sourceworker.ErrWorkerContract) {
+				t.Fatalf("Read() error = %v, want typed fail-closed cursor error", err)
+			}
+		})
+	}
+}
+
+func TestTailscaleSourceExecutionFailuresRemainTyped(t *testing.T) {
+	for name, test := range map[string]struct {
+		err  error
+		kind sourcecdk.ErrorKind
+	}{
+		"authentication": {sourceworker.ErrProviderAuthentication, sourcecdk.ErrorKindAuth},
+		"permission":     {sourceworker.ErrProviderPermission, sourcecdk.ErrorKindPermission},
+		"rate limit":     {sourceworker.ErrProviderRateLimited, sourcecdk.ErrorKindRateLimited},
+		"timeout":        {sourceworker.ErrProviderTimeout, sourcecdk.ErrorKindTransient},
+		"contract":       {sourceworker.ErrWorkerContract, sourcecdk.ErrorKindDecode},
+	} {
+		t.Run(name, func(t *testing.T) {
+			service := tailscaleAuthorityService(t)
+			service.runSourceExecution = func(context.Context, sourceworker.Worker, string, []byte, time.Time, sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+				return nil, test.err
+			}
+			_, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{SourceId: "tailscale", Config: tailscalePreviewConfig("user")})
+			if !errors.Is(err, test.err) || sourcecdk.SourceErrorKind(err) != test.kind {
+				t.Fatalf("Read() error = %v, want %v / %s", err, test.err, test.kind)
+			}
+		})
+	}
+}
+
+type authorityProbeSource struct{ checkCalls, discoverCalls, readCalls int }
+
+func (*authorityProbeSource) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: "tailscale"}
+}
+func (s *authorityProbeSource) Check(context.Context, sourcecdk.Config) error {
+	s.checkCalls++
+	return nil
+}
+func (s *authorityProbeSource) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	s.discoverCalls++
+	return nil, nil
+}
+func (s *authorityProbeSource) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	s.readCalls++
+	return sourcecdk.Pull{}, nil
+}
+
+type previewWorkerStub struct{}
+
+func (previewWorkerStub) Compile(context.Context, sourceworker.SelectionRequest) (*cerebrov1.SourceExecutionPlanV1, error) {
+	return nil, errors.New("unexpected Compile call")
+}
+func (previewWorkerStub) Context(context.Context, sourceworker.ContextRequest) (*cerebrov1.SourceWorkerExecutionContextV1, error) {
+	return nil, errors.New("unexpected Context call")
+}
+func (previewWorkerStub) PlanV2(context.Context, *cerebrov1.SourceWorkerPlanEnvelopeV2) (*cerebrov1.SourceWorkerHTTPExecutionV2, error) {
+	return nil, errors.New("unexpected PlanV2 call")
+}
+func (previewWorkerStub) DecodeV2(context.Context, *cerebrov1.SourceWorkerDecodeEnvelopeV2) (*cerebrov1.SourceWorkerDecodeOutputV2, error) {
+	return nil, errors.New("unexpected DecodeV2 call")
+}
+func (previewWorkerStub) SealPage(context.Context, sourceworker.PageProgramRequest) (*sourceworker.PageProgram, error) {
+	return nil, errors.New("unexpected SealPage call")
+}
+
+func tailscaleAuthorityService(t *testing.T) *Service {
+	t.Helper()
+	registry, err := sourcecdk.NewRegistry(&authorityProbeSource{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := New(registry)
+	service.sourceWorker = previewWorkerStub{}
+	return service
+}
+
+func tailscalePreviewConfig(family string) map[string]string {
+	return map[string]string{"family": family, "tailnet": "example.com", "tenant_id": "tenant-1", "token": "host-only-secret"}
+}
+
+func previewOutput(family, nextCursor, checkpointCursor string, priorWatermark int64) *sourceworker.ExecutionOutput {
+	watermark := max(priorWatermark, 1_725_000_000_000)
+	plan := &cerebrov1.SourceExecutionPlanV1{SourceId: "tailscale", FamilyId: family, EventKind: "tailscale." + family, SchemaRef: "tailscale/" + family + "/v1"}
+	record := &cerebrov1.SourceWorkerRecordV1{
+		ProviderId: family + "-1", EventId: "tailscale-tenant-1-" + family + "-1", OccurredAtUnixMillis: watermark,
+		Attributes:  map[string]string{"tenant_id": "tenant-1", "family": family, "resource_urn": "urn:cerebro:tenant-1:tailscale_" + family + ":" + family + "-1"},
+		PayloadJson: []byte(`{"id":"` + family + `-1"}`),
+	}
+	return &sourceworker.ExecutionOutput{
+		Plan: plan, Result: &cerebrov1.SourceWorkerDecodeResultV1{NextCursor: nextCursor, ResultDigestSha256: "result-digest"},
+		Program: &sourceworker.PageProgram{TransitionDigest: "transition", AdmittedRecords: []*cerebrov1.SourceWorkerRecordV1{record}, CheckpointCursor: checkpointCursor, CheckpointWatermarkUnixMillis: watermark},
+	}
+}

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -251,7 +251,11 @@ func (s *Service) preparePutRuntime(ctx context.Context, input *cerebrov1.Source
 	if err != nil {
 		return nil, err
 	}
-	if err := source.Check(ctx, sourcecdk.NewConfig(resolvedConfig)); err != nil {
+	if _, authoritative := sourceworker.TailscaleFamily(runtime.GetSourceId(), resolvedConfig["family"]); authoritative {
+		if err := s.validateRustSourceRuntimePlan(ctx, runtime, resolvedConfig); err != nil {
+			return nil, err
+		}
+	} else if err := source.Check(ctx, sourcecdk.NewConfig(resolvedConfig)); err != nil {
 		if errors.Is(err, sourcecdk.ErrInvalidConfig) {
 			return nil, fmt.Errorf("%w: %w", ErrInvalidRequest, err)
 		}

--- a/internal/sourceruntime/source_execution.go
+++ b/internal/sourceruntime/source_execution.go
@@ -7,20 +7,55 @@ import (
 	"strings"
 	"time"
 
-	"google.golang.org/protobuf/types/known/timestamppb"
-
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourceruntime/sourceworker"
 )
 
+func (s *Service) validateRustSourceRuntimePlan(ctx context.Context, runtime *cerebrov1.SourceRuntime, config map[string]string) error {
+	familyID, authoritative := sourceworker.TailscaleFamily(runtime.GetSourceId(), config["family"])
+	if !authoritative {
+		return nil
+	}
+	if s == nil || s.sourceWorker == nil {
+		return fmt.Errorf("%w: the closed Rust worker is required for Tailscale", ErrRuntimeUnavailable)
+	}
+	plan, err := s.sourceWorker.Compile(ctx, sourceworker.SelectionRequest{SourceID: runtime.GetSourceId(), FamilyID: familyID})
+	if err != nil {
+		return fmt.Errorf("%w: compile Tailscale source plan: %w", ErrInvalidRequest, err)
+	}
+	now := time.Now().UTC()
+	executionContext, err := s.sourceWorker.Context(ctx, sourceworker.ContextRequest{
+		TenantID: strings.TrimSpace(runtime.GetTenantId()), RuntimeID: strings.TrimSpace(runtime.GetId()),
+		PageNumber: 1, RuntimeGeneration: 1, LeaseGeneration: 1,
+		ObservedAtUnixMillis: now.UnixMilli(), PublicConfig: sourceworker.PublicExecutionConfig(config),
+	})
+	if err != nil {
+		return fmt.Errorf("%w: validate Tailscale execution context: %w", ErrInvalidRequest, err)
+	}
+	_, err = s.sourceWorker.PlanV2(ctx, &cerebrov1.SourceWorkerPlanEnvelopeV2{
+		Request:  &cerebrov1.SourceWorkerPlanRequestV1{Plan: plan, Context: executionContext},
+		Metadata: &cerebrov1.SourceWorkerRuntimeMetadataV2{PublicConfig: sourceworker.PublicExecutionConfig(config)},
+	})
+	if err != nil {
+		return fmt.Errorf("%w: validate Tailscale source plan: %w", ErrInvalidRequest, err)
+	}
+	return nil
+}
+
 func (s *Service) readSourcePull(ctx context.Context, runtime *cerebrov1.SourceRuntime, source sourcecdk.Source, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint, pageNumber uint32) (sourcecdk.Pull, bool, error) {
+	familyID, _ := cfg.Lookup("family")
+	if normalized, authoritative := sourceworker.TailscaleFamily(runtime.GetSourceId(), familyID); authoritative {
+		familyID = normalized
+		if s == nil || s.sourceWorker == nil {
+			return sourcecdk.Pull{}, false, fmt.Errorf("%w: the closed Rust worker is required for Tailscale", ErrRuntimeUnavailable)
+		}
+	}
 	if s == nil || s.sourceWorker == nil {
 		pull, err := readCompatibilitySourcePull(ctx, source, cfg, cursor, checkpoint)
 		return pull, false, err
 	}
-	familyID, _ := cfg.Lookup("family")
 	fence, ok := sourceRuntimeLeaseFenceFromContext(ctx)
 	if !ok || !fence.ExpiresAt.After(time.Now().UTC()) {
 		return sourcecdk.Pull{}, false, fmt.Errorf("%w: source worker requires a current durable lease fence", ErrRuntimeUnavailable)
@@ -38,59 +73,38 @@ func (s *Service) readSourcePull(ctx context.Context, runtime *cerebrov1.SourceR
 	credential := []byte(resolved)
 	host := sourceworker.NewHost(s.sourceWorker, reference, credential, fence.ExpiresAt)
 	clear(credential)
-	publicConfig := publicSourceExecutionConfig(cfg)
+	providerCursor, cursorWatermark, err := sourceworker.ProviderResume(cursor, runtime.GetSourceId(), familyID)
+	if err != nil {
+		return sourcecdk.Pull{}, false, err
+	}
+	publicConfig := sourceworker.PublicExecutionConfig(cfg.Values())
 	priorWatermark := int64(0)
 	if watermark := checkpoint.GetWatermark(); watermark != nil && watermark.CheckValid() == nil {
 		priorWatermark = watermark.AsTime().UTC().UnixMilli()
+	}
+	if cursorWatermark > priorWatermark {
+		priorWatermark = cursorWatermark
 	}
 	output, err := host.Execute(ctx, sourceworker.ExecutionInput{
 		SourceID: runtime.GetSourceId(), FamilyID: strings.TrimSpace(familyID), CredentialReference: reference, PageNumber: pageNumber,
 		Scope: sourceworker.CredentialScope{
 			TenantID: strings.TrimSpace(runtime.GetTenantId()), RuntimeID: strings.TrimSpace(runtime.GetId()),
-			PriorCursor: strings.TrimSpace(cursor.GetOpaque()), LeaseOwner: fence.Owner,
+			PriorCursor: providerCursor, LeaseOwner: fence.Owner,
 			RuntimeGeneration: fence.Generation, LeaseGeneration: fence.Generation, LeaseExpiresAt: fence.ExpiresAt,
 			PublicConfig: publicConfig, PriorTerminalWatermarkUnixMillis: priorWatermark,
 			PriorCheckpoint: strings.TrimSpace(checkpoint.GetCursorOpaque()),
 		},
 	})
-	if errors.Is(err, sourceworker.ErrWorkerUnsupported) {
+	if errors.Is(err, sourceworker.ErrWorkerUnsupported) && !sourceworker.RustAuthoritativeTailscale(runtime.GetSourceId(), familyID) {
 		pull, compatibilityErr := readCompatibilitySourcePull(ctx, source, cfg, cursor, checkpoint)
 		return pull, false, compatibilityErr
 	}
 	if err != nil {
 		return sourcecdk.Pull{}, false, err
 	}
-	if output.Program == nil || output.Program.TransitionDigest == "" {
-		return sourcecdk.Pull{}, false, fmt.Errorf("%w: Rust did not seal the page program", sourceworker.ErrWorkerContract)
-	}
-	events := make([]*cerebrov1.EventEnvelope, 0, len(output.Program.AdmittedRecords))
-	for _, record := range output.Program.AdmittedRecords {
-		events = append(events, &cerebrov1.EventEnvelope{
-			Id: record.GetEventId(), TenantId: runtime.GetTenantId(), SourceId: output.Plan.GetSourceId(),
-			Kind: output.Plan.GetEventKind(), SchemaRef: output.Plan.GetSchemaRef(), Payload: record.GetPayloadJson(),
-			Attributes: record.GetAttributes(), OccurredAt: timestamppb.New(time.UnixMilli(record.GetOccurredAtUnixMillis()).UTC()),
-		})
-	}
-	pull := sourcecdk.Pull{Events: events, Checkpoint: &cerebrov1.SourceCheckpoint{
-		CursorOpaque: output.Result.GetResultDigestSha256(),
-		Watermark:    timestamppb.New(time.UnixMilli(output.Program.CheckpointWatermarkUnixMillis).UTC()),
-	}}
-	if output.Program.CheckpointCursor != "" {
-		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: output.Program.CheckpointCursor}
+	pull, err := sourceworker.PullFromExecutionOutput(output, runtime.GetTenantId())
+	if err != nil {
+		return sourcecdk.Pull{}, false, err
 	}
 	return pull, true, nil
-}
-
-func publicSourceExecutionConfig(cfg sourcecdk.Config) map[string]string {
-	public := make(map[string]string)
-	for _, key := range []string{
-		"audit_end_time", "audit_services", "audit_sort", "audit_start_time", "base_url",
-		"family", "group_id", "group_ids", "insights_base_url", "org_id", "per_page",
-		"tailnet", "user_group_id", "user_group_ids",
-	} {
-		if value, ok := cfg.Lookup(key); ok {
-			public[key] = strings.TrimSpace(value)
-		}
-	}
-	return public
 }

--- a/internal/sourceruntime/source_execution_authority_test.go
+++ b/internal/sourceruntime/source_execution_authority_test.go
@@ -1,0 +1,95 @@
+package sourceruntime
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceconfig"
+	"github.com/writer/cerebro/internal/sourceruntime/sourceworker"
+)
+
+func TestPutTailscaleRuntimeValidatesWithRustWithoutCallingGoCheck(t *testing.T) {
+	legacy := &runtimeTailscaleProbe{}
+	registry, err := sourcecdk.NewRegistry(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker := &runtimePlanWorker{}
+	service := New(registry, &runtimeStore{}, nil, nil)
+	service.sourceWorker = worker
+	_, err = service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{Runtime: &cerebrov1.SourceRuntime{
+		Id: "tailscale-user-runtime", SourceId: "tailscale", TenantId: "tenant-1",
+		Config: map[string]string{"family": "user", "tailnet": "example.com", "token": sourceconfig.CredentialReferenceValue("tailscale", "token")},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy.checkCalls != 0 || worker.planCalls != 1 {
+		t.Fatalf("validation calls = Go %d, Rust %d", legacy.checkCalls, worker.planCalls)
+	}
+	if worker.publicConfig["tailnet"] != "example.com" || worker.publicConfig["family"] != "user" || worker.publicConfig["token"] != "" {
+		t.Fatalf("Rust public config = %#v", worker.publicConfig)
+	}
+}
+
+func TestTailscaleRuntimeFailsClosedWithoutRustWorker(t *testing.T) {
+	legacy := &runtimeTailscaleProbe{}
+	registry, err := sourcecdk.NewRegistry(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := New(registry, &runtimeStore{}, nil, nil)
+	_, err = service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{Runtime: &cerebrov1.SourceRuntime{
+		Id: "tailscale-device-runtime", SourceId: "tailscale", TenantId: "tenant-1",
+		Config: map[string]string{"tailnet": "example.com", "token": sourceconfig.CredentialReferenceValue("tailscale", "token")},
+	}})
+	if !errors.Is(err, ErrRuntimeUnavailable) || legacy.checkCalls != 0 {
+		t.Fatalf("Put() error = %v, Go Check calls = %d", err, legacy.checkCalls)
+	}
+}
+
+type runtimeTailscaleProbe struct{ checkCalls int }
+
+func (*runtimeTailscaleProbe) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: "tailscale"}
+}
+func (s *runtimeTailscaleProbe) Check(context.Context, sourcecdk.Config) error {
+	s.checkCalls++
+	return nil
+}
+func (*runtimeTailscaleProbe) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+	return nil, nil
+}
+func (*runtimeTailscaleProbe) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	return sourcecdk.Pull{}, nil
+}
+
+type runtimePlanWorker struct {
+	planCalls    int
+	publicConfig map[string]string
+}
+
+func (*runtimePlanWorker) Compile(_ context.Context, request sourceworker.SelectionRequest) (*cerebrov1.SourceExecutionPlanV1, error) {
+	return &cerebrov1.SourceExecutionPlanV1{SourceId: request.SourceID, FamilyId: request.FamilyID}, nil
+}
+func (*runtimePlanWorker) Context(_ context.Context, request sourceworker.ContextRequest) (*cerebrov1.SourceWorkerExecutionContextV1, error) {
+	return &cerebrov1.SourceWorkerExecutionContextV1{
+		TenantId: request.TenantID, RuntimeId: request.RuntimeID, LogicalPageId: "page-1",
+		RuntimeGeneration: request.RuntimeGeneration, LeaseGeneration: request.LeaseGeneration,
+		ObservedAtUnixMillis: request.ObservedAtUnixMillis,
+	}, nil
+}
+func (w *runtimePlanWorker) PlanV2(_ context.Context, envelope *cerebrov1.SourceWorkerPlanEnvelopeV2) (*cerebrov1.SourceWorkerHTTPExecutionV2, error) {
+	w.planCalls++
+	w.publicConfig = envelope.GetMetadata().GetPublicConfig()
+	return &cerebrov1.SourceWorkerHTTPExecutionV2{}, nil
+}
+func (*runtimePlanWorker) DecodeV2(context.Context, *cerebrov1.SourceWorkerDecodeEnvelopeV2) (*cerebrov1.SourceWorkerDecodeOutputV2, error) {
+	return nil, errors.New("unexpected DecodeV2 call")
+}
+func (*runtimePlanWorker) SealPage(context.Context, sourceworker.PageProgramRequest) (*sourceworker.PageProgram, error) {
+	return nil, errors.New("unexpected SealPage call")
+}

--- a/internal/sourceruntime/source_execution_test.go
+++ b/internal/sourceruntime/source_execution_test.go
@@ -4,20 +4,20 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/writer/cerebro/internal/sourcecdk"
+	"github.com/writer/cerebro/internal/sourceruntime/sourceworker"
 )
 
 func TestPublicSourceExecutionConfigCarriesTailscaleScopeWithoutSecrets(t *testing.T) {
 	t.Parallel()
 
-	got := publicSourceExecutionConfig(sourcecdk.NewConfig(map[string]string{
+	got := sourceworker.PublicExecutionConfig(map[string]string{
 		"base_url":    " https://api.tailscale.com/api/v2 ",
 		"family":      " user ",
 		"per_page":    " 100 ",
 		"tailnet":     " example.test ",
 		"token":       "must-not-cross",
 		"graph_token": "must-not-cross-either",
-	}))
+	})
 	want := map[string]string{
 		"base_url": "https://api.tailscale.com/api/v2",
 		"family":   "user",
@@ -25,6 +25,6 @@ func TestPublicSourceExecutionConfigCarriesTailscaleScopeWithoutSecrets(t *testi
 		"tailnet":  "example.test",
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("publicSourceExecutionConfig() = %#v, want %#v", got, want)
+		t.Fatalf("PublicExecutionConfig() = %#v, want %#v", got, want)
 	}
 }

--- a/internal/sourceruntime/sourceworker/pull.go
+++ b/internal/sourceruntime/sourceworker/pull.go
@@ -1,0 +1,125 @@
+package sourceworker
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
+)
+
+const rustCheckpointCursorMode = "rust_provider_checkpoint"
+
+var tailscaleFamilies = map[string]struct{}{
+	"device": {}, "grant": {}, "group": {}, "service": {}, "tag": {}, "tailnet": {}, "user": {},
+}
+
+// RustAuthoritativeTailscale reports whether the closed Rust dispatcher owns
+// the exact public Tailscale family.
+func RustAuthoritativeTailscale(sourceID, familyID string) bool {
+	_, ok := TailscaleFamily(sourceID, familyID)
+	return ok
+}
+
+// TailscaleFamily returns the exact closed-dispatch family, including the
+// public default used when family is omitted.
+func TailscaleFamily(sourceID, familyID string) (string, bool) {
+	if strings.TrimSpace(sourceID) != "tailscale" {
+		return "", false
+	}
+	familyID = strings.TrimSpace(familyID)
+	if familyID == "" {
+		familyID = "device"
+	}
+	_, ok := tailscaleFamilies[familyID]
+	return familyID, ok
+}
+
+// PublicExecutionConfig returns only configuration declared safe for the
+// credential-free worker protocol.
+func PublicExecutionConfig(values map[string]string) map[string]string {
+	public := make(map[string]string)
+	for _, key := range []string{
+		"audit_end_time", "audit_services", "audit_sort", "audit_start_time", "base_url",
+		"family", "group_id", "group_ids", "insights_base_url", "org_id", "per_page",
+		"tailnet", "user_group_id", "user_group_ids",
+	} {
+		if value, ok := values[key]; ok {
+			public[key] = strings.TrimSpace(value)
+		}
+	}
+	return public
+}
+
+// ProviderResume unwraps a durable Rust checkpoint without allowing it to
+// switch source or family. Provider-native cursors remain accepted for an
+// active page continuation and are validated again by Rust planning.
+func ProviderResume(cursor *cerebrov1.SourceCursor, sourceID, familyID string) (string, int64, error) {
+	if cursor == nil {
+		return "", 0, nil
+	}
+	opaque := strings.TrimSpace(cursor.GetOpaque())
+	if opaque == "" {
+		return "", 0, nil
+	}
+	envelope, encoded := sourcecdk.DecodeCursorEnvelope(opaque)
+	if !encoded {
+		if strings.HasPrefix(opaque, "{") {
+			return "", 0, fmt.Errorf("%w: malformed durable cursor envelope", ErrWorkerContract)
+		}
+		return opaque, 0, nil
+	}
+	if envelope.Version != 1 || !envelope.ResumableCheckpoint || envelope.Mode != rustCheckpointCursorMode || envelope.Source != strings.TrimSpace(sourceID) || envelope.Family != strings.TrimSpace(familyID) {
+		return "", 0, fmt.Errorf("%w: durable cursor source or family mismatch", ErrWorkerContract)
+	}
+	watermark := sourcecdk.CursorWatermark(envelope)
+	if envelope.Watermark != "" && watermark.IsZero() {
+		return "", 0, fmt.Errorf("%w: durable cursor watermark is malformed", ErrWorkerContract)
+	}
+	return envelope.Token, watermark.UnixMilli(), nil
+}
+
+// PullFromExecutionOutput maps Rust-authored page evidence into the Go host's
+// append input. Result.NextCursor controls only same-run pagination; the
+// lifecycle checkpoint is encoded independently for a later restart.
+func PullFromExecutionOutput(output *ExecutionOutput, tenantID string) (sourcecdk.Pull, error) {
+	if output == nil || output.Plan == nil || output.Result == nil || output.Program == nil || output.Program.TransitionDigest == "" {
+		return sourcecdk.Pull{}, fmt.Errorf("%w: Rust did not seal the page program", ErrWorkerContract)
+	}
+	events := make([]*cerebrov1.EventEnvelope, 0, len(output.Program.AdmittedRecords))
+	for _, record := range output.Program.AdmittedRecords {
+		if record == nil {
+			return sourcecdk.Pull{}, fmt.Errorf("%w: Rust admitted an empty record", ErrWorkerContract)
+		}
+		events = append(events, &cerebrov1.EventEnvelope{
+			Id: record.GetEventId(), TenantId: strings.TrimSpace(tenantID), SourceId: output.Plan.GetSourceId(),
+			Kind: output.Plan.GetEventKind(), SchemaRef: output.Plan.GetSchemaRef(), Payload: record.GetPayloadJson(),
+			Attributes: record.GetAttributes(), OccurredAt: timestamppb.New(time.UnixMilli(record.GetOccurredAtUnixMillis()).UTC()),
+		})
+	}
+	watermark := timestamppb.New(time.UnixMilli(output.Program.CheckpointWatermarkUnixMillis).UTC())
+	if err := watermark.CheckValid(); err != nil {
+		return sourcecdk.Pull{}, fmt.Errorf("%w: Rust checkpoint watermark is invalid", ErrWorkerContract)
+	}
+	checkpointCursor := output.Result.GetResultDigestSha256()
+	if RustAuthoritativeTailscale(output.Plan.GetSourceId(), output.Plan.GetFamilyId()) {
+		envelope := sourcecdk.CursorEnvelope{
+			Version: 1, Source: output.Plan.GetSourceId(), Family: output.Plan.GetFamilyId(),
+			Mode: rustCheckpointCursorMode, ResumableCheckpoint: true, Token: output.Program.CheckpointCursor,
+		}
+		sourcecdk.SetCursorWatermark(&envelope, watermark.AsTime())
+		var err error
+		checkpointCursor, err = sourcecdk.EncodeCursorEnvelope(envelope)
+		if err != nil {
+			return sourcecdk.Pull{}, fmt.Errorf("%w: encode Rust checkpoint: %w", ErrWorkerContract, err)
+		}
+	}
+	pull := sourcecdk.Pull{Events: events, Checkpoint: &cerebrov1.SourceCheckpoint{CursorOpaque: checkpointCursor, Watermark: watermark}}
+	if next := strings.TrimSpace(output.Result.GetNextCursor()); next != "" {
+		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: next}
+	}
+	return pull, nil
+}

--- a/internal/sourceruntime/sourceworker/pull_test.go
+++ b/internal/sourceruntime/sourceworker/pull_test.go
@@ -1,0 +1,81 @@
+package sourceworker
+
+import (
+	"errors"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+)
+
+func TestPullSeparatesTerminalCheckpointFromSameRunContinuation(t *testing.T) {
+	terminal := tailscaleOutput("", "user-1", 1_725_000_000_000)
+	pull, err := PullFromExecutionOutput(terminal, "tenant-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pull.NextCursor != nil {
+		t.Fatalf("terminal NextCursor = %#v, want nil", pull.NextCursor)
+	}
+	providerCursor, watermark, err := ProviderResume(
+		&cerebrov1.SourceCursor{Opaque: pull.Checkpoint.GetCursorOpaque()}, "tailscale", "user",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if providerCursor != "user-1" || watermark != 1_725_000_000_000 {
+		t.Fatalf("restart = (%q, %d), want terminal cursor and watermark", providerCursor, watermark)
+	}
+
+	nonterminal := tailscaleOutput("page-2", "page-2", 1_725_000_001_000)
+	pull, err = PullFromExecutionOutput(nonterminal, "tenant-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pull.NextCursor.GetOpaque() != "page-2" {
+		t.Fatalf("nonterminal NextCursor = %q, want page-2", pull.NextCursor.GetOpaque())
+	}
+	providerCursor, _, err = ProviderResume(
+		&cerebrov1.SourceCursor{Opaque: pull.Checkpoint.GetCursorOpaque()}, "tailscale", "user",
+	)
+	if err != nil || providerCursor != "page-2" {
+		t.Fatalf("nonterminal checkpoint = %q, %v", providerCursor, err)
+	}
+}
+
+func TestProviderResumeFailsClosedForMalformedAndCrossFamilyCheckpoints(t *testing.T) {
+	for name, cursor := range map[string]string{
+		"malformed":    `{"version":1`,
+		"cross family": `{"version":1,"source":"tailscale","family":"device","mode":"rust_provider_checkpoint","resumable_checkpoint":true,"token":"device-1"}`,
+		"cross source": `{"version":1,"source":"other","family":"user","mode":"rust_provider_checkpoint","resumable_checkpoint":true,"token":"user-1"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := ProviderResume(&cerebrov1.SourceCursor{Opaque: cursor}, "tailscale", "user")
+			if !errors.Is(err, ErrWorkerContract) {
+				t.Fatalf("ProviderResume() error = %v, want ErrWorkerContract", err)
+			}
+		})
+	}
+}
+
+func TestPublicExecutionConfigNeverCarriesCredentialMaterial(t *testing.T) {
+	public := PublicExecutionConfig(map[string]string{
+		"family": "user", "tailnet": "example.com", "base_url": "https://api.tailscale.com/api/v2",
+		"token": "secret-token", "graph_token": "secret-graph-token", "tenant_id": "tenant-1",
+	})
+	if len(public) != 3 || public["token"] != "" || public["graph_token"] != "" || public["tenant_id"] != "" {
+		t.Fatalf("public config leaked private fields: %#v", public)
+	}
+}
+
+func tailscaleOutput(nextCursor, checkpointCursor string, watermark int64) *ExecutionOutput {
+	plan := &cerebrov1.SourceExecutionPlanV1{SourceId: "tailscale", FamilyId: "user", EventKind: "tailscale.user", SchemaRef: "tailscale/user/v1"}
+	record := &cerebrov1.SourceWorkerRecordV1{
+		ProviderId: "user-1", EventId: "tailscale-tenant-1-user-user-1", OccurredAtUnixMillis: watermark,
+		Attributes:  map[string]string{"tenant_id": "tenant-1", "family": "user", "resource_urn": "urn:cerebro:tenant-1:tailscale_user:user-1"},
+		PayloadJson: []byte(`{"id":"user-1"}`),
+	}
+	return &ExecutionOutput{
+		Plan: plan, Result: &cerebrov1.SourceWorkerDecodeResultV1{NextCursor: nextCursor, ResultDigestSha256: "digest"},
+		Program: &PageProgram{TransitionDigest: "transition", AdmittedRecords: []*cerebrov1.SourceWorkerRecordV1{record}, CheckpointCursor: checkpointCursor, CheckpointWatermarkUnixMillis: watermark},
+	}
+}


### PR DESCRIPTION
## Scope

Routes Tailscale `Check`, `Discover`, and `Read` through the closed Rust source worker for the exact seven public families: `device`, `grant`, `group`, `service`, `tag`, `tailnet`, and `user`.

Separates provider continuation from durable restart state:

- `result.next_cursor` schedules another page only when the provider emitted a continuation.
- the Rust-sealed lifecycle checkpoint retains the provider continuation or terminal last-record fallback plus watermark.
- the Go host persists that checkpoint as a source/family-bound resumable envelope and unwraps it only on a later run.
- malformed and cross-source/family checkpoint envelopes fail closed.

Tailscale runtime creation validates the Rust plan instead of calling the Go source. Source preview and graph-ingest entry points receive the configured worker path. The existing Go Tailscale loader remains unchanged for independent validation and the later deletion change.

## Boundary

- Base: `3bb7b0c5534b21d30aea0be0c1a76aea04fe57eb`
- Head: `a732baa6c2be4538a9ec1ad422c7030cde514c20`
- Provider-local Tailscale paths: unchanged
- Go Tailscale loader: unchanged
- Handwritten Go delta: `+741/-58` (net `+683`)
  - production: `+359/-54` (net `+305`)
  - tests: `+382/-4` (net `+378`)
- Rust delta: `+36/-3` (net `+33`)

The Go production addition is limited to worker wiring, credential/egress host invocation, public-config allowlisting, protobuf-to-pull marshaling, and syntactic source/family-bound cursor-envelope handling. Rust still owns planning, decode, identity, event admission, cursor choice, watermark lifecycle, and the sealed page program. This PR does not loop or choose append/projection/checkpoint transitions in Go.

## Validation

DDESK v1.12.16, clean exact-base stream `ctauth3b`:

- `go test ./internal/sourceruntime/sourceworker ./internal/sourceops ./internal/sourceruntime ./internal/bootstrap ./cmd/cerebro -count=1`
- `go test -race ./internal/sourceops ./internal/sourceruntime/sourceworker -count=1`
- `make lint-api-cmd`
- `make lint-internal`
- `cargo test --locked -p cerebro-source-runtime-next source_execution::tailscale --lib -- --nocapture` (3/3)
- `cargo test --locked -p cerebro-source-runtime-next source_execution --lib -- --nocapture` (38/38)
- `cargo test --locked -p cerebro-source-runtime-next` (617 library plus 8 DigitalOcean, 7 Linode, 11 PagerDuty; all pass)
- `cargo clippy --locked -p cerebro-source-runtime-next --lib --tests -- -D warnings`
- `cargo build --locked -p cerebro-source-runtime-next --bin source_worker`
- `cargo fmt --all -- --check`
- `go test ./tools/archtests -count=1`
- `git diff --check`

## Remaining states

Draft while hosted checks and independent Go-removal-owner validation run. No deployment, live-provider collection, or authenticated product-read claim is made by this PR.
