### PR TITLE
Fix Tailscale terminal cursor restart

### DIFF
--- a/crates/source-runtime-next/src/source_execution/tailscale.rs
+++ b/crates/source-runtime-next/src/source_execution/tailscale.rs
@@ -666,12 +666,9 @@ mod tests {
                 "{family}"
             );
 
-            let restarted = plan_page(
-                dispatcher,
-                &plan,
-                &context(&program.checkpoint_cursor, 2),
-                &metadata,
-            );
+            let mut restart_metadata = metadata.clone();
+            restart_metadata.prior_terminal_watermark_unix_millis = terminal_watermark;
+            let restarted = plan_page(dispatcher, &plan, &context("", 2), &restart_metadata);
             let restarted_url = reqwest::Url::parse(&restarted.request.unwrap().url).unwrap();
             assert_eq!(
                 restarted_url
@@ -679,7 +676,7 @@ mod tests {
                     .find(|(key, _)| key == "cursor")
                     .map(|(_, value)| value.into_owned())
                     .as_deref(),
-                Some(program.checkpoint_cursor.as_str()),
+                None,
                 "{family}"
             );
 

--- a/internal/sourceops/source_execution.go
+++ b/internal/sourceops/source_execution.go
@@ -51,9 +51,6 @@ func (s *Service) executeTailscale(ctx context.Context, config map[string]string
 	if family == "" {
 		family = "device"
 	}
-	if !sourceworker.RustAuthoritativeTailscale(tailscaleSourceID, family) {
-		return sourcecdk.Pull{}, sourceExecutionError(family, sourceworker.ErrWorkerUnsupported)
-	}
 	tenantID := strings.TrimSpace(config["tenant_id"])
 	credential := []byte(strings.TrimSpace(config["token"]))
 	if tenantID == "" || len(credential) == 0 {

--- a/internal/sourceops/source_execution_test.go
+++ b/internal/sourceops/source_execution_test.go
@@ -58,42 +58,54 @@ func TestTailscaleCheckDiscoverAndReadUseOnlyClosedRustAuthority(t *testing.T) {
 }
 
 func TestTailscaleReadPersistsTerminalRestartWithoutContinuingCurrentRun(t *testing.T) {
-	service := tailscaleAuthorityService(t)
-	var inputs []sourceworker.ExecutionInput
-	service.runSourceExecution = func(_ context.Context, _ sourceworker.Worker, _ string, _ []byte, _ time.Time, input sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
-		inputs = append(inputs, input)
-		return previewOutput("user", "", "user-terminal", max(input.Scope.PriorTerminalWatermarkUnixMillis, 1_725_000_000_000)), nil
-	}
-	config := tailscalePreviewConfig("user")
-	first, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{SourceId: "tailscale", Config: config})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if first.GetNextCursor() != nil {
-		t.Fatalf("terminal page scheduled another page: %#v", first.GetNextCursor())
-	}
-	second, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{
-		SourceId: "tailscale", Config: config, Cursor: &cerebrov1.SourceCursor{Opaque: first.GetCheckpoint().GetCursorOpaque()},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(inputs) != 2 || inputs[1].Scope.PriorCursor != "user-terminal" || inputs[1].Scope.PriorTerminalWatermarkUnixMillis != 1_725_000_000_000 {
-		t.Fatalf("restart input = %#v", inputs)
-	}
-	if second.GetNextCursor() != nil {
-		t.Fatal("restarted terminal page scheduled another page")
+	for _, family := range []string{"device", "grant", "group", "service", "tag", "tailnet", "user"} {
+		t.Run(family, func(t *testing.T) {
+			service := tailscaleAuthorityService(t)
+			var inputs []sourceworker.ExecutionInput
+			service.runSourceExecution = func(_ context.Context, _ sourceworker.Worker, _ string, _ []byte, _ time.Time, input sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+				inputs = append(inputs, input)
+				return previewOutput(family, "", family+"-terminal", max(input.Scope.PriorTerminalWatermarkUnixMillis, 1_725_000_000_000)), nil
+			}
+			config := tailscalePreviewConfig(family)
+			first, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{SourceId: "tailscale", Config: config})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if first.GetNextCursor() != nil {
+				t.Fatalf("terminal page scheduled another page: %#v", first.GetNextCursor())
+			}
+			second, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{
+				SourceId: "tailscale", Config: config, Cursor: &cerebrov1.SourceCursor{Opaque: first.GetCheckpoint().GetCursorOpaque()},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(inputs) != 2 || inputs[1].Scope.PriorCursor != "" || inputs[1].Scope.PriorTerminalWatermarkUnixMillis != 1_725_000_000_000 {
+				t.Fatalf("restart input = %#v", inputs)
+			}
+			if second.GetNextCursor() != nil {
+				t.Fatal("restarted terminal page scheduled another page")
+			}
+		})
 	}
 }
 
 func TestTailscaleReadContinuesOnlyForProviderCursorAndFailsClosed(t *testing.T) {
 	service := tailscaleAuthorityService(t)
+	var inputs []sourceworker.ExecutionInput
 	service.runSourceExecution = func(_ context.Context, _ sourceworker.Worker, _ string, _ []byte, _ time.Time, input sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+		inputs = append(inputs, input)
 		return previewOutput("device", "provider-page-2", "provider-page-2", 1_725_000_000_000), nil
 	}
 	response, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{SourceId: "tailscale", Config: tailscalePreviewConfig("device")})
 	if err != nil || response.GetNextCursor().GetOpaque() != "provider-page-2" {
 		t.Fatalf("Read() continuation = %#v, %v", response, err)
+	}
+	_, err = service.Read(context.Background(), &cerebrov1.ReadSourceRequest{
+		SourceId: "tailscale", Config: tailscalePreviewConfig("device"), Cursor: &cerebrov1.SourceCursor{Opaque: response.GetCheckpoint().GetCursorOpaque()},
+	})
+	if err != nil || len(inputs) != 2 || inputs[1].Scope.PriorCursor != "provider-page-2" {
+		t.Fatalf("continuation restart inputs = %#v, %v", inputs, err)
 	}
 
 	for name, cursor := range map[string]string{
@@ -109,6 +121,32 @@ func TestTailscaleReadContinuesOnlyForProviderCursorAndFailsClosed(t *testing.T)
 				t.Fatalf("Read() error = %v, want typed fail-closed cursor error", err)
 			}
 		})
+	}
+}
+
+func TestUnknownTailscaleFamilyFailsClosedWithoutLegacyCalls(t *testing.T) {
+	legacy := &authorityProbeSource{}
+	registry, err := sourcecdk.NewRegistry(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := New(registry)
+	service.sourceWorker = previewWorkerStub{}
+	service.runSourceExecution = func(context.Context, sourceworker.Worker, string, []byte, time.Time, sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+		return nil, sourceworker.ErrWorkerUnsupported
+	}
+	config := tailscalePreviewConfig("future-family")
+	if _, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{SourceId: "tailscale", Config: config}); !errors.Is(err, sourceworker.ErrWorkerUnsupported) {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if _, err := service.Discover(context.Background(), &cerebrov1.DiscoverSourceRequest{SourceId: "tailscale", Config: config}); !errors.Is(err, sourceworker.ErrWorkerUnsupported) {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if _, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{SourceId: "tailscale", Config: config}); !errors.Is(err, sourceworker.ErrWorkerUnsupported) {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if legacy.checkCalls != 0 || legacy.discoverCalls != 0 || legacy.readCalls != 0 {
+		t.Fatalf("legacy calls = check/discover/read %d/%d/%d", legacy.checkCalls, legacy.discoverCalls, legacy.readCalls)
 	}
 }
 

--- a/internal/sourceruntime/source_execution.go
+++ b/internal/sourceruntime/source_execution.go
@@ -95,9 +95,11 @@ func (s *Service) readSourcePull(ctx context.Context, runtime *cerebrov1.SourceR
 			PriorCheckpoint: strings.TrimSpace(checkpoint.GetCursorOpaque()),
 		},
 	})
