### PR TITLE
Make compliance work easier to navigate

### DIFF
--- a/apps/web/scripts/grc-route-contract.mjs
+++ b/apps/web/scripts/grc-route-contract.mjs
@@ -12,6 +12,6 @@ export function grcBrowserRouteContracts({ adminURN }) {
     { route: "/connectors", pageId: "connectors", heading: "Integrations" },
     { route: `/impact?root_urn=${encodeURIComponent(adminURN)}`, pageId: "impact-map", heading: "Affected assets" },
     { route: "/reports", pageId: "reports", heading: "Reports" },
-    { route: "/reports/audit-packages", pageId: "audit-packages", heading: "Audit packets" },
+    { route: "/reports/audit-packages", pageId: "audit-packages", heading: "Audit workspace" },
   ];
 }

--- a/apps/web/src/app/evidence/page.tsx
+++ b/apps/web/src/app/evidence/page.tsx
@@ -28,12 +28,12 @@ type EvidenceStat = {
 type EvidenceSection = "register" | "package";
 
 const evidenceSections: Array<{ id: EvidenceSection; label: string }> = [
-  { id: "register", label: "Evidence register" },
-  { id: "package", label: "Package workflow" },
+  { id: "package", label: "Evidence work" },
+  { id: "register", label: "Raw evidence" },
 ];
 
 const evidenceSectionFromParam = (value: string): EvidenceSection =>
-  evidenceSections.some((section) => section.id === value) ? value as EvidenceSection : "register";
+  evidenceSections.some((section) => section.id === value) ? value as EvidenceSection : "package";
 
 const inputClass = "mt-1 w-full rounded-md border border-[color:var(--border)] bg-[var(--surface)] px-3 py-1.5 text-[13px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[color:var(--ring)] focus:outline-none focus:ring-1 focus:ring-[color:var(--ring)]";
 const labelClass = "text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]";
@@ -71,7 +71,7 @@ export default function EvidencePage() {
   const activeSection = evidenceSectionFromParam(sectionParam);
   const shouldLoadPackaged = activeSection === "package";
   const setActiveSection = useCallback((section: EvidenceSection) => {
-    setSectionParam(section === "register" ? "" : section);
+    setSectionParam(section === "package" ? "" : section);
   }, [setSectionParam]);
   const path = useMemo(
     () => grcPath("/grc/evidence", {
@@ -229,17 +229,8 @@ export default function EvidencePage() {
   const workflowStats: EvidenceStat[] = [
     { label: "Program", value: evidencePacketReadinessLabel(packagedData?.program?.status), detail: `${packagedData?.program?.readiness_score ?? 0}% readiness`, state: packagedMetricState },
     { label: "Requests", value: packagedMetrics.requests, detail: `${packagedMetrics.missingRequests} missing, ${packagedMetrics.staleRequests} stale`, state: packagedMetricState },
-    { label: "Packets", value: packagedMetrics.packets, detail: `${packagedMetrics.readyPackets} ready`, state: packagedMetricState },
     { label: "Reviews", value: packagedMetrics.openReviews, detail: "open review records", intent: packagedMetrics.openReviews > 0 ? "warning" : "success", state: packagedMetricState },
-    { label: "Answers", value: packagedMetrics.questionnaireAnswers, detail: "questionnaire records", state: packagedMetricState },
     { label: "Sources", value: packagedMetrics.sources, detail: `${packagedMetrics.collectedSources} collected`, state: packagedMetricState },
-    { label: "Evidence items", value: packagedMetrics.evidenceItems, detail: "raw proof records", state: packagedMetricState },
-    { label: "Lineage", value: packagedMetrics.lineage, detail: `${packagedMetrics.linkedLineage} fully linked`, state: packagedMetricState },
-    { label: "Resources", value: packagedMetrics.resources, detail: "graph subjects", state: packagedMetricState },
-    { label: "Claims", value: packagedMetrics.claims, detail: "assertion records", state: packagedMetricState },
-    { label: "Runs", value: packagedMetrics.runs, detail: "evaluation runs", state: packagedMetricState },
-    { label: "Graph paths", value: packagedMetrics.graphPaths, detail: "relationship records", state: packagedMetricState },
-    { label: "Exports", value: packagedData?.export_artifacts?.length ?? 0, detail: "hashed artifacts", state: packagedMetricState },
   ];
   const activeFilterCount = Object.values(filterState.trimmedValues).filter(Boolean).length;
   const scopeLabel = activeFilterCount === 0
@@ -247,7 +238,7 @@ export default function EvidencePage() {
     : `${activeFilterCount} active ${activeFilterCount === 1 ? "filter" : "filters"}`;
   const scopeDescription = shouldLoadPackaged
     ? "Filter package requests, control posture, collection sources, evidence, and lineage by tenant or graph context."
-    : "Narrow the register by tenant, finding, run, rule, or graph root.";
+    : "Narrow the register by tenant, finding, run, rule, or affected asset.";
   const refreshCurrentView = () => {
     void reload();
     if (shouldLoadPackaged) void reloadPackaged();
@@ -258,7 +249,7 @@ export default function EvidencePage() {
       <PageHeader
         contractId="evidence"
         title="Evidence"
-        description={shouldLoadPackaged ? "Package requests, review state, exports, lineage, and evidence completeness." : "Evidence linked to findings, rules, runs, claims, events, and graph roots."}
+        description={shouldLoadPackaged ? "Collect, review, and approve the proof required by your controls." : "Inspect raw proof linked to findings, runs, rules, and affected assets."}
         action={
           <button type="button" onClick={refreshCurrentView} className="inline-flex items-center gap-1.5 rounded-md border border-[color:var(--primary)] bg-[var(--primary)] px-3 py-1.5 text-[13px] font-medium text-white transition hover:bg-[var(--primary-hover)]">
             <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
@@ -267,7 +258,15 @@ export default function EvidencePage() {
         }
       />
 
-      <section className="overflow-hidden rounded-lg border border-[color:var(--border)] bg-[var(--surface)]">
+      <EvidenceSectionSwitcher
+        activeSection={activeSection}
+        evidenceCount={evidence.length}
+        onChange={setActiveSection}
+        packageCount={packagedMetrics.requests}
+        packageLoaded={Boolean(packagedData)}
+      />
+
+      {activeSection === "register" ? <section className="overflow-hidden rounded-lg border border-[color:var(--border)] bg-[var(--surface)]">
         <div className="grid xl:grid-cols-[minmax(0,1fr)_320px]">
           <div className="space-y-4 p-5">
             <div className="flex flex-wrap items-start justify-between gap-4">
@@ -292,7 +291,7 @@ export default function EvidencePage() {
               <label className={labelClass}>Finding<input value={findingID} onChange={(e) => setFindingID(e.target.value)} placeholder="All" className={inputClass} /></label>
               <label className={labelClass}>Run<input value={runID} onChange={(e) => setRunID(e.target.value)} placeholder="All" className={inputClass} /></label>
               <label className={labelClass}>Rule<input value={ruleID} onChange={(e) => setRuleID(e.target.value)} placeholder="All" className={inputClass} /></label>
-              <label className={labelClass}>Graph Root<input value={graphRoot} onChange={(e) => setGraphRoot(e.target.value)} placeholder="urn:cerebro:..." className={inputClass} /></label>
+              <label className={labelClass}>Affected asset<input value={graphRoot} onChange={(e) => setGraphRoot(e.target.value)} placeholder="Asset ID or URN" className={inputClass} /></label>
             </div>
             <AppliedFilterChips filters={filterState.chips} onClearAll={filterState.clearAll} />
           </div>
@@ -311,15 +310,15 @@ export default function EvidencePage() {
             />
           </div>
         </div>
-      </section>
-
-      <EvidenceSectionSwitcher
-        activeSection={activeSection}
-        evidenceCount={evidence.length}
-        onChange={setActiveSection}
-        packageCount={packagedMetrics.requests}
-        packageLoaded={Boolean(packagedData)}
-      />
+      </section> : (
+        <section className="flex flex-wrap items-end justify-between gap-4 rounded-lg border border-[color:var(--border)] bg-[var(--surface)] px-5 py-4">
+          <label className={`${labelClass} w-full max-w-xs`}>Tenant<input value={tenantID} onChange={(event) => setTenantID(event.target.value)} placeholder="All tenants" className={inputClass} /></label>
+          <div className="text-[12px] text-[var(--text-muted)]">
+            {packagedData?.generated_at ? <>Evidence work updated <span className="font-medium text-[var(--text-secondary)]">{displayDate(packagedData.generated_at)}</span></> : "Evidence work is loading."}
+          </div>
+          <AppliedFilterChips filters={filterState.chips.filter((filter) => filter.label === "Tenant")} onClearAll={() => setTenantID("")} />
+        </section>
+      )}
 
       {activeSection === "register" && (
         <EvidenceMetricStrip blockedLabel="Evidence totals did not load." stats={evidenceStats} pendingLabel="Loading evidence totals..." />
@@ -331,10 +330,10 @@ export default function EvidencePage() {
             <div>
               <div className="flex items-center gap-2">
                 <PackageCheck className="h-4 w-4 text-[var(--text-muted)]" aria-hidden="true" />
-                <h2 className="text-[15px] font-semibold text-[var(--text-primary)]">Package workflow</h2>
+                <h2 className="text-[15px] font-semibold text-[var(--text-primary)]">Evidence work</h2>
               </div>
               <p className="mt-1 text-[13px] text-[var(--text-muted)]">
-                Request, packet, review, export, and lineage records assembled from the evidence register.
+                Proof requests and reviews that block control readiness or packet export.
               </p>
             </div>
             <button type="button" onClick={() => void reloadPackaged()} className="inline-flex items-center gap-1.5 rounded-md border border-[color:var(--border)] px-3 py-1.5 text-[13px] font-medium text-[var(--text-secondary)] transition hover:border-[color:var(--ring)] hover:text-[var(--primary)]">
@@ -353,7 +352,8 @@ export default function EvidencePage() {
           />
           {packagedError && <p className="text-[13px] text-[var(--text-muted)]">{packagedData ? "Showing the last loaded packaged evidence records; refresh will update when the endpoint is reachable." : "Packaged evidence records will appear when this endpoint is available."}</p>}
           {packagedData && (
-            <div className="grid gap-4 xl:grid-cols-2">
+            <div className="space-y-4">
+              <div className="grid gap-4 xl:grid-cols-2">
               <WorklistTable
                 title="Evidence requests"
                 description="Requested proof units with quality, freshness, and review posture."
@@ -365,20 +365,6 @@ export default function EvidencePage() {
                 pageSize={25}
                 resultLimit={GRC_WORKLIST_LIMIT}
                 resultNoun="requests"
-                getRowKey={(item) => item.id}
-                refreshing={packagedLoading}
-              />
-              <WorklistTable
-                title="Questionnaire answers"
-                description="Answer records linked to packets, controls, citations, and evidence gaps."
-                rows={packagedData.questionnaire_answers ?? []}
-                columns={questionnaireAnswerColumns}
-                emptyMessage="No questionnaire answer records are available."
-                searchPlaceholder="Filter loaded answers"
-                filterKeys={["id", "question_id", "question", "answer", "answer_state", "review_state"]}
-                pageSize={25}
-                resultLimit={GRC_WORKLIST_LIMIT}
-                resultNoun="answers"
                 getRowKey={(item) => item.id}
                 refreshing={packagedLoading}
               />
@@ -396,48 +382,71 @@ export default function EvidencePage() {
                 getRowKey={(item) => item.id}
                 refreshing={packagedLoading}
               />
-              <WorklistTable
-                title="Collection sources"
-                description="Runtime collection status, sync freshness, and evidence coverage."
-                rows={packagedData.collection_sources ?? []}
-                columns={sourceColumns}
-                emptyMessage="No collection source records are available."
-                searchPlaceholder="Filter loaded sources"
-                filterKeys={["id", "runtime_id", "source_id", "tenant_id", "status"]}
-                pageSize={25}
-                resultLimit={GRC_WORKLIST_LIMIT}
-                resultNoun="sources"
-                getRowKey={(item) => item.id}
-                refreshing={packagedLoading}
-              />
-              <WorklistTable
-                title="Evidence items"
-                description="Raw proof records linked to findings, requests, packets, and graph anchors."
-                rows={packagedData.evidence_items ?? []}
-                columns={itemColumns}
-                emptyMessage="No evidence item records are available."
-                searchPlaceholder="Filter loaded evidence items"
-                filterKeys={["id", "finding_id", "rule_id", "run_id", "source_id", "runtime_id", "graph_root_urns"]}
-                pageSize={25}
-                resultLimit={GRC_WORKLIST_LIMIT}
-                resultNoun="evidence items"
-                getRowKey={(item) => item.id}
-                refreshing={packagedLoading}
-              />
-              <WorklistTable
-                title="Evidence lineage"
-                description="End-to-end links from raw proof through packets, controls, claims, events, and graph roots."
-                rows={packagedData.evidence_lineage ?? []}
-                columns={lineageColumns}
-                emptyMessage="No evidence lineage records are available."
-                searchPlaceholder="Filter loaded lineage"
-                filterKeys={["id", "evidence_id", "finding_id", "rule_id", "source_id", "runtime_id", "graph_root_urns"]}
-                pageSize={25}
-                resultLimit={GRC_WORKLIST_LIMIT}
-                resultNoun="lineage records"
-                getRowKey={(item) => item.id}
-                refreshing={packagedLoading}
-              />
+              </div>
+              <details className="overflow-hidden rounded-lg border border-[color:var(--border)] bg-[var(--surface)]">
+                <summary className="cursor-pointer px-5 py-4 text-[13px] font-semibold text-[var(--text-primary)] hover:bg-[var(--surface-muted)]">
+                  Supporting records
+                  <span className="ml-2 font-normal text-[var(--text-muted)]">Questionnaire answers, collection sources, raw items, and lineage</span>
+                </summary>
+                <div className="grid gap-4 border-t border-[color:var(--border)] p-4 xl:grid-cols-2">
+                  <WorklistTable
+                    title="Questionnaire answers"
+                    description="Answer records linked to packets, controls, citations, and evidence gaps."
+                    rows={packagedData.questionnaire_answers ?? []}
+                    columns={questionnaireAnswerColumns}
+                    emptyMessage="No questionnaire answer records are available."
+                    searchPlaceholder="Filter loaded answers"
+                    filterKeys={["id", "question_id", "question", "answer", "answer_state", "review_state"]}
+                    pageSize={25}
+                    resultLimit={GRC_WORKLIST_LIMIT}
+                    resultNoun="answers"
+                    getRowKey={(item) => item.id}
+                    refreshing={packagedLoading}
+                  />
+                  <WorklistTable
+                    title="Collection sources"
+                    description="Runtime collection status, sync freshness, and evidence coverage."
+                    rows={packagedData.collection_sources ?? []}
+                    columns={sourceColumns}
+                    emptyMessage="No collection source records are available."
+                    searchPlaceholder="Filter loaded sources"
+                    filterKeys={["id", "runtime_id", "source_id", "tenant_id", "status"]}
+                    pageSize={25}
+                    resultLimit={GRC_WORKLIST_LIMIT}
+                    resultNoun="sources"
+                    getRowKey={(item) => item.id}
+                    refreshing={packagedLoading}
+                  />
+                  <WorklistTable
+                    title="Evidence items"
+                    description="Raw proof records linked to findings, requests, packets, and graph anchors."
+                    rows={packagedData.evidence_items ?? []}
+                    columns={itemColumns}
+                    emptyMessage="No evidence item records are available."
+                    searchPlaceholder="Filter loaded evidence items"
+                    filterKeys={["id", "finding_id", "rule_id", "run_id", "source_id", "runtime_id", "graph_root_urns"]}
+                    pageSize={25}
+                    resultLimit={GRC_WORKLIST_LIMIT}
+                    resultNoun="evidence items"
+                    getRowKey={(item) => item.id}
+                    refreshing={packagedLoading}
+                  />
+                  <WorklistTable
+                    title="Evidence lineage"
+                    description="End-to-end links from raw proof through packets, controls, claims, events, and graph roots."
+                    rows={packagedData.evidence_lineage ?? []}
+                    columns={lineageColumns}
+                    emptyMessage="No evidence lineage records are available."
+                    searchPlaceholder="Filter loaded lineage"
+                    filterKeys={["id", "evidence_id", "finding_id", "rule_id", "source_id", "runtime_id", "graph_root_urns"]}
+                    pageSize={25}
+                    resultLimit={GRC_WORKLIST_LIMIT}
+                    resultNoun="lineage records"
+                    getRowKey={(item) => item.id}
+                    refreshing={packagedLoading}
+                  />
+                </div>
+              </details>
             </div>
           )}
         </section>

--- a/apps/web/src/app/frameworks/[frameworkID]/page.tsx
+++ b/apps/web/src/app/frameworks/[frameworkID]/page.tsx
@@ -9,8 +9,9 @@ import { Badge, ErrorBlock, LoadingBlock, MetricCard, PageHeader, Panel, ResultL
 import TrendsChart from "@/components/grc/LazyTrendsChart";
 import { useApiKey } from "@/components/providers";
 import type { GRCControl, GRCControlEvidencePacketResponse, GRCFinding, GRCFramework, GRCFrameworksResponse, GRCListMeta, GRCTrends } from "@/lib/grc";
-import { displayDate, humanize, riskSort } from "@/lib/grc";
+import { displayDate, riskSort } from "@/lib/grc";
 import { downloadGRCExport, grcPath, useGRCQuery } from "@/lib/grc-client";
+import { deriveFrameworkReadiness, type FrameworkReadiness } from "@/lib/framework-readiness";
 import { frameworkMatchesRouteSegment, frameworkRouteSegment, isUpcomingGRCFramework, staticGRCFrameworkCatalog } from "@/lib/grc-frameworks";
 import { GRC_DETAIL_LIMIT, GRC_WORKLIST_LIMIT, grcBoundedRows } from "@/lib/grc-list";
 import { hasTrendActivity } from "@/lib/trends";
@@ -20,52 +21,40 @@ type FindingsResponse = { findings: GRCFinding[]; meta?: GRCListMeta; generated_
 const FRAMEWORK_CONTROL_LIMIT = GRC_WORKLIST_LIMIT;
 const FRAMEWORK_FINDING_LIMIT = GRC_DETAIL_LIMIT;
 
-const readinessTotal = (framework?: GRCFramework) =>
-  (framework?.readiness?.auditor_ready_controls ?? 0) +
-  (framework?.readiness?.needs_enrichment_controls ?? 0) +
-  (framework?.readiness?.placeholder_controls ?? 0);
-
 const countLabel = (count: number, singular: string, plural = `${singular}s`) =>
   `${count.toLocaleString()} ${count === 1 ? singular : plural}`;
 
 const frameworkNameFromSegment = (segment: string) =>
   decodeURIComponent(segment).replace(/-/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 
-const actionHref = (framework: GRCFramework, code: string) => {
-  const frameworkParam = encodeURIComponent(framework.name);
-  if (code === "plan_framework_scope") return `/controls/builder?framework_name=${frameworkParam}`;
-  if (code === "export_audit_packet") return "";
-  return `/controls?framework=${frameworkParam}`;
-};
+function GapActions({ framework, onExport, readiness, exportState }: { framework: GRCFramework; onExport: () => void; readiness: FrameworkReadiness; exportState: string }) {
+  if (readiness.needsWorkControls > 0) {
+    const reasons = [
+      readiness.failingControls > 0 ? countLabel(readiness.failingControls, "failing control") : "",
+      readiness.evidenceGapControls > 0 ? countLabel(readiness.evidenceGapControls, "control with evidence gaps", "controls with evidence gaps") : "",
+    ].filter(Boolean);
+    return (
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-[color:var(--border)] p-3">
+        <div>
+          <div className="text-[13px] font-semibold text-[var(--text-primary)]">Review {countLabel(readiness.needsWorkControls, "control")}</div>
+          <div className="mt-1 text-[12px] text-[var(--text-muted)]">{reasons.join(" and ") || "Resolve the remaining control checks before export."}</div>
+        </div>
+        <Link href={`/controls?framework=${encodeURIComponent(framework.name)}`} className="rounded-md bg-[var(--primary)] px-3 py-1.5 text-[12px] font-medium text-white transition hover:bg-[var(--primary-hover)]">
+          Open controls
+        </Link>
+      </div>
+    );
+  }
 
-function GapActions({ framework, onExport, exportState }: { framework: GRCFramework; onExport: () => void; exportState: string }) {
-  const actions = framework.gap_actions ?? [];
   return (
-    <div className="space-y-3">
-      {actions.map((action) => {
-        const href = actionHref(framework, action.code);
-        return (
-          <div key={action.code} className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-[color:var(--border)] p-3">
-            <div>
-              <div className="flex flex-wrap items-center gap-2">
-                <Badge value={action.code} />
-                <span className="text-[12px] text-[var(--text-muted)]">Priority {action.priority}</span>
-                {action.count ? <span className="text-[12px] text-[var(--text-muted)]">{countLabel(action.count, "control")}</span> : null}
-              </div>
-              <div className="mt-2 text-[13px] text-[var(--text-primary)]">{action.label}</div>
-            </div>
-            {href ? (
-              <Link href={href} className="rounded-md border border-[color:var(--border)] px-3 py-1.5 text-[12px] font-medium text-[var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[var(--text-primary)]">
-                Open
-              </Link>
-            ) : (
-              <button type="button" onClick={onExport} disabled={exportState === "working"} className="rounded-md border border-[color:var(--border)] px-3 py-1.5 text-[12px] font-medium text-[var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[var(--text-primary)] disabled:opacity-60">
-                {exportState === "working" ? "Exporting..." : "Export"}
-              </button>
-            )}
-          </div>
-        );
-      })}
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-emerald-950">
+      <div>
+        <div className="text-[13px] font-semibold">Packet ready for review</div>
+        <div className="mt-1 text-[12px] text-emerald-800">All measured controls are passing with current evidence.</div>
+      </div>
+      <button type="button" onClick={onExport} disabled={exportState === "working"} className="rounded-md border border-emerald-300 bg-white px-3 py-1.5 text-[12px] font-medium text-emerald-900 transition hover:bg-emerald-100 disabled:opacity-60">
+        {exportState === "working" ? "Exporting..." : "Export packet"}
+      </button>
     </div>
   );
 }
@@ -188,15 +177,14 @@ export default function FrameworkDetailPage() {
   const loadedFindings = boundedFindingRows.rows;
   const findingListMeta = findingsQuery.data ? boundedFindingRows.meta : undefined;
   const findings = useMemo(() => loadedFindings.slice().sort(riskSort), [loadedFindings]);
-  const readinessCount = readinessTotal(framework);
-  const maturityScore = framework?.maturity?.score ?? 0;
-  const evidenceGapCount = (framework?.readiness?.needs_enrichment_controls ?? 0) + (framework?.readiness?.placeholder_controls ?? 0);
   const packetControlTotal = controlListMeta?.total ?? packetQuery.data?.packet?.summary?.total ?? controls.length;
-  const measuredControlCount = packetQuery.data ? packetControlTotal : framework?.coverage?.selected_controls ?? 0;
-  const measuredControlDetail = packetQuery.data
-    ? countLabel(controls.length, "loaded control")
-    : countLabel(framework?.control_count ?? 0, "catalog control");
-  const readinessDetail = countLabel(readinessCount, "readiness-scored control");
+  const verifiedReadiness = useMemo(() => deriveFrameworkReadiness({
+    byStatus: packetQuery.data?.packet?.summary?.by_status,
+    controls,
+    total: packetControlTotal,
+  }), [controls, packetControlTotal, packetQuery.data?.packet?.summary?.by_status]);
+  const openFindingCount = findingListMeta?.total ?? findings.length;
+  const readinessState = packetQuery.loading && !packetQuery.data ? "loading" : packetQuery.data ? "ready" : packetQuery.error ? "unavailable" : "empty";
   const isLoadingFramework = frameworksQuery.loading && !frameworksQuery.data && !framework;
 
   if (!isLoadingFramework && !framework) {
@@ -213,12 +201,12 @@ export default function FrameworkDetailPage() {
       <PageHeader
         contractId="framework-detail"
         title={displayName}
-        description={framework?.description || "Framework posture, maturity, gaps, findings, controls, and audit packet exports."}
+        description={framework?.description || "Control readiness, evidence gaps, open findings, and audit packet work."}
         action={
           <div className="flex flex-wrap items-center gap-2">
             {framework && <Badge value={framework.lifecycle} />}
             <Link href="/frameworks" className="rounded-md border border-[color:var(--border)] px-3 py-1.5 text-[12px] font-medium text-[var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[var(--text-primary)]">All frameworks</Link>
-            {!isUpcoming && framework && (
+            {!isUpcoming && framework && verifiedReadiness.needsWorkControls === 0 && verifiedReadiness.totalControls > 0 && (
               <button type="button" onClick={exportPacket} disabled={exportState === "working"} className="rounded-md bg-[var(--primary)] px-3 py-1.5 text-[12px] font-medium text-white transition hover:bg-[var(--primary-hover)] disabled:opacity-60">
                 {exportState === "working" ? "Exporting..." : "Export packet"}
               </button>
@@ -233,33 +221,37 @@ export default function FrameworkDetailPage() {
       {framework && (
         <>
           <div className="grid gap-4 md:grid-cols-4">
-            <MetricCard label="Maturity" value={isUpcoming ? "N/A" : `${maturityScore}%`} detail={framework.maturity?.summary || "Not measured"} state={isLoadingFramework ? "loading" : "ready"} />
-            <MetricCard label="Measured controls" value={isUpcoming ? "N/A" : measuredControlCount} detail={measuredControlDetail} state={isLoadingFramework ? "loading" : "ready"} />
-            <MetricCard label="Audit-ready" value={isUpcoming ? "N/A" : framework.readiness?.auditor_ready_controls ?? 0} detail={readinessDetail} state={isLoadingFramework ? "loading" : "ready"} />
-            <MetricCard label="Evidence gaps" value={isUpcoming ? "N/A" : evidenceGapCount} detail={isUpcoming ? "Planning only" : "Controls needing enrichment"} intent={evidenceGapCount > 0 ? "warning" : "success"} state={isLoadingFramework ? "loading" : "ready"} />
+            <MetricCard label="Readiness" value={isUpcoming ? "N/A" : `${verifiedReadiness.score}%`} detail={isUpcoming ? "Planning only" : `${verifiedReadiness.readyControls} of ${verifiedReadiness.totalControls} controls ready`} intent={verifiedReadiness.score === 100 ? "success" : "warning"} state={isUpcoming ? "ready" : readinessState} />
+            <MetricCard label="Controls ready" value={isUpcoming ? "N/A" : `${verifiedReadiness.readyControls}/${verifiedReadiness.totalControls}`} detail={isUpcoming ? "Planning only" : countLabel(verifiedReadiness.needsWorkControls, "control needs work", "controls need work")} intent={verifiedReadiness.needsWorkControls > 0 ? "warning" : "success"} state={isUpcoming ? "ready" : readinessState} />
+            <MetricCard label="Open findings" value={isUpcoming ? "N/A" : openFindingCount} detail={isUpcoming ? "Planning only" : "Mapped to this framework"} intent={openFindingCount > 0 ? "danger" : "success"} state={isUpcoming ? "ready" : findingsQuery.loading && !findingsQuery.data ? "loading" : findingsQuery.data ? "ready" : "unavailable"} />
+            <MetricCard label="Evidence gaps" value={isUpcoming ? "N/A" : verifiedReadiness.evidenceGapControls} detail={isUpcoming ? "Planning only" : "Controls missing or using stale evidence"} intent={verifiedReadiness.evidenceGapControls > 0 ? "warning" : "success"} state={isUpcoming ? "ready" : readinessState} />
           </div>
 
           {isUpcoming ? <PlanningMode framework={framework} /> : null}
 
-          <Panel title="Gap-to-action workflow">
-            <GapActions framework={framework} onExport={exportPacket} exportState={exportState} />
-            {exportState === "failed" && <div className="mt-3 text-[12px] text-red-600">Export failed. Check API connectivity and try again.</div>}
-          </Panel>
+          {!isUpcoming && (
+            <Panel title="Next action">
+              {packetQuery.loading && !packetQuery.data ? <LoadingBlock label="Loading control readiness..." /> : null}
+              {packetQuery.error && !packetQuery.data ? <ErrorBlock error={packetQuery.error} onRetry={packetQuery.reload} /> : null}
+              {packetQuery.data ? <GapActions framework={framework} onExport={exportPacket} readiness={verifiedReadiness} exportState={exportState} /> : null}
+              {exportState === "failed" && <div className="mt-3 text-[12px] text-red-600">Export failed. Check API connectivity and try again.</div>}
+            </Panel>
+          )}
 
           {!isUpcoming && (
             <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
               <Panel title={`${displayName} tracking snapshot`}>
                 <div className="grid gap-3 sm:grid-cols-3">
                   <div className="rounded-lg bg-[var(--surface-muted)] p-3">
-                    <div className="text-xl font-semibold text-[var(--text-primary)]">{humanize(framework.maturity?.status || "not configured")}</div>
-                    <div className="mt-1 text-[12px] text-[var(--text-muted)]">Maturity stage</div>
+                    <div className="text-xl font-semibold text-[var(--text-primary)]">{verifiedReadiness.needsWorkControls === 0 ? "Ready" : countLabel(verifiedReadiness.needsWorkControls, "control")}</div>
+                    <div className="mt-1 text-[12px] text-[var(--text-muted)]">Needs work</div>
                   </div>
                   <div className="rounded-lg bg-[var(--surface-muted)] p-3">
                     <div className="text-xl font-semibold text-[var(--text-primary)]">{framework.coverage?.mapped_rules ?? 0}</div>
                     <div className="mt-1 text-[12px] text-[var(--text-muted)]">Mapped rules</div>
                   </div>
                   <div className="rounded-lg bg-[var(--surface-muted)] p-3">
-                    <div className="text-xl font-semibold text-[var(--text-primary)]">{findings.length}</div>
+                    <div className="text-xl font-semibold text-[var(--text-primary)]">{openFindingCount}</div>
                     <div className="mt-1 text-[12px] text-[var(--text-muted)]">Open findings</div>
                   </div>
                 </div>

--- a/apps/web/src/app/frameworks/page.test.ts
+++ b/apps/web/src/app/frameworks/page.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import type { GRCFramework } from "@/lib/grc";
+
+import { frameworkNeedsWork, frameworkPreview } from "./page";
+
+const framework = (name: string, overrides: Partial<GRCFramework> = {}): GRCFramework => ({
+  control_count: 1,
+  family_count: 1,
+  lifecycle: "active",
+  name,
+  ...overrides,
+});
+
+describe("framework program list", () => {
+  it("keeps the default program view bounded until the user browses the full catalog", () => {
+    const programs = Array.from({ length: 8 }, (_, index) => framework(`Program ${index + 1}`));
+
+    expect(frameworkPreview(programs, false, false)).toHaveLength(6);
+    expect(frameworkPreview(programs, true, false)).toHaveLength(8);
+    expect(frameworkPreview(programs, false, true)).toHaveLength(8);
+  });
+
+  it("describes setup gaps as work without treating export as a blocker", () => {
+    expect(frameworkNeedsWork(framework("Setup complete", { gap_actions: [{ code: "export_audit_packet", label: "Export", priority: 1 }] }))).toBe(false);
+    expect(frameworkNeedsWork(framework("Needs setup", { readiness: { auditor_ready_controls: 0, needs_enrichment_controls: 1, placeholder_controls: 0 } }))).toBe(true);
+    expect(frameworkNeedsWork(framework("Planned", { lifecycle: "upcoming" }))).toBe(true);
+  });
+});

--- a/apps/web/src/app/frameworks/page.tsx
+++ b/apps/web/src/app/frameworks/page.tsx
@@ -5,28 +5,30 @@ import { useMemo, useState } from "react";
 
 import { Badge, ErrorBlock, LoadingBlock, MetricCard, PageHeader, Panel } from "@/components/grc/Primitives";
 import type { GRCFramework, GRCFrameworksResponse } from "@/lib/grc";
-import { humanize } from "@/lib/grc";
 import { grcPath, useGRCQuery } from "@/lib/grc-client";
 import { frameworkRouteSegment, staticGRCFrameworkCatalog } from "@/lib/grc-frameworks";
 
 const inputClass = "control-input px-3 py-1.5 text-[13px]";
 
-const maturityScore = (framework: GRCFramework) =>
-  framework.lifecycle === "upcoming" ? null : framework.maturity?.score ?? null;
+const FRAMEWORK_PREVIEW_LIMIT = 6;
 
-const maturityLabel = (framework: GRCFramework) =>
-  framework.lifecycle === "upcoming" ? "Planning" : humanize(framework.maturity?.status || "not configured");
+const setupControlCount = (framework: GRCFramework) =>
+  (framework.readiness?.needs_enrichment_controls ?? 0) + (framework.readiness?.placeholder_controls ?? 0);
 
-const maturityDetail = (framework: GRCFramework) => {
-  if (framework.lifecycle === "upcoming") return "Not measured yet";
-  const coverage = framework.coverage;
-  if (!coverage || coverage.selected_controls === 0) return "No measured controls";
-  return `${coverage.mapped_controls}/${coverage.selected_controls} controls mapped`;
-};
+export const frameworkNeedsWork = (framework: GRCFramework) =>
+  framework.lifecycle === "upcoming" ||
+  (framework.gap_actions ?? []).some((action) => action.code !== "export_audit_packet") ||
+  setupControlCount(framework) > 0;
+
+export const frameworkPreview = (frameworks: GRCFramework[], expanded: boolean, filtering: boolean) =>
+  expanded || filtering ? frameworks : frameworks.slice(0, FRAMEWORK_PREVIEW_LIMIT);
 
 function FrameworkCard({ framework }: { framework: GRCFramework }) {
-  const score = maturityScore(framework);
   const gapActions = framework.gap_actions ?? [];
+  const selectedControls = framework.coverage?.selected_controls ?? framework.control_count;
+  const mappedControls = framework.coverage?.mapped_controls ?? 0;
+  const needsSetup = setupControlCount(framework);
+  const stateLabel = framework.lifecycle === "upcoming" ? "Planning" : frameworkNeedsWork(framework) ? "Needs setup" : "Setup complete";
   return (
     <Link href={`/frameworks/${frameworkRouteSegment(framework)}`} className="surface-panel block p-4 transition hover:border-[color:var(--ring)]">
       <div className="flex items-start justify-between gap-3">
@@ -37,23 +39,20 @@ function FrameworkCard({ framework }: { framework: GRCFramework }) {
           </div>
           <p className="mt-2 line-clamp-2 text-[13px] leading-5 text-[var(--text-muted)]">{framework.description || "Framework tracking and audit readiness workspace."}</p>
         </div>
-        <div className="shrink-0 text-right">
-          <div className="text-2xl font-semibold text-[var(--text-primary)]">{score === null ? "N/A" : `${score}%`}</div>
-          <div className="mt-1 text-[11px] uppercase tracking-wider text-[var(--text-muted)]">Maturity</div>
-        </div>
+        <Badge value={stateLabel} />
       </div>
       <div className="mt-4 grid gap-3 text-[12px] text-[var(--text-muted)] sm:grid-cols-3">
         <div>
-          <div className="font-medium text-[var(--text-primary)]">{maturityLabel(framework)}</div>
-          <div>{maturityDetail(framework)}</div>
+          <div className="font-medium text-[var(--text-primary)]">{mappedControls}/{selectedControls}</div>
+          <div>Controls mapped</div>
         </div>
         <div>
-          <div className="font-medium text-[var(--text-primary)]">{framework.family_count}</div>
-          <div>{framework.family_count === 1 ? "Family" : "Families"}</div>
+          <div className="font-medium text-[var(--text-primary)]">{needsSetup}</div>
+          <div>{needsSetup === 1 ? "Control needs setup" : "Controls need setup"}</div>
         </div>
         <div>
-          <div className="font-medium text-[var(--text-primary)]">{framework.control_count}</div>
-          <div>{framework.control_count === 1 ? "Catalog control" : "Catalog controls"}</div>
+          <div className="font-medium text-[var(--text-primary)]">{framework.coverage?.mapped_rules ?? 0}</div>
+          <div>Automated checks</div>
         </div>
       </div>
       {gapActions.length > 0 && (
@@ -68,6 +67,7 @@ function FrameworkCard({ framework }: { framework: GRCFramework }) {
 export default function FrameworksPage() {
   const [query, setQuery] = useState("");
   const [lifecycle, setLifecycle] = useState<"all" | "active" | "upcoming">("all");
+  const [showAll, setShowAll] = useState(false);
   const { data, error, loading, reload } = useGRCQuery<GRCFrameworksResponse>(grcPath("/grc/frameworks"));
   const frameworks = useMemo(() => data?.frameworks?.length ? data.frameworks : staticGRCFrameworkCatalog, [data?.frameworks]);
   const filteredFrameworks = useMemo(() => {
@@ -82,11 +82,12 @@ export default function FrameworksPage() {
         .includes(normalizedQuery);
     });
   }, [frameworks, lifecycle, query]);
+  const filtering = Boolean(query.trim()) || lifecycle !== "all";
+  const visibleFrameworks = frameworkPreview(filteredFrameworks, showAll, filtering);
   const activeCount = frameworks.filter((framework) => framework.lifecycle !== "upcoming").length;
   const upcomingCount = frameworks.filter((framework) => framework.lifecycle === "upcoming").length;
-  const measured = frameworks.filter((framework) => framework.lifecycle !== "upcoming" && typeof framework.maturity?.score === "number");
-  const averageMaturity = measured.length === 0 ? 0 : Math.round(measured.reduce((sum, framework) => sum + (framework.maturity?.score ?? 0), 0) / measured.length);
-  const needsAction = frameworks.filter((framework) => (framework.gap_actions ?? []).some((action) => action.code !== "export_audit_packet")).length;
+  const needsAction = frameworks.filter((framework) => framework.lifecycle !== "upcoming" && frameworkNeedsWork(framework)).length;
+  const setupComplete = frameworks.filter((framework) => framework.lifecycle !== "upcoming" && !frameworkNeedsWork(framework)).length;
   const soc2 = frameworks.find((framework) => framework.name === "SOC 2");
 
   return (
@@ -94,7 +95,7 @@ export default function FrameworksPage() {
       <PageHeader
         contractId="frameworks"
         title="Frameworks"
-        description="Track framework status, controls, gaps, planning, and reports."
+        description="Open the programs your team is working on, resolve control gaps, and prepare audit packets."
         action={soc2 ? (
           <Link href={`/frameworks/${frameworkRouteSegment(soc2)}`} className="rounded-md bg-[var(--primary)] px-3 py-1.5 text-[12px] font-medium text-white transition hover:bg-[var(--primary-hover)]">
             Open SOC 2
@@ -103,18 +104,18 @@ export default function FrameworksPage() {
       />
 
       <div className="grid gap-4 md:grid-cols-4">
-        <MetricCard label="Frameworks" value={frameworks.length} detail={`${activeCount} active`} state={loading && !data ? "loading" : "ready"} />
-        <MetricCard label="Average maturity" value={`${averageMaturity}%`} detail={`${measured.length} measured frameworks`} state={loading && !data ? "loading" : "ready"} />
-        <MetricCard label="Needs action" value={needsAction} detail="Frameworks with open gap actions" intent={needsAction > 0 ? "warning" : "success"} state={loading && !data ? "loading" : "ready"} />
-        <MetricCard label="Upcoming" value={upcomingCount} detail="Planning mode, not measured" state={loading && !data ? "loading" : "ready"} />
+        <MetricCard label="Active programs" value={activeCount} detail="Available for control work" state={loading && !data ? "loading" : "ready"} />
+        <MetricCard label="Needs work" value={needsAction} detail="Programs with setup or evidence gaps" intent={needsAction > 0 ? "warning" : "success"} state={loading && !data ? "loading" : "ready"} />
+        <MetricCard label="Setup complete" value={setupComplete} detail="No catalog setup gaps" intent={setupComplete > 0 ? "success" : "neutral"} state={loading && !data ? "loading" : "ready"} />
+        <MetricCard label="Planned" value={upcomingCount} detail="Not included in readiness" state={loading && !data ? "loading" : "ready"} />
       </div>
 
       <Panel
-        title="Compliance catalog"
+        title="Compliance programs"
         action={
           <div className="flex flex-wrap items-center gap-2">
             <select value={lifecycle} onChange={(event) => setLifecycle(event.target.value as typeof lifecycle)} className={inputClass}>
-              <option value="all">All lifecycles</option>
+              <option value="all">All programs</option>
               <option value="active">Active</option>
               <option value="upcoming">Upcoming</option>
             </select>
@@ -134,8 +135,16 @@ export default function FrameworksPage() {
           <div className="rounded-lg border border-dashed border-[color:var(--border-strong)] p-8 text-center text-[13px] text-[var(--text-muted)]">No frameworks match the current filters.</div>
         )}
         <div className="grid gap-4 lg:grid-cols-2">
-          {filteredFrameworks.map((framework) => <FrameworkCard key={framework.id || framework.name} framework={framework} />)}
+          {visibleFrameworks.map((framework) => <FrameworkCard key={framework.id || framework.name} framework={framework} />)}
         </div>
+        {!filtering && filteredFrameworks.length > FRAMEWORK_PREVIEW_LIMIT && (
+          <div className="mt-4 flex items-center justify-between border-t border-[color:var(--border)] pt-4">
+            <span className="text-[12px] text-[var(--text-muted)]">Showing {visibleFrameworks.length} of {filteredFrameworks.length} programs</span>
+            <button type="button" onClick={() => setShowAll((current) => !current)} className="secondary-button px-3 py-1.5 text-[12px]">
+              {showAll ? "Show priority programs" : "Browse all programs"}
+            </button>
+          </div>
+        )}
       </Panel>
     </div>
   );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -6,6 +6,7 @@ import { useMemo } from "react";
 import { useUserPreferences } from "@/components/providers";
 import { AttentionBanner, DataStateBanner, PageHeader } from "@/components/grc/Primitives";
 import { countLabel } from "@/lib/format";
+import { isControlAuditReady } from "@/lib/framework-readiness";
 import {
   displayDate,
   displayDurationSeconds,
@@ -382,12 +383,10 @@ function HealthRow({
 
 function ProgramHealthPanel({
   coverageSourceCount,
-  dashboardBackedReadiness,
   metrics,
   readinessLabel,
 }: {
   coverageSourceCount: number;
-  dashboardBackedReadiness: boolean;
   metrics: HomeMetrics;
   readinessLabel: string;
 }) {
@@ -405,18 +404,13 @@ function ProgramHealthPanel({
           <div className="mt-0.5 text-[11px] uppercase tracking-wide text-[var(--text-muted)]">{readinessLabel}</div>
         </div>
       </div>
-      {dashboardBackedReadiness && (
-        <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] leading-5 text-amber-900">
-          Readiness API is unavailable; using current control counts.
-        </div>
-      )}
       <div className="mt-4 divide-y divide-[color:var(--border)]">
         <HealthRow
           href="/controls"
           label="Controls"
-          value={metrics.summary.controls_failing}
-          detail={`${metrics.passingControls} of ${metrics.controlTotal} passing`}
-          tone={metrics.summary.controls_failing > 0 ? "warning" : "success"}
+          value={Math.max(0, metrics.controlTotal - metrics.passingControls)}
+          detail={`${metrics.passingControls} of ${metrics.controlTotal} ready`}
+          tone={metrics.passingControls < metrics.controlTotal ? "warning" : "success"}
         />
         <HealthRow
           href="/evidence"
@@ -457,7 +451,6 @@ export default function Home() {
   const priorityFindings = useMemo(() => (data?.findings ?? []).slice().sort(riskSort), [data?.findings]);
 
   const summary = data?.summary;
-  const dashboardBackedReadiness = Boolean(readinessQuery.error && data);
   const coverageBlindSpots = useMemo(
     () => coverageQuery.data?.blind_spots ?? coverageQuery.data?.records ?? readinessQuery.data?.coverage_blind_spots ?? data?.coverage_blind_spots ?? [],
     [coverageQuery.data?.blind_spots, coverageQuery.data?.records, data?.coverage_blind_spots, readinessQuery.data?.coverage_blind_spots],
@@ -470,13 +463,20 @@ export default function Home() {
   const coverageSourceCount = coverageSummaries.filter((source) => source.blind_spots > 0).length;
   const missingEvidenceItems = (data?.controls ?? []).reduce((total, control) => total + (control.missing_evidence_items ?? 0), 0);
   const staleEvidenceItems = (data?.controls ?? []).reduce((total, control) => total + (control.stale_evidence_items ?? 0), 0);
-  const controlTotal = data?.controls?.length ?? 0;
-  const passingControls = Math.max(0, controlTotal - (summary?.controls_failing ?? 0));
-  const controlProgress = controlTotal === 0 ? 100 : (passingControls / controlTotal) * 100;
+  const primaryFrameworkRecord = readinessQuery.data?.frameworks?.[0];
+  const primaryFramework = primaryFrameworkRecord?.framework_name || "Program";
+  const scopedDashboardControls = (data?.controls ?? []).filter((control) =>
+    !primaryFrameworkRecord || control.framework_name === primaryFrameworkRecord.framework_name,
+  );
+  const controlTotal = primaryFrameworkRecord?.controls ?? scopedDashboardControls.length;
+  const passingControls = primaryFrameworkRecord
+    ? Math.max(0, Math.min(primaryFrameworkRecord.passing_controls, controlTotal))
+    : scopedDashboardControls.filter(isControlAuditReady).length;
+  const controlProgress = controlTotal === 0 ? 0 : (passingControls / controlTotal) * 100;
   const criticalOrHighFindings = (summary?.critical_findings ?? 0) + (summary?.high_findings ?? 0);
   const evidenceIssues = missingEvidenceItems + staleEvidenceItems;
   const homeMetrics: HomeMetrics | null = summary ? {
-    auditReadinessScore: readiness?.score ?? controlProgress,
+    auditReadinessScore: controlProgress,
     controlTotal,
     coverageBlindSpotCount,
     criticalOrHighFindings,
@@ -493,8 +493,7 @@ export default function Home() {
     findings: priorityFindings,
     readinessData: readinessQuery.data ?? undefined,
   }), [coverageBlindSpots, data?.connectors, data?.controls, priorityFindings, readinessQuery.data]);
-  const readinessLabel = readiness ? humanize(readiness.status) : "current counts";
-  const primaryFramework = readinessQuery.data?.frameworks?.[0]?.framework_name || "Program";
+  const readinessLabel = "Control readiness";
 
   const reload = () => {
     void dashboard.reload();
@@ -534,7 +533,6 @@ export default function Home() {
               {visibleSections.programHealth && (
                 <ProgramHealthPanel
                   coverageSourceCount={coverageSourceCount}
-                  dashboardBackedReadiness={dashboardBackedReadiness}
                   metrics={homeMetrics}
                   readinessLabel={readinessLabel}
                 />

--- a/apps/web/src/app/policies/page.tsx
+++ b/apps/web/src/app/policies/page.tsx
@@ -449,6 +449,7 @@ export default function PoliciesPage() {
   const [query, setQuery] = useQueryParamState("q");
   const [selectedPolicyID, setSelectedPolicyID] = useState<string | null>(null);
   const [policySection, setPolicySection] = useState<PolicySection>("queues");
+  const [showUpload, setShowUpload] = useState(false);
   const [selectedAction, setSelectedAction] = useState<GRCPolicyLifecycleAction | null>(null);
   const [actionReason, setActionReason] = useState("");
   const [actionDate, setActionDate] = useState("");
@@ -966,11 +967,15 @@ export default function PoliciesPage() {
         description="Policy documents, risk-register records, versions, approvals, attestations, exceptions, reminders, and control mappings."
         action={
           <div className="flex flex-wrap items-center gap-2">
+            <button type="button" onClick={() => setShowUpload((current) => !current)} aria-expanded={showUpload} className="inline-flex items-center gap-1.5 rounded-md border border-indigo-500 bg-indigo-500 px-3 py-1.5 text-[13px] font-medium text-white transition hover:bg-indigo-600">
+              <Upload className="h-3.5 w-3.5" aria-hidden="true" />
+              {showUpload ? "Close upload" : "Upload policy"}
+            </button>
             <button type="button" onClick={() => void exportPolicies()} disabled={exporting} className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-[13px] font-medium text-slate-700 transition hover:border-indigo-200 hover:text-indigo-700 disabled:opacity-60">
               <Download className="h-3.5 w-3.5" aria-hidden="true" />
               {exporting ? "Exporting" : "Export"}
             </button>
-            <button type="button" onClick={() => void reload()} className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-indigo-500 px-3 py-1.5 text-[13px] font-medium text-white transition hover:bg-indigo-600">
+            <button type="button" onClick={() => void reload()} className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-[13px] font-medium text-slate-700 transition hover:border-indigo-200 hover:text-indigo-700">
               <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
               Refresh
             </button>
@@ -1015,7 +1020,7 @@ export default function PoliciesPage() {
         <AppliedFilterChips filters={filterState.chips} onClearAll={filterState.clearAll} />
       </div>
 
-      <Panel
+      {showUpload && <Panel
         title="Upload policy document"
         action={<Upload className="h-4 w-4 text-slate-400" aria-hidden="true" />}
       >
@@ -1117,7 +1122,7 @@ export default function PoliciesPage() {
           </div>
         )}
         <GRCUploadHistoryList uploads={policyUploadHistory} />
-      </Panel>
+      </Panel>}
 
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-6">
         <MetricCard label="Policies" value={summary?.policies ?? 0} detail={`${summary?.templates ?? 0} templates`} state={metricState} />

--- a/apps/web/src/app/reports/audit-packages/page.tsx
+++ b/apps/web/src/app/reports/audit-packages/page.tsx
@@ -279,8 +279,8 @@ export default function AuditPackagesPage() {
     <div className="space-y-6">
       <PageHeader
         contractId="audit-packages"
-        title="Audit packets"
-        description="Resolve evidence and source blockers before exporting or sharing a packet."
+        title="Audit workspace"
+        description="Resolve control, evidence, review, and source blockers before sharing an audit packet."
         action={
           <div className="flex flex-wrap items-center justify-end gap-2">
             <Link href="/reports" className={buttonClass}>Packet builder</Link>

--- a/apps/web/src/components/Sidebar.test.tsx
+++ b/apps/web/src/components/Sidebar.test.tsx
@@ -40,7 +40,6 @@ describe("isSidebarLinkActive", () => {
     expect(advancedGroup?.label).toBe("Advanced");
     expect(advancedGroup?.href).toBeUndefined();
     expect(hrefs).toEqual([
-      "/risk-inbox",
       "/actions",
       "/inventory",
       "/impact",
@@ -51,17 +50,26 @@ describe("isSidebarLinkActive", () => {
     ]);
   });
 
+  it("keeps specialist compliance records available without leading with them", () => {
+    const complianceGroup = sidebarNavGroups.find((group) => group.id === "compliance");
+
+    expect(complianceGroup?.label).toBe("Compliance");
+    expect(complianceGroup?.links.map((link) => link.href)).toEqual([
+      "/controls",
+      "/evidence",
+      "/questionnaires",
+    ]);
+  });
+
   it("leads with the compliance jobs customers use every week", () => {
     expect(sidebarPrimaryLinks.map((link) => link.href)).toEqual([
       "/",
+      "/risk-inbox",
       "/frameworks",
-      "/evidence",
-      "/controls",
       "/policies",
       "/vendors",
-      "/questionnaires",
-      "/reports/audit-packages",
       "/connectors",
+      "/reports/audit-packages",
     ]);
     expect(sidebarSupportLinks).toEqual([]);
   });

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -5,7 +5,6 @@ import { usePathname } from "next/navigation";
 import { useMemo, useState, type ReactNode } from "react";
 
 import { useSidebar } from "@/components/providers";
-import { appVersionLabel } from "@/lib/app-version";
 import { operatorNavLinks, utilityLinks, type NavigationEntry } from "@/lib/navigation";
 
 const icons: Record<string, ReactNode> = {
@@ -52,23 +51,27 @@ const linksFor = (hrefs: string[]) =>
 
 export const sidebarPrimaryLinks = linksFor([
   "/",
+  "/risk-inbox",
   "/frameworks",
-  "/evidence",
-  "/controls",
   "/policies",
   "/vendors",
-  "/questionnaires",
-  "/reports/audit-packages",
   "/connectors",
+  "/reports/audit-packages",
 ]);
 export const sidebarSupportLinks: NavigationEntry[] = [];
 
 export const sidebarNavGroups: SidebarNavGroup[] = [
   {
+    id: "compliance",
+    label: "Compliance",
+    iconHref: "/controls",
+    links: linksFor(["/controls", "/evidence", "/questionnaires"]),
+  },
+  {
     id: "advanced",
     label: "Advanced",
     iconHref: "/explore",
-    links: linksFor(["/risk-inbox", "/actions", "/inventory", "/impact", "/explore", "/ask", "/security/lifecycle", "/credential-stores"]),
+    links: linksFor(["/actions", "/inventory", "/impact", "/explore", "/ask", "/security/lifecycle", "/credential-stores"]),
   },
 ];
 
@@ -236,8 +239,7 @@ export default function Sidebar() {
         {utilityLinks.map((link) => renderLink(link))}
       </nav>
 
-      <div className="flex items-center justify-between border-t border-[color:var(--border)] px-3 py-2.5">
-        {!collapsed && <div className="text-[11px] text-[var(--sidebar-muted)] max-md:hidden">{appVersionLabel}</div>}
+      <div className="flex items-center justify-end border-t border-[color:var(--border)] px-3 py-2.5">
         <button
           type="button"
           onClick={toggleSidebar}

--- a/apps/web/src/components/agent/dense-routes.test.ts
+++ b/apps/web/src/components/agent/dense-routes.test.ts
@@ -9,6 +9,8 @@ describe("dense agent route labels", () => {
     expect(isDenseAgentRouteLabel("Shared snapshot")).toBe(true);
     expect(isDenseAgentRouteLabel("Reports")).toBe(true);
     expect(isDenseAgentRouteLabel("Compliance")).toBe(true);
+    expect(isDenseAgentRouteLabel("Policies")).toBe(true);
+    expect(isDenseAgentRouteLabel("Audit workspace")).toBe(true);
   });
 
   it("uses the full launcher on lighter pages", () => {

--- a/apps/web/src/components/agent/dense-routes.ts
+++ b/apps/web/src/components/agent/dense-routes.ts
@@ -5,7 +5,10 @@ export const denseAgentRouteLabels = new Set([
   "Evidence",
   "Frameworks",
   "Issues",
+  "Work",
   "Audit packets",
+  "Audit workspace",
+  "Policies",
   "Reports",
   "Shared snapshot",
 ]);

--- a/apps/web/src/lib/framework-readiness.test.ts
+++ b/apps/web/src/lib/framework-readiness.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import type { GRCControl } from "@/lib/grc";
+
+import { deriveFrameworkReadiness, isControlAuditReady } from "./framework-readiness";
+
+const control = (overrides: Partial<GRCControl> = {}): GRCControl => ({
+  control_id: "CC1.1",
+  critical_findings: 0,
+  evidence_items: 1,
+  framework_name: "SOC 2",
+  high_findings: 0,
+  open_findings: 0,
+  status: "passing",
+  ...overrides,
+});
+
+describe("framework readiness", () => {
+  it("does not call a passing control ready when findings or evidence gaps remain", () => {
+    expect(isControlAuditReady(control())).toBe(true);
+    expect(isControlAuditReady(control({ open_findings: 1 }))).toBe(false);
+    expect(isControlAuditReady(control({ missing_evidence_items: 1 }))).toBe(false);
+    expect(isControlAuditReady(control({ stale_evidence_items: 1 }))).toBe(false);
+  });
+
+  it("derives the displayed score from the packet status ledger", () => {
+    expect(deriveFrameworkReadiness({
+      byStatus: { failing: 4, missing_evidence: 32 },
+      controls: [],
+      total: 36,
+    })).toEqual({
+      evidenceGapControls: 32,
+      failingControls: 4,
+      needsWorkControls: 36,
+      readyControls: 0,
+      score: 0,
+      totalControls: 36,
+    });
+  });
+
+  it("uses loaded controls when a summary is not available", () => {
+    expect(deriveFrameworkReadiness({
+      controls: [control(), control({ control_id: "CC1.2", status: "missing_evidence", missing_evidence_items: 1 })],
+    })).toMatchObject({ readyControls: 1, totalControls: 2, score: 50, evidenceGapControls: 1 });
+  });
+
+  it("does not hide loaded evidence gaps behind a coarse status summary", () => {
+    expect(deriveFrameworkReadiness({
+      byStatus: { failing: 1, manual_review: 1 },
+      controls: [
+        control({ status: "failing", open_findings: 1 }),
+        control({ control_id: "CC1.2", status: "manual_review", stale_evidence_items: 1 }),
+      ],
+      total: 2,
+    })).toMatchObject({ readyControls: 0, totalControls: 2, score: 0, evidenceGapControls: 1, failingControls: 1 });
+  });
+});

--- a/apps/web/src/lib/framework-readiness.ts
+++ b/apps/web/src/lib/framework-readiness.ts
@@ -1,0 +1,67 @@
+import type { GRCControl } from "@/lib/grc";
+
+const readyStatuses = new Set(["audit_ready", "passing", "ready"]);
+
+const normalizedStatus = (value?: string) => (value ?? "").trim().toLowerCase();
+
+export const isControlAuditReady = (control: GRCControl) =>
+  readyStatuses.has(normalizedStatus(control.status)) &&
+  control.open_findings === 0 &&
+  (control.missing_evidence_items ?? 0) === 0 &&
+  (control.stale_evidence_items ?? 0) === 0;
+
+export type FrameworkReadiness = {
+  evidenceGapControls: number;
+  failingControls: number;
+  needsWorkControls: number;
+  readyControls: number;
+  score: number;
+  totalControls: number;
+};
+
+export function deriveFrameworkReadiness({
+  byStatus,
+  controls,
+  total,
+}: {
+  byStatus?: Record<string, number>;
+  controls: GRCControl[];
+  total?: number;
+}): FrameworkReadiness {
+  const normalizedCounts = Object.entries(byStatus ?? {}).reduce<Record<string, number>>((counts, [status, count]) => {
+    counts[normalizedStatus(status)] = count;
+    return counts;
+  }, {});
+  const statusCount = Object.values(normalizedCounts).reduce((sum, count) => sum + count, 0);
+  const totalControls = Math.max(total ?? 0, statusCount, controls.length);
+  const readyFromSummary = [...readyStatuses].reduce((sum, status) => sum + (normalizedCounts[status] ?? 0), 0);
+  const readyFromControls = controls.filter(isControlAuditReady).length;
+  const summaryReadyControlsWithBlockers = controls.filter((control) =>
+    readyStatuses.has(normalizedStatus(control.status)) && !isControlAuditReady(control),
+  ).length;
+  const readyControls = Math.min(
+    totalControls,
+    statusCount > 0
+      ? controls.length >= totalControls
+        ? readyFromControls
+        : Math.max(0, readyFromSummary - summaryReadyControlsWithBlockers)
+      : readyFromControls,
+  );
+  const failingControls = Math.max(
+    (normalizedCounts.failing ?? 0) + (normalizedCounts.failed ?? 0),
+    controls.filter((control) => normalizedStatus(control.status) === "failing" || control.open_findings > 0).length,
+  );
+  const evidenceGapControls = Math.max(
+    (normalizedCounts.missing_evidence ?? 0) + (normalizedCounts.stale_evidence ?? 0),
+    controls.filter((control) => (control.missing_evidence_items ?? 0) > 0 || (control.stale_evidence_items ?? 0) > 0).length,
+  );
+
+  return {
+    evidenceGapControls,
+    failingControls,
+    needsWorkControls: Math.max(0, totalControls - readyControls),
+    readyControls,
+    score: totalControls === 0 ? 0 : Math.round((readyControls / totalControls) * 100),
+    totalControls,
+  };
+}

--- a/apps/web/src/lib/navigation.test.ts
+++ b/apps/web/src/lib/navigation.test.ts
@@ -31,9 +31,9 @@ describe("navigation entries", () => {
     expect(hrefs).toContain("/credential-stores");
   });
 
-  it("uses operator labels for issues, Actions, and compliance", () => {
+  it("uses operator labels for work, actions, and compliance", () => {
     expect(operatorNavLinks.find((entry) => entry.href === "/risk-inbox")).toMatchObject({
-      label: "Issues",
+      label: "Work",
     });
     expect(operatorNavLinks.find((entry) => entry.href === "/grc")).toMatchObject({
       label: "Compliance",

--- a/apps/web/src/lib/route-labels.test.ts
+++ b/apps/web/src/lib/route-labels.test.ts
@@ -11,7 +11,7 @@ describe("route labels", () => {
     expect(routeLabelForPath("/connectors/activation")).toBe("Source activation");
     expect(routeLabelForPath("/credential-stores")).toBe("Credential stores");
     expect(routeLabelForPath("/identity")).toBe("Members");
-    expect(routeLabelForPath("/reports/audit-packages")).toBe("Audit packets");
+    expect(routeLabelForPath("/reports/audit-packages")).toBe("Audit workspace");
     expect(routeLabelForPath("/reports/shared/fixture-snapshot-1")).toBe("Shared snapshot");
     expect(routeLabelForPath("/developer/audit-log")).toBe("Audit events");
     expect(routeLabelForPath("/developer/security-producers")).toBe("Security producers");

--- a/apps/web/src/lib/routes.ts
+++ b/apps/web/src/lib/routes.ts
@@ -17,9 +17,9 @@ export const operatorNavLinks: NavigationEntry[] = [
     keywords: ["dashboard", "overview", "metrics", "home"],
   },
   {
-    label: "Issues",
+    label: "Work",
     href: "/risk-inbox",
-    description: "Findings and control issues by severity, owner, entity, SLA, and evidence.",
+    description: "Prioritized findings and control work by owner, due date, and evidence state.",
     section: "Operator",
     keywords: ["issues", "findings", "risk", "sla", "triage", "owner", "framework", ...supportedGRCFrameworkNames],
   },
@@ -136,9 +136,9 @@ export const operatorNavLinks: NavigationEntry[] = [
     keywords: ["audit packet", "export", "report", "evidence"],
   },
   {
-    label: "Audit packets",
+    label: "Audit workspace",
     href: "/reports/audit-packages",
-    description: "Review packet blockers, evidence gaps, source freshness, and shared snapshots.",
+    description: "Review packet blockers, evidence, source freshness, reviewer questions, and shared snapshots.",
     section: "Operator",
     keywords: ["audit package", "packet review", "evidence review", "control owners", "snapshot", "scope", "exceptions"],
   },

--- a/apps/web/src/lib/ui-contract.test.ts
+++ b/apps/web/src/lib/ui-contract.test.ts
@@ -237,14 +237,17 @@ describe("product UI contract", () => {
     expect(source).toContain("Page actions are ready. Searching live data...");
   });
 
-  it("keeps overview audit readiness fallbacks dashboard-backed instead of sample-labeled", () => {
+  it("keeps overview readiness scoped to explicit framework control counts", () => {
     const overviewSource = readProjectFile("src/app/page.tsx");
 
     expect(overviewSource).toContain("data?.coverage_blind_spots");
     expect(overviewSource).toContain("data?.coverage_summaries");
     expect(overviewSource).toContain('coverage_view: "page"');
     expect(overviewSource).toContain("coverageSummaries.reduce");
-    expect(overviewSource).toContain("dashboardBackedReadiness");
+    expect(overviewSource).toContain("isControlAuditReady");
+    expect(overviewSource).toContain("primaryFrameworkRecord");
+    expect(overviewSource).toContain("passing_controls");
+    expect(overviewSource).toContain("controlProgress");
     expect(overviewSource).not.toContain("sampled dashboard values");
     expect(overviewSource).not.toContain("sampled total");
   });


### PR DESCRIPTION
## What changed

- lead the sidebar with recurring compliance jobs and move specialist records into a Compliance group
- derive readiness from explicit control state so findings and evidence gaps cannot appear audit-ready
- keep the framework catalog bounded until the user chooses to browse all programs
- open Evidence on requests and control posture, with raw and supporting records available on demand
- keep policy work queues ahead of the upload form and rename the packet page to Audit workspace

## Validation

- `npm run verify:fast --workspace @writer/cerebro-web`
- `npm run verify:build --workspace @writer/cerebro-web`
- fixture-backed browser walkthrough: overview, frameworks, SOC 2, evidence, policies, audit workspace
- responsive check at 390x844 across the same core routes with no document overflow

## Environment note

- the repository browser-check script reached the fixture server but the local Playwright browser executable is not installed; the same user paths were exercised in the in-app Chromium browser