### PR TITLE
Register Twilio audit events in the Rust dispatcher

### DIFF
--- a/crates/source-runtime-next/src/source_execution/dispatcher.rs
+++ b/crates/source-runtime-next/src/source_execution/dispatcher.rs
@@ -1,7 +1,9 @@
 use prost::Message;
 
 use crate::sentinelone::SentinelOneAgentSourceExecutionAdapter;
-use crate::twilio::adapter::TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER;
+use crate::twilio::adapter::{
+    TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER, TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER,
+};
 
 use super::{
     azure_authorization_policy::AzureAuthorizationPolicyAdapter,
@@ -124,6 +126,11 @@ impl SourceExecutionDispatcher {
         {
             return Ok(TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER.compiled_plan());
         }
+        if request.source_id == TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER.source_id()
+            && request.family_id == TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER.family_id()
+        {
+            return Ok(TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER.compiled_plan());
+        }
         if let Some(adapter) = JUMPCLOUD_ADAPTERS.iter().find(|adapter| {
             request.source_id == adapter.source_id() && request.family_id == adapter.family_id()
         }) {
@@ -159,6 +166,13 @@ impl SourceExecutionDispatcher {
             && plan.provider_kernel == TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER.provider_kernel()
         {
             return Ok(&TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER);
+        }
+        if plan.source_id == TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER.source_id()
+            && plan.family_id == TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER.family_id()
+            && plan.provider_kernel
+                == TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER.provider_kernel()
+        {
+            return Ok(&TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER);
         }
         if let Some(adapter) = JUMPCLOUD_ADAPTERS.iter().find(|adapter| {
             plan.source_id == adapter.source_id()

--- a/crates/source-runtime-next/src/source_execution/tests.rs
+++ b/crates/source-runtime-next/src/source_execution/tests.rs
@@ -639,6 +639,35 @@ fn closed_dispatcher_registers_and_executes_the_exact_twilio_accounts_plan() {
 }
 
 #[test]
+fn closed_dispatcher_registers_the_exact_twilio_audit_events_plan() {
+    let dispatcher = super::SourceExecutionDispatcher;
+    let plan = dispatcher
+        .compile_plan(&SourceExecutionSelectionRequestV1 {
+            source_id: "twilio".to_owned(),
+            family_id: "audit_events".to_owned(),
+        })
+        .unwrap();
+    assert_eq!(plan.source_id, "twilio");
+    assert_eq!(plan.family_id, "audit_events");
+    assert_eq!(plan.provider_kernel, "twilio.audit_events");
+    assert_eq!(plan.origin, "https://api.twilio.com");
+    assert_eq!(plan.path, "/v1/Events");
+    assert_eq!(plan.event_kind, "twilio.audit_events");
+    assert_eq!(plan.schema_ref, "twilio/audit_events/v1");
+    assert_eq!(
+        dispatcher.adapter_for(&plan).unwrap().family_id(),
+        "audit_events"
+    );
+    assert_eq!(
+        dispatcher.compile_plan(&SourceExecutionSelectionRequestV1 {
+            source_id: "twilio".to_owned(),
+            family_id: "keys".to_owned(),
+        }),
+        Err(SourceExecutionError::UnknownAdapter)
+    );
+}
+
+#[test]
 fn rejects_tenant_generation_timestamp_and_intent_mismatches() {
     let context = exact_context("tenant-a");
     let mut tenant = exact_decode_request(&context);

--- a/crates/source-runtime-next/src/twilio/adapter/mod.rs
+++ b/crates/source-runtime-next/src/twilio/adapter/mod.rs
@@ -1,4 +1,4 @@
-//! Accounts-first Twilio source-execution adapter core.
+//! Provider-local Twilio source-execution adapter core.
 
 use std::{error::Error, fmt};
 
@@ -6,35 +6,39 @@ use time::OffsetDateTime;
 
 use super::{TwilioError, TwilioFamily, TwilioFilters, TwilioKernel, TwilioPage, TwilioRequest};
 
-const ACCOUNTS_PATH: &str = "/2010-04-01/Accounts.json";
 const DEFAULT_ORIGIN: &str = "https://api.twilio.com";
 const MAX_RESPONSE_BYTES: u64 = 8 << 20;
 const PAGE_SIZE: usize = 100;
 
-/// Provider-local accounts adapter used by the canonical source-execution edge.
+/// Provider-local family adapter used by the canonical source-execution edge.
 ///
 /// The authenticated tenant and provider origin are supplied by the trusted
 /// host. This type accepts no credential value and performs no network I/O.
 #[derive(Clone, Debug)]
-pub(crate) struct TwilioAccountsAdapter {
+pub(crate) struct TwilioFamilyAdapter {
     kernel: TwilioKernel,
+    family: TwilioFamily,
 }
 
-impl TwilioAccountsAdapter {
+impl TwilioFamilyAdapter {
     pub(crate) const fn source_id() -> &'static str {
         "twilio"
     }
 
-    pub(crate) const fn family_id() -> &'static str {
-        "accounts"
+    pub(crate) const fn family_id(&self) -> &'static str {
+        self.family.as_str()
     }
 
-    pub(crate) const fn provider_kernel() -> &'static str {
-        "twilio.accounts"
+    pub(crate) const fn provider_kernel(&self) -> &'static str {
+        self.family.provider_kind()
     }
 
-    pub(crate) const fn path() -> &'static str {
-        ACCOUNTS_PATH
+    pub(crate) const fn path(&self) -> &'static str {
+        match self.family {
+            TwilioFamily::Accounts => "/2010-04-01/Accounts.json",
+            TwilioFamily::Keys => "/2010-04-01/Accounts/{account_sid}/Keys.json",
+            TwilioFamily::AuditEvents => "/v1/Events",
+        }
     }
 
     pub(crate) const fn default_origin() -> &'static str {
@@ -55,23 +59,27 @@ impl TwilioAccountsAdapter {
         "Basic"
     }
 
-    /// Build an accounts adapter for authenticated execution scope.
-    pub(crate) fn new(origin: &str, tenant_id: &str) -> Result<Self, TwilioAccountsAdapterError> {
+    /// Build a family adapter for authenticated execution scope.
+    pub(crate) fn new(
+        origin: &str,
+        tenant_id: &str,
+        family: TwilioFamily,
+    ) -> Result<Self, TwilioFamilyAdapterError> {
         let kernel = TwilioKernel::new(
             Some(origin),
             tenant_id,
-            TwilioFamily::Accounts,
+            family,
             TwilioFilters::default(),
             Some(PAGE_SIZE),
         )?;
-        Ok(Self { kernel })
+        Ok(Self { kernel, family })
     }
 
     /// Produce one deterministic credential-free provider request.
     pub(crate) fn plan(
         &self,
         prior_cursor: Option<&str>,
-    ) -> Result<TwilioRequest, TwilioAccountsAdapterError> {
+    ) -> Result<TwilioRequest, TwilioFamilyAdapterError> {
         self.kernel
             .plan(canonical_prior_cursor(prior_cursor)?)
             .map_err(Into::into)
@@ -84,10 +92,10 @@ impl TwilioAccountsAdapter {
         status_code: u32,
         response_body: &[u8],
         observed_at: OffsetDateTime,
-    ) -> Result<TwilioPage, TwilioAccountsAdapterError> {
+    ) -> Result<TwilioPage, TwilioFamilyAdapterError> {
         validate_status(status_code)?;
         if response_body.len() as u64 > MAX_RESPONSE_BYTES {
-            return Err(TwilioAccountsAdapterError::Kernel(
+            return Err(TwilioFamilyAdapterError::Kernel(
                 TwilioError::ResponseTooLarge,
             ));
         }
@@ -100,7 +108,7 @@ impl TwilioAccountsAdapter {
 
 /// Stable, provider-local execution failures mapped closed at the shared edge.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum TwilioAccountsAdapterError {
+pub(crate) enum TwilioFamilyAdapterError {
     AuthenticationRejected,
     RequiredScopeMissing,
     ProviderTimeout,
@@ -110,7 +118,7 @@ pub(crate) enum TwilioAccountsAdapterError {
     Kernel(TwilioError),
 }
 
-impl TwilioAccountsAdapterError {
+impl TwilioFamilyAdapterError {
     pub(crate) const fn code(self) -> &'static str {
         match self {
             Self::AuthenticationRejected => "twilio.authentication_rejected",
@@ -147,13 +155,13 @@ impl TwilioAccountsAdapterError {
     }
 }
 
-impl From<TwilioError> for TwilioAccountsAdapterError {
+impl From<TwilioError> for TwilioFamilyAdapterError {
     fn from(value: TwilioError) -> Self {
         Self::Kernel(value)
     }
 }
 
-impl fmt::Display for TwilioAccountsAdapterError {
+impl fmt::Display for TwilioFamilyAdapterError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::UnexpectedStatus(status) => {
@@ -169,7 +177,7 @@ impl fmt::Display for TwilioAccountsAdapterError {
     }
 }
 
-impl Error for TwilioAccountsAdapterError {
+impl Error for TwilioFamilyAdapterError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             Self::Kernel(error) => Some(error),
@@ -178,21 +186,21 @@ impl Error for TwilioAccountsAdapterError {
     }
 }
 
-fn validate_status(status_code: u32) -> Result<(), TwilioAccountsAdapterError> {
+fn validate_status(status_code: u32) -> Result<(), TwilioFamilyAdapterError> {
     match status_code {
         200 => Ok(()),
-        401 => Err(TwilioAccountsAdapterError::AuthenticationRejected),
-        403 => Err(TwilioAccountsAdapterError::RequiredScopeMissing),
-        408 => Err(TwilioAccountsAdapterError::ProviderTimeout),
-        429 => Err(TwilioAccountsAdapterError::RateLimited),
-        500..=599 => Err(TwilioAccountsAdapterError::ProviderUnavailable),
-        status => Err(TwilioAccountsAdapterError::UnexpectedStatus(status)),
+        401 => Err(TwilioFamilyAdapterError::AuthenticationRejected),
+        403 => Err(TwilioFamilyAdapterError::RequiredScopeMissing),
+        408 => Err(TwilioFamilyAdapterError::ProviderTimeout),
+        429 => Err(TwilioFamilyAdapterError::RateLimited),
+        500..=599 => Err(TwilioFamilyAdapterError::ProviderUnavailable),
+        status => Err(TwilioFamilyAdapterError::UnexpectedStatus(status)),
     }
 }
 
 fn canonical_prior_cursor(
     prior_cursor: Option<&str>,
-) -> Result<Option<&str>, TwilioAccountsAdapterError> {
+) -> Result<Option<&str>, TwilioFamilyAdapterError> {
     match prior_cursor {
         None | Some("") => Ok(None),
         Some(cursor) if cursor.trim() != cursor => Err(TwilioError::InvalidCursor.into()),
@@ -205,4 +213,6 @@ mod source_execution;
 // The closed shared dispatcher consumes this export without exposing provider
 // implementation details outside the crate.
 #[allow(unused_imports)]
-pub(crate) use source_execution::TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER;
+pub(crate) use source_execution::{
+    TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER, TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER,
+};

--- a/crates/source-runtime-next/src/twilio/adapter/source_execution.rs
+++ b/crates/source-runtime-next/src/twilio/adapter/source_execution.rs
@@ -1,4 +1,4 @@
-//! Canonical source-execution edge for Twilio accounts.
+//! Canonical source-execution edge for closed Twilio families.
 //!
 //! This file intentionally defines no wire messages. It compiles against the
 //! shared `source_execution` API and is selected only by the closed dispatcher.
@@ -18,42 +18,49 @@ use crate::source_execution::{
     validate_runtime_metadata, validate_safe_receipt,
 };
 
-use super::{TwilioAccountsAdapter, TwilioAccountsAdapterError};
+use super::{TwilioFamilyAdapter, TwilioFamilyAdapterError};
 use crate::twilio::{TwilioError, TwilioFamily, normalize::event_id};
 
-const PLAN_ID: &str = "source-plan-v1:twilio:accounts";
-const EVENT_KIND: &str = "twilio.accounts";
-const SCHEMA_REF: &str = "twilio/accounts/v1";
 const RECORD_SELECTOR: &str = "data";
 const ID_FIELD: &str = "id";
-const REQUIRED_ATTRIBUTES: [&str; 3] = ["tenant_id", "source_event_id", "user_id"];
 const REQUIRED_PAYLOAD_FIELDS: [&str; 1] = ["id"];
 
-/// Registry value for the accounts-first Twilio source adapter.
-pub(crate) static TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER: TwilioAccountsSourceExecutionAdapter =
-    TwilioAccountsSourceExecutionAdapter;
+/// Closed registry values for Twilio families with production-shaped adapters.
+pub(crate) static TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER: TwilioSourceExecutionAdapter =
+    TwilioSourceExecutionAdapter::new(TwilioFamily::Accounts);
+pub(crate) static TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER: TwilioSourceExecutionAdapter =
+    TwilioSourceExecutionAdapter::new(TwilioFamily::AuditEvents);
 
 /// Stateless canonical edge. Trusted execution scope arrives on every call.
-#[derive(Clone, Copy, Debug, Default)]
-pub(crate) struct TwilioAccountsSourceExecutionAdapter;
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct TwilioSourceExecutionAdapter {
+    family: TwilioFamily,
+}
 
-impl TwilioAccountsSourceExecutionAdapter {
+impl TwilioSourceExecutionAdapter {
+    const fn new(family: TwilioFamily) -> Self {
+        Self { family }
+    }
+
     pub(crate) fn compiled_plan(&self) -> SourceExecutionPlanV1 {
         let mut plan = SourceExecutionPlanV1 {
-            plan_id: PLAN_ID.to_owned(),
-            source_id: TwilioAccountsAdapter::source_id().to_owned(),
-            family_id: TwilioAccountsAdapter::family_id().to_owned(),
-            provider_kernel: TwilioAccountsAdapter::provider_kernel().to_owned(),
+            plan_id: format!("source-plan-v1:twilio:{}", self.family.as_str()),
+            source_id: TwilioFamilyAdapter::source_id().to_owned(),
+            family_id: self.family.as_str().to_owned(),
+            provider_kernel: self.family.provider_kind().to_owned(),
             method: "GET".to_owned(),
-            origin: TwilioAccountsAdapter::default_origin().to_owned(),
-            path: TwilioAccountsAdapter::path().to_owned(),
+            origin: TwilioFamilyAdapter::default_origin().to_owned(),
+            path: family_path(self.family).to_owned(),
             record_selector: RECORD_SELECTOR.to_owned(),
             id_field: ID_FIELD.to_owned(),
             singleton_fallback_id: String::new(),
-            max_response_bytes: TwilioAccountsAdapter::max_response_bytes(),
-            event_kind: EVENT_KIND.to_owned(),
-            schema_ref: SCHEMA_REF.to_owned(),
-            required_attributes: REQUIRED_ATTRIBUTES.map(str::to_owned).to_vec(),
+            max_response_bytes: TwilioFamilyAdapter::max_response_bytes(),
+            event_kind: self.family.provider_kind().to_owned(),
+            schema_ref: self.family.schema_ref().to_owned(),
+            required_attributes: required_attributes(self.family)
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
             required_payload_fields: REQUIRED_PAYLOAD_FIELDS.map(str::to_owned).to_vec(),
             plan_digest_sha256: String::new(),
         };
@@ -62,17 +69,17 @@ impl TwilioAccountsSourceExecutionAdapter {
     }
 }
 
-impl SourceExecutionAdapter for TwilioAccountsSourceExecutionAdapter {
+impl SourceExecutionAdapter for TwilioSourceExecutionAdapter {
     fn source_id(&self) -> &'static str {
-        TwilioAccountsAdapter::source_id()
+        TwilioFamilyAdapter::source_id()
     }
 
     fn family_id(&self) -> &'static str {
-        TwilioAccountsAdapter::family_id()
+        self.family.as_str()
     }
 
     fn provider_kernel(&self) -> &'static str {
-        TwilioAccountsAdapter::provider_kernel()
+        self.family.provider_kind()
     }
 
     fn validate_record_identity(
@@ -82,9 +89,9 @@ impl SourceExecutionAdapter for TwilioAccountsSourceExecutionAdapter {
     ) -> Result<(), SourceExecutionError> {
         let expected = event_id(
             &context.tenant_id,
-            TwilioAccountsAdapter::default_origin(),
-            TwilioAccountsAdapter::path(),
-            TwilioFamily::Accounts,
+            TwilioFamilyAdapter::default_origin(),
+            family_path(self.family),
+            self.family,
             &record.provider_id,
         );
         if record.event_id != expected {
@@ -98,15 +105,15 @@ impl SourceExecutionAdapter for TwilioAccountsSourceExecutionAdapter {
         request: &SourceWorkerPlanRequestV1,
     ) -> Result<SourceWorkerHttpRequestV1, SourceExecutionError> {
         let (plan, context) =
-            validated_plan_context(request.plan.as_ref(), request.context.as_ref())?;
-        let adapter = TwilioAccountsAdapter::new(&plan.origin, &context.tenant_id)
+            self.validated_plan_context(request.plan.as_ref(), request.context.as_ref())?;
+        let adapter = TwilioFamilyAdapter::new(&plan.origin, &context.tenant_id, self.family)
             .map_err(map_provider_error)?;
         let provider_request = adapter
             .plan(optional_cursor(&context.prior_cursor))
             .map_err(map_provider_error)?;
         if provider_request.url().path() != plan.path
             || provider_request.url().origin().unicode_serialization() != plan.origin
-            || provider_request.authorization_scheme() != TwilioAccountsAdapter::credential_scheme()
+            || provider_request.authorization_scheme() != TwilioFamilyAdapter::credential_scheme()
         {
             return Err(SourceExecutionError::InvalidPlan);
         }
@@ -150,8 +157,8 @@ impl SourceExecutionAdapter for TwilioAccountsSourceExecutionAdapter {
             .get("base_url")
             .map(String::as_str)
             .filter(|value| !value.is_empty())
-            .unwrap_or(TwilioAccountsAdapter::default_origin());
-        if configured_origin != TwilioAccountsAdapter::default_origin() {
+            .unwrap_or(TwilioFamilyAdapter::default_origin());
+        if configured_origin != TwilioFamilyAdapter::default_origin() {
             return Err(SourceExecutionError::InvalidPlan);
         }
         let planned = self.plan(request)?;
@@ -160,7 +167,7 @@ impl SourceExecutionAdapter for TwilioAccountsSourceExecutionAdapter {
             body: Vec::new(),
             declared_headers: Default::default(),
             execution_intent_digest_sha256: String::new(),
-            credential_operation: TwilioAccountsAdapter::credential_operation().to_owned(),
+            credential_operation: TwilioFamilyAdapter::credential_operation().to_owned(),
             allowed_origin: plan.origin.clone(),
         };
         execution.execution_intent_digest_sha256 =
@@ -173,7 +180,7 @@ impl SourceExecutionAdapter for TwilioAccountsSourceExecutionAdapter {
         request: &SourceWorkerDecodeRequestV1,
     ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
         let (plan, context) =
-            validated_plan_context(request.plan.as_ref(), request.context.as_ref())?;
+            self.validated_plan_context(request.plan.as_ref(), request.context.as_ref())?;
         if request.logical_page_id != context.logical_page_id
             || request.request_intent_digest.trim().is_empty()
         {
@@ -196,7 +203,7 @@ impl SourceExecutionAdapter for TwilioAccountsSourceExecutionAdapter {
             .receipt
             .as_ref()
             .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
-        if receipt.credential_operation != TwilioAccountsAdapter::credential_operation() {
+        if receipt.credential_operation != TwilioFamilyAdapter::credential_operation() {
             return Err(SourceExecutionError::MissingExecutionIdentity);
         }
         validate_safe_receipt(
@@ -209,7 +216,7 @@ impl SourceExecutionAdapter for TwilioAccountsSourceExecutionAdapter {
         )?;
 
         let observed_at = observed_at(context)?;
-        let adapter = TwilioAccountsAdapter::new(&plan.origin, &context.tenant_id)
+        let adapter = TwilioFamilyAdapter::new(&plan.origin, &context.tenant_id, self.family)
             .map_err(map_provider_error)?;
         let page = adapter
             .decode(
@@ -261,29 +268,41 @@ impl SourceExecutionAdapter for TwilioAccountsSourceExecutionAdapter {
     }
 }
 
-fn validated_plan_context<'a>(
-    plan: Option<&'a SourceExecutionPlanV1>,
-    context: Option<&'a SourceWorkerExecutionContextV1>,
-) -> Result<
-    (
-        &'a SourceExecutionPlanV1,
-        &'a SourceWorkerExecutionContextV1,
-    ),
-    SourceExecutionError,
-> {
-    let plan = plan.ok_or(SourceExecutionError::InvalidPlan)?;
-    validate_accounts_plan(plan)?;
-    let context = context.ok_or(SourceExecutionError::InvalidExecutionContext)?;
-    validate_execution_context(context)?;
-    Ok((plan, context))
+impl TwilioSourceExecutionAdapter {
+    fn validated_plan_context<'a>(
+        &self,
+        plan: Option<&'a SourceExecutionPlanV1>,
+        context: Option<&'a SourceWorkerExecutionContextV1>,
+    ) -> Result<
+        (
+            &'a SourceExecutionPlanV1,
+            &'a SourceWorkerExecutionContextV1,
+        ),
+        SourceExecutionError,
+    > {
+        let plan = plan.ok_or(SourceExecutionError::InvalidPlan)?;
+        if plan != &self.compiled_plan() {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        let context = context.ok_or(SourceExecutionError::InvalidExecutionContext)?;
+        validate_execution_context(context)?;
+        Ok((plan, context))
+    }
 }
 
-fn validate_accounts_plan(plan: &SourceExecutionPlanV1) -> Result<(), SourceExecutionError> {
-    let exact = plan == &TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER.compiled_plan();
-    if exact {
-        Ok(())
-    } else {
-        Err(SourceExecutionError::InvalidPlan)
+const fn family_path(family: TwilioFamily) -> &'static str {
+    match family {
+        TwilioFamily::Accounts => "/2010-04-01/Accounts.json",
+        TwilioFamily::Keys => "/2010-04-01/Accounts/{account_sid}/Keys.json",
+        TwilioFamily::AuditEvents => "/v1/Events",
+    }
+}
+
+const fn required_attributes(family: TwilioFamily) -> &'static [&'static str] {
+    match family {
+        TwilioFamily::Accounts => &["tenant_id", "source_event_id", "user_id"],
+        TwilioFamily::Keys => &["tenant_id", "source_event_id", "secret_id", "secret_name"],
+        TwilioFamily::AuditEvents => &["tenant_id", "source_event_id", "event_type", "actor_id"],
     }
 }
 
@@ -329,43 +348,43 @@ fn occurred_at_unix_millis(value: &str) -> Result<i64, SourceExecutionError> {
         .ok_or(SourceExecutionError::MissingStableIdentity)
 }
 
-fn map_provider_error(error: TwilioAccountsAdapterError) -> SourceExecutionError {
+fn map_provider_error(error: TwilioFamilyAdapterError) -> SourceExecutionError {
     match error {
-        TwilioAccountsAdapterError::AuthenticationRejected => {
+        TwilioFamilyAdapterError::AuthenticationRejected => {
             SourceExecutionError::AuthenticationRejected
         }
-        TwilioAccountsAdapterError::RequiredScopeMissing => {
+        TwilioFamilyAdapterError::RequiredScopeMissing => {
             SourceExecutionError::RequiredProviderScopeMissing
         }
-        TwilioAccountsAdapterError::ProviderTimeout => SourceExecutionError::ProviderTimeout,
-        TwilioAccountsAdapterError::RateLimited => SourceExecutionError::ProviderRateLimit,
-        TwilioAccountsAdapterError::ProviderUnavailable
-        | TwilioAccountsAdapterError::UnexpectedStatus(_) => {
+        TwilioFamilyAdapterError::ProviderTimeout => SourceExecutionError::ProviderTimeout,
+        TwilioFamilyAdapterError::RateLimited => SourceExecutionError::ProviderRateLimit,
+        TwilioFamilyAdapterError::ProviderUnavailable
+        | TwilioFamilyAdapterError::UnexpectedStatus(_) => {
             SourceExecutionError::UnexpectedProviderStatus
         }
-        TwilioAccountsAdapterError::Kernel(TwilioError::InvalidCursor) => {
+        TwilioFamilyAdapterError::Kernel(TwilioError::InvalidCursor) => {
             SourceExecutionError::InvalidCursor
         }
-        TwilioAccountsAdapterError::Kernel(TwilioError::ResponseTooLarge) => {
+        TwilioFamilyAdapterError::Kernel(TwilioError::ResponseTooLarge) => {
             SourceExecutionError::ResponseTooLarge
         }
-        TwilioAccountsAdapterError::Kernel(TwilioError::TooManyRecords) => {
+        TwilioFamilyAdapterError::Kernel(TwilioError::TooManyRecords) => {
             SourceExecutionError::ResultTooLarge
         }
-        TwilioAccountsAdapterError::Kernel(TwilioError::MissingProviderIdentity)
-        | TwilioAccountsAdapterError::Kernel(TwilioError::InvalidEventIdentity) => {
+        TwilioFamilyAdapterError::Kernel(TwilioError::MissingProviderIdentity)
+        | TwilioFamilyAdapterError::Kernel(TwilioError::InvalidEventIdentity) => {
             SourceExecutionError::MissingStableIdentity
         }
-        TwilioAccountsAdapterError::Kernel(TwilioError::ConflictingProviderIdentity) => {
+        TwilioFamilyAdapterError::Kernel(TwilioError::ConflictingProviderIdentity) => {
             SourceExecutionError::DuplicateConflict
         }
-        TwilioAccountsAdapterError::Kernel(TwilioError::InvalidResponse) => {
+        TwilioFamilyAdapterError::Kernel(TwilioError::InvalidResponse) => {
             SourceExecutionError::MalformedResponse
         }
-        TwilioAccountsAdapterError::Kernel(
+        TwilioFamilyAdapterError::Kernel(
             TwilioError::MissingRequiredPayloadField(_) | TwilioError::MissingRequiredAttribute(_),
         ) => SourceExecutionError::InvalidProviderRecord,
-        TwilioAccountsAdapterError::Kernel(
+        TwilioFamilyAdapterError::Kernel(
             TwilioError::InvalidBaseUrl
             | TwilioError::InvalidFamily
             | TwilioError::MissingTenantId
@@ -385,6 +404,16 @@ mod tests {
         env!("CARGO_MANIFEST_DIR"),
         "/../../sources/twilio/testdata/source_worker_accounts_page.json"
     ));
+    const AUDIT_EVENTS_PAGE: &[u8] = br#"{
+        "audit_events":[{
+            "id":"event-1",
+            "action":"user.login",
+            "actor":{"id":"user-1","email":"user@example.test"},
+            "target":{"id":"app-1","type":"application"},
+            "created_at":"2026-06-01T00:00:00Z"
+        }],
+        "next_cursor":"audit-page-2"
+    }"#;
 
     fn context(prior_cursor: &str) -> SourceWorkerExecutionContextV1 {
         SourceWorkerExecutionContextV1 {
@@ -400,6 +429,18 @@ mod tests {
 
     fn exact_plan() -> SourceExecutionPlanV1 {
         TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER.compiled_plan()
+    }
+
+    fn audit_context(prior_cursor: &str) -> SourceWorkerExecutionContextV1 {
+        SourceWorkerExecutionContextV1 {
+            tenant_id: "trusted-tenant".to_owned(),
+            runtime_id: "twilio-audit-events-runtime".to_owned(),
+            logical_page_id: "audit-page-1".to_owned(),
+            prior_cursor: prior_cursor.to_owned(),
+            runtime_generation: 7,
+            lease_generation: 11,
+            observed_at_unix_millis: 1_780_372_800_000,
+        }
     }
 
     fn decode_request(status_code: u32) -> SourceWorkerDecodeRequestV1 {
@@ -418,7 +459,7 @@ mod tests {
             request_intent_digest: intent.clone(),
             runtime_generation: execution.runtime_generation,
             lease_generation: execution.lease_generation,
-            credential_operation: TwilioAccountsAdapter::credential_operation().to_owned(),
+            credential_operation: TwilioFamilyAdapter::credential_operation().to_owned(),
             status_code,
             response_bytes: ACCOUNTS_PAGE.len() as u64,
             response_sha256: response_digest(ACCOUNTS_PAGE),
@@ -493,5 +534,60 @@ mod tests {
                 .validate_record_identity(&context("accounts-page-1"), &record),
             Err(SourceExecutionError::TenantMismatch)
         );
+    }
+
+    #[test]
+    fn audit_events_edge_plans_and_decodes_the_exact_closed_contract() {
+        let plan = TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER.compiled_plan();
+        assert_eq!(plan.family_id, "audit_events");
+        assert_eq!(plan.event_kind, "twilio.audit_events");
+        assert_eq!(plan.schema_ref, "twilio/audit_events/v1");
+        assert_eq!(
+            plan.required_attributes,
+            ["tenant_id", "source_event_id", "event_type", "actor_id"]
+        );
+        let execution = audit_context("audit-page-1");
+        let planned = TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER
+            .plan(&SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(execution.clone()),
+            })
+            .unwrap();
+        assert_eq!(
+            planned.url,
+            "https://api.twilio.com/v1/Events?limit=100&cursor=audit-page-1"
+        );
+        let receipt = SourceWorkerSafeReceiptV1 {
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            logical_page_id: execution.logical_page_id.clone(),
+            request_intent_digest: planned.request_intent_digest.clone(),
+            runtime_generation: execution.runtime_generation,
+            lease_generation: execution.lease_generation,
+            credential_operation: TwilioFamilyAdapter::credential_operation().to_owned(),
+            status_code: 200,
+            response_bytes: AUDIT_EVENTS_PAGE.len() as u64,
+            response_sha256: response_digest(AUDIT_EVENTS_PAGE),
+            tenant_id: execution.tenant_id.clone(),
+            runtime_id: execution.runtime_id.clone(),
+            observed_at_unix_millis: execution.observed_at_unix_millis,
+        };
+        let decoded = TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER
+            .decode(&SourceWorkerDecodeRequestV1 {
+                plan: Some(plan),
+                status_code: 200,
+                response_body: AUDIT_EVENTS_PAGE.to_vec(),
+                logical_page_id: execution.logical_page_id.clone(),
+                request_intent_digest: planned.request_intent_digest,
+                receipt: Some(receipt),
+                context: Some(execution.clone()),
+            })
+            .unwrap();
+        assert_eq!(decoded.next_cursor, "audit-page-2");
+        assert_eq!(decoded.records.len(), 1);
+        assert_eq!(decoded.records[0].attributes["actor_id"], "user-1");
+        assert_eq!(decoded.records[0].attributes["event_type"], "user.login");
+        TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER
+            .validate_record_identity(&execution, &decoded.records[0])
+            .unwrap();
     }
 }

--- a/crates/source-runtime-next/src/twilio/tests/adapter.rs
+++ b/crates/source-runtime-next/src/twilio/tests/adapter.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::twilio::adapter::{TwilioAccountsAdapter, TwilioAccountsAdapterError};
+use crate::twilio::adapter::{TwilioFamilyAdapter, TwilioFamilyAdapterError};
 
 const SOURCE_WORKER_ACCOUNTS_FIXTURE: &[u8] = include_bytes!(concat!(
     env!("CARGO_MANIFEST_DIR"),
@@ -8,20 +8,21 @@ const SOURCE_WORKER_ACCOUNTS_FIXTURE: &[u8] = include_bytes!(concat!(
 
 #[test]
 fn accounts_adapter_plans_credential_free_bounded_cursor_request() {
-    let adapter = TwilioAccountsAdapter::new(TwilioAccountsAdapter::default_origin(), TENANT_ID)
-        .expect("authenticated execution scope");
+    let adapter = TwilioFamilyAdapter::new(
+        TwilioFamilyAdapter::default_origin(),
+        TENANT_ID,
+        TwilioFamily::Accounts,
+    )
+    .expect("authenticated execution scope");
     let request = adapter.plan(Some("accounts-page-1")).unwrap();
 
-    assert_eq!(TwilioAccountsAdapter::source_id(), "twilio");
-    assert_eq!(TwilioAccountsAdapter::family_id(), "accounts");
-    assert_eq!(TwilioAccountsAdapter::provider_kernel(), "twilio.accounts");
-    assert_eq!(TwilioAccountsAdapter::path(), "/2010-04-01/Accounts.json");
-    assert_eq!(TwilioAccountsAdapter::max_response_bytes(), 8 << 20);
-    assert_eq!(
-        TwilioAccountsAdapter::credential_operation(),
-        "twilio.basic"
-    );
-    assert_eq!(TwilioAccountsAdapter::credential_scheme(), "Basic");
+    assert_eq!(TwilioFamilyAdapter::source_id(), "twilio");
+    assert_eq!(adapter.family_id(), "accounts");
+    assert_eq!(adapter.provider_kernel(), "twilio.accounts");
+    assert_eq!(adapter.path(), "/2010-04-01/Accounts.json");
+    assert_eq!(TwilioFamilyAdapter::max_response_bytes(), 8 << 20);
+    assert_eq!(TwilioFamilyAdapter::credential_operation(), "twilio.basic");
+    assert_eq!(TwilioFamilyAdapter::credential_scheme(), "Basic");
     assert_eq!(request.authorization_scheme(), "Basic");
     assert_eq!(request.accept(), "application/json");
     assert_eq!(
@@ -32,14 +33,18 @@ fn accounts_adapter_plans_credential_free_bounded_cursor_request() {
     assert!(!request.url().as_str().contains("token"));
     assert_eq!(
         adapter.plan(Some(" accounts-page-1")).unwrap_err(),
-        TwilioAccountsAdapterError::Kernel(TwilioError::InvalidCursor)
+        TwilioFamilyAdapterError::Kernel(TwilioError::InvalidCursor)
     );
 }
 
 #[test]
 fn accounts_adapter_decodes_fixture_with_stable_tenant_identity_dedupe_and_cursor() {
-    let adapter = TwilioAccountsAdapter::new(TwilioAccountsAdapter::default_origin(), TENANT_ID)
-        .expect("authenticated execution scope");
+    let adapter = TwilioFamilyAdapter::new(
+        TwilioFamilyAdapter::default_origin(),
+        TENANT_ID,
+        TwilioFamily::Accounts,
+    )
+    .expect("authenticated execution scope");
     let page = adapter
         .decode(
             Some("accounts-page-1"),
@@ -67,8 +72,12 @@ fn accounts_adapter_decodes_fixture_with_stable_tenant_identity_dedupe_and_curso
 
 #[test]
 fn accounts_adapter_never_derives_tenant_from_provider_payload() {
-    let adapter = TwilioAccountsAdapter::new(TwilioAccountsAdapter::default_origin(), TENANT_ID)
-        .expect("authenticated execution scope");
+    let adapter = TwilioFamilyAdapter::new(
+        TwilioFamilyAdapter::default_origin(),
+        TENANT_ID,
+        TwilioFamily::Accounts,
+    )
+    .expect("authenticated execution scope");
     let page = adapter
         .decode(
             None,
@@ -90,42 +99,46 @@ fn accounts_adapter_never_derives_tenant_from_provider_payload() {
 
 #[test]
 fn accounts_adapter_maps_provider_statuses_without_response_data() {
-    let adapter = TwilioAccountsAdapter::new(TwilioAccountsAdapter::default_origin(), TENANT_ID)
-        .expect("authenticated execution scope");
+    let adapter = TwilioFamilyAdapter::new(
+        TwilioFamilyAdapter::default_origin(),
+        TENANT_ID,
+        TwilioFamily::Accounts,
+    )
+    .expect("authenticated execution scope");
     for (status, expected, retryable, action) in [
         (
             401,
-            TwilioAccountsAdapterError::AuthenticationRejected,
+            TwilioFamilyAdapterError::AuthenticationRejected,
             false,
             "repair credential binding",
         ),
         (
             403,
-            TwilioAccountsAdapterError::RequiredScopeMissing,
+            TwilioFamilyAdapterError::RequiredScopeMissing,
             false,
             "grant required provider scope",
         ),
         (
             408,
-            TwilioAccountsAdapterError::ProviderTimeout,
+            TwilioFamilyAdapterError::ProviderTimeout,
             true,
             "retry later",
         ),
         (
             429,
-            TwilioAccountsAdapterError::RateLimited,
+            TwilioFamilyAdapterError::RateLimited,
             true,
             "retry later",
         ),
         (
             503,
-            TwilioAccountsAdapterError::ProviderUnavailable,
+            TwilioFamilyAdapterError::ProviderUnavailable,
             true,
             "retry later",
         ),
         (
             418,
-            TwilioAccountsAdapterError::UnexpectedStatus(418),
+            TwilioFamilyAdapterError::UnexpectedStatus(418),
             false,
             "inspect provider status",
         ),


### PR DESCRIPTION
## Summary

- generalize the provider-local Twilio source-execution adapter across explicitly registered families
- register `twilio.audit_events` in the closed Rust dispatcher with its exact request, event, schema, identity, cursor, and Basic-auth operation contracts
- keep `twilio.keys` unregistered and leave production authority unchanged

This is stacked on #2532 because it reuses the trusted-host Twilio credential operation introduced there. The pull request is runtime plumbing only; a separate protected change must select Rust production authority for audit events.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p cerebro-source-runtime-next` (621 unit tests and 26 provider integration tests passed)
- `cargo clippy --locked -p cerebro-source-runtime-next --all-targets --all-features -- -D warnings`
- `make check-structural`
- `make check-arch`
- `git diff --check`
