### PR TITLE
Activate Azure and JumpCloud Rust source previews

### DIFF
--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -73,8 +73,8 @@ func (s *Service) Check(ctx context.Context, req *cerebrov1.CheckSourceRequest) 
 	if err != nil {
 		return nil, err
 	}
-	if tailscaleSource(req.GetSourceId()) {
-		if _, err := s.executeTailscale(ctx, config, nil); err != nil {
+	if family, authoritative := rustSourceFamily(req.GetSourceId(), config); authoritative {
+		if _, err := s.executeRustSource(ctx, req.GetSourceId(), family, config, nil); err != nil {
 			return nil, sourceOperationError(err)
 		}
 	} else if err := source.Check(ctx, sourcecdk.NewConfig(config)); err != nil {
@@ -108,8 +108,8 @@ func (s *Service) Discover(ctx context.Context, req *cerebrov1.DiscoverSourceReq
 		return nil, err
 	}
 	var urns []sourcecdk.URN
-	if tailscaleSource(req.GetSourceId()) {
-		pull, executeErr := s.executeTailscale(ctx, config, nil)
+	if family, authoritative := rustSourceFamily(req.GetSourceId(), config); authoritative {
+		pull, executeErr := s.executeRustSource(ctx, req.GetSourceId(), family, config, nil)
 		if executeErr != nil {
 			return nil, sourceOperationError(executeErr)
 		}
@@ -153,8 +153,8 @@ func (s *Service) Read(ctx context.Context, req *cerebrov1.ReadSourceRequest) (_
 		return nil, err
 	}
 	var pull sourcecdk.Pull
-	if tailscaleSource(req.GetSourceId()) {
-		pull, err = s.executeTailscale(ctx, config, req.GetCursor())
+	if family, authoritative := rustSourceFamily(req.GetSourceId(), config); authoritative {
+		pull, err = s.executeRustSource(ctx, req.GetSourceId(), family, config, req.GetCursor())
 	} else {
 		pull, err = source.Read(ctx, sourcecdk.NewConfig(config), req.GetCursor())
 	}

--- a/internal/sourceops/service.go
+++ b/internal/sourceops/service.go
@@ -109,11 +109,7 @@ func (s *Service) Discover(ctx context.Context, req *cerebrov1.DiscoverSourceReq
 	}
 	var urns []sourcecdk.URN
 	if family, authoritative := rustSourceFamily(req.GetSourceId(), config); authoritative {
-		pull, executeErr := s.executeRustSource(ctx, req.GetSourceId(), family, config, nil)
-		if executeErr != nil {
-			return nil, sourceOperationError(executeErr)
-		}
-		urns, err = discoverURNs(pull)
+		urns, err = s.discoverRustSource(ctx, req.GetSourceId(), family, config)
 	} else {
 		urns, err = source.Discover(ctx, sourcecdk.NewConfig(config))
 	}

--- a/internal/sourceops/source_execution.go
+++ b/internal/sourceops/source_execution.go
@@ -17,6 +17,7 @@ const (
 	previewLeaseOwner                 = "source-preview"
 	previewRuntimeGeneration   uint64 = 1
 	previewLeaseGeneration     uint64 = 1
+	maxRustDiscoveryPages             = 10_000
 )
 
 type sourceExecutionRunner func(context.Context, sourceworker.Worker, string, []byte, time.Time, sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error)
@@ -90,6 +91,43 @@ func (s *Service) executeRustSource(ctx context.Context, sourceID, family string
 		return sourcecdk.Pull{}, sourceExecutionError(sourceID, family, err)
 	}
 	return pull, nil
+}
+
+func (s *Service) discoverRustSource(ctx context.Context, sourceID, family string, config map[string]string) ([]sourcecdk.URN, error) {
+	seenURNs := make(map[string]struct{})
+	seenCursors := make(map[string]struct{})
+	urns := make([]sourcecdk.URN, 0)
+	var cursor *cerebrov1.SourceCursor
+	for page := 0; page < maxRustDiscoveryPages; page++ {
+		pull, err := s.executeRustSource(ctx, sourceID, family, config, cursor)
+		if err != nil {
+			return nil, err
+		}
+		pageURNs, err := discoverURNs(pull)
+		if err != nil {
+			return nil, err
+		}
+		for _, urn := range pageURNs {
+			if _, ok := seenURNs[urn.String()]; ok {
+				continue
+			}
+			seenURNs[urn.String()] = struct{}{}
+			urns = append(urns, urn)
+		}
+		if pull.NextCursor == nil {
+			return urns, nil
+		}
+		next := strings.TrimSpace(pull.NextCursor.GetOpaque())
+		if next == "" {
+			return nil, fmt.Errorf("%w: Rust discovery continuation is empty", sourceworker.ErrWorkerContract)
+		}
+		if _, ok := seenCursors[next]; ok {
+			return nil, fmt.Errorf("%w: Rust discovery continuation repeated", sourceworker.ErrWorkerContract)
+		}
+		seenCursors[next] = struct{}{}
+		cursor = &cerebrov1.SourceCursor{Opaque: next}
+	}
+	return nil, fmt.Errorf("%w: Rust discovery exceeded %d pages", sourceworker.ErrWorkerContract, maxRustDiscoveryPages)
 }
 
 func previewCredential(sourceID string, config map[string]string) string {

--- a/internal/sourceops/source_execution.go
+++ b/internal/sourceops/source_execution.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	tailscaleSourceID                 = "tailscale"
 	previewCredentialReference        = "credential:source-preview:token" // #nosec G101 -- opaque credential-reference label.
 	previewLeaseOwner                 = "source-preview"
 	previewRuntimeGeneration   uint64 = 1
@@ -39,36 +38,33 @@ func (s *Service) WithSourceExecutionWorkerPath(path string) *Service {
 	return s
 }
 
-func tailscaleSource(sourceID string) bool {
-	return strings.TrimSpace(sourceID) == tailscaleSourceID
+func rustSourceFamily(sourceID string, config map[string]string) (string, bool) {
+	return sourceworker.RustAuthoritativeFamily(sourceID, config["family"])
 }
 
-func (s *Service) executeTailscale(ctx context.Context, config map[string]string, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
+func (s *Service) executeRustSource(ctx context.Context, sourceID, family string, config map[string]string, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {
 	if s == nil || s.sourceWorker == nil || s.runSourceExecution == nil {
-		return sourcecdk.Pull{}, sourceExecutionError("", sourceworker.ErrWorkerUnsupported)
+		return sourcecdk.Pull{}, sourceExecutionError(sourceID, family, sourceworker.ErrWorkerUnsupported)
 	}
-	family := strings.TrimSpace(config["family"])
-	if family == "" {
-		family = "device"
-	}
+	sourceID, family = strings.TrimSpace(sourceID), strings.TrimSpace(family)
 	tenantID := strings.TrimSpace(config["tenant_id"])
-	credential := []byte(strings.TrimSpace(config["token"]))
+	credential := []byte(previewCredential(sourceID, config))
 	if tenantID == "" || len(credential) == 0 {
 		clear(credential)
-		return sourcecdk.Pull{}, sourceExecutionError(family, sourceworker.ErrSourceConfiguration)
+		return sourcecdk.Pull{}, sourceExecutionError(sourceID, family, sourceworker.ErrSourceConfiguration)
 	}
-	providerCursor, priorWatermark, err := sourceworker.ProviderResume(cursor, tailscaleSourceID, family)
+	providerCursor, priorWatermark, err := sourceworker.ProviderResume(cursor, sourceID, family)
 	if err != nil {
 		clear(credential)
-		return sourcecdk.Pull{}, sourceExecutionError(family, err)
+		return sourcecdk.Pull{}, sourceExecutionError(sourceID, family, err)
 	}
 	publicConfig := sourceworker.PublicExecutionConfig(config)
 	publicConfig["family"] = family
 	now := time.Now().UTC()
 	input := sourceworker.ExecutionInput{
-		SourceID: tailscaleSourceID, FamilyID: family, CredentialReference: previewCredentialReference, PageNumber: 1,
+		SourceID: sourceID, FamilyID: family, CredentialReference: previewCredentialReference, PageNumber: 1,
 		Scope: sourceworker.CredentialScope{
-			TenantID: tenantID, RuntimeID: "source-preview-tailscale-" + family,
+			TenantID: tenantID, RuntimeID: "source-preview-" + sourceID + "-" + family,
 			PriorCursor: providerCursor, PublicConfig: publicConfig,
 			PriorTerminalWatermarkUnixMillis: priorWatermark, PriorCheckpoint: strings.TrimSpace(cursor.GetOpaque()),
 			LeaseOwner: previewLeaseOwner, RuntimeGeneration: previewRuntimeGeneration,
@@ -78,13 +74,22 @@ func (s *Service) executeTailscale(ctx context.Context, config map[string]string
 	output, err := s.runSourceExecution(ctx, s.sourceWorker, previewCredentialReference, credential, now.Add(time.Minute), input)
 	clear(credential)
 	if err != nil {
-		return sourcecdk.Pull{}, sourceExecutionError(family, err)
+		return sourcecdk.Pull{}, sourceExecutionError(sourceID, family, err)
 	}
 	pull, err := sourceworker.PullFromExecutionOutput(output, tenantID)
 	if err != nil {
-		return sourcecdk.Pull{}, sourceExecutionError(family, err)
+		return sourcecdk.Pull{}, sourceExecutionError(sourceID, family, err)
 	}
 	return pull, nil
+}
+
+func previewCredential(sourceID string, config map[string]string) string {
+	if strings.TrimSpace(sourceID) == "azure" {
+		if credential := strings.TrimSpace(config["graph_token"]); credential != "" {
+			return credential
+		}
+	}
+	return strings.TrimSpace(config["token"])
 }
 
 func discoverURNs(pull sourcecdk.Pull) ([]sourcecdk.URN, error) {
@@ -92,6 +97,15 @@ func discoverURNs(pull sourcecdk.Pull) ([]sourcecdk.URN, error) {
 	urns := make([]sourcecdk.URN, 0, len(pull.Events))
 	for _, event := range pull.Events {
 		raw := strings.TrimSpace(event.GetAttributes()["resource_urn"])
+		if raw == "" {
+			attributes := event.GetAttributes()
+			provider := strings.TrimSpace(attributes["resource_provider"])
+			resourceType := strings.TrimSpace(attributes["resource_type"])
+			resourceID := strings.TrimSpace(attributes["resource_id"])
+			if provider != "" && resourceType != "" && resourceID != "" {
+				raw = fmt.Sprintf("urn:cerebro:%s:%s_%s:%s", event.GetTenantId(), provider, resourceType, resourceID)
+			}
+		}
 		urn, err := sourcecdk.ParseURN(raw)
 		if err != nil {
 			return nil, fmt.Errorf("%w: Rust record resource URN is invalid", sourceworker.ErrWorkerContract)
@@ -105,7 +119,7 @@ func discoverURNs(pull sourcecdk.Pull) ([]sourcecdk.URN, error) {
 	return urns, nil
 }
 
-func sourceExecutionError(family string, err error) error {
+func sourceExecutionError(sourceID, family string, err error) error {
 	kind := sourcecdk.ErrorKindProvider
 	switch {
 	case errors.Is(err, sourceworker.ErrSourceConfiguration), errors.Is(err, sourceworker.ErrCredentialReferenceMissing), errors.Is(err, sourceworker.ErrWorkerUnsupported):
@@ -121,5 +135,5 @@ func sourceExecutionError(family string, err error) error {
 	case errors.Is(err, sourceworker.ErrProviderMalformedResponse), errors.Is(err, sourceworker.ErrWorkerContract), errors.Is(err, sourceworker.ErrInvalidExecution):
 		kind = sourcecdk.ErrorKindDecode
 	}
-	return sourcecdk.WrapSourceError(kind, tailscaleSourceID, family, err)
+	return sourcecdk.WrapSourceError(kind, sourceID, family, err)
 }

--- a/internal/sourceops/source_execution.go
+++ b/internal/sourceops/source_execution.go
@@ -39,7 +39,16 @@ func (s *Service) WithSourceExecutionWorkerPath(path string) *Service {
 }
 
 func rustSourceFamily(sourceID string, config map[string]string) (string, bool) {
-	return sourceworker.RustAuthoritativeFamily(sourceID, config["family"])
+	sourceID = strings.TrimSpace(sourceID)
+	// Preview authority is promoted separately from the durable runtime. A new
+	// runtime-authoritative provider must keep its existing sourceops path until
+	// its preview credential adapter and product-surface parity are ready.
+	switch sourceID {
+	case "azure", "tailscale":
+		return sourceworker.RustAuthoritativeFamily(sourceID, config["family"])
+	default:
+		return "", false
+	}
 }
 
 func (s *Service) executeRustSource(ctx context.Context, sourceID, family string, config map[string]string, cursor *cerebrov1.SourceCursor) (sourcecdk.Pull, error) {

--- a/internal/sourceops/source_execution.go
+++ b/internal/sourceops/source_execution.go
@@ -47,6 +47,14 @@ func rustSourceFamily(sourceID string, config map[string]string) (string, bool) 
 	switch sourceID {
 	case "azure", "tailscale":
 		return sourceworker.RustAuthoritativeFamily(sourceID, config["family"])
+	case "jumpcloud":
+		family := strings.TrimSpace(config["family"])
+		if family == "" {
+			family = "users"
+		}
+		// The Rust dispatcher owns the closed family catalog. Keeping unknown
+		// names authoritative makes them fail closed instead of reaching Go.
+		return family, true
 	default:
 		return "", false
 	}
@@ -131,10 +139,18 @@ func (s *Service) discoverRustSource(ctx context.Context, sourceID, family strin
 }
 
 func previewCredential(sourceID string, config map[string]string) string {
-	if strings.TrimSpace(sourceID) == "azure" {
+	switch strings.TrimSpace(sourceID) {
+	case "azure":
 		if credential := strings.TrimSpace(config["graph_token"]); credential != "" {
 			return credential
 		}
+	case "jumpcloud":
+		for _, key := range []string{"api_key", "api_token", "token"} {
+			if credential := strings.TrimSpace(config[key]); credential != "" {
+				return credential
+			}
+		}
+		return ""
 	}
 	return strings.TrimSpace(config["token"])
 }
@@ -143,9 +159,31 @@ func discoverURNs(pull sourcecdk.Pull) ([]sourcecdk.URN, error) {
 	seen := make(map[string]struct{}, len(pull.Events))
 	urns := make([]sourcecdk.URN, 0, len(pull.Events))
 	for _, event := range pull.Events {
-		raw := strings.TrimSpace(event.GetAttributes()["resource_urn"])
+		attributes := event.GetAttributes()
+		raw := strings.TrimSpace(attributes["resource_urn"])
+		if raw == "" && strings.TrimSpace(event.GetSourceId()) == "jumpcloud" {
+			family := strings.TrimSpace(attributes["family"])
+			if family == "" {
+				family = strings.TrimPrefix(strings.TrimSpace(event.GetKind()), "jumpcloud.")
+			}
+			stableID := firstNonEmpty(attributes, "source_event_id", "resource_id")
+			var urn sourcecdk.URN
+			var err error
+			if family == "group_members" {
+				memberID := firstNonEmpty(attributes, "member_user_id", "member_id", "resource_id", "source_event_id")
+				urn, err = sourcecdk.URNForEscaped(event.GetTenantId(), "jumpcloud_group_members", strings.TrimSpace(attributes["group_id"]), memberID)
+			} else {
+				if family == "audit_events" {
+					stableID = sourcecdk.StableExternalID(stableID, "event")
+				}
+				urn, err = sourcecdk.URNFor(event.GetTenantId(), "jumpcloud_"+family, stableID)
+			}
+			if err != nil {
+				return nil, fmt.Errorf("%w: JumpCloud discovery identity is invalid", sourceworker.ErrWorkerContract)
+			}
+			raw = urn.String()
+		}
 		if raw == "" {
-			attributes := event.GetAttributes()
 			provider := strings.TrimSpace(attributes["resource_provider"])
 			resourceType := strings.TrimSpace(attributes["resource_type"])
 			resourceID := strings.TrimSpace(attributes["resource_id"])
@@ -164,6 +202,15 @@ func discoverURNs(pull sourcecdk.Pull) ([]sourcecdk.URN, error) {
 		urns = append(urns, urn)
 	}
 	return urns, nil
+}
+
+func firstNonEmpty(values map[string]string, keys ...string) string {
+	for _, key := range keys {
+		if value := strings.TrimSpace(values[key]); value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func sourceExecutionError(sourceID, family string, err error) error {

--- a/internal/sourceops/source_execution_test.go
+++ b/internal/sourceops/source_execution_test.go
@@ -172,7 +172,7 @@ func TestRustDiscoveryRejectsRepeatedContinuation(t *testing.T) {
 		return previewOutput("device", "provider-page-2", "provider-page-2", input.Scope.PriorTerminalWatermarkUnixMillis), nil
 	}
 	_, err := service.discoverRustSource(context.Background(), "tailscale", "device", tailscalePreviewConfig("device"))
-	if !errors.Is(err, sourceworker.ErrWorkerContract) || !strings.Contains(err.Error(), "continuation repeated") {
+	if !errors.Is(err, sourceworker.ErrWorkerContract) {
 		t.Fatalf("discoverRustSource() error = %v", err)
 	}
 }

--- a/internal/sourceops/source_execution_test.go
+++ b/internal/sourceops/source_execution_test.go
@@ -21,13 +21,112 @@ func TestRustSourceFamilyPreviewAuthorityIsExact(t *testing.T) {
 		"Azure authorization policy": {"azure", "authorization_policy", "authorization_policy", true},
 		"other Azure family":         {"azure", "user", "user", false},
 		"Tailscale default":          {"tailscale", "", "device", true},
-		"JumpCloud runtime only":     {"jumpcloud", "users", "", false},
+		"JumpCloud default":          {"jumpcloud", "", "users", true},
+		"JumpCloud family":           {"jumpcloud", "group_members", "group_members", true},
+		"unknown JumpCloud family":   {"jumpcloud", "future-family", "future-family", true},
 		"compatibility source":       {"gcp", "audit", "", false},
 	} {
 		t.Run(name, func(t *testing.T) {
 			family, authoritative := rustSourceFamily(test.source, map[string]string{"family": test.family})
 			if family != test.wantFamily || authoritative != test.wantAuthoritative {
 				t.Fatalf("rustSourceFamily() = (%q, %v), want (%q, %v)", family, authoritative, test.wantFamily, test.wantAuthoritative)
+			}
+		})
+	}
+}
+
+func TestJumpCloudCheckDiscoverAndReadUseOnlyClosedRustAuthority(t *testing.T) {
+	const credentialFixture = "host-only-jumpcloud-secret" // #nosec G101 -- synthetic boundary-test sentinel, not credential material.
+	for _, family := range []string{"users", "groups", "systems", "applications", "system_groups", "group_members", "audit_events"} {
+		t.Run(family, func(t *testing.T) {
+			legacy := &authorityProbeSource{sourceID: "jumpcloud"}
+			registry, err := sourcecdk.NewRegistry(legacy)
+			if err != nil {
+				t.Fatal(err)
+			}
+			service := New(registry)
+			service.sourceWorker = previewWorkerStub{}
+			calls := 0
+			service.runSourceExecution = func(_ context.Context, _ sourceworker.Worker, reference string, credential []byte, _ time.Time, input sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+				calls++
+				if reference != previewCredentialReference || string(credential) != credentialFixture {
+					t.Fatal("JumpCloud credential was not confined to the trusted runner boundary")
+				}
+				encoded, marshalErr := json.Marshal(input)
+				if marshalErr != nil || strings.Contains(string(encoded), credentialFixture) || input.Scope.PublicConfig["api_key"] != "" {
+					t.Fatalf("credential crossed the worker protocol: %s, %v", encoded, marshalErr)
+				}
+				if input.SourceID != "jumpcloud" || input.FamilyID != family {
+					t.Fatalf("Rust selection = %s.%s", input.SourceID, input.FamilyID)
+				}
+				return jumpCloudPreviewOutput(family, input.Scope.PriorTerminalWatermarkUnixMillis), nil
+			}
+			config := map[string]string{"family": family, "tenant_id": "tenant-1", "api_key": credentialFixture}
+			if family == "group_members" {
+				config["group_ids"] = "group-1,group-2"
+			}
+			if _, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{SourceId: "jumpcloud", Config: config}); err != nil {
+				t.Fatal(err)
+			}
+			discovered, err := service.Discover(context.Background(), &cerebrov1.DiscoverSourceRequest{SourceId: "jumpcloud", Config: config})
+			if err != nil || len(discovered.GetUrns()) != 1 {
+				t.Fatalf("Discover() = %#v, %v", discovered, err)
+			}
+			providerID := family + "-1"
+			if family == "audit_events" {
+				providerID = sourcecdk.StableExternalID("event-1", "event")
+			}
+			wantURN, urnErr := sourcecdk.URNFor("tenant-1", "jumpcloud_"+family, providerID)
+			if family == "group_members" {
+				wantURN, urnErr = sourcecdk.URNForEscaped("tenant-1", "jumpcloud_group_members", "group-1", family+"-1")
+			}
+			if urnErr != nil || discovered.GetUrns()[0] != wantURN.String() {
+				t.Fatalf("Discover() URN = %q, want %q, %v", discovered.GetUrns()[0], wantURN.String(), urnErr)
+			}
+			read, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{SourceId: "jumpcloud", Config: config})
+			if err != nil || len(read.GetEvents()) != 1 || read.GetEvents()[0].GetSourceId() != "jumpcloud" || read.GetCheckpoint().GetCursorOpaque() == "" {
+				t.Fatalf("Read() = %#v, %v", read, err)
+			}
+			if calls != 3 || legacy.checkCalls != 0 || legacy.discoverCalls != 0 || legacy.readCalls != 0 {
+				t.Fatalf("calls = Rust %d, Go check/discover/read %d/%d/%d", calls, legacy.checkCalls, legacy.discoverCalls, legacy.readCalls)
+			}
+		})
+	}
+}
+
+func TestUnknownJumpCloudFamilyFailsClosedWithoutLegacyCalls(t *testing.T) {
+	legacy := &authorityProbeSource{sourceID: "jumpcloud"}
+	registry, err := sourcecdk.NewRegistry(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := New(registry)
+	service.sourceWorker = previewWorkerStub{}
+	service.runSourceExecution = func(context.Context, sourceworker.Worker, string, []byte, time.Time, sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+		return nil, sourceworker.ErrWorkerUnsupported
+	}
+	config := map[string]string{"family": "future-family", "tenant_id": "tenant-1", "api_key": "host-only-secret"}
+	if _, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{SourceId: "jumpcloud", Config: config}); !errors.Is(err, sourceworker.ErrWorkerUnsupported) {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if legacy.checkCalls != 0 {
+		t.Fatalf("legacy check calls = %d", legacy.checkCalls)
+	}
+}
+
+func TestJumpCloudPreviewCredentialAliases(t *testing.T) {
+	for name, test := range map[string]struct {
+		config map[string]string
+		want   string
+	}{
+		"api key":   {map[string]string{"api_key": "api-key", "token": "fallback"}, "api-key"},
+		"api token": {map[string]string{"api_token": "api-token", "token": "fallback"}, "api-token"},
+		"token":     {map[string]string{"token": "token"}, "token"},
+		"missing":   {map[string]string{"graph_token": "wrong-provider"}, ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := previewCredential("jumpcloud", test.config); got != test.want {
+				t.Fatalf("previewCredential() = %q, want %q", got, test.want)
 			}
 		})
 	}
@@ -384,5 +483,37 @@ func azureAuthorizationPolicyPreviewOutput(priorWatermark int64) *sourceworker.E
 	return &sourceworker.ExecutionOutput{
 		Plan: plan, Result: &cerebrov1.SourceWorkerDecodeResultV1{ResultDigestSha256: "result-digest"},
 		Program: &sourceworker.PageProgram{TransitionDigest: "transition", AdmittedRecords: []*cerebrov1.SourceWorkerRecordV1{record}, CheckpointCursor: "authorizationPolicy", CheckpointWatermarkUnixMillis: watermark},
+	}
+}
+
+func jumpCloudPreviewOutput(family string, priorWatermark int64) *sourceworker.ExecutionOutput {
+	watermark := max(priorWatermark, 1_725_000_000_000)
+	providerID := family + "-1"
+	if family == "audit_events" {
+		providerID = "event-1"
+	}
+	plan := &cerebrov1.SourceExecutionPlanV1{
+		SourceId: "jumpcloud", FamilyId: family, EventKind: "jumpcloud." + family, SchemaRef: "jumpcloud/" + family + "/v1",
+	}
+	attributes := map[string]string{
+		"family": family, "provider": "jumpcloud", "source_event_id": providerID,
+		"resource_id": providerID, "resource_type": family,
+	}
+	if family == "users" || family == "systems" || family == "applications" {
+		attributes["resource_urn"] = "urn:cerebro:tenant-1:jumpcloud_" + family + ":" + family + "-1"
+	}
+	if family == "group_members" {
+		attributes["group_id"] = "group-1"
+		attributes["member_id"] = family + "-1"
+		attributes["member_user_id"] = family + "-1"
+	}
+	record := &cerebrov1.SourceWorkerRecordV1{
+		ProviderId: providerID, EventId: "jumpcloud-tenant-1-" + providerID, OccurredAtUnixMillis: watermark,
+		Attributes:  attributes,
+		PayloadJson: []byte(`{"id":"` + family + `-1"}`),
+	}
+	return &sourceworker.ExecutionOutput{
+		Plan: plan, Result: &cerebrov1.SourceWorkerDecodeResultV1{ResultDigestSha256: "result-digest"},
+		Program: &sourceworker.PageProgram{TransitionDigest: "transition", AdmittedRecords: []*cerebrov1.SourceWorkerRecordV1{record}, CheckpointCursor: family + "-1", CheckpointWatermarkUnixMillis: watermark},
 	}
 }

--- a/internal/sourceops/source_execution_test.go
+++ b/internal/sourceops/source_execution_test.go
@@ -174,10 +174,86 @@ func TestTailscaleSourceExecutionFailuresRemainTyped(t *testing.T) {
 	}
 }
 
-type authorityProbeSource struct{ checkCalls, discoverCalls, readCalls int }
+func TestAzureAuthorizationPolicyCheckDiscoverAndReadUseOnlyClosedRustAuthority(t *testing.T) {
+	const graphCredentialFixture = "host-only-graph-secret" // #nosec G101 -- synthetic boundary-test sentinel, not credential material.
+	legacy := &authorityProbeSource{sourceID: "azure"}
+	registry, err := sourcecdk.NewRegistry(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := New(registry)
+	service.sourceWorker = previewWorkerStub{}
+	calls := 0
+	service.runSourceExecution = func(_ context.Context, _ sourceworker.Worker, reference string, credential []byte, _ time.Time, input sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+		calls++
+		if reference != previewCredentialReference || string(credential) != graphCredentialFixture {
+			t.Fatal("Azure graph credential was not confined to the trusted runner boundary")
+		}
+		encoded, marshalErr := json.Marshal(input)
+		if marshalErr != nil || strings.Contains(string(encoded), graphCredentialFixture) || input.Scope.PublicConfig["graph_token"] != "" {
+			t.Fatalf("credential crossed the worker protocol: %s, %v", encoded, marshalErr)
+		}
+		if input.SourceID != "azure" || input.FamilyID != "authorization_policy" {
+			t.Fatalf("Rust selection = %s.%s", input.SourceID, input.FamilyID)
+		}
+		return azureAuthorizationPolicyPreviewOutput(input.Scope.PriorTerminalWatermarkUnixMillis), nil
+	}
+	config := map[string]string{
+		"family": "authorization_policy", "tenant_id": "tenant-1", "graph_token": graphCredentialFixture,
+	}
+	if _, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{SourceId: "azure", Config: config}); err != nil {
+		t.Fatal(err)
+	}
+	discovered, err := service.Discover(context.Background(), &cerebrov1.DiscoverSourceRequest{SourceId: "azure", Config: config})
+	if err != nil || len(discovered.GetUrns()) != 1 || discovered.GetUrns()[0] != "urn:cerebro:tenant-1:azure_authorization_policy:authorizationPolicy" {
+		t.Fatalf("Discover() = %#v, %v", discovered, err)
+	}
+	read, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{SourceId: "azure", Config: config})
+	if err != nil || len(read.GetEvents()) != 1 || read.GetEvents()[0].GetSourceId() != "azure" {
+		t.Fatalf("Read() = %#v, %v", read, err)
+	}
+	if calls != 3 || legacy.checkCalls != 0 || legacy.discoverCalls != 0 || legacy.readCalls != 0 {
+		t.Fatalf("calls = Rust %d, Go check/discover/read %d/%d/%d", calls, legacy.checkCalls, legacy.discoverCalls, legacy.readCalls)
+	}
+}
 
-func (*authorityProbeSource) Spec() *cerebrov1.SourceSpec {
-	return &cerebrov1.SourceSpec{Id: "tailscale"}
+func TestOtherAzureFamilyRemainsOnGoPreview(t *testing.T) {
+	legacy := &authorityProbeSource{sourceID: "azure"}
+	registry, err := sourcecdk.NewRegistry(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := New(registry)
+	service.sourceWorker = previewWorkerStub{}
+	service.runSourceExecution = func(context.Context, sourceworker.Worker, string, []byte, time.Time, sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+		t.Fatal("Rust preview executed for a Go-compatible Azure family")
+		return nil, nil
+	}
+	config := map[string]string{"family": "user"}
+	if _, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{SourceId: "azure", Config: config}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Discover(context.Background(), &cerebrov1.DiscoverSourceRequest{SourceId: "azure", Config: config}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{SourceId: "azure", Config: config}); err != nil {
+		t.Fatal(err)
+	}
+	if legacy.checkCalls != 1 || legacy.discoverCalls != 1 || legacy.readCalls != 1 {
+		t.Fatalf("Go calls = check/discover/read %d/%d/%d", legacy.checkCalls, legacy.discoverCalls, legacy.readCalls)
+	}
+}
+
+type authorityProbeSource struct {
+	sourceID                             string
+	checkCalls, discoverCalls, readCalls int
+}
+
+func (s *authorityProbeSource) Spec() *cerebrov1.SourceSpec {
+	if s.sourceID == "" {
+		return &cerebrov1.SourceSpec{Id: "tailscale"}
+	}
+	return &cerebrov1.SourceSpec{Id: s.sourceID}
 }
 func (s *authorityProbeSource) Check(context.Context, sourcecdk.Config) error {
 	s.checkCalls++
@@ -236,5 +312,24 @@ func previewOutput(family, nextCursor, checkpointCursor string, priorWatermark i
 	return &sourceworker.ExecutionOutput{
 		Plan: plan, Result: &cerebrov1.SourceWorkerDecodeResultV1{NextCursor: nextCursor, ResultDigestSha256: "result-digest"},
 		Program: &sourceworker.PageProgram{TransitionDigest: "transition", AdmittedRecords: []*cerebrov1.SourceWorkerRecordV1{record}, CheckpointCursor: checkpointCursor, CheckpointWatermarkUnixMillis: watermark},
+	}
+}
+
+func azureAuthorizationPolicyPreviewOutput(priorWatermark int64) *sourceworker.ExecutionOutput {
+	watermark := max(priorWatermark, 1_725_000_000_000)
+	plan := &cerebrov1.SourceExecutionPlanV1{
+		SourceId: "azure", FamilyId: "authorization_policy", EventKind: "azure.authorization_policy", SchemaRef: "azure/authorization_policy/v1",
+	}
+	record := &cerebrov1.SourceWorkerRecordV1{
+		ProviderId: "authorizationPolicy", EventId: "azure-authorization-policy-authorizationPolicy", OccurredAtUnixMillis: watermark,
+		Attributes: map[string]string{
+			"family": "authorization_policy", "resource_id": "authorizationPolicy", "resource_name": "authorizationPolicy",
+			"resource_provider": "azure", "resource_type": "authorization_policy",
+		},
+		PayloadJson: []byte(`{"id":"authorizationPolicy"}`),
+	}
+	return &sourceworker.ExecutionOutput{
+		Plan: plan, Result: &cerebrov1.SourceWorkerDecodeResultV1{ResultDigestSha256: "result-digest"},
+		Program: &sourceworker.PageProgram{TransitionDigest: "transition", AdmittedRecords: []*cerebrov1.SourceWorkerRecordV1{record}, CheckpointCursor: "authorizationPolicy", CheckpointWatermarkUnixMillis: watermark},
 	}
 }

--- a/internal/sourceops/source_execution_test.go
+++ b/internal/sourceops/source_execution_test.go
@@ -144,6 +144,39 @@ func TestTailscaleReadContinuesOnlyForProviderCursorAndFailsClosed(t *testing.T)
 	}
 }
 
+func TestRustDiscoveryReadsEveryPageAndDeduplicatesURNs(t *testing.T) {
+	service := tailscaleAuthorityService(t)
+	var inputs []sourceworker.ExecutionInput
+	service.runSourceExecution = func(_ context.Context, _ sourceworker.Worker, _ string, _ []byte, _ time.Time, input sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+		inputs = append(inputs, input)
+		if len(inputs) == 1 {
+			return previewOutput("device", "provider-page-2", "provider-page-2", 1_725_000_000_000), nil
+		}
+		return previewOutput("device", "", "device-terminal", 1_725_000_001_000), nil
+	}
+	urns, err := service.discoverRustSource(context.Background(), "tailscale", "device", tailscalePreviewConfig("device"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inputs) != 2 || inputs[1].Scope.PriorCursor != "provider-page-2" {
+		t.Fatalf("discovery inputs = %#v", inputs)
+	}
+	if len(urns) != 1 || urns[0].String() != "urn:cerebro:tenant-1:tailscale_device:device-1" {
+		t.Fatalf("deduplicated URNs = %#v", urns)
+	}
+}
+
+func TestRustDiscoveryRejectsRepeatedContinuation(t *testing.T) {
+	service := tailscaleAuthorityService(t)
+	service.runSourceExecution = func(_ context.Context, _ sourceworker.Worker, _ string, _ []byte, _ time.Time, input sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+		return previewOutput("device", "provider-page-2", "provider-page-2", input.Scope.PriorTerminalWatermarkUnixMillis), nil
+	}
+	_, err := service.discoverRustSource(context.Background(), "tailscale", "device", tailscalePreviewConfig("device"))
+	if !errors.Is(err, sourceworker.ErrWorkerContract) || !strings.Contains(err.Error(), "continuation repeated") {
+		t.Fatalf("discoverRustSource() error = %v", err)
+	}
+}
+
 func TestUnknownTailscaleFamilyFailsClosedWithoutLegacyCalls(t *testing.T) {
 	legacy := &authorityProbeSource{}
 	registry, err := sourcecdk.NewRegistry(legacy)

--- a/internal/sourceops/source_execution_test.go
+++ b/internal/sourceops/source_execution_test.go
@@ -13,6 +13,26 @@ import (
 	"github.com/writer/cerebro/internal/sourceruntime/sourceworker"
 )
 
+func TestRustSourceFamilyPreviewAuthorityIsExact(t *testing.T) {
+	for name, test := range map[string]struct {
+		source, family, wantFamily string
+		wantAuthoritative          bool
+	}{
+		"Azure authorization policy": {"azure", "authorization_policy", "authorization_policy", true},
+		"other Azure family":         {"azure", "user", "user", false},
+		"Tailscale default":          {"tailscale", "", "device", true},
+		"JumpCloud runtime only":     {"jumpcloud", "users", "", false},
+		"compatibility source":       {"gcp", "audit", "", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			family, authoritative := rustSourceFamily(test.source, map[string]string{"family": test.family})
+			if family != test.wantFamily || authoritative != test.wantAuthoritative {
+				t.Fatalf("rustSourceFamily() = (%q, %v), want (%q, %v)", family, authoritative, test.wantFamily, test.wantAuthoritative)
+			}
+		})
+	}
+}
+
 func TestTailscaleCheckDiscoverAndReadUseOnlyClosedRustAuthority(t *testing.T) {
 	for _, family := range []string{"device", "grant", "group", "service", "tag", "tailnet", "user"} {
 		t.Run(family, func(t *testing.T) {


### PR DESCRIPTION
## Scope

- route Azure `authorization_policy` check, discovery, and read previews through the Rust-authoritative source runtime
- route all seven JumpCloud preview families through the same Rust execution path
- keep preview authority explicit and fail closed for unknown or compatibility-only families
- preserve provider-specific discovery URNs, bounded pagination, duplicate collapse, and typed cursor failures

## Delivery context

PRs #2524 and #2526 were merged through their stacked branches after their parent PR #2522 had already merged to `main`. This forward integration PR carries only the three reviewed `internal/sourceops` paths from that completed stack onto current `main`.

## Validation already completed on the stacked heads

- focused `internal/sourceops`, `internal/sourcehttp`, bootstrap, and command tests
- `go test -race ./internal/sourceops/...`
- Go lint with zero issues
- architecture and structural checks

The integration PR must pass a fresh hosted check set against current `main`. This change does not add credentials, deploy private infrastructure, or claim a live-provider receipt.
