### PR TITLE
Close SentinelOne agent Rust execution plumbing

### DIFF
--- a/crates/source-runtime-next/src/sentinelone.rs
+++ b/crates/source-runtime-next/src/sentinelone.rs
@@ -12,7 +12,9 @@ mod model;
 mod response;
 mod source_execution_adapter;
 
-pub(crate) use source_execution_adapter::SentinelOneAgentSourceExecutionAdapter;
+pub(crate) use source_execution_adapter::{
+    SentinelOneAgentSourceExecutionAdapter, durable_checkpoint_cursor,
+};
 
 pub use kernel::SentinelOneKernel;
 pub use model::{

--- a/crates/source-runtime-next/src/sentinelone/source_execution_adapter.rs
+++ b/crates/source-runtime-next/src/sentinelone/source_execution_adapter.rs
@@ -7,8 +7,9 @@
 
 use crate::source_execution::{
     SourceExecutionAdapter, SourceExecutionError, SourceExecutionPlanV1,
-    SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1, SourceWorkerExecutionContextV1,
-    SourceWorkerHttpRequestV1, SourceWorkerPlanRequestV1, SourceWorkerRecordV1,
+    SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1,
+    SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2, SourceWorkerHttpRequestV1,
+    SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1, SourceWorkerRecordV1,
     canonical_plan_digest, canonical_request_intent_digest, canonical_result_digest,
     validate_and_deduplicate_records, validate_decode_result, validate_execution_context,
     validate_http_request, validate_safe_receipt,
@@ -22,6 +23,8 @@ use super::{
 mod error;
 #[path = "source_execution_adapter/normalization.rs"]
 mod normalization;
+#[path = "source_execution_adapter/runtime.rs"]
+mod runtime;
 
 use error::SentinelOneAgentAdapterError;
 use normalization::normalize_agent_record;
@@ -30,6 +33,8 @@ const SOURCE_ID: &str = "sentinelone";
 const FAMILY_ID: &str = "agent";
 const PROVIDER_KERNEL: &str = "sentinelone.agent";
 const PLAN_ID: &str = "source-plan-v1:sentinelone:agent";
+const COMPILED_ORIGIN: &str = "https://sentinelone.invalid";
+const CREDENTIAL_OPERATION: &str = "sentinelone.api_token";
 const METHOD: &str = "GET";
 const PATH: &str = "/web/api/v2.1/agents";
 const RECORD_SELECTOR: &str = "$.data[*]";
@@ -42,6 +47,31 @@ const PAGE_SIZE: usize = 200;
 /// Credential-free adapter for the representative SentinelOne agent family.
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct SentinelOneAgentSourceExecutionAdapter;
+
+impl SentinelOneAgentSourceExecutionAdapter {
+    pub(crate) fn compiled_plan(&self) -> SourceExecutionPlanV1 {
+        let mut plan = SourceExecutionPlanV1 {
+            plan_id: PLAN_ID.to_owned(),
+            source_id: SOURCE_ID.to_owned(),
+            family_id: FAMILY_ID.to_owned(),
+            provider_kernel: PROVIDER_KERNEL.to_owned(),
+            method: METHOD.to_owned(),
+            origin: COMPILED_ORIGIN.to_owned(),
+            path: PATH.to_owned(),
+            record_selector: RECORD_SELECTOR.to_owned(),
+            id_field: ID_FIELD.to_owned(),
+            singleton_fallback_id: String::new(),
+            max_response_bytes: MAX_RESPONSE_BYTES,
+            event_kind: EVENT_KIND.to_owned(),
+            schema_ref: SCHEMA_REF.to_owned(),
+            required_attributes: vec!["family".to_owned()],
+            required_payload_fields: vec!["id".to_owned()],
+            plan_digest_sha256: String::new(),
+        };
+        plan.plan_digest_sha256 = canonical_plan_digest(&plan);
+        plan
+    }
+}
 
 impl SourceExecutionAdapter for SentinelOneAgentSourceExecutionAdapter {
     fn source_id(&self) -> &'static str {
@@ -76,11 +106,25 @@ impl SourceExecutionAdapter for SentinelOneAgentSourceExecutionAdapter {
         plan_agent_request(request)
     }
 
+    fn plan_v2(
+        &self,
+        envelope: &SourceWorkerPlanEnvelopeV2,
+    ) -> Result<SourceWorkerHttpExecutionV2, SourceExecutionError> {
+        runtime::plan_v2(envelope)
+    }
+
     fn decode(
         &self,
         request: &SourceWorkerDecodeRequestV1,
     ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
         decode_agent_response(request)
+    }
+
+    fn decode_v2(
+        &self,
+        envelope: &SourceWorkerDecodeEnvelopeV2,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        runtime::decode_v2(envelope)
     }
 }
 
@@ -100,12 +144,23 @@ fn plan_agent_request(
     validate_agent_tenant(&context.tenant_id).map_err(SourceExecutionError::from)?;
 
     let kernel = agent_kernel(plan)?;
+    let result = plan_with_kernel(plan, context, &kernel, &plan.origin)?;
+    validate_http_request(plan, context, &result)?;
+    Ok(result)
+}
+
+fn plan_with_kernel(
+    plan: &SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    kernel: &SentinelOneKernel,
+    allowed_origin: &str,
+) -> Result<SourceWorkerHttpRequestV1, SourceExecutionError> {
     let provider_request = kernel
         .plan(optional_cursor(&context.prior_cursor))
         .map_err(map_kernel_error)
         .map_err(SourceExecutionError::from)?;
-    validate_provider_request(plan, &provider_request).map_err(SourceExecutionError::from)?;
-
+    validate_provider_request(plan, allowed_origin, &provider_request)
+        .map_err(SourceExecutionError::from)?;
     let mut result = SourceWorkerHttpRequestV1 {
         plan_id: plan.plan_id.clone(),
         method: METHOD.to_owned(),
@@ -116,7 +171,6 @@ fn plan_agent_request(
         request_intent_digest: String::new(),
     };
     result.request_intent_digest = canonical_request_intent_digest(plan, context, &result);
-    validate_http_request(plan, context, &result)?;
     Ok(result)
 }
 
@@ -131,11 +185,29 @@ fn decode_agent_response(
         .context
         .as_ref()
         .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+    let kernel = agent_kernel(plan)?;
+    let expected = plan_with_kernel(plan, context, &kernel, &plan.origin)?;
+    decode_agent_response_with_kernel(request, &kernel, &plan.origin, &expected)
+}
+
+fn decode_agent_response_with_kernel(
+    request: &SourceWorkerDecodeRequestV1,
+    kernel: &SentinelOneKernel,
+    allowed_origin: &str,
+    expected: &SourceWorkerHttpRequestV1,
+) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+    let plan = request
+        .plan
+        .as_ref()
+        .ok_or(SourceExecutionError::InvalidPlan)?;
+    let context = request
+        .context
+        .as_ref()
+        .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
     let receipt = request
         .receipt
         .as_ref()
         .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
-
     validate_plan(plan).map_err(SourceExecutionError::from)?;
     validate_execution_context(context)?;
     validate_agent_tenant(&context.tenant_id).map_err(SourceExecutionError::from)?;
@@ -154,21 +226,15 @@ fn decode_agent_response(
         request.status_code,
         &request.request_intent_digest,
     )?;
-    let expected_intent = plan_agent_request(&SourceWorkerPlanRequestV1 {
-        plan: Some(plan.clone()),
-        context: Some(context.clone()),
-    })?
-    .request_intent_digest;
-    if request.request_intent_digest != expected_intent {
+    if request.request_intent_digest != expected.request_intent_digest {
         return Err(SourceExecutionError::InvalidDigest);
     }
-
-    let kernel = agent_kernel(plan)?;
     let provider_request = kernel
         .plan(optional_cursor(&context.prior_cursor))
         .map_err(map_kernel_error)
         .map_err(SourceExecutionError::from)?;
-    validate_provider_request(plan, &provider_request).map_err(SourceExecutionError::from)?;
+    validate_provider_request(plan, allowed_origin, &provider_request)
+        .map_err(SourceExecutionError::from)?;
     let SentinelOneOutcome::Page(page) = kernel
         .decode(&provider_request, &request.response_body)
         .map_err(map_kernel_error)
@@ -208,24 +274,7 @@ fn decode_agent_response(
 }
 
 fn validate_plan(plan: &SourceExecutionPlanV1) -> Result<(), SentinelOneAgentAdapterError> {
-    let expected_attributes = ["family"];
-    let expected_payload_fields = ["id"];
-    let exact = plan.plan_id == PLAN_ID
-        && plan.source_id == SOURCE_ID
-        && plan.family_id == FAMILY_ID
-        && plan.provider_kernel == PROVIDER_KERNEL
-        && plan.method == METHOD
-        && plan.path == PATH
-        && plan.record_selector == RECORD_SELECTOR
-        && plan.id_field == ID_FIELD
-        && plan.singleton_fallback_id.is_empty()
-        && plan.max_response_bytes == MAX_RESPONSE_BYTES
-        && plan.event_kind == EVENT_KIND
-        && plan.schema_ref == SCHEMA_REF
-        && plan.required_attributes == expected_attributes
-        && plan.required_payload_fields == expected_payload_fields
-        && canonical_plan_digest(plan) == plan.plan_digest_sha256;
-    if !exact {
+    if plan != &SentinelOneAgentSourceExecutionAdapter.compiled_plan() {
         return Err(SentinelOneAgentAdapterError::InvalidPlan);
     }
     Ok(())
@@ -233,9 +282,10 @@ fn validate_plan(plan: &SourceExecutionPlanV1) -> Result<(), SentinelOneAgentAda
 
 fn validate_provider_request(
     plan: &SourceExecutionPlanV1,
+    allowed_origin: &str,
     request: &super::SentinelOneRequest,
 ) -> Result<(), SentinelOneAgentAdapterError> {
-    if request.url().origin().ascii_serialization() != plan.origin
+    if request.url().origin().ascii_serialization() != allowed_origin
         || request.url().path() != plan.path
         || request.authorization_scheme() != "ApiToken"
         || request.accept() != "application/json"
@@ -294,6 +344,25 @@ fn map_kernel_error(error: SentinelOneError) -> SentinelOneAgentAdapterError {
 
 fn optional_cursor(value: &str) -> Option<&str> {
     (!value.is_empty()).then_some(value)
+}
+
+pub(crate) fn durable_checkpoint_cursor(
+    plan: &SourceExecutionPlanV1,
+    result: &SourceWorkerDecodeResultV1,
+) -> Option<String> {
+    if plan.source_id != SOURCE_ID || plan.family_id != FAMILY_ID {
+        return None;
+    }
+    if !result.next_cursor.is_empty() {
+        return Some(result.next_cursor.clone());
+    }
+    Some(
+        result
+            .records
+            .last()
+            .map(|record| record.provider_id.clone())
+            .unwrap_or_default(),
+    )
 }
 
 fn validate_agent_tenant(tenant_id: &str) -> Result<(), SentinelOneAgentAdapterError> {

--- a/crates/source-runtime-next/src/sentinelone/source_execution_adapter/runtime.rs
+++ b/crates/source-runtime-next/src/sentinelone/source_execution_adapter/runtime.rs
@@ -1,0 +1,119 @@
+//! Metadata-aware SentinelOne agent execution bridge.
+
+use std::collections::HashMap;
+
+use crate::source_execution::{
+    SourceExecutionError, SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeResultV1,
+    SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2, SourceWorkerPlanEnvelopeV2,
+    SourceWorkerRuntimeMetadataV2, canonical_http_execution_digest, validate_execution_context,
+    validate_runtime_metadata,
+};
+
+use super::{
+    CREDENTIAL_OPERATION, decode_agent_response_with_kernel, map_kernel_error, plan_with_kernel,
+    validate_agent_tenant, validate_plan,
+};
+use crate::sentinelone::{SentinelOneFamily, SentinelOneFilters, SentinelOneKernel};
+
+pub(super) fn plan_v2(
+    envelope: &SourceWorkerPlanEnvelopeV2,
+) -> Result<SourceWorkerHttpExecutionV2, SourceExecutionError> {
+    let request = envelope
+        .request
+        .as_ref()
+        .ok_or(SourceExecutionError::InvalidPlan)?;
+    let plan = request
+        .plan
+        .as_ref()
+        .ok_or(SourceExecutionError::InvalidPlan)?;
+    let context = request
+        .context
+        .as_ref()
+        .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+    let metadata = envelope
+        .metadata
+        .as_ref()
+        .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+    validate_plan(plan).map_err(SourceExecutionError::from)?;
+    let (kernel, allowed_origin) = kernel(context, metadata)?;
+    let planned = plan_with_kernel(plan, context, &kernel, &allowed_origin)?;
+    let mut execution = SourceWorkerHttpExecutionV2 {
+        request: Some(planned),
+        body: Vec::new(),
+        declared_headers: HashMap::new(),
+        execution_intent_digest_sha256: String::new(),
+        credential_operation: CREDENTIAL_OPERATION.to_owned(),
+        allowed_origin,
+    };
+    execution.execution_intent_digest_sha256 =
+        canonical_http_execution_digest(plan, context, metadata, &execution);
+    Ok(execution)
+}
+
+pub(super) fn decode_v2(
+    envelope: &SourceWorkerDecodeEnvelopeV2,
+) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+    let request = envelope
+        .request
+        .as_ref()
+        .ok_or(SourceExecutionError::InvalidPlan)?;
+    let plan = request
+        .plan
+        .as_ref()
+        .ok_or(SourceExecutionError::InvalidPlan)?;
+    let context = request
+        .context
+        .as_ref()
+        .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+    let metadata = envelope
+        .metadata
+        .as_ref()
+        .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+    validate_plan(plan).map_err(SourceExecutionError::from)?;
+    let (kernel, allowed_origin) = kernel(context, metadata)?;
+    let expected = plan_with_kernel(plan, context, &kernel, &allowed_origin)?;
+    decode_agent_response_with_kernel(request, &kernel, &allowed_origin, &expected)
+}
+
+fn kernel(
+    context: &SourceWorkerExecutionContextV1,
+    metadata: &SourceWorkerRuntimeMetadataV2,
+) -> Result<(SentinelOneKernel, String), SourceExecutionError> {
+    validate_execution_context(context)?;
+    validate_runtime_metadata(metadata)?;
+    validate_agent_tenant(&context.tenant_id).map_err(SourceExecutionError::from)?;
+    let base_url = public_value(&metadata.public_config, "base_url")
+        .ok_or(SourceExecutionError::MissingConfiguration)?;
+    let page_size = public_value(&metadata.public_config, "per_page")
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .map_err(|_| SourceExecutionError::InvalidPlan)
+        })
+        .transpose()?;
+    let filters = SentinelOneFilters {
+        site_id: public_owned(&metadata.public_config, "site_id"),
+        group_id: public_owned(&metadata.public_config, "group_id"),
+        ..SentinelOneFilters::default()
+    };
+    let kernel = SentinelOneKernel::new(base_url, SentinelOneFamily::Agent, filters, page_size)
+        .map_err(map_kernel_error)
+        .map_err(SourceExecutionError::from)?;
+    let allowed_origin = reqwest::Url::parse(base_url)
+        .map_err(|_| SourceExecutionError::InvalidPlan)?
+        .origin()
+        .ascii_serialization();
+    Ok((kernel, allowed_origin))
+}
+
+fn public_value<'a>(config: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    config
+        .get(key)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn public_owned(config: &HashMap<String, String>, key: &str) -> Option<String> {
+    public_value(config, key).map(str::to_owned)
+}

--- a/crates/source-runtime-next/src/sentinelone/source_execution_adapter_tests.rs
+++ b/crates/source-runtime-next/src/sentinelone/source_execution_adapter_tests.rs
@@ -1,7 +1,11 @@
+use std::collections::HashMap;
+
 use prost::Message;
 use serde_json::Value;
 
-use crate::source_execution::{SourceWorkerSafeReceiptV1, response_digest};
+use crate::source_execution::{
+    SourceWorkerRuntimeMetadataV2, SourceWorkerSafeReceiptV1, response_digest,
+};
 
 use super::*;
 
@@ -21,26 +25,7 @@ fn context(cursor: &str) -> SourceWorkerExecutionContextV1 {
 }
 
 fn exact_plan() -> SourceExecutionPlanV1 {
-    let mut plan = SourceExecutionPlanV1 {
-        plan_id: PLAN_ID.to_owned(),
-        source_id: SOURCE_ID.to_owned(),
-        family_id: FAMILY_ID.to_owned(),
-        provider_kernel: PROVIDER_KERNEL.to_owned(),
-        method: METHOD.to_owned(),
-        origin: "https://sentinelone.example.test".to_owned(),
-        path: PATH.to_owned(),
-        record_selector: RECORD_SELECTOR.to_owned(),
-        id_field: ID_FIELD.to_owned(),
-        singleton_fallback_id: String::new(),
-        max_response_bytes: MAX_RESPONSE_BYTES,
-        event_kind: EVENT_KIND.to_owned(),
-        schema_ref: SCHEMA_REF.to_owned(),
-        required_attributes: vec!["family".to_owned()],
-        required_payload_fields: vec!["id".to_owned()],
-        plan_digest_sha256: String::new(),
-    };
-    plan.plan_digest_sha256 = canonical_plan_digest(&plan);
-    plan
+    SentinelOneAgentSourceExecutionAdapter.compiled_plan()
 }
 
 fn receipt(
@@ -97,7 +82,7 @@ fn plans_deterministic_agent_request_without_credentials() {
     assert_eq!(output.method, "GET");
     assert_eq!(
         output.url,
-        "https://sentinelone.example.test/web/api/v2.1/agents?limit=200&cursor=cursor-A-1"
+        "https://sentinelone.invalid/web/api/v2.1/agents?limit=200&cursor=cursor-A-1"
     );
     assert_eq!(output.request_intent_digest.len(), 64);
     let first_page = plan_agent_request(&SourceWorkerPlanRequestV1 {
@@ -121,6 +106,118 @@ fn plans_deterministic_agent_request_without_credentials() {
                 .windows(secret_shape.len())
                 .any(|window| window == secret_shape)
         );
+    }
+}
+
+#[test]
+fn metadata_aware_dispatch_uses_dynamic_origin_closed_auth_and_restart_boundary() {
+    let dispatcher = crate::source_execution::SourceExecutionDispatcher;
+    let plan = dispatcher
+        .compile_plan(
+            &crate::source_execution::SourceExecutionSelectionRequestV1 {
+                source_id: SOURCE_ID.to_owned(),
+                family_id: FAMILY_ID.to_owned(),
+            },
+        )
+        .unwrap();
+    let execution_context = context("cursor-A-1");
+    let metadata = SourceWorkerRuntimeMetadataV2 {
+        public_config: HashMap::from([
+            (
+                "base_url".to_owned(),
+                "https://sentinelone.example.test/".to_owned(),
+            ),
+            ("per_page".to_owned(), "200".to_owned()),
+            ("site_id".to_owned(), "site-1".to_owned()),
+        ]),
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    };
+    let planned = dispatcher
+        .dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(execution_context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+        })
+        .unwrap();
+    assert_eq!(planned.allowed_origin, "https://sentinelone.example.test");
+    assert_eq!(planned.credential_operation, CREDENTIAL_OPERATION);
+    assert_eq!(
+        planned.request.as_ref().unwrap().url,
+        "https://sentinelone.example.test/web/api/v2.1/agents?limit=200&cursor=cursor-A-1&siteIds=site-1"
+    );
+    assert!(planned.body.is_empty());
+    assert!(planned.declared_headers.is_empty());
+
+    let first_context = context("");
+    let first = dispatcher
+        .dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(first_context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+        })
+        .unwrap();
+    let first_request = first.request.as_ref().unwrap();
+    let decoded = dispatcher
+        .dispatch_decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+            request: Some(SourceWorkerDecodeRequestV1 {
+                plan: Some(plan.clone()),
+                status_code: 200,
+                response_body: AGENT_PAGE.to_vec(),
+                logical_page_id: first_context.logical_page_id.clone(),
+                request_intent_digest: first_request.request_intent_digest.clone(),
+                receipt: None,
+                context: Some(first_context),
+            }),
+            metadata: Some(metadata),
+            response_headers: HashMap::new(),
+            execution_intent_digest_sha256: first.execution_intent_digest_sha256,
+            response_headers_sha256: String::new(),
+        })
+        .unwrap();
+    let result = decoded.result.unwrap();
+    assert_eq!(result.next_cursor, "cursor-A-2");
+    assert_eq!(
+        durable_checkpoint_cursor(&plan, &result).as_deref(),
+        Some("cursor-A-2")
+    );
+    let mut terminal = result;
+    terminal.next_cursor.clear();
+    assert_eq!(
+        durable_checkpoint_cursor(&plan, &terminal).as_deref(),
+        Some("A-1")
+    );
+}
+
+#[test]
+fn metadata_aware_dispatch_requires_a_safe_public_origin() {
+    let plan = SentinelOneAgentSourceExecutionAdapter.compiled_plan();
+    for config in [
+        HashMap::new(),
+        HashMap::from([(
+            "base_url".to_owned(),
+            "http://sentinelone.example.test".to_owned(),
+        )]),
+    ] {
+        let result = SentinelOneAgentSourceExecutionAdapter.plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(context("")),
+            }),
+            metadata: Some(SourceWorkerRuntimeMetadataV2 {
+                public_config: config,
+                prior_terminal_watermark_unix_millis: 0,
+                prior_checkpoint: String::new(),
+            }),
+        });
+        assert!(matches!(
+            result,
+            Err(SourceExecutionError::MissingConfiguration | SourceExecutionError::InvalidPlan)
+        ));
     }
 }
 

--- a/crates/source-runtime-next/src/source_execution.rs
+++ b/crates/source-runtime-next/src/source_execution.rs
@@ -28,9 +28,10 @@ mod wire;
 pub use contract::{
     MAX_CONTEXT_IDENTIFIER_BYTES, MAX_CURSOR_BYTES, MAX_PUBLIC_CONFIG_BYTES,
     MAX_PUBLIC_CONFIG_ENTRIES, MAX_RECORD_PAYLOAD_BYTES, MAX_RECORDS_PER_RESULT,
-    MAX_REQUEST_BODY_BYTES, MAX_SAFE_HEADER_BYTES, MAX_SAFE_HEADER_ENTRIES, canonical_plan_digest,
-    canonical_request_intent_digest, canonical_response_headers_digest, canonical_result_digest,
-    response_digest, tenant_scoped_event_id, validate_and_deduplicate_records, validate_cursor,
+    MAX_REQUEST_BODY_BYTES, MAX_SAFE_HEADER_BYTES, MAX_SAFE_HEADER_ENTRIES,
+    canonical_http_execution_digest, canonical_plan_digest, canonical_request_intent_digest,
+    canonical_response_headers_digest, canonical_result_digest, response_digest,
+    tenant_scoped_event_id, validate_and_deduplicate_records, validate_cursor,
     validate_declared_headers, validate_decode_envelope, validate_decode_result,
     validate_execution_context, validate_http_execution, validate_http_request,
     validate_public_config, validate_response_headers, validate_runtime_metadata,

--- a/crates/source-runtime-next/src/source_execution/contract.rs
+++ b/crates/source-runtime-next/src/source_execution/contract.rs
@@ -153,7 +153,7 @@ pub fn validate_http_execution(
         || !matches!(request.method.as_str(), "GET" | "POST")
         || !matches!(
             execution.credential_operation.as_str(),
-            "source.bearer" | "jumpcloud.x_api_key"
+            "source.bearer" | "jumpcloud.x_api_key" | "sentinelone.api_token"
         )
     {
         return Err(SourceExecutionError::InvalidPlan);

--- a/crates/source-runtime-next/src/source_execution/dispatcher.rs
+++ b/crates/source-runtime-next/src/source_execution/dispatcher.rs
@@ -114,6 +114,11 @@ impl SourceExecutionDispatcher {
         {
             return Ok(AZURE_AUTHORIZATION_POLICY.compiled_plan());
         }
+        if request.source_id == SENTINELONE_AGENT.source_id()
+            && request.family_id == SENTINELONE_AGENT.family_id()
+        {
+            return Ok(SENTINELONE_AGENT.compiled_plan());
+        }
         if let Some(adapter) = JUMPCLOUD_ADAPTERS.iter().find(|adapter| {
             request.source_id == adapter.source_id() && request.family_id == adapter.family_id()
         }) {

--- a/crates/source-runtime-next/src/source_execution/runtime.rs
+++ b/crates/source-runtime-next/src/source_execution/runtime.rs
@@ -100,10 +100,14 @@ fn seal_page_program_inner(
             |watermark| watermark.max(prior_watermark),
         );
 
-    let checkpoint_cursor = if plan.source_id == "tailscale" {
-        super::tailscale::durable_checkpoint_cursor(plan, result).unwrap_or_default()
-    } else {
-        result.next_cursor.clone()
+    let checkpoint_cursor = match plan.source_id.as_str() {
+        "sentinelone" => {
+            crate::sentinelone::durable_checkpoint_cursor(plan, result).unwrap_or_default()
+        }
+        "tailscale" => {
+            super::tailscale::durable_checkpoint_cursor(plan, result).unwrap_or_default()
+        }
+        _ => result.next_cursor.clone(),
     };
 
     Ok(SourceExecutionLifecycleDecisionV1 {

--- a/crates/source-runtime-next/src/source_execution/tests.rs
+++ b/crates/source-runtime-next/src/source_execution/tests.rs
@@ -69,26 +69,7 @@ fn exact_plan() -> SourceExecutionPlanV1 {
 }
 
 fn sentinelone_plan() -> SourceExecutionPlanV1 {
-    let mut plan = SourceExecutionPlanV1 {
-        plan_id: "source-plan-v1:sentinelone:agent".to_owned(),
-        source_id: "sentinelone".to_owned(),
-        family_id: "agent".to_owned(),
-        provider_kernel: "sentinelone.agent".to_owned(),
-        method: "GET".to_owned(),
-        origin: "https://sentinelone.example.test".to_owned(),
-        path: "/web/api/v2.1/agents".to_owned(),
-        record_selector: "$.data[*]".to_owned(),
-        id_field: "id".to_owned(),
-        singleton_fallback_id: String::new(),
-        max_response_bytes: 8 << 20,
-        event_kind: "sentinelone.agent".to_owned(),
-        schema_ref: "sentinelone/agent/v1".to_owned(),
-        required_attributes: vec!["family".to_owned()],
-        required_payload_fields: vec!["id".to_owned()],
-        plan_digest_sha256: String::new(),
-    };
-    plan.plan_digest_sha256 = canonical_plan_digest(&plan);
-    plan
+    crate::sentinelone::SentinelOneAgentSourceExecutionAdapter.compiled_plan()
 }
 
 fn sentinelone_context(cursor: &str) -> SourceWorkerExecutionContextV1 {
@@ -545,7 +526,7 @@ fn closed_dispatcher_registers_and_executes_the_exact_sentinelone_agent_plan() {
         .unwrap();
     assert_eq!(
         planned.url,
-        "https://sentinelone.example.test/web/api/v2.1/agents?limit=200&cursor=cursor-A-1"
+        "https://sentinelone.invalid/web/api/v2.1/agents?limit=200&cursor=cursor-A-1"
     );
 
     let context = sentinelone_context("");

--- a/internal/sourceruntime/sourceworker/host.go
+++ b/internal/sourceruntime/sourceworker/host.go
@@ -192,6 +192,8 @@ func credentialHeader(operation string, credential []byte) (string, []byte, erro
 		return "Authorization", append([]byte("Bearer "), credential...), nil
 	case "jumpcloud.x_api_key":
 		return "X-Api-Key", append([]byte(nil), credential...), nil
+	case "sentinelone.api_token":
+		return "Authorization", append([]byte("ApiToken "), credential...), nil
 	default:
 		return "", nil, fmt.Errorf("%w: credential operation is not registered", ErrWorkerContract)
 	}

--- a/internal/sourceruntime/sourceworker/host_test.go
+++ b/internal/sourceruntime/sourceworker/host_test.go
@@ -204,6 +204,20 @@ func TestHostCarriesCredentialFreeBodyAndHeadersBeforeApplyingJumpCloudAuth(t *t
 	}
 }
 
+func TestCredentialHeaderAppliesOnlyTheClosedSentinelOneScheme(t *testing.T) {
+	header, value, err := credentialHeader("sentinelone.api_token", []byte("synthetic-secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clear(value)
+	if header != "Authorization" || string(value) != "ApiToken synthetic-secret" {
+		t.Fatal("SentinelOne credential operation did not produce the exact provider scheme")
+	}
+	if _, _, err := credentialHeader("sentinelone.bearer", []byte("synthetic-secret")); !errors.Is(err, ErrWorkerContract) {
+		t.Fatalf("unregistered credential operation error = %v, want ErrWorkerContract", err)
+	}
+}
+
 func TestSafeResponseHeadersRedactsAndBounds(t *testing.T) {
 	headers := http.Header{
 		"X-Result-Count": {"2"}, "X-Limit": {"2"}, "X-Search_after": {`{"id":"event-2"}`}, "Retry-After": {"30"},

--- a/internal/sourceruntime/sourceworker/pull.go
+++ b/internal/sourceruntime/sourceworker/pull.go
@@ -76,7 +76,7 @@ func PublicExecutionConfig(values map[string]string) map[string]string {
 	for _, key := range []string{
 		"audit_end_time", "audit_services", "audit_sort", "audit_start_time", "base_url",
 		"family", "group_id", "group_ids", "insights_base_url", "org_id", "per_page",
-		"tailnet", "user_group_id", "user_group_ids",
+		"site_id", "tailnet", "user_group_id", "user_group_ids",
 	} {
 		if value, ok := values[key]; ok {
 			public[key] = strings.TrimSpace(value)

--- a/internal/sourceruntime/sourceworker/pull_test.go
+++ b/internal/sourceruntime/sourceworker/pull_test.go
@@ -71,9 +71,10 @@ func TestProviderResumeFailsClosedForMalformedAndCrossFamilyCheckpoints(t *testi
 func TestPublicExecutionConfigNeverCarriesCredentialMaterial(t *testing.T) {
 	public := PublicExecutionConfig(map[string]string{
 		"family": "user", "tailnet": "example.com", "base_url": "https://api.tailscale.com/api/v2",
-		"token": "secret-token", "graph_token": "secret-graph-token", "tenant_id": "tenant-1",
+		"site_id": "site-1",
+		"token":   "secret-token", "graph_token": "secret-graph-token", "tenant_id": "tenant-1",
 	})
-	if len(public) != 3 || public["token"] != "" || public["graph_token"] != "" || public["tenant_id"] != "" {
+	if len(public) != 4 || public["site_id"] != "site-1" || public["token"] != "" || public["graph_token"] != "" || public["tenant_id"] != "" {
 		t.Fatalf("public config leaked private fields: %#v", public)
 	}
 }


### PR DESCRIPTION
## Scope

- compile the existing credential-free `sentinelone.agent` kernel through the closed Rust dispatcher
- accept the required public SentinelOne origin and bounded agent filters through runtime metadata
- keep credential redemption and `Authorization: ApiToken` application in the trusted Go host
- seal provider continuations and terminal provider-ID restart boundaries in Rust
- preserve Go-compatible tenant-scoped event identity, normalization, deduplication, and checked-in fixture parity

## Authority boundary

This PR adds execution plumbing only. It does not add `sentinelone.agent` to the production Rust-authority allowlist, retire the Go path, add credentials, deploy anything, or claim live-provider proof. The authority switch remains a separate forward PR after this contract passes hosted checks.

## Local validation

- `cargo fmt --all -- --check`
- `cargo clippy --manifest-path crates/source-runtime-next/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path crates/source-runtime-next/Cargo.toml --all-targets` — 619 library tests plus provider integration tests passed
- `go test ./internal/sourceruntime/...`
- `go test -race ./internal/sourceruntime/...`
- `golangci-lint run ./internal/sourceruntime/sourceworker/...` — 0 issues
- `make check-structural`
- `make check-arch`

DDESK workstation readiness is healthy, but this repository is still `waiting-for-disk` at the project preflight. No project disk was provisioned. The commands above ran on the explicitly authorized local recovery path with the repository-managed Cargo wrapper.
