### PR TITLE
Bind Twilio keys to public Rust execution scope

### DIFF
--- a/crates/source-runtime-next/src/source_execution/dispatcher.rs
+++ b/crates/source-runtime-next/src/source_execution/dispatcher.rs
@@ -3,6 +3,7 @@ use prost::Message;
 use crate::sentinelone::SentinelOneAgentSourceExecutionAdapter;
 use crate::twilio::adapter::{
     TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER, TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER,
+    TWILIO_KEYS_SOURCE_EXECUTION_ADAPTER,
 };
 
 use super::{
@@ -20,7 +21,7 @@ use super::{
         SourceWorkerDecodeOutputV2, SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1,
         SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2, SourceWorkerHttpRequestV1,
         SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1, SourceWorkerRecordV1,
-        SourceWorkerSafeReceiptV1,
+        SourceWorkerRuntimeMetadataV2, SourceWorkerSafeReceiptV1,
     },
 };
 
@@ -38,6 +39,15 @@ pub trait SourceExecutionAdapter: Send + Sync {
         context: &SourceWorkerExecutionContextV1,
         record: &SourceWorkerRecordV1,
     ) -> Result<(), SourceExecutionError>;
+    /// Validates identity for adapters whose public v2 scope affects provider identity.
+    fn validate_record_identity_v2(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+        _metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(), SourceExecutionError> {
+        self.validate_record_identity(context, record)
+    }
     /// Builds a bounded, credential-free request description.
     fn plan(
         &self,
@@ -131,6 +141,11 @@ impl SourceExecutionDispatcher {
         {
             return Ok(TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER.compiled_plan());
         }
+        if request.source_id == TWILIO_KEYS_SOURCE_EXECUTION_ADAPTER.source_id()
+            && request.family_id == TWILIO_KEYS_SOURCE_EXECUTION_ADAPTER.family_id()
+        {
+            return Ok(TWILIO_KEYS_SOURCE_EXECUTION_ADAPTER.compiled_plan());
+        }
         if let Some(adapter) = JUMPCLOUD_ADAPTERS.iter().find(|adapter| {
             request.source_id == adapter.source_id() && request.family_id == adapter.family_id()
         }) {
@@ -173,6 +188,12 @@ impl SourceExecutionDispatcher {
                 == TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER.provider_kernel()
         {
             return Ok(&TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER);
+        }
+        if plan.source_id == TWILIO_KEYS_SOURCE_EXECUTION_ADAPTER.source_id()
+            && plan.family_id == TWILIO_KEYS_SOURCE_EXECUTION_ADAPTER.family_id()
+            && plan.provider_kernel == TWILIO_KEYS_SOURCE_EXECUTION_ADAPTER.provider_kernel()
+        {
+            return Ok(&TWILIO_KEYS_SOURCE_EXECUTION_ADAPTER);
         }
         if let Some(adapter) = JUMPCLOUD_ADAPTERS.iter().find(|adapter| {
             plan.source_id == adapter.source_id()
@@ -361,7 +382,7 @@ impl SourceExecutionDispatcher {
         let result = adapter.decode_v2(&bound_envelope)?;
         validate_decode_result(&bound_request, &result)?;
         for record in &result.records {
-            adapter.validate_record_identity(context, record)?;
+            adapter.validate_record_identity_v2(context, record, metadata)?;
         }
         Ok(SourceWorkerDecodeOutputV2 {
             receipt: Some(receipt),

--- a/crates/source-runtime-next/src/source_execution/tests.rs
+++ b/crates/source-runtime-next/src/source_execution/tests.rs
@@ -658,13 +658,116 @@ fn closed_dispatcher_registers_the_exact_twilio_audit_events_plan() {
         dispatcher.adapter_for(&plan).unwrap().family_id(),
         "audit_events"
     );
-    assert_eq!(
-        dispatcher.compile_plan(&SourceExecutionSelectionRequestV1 {
+    let keys = dispatcher
+        .compile_plan(&SourceExecutionSelectionRequestV1 {
             source_id: "twilio".to_owned(),
             family_id: "keys".to_owned(),
+        })
+        .unwrap();
+    assert_eq!(keys.provider_kernel, "twilio.keys");
+    assert_eq!(keys.path, "/2010-04-01/Accounts/{account_sid}/Keys.json");
+}
+
+#[test]
+fn twilio_keys_require_and_bind_public_account_scope_in_v2() {
+    let dispatcher = super::SourceExecutionDispatcher;
+    let plan = dispatcher
+        .compile_plan(&SourceExecutionSelectionRequestV1 {
+            source_id: "twilio".to_owned(),
+            family_id: "keys".to_owned(),
+        })
+        .unwrap();
+    let context = SourceWorkerExecutionContextV1 {
+        tenant_id: "trusted-tenant".to_owned(),
+        runtime_id: "twilio-keys-runtime".to_owned(),
+        logical_page_id: "keys-page-1".to_owned(),
+        prior_cursor: "keys-page-1".to_owned(),
+        runtime_generation: 7,
+        lease_generation: 11,
+        observed_at_unix_millis: 1_780_372_800_000,
+    };
+    let metadata = SourceWorkerRuntimeMetadataV2 {
+        public_config: HashMap::from([("account_sid".to_owned(), "AC123".to_owned())]),
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    };
+    assert_eq!(
+        dispatcher.dispatch_plan(&SourceWorkerPlanRequestV1 {
+            plan: Some(plan.clone()),
+            context: Some(context.clone()),
         }),
-        Err(SourceExecutionError::UnknownAdapter)
+        Err(SourceExecutionError::InvalidPlan)
     );
+    assert_eq!(
+        dispatcher.dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(context.clone()),
+            }),
+            metadata: Some(SourceWorkerRuntimeMetadataV2::default()),
+        }),
+        Err(SourceExecutionError::InvalidPlan)
+    );
+    let execution = dispatcher
+        .dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+        })
+        .unwrap();
+    assert_eq!(execution.credential_operation, "twilio.basic");
+    let planned = execution.request.unwrap();
+    assert_eq!(
+        planned.url,
+        "https://api.twilio.com/2010-04-01/Accounts/AC123/Keys.json?limit=100&cursor=keys-page-1"
+    );
+    let body = br#"{
+        "keys":[{
+            "id":"key-1",
+            "name":"Key One",
+            "created_at":"2026-06-01T00:00:00Z"
+        }],
+        "next_cursor":"keys-page-2"
+    }"#;
+    let decode_request = SourceWorkerDecodeRequestV1 {
+        plan: Some(plan),
+        status_code: 200,
+        response_body: body.to_vec(),
+        logical_page_id: context.logical_page_id.clone(),
+        request_intent_digest: planned.request_intent_digest,
+        receipt: None,
+        context: Some(context),
+    };
+    let mut changed_scope = metadata.clone();
+    changed_scope
+        .public_config
+        .insert("account_sid".to_owned(), "AC999".to_owned());
+    assert_eq!(
+        dispatcher.dispatch_decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+            request: Some(decode_request.clone()),
+            metadata: Some(changed_scope),
+            response_headers: HashMap::new(),
+            response_headers_sha256: String::new(),
+            execution_intent_digest_sha256: execution.execution_intent_digest_sha256.clone(),
+        }),
+        Err(SourceExecutionError::InvalidDigest)
+    );
+    let output = dispatcher
+        .dispatch_decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+            request: Some(decode_request),
+            metadata: Some(metadata),
+            response_headers: HashMap::new(),
+            response_headers_sha256: String::new(),
+            execution_intent_digest_sha256: execution.execution_intent_digest_sha256,
+        })
+        .unwrap();
+    let result = output.result.unwrap();
+    assert_eq!(result.next_cursor, "keys-page-2");
+    assert_eq!(result.records.len(), 1);
+    assert_eq!(result.records[0].attributes["secret_id"], "key-1");
+    assert_eq!(result.records[0].attributes["secret_name"], "Key One");
 }
 
 #[test]

--- a/crates/source-runtime-next/src/twilio/adapter/mod.rs
+++ b/crates/source-runtime-next/src/twilio/adapter/mod.rs
@@ -65,13 +65,17 @@ impl TwilioFamilyAdapter {
         tenant_id: &str,
         family: TwilioFamily,
     ) -> Result<Self, TwilioFamilyAdapterError> {
-        let kernel = TwilioKernel::new(
-            Some(origin),
-            tenant_id,
-            family,
-            TwilioFilters::default(),
-            Some(PAGE_SIZE),
-        )?;
+        Self::new_with_filters(origin, tenant_id, family, TwilioFilters::default())
+    }
+
+    /// Build a scoped family adapter from public, non-secret provider filters.
+    pub(crate) fn new_with_filters(
+        origin: &str,
+        tenant_id: &str,
+        family: TwilioFamily,
+        filters: TwilioFilters,
+    ) -> Result<Self, TwilioFamilyAdapterError> {
+        let kernel = TwilioKernel::new(Some(origin), tenant_id, family, filters, Some(PAGE_SIZE))?;
         Ok(Self { kernel, family })
     }
 
@@ -215,4 +219,5 @@ mod source_execution;
 #[allow(unused_imports)]
 pub(crate) use source_execution::{
     TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER, TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER,
+    TWILIO_KEYS_SOURCE_EXECUTION_ADAPTER,
 };

--- a/crates/source-runtime-next/src/twilio/adapter/source_execution.rs
+++ b/crates/source-runtime-next/src/twilio/adapter/source_execution.rs
@@ -10,16 +10,16 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use crate::source_execution::{
     SourceExecutionAdapter, SourceExecutionError, SourceExecutionPlanV1,
-    SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1, SourceWorkerExecutionContextV1,
-    SourceWorkerHttpExecutionV2, SourceWorkerHttpRequestV1, SourceWorkerPlanEnvelopeV2,
-    SourceWorkerPlanRequestV1, SourceWorkerRecordV1, canonical_http_execution_digest,
-    canonical_plan_digest, canonical_request_intent_digest, canonical_result_digest,
-    validate_and_deduplicate_records, validate_cursor, validate_execution_context,
-    validate_runtime_metadata, validate_safe_receipt,
+    SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1,
+    SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2, SourceWorkerHttpRequestV1,
+    SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1, SourceWorkerRecordV1,
+    canonical_http_execution_digest, canonical_plan_digest, canonical_request_intent_digest,
+    canonical_result_digest, validate_and_deduplicate_records, validate_cursor,
+    validate_execution_context, validate_runtime_metadata, validate_safe_receipt,
 };
 
 use super::{TwilioFamilyAdapter, TwilioFamilyAdapterError};
-use crate::twilio::{TwilioError, TwilioFamily, normalize::event_id};
+use crate::twilio::{TwilioError, TwilioFamily, TwilioFilters, normalize::event_id};
 
 const RECORD_SELECTOR: &str = "data";
 const ID_FIELD: &str = "id";
@@ -30,6 +30,8 @@ pub(crate) static TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER: TwilioSourceExecutio
     TwilioSourceExecutionAdapter::new(TwilioFamily::Accounts);
 pub(crate) static TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER: TwilioSourceExecutionAdapter =
     TwilioSourceExecutionAdapter::new(TwilioFamily::AuditEvents);
+pub(crate) static TWILIO_KEYS_SOURCE_EXECUTION_ADAPTER: TwilioSourceExecutionAdapter =
+    TwilioSourceExecutionAdapter::new(TwilioFamily::Keys);
 
 /// Stateless canonical edge. Trusted execution scope arrives on every call.
 #[derive(Clone, Copy, Debug)]
@@ -67,51 +69,43 @@ impl TwilioSourceExecutionAdapter {
         plan.plan_digest_sha256 = canonical_plan_digest(&plan);
         plan
     }
-}
 
