### PR TITLE
Move Twilio keys to Rust authority

### DIFF
--- a/internal/sourceruntime/source_execution_authority_test.go
+++ b/internal/sourceruntime/source_execution_authority_test.go
@@ -275,19 +275,59 @@ func TestTwilioAuditEventsNeverFallsBackToGoAuthority(t *testing.T) {
 	}
 }
 
-func TestTwilioKeysRemainsGoCompatible(t *testing.T) {
+func TestPutTwilioKeysRuntimeValidatesWithRustWithoutCallingGoCheck(t *testing.T) {
 	legacy := &runtimeAuthorityProbe{sourceID: "twilio"}
-	service := &Service{sourceWorker: &runtimePlanWorker{}}
-	runtime := &cerebrov1.SourceRuntime{Id: "twilio-keys-runtime", SourceId: "twilio", TenantId: "tenant-1"}
-	config := sourcecdk.NewConfig(map[string]string{"family": "keys"})
-
-	if _, rustPage, err := service.readSourcePull(context.Background(), runtime, legacy, config, nil, nil, 1); err != nil {
-		t.Fatalf("readSourcePull() error = %v", err)
-	} else if rustPage {
-		t.Fatal("readSourcePull() reported a Rust page for a Go-authoritative Twilio family")
+	registry, err := sourcecdk.NewRegistry(legacy)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if legacy.readCalls != 1 {
-		t.Fatalf("Go Read calls = %d, want 1", legacy.readCalls)
+	worker := &runtimePlanWorker{}
+	service := New(registry, &runtimeStore{}, nil, nil)
+	service.sourceWorker = worker
+	_, err = service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{Runtime: &cerebrov1.SourceRuntime{
+		Id: "twilio-keys-runtime", SourceId: "twilio", TenantId: "tenant-1",
+		Config: map[string]string{
+			"family": "keys", "account_sid": "AC123", "username": "AC123",
+			"password": sourceconfig.CredentialReferenceValue("twilio", "password"),
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy.checkCalls != 0 || worker.planCalls != 1 {
+		t.Fatalf("validation calls = Go %d, Rust %d", legacy.checkCalls, worker.planCalls)
+	}
+	if worker.selection.SourceID != "twilio" || worker.selection.FamilyID != "keys" {
+		t.Fatalf("Rust selection = %#v", worker.selection)
+	}
+	if worker.publicConfig["family"] != "keys" || worker.publicConfig["account_sid"] != "AC123" || worker.publicConfig["username"] != "" || worker.publicConfig["password"] != "" {
+		t.Fatalf("Rust public config = %#v", worker.publicConfig)
+	}
+}
+
+func TestTwilioKeysNeverFallsBackToGoAuthority(t *testing.T) {
+	legacy := &runtimeAuthorityProbe{sourceID: "twilio"}
+	worker := &runtimePlanWorker{compileErr: sourceworker.ErrWorkerUnsupported}
+	service := &Service{sourceWorker: worker}
+	runtime := &cerebrov1.SourceRuntime{
+		Id: "twilio-keys-runtime", SourceId: "twilio", TenantId: "tenant-1",
+		Config: map[string]string{
+			"family": "keys", "account_sid": "AC123", "username": "AC123",
+			"password": sourceconfig.CredentialReferenceValue("twilio", "password"),
+		},
+	}
+	ctx := context.WithValue(context.Background(), sourceRuntimeLeaseFenceContextKey{}, sourceRuntimeLeaseAuthority{fence: ports.SourceRuntimeLeaseFence{
+		Owner: "owner-1", Generation: 1, ExpiresAt: time.Now().Add(time.Minute),
+	}})
+	resolved := sourcecdk.NewConfig(map[string]string{
+		"family": "keys", "account_sid": "AC123", "username": "AC123", "password": "host-only-secret",
+	})
+
+	if _, _, err := service.readSourcePull(ctx, runtime, legacy, resolved, nil, nil, 1); !errors.Is(err, sourceworker.ErrWorkerUnsupported) {
+		t.Fatalf("readSourcePull() error = %v", err)
+	}
+	if legacy.readCalls != 0 || worker.selection.SourceID != "twilio" || worker.selection.FamilyID != "keys" {
+		t.Fatalf("authority calls = Go %d, Rust selection %#v", legacy.readCalls, worker.selection)
 	}
 }
 

--- a/internal/sourceruntime/sourceworker/pull.go
+++ b/internal/sourceruntime/sourceworker/pull.go
@@ -36,7 +36,7 @@ func RustAuthoritativeFamily(sourceID, familyID string) (string, bool) {
 	case "tailscale":
 		return TailscaleFamily(sourceID, familyID)
 	case "twilio":
-		return familyID, familyID == "accounts" || familyID == "audit_events"
+		return familyID, familyID == "accounts" || familyID == "audit_events" || familyID == "keys"
 	default:
 		return "", false
 	}

--- a/internal/sourceruntime/sourceworker/pull_test.go
+++ b/internal/sourceruntime/sourceworker/pull_test.go
@@ -96,7 +96,8 @@ func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
 		"unknown Tailscale family":   {"tailscale", "future-family", "future-family", true},
 		"Twilio accounts":            {"twilio", "accounts", "accounts", true},
 		"Twilio audit events":        {"twilio", "audit_events", "audit_events", true},
-		"Twilio keys":                {"twilio", "keys", "keys", false},
+		"Twilio keys":                {"twilio", "keys", "keys", true},
+		"unknown Twilio family":      {"twilio", "future-family", "future-family", false},
 		"compatibility source":       {"gcp", "audit", "", false},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- select Rust production authority for the exact `twilio.keys` family after its v2 public-scope dispatcher registration
- fail closed when the Rust worker cannot compile the family instead of restoring Go execution
- keep unknown Twilio families outside the production authority allowlist

This is stacked on #2539. The non-secret `account_sid` reaches Rust as bound public execution scope. Username, password, and derived Basic credentials remain in the trusted Go host.

## Validation

- `go test ./internal/sourceruntime/sourceworker ./internal/sourceruntime -count=1`
- `go test -race ./internal/sourceruntime/sourceworker ./internal/sourceruntime -count=1`
- `golangci-lint run ./internal/sourceruntime/...`
- `make check-structural`
- `make check-arch`
- `git diff --check`
