### PR TITLE
Improve vendor workflow focus

### DIFF
--- a/apps/web/src/app/vendors/[urn]/page.tsx
+++ b/apps/web/src/app/vendors/[urn]/page.tsx
@@ -932,7 +932,7 @@ function VendorHero({
             Refresh
           </button>
           <button type="button" onClick={onOpenReview} className="primary-button inline-flex items-center gap-2 px-4 py-2 text-[13px]">
-            Open review
+            Review questionnaire
             <ArrowRight className="h-4 w-4" aria-hidden="true" />
           </button>
           <button type="button" className="secondary-button p-2" aria-label="More vendor actions">

--- a/apps/web/src/app/vendors/page.tsx
+++ b/apps/web/src/app/vendors/page.tsx
@@ -1183,101 +1183,6 @@ function DiscoveryQueue({
   );
 }
 
-function DuplicateQueue({
-  decisionSaving,
-  discoveries,
-  duplicateMatchesByURN,
-  onDecision,
-  onOpenVendor,
-}: {
-  decisionSaving: boolean;
-  discoveries: GRCVendorDiscovery[];
-  duplicateMatchesByURN: Record<string, DuplicateMatch[]>;
-  onDecision: (discovery: GRCVendorDiscovery, decision: DiscoveryDecision, draft?: DiscoveryDecisionDraft) => Promise<void> | void;
-  onOpenVendor: (vendorURN: string) => void;
-}) {
-  const duplicateRows = discoveries
-    .filter(discoveryNeedsReview)
-    .map((discovery) => ({
-      discovery,
-      matches: duplicateMatchesByURN[discovery.urn] ?? [],
-    }))
-    .filter((row) => row.matches.length > 0)
-    .slice(0, 6);
-
-  if (duplicateRows.length === 0) return null;
-
-  return (
-    <section className="surface-panel overflow-hidden">
-      <div className="flex flex-wrap items-start justify-between gap-3 border-b border-[color:var(--border)] px-5 py-3">
-        <div>
-          <h2 className="text-[13px] font-semibold text-[var(--text-primary)]">Possible duplicates</h2>
-          <p className="mt-1 text-[12px] text-[var(--text-muted)]">
-            {countLabel(duplicateRows.length, "candidate")} match a vendor or another discovery.
-          </p>
-        </div>
-        <GitMerge className="h-4 w-4 text-[var(--text-muted)]" aria-hidden="true" />
-      </div>
-      <div className="divide-y divide-[color:var(--border)]">
-        {duplicateRows.map(({ discovery, matches }) => {
-          const firstVendorMatch = matches.find((match) => match.vendorURN);
-          return (
-            <div key={discovery.urn} className="grid gap-3 px-5 py-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
-              <div className="min-w-0">
-                <div className="font-semibold text-[var(--text-primary)]">{discovery.name || shortEntity(discovery.urn)}</div>
-                <div className="mt-1 text-[12px] text-[var(--text-muted)]">{discovery.provider || discovery.source_id || "Source not set"} · Confidence {confidenceLabel(discovery.confidence_score)}</div>
-              </div>
-              <div className="space-y-2">
-                {matches.slice(0, 2).map((match) => (
-                  <div key={match.id} className="rounded-md border border-[color:var(--border)] bg-[var(--surface-muted)] px-3 py-2 text-[12px]">
-                    <div className="font-semibold text-[var(--text-primary)]">{match.label}</div>
-                    <div className="text-[var(--text-muted)]">{match.reason}. {match.detail}</div>
-                  </div>
-                ))}
-              </div>
-              <div className="flex flex-wrap items-start gap-2 lg:justify-end">
-                {firstVendorMatch?.vendorURN && (
-                  <>
-                    <button type="button" onClick={() => onOpenVendor(firstVendorMatch.vendorURN!)} className="secondary-button px-3 py-1.5 text-[12px]">
-                      Open match
-                    </button>
-                    <button
-                      type="button"
-                      disabled={decisionSaving}
-                      onClick={() => {
-                        void Promise.resolve(onDecision(discovery, "linked", {
-                          linkedVendorURN: firstVendorMatch.vendorURN!,
-                          reason: "Linked from duplicate review.",
-                        })).catch(() => undefined);
-                      }}
-                      className="primary-button px-3 py-1.5 text-[12px] disabled:opacity-50"
-                    >
-                      Link match
-                    </button>
-                  </>
-                )}
-                <button
-                  type="button"
-                  disabled={decisionSaving}
-                  onClick={() => {
-                    void Promise.resolve(onDecision(discovery, "ignored", {
-                      linkedVendorURN: "",
-                      reason: "Dismissed from duplicate review.",
-                    })).catch(() => undefined);
-                  }}
-                  className="secondary-button px-3 py-1.5 text-[12px] disabled:opacity-50"
-                >
-                  Dismiss
-                </button>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    </section>
-  );
-}
-
 function VendorRegisterSection({
   assuranceItems,
   meta,
@@ -2494,25 +2399,6 @@ export default function VendorsPage() {
 
       {activeSection === "discoveries" && (
         <>
-          <DiscoverySourceSummary
-            loading={discoveriesQuery.loading && !discoveriesQuery.data}
-            onRefresh={() => { void discoveriesQuery.reload(); }}
-            onRunSource={(runSourceID) => { void runDiscoverySync(runSourceID).catch(() => undefined); }}
-            onSelectSource={setSourceID}
-            runSaving={syncSaving}
-            selectedSourceID={sourceID}
-            sources={discoverySources}
-            summary={discoverySummary}
-          />
-
-          <DuplicateQueue
-            decisionSaving={decisionSaving}
-            discoveries={discoveries}
-            duplicateMatchesByURN={duplicateMatchesByURN}
-            onDecision={setDiscoveryDecision}
-            onOpenVendor={openVendorDrawer}
-          />
-
           {discoveriesQuery.loading && !discoveriesQuery.data ? (
             <LoadingBlock label="Loading vendor discoveries..." />
           ) : (
@@ -2547,6 +2433,17 @@ export default function VendorsPage() {
               />
             </div>
           )}
+
+          <DiscoverySourceSummary
+            loading={discoveriesQuery.loading && !discoveriesQuery.data}
+            onRefresh={() => { void discoveriesQuery.reload(); }}
+            onRunSource={(runSourceID) => { void runDiscoverySync(runSourceID).catch(() => undefined); }}
+            onSelectSource={setSourceID}
+            runSaving={syncSaving}
+            selectedSourceID={sourceID}
+            sources={discoverySources}
+            summary={discoverySummary}
+          />
         </>
       )}
 

--- a/apps/web/src/lib/ui-contract.test.ts
+++ b/apps/web/src/lib/ui-contract.test.ts
@@ -187,6 +187,18 @@ describe("product UI contract", () => {
     expect(page.indexOf("ReadinessMix")).toBeGreaterThan(advancedTools);
   });
 
+  it("keeps vendor decisions ahead of source diagnostics without a duplicate queue", () => {
+    const vendorSource = readProjectFile("src/app/vendors/page.tsx");
+    const vendorDetailSource = readProjectFile("src/app/vendors/[urn]/page.tsx");
+    const page = vendorSource.slice(vendorSource.indexOf("export default function VendorsPage"));
+
+    expect(page.indexOf("<DiscoveryQueue")).toBeGreaterThan(0);
+    expect(page.indexOf("<DiscoverySourceSummary")).toBeGreaterThan(page.indexOf("<DiscoveryQueue"));
+    expect(vendorSource).not.toContain("function DuplicateQueue");
+    expect(vendorDetailSource).toContain("Review questionnaire");
+    expect(vendorDetailSource).not.toContain("Open review");
+  });
+
   it("keeps lifecycle details modal and lifecycle records usable at mobile width", () => {
     const lifecycleSource = readProjectFile("src/app/security/lifecycle/page.tsx");
 


### PR DESCRIPTION
Summary
- put vendor candidate decisions ahead of discovery diagnostics
- remove the repeated duplicate-candidate panel while keeping match actions in each candidate row
- name the vendor review action for the questionnaire queue it opens

Validation
- product UI contract: 14 passed
- focused ESLint: passed
- fixture browser flow: discovery queue first, questionnaire action opens its queue, no page overflow
- full web suite: 641 passed; one unchanged local Node 26 localStorage failure reproduced on the base checkout
- production compile completed before inherited route-export type failures outside this change
