### PR TITLE
Activate JumpCloud Rust runtime authority

### DIFF
--- a/internal/sourceruntime/source_execution.go
+++ b/internal/sourceruntime/source_execution.go
@@ -58,13 +58,7 @@ func (s *Service) readSourcePull(ctx context.Context, runtime *cerebrov1.SourceR
 	if !ok || !fence.ExpiresAt.After(time.Now().UTC()) {
 		return sourcecdk.Pull{}, false, fmt.Errorf("%w: source worker requires a current durable lease fence", ErrRuntimeUnavailable)
 	}
-	reference, resolved := strings.TrimSpace(runtime.GetConfig()["graph_token"]), strings.TrimSpace(cfg.Values()["graph_token"])
-	if reference == "" {
-		reference = strings.TrimSpace(runtime.GetConfig()["token"])
-	}
-	if resolved == "" {
-		resolved = strings.TrimSpace(cfg.Values()["token"])
-	}
+	reference, resolved := sourceworker.CredentialBinding(runtime.GetSourceId(), runtime.GetConfig(), cfg.Values())
 	if reference == "" || resolved == "" || reference == resolved || (!sourceconfig.IsCredentialReference(reference) && !sourceconfig.IsSecretReference(reference)) {
 		return sourcecdk.Pull{}, false, fmt.Errorf("%w: Rust source execution requires an opaque credential reference", ErrInvalidRequest)
 	}

--- a/internal/sourceruntime/source_execution_authority_test.go
+++ b/internal/sourceruntime/source_execution_authority_test.go
@@ -163,6 +163,64 @@ func TestOtherAzureFamilyRemainsGoCompatible(t *testing.T) {
 	}
 }
 
