### PR TITLE
Route Azure source preview through Rust authority

### DIFF
--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -73,8 +73,8 @@ func (s *Service) Check(ctx context.Context, req *cerebrov1.CheckSourceRequest) 
 	if err != nil {
 		return nil, err
 	}
-	if tailscaleSource(req.GetSourceId()) {
-		if _, err := s.executeTailscale(ctx, config, nil); err != nil {
+	if family, authoritative := rustSourceFamily(req.GetSourceId(), config); authoritative {
+		if _, err := s.executeRustSource(ctx, req.GetSourceId(), family, config, nil); err != nil {
 			return nil, sourceOperationError(err)
 		}
 	} else if err := source.Check(ctx, sourcecdk.NewConfig(config)); err != nil {
@@ -108,8 +108,8 @@ func (s *Service) Discover(ctx context.Context, req *cerebrov1.DiscoverSourceReq
 		return nil, err
 	}
 	var urns []sourcecdk.URN
-	if tailscaleSource(req.GetSourceId()) {
-		pull, executeErr := s.executeTailscale(ctx, config, nil)
+	if family, authoritative := rustSourceFamily(req.GetSourceId(), config); authoritative {
+		pull, executeErr := s.executeRustSource(ctx, req.GetSourceId(), family, config, nil)
 		if executeErr != nil {
 			return nil, sourceOperationError(executeErr)
 		}
@@ -153,8 +153,8 @@ func (s *Service) Read(ctx context.Context, req *cerebrov1.ReadSourceRequest) (_
 		return nil, err
 	}
 	var pull sourcecdk.Pull
-	if tailscaleSource(req.GetSourceId()) {
-		pull, err = s.executeTailscale(ctx, config, req.GetCursor())
+	if family, authoritative := rustSourceFamily(req.GetSourceId(), config); authoritative {
+		pull, err = s.executeRustSource(ctx, req.GetSourceId(), family, config, req.GetCursor())
 	} else {
 		pull, err = source.Read(ctx, sourcecdk.NewConfig(config), req.GetCursor())
 	}

--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -109,11 +109,7 @@ func (s *Service) Discover(ctx context.Context, req *cerebrov1.DiscoverSourceReq
 	}
 	var urns []sourcecdk.URN
 	if family, authoritative := rustSourceFamily(req.GetSourceId(), config); authoritative {
-		pull, executeErr := s.executeRustSource(ctx, req.GetSourceId(), family, config, nil)
-		if executeErr != nil {
-			return nil, sourceOperationError(executeErr)
-		}
-		urns, err = discoverURNs(pull)
+		urns, err = s.discoverRustSource(ctx, req.GetSourceId(), family, config)
 	} else {
 		urns, err = source.Discover(ctx, sourcecdk.NewConfig(config))
 	}

--- a/internal/sourceops/source_execution.go
+++ b/internal/sourceops/source_execution.go
@@ -17,6 +17,7 @@ const (
 	previewLeaseOwner                 = "source-preview"
 	previewRuntimeGeneration   uint64 = 1
 	previewLeaseGeneration     uint64 = 1
+	maxRustDiscoveryPages             = 10_000
 )
 
 type sourceExecutionRunner func(context.Context, sourceworker.Worker, string, []byte, time.Time, sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error)
@@ -90,6 +91,43 @@ func (s *Service) executeRustSource(ctx context.Context, sourceID, family string
 		return sourcecdk.Pull{}, sourceExecutionError(sourceID, family, err)
 	}
 	return pull, nil
+}
+
+func (s *Service) discoverRustSource(ctx context.Context, sourceID, family string, config map[string]string) ([]sourcecdk.URN, error) {
+	seenURNs := make(map[string]struct{})
+	seenCursors := make(map[string]struct{})
+	urns := make([]sourcecdk.URN, 0)
+	var cursor *cerebrov1.SourceCursor
+	for page := 0; page < maxRustDiscoveryPages; page++ {
+		pull, err := s.executeRustSource(ctx, sourceID, family, config, cursor)
+		if err != nil {
+			return nil, err
+		}
+		pageURNs, err := discoverURNs(pull)
+		if err != nil {
+			return nil, err
+		}
+		for _, urn := range pageURNs {
+			if _, ok := seenURNs[urn.String()]; ok {
+				continue
+			}
+			seenURNs[urn.String()] = struct{}{}
+			urns = append(urns, urn)
+		}
+		if pull.NextCursor == nil {
+			return urns, nil
+		}
+		next := strings.TrimSpace(pull.NextCursor.GetOpaque())
+		if next == "" {
+			return nil, fmt.Errorf("%w: Rust discovery continuation is empty", sourceworker.ErrWorkerContract)
+		}
+		if _, ok := seenCursors[next]; ok {
+			return nil, fmt.Errorf("%w: Rust discovery continuation repeated", sourceworker.ErrWorkerContract)
+		}
+		seenCursors[next] = struct{}{}
+		cursor = &cerebrov1.SourceCursor{Opaque: next}
+	}
+	return nil, fmt.Errorf("%w: Rust discovery exceeded %d pages", sourceworker.ErrWorkerContract, maxRustDiscoveryPages)
 }
 
 func previewCredential(sourceID string, config map[string]string) string {

--- a/internal/sourceops/source_execution.go
+++ b/internal/sourceops/source_execution.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	tailscaleSourceID                 = "tailscale"
 	previewCredentialReference        = "credential:source-preview:token" // #nosec G101 -- opaque credential-reference label.
 	previewLeaseOwner                 = "source-preview"
 	previewRuntimeGeneration   uint64 = 1
@@ -39,36 +38,33 @@ func (s *Service) WithSourceExecutionWorkerPath(path string) *Service {
 	return s
 }
 
-func tailscaleSource(sourceID string) bool {
-	return strings.TrimSpace(sourceID) == tailscaleSourceID
+func rustSourceFamily(sourceID string, config map[string]string) (string, bool) {
+	return sourceworker.RustAuthoritativeFamily(sourceID, config["family"])
 }
 
-func (s *Service) executeTailscale(ctx context.Context, config map[string]string, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+func (s *Service) executeRustSource(ctx context.Context, sourceID, family string, config map[string]string, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
 	if s == nil || s.sourceWorker == nil || s.runSourceExecution == nil {
-		return sourcecdk.Pull{}, sourceExecutionError("", sourceworker.ErrWorkerUnsupported)
+		return sourcecdk.Pull{}, sourceExecutionError(sourceID, family, sourceworker.ErrWorkerUnsupported)
 	}
-	family := strings.TrimSpace(config["family"])
-	if family == "" {
-		family = "device"
-	}
+	sourceID, family = strings.TrimSpace(sourceID), strings.TrimSpace(family)
 	tenantID := strings.TrimSpace(config["tenant_id"])
-	credential := []byte(strings.TrimSpace(config["token"]))
+	credential := []byte(previewCredential(sourceID, config))
 	if tenantID == "" || len(credential) == 0 {
 		clear(credential)
-		return sourcecdk.Pull{}, sourceExecutionError(family, sourceworker.ErrSourceConfiguration)
+		return sourcecdk.Pull{}, sourceExecutionError(sourceID, family, sourceworker.ErrSourceConfiguration)
 	}
-	providerCursor, priorWatermark, err := sourceworker.ProviderResume(cursor, tailscaleSourceID, family)
+	providerCursor, priorWatermark, err := sourceworker.ProviderResume(cursor, sourceID, family)
 	if err != nil {
 		clear(credential)
-		return sourcecdk.Pull{}, sourceExecutionError(family, err)
+		return sourcecdk.Pull{}, sourceExecutionError(sourceID, family, err)
 	}
 	publicConfig := sourceworker.PublicExecutionConfig(config)
 	publicConfig["family"] = family
 	now := time.Now().UTC()
 	input := sourceworker.ExecutionInput{
-		SourceID: tailscaleSourceID, FamilyID: family, CredentialReference: previewCredentialReference, PageNumber: 1,
+		SourceID: sourceID, FamilyID: family, CredentialReference: previewCredentialReference, PageNumber: 1,
 		Scope: sourceworker.CredentialScope{
-			TenantID: tenantID, RuntimeID: "source-preview-tailscale-" + family,
+			TenantID: tenantID, RuntimeID: "source-preview-" + sourceID + "-" + family,
 			PriorCursor: providerCursor, PublicConfig: publicConfig,
 			PriorTerminalWatermarkUnixMillis: priorWatermark, PriorCheckpoint: strings.TrimSpace(cursor.GetOpaque()),
 			LeaseOwner: previewLeaseOwner, RuntimeGeneration: previewRuntimeGeneration,
@@ -78,13 +74,22 @@ func (s *Service) executeTailscale(ctx context.Context, config map[string]string
 	output, err := s.runSourceExecution(ctx, s.sourceWorker, previewCredentialReference, credential, now.Add(time.Minute), input)
 	clear(credential)
 	if err != nil {
-		return sourcecdk.Pull{}, sourceExecutionError(family, err)
+		return sourcecdk.Pull{}, sourceExecutionError(sourceID, family, err)
 	}
 	pull, err := sourceworker.PullFromExecutionOutput(output, tenantID)
 	if err != nil {
-		return sourcecdk.Pull{}, sourceExecutionError(family, err)
+		return sourcecdk.Pull{}, sourceExecutionError(sourceID, family, err)
 	}
 	return pull, nil
+}
+
+func previewCredential(sourceID string, config map[string]string) string {
+	if strings.TrimSpace(sourceID) == "azure" {
+		if credential := strings.TrimSpace(config["graph_token"]); credential != "" {
+			return credential
+		}
+	}
+	return strings.TrimSpace(config["token"])
 }
 
 func discoverURNs(pull sourcecdk.Pull) ([]sourcecdk.URN, error) {
@@ -92,6 +97,15 @@ func discoverURNs(pull sourcecdk.Pull) ([]sourcecdk.URN, error) {
 	urns := make([]sourcecdk.URN, 0, len(pull.Events))
 	for _, event := range pull.Events {
 		raw := strings.TrimSpace(event.GetAttributes()["resource_urn"])
+		if raw == "" {
+			attributes := event.GetAttributes()
+			provider := strings.TrimSpace(attributes["resource_provider"])
+			resourceType := strings.TrimSpace(attributes["resource_type"])
+			resourceID := strings.TrimSpace(attributes["resource_id"])
+			if provider != "" && resourceType != "" && resourceID != "" {
+				raw = fmt.Sprintf("urn:cerebro:%s:%s_%s:%s", event.GetTenantId(), provider, resourceType, resourceID)
+			}
+		}
 		urn, err := sourcecdk.ParseURN(raw)
 		if err != nil {
 			return nil, fmt.Errorf("%w: Rust record resource URN is invalid", sourceworker.ErrWorkerContract)
@@ -105,7 +119,7 @@ func discoverURNs(pull sourcecdk.Pull) ([]sourcecdk.URN, error) {
 	return urns, nil
 }
 
-func sourceExecutionError(family string, err error) error {
+func sourceExecutionError(sourceID, family string, err error) error {
 	kind := sourcecdk.ErrorKindProvider
 	switch {
 	case errors.Is(err, sourceworker.ErrSourceConfiguration), errors.Is(err, sourceworker.ErrCredentialReferenceMissing), errors.Is(err, sourceworker.ErrWorkerUnsupported):
@@ -121,5 +135,5 @@ func sourceExecutionError(family string, err error) error {
 	case errors.Is(err, sourceworker.ErrProviderMalformedResponse), errors.Is(err, sourceworker.ErrWorkerContract), errors.Is(err, sourceworker.ErrInvalidExecution):
 		kind = sourcecdk.ErrorKindDecode
 	}
-	return sourcecdk.WrapSourceError(kind, tailscaleSourceID, family, err)
+	return sourcecdk.WrapSourceError(kind, sourceID, family, err)
 }

--- a/internal/sourceops/source_execution.go
+++ b/internal/sourceops/source_execution.go
@@ -39,7 +39,16 @@ func (s *Service) WithSourceExecutionWorkerPath(path string) *Service {
 }
 
 func rustSourceFamily(sourceID string, config map[string]string) (string, bool) {
-	return sourceworker.RustAuthoritativeFamily(sourceID, config["family"])
+	sourceID = strings.TrimSpace(sourceID)
+	// Preview authority is promoted separately from the durable runtime. A new
+	// runtime-authoritative provider must keep its existing sourceops path until
+	// its preview credential adapter and product-surface parity are ready.
+	switch sourceID {
+	case "azure", "tailscale":
+		return sourceworker.RustAuthoritativeFamily(sourceID, config["family"])
+	default:
+		return "", false
+	}
 }
 
 func (s *Service) executeRustSource(ctx context.Context, sourceID, family string, config map[string]string, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {

--- a/internal/sourceops/source_execution_test.go
+++ b/internal/sourceops/source_execution_test.go
@@ -172,7 +172,7 @@ func TestRustDiscoveryRejectsRepeatedContinuation(t *testing.T) {
 		return previewOutput("device", "provider-page-2", "provider-page-2", input.Scope.PriorTerminalWatermarkUnixMillis), nil
 	}
 	_, err := service.discoverRustSource(context.Background(), "tailscale", "device", tailscalePreviewConfig("device"))
-	if !errors.Is(err, sourceworker.ErrWorkerContract) || !strings.Contains(err.Error(), "continuation repeated") {
+	if !errors.Is(err, sourceworker.ErrWorkerContract) {
 		t.Fatalf("discoverRustSource() error = %v", err)
 	}
 }

--- a/internal/sourceops/source_execution_test.go
+++ b/internal/sourceops/source_execution_test.go
@@ -174,10 +174,86 @@ func TestTailscaleSourceExecutionFailuresRemainTyped(t *testing.T) {
 	}
 }
 
-type authorityProbeSource struct{ checkCalls, discoverCalls, readCalls int }
+func TestAzureAuthorizationPolicyCheckDiscoverAndReadUseOnlyClosedRustAuthority(t *testing.T) {
+	const graphCredentialFixture = "host-only-graph-secret" // #nosec G101 -- synthetic boundary-test sentinel, not credential material.
+	legacy := &authorityProbeSource{sourceID: "azure"}
+	registry, err := sourcecdk.NewRegistry(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := New(registry)
+	service.sourceWorker = previewWorkerStub{}
+	calls := 0
+	service.runSourceExecution = func(_ context.Context, _ sourceworker.Worker, reference string, credential []byte, _ time.Time, input sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+		calls++
+		if reference != previewCredentialReference || string(credential) != graphCredentialFixture {
+			t.Fatal("Azure graph credential was not confined to the trusted runner boundary")
+		}
+		encoded, marshalErr := json.Marshal(input)
+		if marshalErr != nil || strings.Contains(string(encoded), graphCredentialFixture) || input.Scope.PublicConfig["graph_token"] != "" {
+			t.Fatalf("credential crossed the worker protocol: %s, %v", encoded, marshalErr)
+		}
+		if input.SourceID != "azure" || input.FamilyID != "authorization_policy" {
+			t.Fatalf("Rust selection = %s.%s", input.SourceID, input.FamilyID)
+		}
+		return azureAuthorizationPolicyPreviewOutput(input.Scope.PriorTerminalWatermarkUnixMillis), nil
+	}
+	config := map[string]string{
+		"family": "authorization_policy", "tenant_id": "tenant-1", "graph_token": graphCredentialFixture,
+	}
+	if _, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{SourceId: "azure", Config: config}); err != nil {
+		t.Fatal(err)
+	}
+	discovered, err := service.Discover(context.Background(), &cerebrov1.DiscoverSourceRequest{SourceId: "azure", Config: config})
+	if err != nil || len(discovered.GetUrns()) != 1 || discovered.GetUrns()[0] != "urn:cerebro:tenant-1:azure_authorization_policy:authorizationPolicy" {
+		t.Fatalf("Discover() = %#v, %v", discovered, err)
+	}
+	read, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{SourceId: "azure", Config: config})
+	if err != nil || len(read.GetEvents()) != 1 || read.GetEvents()[0].GetSourceId() != "azure" {
+		t.Fatalf("Read() = %#v, %v", read, err)
+	}
+	if calls != 3 || legacy.checkCalls != 0 || legacy.discoverCalls != 0 || legacy.readCalls != 0 {
+		t.Fatalf("calls = Rust %d, Go check/discover/read %d/%d/%d", calls, legacy.checkCalls, legacy.discoverCalls, legacy.readCalls)
+	}
+}
 
-func (*authorityProbeSource) Spec() *cerebrov1.SourceSpec {
-	return &cerebrov1.SourceSpec{Id: "tailscale"}
+func TestOtherAzureFamilyRemainsOnGoPreview(t *testing.T) {
+	legacy := &authorityProbeSource{sourceID: "azure"}
+	registry, err := sourcecdk.NewRegistry(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := New(registry)
+	service.sourceWorker = previewWorkerStub{}
+	service.runSourceExecution = func(context.Context, sourceworker.Worker, string, []byte, time.Time, sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+		t.Fatal("Rust preview executed for a Go-compatible Azure family")
+		return nil, nil
+	}
+	config := map[string]string{"family": "user"}
+	if _, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{SourceId: "azure", Config: config}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Discover(context.Background(), &cerebrov1.DiscoverSourceRequest{SourceId: "azure", Config: config}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{SourceId: "azure", Config: config}); err != nil {
+		t.Fatal(err)
+	}
+	if legacy.checkCalls != 1 || legacy.discoverCalls != 1 || legacy.readCalls != 1 {
+		t.Fatalf("Go calls = check/discover/read %d/%d/%d", legacy.checkCalls, legacy.discoverCalls, legacy.readCalls)
+	}
+}
+
+type authorityProbeSource struct {
+	sourceID                             string
+	checkCalls, discoverCalls, readCalls int
+}
+
+func (s *authorityProbeSource) Spec() *cerebrov1.SourceSpec {
+	if s.sourceID == "" {
+		return &cerebrov1.SourceSpec{Id: "tailscale"}
+	}
+	return &cerebrov1.SourceSpec{Id: s.sourceID}
 }
 func (s *authorityProbeSource) Check(context.Context, sourcecdk.Config) error {
 	s.checkCalls++
@@ -236,5 +312,24 @@ func previewOutput(family, nextCursor, checkpointCursor string, priorWatermark i
 	return &sourceworker.ExecutionOutput{
 		Plan: plan, Result: &cerebrov1.SourceWorkerDecodeResultV1{NextCursor: nextCursor, ResultDigestSha256: "result-digest"},
 		Program: &sourceworker.PageProgram{TransitionDigest: "transition", AdmittedRecords: []*cerebrov1.SourceWorkerRecordV1{record}, CheckpointCursor: checkpointCursor, CheckpointWatermarkUnixMillis: watermark},
+	}
+}
+
+func azureAuthorizationPolicyPreviewOutput(priorWatermark int64) *sourceworker.ExecutionOutput {
+	watermark := max(priorWatermark, 1_725_000_000_000)
+	plan := &cerebrov1.SourceExecutionPlanV1{
+		SourceId: "azure", FamilyId: "authorization_policy", EventKind: "azure.authorization_policy", SchemaRef: "azure/authorization_policy/v1",
+	}
+	record := &cerebrov1.SourceWorkerRecordV1{
+		ProviderId: "authorizationPolicy", EventId: "azure-authorization-policy-authorizationPolicy", OccurredAtUnixMillis: watermark,
+		Attributes: map[string]string{
+			"family": "authorization_policy", "resource_id": "authorizationPolicy", "resource_name": "authorizationPolicy",
+			"resource_provider": "azure", "resource_type": "authorization_policy",
+		},
+		PayloadJson: []byte(`{"id":"authorizationPolicy"}`),
+	}
+	return &sourceworker.ExecutionOutput{
+		Plan: plan, Result: &cerebrov1.SourceWorkerDecodeResultV1{ResultDigestSha256: "result-digest"},
+		Program: &sourceworker.PageProgram{TransitionDigest: "transition", AdmittedRecords: []*cerebrov1.SourceWorkerRecordV1{record}, CheckpointCursor: "authorizationPolicy", CheckpointWatermarkUnixMillis: watermark},
 	}
 }

--- a/internal/sourceops/source_execution_test.go
+++ b/internal/sourceops/source_execution_test.go
@@ -144,6 +144,39 @@ func TestTailscaleReadContinuesOnlyForProviderCursorAndFailsClosed(t *testing.T)
 	}
 }
 
+func TestRustDiscoveryReadsEveryPageAndDeduplicatesURNs(t *testing.T) {
+	service := tailscaleAuthorityService(t)
+	var inputs []sourceworker.ExecutionInput
+	service.runSourceExecution = func(_ context.Context, _ sourceworker.Worker, _ string, _ []byte, _ time.Time, input sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+		inputs = append(inputs, input)
+		if len(inputs) == 1 {
+			return previewOutput("device", "provider-page-2", "provider-page-2", 1_725_000_000_000), nil
+		}
+		return previewOutput("device", "", "device-terminal", 1_725_000_001_000), nil
+	}
+	urns, err := service.discoverRustSource(context.Background(), "tailscale", "device", tailscalePreviewConfig("device"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inputs) != 2 || inputs[1].Scope.PriorCursor != "provider-page-2" {
+		t.Fatalf("discovery inputs = %#v", inputs)
+	}
+	if len(urns) != 1 || urns[0].String() != "urn:cerebro:tenant-1:tailscale_device:device-1" {
+		t.Fatalf("deduplicated URNs = %#v", urns)
+	}
+}
+
+func TestRustDiscoveryRejectsRepeatedContinuation(t *testing.T) {
+	service := tailscaleAuthorityService(t)
+	service.runSourceExecution = func(_ context.Context, _ sourceworker.Worker, _ string, _ []byte, _ time.Time, input sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+		return previewOutput("device", "provider-page-2", "provider-page-2", input.Scope.PriorTerminalWatermarkUnixMillis), nil
+	}
+	_, err := service.discoverRustSource(context.Background(), "tailscale", "device", tailscalePreviewConfig("device"))
+	if !errors.Is(err, sourceworker.ErrWorkerContract) || !strings.Contains(err.Error(), "continuation repeated") {
+		t.Fatalf("discoverRustSource() error = %v", err)
+	}
+}
+
 func TestUnknownTailscaleFamilyFailsClosedWithoutLegacyCalls(t *testing.T) {
 	legacy := &authorityProbeSource{}
 	registry, err := sourcecdk.NewRegistry(legacy)

--- a/internal/sourceops/source_execution_test.go
+++ b/internal/sourceops/source_execution_test.go
@@ -13,6 +13,26 @@ import (
 	"github.com/writer/cerebro/internal/sourceruntime/sourceworker"
 )
 
+func TestRustSourceFamilyPreviewAuthorityIsExact(t *testing.T) {
+	for name, test := range map[string]struct {
+		source, family, wantFamily string
+		wantAuthoritative          bool
+	}{
+		"Azure authorization policy": {"azure", "authorization_policy", "authorization_policy", true},
+		"other Azure family":         {"azure", "user", "user", false},
+		"Tailscale default":          {"tailscale", "", "device", true},
+		"JumpCloud runtime only":     {"jumpcloud", "users", "", false},
+		"compatibility source":       {"gcp", "audit", "", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			family, authoritative := rustSourceFamily(test.source, map[string]string{"family": test.family})
+			if family != test.wantFamily || authoritative != test.wantAuthoritative {
+				t.Fatalf("rustSourceFamily() = (%q, %v), want (%q, %v)", family, authoritative, test.wantFamily, test.wantAuthoritative)
+			}
+		})
+	}
+}
+
 func TestTailscaleCheckDiscoverAndReadUseOnlyClosedRustAuthority(t *testing.T) {
 	for _, family := range []string{"device", "grant", "group", "service", "tag", "tailnet", "user"} {
 		t.Run(family, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- route Azure `authorization_policy` preview check, discover, and read through the same closed Rust authority used by persisted runtime collection
- keep Azure graph credentials inside the trusted Go host and out of the worker protocol
- derive the preview URN from Rust-normalized resource identity without calling the Go provider implementation
- keep every other Azure family on Go compatibility

## Dependency

Stacked on #2522 so this pull request contains only the source-preview entry-point change. Retarget to `main` after #2522 merges.

## Validation

- `go test ./internal/sourceops ./internal/sourcehttp/... ./internal/bootstrap ./cmd/cerebro`
- `go test -race ./internal/sourceops`
- `golangci-lint run -j 4 --timeout 20m ./internal/sourceops`
- `go test ./tools/archtests/...`