-	if errors.Is(err, sourceworker.ErrWorkerUnsupported) && !sourceworker.RustAuthoritativeTailscale(runtime.GetSourceId(), familyID) {
-		pull, compatibilityErr := readCompatibilitySourcePull(ctx, source, cfg, cursor, checkpoint)
-		return pull, false, compatibilityErr
+	if errors.Is(err, sourceworker.ErrWorkerUnsupported) {
+		if _, tailscale := sourceworker.TailscaleFamily(runtime.GetSourceId(), familyID); !tailscale {
+			pull, compatibilityErr := readCompatibilitySourcePull(ctx, source, cfg, cursor, checkpoint)
+			return pull, false, compatibilityErr
+		}
 	}
 	if err != nil {
 		return sourcecdk.Pull{}, false, err

--- a/internal/sourceruntime/source_execution_authority_test.go
+++ b/internal/sourceruntime/source_execution_authority_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourceruntime/sourceworker"
@@ -51,7 +53,41 @@ func TestTailscaleRuntimeFailsClosedWithoutRustWorker(t *testing.T) {
 	}
 }
 
-type runtimeTailscaleProbe struct{ checkCalls int }
+func TestUnknownTailscaleFamilyNeverFallsBackToGoAuthority(t *testing.T) {
+	legacy := &runtimeTailscaleProbe{}
+	registry, err := sourcecdk.NewRegistry(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker := &runtimePlanWorker{compileErr: sourceworker.ErrWorkerUnsupported}
+	service := New(registry, &runtimeStore{}, nil, nil)
+	service.sourceWorker = worker
+	runtime := &cerebrov1.SourceRuntime{
+		Id: "tailscale-future-runtime", SourceId: "tailscale", TenantId: "tenant-1",
+		Config: map[string]string{"family": "future-family", "tailnet": "example.com", "token": sourceconfig.CredentialReferenceValue("tailscale", "token")},
+	}
+	if _, err := service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{Runtime: runtime}); !errors.Is(err, sourceworker.ErrWorkerUnsupported) {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if legacy.checkCalls != 0 {
+		t.Fatalf("Go Check calls = %d", legacy.checkCalls)
+	}
+
+	ctx := context.WithValue(context.Background(), sourceRuntimeLeaseFenceContextKey{}, sourceRuntimeLeaseAuthority{fence: ports.SourceRuntimeLeaseFence{
+		Owner: "owner-1", Generation: 1, ExpiresAt: time.Now().Add(time.Minute),
+	}})
+	resolved := sourcecdk.NewConfig(map[string]string{
+		"family": "future-family", "tailnet": "example.com", "token": "host-only-secret",
+	})
+	if _, _, err := service.readSourcePull(ctx, runtime, legacy, resolved, nil, nil, 1); !errors.Is(err, sourceworker.ErrWorkerUnsupported) {
+		t.Fatalf("readSourcePull() error = %v", err)
+	}
+	if legacy.readCalls != 0 {
+		t.Fatalf("Go Read calls = %d", legacy.readCalls)
+	}
+}
+
+type runtimeTailscaleProbe struct{ checkCalls, readCalls int }
 
 func (*runtimeTailscaleProbe) Spec() *cerebrov1.SourceSpec {
 	return &cerebrov1.SourceSpec{Id: "tailscale"}
@@ -63,16 +99,21 @@ func (s *runtimeTailscaleProbe) Check(context.Context, sourcecdk.Config) error {
 func (*runtimeTailscaleProbe) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
 	return nil, nil
 }
-func (*runtimeTailscaleProbe) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+func (s *runtimeTailscaleProbe) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+	s.readCalls++
 	return sourcecdk.Pull{}, nil
 }
 
 type runtimePlanWorker struct {
 	planCalls    int
 	publicConfig map[string]string
+	compileErr   error
 }
 
-func (*runtimePlanWorker) Compile(_ context.Context, request sourceworker.SelectionRequest) (*cerebrov1.SourceExecutionPlanV1, error) {
+func (w *runtimePlanWorker) Compile(_ context.Context, request sourceworker.SelectionRequest) (*cerebrov1.SourceExecutionPlanV1, error) {
+	if w.compileErr != nil {
+		return nil, w.compileErr
+	}
 	return &cerebrov1.SourceExecutionPlanV1{SourceId: request.SourceID, FamilyId: request.FamilyID}, nil
 }
 func (*runtimePlanWorker) Context(_ context.Context, request sourceworker.ContextRequest) (*cerebrov1.SourceWorkerExecutionContextV1, error) {

--- a/internal/sourceruntime/sourceworker/pull.go
+++ b/internal/sourceruntime/sourceworker/pull.go
@@ -13,19 +13,10 @@ import (
 
 const rustCheckpointCursorMode = "rust_provider_checkpoint"
 
-var tailscaleFamilies = map[string]struct{}{
-	"device": {}, "grant": {}, "group": {}, "service": {}, "tag": {}, "tailnet": {}, "user": {},
-}
-
-// RustAuthoritativeTailscale reports whether the closed Rust dispatcher owns
-// the exact public Tailscale family.
-func RustAuthoritativeTailscale(sourceID, familyID string) bool {
-	_, ok := TailscaleFamily(sourceID, familyID)
-	return ok
-}
-
-// TailscaleFamily returns the exact closed-dispatch family, including the
-// public default used when family is omitted.
+// TailscaleFamily normalizes the requested Tailscale family, including the
+// public default used when family is omitted. The closed Rust dispatcher owns
+// family membership validation; Go must not restore legacy authority for an
+// unknown family.
 func TailscaleFamily(sourceID, familyID string) (string, bool) {
 	if strings.TrimSpace(sourceID) != "tailscale" {
 		return "", false
@@ -34,8 +25,7 @@ func TailscaleFamily(sourceID, familyID string) (string, bool) {
 	if familyID == "" {
 		familyID = "device"
 	}
-	_, ok := tailscaleFamilies[familyID]
-	return familyID, ok
+	return familyID, true
 }
 
 // PublicExecutionConfig returns only configuration declared safe for the
@@ -75,6 +65,9 @@ func ProviderResume(cursor *cerebrov1.SourceCursor, sourceID, familyID string) (
 	if envelope.Version != 1 || !envelope.ResumableCheckpoint || envelope.Mode != rustCheckpointCursorMode || envelope.Source != strings.TrimSpace(sourceID) || envelope.Family != strings.TrimSpace(familyID) {
 		return "", 0, fmt.Errorf("%w: durable cursor source or family mismatch", ErrWorkerContract)
 	}
+	if envelope.Token != "" && len(envelope.BoundaryIDs) != 0 {
+		return "", 0, fmt.Errorf("%w: durable cursor mixes continuation and terminal boundary", ErrWorkerContract)
+	}
 	watermark := sourcecdk.CursorWatermark(envelope)
 	if envelope.Watermark != "" && watermark.IsZero() {
 		return "", 0, fmt.Errorf("%w: durable cursor watermark is malformed", ErrWorkerContract)
@@ -105,10 +98,14 @@ func PullFromExecutionOutput(output *ExecutionOutput, tenantID string) (sourcecd
 		return sourcecdk.Pull{}, fmt.Errorf("%w: Rust checkpoint watermark is invalid", ErrWorkerContract)
 	}
 	checkpointCursor := output.Result.GetResultDigestSha256()
-	if RustAuthoritativeTailscale(output.Plan.GetSourceId(), output.Plan.GetFamilyId()) {
+	nextCursor := strings.TrimSpace(output.Result.GetNextCursor())
+	if _, tailscale := TailscaleFamily(output.Plan.GetSourceId(), output.Plan.GetFamilyId()); tailscale {
 		envelope := sourcecdk.CursorEnvelope{
 			Version: 1, Source: output.Plan.GetSourceId(), Family: output.Plan.GetFamilyId(),
-			Mode: rustCheckpointCursorMode, ResumableCheckpoint: true, Token: output.Program.CheckpointCursor,
+			Mode: rustCheckpointCursorMode, ResumableCheckpoint: true, Token: nextCursor,
+		}
+		if boundary := strings.TrimSpace(output.Program.CheckpointCursor); nextCursor == "" && boundary != "" {
+			envelope.BoundaryIDs = []string{boundary}
 		}
 		sourcecdk.SetCursorWatermark(&envelope, watermark.AsTime())
 		var err error
@@ -118,8 +115,8 @@ func PullFromExecutionOutput(output *ExecutionOutput, tenantID string) (sourcecd
 		}
 	}
 	pull := sourcecdk.Pull{Events: events, Checkpoint: &cerebrov1.SourceCheckpoint{CursorOpaque: checkpointCursor, Watermark: watermark}}
-	if next := strings.TrimSpace(output.Result.GetNextCursor()); next != "" {
-		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: next}
+	if nextCursor != "" {
+		pull.NextCursor = &cerebrov1.SourceCursor{Opaque: nextCursor}
 	}
 	return pull, nil
 }

--- a/internal/sourceruntime/sourceworker/pull_test.go
+++ b/internal/sourceruntime/sourceworker/pull_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/sourcecdk"
 )
 
 func TestPullSeparatesTerminalCheckpointFromSameRunContinuation(t *testing.T) {
@@ -22,8 +23,12 @@ func TestPullSeparatesTerminalCheckpointFromSameRunContinuation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if providerCursor != "user-1" || watermark != 1_725_000_000_000 {
-		t.Fatalf("restart = (%q, %d), want terminal cursor and watermark", providerCursor, watermark)
+	if providerCursor != "" || watermark != 1_725_000_000_000 {
+		t.Fatalf("restart = (%q, %d), want no provider cursor and terminal watermark", providerCursor, watermark)
+	}
+	terminalEnvelope, ok := sourcecdk.DecodeCursorEnvelope(pull.Checkpoint.GetCursorOpaque())
+	if !ok || terminalEnvelope.Token != "" || len(terminalEnvelope.BoundaryIDs) != 1 || terminalEnvelope.BoundaryIDs[0] != "user-1" {
+		t.Fatalf("terminal checkpoint envelope = %#v, %v", terminalEnvelope, ok)
 	}
 
 	nonterminal := tailscaleOutput("page-2", "page-2", 1_725_000_001_000)
@@ -40,6 +45,10 @@ func TestPullSeparatesTerminalCheckpointFromSameRunContinuation(t *testing.T) {
 	if err != nil || providerCursor != "page-2" {
 		t.Fatalf("nonterminal checkpoint = %q, %v", providerCursor, err)
 	}
+	continuationEnvelope, ok := sourcecdk.DecodeCursorEnvelope(pull.Checkpoint.GetCursorOpaque())
+	if !ok || continuationEnvelope.Token != "page-2" || len(continuationEnvelope.BoundaryIDs) != 0 {
+		t.Fatalf("continuation checkpoint envelope = %#v, %v", continuationEnvelope, ok)
+	}
 }
 
 func TestProviderResumeFailsClosedForMalformedAndCrossFamilyCheckpoints(t *testing.T) {
@@ -47,6 +56,8 @@ func TestProviderResumeFailsClosedForMalformedAndCrossFamilyCheckpoints(t *testi
 		"malformed":    `{"version":1`,
 		"cross family": `{"version":1,"source":"tailscale","family":"device","mode":"rust_provider_checkpoint","resumable_checkpoint":true,"token":"device-1"}`,
 		"cross source": `{"version":1,"source":"other","family":"user","mode":"rust_provider_checkpoint","resumable_checkpoint":true,"token":"user-1"}`,
+		"mixed continuation and boundary": `{"version":1,"source":"tailscale","family":"user","mode":"rust_provider_checkpoint",` +
+			`"resumable_checkpoint":true,"token":"page-2","boundary_ids":["user-1"]}`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			_, _, err := ProviderResume(&cerebrov1.SourceCursor{Opaque: cursor}, "tailscale", "user")


### PR DESCRIPTION
## Summary

- keep terminal Tailscale checkpoint continuation tokens empty while retaining the terminal watermark and boundary
- replay only genuine provider continuations from `Result.NextCursor`
- route every Tailscale family request to the closed Rust dispatcher, including unknown families that must fail without legacy Go calls
- cover all seven families, pagination replay, malformed and cross-family cursors, and unknown-family fail-closed behavior

## Validation

- `go test ./internal/sourceruntime/sourceworker ./internal/sourceops ./internal/sourceruntime -count=1`
- `cargo test -p cerebro-source-runtime-next source_execution::tailscale::tests::combined_provider_and_dispatcher_seal_terminal_progress_for_all_seven_families -- --exact`
- `cargo test -p cerebro-source-runtime-next source_execution::tailscale::tests::cursor_checkpoint_and_restart_are_rust_sealed_and_fail_closed -- --exact`
- `cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The local focused checks ran on the Mac recovery path because DDESK reported this checkout as `waiting-for-disk` with critical shared capacity. Hosted checks remain required.