+func TestPutJumpCloudFamiliesValidateWithRustWithoutCallingGoCheck(t *testing.T) {
+	families := []string{"users", "groups", "systems", "applications", "system_groups", "group_members", "audit_events"}
+	for _, family := range families {
+		t.Run(family, func(t *testing.T) {
+			legacy := &runtimeAuthorityProbe{sourceID: "jumpcloud"}
+			registry, err := sourcecdk.NewRegistry(legacy)
+			if err != nil {
+				t.Fatal(err)
+			}
+			worker := &runtimePlanWorker{}
+			service := New(registry, &runtimeStore{}, nil, nil)
+			service.sourceWorker = worker
+			config := map[string]string{
+				"family": family, "api_key": sourceconfig.CredentialReferenceValue("jumpcloud", "api_key"),
+			}
+			if family == "group_members" {
+				config["group_ids"] = "group-1,group-2"
+			}
+			_, err = service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{Runtime: &cerebrov1.SourceRuntime{
+				Id: "jumpcloud-" + family + "-runtime", SourceId: "jumpcloud", TenantId: "tenant-1", Config: config,
+			}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if legacy.checkCalls != 0 || worker.planCalls != 1 {
+				t.Fatalf("validation calls = Go %d, Rust %d", legacy.checkCalls, worker.planCalls)
+			}
+			if worker.selection.SourceID != "jumpcloud" || worker.selection.FamilyID != family {
+				t.Fatalf("Rust selection = %#v", worker.selection)
+			}
+			if worker.publicConfig["api_key"] != "" || worker.publicConfig["family"] != family {
+				t.Fatalf("Rust public config = %#v", worker.publicConfig)
+			}
+		})
+	}
+}
+
+func TestUnknownJumpCloudFamilyNeverFallsBackToGoAuthority(t *testing.T) {
+	legacy := &runtimeAuthorityProbe{sourceID: "jumpcloud"}
+	worker := &runtimePlanWorker{compileErr: sourceworker.ErrWorkerUnsupported}
+	service := &Service{sourceWorker: worker}
+	runtime := &cerebrov1.SourceRuntime{
+		Id: "jumpcloud-future-runtime", SourceId: "jumpcloud", TenantId: "tenant-1",
+		Config: map[string]string{"family": "future-family", "api_key": sourceconfig.CredentialReferenceValue("jumpcloud", "api_key")},
+	}
+	ctx := context.WithValue(context.Background(), sourceRuntimeLeaseFenceContextKey{}, sourceRuntimeLeaseAuthority{fence: ports.SourceRuntimeLeaseFence{
+		Owner: "owner-1", Generation: 1, ExpiresAt: time.Now().Add(time.Minute),
+	}})
+	resolved := sourcecdk.NewConfig(map[string]string{"family": "future-family", "api_key": "host-only-value"})
+
+	if _, _, err := service.readSourcePull(ctx, runtime, legacy, resolved, nil, nil, 1); !errors.Is(err, sourceworker.ErrWorkerUnsupported) {
+		t.Fatalf("readSourcePull() error = %v", err)
+	}
+	if legacy.readCalls != 0 || worker.selection.SourceID != "jumpcloud" || worker.selection.FamilyID != "future-family" {
+		t.Fatalf("authority calls = Go %d, Rust selection %#v", legacy.readCalls, worker.selection)
+	}
+}
+
 type runtimeAuthorityProbe struct {
 	sourceID              string
 	checkCalls, readCalls int

--- a/internal/sourceruntime/sourceworker/pull.go
+++ b/internal/sourceruntime/sourceworker/pull.go
@@ -23,11 +23,35 @@ func RustAuthoritativeFamily(sourceID, familyID string) (string, bool) {
 	switch sourceID {
 	case "azure":
 		return familyID, familyID == "authorization_policy"
+	case "jumpcloud":
+		if familyID == "" {
+			familyID = "users"
+		}
+		// Every public JumpCloud family is closed in the Rust dispatcher. An
+		// unknown future family must fail there instead of restoring Go authority.
+		return familyID, true
 	case "tailscale":
 		return TailscaleFamily(sourceID, familyID)
 	default:
 		return "", false
 	}
+}
+
+// CredentialBinding selects the provider's ordered credential aliases from
+// stored references and trusted-host resolved values. It returns strings only
+// to the Go host; callers must never include the resolved value in worker
+// metadata, receipts, or errors.
+func CredentialBinding(sourceID string, references, resolved map[string]string) (string, string) {
+	keys := []string{"graph_token", "token"}
+	if strings.TrimSpace(sourceID) == "jumpcloud" {
+		keys = []string{"api_key", "api_token", "token"}
+	}
+	for _, key := range keys {
+		if reference := strings.TrimSpace(references[key]); reference != "" {
+			return reference, strings.TrimSpace(resolved[key])
+		}
+	}
+	return "", ""
 }
 
 // TailscaleFamily normalizes the requested Tailscale family, including the

--- a/internal/sourceruntime/sourceworker/pull_test.go
+++ b/internal/sourceruntime/sourceworker/pull_test.go
@@ -85,6 +85,9 @@ func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
 	}{
 		"Azure authorization policy": {" azure ", " authorization_policy ", "authorization_policy", true},
 		"other Azure family":         {"azure", "user", "user", false},
+		"JumpCloud default":          {"jumpcloud", "", "users", true},
+		"JumpCloud family":           {"jumpcloud", "group_members", "group_members", true},
+		"unknown JumpCloud family":   {"jumpcloud", "future-family", "future-family", true},
 		"Tailscale default":          {"tailscale", "", "device", true},
 		"unknown Tailscale family":   {"tailscale", "future-family", "future-family", true},
 		"compatibility source":       {"gcp", "audit", "", false},
@@ -93,6 +96,36 @@ func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
 			family, authoritative := RustAuthoritativeFamily(test.source, test.family)
 			if family != test.wantFamily || authoritative != test.wantAuthoritative {
 				t.Fatalf("RustAuthoritativeFamily() = (%q, %v), want (%q, %v)", family, authoritative, test.wantFamily, test.wantAuthoritative)
+			}
+		})
+	}
+}
+
+func TestCredentialBindingUsesOnlyTheSelectedProviderAliases(t *testing.T) {
+	for name, test := range map[string]struct {
+		source                      string
+		references, resolved        map[string]string
+		wantReference, wantResolved string
+	}{
+		"Azure graph token": {
+			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.
+			source: "azure", references: map[string]string{"graph_token": "credential:azure:graph", "token": "credential:azure:fallback"},
+			resolved: map[string]string{"graph_token": "resolved-graph", "token": "resolved-fallback"}, wantReference: "credential:azure:graph", wantResolved: "resolved-graph",
+		},
+		"JumpCloud api key": {
+			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.
+			source: "jumpcloud", references: map[string]string{"api_key": "credential:jumpcloud:api-key", "token": "credential:jumpcloud:fallback"},
+			resolved: map[string]string{"api_key": "resolved-api-key", "token": "resolved-fallback"}, wantReference: "credential:jumpcloud:api-key", wantResolved: "resolved-api-key",
+		},
+		"aliases cannot cross": {
+			source: "jumpcloud", references: map[string]string{"api_key": "credential:jumpcloud:api-key"},
+			resolved: map[string]string{"token": "resolved-different-alias"}, wantReference: "credential:jumpcloud:api-key", wantResolved: "",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			reference, resolved := CredentialBinding(test.source, test.references, test.resolved)
+			if reference != test.wantReference || resolved != test.wantResolved {
+				t.Fatalf("CredentialBinding() = (%q, %q), want (%q, %q)", reference, resolved, test.wantReference, test.wantResolved)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- make the closed Rust dispatcher authoritative for the seven public JumpCloud families, with `users` as the catalog default
- bind `api_key`, `api_token`, and `token` references in the trusted Go host while keeping resolved credential bytes out of the Rust protocol
- require the resolved credential to use the same declared alias, and fail unknown future families closed instead of restoring Go authority
- preserve Rust restart checkpoints and tenant-scoped normalization already implemented by the JumpCloud kernels

This PR is stacked on #2522 so its diff stays limited to the JumpCloud authority activation. Retarget it to `main` after #2522 merges.

## Families

- `users`
- `groups`
- `systems`
- `applications`
- `system_groups`
- `group_members`
- `audit_events`

## Local validation

- `go test ./internal/sourceruntime/sourceworker ./internal/sourceruntime`
- `go test -race ./internal/sourceruntime/...`
- `golangci-lint run --timeout=10m ./internal/sourceruntime/...` — 0 issues
- `go test ./tools/archtests/...`

DDESK readiness is healthy. Project execution is blocked by the current desk capacity preflight, which requires a new project disk; this PR does not provision one without an approved capacity plan.