### PR TITLE
ui: simplify vendor work surfaces

### DIFF
--- a/apps/web/src/app/vendors/[urn]/page.tsx
+++ b/apps/web/src/app/vendors/[urn]/page.tsx
@@ -24,7 +24,7 @@ import { useParams, useSearchParams } from "next/navigation";
 import { type FormEvent, type ReactNode, useMemo, useState } from "react";
 
 import GraphViewer from "@/components/grc/LazyGraphViewer";
-import { Badge, ErrorBlock, LoadingBlock, MetricCard, Panel, ResultLimitNotice, SeverityDot } from "@/components/grc/Primitives";
+import { Badge, ErrorBlock, LoadingBlock, Panel, ResultLimitNotice, SeverityDot } from "@/components/grc/Primitives";
 import {
   displayDate,
   GRCRiskScoreFactor,
@@ -379,12 +379,12 @@ function QuestionnaireReviewsPanel({ tenantID, vendorURN }: { tenantID: string; 
         <LoadingBlock label="Loading questionnaire queue..." />
       ) : (
         <div className="space-y-5">
-          <div className="grid gap-3 md:grid-cols-5">
-            <MetricCard label="Reviews" value={rollups.total} detail="vendor questionnaires" />
-            <MetricCard label="Blocked" value={rollups.blocked} detail="answers blocked" intent={rollups.blocked > 0 ? "danger" : "success"} />
-            <MetricCard label="Needs review" value={rollups.needsReview} detail="answers queued" intent={rollups.needsReview > 0 ? "warning" : "success"} />
-            <MetricCard label="Ready" value={rollups.ready} detail="answers with citations" intent="success" />
-            <MetricCard label="Stale evidence" value={rollups.stale} detail="answers affected" intent={rollups.stale > 0 ? "warning" : "success"} />
+          <div className="grid gap-x-7 gap-y-4 border-y border-[color:var(--border)] py-4 sm:grid-cols-2 xl:grid-cols-5" data-questionnaire-summary>
+            <VendorMetric label="Reviews" value={rollups.total} detail="vendor questionnaires" />
+            <VendorMetric label="Blocked" value={rollups.blocked} detail="answers blocked" tone={rollups.blocked > 0 ? "danger" : "success"} />
+            <VendorMetric label="Needs review" value={rollups.needsReview} detail="answers queued" tone={rollups.needsReview > 0 ? "warning" : "success"} />
+            <VendorMetric label="Ready" value={rollups.ready} detail="answers with citations" tone="success" />
+            <VendorMetric label="Stale evidence" value={rollups.stale} detail="answers affected" tone={rollups.stale > 0 ? "warning" : "success"} />
           </div>
 
           {mutation.error && <ErrorBlock error={mutation.error} recoveryDetail="The questionnaire action did not save." />}
@@ -525,11 +525,11 @@ function QuestionnaireRunDetail({
         </button>
       </div>
 
-      <div className="grid gap-3 md:grid-cols-4">
-        <MetricCard label="Citations" value={citations.length} detail="linked sources" intent={citations.length > 0 ? "success" : "warning"} />
-        <MetricCard label="Missing" value={gaps.length} detail="open gaps" intent={gaps.length > 0 ? "warning" : "success"} />
-        <MetricCard label="Freshness" value={humanize(answer?.freshness?.status || "unknown")} detail={answer?.freshness?.observed_at ? `Observed ${displayDate(answer.freshness.observed_at)}` : "No observed date"} intent={(answer?.freshness?.status || "").toLowerCase() === "stale" ? "warning" : "neutral"} />
-        <MetricCard label="Controls" value={row.mappedControls.length} detail={row.mappedControls.slice(0, 2).join(", ") || "none mapped"} />
+      <div className="grid gap-x-7 gap-y-4 border-y border-[color:var(--border)] py-4 sm:grid-cols-2 lg:grid-cols-4" data-questionnaire-answer-summary>
+        <VendorMetric label="Citations" value={citations.length} detail="linked sources" tone={citations.length > 0 ? "success" : "warning"} />
+        <VendorMetric label="Missing" value={gaps.length} detail="open gaps" tone={gaps.length > 0 ? "warning" : "success"} />
+        <VendorMetric label="Freshness" value={humanize(answer?.freshness?.status || "unknown")} detail={answer?.freshness?.observed_at ? `Observed ${displayDate(answer.freshness.observed_at)}` : "No observed date"} tone={(answer?.freshness?.status || "").toLowerCase() === "stale" ? "warning" : "neutral"} />
+        <VendorMetric label="Controls" value={row.mappedControls.length} detail={row.mappedControls.slice(0, 2).join(", ") || "none mapped"} />
       </div>
 
       <QuestionnaireSection title="Draft answer">
@@ -845,7 +845,7 @@ function InitialBadge({ label }: { label?: string }) {
   );
 }
 
-function ConsoleStatCard({
+function VendorMetric({
   detail,
   label,
   progress,
@@ -855,25 +855,22 @@ function ConsoleStatCard({
   detail: ReactNode;
   label: string;
   progress?: number;
-  tone?: "danger" | "neutral" | "primary" | "warning";
+  tone?: "danger" | "neutral" | "primary" | "success" | "warning";
   value: ReactNode;
 }) {
-  const dotClass = tone === "danger" ? "bg-rose-500" : tone === "warning" ? "bg-amber-500" : tone === "primary" ? "bg-violet-400" : "bg-[var(--text-muted)]";
+  const dotClass = tone === "danger" ? "bg-rose-500" : tone === "warning" ? "bg-amber-500" : tone === "primary" ? "bg-violet-400" : tone === "success" ? "bg-emerald-500" : "bg-[var(--text-muted)]";
 
   return (
-    <div className="surface-panel group min-h-[118px] p-4 transition hover:border-[color:var(--border-strong)]">
-      <div className="flex items-start justify-between gap-3">
-        <div className="text-[13px] text-[var(--text-muted)]">{label}</div>
-        <ChevronRight className="h-4 w-4 text-[var(--text-muted)] transition group-hover:text-[var(--text-primary)]" aria-hidden="true" />
-      </div>
-      <div className={`mt-2 text-[26px] font-semibold leading-none ${tone === "danger" ? "text-rose-400" : "text-[var(--text-primary)]"}`}>{value}</div>
+    <div className="min-w-0">
+      <div className="text-[11px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">{label}</div>
+      <div className={`mt-1 text-xl font-semibold leading-tight ${tone === "danger" ? "text-rose-400" : "text-[var(--text-primary)]"}`}>{value}</div>
       {progress == null ? (
-        <div className="mt-3 flex items-center gap-2 text-[12px] text-[var(--text-muted)]">
+        <div className="mt-1 flex items-center gap-2 text-[12px] text-[var(--text-muted)]">
           <span className={`h-1.5 w-1.5 rounded-full ${dotClass}`} />
           <span>{detail}</span>
         </div>
       ) : (
-        <div className="mt-4 h-1.5 w-[70%] rounded-full bg-[var(--surface-muted)]">
+        <div className="mt-2 h-1.5 w-full max-w-36 rounded-full bg-[var(--surface-muted)]">
           <div className="h-full rounded-full bg-violet-400" style={{ width: `${Math.max(0, Math.min(100, progress))}%` }} />
         </div>
       )}
@@ -955,11 +952,11 @@ function VendorHero({
         <span>Freshness <span className="ml-1 inline-flex items-center gap-1 font-semibold text-[var(--text-primary)]"><span className={`h-1.5 w-1.5 rounded-full ${vendor.evidence_freshness_state === "stale" ? "bg-amber-400" : "bg-emerald-400"}`} /> {freshnessLabel}</span></span>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <ConsoleStatCard label="Open risks" value={vendor.open_findings ?? 0} detail={`${vendor.high_findings ?? 0} high`} tone={(vendor.open_findings ?? 0) > 0 ? "danger" : "neutral"} />
-        <ConsoleStatCard label="Assessment progress" value={`${assessmentProgress}%`} detail="complete" progress={assessmentProgress} tone="primary" />
-        <ConsoleStatCard label="Pending actions" value={actions.length} detail={actions.length ? "Requires attention" : "No pending actions"} tone={actions.length ? "warning" : "neutral"} />
-        <ConsoleStatCard label="Exposure" value={humanize(exposureLevel)} detail={`${exposureDriverCount} driver${exposureDriverCount === 1 ? "" : "s"}`} tone={["critical", "high"].includes(exposureLevel) ? "danger" : "neutral"} />
+      <div className="grid gap-x-8 gap-y-4 border-y border-[color:var(--border)] py-4 sm:grid-cols-2 lg:grid-cols-4" data-vendor-summary>
+        <VendorMetric label="Open risks" value={vendor.open_findings ?? 0} detail={`${vendor.high_findings ?? 0} high`} tone={(vendor.open_findings ?? 0) > 0 ? "danger" : "neutral"} />
+        <VendorMetric label="Assessment progress" value={`${assessmentProgress}%`} detail="complete" progress={assessmentProgress} tone="primary" />
+        <VendorMetric label="Pending actions" value={actions.length} detail={actions.length ? "Requires attention" : "No pending actions"} tone={actions.length ? "warning" : "neutral"} />
+        <VendorMetric label="Exposure" value={humanize(exposureLevel)} detail={`${exposureDriverCount} driver${exposureDriverCount === 1 ? "" : "s"}`} tone={["critical", "high"].includes(exposureLevel) ? "danger" : "neutral"} />
       </div>
     </div>
   );

--- a/apps/web/src/app/vendors/page.tsx
+++ b/apps/web/src/app/vendors/page.tsx
@@ -1342,8 +1342,8 @@ function VendorSectionSwitcher({
     uploads: uploadCount > 0 ? countLabel(uploadCount, "recent upload") : "Add documents",
   };
   return (
-    <section className="border-b border-[color:var(--border)] pb-2">
-      <div role="tablist" aria-label="Vendor work areas" className="flex flex-wrap gap-1.5">
+    <section className="overflow-x-auto border-b border-[color:var(--border)]" data-vendor-sections>
+      <div role="tablist" aria-label="Vendor work areas" className="flex min-w-max gap-6">
         {vendorSections.map((section) => {
           const selected = activeSection === section.id;
           return (
@@ -1353,10 +1353,10 @@ function VendorSectionSwitcher({
               role="tab"
               aria-selected={selected}
               onClick={() => onChange(section.id)}
-              className={`rounded-md border px-3 py-2 text-left text-[13px] transition ${selected ? "border-[color:var(--border-strong)] bg-[var(--surface-muted)] text-[var(--text-primary)]" : "border-transparent text-[var(--text-secondary)] hover:border-[color:var(--border)] hover:bg-[var(--surface-muted)] hover:text-[var(--text-primary)]"}`}
+              className={`border-b-2 px-0 py-2.5 text-left text-[13px] transition ${selected ? "border-[var(--primary)] text-[var(--primary)]" : "border-transparent text-[var(--text-secondary)] hover:border-[color:var(--border-strong)] hover:text-[var(--text-primary)]"}`}
             >
               <span className="block font-semibold">{section.label}</span>
-              <span className="mt-0.5 block text-[11px] text-[var(--text-muted)]">{detailBySection[section.id]}</span>
+              <span className="mt-0.5 block text-[11px] font-normal text-[var(--text-muted)]">{detailBySection[section.id]}</span>
             </button>
           );
         })}
@@ -2334,7 +2334,7 @@ export default function VendorsPage() {
       )}
 
       {activeSection !== "uploads" && (
-      <section className="surface-panel p-4">
+      <section className="border-b border-[color:var(--border)] pb-4" data-vendor-filters>
         <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_180px_160px]">
           <label className={labelClass}>
             Search

--- a/apps/web/src/lib/ui-contract.test.ts
+++ b/apps/web/src/lib/ui-contract.test.ts
@@ -226,6 +226,22 @@ describe("product UI contract", () => {
     expect(page.indexOf("data-policy-status-summary")).toBeLessThan(page.indexOf("data-policy-sections"));
   });
 
+  it("keeps vendor navigation and filters out of standalone card shells", () => {
+    const vendorSource = readProjectFile("src/app/vendors/page.tsx");
+    const vendorDetailSource = readProjectFile("src/app/vendors/[urn]/page.tsx");
+    const page = vendorSource.slice(vendorSource.indexOf("export default function VendorsPage"));
+
+    expect(vendorSource).toContain("data-vendor-sections");
+    expect(vendorSource).toContain("border-b-2 px-0 py-2.5");
+    expect(page).toContain('className="border-b border-[color:var(--border)] pb-4" data-vendor-filters');
+    expect(page).not.toContain('className="surface-panel p-4"');
+    expect(vendorDetailSource).toContain("data-vendor-summary");
+    expect(vendorDetailSource).toContain("data-questionnaire-summary");
+    expect(vendorDetailSource).toContain("data-questionnaire-answer-summary");
+    expect(vendorDetailSource).not.toContain("<MetricCard");
+    expect(vendorDetailSource).not.toContain("function ConsoleStatCard");
+  });
+
   it("keeps lifecycle details modal and lifecycle records usable at mobile width", () => {
     const lifecycleSource = readProjectFile("src/app/security/lifecycle/page.tsx");
 


### PR DESCRIPTION
## What changed
- replace the vendor work-area card buttons with underline navigation
- remove the standalone filter card while preserving all filters and URL state
- replace non-actionable vendor and questionnaire metric cards with compact status summaries
- add UI contract coverage for the lighter hierarchy

## Local validation
- vendor and UI contract tests: 19 passed
- focused ESLint: passed
- production web build: passed, including TypeScript and static page generation
- local vendor route smoke test: passed

## Scope
Web UI only. No vendor APIs, runtime logic, source registry, provider code, or persistence changed.