-impl SourceExecutionAdapter for TwilioSourceExecutionAdapter {
-    fn source_id(&self) -> &'static str {
-        TwilioFamilyAdapter::source_id()
-    }
-
-    fn family_id(&self) -> &'static str {
-        self.family.as_str()
-    }
-
-    fn provider_kernel(&self) -> &'static str {
-        self.family.provider_kind()
-    }
-
-    fn validate_record_identity(
+    fn public_filters(
         &self,
-        context: &SourceWorkerExecutionContextV1,
-        record: &SourceWorkerRecordV1,
-    ) -> Result<(), SourceExecutionError> {
-        let expected = event_id(
-            &context.tenant_id,
-            TwilioFamilyAdapter::default_origin(),
-            family_path(self.family),
-            self.family,
-            &record.provider_id,
-        );
-        if record.event_id != expected {
-            return Err(SourceExecutionError::TenantMismatch);
+        metadata: &crate::source_execution::SourceWorkerRuntimeMetadataV2,
+    ) -> Result<TwilioFilters, SourceExecutionError> {
+        if self.family != TwilioFamily::Keys {
+            return Ok(TwilioFilters::default());
         }
-        Ok(())
+        let account_sid = metadata
+            .public_config
+            .get("account_sid")
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        Ok(TwilioFilters {
+            account_sid: Some(account_sid.to_owned()),
+        })
     }
 
-    fn plan(
+    fn plan_with_filters(
         &self,
         request: &SourceWorkerPlanRequestV1,
+        filters: TwilioFilters,
     ) -> Result<SourceWorkerHttpRequestV1, SourceExecutionError> {
         let (plan, context) =
             self.validated_plan_context(request.plan.as_ref(), request.context.as_ref())?;
-        let adapter = TwilioFamilyAdapter::new(&plan.origin, &context.tenant_id, self.family)
-            .map_err(map_provider_error)?;
+        let adapter = TwilioFamilyAdapter::new_with_filters(
+            &plan.origin,
+            &context.tenant_id,
+            self.family,
+            filters,
+        )
+        .map_err(map_provider_error)?;
         let provider_request = adapter
             .plan(optional_cursor(&context.prior_cursor))
             .map_err(map_provider_error)?;
-        if provider_request.url().path() != plan.path
+        if (self.family != TwilioFamily::Keys && provider_request.url().path() != plan.path)
             || provider_request.url().origin().unicode_serialization() != plan.origin
             || provider_request.authorization_scheme() != TwilioFamilyAdapter::credential_scheme()
         {
@@ -131,53 +125,10 @@ impl SourceExecutionAdapter for TwilioSourceExecutionAdapter {
         Ok(output)
     }
 
-    fn plan_v2(
-        &self,
-        envelope: &SourceWorkerPlanEnvelopeV2,
-    ) -> Result<SourceWorkerHttpExecutionV2, SourceExecutionError> {
-        let request = envelope
-            .request
-            .as_ref()
-            .ok_or(SourceExecutionError::InvalidPlan)?;
-        let plan = request
-            .plan
-            .as_ref()
-            .ok_or(SourceExecutionError::InvalidPlan)?;
-        let context = request
-            .context
-            .as_ref()
-            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
-        let metadata = envelope
-            .metadata
-            .as_ref()
-            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
-        validate_runtime_metadata(metadata)?;
-        let configured_origin = metadata
-            .public_config
-            .get("base_url")
-            .map(String::as_str)
-            .filter(|value| !value.is_empty())
-            .unwrap_or(TwilioFamilyAdapter::default_origin());
-        if configured_origin != TwilioFamilyAdapter::default_origin() {
-            return Err(SourceExecutionError::InvalidPlan);
-        }
-        let planned = self.plan(request)?;
-        let mut execution = SourceWorkerHttpExecutionV2 {
-            request: Some(planned),
-            body: Vec::new(),
-            declared_headers: Default::default(),
-            execution_intent_digest_sha256: String::new(),
-            credential_operation: TwilioFamilyAdapter::credential_operation().to_owned(),
-            allowed_origin: plan.origin.clone(),
-        };
-        execution.execution_intent_digest_sha256 =
-            canonical_http_execution_digest(plan, context, metadata, &execution);
-        Ok(execution)
-    }
-
-    fn decode(
+    fn decode_with_filters(
         &self,
         request: &SourceWorkerDecodeRequestV1,
+        filters: TwilioFilters,
     ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
         let (plan, context) =
             self.validated_plan_context(request.plan.as_ref(), request.context.as_ref())?;
@@ -186,12 +137,12 @@ impl SourceExecutionAdapter for TwilioSourceExecutionAdapter {
         {
             return Err(SourceExecutionError::MissingExecutionIdentity);
         }
-        let planned = <Self as SourceExecutionAdapter>::plan(
-            self,
+        let planned = self.plan_with_filters(
             &SourceWorkerPlanRequestV1 {
                 plan: Some(plan.clone()),
                 context: Some(context.clone()),
             },
+            filters.clone(),
         )?;
         if planned.request_intent_digest != request.request_intent_digest {
             return Err(SourceExecutionError::InvalidDigest);
@@ -216,8 +167,13 @@ impl SourceExecutionAdapter for TwilioSourceExecutionAdapter {
         )?;
 
         let observed_at = observed_at(context)?;
-        let adapter = TwilioFamilyAdapter::new(&plan.origin, &context.tenant_id, self.family)
-            .map_err(map_provider_error)?;
+        let adapter = TwilioFamilyAdapter::new_with_filters(
+            &plan.origin,
+            &context.tenant_id,
+            self.family,
+            filters,
+        )
+        .map_err(map_provider_error)?;
         let page = adapter
             .decode(
                 optional_cursor(&context.prior_cursor),
@@ -265,6 +221,149 @@ impl SourceExecutionAdapter for TwilioSourceExecutionAdapter {
             lease_generation: context.lease_generation,
             observed_at_unix_millis: context.observed_at_unix_millis,
         })
+    }
+}
+
+impl SourceExecutionAdapter for TwilioSourceExecutionAdapter {
+    fn source_id(&self) -> &'static str {
+        TwilioFamilyAdapter::source_id()
+    }
+
+    fn family_id(&self) -> &'static str {
+        self.family.as_str()
+    }
+
+    fn provider_kernel(&self) -> &'static str {
+        self.family.provider_kind()
+    }
+
+    fn validate_record_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+    ) -> Result<(), SourceExecutionError> {
+        let expected = event_id(
+            &context.tenant_id,
+            TwilioFamilyAdapter::default_origin(),
+            family_path(self.family),
+            self.family,
+            &record.provider_id,
+        );
+        if record.event_id != expected {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        Ok(())
+    }
+
+    fn validate_record_identity_v2(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+        metadata: &crate::source_execution::SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(), SourceExecutionError> {
+        if self.family != TwilioFamily::Keys {
+            return self.validate_record_identity(context, record);
+        }
+        let adapter = TwilioFamilyAdapter::new_with_filters(
+            TwilioFamilyAdapter::default_origin(),
+            &context.tenant_id,
+            self.family,
+            self.public_filters(metadata)?,
+        )
+        .map_err(map_provider_error)?;
+        let request = adapter.plan(None).map_err(map_provider_error)?;
+        let expected = event_id(
+            &context.tenant_id,
+            TwilioFamilyAdapter::default_origin(),
+            request.url().path(),
+            self.family,
+            &record.provider_id,
+        );
+        if record.event_id != expected {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        Ok(())
+    }
+
+    fn plan(
+        &self,
+        request: &SourceWorkerPlanRequestV1,
+    ) -> Result<SourceWorkerHttpRequestV1, SourceExecutionError> {
+        if self.family == TwilioFamily::Keys {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        self.plan_with_filters(request, TwilioFilters::default())
+    }
+
+    fn plan_v2(
+        &self,
+        envelope: &SourceWorkerPlanEnvelopeV2,
+    ) -> Result<SourceWorkerHttpExecutionV2, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        validate_runtime_metadata(metadata)?;
+        let configured_origin = metadata
+            .public_config
+            .get("base_url")
+            .map(String::as_str)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(TwilioFamilyAdapter::default_origin());
+        if configured_origin != TwilioFamilyAdapter::default_origin() {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        let filters = self.public_filters(metadata)?;
+        let planned = self.plan_with_filters(request, filters)?;
+        let mut execution = SourceWorkerHttpExecutionV2 {
+            request: Some(planned),
+            body: Vec::new(),
+            declared_headers: Default::default(),
+            execution_intent_digest_sha256: String::new(),
+            credential_operation: TwilioFamilyAdapter::credential_operation().to_owned(),
+            allowed_origin: plan.origin.clone(),
+        };
+        execution.execution_intent_digest_sha256 =
+            canonical_http_execution_digest(plan, context, metadata, &execution);
+        Ok(execution)
+    }
+
+    fn decode(
+        &self,
+        request: &SourceWorkerDecodeRequestV1,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        if self.family == TwilioFamily::Keys {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        self.decode_with_filters(request, TwilioFilters::default())
+    }
+
+    fn decode_v2(
+        &self,
+        envelope: &SourceWorkerDecodeEnvelopeV2,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        validate_runtime_metadata(metadata)?;
+        self.decode_with_filters(request, self.public_filters(metadata)?)
     }
 }
 

--- a/internal/sourceruntime/sourceworker/pull.go
+++ b/internal/sourceruntime/sourceworker/pull.go
@@ -94,7 +94,7 @@ func TailscaleFamily(sourceID, familyID string) (string, bool) {
 func PublicExecutionConfig(values map[string]string) map[string]string {
 	public := make(map[string]string)
 	for _, key := range []string{
-		"audit_end_time", "audit_services", "audit_sort", "audit_start_time", "base_url",
+		"account_sid", "audit_end_time", "audit_services", "audit_sort", "audit_start_time", "base_url",
 		"family", "group_id", "group_ids", "insights_base_url", "org_id", "per_page",
 		"site_id", "tailnet", "user_group_id", "user_group_ids",
 	} {

--- a/internal/sourceruntime/sourceworker/pull_test.go
+++ b/internal/sourceruntime/sourceworker/pull_test.go
@@ -70,11 +70,11 @@ func TestProviderResumeFailsClosedForMalformedAndCrossFamilyCheckpoints(t *testi
 
 func TestPublicExecutionConfigNeverCarriesCredentialMaterial(t *testing.T) {
 	public := PublicExecutionConfig(map[string]string{
-		"family": "user", "tailnet": "example.com", "base_url": "https://api.tailscale.com/api/v2",
+		"account_sid": " AC123 ", "family": "user", "tailnet": "example.com", "base_url": "https://api.tailscale.com/api/v2",
 		"site_id": "site-1",
 		"token":   "secret-token", "graph_token": "secret-graph-token", "tenant_id": "tenant-1",
 	})
-	if len(public) != 4 || public["site_id"] != "site-1" || public["token"] != "" || public["graph_token"] != "" || public["tenant_id"] != "" {
+	if len(public) != 5 || public["account_sid"] != "AC123" || public["site_id"] != "site-1" || public["token"] != "" || public["graph_token"] != "" || public["tenant_id"] != "" {
 		t.Fatalf("public config leaked private fields: %#v", public)
 	}
 }


### PR DESCRIPTION
## Summary

- register `twilio.keys` in the closed Rust dispatcher without changing production authority
- carry the non-secret `account_sid` scope through the v2 public execution contract and bind it into planning, decoding, identity validation, and execution digests
- reject v1 keys execution, missing account scope, and decode attempts with a changed account scope
- keep username, password, and derived Basic credentials in the trusted Go host

This is stacked on #2537. A separate protected change must select Rust authority for keys after this dispatcher contract passes hosted validation.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p cerebro-source-runtime-next` (622 unit tests and 26 provider integration tests passed)
- `cargo clippy --locked -p cerebro-source-runtime-next --all-targets --all-features -- -D warnings`
- `go test ./internal/sourceruntime/sourceworker ./internal/sourceruntime -count=1`
- `go test -race ./internal/sourceruntime/sourceworker ./internal/sourceruntime -count=1`
- `golangci-lint run ./internal/sourceruntime/...`
- `make check-structural`
- `make check-arch`
- `git diff --check`
