### PR TITLE
fix(source-runtime): keep compatibility sources on declared engine

### DIFF
--- a/internal/sourceruntime/source_execution.go
+++ b/internal/sourceruntime/source_execution.go
@@ -2,7 +2,6 @@ package sourceruntime
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -46,15 +45,14 @@ func (s *Service) validateRustSourceRuntimePlan(ctx context.Context, runtime *ce
 
 func (s *Service) readSourcePull(ctx context.Context, runtime *cerebrov1.SourceRuntime, source sourcecdk.Source, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint, pageNumber uint32) (sourcecdk.Pull, bool, error) {
 	familyID, _ := cfg.Lookup("family")
-	if normalized, authoritative := sourceworker.TailscaleFamily(runtime.GetSourceId(), familyID); authoritative {
-		familyID = normalized
-		if s == nil || s.sourceWorker == nil {
-			return sourcecdk.Pull{}, false, fmt.Errorf("%w: the closed Rust worker is required for Tailscale", ErrRuntimeUnavailable)
-		}
-	}
-	if s == nil || s.sourceWorker == nil {
+	normalizedFamilyID, authoritative := sourceworker.TailscaleFamily(runtime.GetSourceId(), familyID)
+	if !authoritative {
 		pull, err := readCompatibilitySourcePull(ctx, source, cfg, cursor, checkpoint)
 		return pull, false, err
+	}
+	familyID = normalizedFamilyID
+	if s == nil || s.sourceWorker == nil {
+		return sourcecdk.Pull{}, false, fmt.Errorf("%w: the closed Rust worker is required for Tailscale", ErrRuntimeUnavailable)
 	}
 	fence, ok := sourceRuntimeLeaseFenceFromContext(ctx)
 	if !ok || !fence.ExpiresAt.After(time.Now().UTC()) {
@@ -95,12 +93,6 @@ func (s *Service) readSourcePull(ctx context.Context, runtime *cerebrov1.SourceR
 			PriorCheckpoint: strings.TrimSpace(checkpoint.GetCursorOpaque()),
 		},
 	})
-	if errors.Is(err, sourceworker.ErrWorkerUnsupported) {
-		if _, tailscale := sourceworker.TailscaleFamily(runtime.GetSourceId(), familyID); !tailscale {
-			pull, compatibilityErr := readCompatibilitySourcePull(ctx, source, cfg, cursor, checkpoint)
-			return pull, false, compatibilityErr
-		}
-	}
 	if err != nil {
 		return sourcecdk.Pull{}, false, err
 	}

--- a/internal/sourceruntime/source_execution_authority_test.go
+++ b/internal/sourceruntime/source_execution_authority_test.go
@@ -87,6 +87,21 @@ func TestUnknownTailscaleFamilyNeverFallsBackToGoAuthority(t *testing.T) {
 	}
 }
 
+func TestNonTailscaleRuntimeUsesGoCompatibilityBeforeRustCredentialChecks(t *testing.T) {
+	legacy := &runtimeTailscaleProbe{}
+	service := &Service{sourceWorker: &runtimePlanWorker{}}
+	runtime := &cerebrov1.SourceRuntime{Id: "gcp-runtime", SourceId: "gcp", TenantId: "tenant-1"}
+
+	if _, rustPage, err := service.readSourcePull(context.Background(), runtime, legacy, sourcecdk.NewConfig(nil), nil, nil, 1); err != nil {
+		t.Fatalf("readSourcePull() error = %v", err)
+	} else if rustPage {
+		t.Fatal("readSourcePull() reported a Rust page for a Go-authoritative source")
+	}
+	if legacy.readCalls != 1 {
+		t.Fatalf("Go Read calls = %d, want 1", legacy.readCalls)
+	}
+}
+
 type runtimeTailscaleProbe struct{ checkCalls, readCalls int }
 
 func (*runtimeTailscaleProbe) Spec() *cerebrov1.SourceSpec {


### PR DESCRIPTION
## Summary

- route sources outside the Rust-authoritative family directly to the compatibility reader
- keep the Rust-authoritative family fail closed when its worker or credential reference is unavailable
- cover compatibility routing before Rust credential validation with a regression test

## Validation

- `go test ./internal/sourceruntime ./cmd/cerebro -count=1`
- `go test -race ./internal/sourceruntime -run 'Test(NonTailscaleRuntimeUsesGoCompatibilityBeforeRustCredentialChecks|UnknownTailscaleFamilyNeverFallsBackToGoAuthority)$' -count=1`\n- `make check-structural check-structural-test check-arch`\n- `git diff --check origin/main...HEAD`