### PR TITLE
Activate Azure and JumpCloud Rust runtime authority

### DIFF
--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -251,7 +251,7 @@ func (s *Service) preparePutRuntime(ctx context.Context, input *cerebrov1.Source
 	if err != nil {
 		return nil, err
 	}
-	if _, authoritative := sourceworker.TailscaleFamily(runtime.GetSourceId(), resolvedConfig["family"]); authoritative {
+	if _, authoritative := sourceworker.RustAuthoritativeFamily(runtime.GetSourceId(), resolvedConfig["family"]); authoritative {
 		if err := s.validateRustSourceRuntimePlan(ctx, runtime, resolvedConfig); err != nil {
 			return nil, err
 		}

--- a/internal/sourceruntime/source_execution.go
+++ b/internal/sourceruntime/source_execution.go
@@ -58,13 +58,7 @@ func (s *Service) readSourcePull(ctx context.Context, runtime *cerebrov1.SourceR
 	if !ok || !fence.ExpiresAt.After(time.Now().UTC()) {
 		return sourcecdk.Pull{}, false, fmt.Errorf("%w: source worker requires a current durable lease fence", ErrRuntimeUnavailable)
 	}
-	reference, resolved := strings.TrimSpace(runtime.GetConfig()["graph_token"]), strings.TrimSpace(cfg.Values()["graph_token"])
-	if reference == "" {
-		reference = strings.TrimSpace(runtime.GetConfig()["token"])
-	}
-	if resolved == "" {
-		resolved = strings.TrimSpace(cfg.Values()["token"])
-	}
+	reference, resolved := sourceworker.CredentialBinding(runtime.GetSourceId(), runtime.GetConfig(), cfg.Values())
 	if reference == "" || resolved == "" || reference == resolved || (!sourceconfig.IsCredentialReference(reference) && !sourceconfig.IsSecretReference(reference)) {
 		return sourcecdk.Pull{}, false, fmt.Errorf("%w: Rust source execution requires an opaque credential reference", ErrInvalidRequest)
 	}

--- a/internal/sourceruntime/source_execution.go
+++ b/internal/sourceruntime/source_execution.go
@@ -13,16 +13,16 @@ import (
 )
 
 func (s *Service) validateRustSourceRuntimePlan(ctx context.Context, runtime *cerebrov1.SourceRuntime, config map[string]string) error {
-	familyID, authoritative := sourceworker.TailscaleFamily(runtime.GetSourceId(), config["family"])
+	familyID, authoritative := sourceworker.RustAuthoritativeFamily(runtime.GetSourceId(), config["family"])
 	if !authoritative {
 		return nil
 	}
 	if s == nil || s.sourceWorker == nil {
-		return fmt.Errorf("%w: the closed Rust worker is required for Tailscale", ErrRuntimeUnavailable)
+		return fmt.Errorf("%w: the closed Rust worker is required for %s.%s", ErrRuntimeUnavailable, runtime.GetSourceId(), familyID)
 	}
 	plan, err := s.sourceWorker.Compile(ctx, sourceworker.SelectionRequest{SourceID: runtime.GetSourceId(), FamilyID: familyID})
 	if err != nil {
-		return fmt.Errorf("%w: compile Tailscale source plan: %w", ErrInvalidRequest, err)
+		return fmt.Errorf("%w: compile Rust source plan: %w", ErrInvalidRequest, err)
 	}
 	now := time.Now().UTC()
 	executionContext, err := s.sourceWorker.Context(ctx, sourceworker.ContextRequest{
@@ -31,28 +31,28 @@ func (s *Service) validateRustSourceRuntimePlan(ctx context.Context, runtime *ce
 		ObservedAtUnixMillis: now.UnixMilli(), PublicConfig: sourceworker.PublicExecutionConfig(config),
 	})
 	if err != nil {
-		return fmt.Errorf("%w: validate Tailscale execution context: %w", ErrInvalidRequest, err)
+		return fmt.Errorf("%w: validate Rust execution context: %w", ErrInvalidRequest, err)
 	}
 	_, err = s.sourceWorker.PlanV2(ctx, &cerebrov1.SourceWorkerPlanEnvelopeV2{
 		Request:  &cerebrov1.SourceWorkerPlanRequestV1{Plan: plan, Context: executionContext},
 		Metadata: &cerebrov1.SourceWorkerRuntimeMetadataV2{PublicConfig: sourceworker.PublicExecutionConfig(config)},
 	})
 	if err != nil {
-		return fmt.Errorf("%w: validate Tailscale source plan: %w", ErrInvalidRequest, err)
+		return fmt.Errorf("%w: validate Rust source plan: %w", ErrInvalidRequest, err)
 	}
 	return nil
 }
 
 func (s *Service) readSourcePull(ctx context.Context, runtime *cerebrov1.SourceRuntime, source sourcecdk.Source, cfg sourcecdk.Config, cursor *cerebrov1.SourceCursor, checkpoint *cerebrov1.SourceCheckpoint, pageNumber uint32) (sourcecdk.Pull, bool, error) {
 	familyID, _ := cfg.Lookup("family")
-	normalizedFamilyID, authoritative := sourceworker.TailscaleFamily(runtime.GetSourceId(), familyID)
+	normalizedFamilyID, authoritative := sourceworker.RustAuthoritativeFamily(runtime.GetSourceId(), familyID)
 	if !authoritative {
 		pull, err := readCompatibilitySourcePull(ctx, source, cfg, cursor, checkpoint)
 		return pull, false, err
 	}
 	familyID = normalizedFamilyID
 	if s == nil || s.sourceWorker == nil {
-		return sourcecdk.Pull{}, false, fmt.Errorf("%w: the closed Rust worker is required for Tailscale", ErrRuntimeUnavailable)
+		return sourcecdk.Pull{}, false, fmt.Errorf("%w: the closed Rust worker is required for %s.%s", ErrRuntimeUnavailable, runtime.GetSourceId(), familyID)
 	}
 	fence, ok := sourceRuntimeLeaseFenceFromContext(ctx)
 	if !ok || !fence.ExpiresAt.After(time.Now().UTC()) {

--- a/internal/sourceruntime/source_execution_authority_test.go
+++ b/internal/sourceruntime/source_execution_authority_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestPutTailscaleRuntimeValidatesWithRustWithoutCallingGoCheck(t *testing.T) {
-	legacy := &runtimeTailscaleProbe{}
+	legacy := &runtimeAuthorityProbe{sourceID: "tailscale"}
 	registry, err := sourcecdk.NewRegistry(legacy)
 	if err != nil {
 		t.Fatal(err)
@@ -38,7 +38,7 @@ func TestPutTailscaleRuntimeValidatesWithRustWithoutCallingGoCheck(t *testing.T)
 }
 
 func TestTailscaleRuntimeFailsClosedWithoutRustWorker(t *testing.T) {
-	legacy := &runtimeTailscaleProbe{}
+	legacy := &runtimeAuthorityProbe{sourceID: "tailscale"}
 	registry, err := sourcecdk.NewRegistry(legacy)
 	if err != nil {
 		t.Fatal(err)
@@ -54,7 +54,7 @@ func TestTailscaleRuntimeFailsClosedWithoutRustWorker(t *testing.T) {
 }
 
 func TestUnknownTailscaleFamilyNeverFallsBackToGoAuthority(t *testing.T) {
-	legacy := &runtimeTailscaleProbe{}
+	legacy := &runtimeAuthorityProbe{sourceID: "tailscale"}
 	registry, err := sourcecdk.NewRegistry(legacy)
 	if err != nil {
 		t.Fatal(err)
@@ -88,7 +88,7 @@ func TestUnknownTailscaleFamilyNeverFallsBackToGoAuthority(t *testing.T) {
 }
 
 func TestNonTailscaleRuntimeUsesGoCompatibilityBeforeRustCredentialChecks(t *testing.T) {
-	legacy := &runtimeTailscaleProbe{}
+	legacy := &runtimeAuthorityProbe{sourceID: "gcp"}
 	service := &Service{sourceWorker: &runtimePlanWorker{}}
 	runtime := &cerebrov1.SourceRuntime{Id: "gcp-runtime", SourceId: "gcp", TenantId: "tenant-1"}
 
@@ -102,19 +102,83 @@ func TestNonTailscaleRuntimeUsesGoCompatibilityBeforeRustCredentialChecks(t *tes
 	}
 }
 
-type runtimeTailscaleProbe struct{ checkCalls, readCalls int }
-
-func (*runtimeTailscaleProbe) Spec() *cerebrov1.SourceSpec {
-	return &cerebrov1.SourceSpec{Id: "tailscale"}
+func TestAzureAuthorizationPolicyValidatesWithRustWithoutCallingGoCheck(t *testing.T) {
+	legacy := &runtimeAuthorityProbe{sourceID: "azure"}
+	registry, err := sourcecdk.NewRegistry(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker := &runtimePlanWorker{}
+	service := New(registry, &runtimeStore{}, nil, nil)
+	service.sourceWorker = worker
+	_, err = service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{Runtime: &cerebrov1.SourceRuntime{
+		Id: "azure-authorization-policy-runtime", SourceId: "azure", TenantId: "tenant-1",
+		Config: map[string]string{"family": "authorization_policy", "graph_token": sourceconfig.CredentialReferenceValue("azure", "graph_token")},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy.checkCalls != 0 || worker.planCalls != 1 {
+		t.Fatalf("validation calls = Go %d, Rust %d", legacy.checkCalls, worker.planCalls)
+	}
+	if worker.selection.SourceID != "azure" || worker.selection.FamilyID != "authorization_policy" {
+		t.Fatalf("Rust selection = %#v", worker.selection)
+	}
 }
-func (s *runtimeTailscaleProbe) Check(context.Context, sourcecdk.Config) error {
+
+func TestAzureAuthorizationPolicyNeverFallsBackToGoAuthority(t *testing.T) {
+	legacy := &runtimeAuthorityProbe{sourceID: "azure"}
+	worker := &runtimePlanWorker{compileErr: sourceworker.ErrWorkerUnsupported}
+	service := &Service{sourceWorker: worker}
+	runtime := &cerebrov1.SourceRuntime{
+		Id: "azure-authorization-policy-runtime", SourceId: "azure", TenantId: "tenant-1",
+		Config: map[string]string{"family": "authorization_policy", "graph_token": sourceconfig.CredentialReferenceValue("azure", "graph_token")},
+	}
+	ctx := context.WithValue(context.Background(), sourceRuntimeLeaseFenceContextKey{}, sourceRuntimeLeaseAuthority{fence: ports.SourceRuntimeLeaseFence{
+		Owner: "owner-1", Generation: 1, ExpiresAt: time.Now().Add(time.Minute),
+	}})
+	resolved := sourcecdk.NewConfig(map[string]string{"family": "authorization_policy", "graph_token": "host-only-secret"})
+
+	if _, _, err := service.readSourcePull(ctx, runtime, legacy, resolved, nil, nil, 1); !errors.Is(err, sourceworker.ErrWorkerUnsupported) {
+		t.Fatalf("readSourcePull() error = %v", err)
+	}
+	if legacy.readCalls != 0 || worker.selection.SourceID != "azure" || worker.selection.FamilyID != "authorization_policy" {
+		t.Fatalf("authority calls = Go %d, Rust selection %#v", legacy.readCalls, worker.selection)
+	}
+}
+
+func TestOtherAzureFamilyRemainsGoCompatible(t *testing.T) {
+	legacy := &runtimeAuthorityProbe{sourceID: "azure"}
+	service := &Service{sourceWorker: &runtimePlanWorker{}}
+	runtime := &cerebrov1.SourceRuntime{Id: "azure-user-runtime", SourceId: "azure", TenantId: "tenant-1"}
+	config := sourcecdk.NewConfig(map[string]string{"family": "user"})
+
+	if _, rustPage, err := service.readSourcePull(context.Background(), runtime, legacy, config, nil, nil, 1); err != nil {
+		t.Fatalf("readSourcePull() error = %v", err)
+	} else if rustPage {
+		t.Fatal("readSourcePull() reported a Rust page for a Go-authoritative Azure family")
+	}
+	if legacy.readCalls != 1 {
+		t.Fatalf("Go Read calls = %d, want 1", legacy.readCalls)
+	}
+}
+
+type runtimeAuthorityProbe struct {
+	sourceID              string
+	checkCalls, readCalls int
+}
+
+func (s *runtimeAuthorityProbe) Spec() *cerebrov1.SourceSpec {
+	return &cerebrov1.SourceSpec{Id: s.sourceID}
+}
+func (s *runtimeAuthorityProbe) Check(context.Context, sourcecdk.Config) error {
 	s.checkCalls++
 	return nil
 }
-func (*runtimeTailscaleProbe) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
+func (*runtimeAuthorityProbe) Discover(context.Context, sourcecdk.Config) ([]sourcecdk.URN, error) {
 	return nil, nil
 }
-func (s *runtimeTailscaleProbe) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+func (s *runtimeAuthorityProbe) Read(context.Context, sourcecdk.Config, *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
 	s.readCalls++
 	return sourcecdk.Pull{}, nil
 }
@@ -123,9 +187,11 @@ type runtimePlanWorker struct {
 	planCalls    int
 	publicConfig map[string]string
 	compileErr   error
+	selection    sourceworker.SelectionRequest
 }
 
 func (w *runtimePlanWorker) Compile(_ context.Context, request sourceworker.SelectionRequest) (*cerebrov1.SourceExecutionPlanV1, error) {
+	w.selection = request
 	if w.compileErr != nil {
 		return nil, w.compileErr
 	}

--- a/internal/sourceruntime/source_execution_authority_test.go
+++ b/internal/sourceruntime/source_execution_authority_test.go
@@ -163,6 +163,64 @@ func TestOtherAzureFamilyRemainsGoCompatible(t *testing.T) {
 	}
 }
 
+func TestPutJumpCloudFamiliesValidateWithRustWithoutCallingGoCheck(t *testing.T) {
+	families := []string{"users", "groups", "systems", "applications", "system_groups", "group_members", "audit_events"}
+	for _, family := range families {
+		t.Run(family, func(t *testing.T) {
+			legacy := &runtimeAuthorityProbe{sourceID: "jumpcloud"}
+			registry, err := sourcecdk.NewRegistry(legacy)
+			if err != nil {
+				t.Fatal(err)
+			}
+			worker := &runtimePlanWorker{}
+			service := New(registry, &runtimeStore{}, nil, nil)
+			service.sourceWorker = worker
+			config := map[string]string{
+				"family": family, "api_key": sourceconfig.CredentialReferenceValue("jumpcloud", "api_key"),
+			}
+			if family == "group_members" {
+				config["group_ids"] = "group-1,group-2"
+			}
+			_, err = service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{Runtime: &cerebrov1.SourceRuntime{
+				Id: "jumpcloud-" + family + "-runtime", SourceId: "jumpcloud", TenantId: "tenant-1", Config: config,
+			}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if legacy.checkCalls != 0 || worker.planCalls != 1 {
+				t.Fatalf("validation calls = Go %d, Rust %d", legacy.checkCalls, worker.planCalls)
+			}
+			if worker.selection.SourceID != "jumpcloud" || worker.selection.FamilyID != family {
+				t.Fatalf("Rust selection = %#v", worker.selection)
+			}
+			if worker.publicConfig["api_key"] != "" || worker.publicConfig["family"] != family {
+				t.Fatalf("Rust public config = %#v", worker.publicConfig)
+			}
+		})
+	}
+}
+
+func TestUnknownJumpCloudFamilyNeverFallsBackToGoAuthority(t *testing.T) {
+	legacy := &runtimeAuthorityProbe{sourceID: "jumpcloud"}
+	worker := &runtimePlanWorker{compileErr: sourceworker.ErrWorkerUnsupported}
+	service := &Service{sourceWorker: worker}
+	runtime := &cerebrov1.SourceRuntime{
+		Id: "jumpcloud-future-runtime", SourceId: "jumpcloud", TenantId: "tenant-1",
+		Config: map[string]string{"family": "future-family", "api_key": sourceconfig.CredentialReferenceValue("jumpcloud", "api_key")},
+	}
+	ctx := context.WithValue(context.Background(), sourceRuntimeLeaseFenceContextKey{}, sourceRuntimeLeaseAuthority{fence: ports.SourceRuntimeLeaseFence{
+		Owner: "owner-1", Generation: 1, ExpiresAt: time.Now().Add(time.Minute),
+	}})
+	resolved := sourcecdk.NewConfig(map[string]string{"family": "future-family", "api_key": "host-only-value"})
+
+	if _, _, err := service.readSourcePull(ctx, runtime, legacy, resolved, nil, nil, 1); !errors.Is(err, sourceworker.ErrWorkerUnsupported) {
+		t.Fatalf("readSourcePull() error = %v", err)
+	}
+	if legacy.readCalls != 0 || worker.selection.SourceID != "jumpcloud" || worker.selection.FamilyID != "future-family" {
+		t.Fatalf("authority calls = Go %d, Rust selection %#v", legacy.readCalls, worker.selection)
+	}
+}
+
 type runtimeAuthorityProbe struct {
 	sourceID              string
 	checkCalls, readCalls int

--- a/internal/sourceruntime/sourceworker/pull.go
+++ b/internal/sourceruntime/sourceworker/pull.go
@@ -13,6 +13,23 @@ import (
 
 const rustCheckpointCursorMode = "rust_provider_checkpoint"
 
+// RustAuthoritativeFamily returns the normalized family only when the closed
+// Rust dispatcher owns production execution for that exact source-family
+// pair. Keep this allowlist narrower than the dispatcher's compiled adapters:
+// an adapter contract alone is not an authority decision.
+func RustAuthoritativeFamily(sourceID, familyID string) (string, bool) {
+	sourceID = strings.TrimSpace(sourceID)
+	familyID = strings.TrimSpace(familyID)
+	switch sourceID {
+	case "azure":
+		return familyID, familyID == "authorization_policy"
+	case "tailscale":
+		return TailscaleFamily(sourceID, familyID)
+	default:
+		return "", false
+	}
+}
+
 // TailscaleFamily normalizes the requested Tailscale family, including the
 // public default used when family is omitted. The closed Rust dispatcher owns
 // family membership validation; Go must not restore legacy authority for an
@@ -99,7 +116,7 @@ func PullFromExecutionOutput(output *ExecutionOutput, tenantID string) (sourcecd
 	}
 	checkpointCursor := output.Result.GetResultDigestSha256()
 	nextCursor := strings.TrimSpace(output.Result.GetNextCursor())
-	if _, tailscale := TailscaleFamily(output.Plan.GetSourceId(), output.Plan.GetFamilyId()); tailscale {
+	if _, authoritative := RustAuthoritativeFamily(output.Plan.GetSourceId(), output.Plan.GetFamilyId()); authoritative {
 		envelope := sourcecdk.CursorEnvelope{
 			Version: 1, Source: output.Plan.GetSourceId(), Family: output.Plan.GetFamilyId(),
 			Mode: rustCheckpointCursorMode, ResumableCheckpoint: true, Token: nextCursor,

--- a/internal/sourceruntime/sourceworker/pull.go
+++ b/internal/sourceruntime/sourceworker/pull.go
@@ -23,11 +23,35 @@ func RustAuthoritativeFamily(sourceID, familyID string) (string, bool) {
 	switch sourceID {
 	case "azure":
 		return familyID, familyID == "authorization_policy"
+	case "jumpcloud":
+		if familyID == "" {
+			familyID = "users"
+		}
+		// Every public JumpCloud family is closed in the Rust dispatcher. An
+		// unknown future family must fail there instead of restoring Go authority.
+		return familyID, true
 	case "tailscale":
 		return TailscaleFamily(sourceID, familyID)
 	default:
 		return "", false
 	}
+}
+
+// CredentialBinding selects the provider's ordered credential aliases from
+// stored references and trusted-host resolved values. It returns strings only
+// to the Go host; callers must never include the resolved value in worker
+// metadata, receipts, or errors.
+func CredentialBinding(sourceID string, references, resolved map[string]string) (string, string) {
+	keys := []string{"graph_token", "token"}
+	if strings.TrimSpace(sourceID) == "jumpcloud" {
+		keys = []string{"api_key", "api_token", "token"}
+	}
+	for _, key := range keys {
+		if reference := strings.TrimSpace(references[key]); reference != "" {
+			return reference, strings.TrimSpace(resolved[key])
+		}
+	}
+	return "", ""
 }
 
 // TailscaleFamily normalizes the requested Tailscale family, including the

--- a/internal/sourceruntime/sourceworker/pull_test.go
+++ b/internal/sourceruntime/sourceworker/pull_test.go
@@ -85,6 +85,9 @@ func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
 	}{
 		"Azure authorization policy": {" azure ", " authorization_policy ", "authorization_policy", true},
 		"other Azure family":         {"azure", "user", "user", false},
+		"JumpCloud default":          {"jumpcloud", "", "users", true},
+		"JumpCloud family":           {"jumpcloud", "group_members", "group_members", true},
+		"unknown JumpCloud family":   {"jumpcloud", "future-family", "future-family", true},
 		"Tailscale default":          {"tailscale", "", "device", true},
 		"unknown Tailscale family":   {"tailscale", "future-family", "future-family", true},
 		"compatibility source":       {"gcp", "audit", "", false},
@@ -93,6 +96,36 @@ func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
 			family, authoritative := RustAuthoritativeFamily(test.source, test.family)
 			if family != test.wantFamily || authoritative != test.wantAuthoritative {
 				t.Fatalf("RustAuthoritativeFamily() = (%q, %v), want (%q, %v)", family, authoritative, test.wantFamily, test.wantAuthoritative)
+			}
+		})
+	}
+}
+
+func TestCredentialBindingUsesOnlyTheSelectedProviderAliases(t *testing.T) {
+	for name, test := range map[string]struct {
+		source                      string
+		references, resolved        map[string]string
+		wantReference, wantResolved string
+	}{
+		"Azure graph token": {
+			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.
+			source: "azure", references: map[string]string{"graph_token": "credential:azure:graph", "token": "credential:azure:fallback"},
+			resolved: map[string]string{"graph_token": "resolved-graph", "token": "resolved-fallback"}, wantReference: "credential:azure:graph", wantResolved: "resolved-graph",
+		},
+		"JumpCloud api key": {
+			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.
+			source: "jumpcloud", references: map[string]string{"api_key": "credential:jumpcloud:api-key", "token": "credential:jumpcloud:fallback"},
+			resolved: map[string]string{"api_key": "resolved-api-key", "token": "resolved-fallback"}, wantReference: "credential:jumpcloud:api-key", wantResolved: "resolved-api-key",
+		},
+		"aliases cannot cross": {
+			source: "jumpcloud", references: map[string]string{"api_key": "credential:jumpcloud:api-key"},
+			resolved: map[string]string{"token": "resolved-different-alias"}, wantReference: "credential:jumpcloud:api-key", wantResolved: "",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			reference, resolved := CredentialBinding(test.source, test.references, test.resolved)
+			if reference != test.wantReference || resolved != test.wantResolved {
+				t.Fatalf("CredentialBinding() = (%q, %q), want (%q, %q)", reference, resolved, test.wantReference, test.wantResolved)
 			}
 		})
 	}

--- a/internal/sourceruntime/sourceworker/pull_test.go
+++ b/internal/sourceruntime/sourceworker/pull_test.go
@@ -78,6 +78,45 @@ func TestPublicExecutionConfigNeverCarriesCredentialMaterial(t *testing.T) {
 	}
 }
 
+func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
+	for name, test := range map[string]struct {
+		source, family, wantFamily string
+		wantAuthoritative          bool
+	}{
+		"Azure authorization policy": {" azure ", " authorization_policy ", "authorization_policy", true},
+		"other Azure family":         {"azure", "user", "user", false},
+		"Tailscale default":          {"tailscale", "", "device", true},
+		"unknown Tailscale family":   {"tailscale", "future-family", "future-family", true},
+		"compatibility source":       {"gcp", "audit", "", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			family, authoritative := RustAuthoritativeFamily(test.source, test.family)
+			if family != test.wantFamily || authoritative != test.wantAuthoritative {
+				t.Fatalf("RustAuthoritativeFamily() = (%q, %v), want (%q, %v)", family, authoritative, test.wantFamily, test.wantAuthoritative)
+			}
+		})
+	}
+}
+
+func TestAzureAuthorizationPolicyPersistsARestartableRustCheckpoint(t *testing.T) {
+	output := tailscaleOutput("", "authorizationPolicy", 1_725_000_000_000)
+	output.Plan.SourceId = "azure"
+	output.Plan.FamilyId = "authorization_policy"
+	pull, err := PullFromExecutionOutput(output, "tenant-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	providerCursor, watermark, err := ProviderResume(
+		&cerebrov1.SourceCursor{Opaque: pull.Checkpoint.GetCursorOpaque()}, "azure", "authorization_policy",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if providerCursor != "" || watermark != 1_725_000_000_000 {
+		t.Fatalf("restart = (%q, %d), want no provider cursor and terminal watermark", providerCursor, watermark)
+	}
+}
+
 func tailscaleOutput(nextCursor, checkpointCursor string, watermark int64) *ExecutionOutput {
 	plan := &cerebrov1.SourceExecutionPlanV1{SourceId: "tailscale", FamilyId: "user", EventKind: "tailscale.user", SchemaRef: "tailscale/user/v1"}
 	record := &cerebrov1.SourceWorkerRecordV1{


### PR DESCRIPTION
## Summary

- define one closed production authority allowlist separate from the larger compiled-adapter registry
- route `azure.authorization_policy` plus all seven public JumpCloud families through the credential-free Rust worker
- keep credentials in the trusted Go host: Azure uses the Graph token binding; JumpCloud uses `api_key`, `api_token`, or `token` with exact-alias resolution
- persist Rust-authored restart checkpoints and fail closed when an authoritative worker, adapter, family, or credential binding is unavailable
- keep every other Azure family and non-promoted provider on Go compatibility

## JumpCloud families

- `users`
- `groups`
- `systems`
- `applications`
- `system_groups`
- `group_members`
- `audit_events`

## Validation

- `go test ./internal/sourceruntime/sourceworker ./internal/sourceruntime`
- `make test`
- `go test -race ./internal/sourceruntime/...`
- `make rust-fmt-check rust-clippy rust-test`
- `make lint-internal`
- `make catalog-check connector-contract-check docs-drift-check check-structural check-structural-test check-arch`

JumpCloud authority validation also passed focused runtime tests, the full source-runtime race suite, source-runtime lint with zero issues, and architecture tests.

`make proto-generate-check` was not completed locally because the managed Cargo cache lacked capacity to install the pinned generator. The hosted proto check is the exact-head receipt; this change does not modify protobuf or generated files.