### PR TITLE
Activate Twilio accounts Rust source authority

### DIFF
--- a/internal/sourceruntime/source_execution_authority_test.go
+++ b/internal/sourceruntime/source_execution_authority_test.go
@@ -163,6 +163,78 @@ func TestOtherAzureFamilyRemainsGoCompatible(t *testing.T) {
 	}
 }
 
+func TestPutTwilioAccountsRuntimeValidatesWithRustWithoutCallingGoCheck(t *testing.T) {
+	legacy := &runtimeAuthorityProbe{sourceID: "twilio"}
+	registry, err := sourcecdk.NewRegistry(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker := &runtimePlanWorker{}
+	service := New(registry, &runtimeStore{}, nil, nil)
+	service.sourceWorker = worker
+	_, err = service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{Runtime: &cerebrov1.SourceRuntime{
+		Id: "twilio-accounts-runtime", SourceId: "twilio", TenantId: "tenant-1",
+		Config: map[string]string{
+			"family": "accounts", "username": "AC123",
+			"password": sourceconfig.CredentialReferenceValue("twilio", "password"),
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy.checkCalls != 0 || worker.planCalls != 1 {
+		t.Fatalf("validation calls = Go %d, Rust %d", legacy.checkCalls, worker.planCalls)
+	}
+	if worker.selection.SourceID != "twilio" || worker.selection.FamilyID != "accounts" {
+		t.Fatalf("Rust selection = %#v", worker.selection)
+	}
+	if worker.publicConfig["family"] != "accounts" || worker.publicConfig["username"] != "" || worker.publicConfig["password"] != "" {
+		t.Fatalf("Rust public config = %#v", worker.publicConfig)
+	}
+}
+
+func TestTwilioAccountsNeverFallsBackToGoAuthority(t *testing.T) {
+	legacy := &runtimeAuthorityProbe{sourceID: "twilio"}
+	worker := &runtimePlanWorker{compileErr: sourceworker.ErrWorkerUnsupported}
+	service := &Service{sourceWorker: worker}
+	runtime := &cerebrov1.SourceRuntime{
+		Id: "twilio-accounts-runtime", SourceId: "twilio", TenantId: "tenant-1",
+		Config: map[string]string{
+			"family": "accounts", "username": "AC123",
+			"password": sourceconfig.CredentialReferenceValue("twilio", "password"),
+		},
+	}
+	ctx := context.WithValue(context.Background(), sourceRuntimeLeaseFenceContextKey{}, sourceRuntimeLeaseAuthority{fence: ports.SourceRuntimeLeaseFence{
+		Owner: "owner-1", Generation: 1, ExpiresAt: time.Now().Add(time.Minute),
+	}})
+	resolved := sourcecdk.NewConfig(map[string]string{
+		"family": "accounts", "username": "AC123", "password": "host-only-secret",
+	})
+
+	if _, _, err := service.readSourcePull(ctx, runtime, legacy, resolved, nil, nil, 1); !errors.Is(err, sourceworker.ErrWorkerUnsupported) {
+		t.Fatalf("readSourcePull() error = %v", err)
+	}
+	if legacy.readCalls != 0 || worker.selection.SourceID != "twilio" || worker.selection.FamilyID != "accounts" {
+		t.Fatalf("authority calls = Go %d, Rust selection %#v", legacy.readCalls, worker.selection)
+	}
+}
+
+func TestOtherTwilioFamilyRemainsGoCompatible(t *testing.T) {
+	legacy := &runtimeAuthorityProbe{sourceID: "twilio"}
+	service := &Service{sourceWorker: &runtimePlanWorker{}}
+	runtime := &cerebrov1.SourceRuntime{Id: "twilio-keys-runtime", SourceId: "twilio", TenantId: "tenant-1"}
+	config := sourcecdk.NewConfig(map[string]string{"family": "keys"})
+
+	if _, rustPage, err := service.readSourcePull(context.Background(), runtime, legacy, config, nil, nil, 1); err != nil {
+		t.Fatalf("readSourcePull() error = %v", err)
+	} else if rustPage {
+		t.Fatal("readSourcePull() reported a Rust page for a Go-authoritative Twilio family")
+	}
+	if legacy.readCalls != 1 {
+		t.Fatalf("Go Read calls = %d, want 1", legacy.readCalls)
+	}
+}
+
 func TestPutJumpCloudFamiliesValidateWithRustWithoutCallingGoCheck(t *testing.T) {
 	families := []string{"users", "groups", "systems", "applications", "system_groups", "group_members", "audit_events"}
 	for _, family := range families {

--- a/internal/sourceruntime/sourceworker/pull.go
+++ b/internal/sourceruntime/sourceworker/pull.go
@@ -1,6 +1,7 @@
 package sourceworker
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strings"
 	"time"
@@ -32,6 +33,8 @@ func RustAuthoritativeFamily(sourceID, familyID string) (string, bool) {
 		return familyID, true
 	case "tailscale":
 		return TailscaleFamily(sourceID, familyID)
+	case "twilio":
+		return familyID, familyID == "accounts"
 	default:
 		return "", false
 	}
@@ -42,6 +45,21 @@ func RustAuthoritativeFamily(sourceID, familyID string) (string, bool) {
 // to the Go host; callers must never include the resolved value in worker
 // metadata, receipts, or errors.
 func CredentialBinding(sourceID string, references, resolved map[string]string) (string, string) {
+	if strings.TrimSpace(sourceID) == "twilio" {
+		username := strings.TrimSpace(resolved["username"])
+		passwordReference := strings.TrimSpace(references["password"])
+		password := strings.TrimSpace(resolved["password"])
+		if username == "" || passwordReference == "" || password == "" {
+			return "", ""
+		}
+		basic := make([]byte, 0, len(username)+1+len(password))
+		basic = append(basic, username...)
+		basic = append(basic, ':')
+		basic = append(basic, password...)
+		encoded := base64.StdEncoding.EncodeToString(basic)
+		clear(basic)
+		return passwordReference, encoded
+	}
 	keys := []string{"graph_token", "token"}
 	if strings.TrimSpace(sourceID) == "jumpcloud" {
 		keys = []string{"api_key", "api_token", "token"}

--- a/internal/sourceruntime/sourceworker/pull_test.go
+++ b/internal/sourceruntime/sourceworker/pull_test.go
@@ -91,6 +91,8 @@ func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
 		"unknown JumpCloud family":   {"jumpcloud", "future-family", "future-family", true},
 		"Tailscale default":          {"tailscale", "", "device", true},
 		"unknown Tailscale family":   {"tailscale", "future-family", "future-family", true},
+		"Twilio accounts":            {"twilio", "accounts", "accounts", true},
+		"other Twilio family":        {"twilio", "keys", "keys", false},
 		"compatibility source":       {"gcp", "audit", "", false},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -117,6 +119,11 @@ func TestCredentialBindingUsesOnlyTheSelectedProviderAliases(t *testing.T) {
 			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.
 			source: "jumpcloud", references: map[string]string{"api_key": "credential:jumpcloud:api-key", "token": "credential:jumpcloud:fallback"},
 			resolved: map[string]string{"api_key": "resolved-api-key", "token": "resolved-fallback"}, wantReference: "credential:jumpcloud:api-key", wantResolved: "resolved-api-key",
+		},
+		"Twilio basic credentials": {
+			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.
+			source: "twilio", references: map[string]string{"username": "AC123", "password": "credential:twilio:password"},
+			resolved: map[string]string{"username": "AC123", "password": "synthetic-password"}, wantReference: "credential:twilio:password", wantResolved: "QUMxMjM6c3ludGhldGljLXBhc3N3b3Jk",
 		},
 		"aliases cannot cross": {
 			source: "jumpcloud", references: map[string]string{"api_key": "credential:jumpcloud:api-key"},


### PR DESCRIPTION
## State

Stacked draft authority slice on PR #2532. This PR must not merge before the Twilio accounts Rust execution plumbing it depends on.

## Change

- add only `twilio.accounts` to the production Rust authority allowlist
- construct the provider Basic credential payload inside the trusted Go host from the resolved username and password
- bind the operation to the opaque password reference and clear the temporary raw `username:password` buffer after encoding
- prove source-runtime validation uses Rust without calling the Go source check
- prove a Rust compile failure never falls back to the Go reader
- keep Twilio `keys`, `audit_events`, and unknown families on Go compatibility

## Invariants

- username, password, and the derived Basic credential never enter the Rust worker protocol, public runtime metadata, receipts, or errors
- Rust constructs and validates the bounded provider request but performs no network I/O
- the trusted Go host remains the only component that applies authentication and executes the request
- one exact source-family owns production writes; Rust failure does not restore Go authority
- this PR does not change the authority of any other Twilio family

## Local validation

Passed on exact head `8177c9c22`:

- `go test ./internal/sourceruntime/sourceworker ./internal/sourceruntime -count=1`
- `go test -race ./internal/sourceruntime/sourceworker ./internal/sourceruntime -count=1`
- `go test ./internal/sourceruntime/... -count=1`
- `golangci-lint run ./internal/sourceruntime/...` (0 issues)
- `make check-structural`
- `make check-arch`
- `git diff --check`

## Follow-up

After PR #2532 merges, rebase this branch onto refreshed `main`, rerun exact-head validation and hosted checks, and merge only through normal protection. Deployment and live authenticated pagination, interrupt/resume, durable append/projection/checkpoint, and product-read proof remain separate release gates.
