### PR TITLE
Activate DigitalOcean droplets Rust source authority

### DIFF
--- a/internal/sourceruntime/source_execution_authority_test.go
+++ b/internal/sourceruntime/source_execution_authority_test.go
@@ -163,6 +163,78 @@ func TestOtherAzureFamilyRemainsGoCompatible(t *testing.T) {
 	}
 }
 
+func TestPutDigitalOceanDropletsRuntimeValidatesWithRustWithoutCallingGoCheck(t *testing.T) {
+	legacy := &runtimeAuthorityProbe{sourceID: "digitalocean"}
+	registry, err := sourcecdk.NewRegistry(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker := &runtimePlanWorker{}
+	service := New(registry, &runtimeStore{}, nil, nil)
+	service.sourceWorker = worker
+	_, err = service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{Runtime: &cerebrov1.SourceRuntime{
+		Id: "digitalocean-droplets-runtime", SourceId: "digitalocean", TenantId: "tenant-1",
+		Config: map[string]string{
+			"family": "droplets", "per_page": "100",
+			"token": sourceconfig.CredentialReferenceValue("digitalocean", "token"),
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy.checkCalls != 0 || worker.planCalls != 1 {
+		t.Fatalf("validation calls = Go %d, Rust %d", legacy.checkCalls, worker.planCalls)
+	}
+	if worker.selection.SourceID != "digitalocean" || worker.selection.FamilyID != "droplets" {
+		t.Fatalf("Rust selection = %#v", worker.selection)
+	}
+	if worker.publicConfig["family"] != "droplets" || worker.publicConfig["per_page"] != "100" || worker.publicConfig["token"] != "" {
+		t.Fatalf("Rust public config = %#v", worker.publicConfig)
+	}
+}
+
+func TestDigitalOceanDropletsNeverFallsBackToGoAuthority(t *testing.T) {
+	legacy := &runtimeAuthorityProbe{sourceID: "digitalocean"}
+	worker := &runtimePlanWorker{compileErr: sourceworker.ErrWorkerUnsupported}
+	service := &Service{sourceWorker: worker}
+	runtime := &cerebrov1.SourceRuntime{
+		Id: "digitalocean-droplets-runtime", SourceId: "digitalocean", TenantId: "tenant-1",
+		Config: map[string]string{
+			"family": "droplets", "per_page": "100",
+			"token": sourceconfig.CredentialReferenceValue("digitalocean", "token"),
+		},
+	}
+	ctx := context.WithValue(context.Background(), sourceRuntimeLeaseFenceContextKey{}, sourceRuntimeLeaseAuthority{fence: ports.SourceRuntimeLeaseFence{
+		Owner: "owner-1", Generation: 1, ExpiresAt: time.Now().Add(time.Minute),
+	}})
+	resolved := sourcecdk.NewConfig(map[string]string{
+		"family": "droplets", "per_page": "100", "token": "host-only-secret",
+	})
+
+	if _, _, err := service.readSourcePull(ctx, runtime, legacy, resolved, nil, nil, 1); !errors.Is(err, sourceworker.ErrWorkerUnsupported) {
+		t.Fatalf("readSourcePull() error = %v", err)
+	}
+	if legacy.readCalls != 0 || worker.selection.SourceID != "digitalocean" || worker.selection.FamilyID != "droplets" {
+		t.Fatalf("authority calls = Go %d, Rust selection %#v", legacy.readCalls, worker.selection)
+	}
+}
+
+func TestOtherDigitalOceanFamilyRemainsGoCompatible(t *testing.T) {
+	legacy := &runtimeAuthorityProbe{sourceID: "digitalocean"}
+	service := &Service{sourceWorker: &runtimePlanWorker{}}
+	runtime := &cerebrov1.SourceRuntime{Id: "digitalocean-vpcs-runtime", SourceId: "digitalocean", TenantId: "tenant-1"}
+	config := sourcecdk.NewConfig(map[string]string{"family": "vpcs"})
+
+	if _, rustPage, err := service.readSourcePull(context.Background(), runtime, legacy, config, nil, nil, 1); err != nil {
+		t.Fatalf("readSourcePull() error = %v", err)
+	} else if rustPage {
+		t.Fatal("readSourcePull() reported a Rust page for a Go-authoritative DigitalOcean family")
+	}
+	if legacy.readCalls != 1 {
+		t.Fatalf("Go Read calls = %d, want 1", legacy.readCalls)
+	}
+}
+
 func TestPutSentinelOneAgentRuntimeValidatesWithRustWithoutCallingGoCheck(t *testing.T) {
 	legacy := &runtimeAuthorityProbe{sourceID: "sentinelone"}
 	registry, err := sourcecdk.NewRegistry(legacy)

--- a/internal/sourceruntime/sourceworker/pull.go
+++ b/internal/sourceruntime/sourceworker/pull.go
@@ -23,6 +23,11 @@ func RustAuthoritativeFamily(sourceID, familyID string) (string, bool) {
 	switch sourceID {
 	case "azure":
 		return familyID, familyID == "authorization_policy"
+	case "digitalocean":
+		if familyID == "" {
+			familyID = "droplets"
+		}
+		return familyID, familyID == "droplets"
 	case "jumpcloud":
 		if familyID == "" {
 			familyID = "users"

--- a/internal/sourceruntime/sourceworker/pull_test.go
+++ b/internal/sourceruntime/sourceworker/pull_test.go
@@ -86,6 +86,9 @@ func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
 	}{
 		"Azure authorization policy": {" azure ", " authorization_policy ", "authorization_policy", true},
 		"other Azure family":         {"azure", "user", "user", false},
+		"DigitalOcean default":       {" digitalocean ", "", "droplets", true},
+		"DigitalOcean droplets":      {"digitalocean", " droplets ", "droplets", true},
+		"other DigitalOcean family":  {"digitalocean", "vpcs", "vpcs", false},
 		"JumpCloud default":          {"jumpcloud", "", "users", true},
 		"JumpCloud family":           {"jumpcloud", "group_members", "group_members", true},
 		"unknown JumpCloud family":   {"jumpcloud", "future-family", "future-family", true},


### PR DESCRIPTION
## State

Code complete and locally validated. This authority switch is stacked on runtime-registration PR #2542.

## Change

- make only `digitalocean.droplets` Rust-authoritative in the production source-worker allowlist
- preserve the omitted/default family as `droplets`
- keep `digitalocean.vpcs`, `digitalocean.firewalls`, and other DigitalOcean families on Go compatibility
- prove runtime validation uses Rust without calling Go, Rust compile failure never falls back to Go, and an unselected family still uses Go

## Invariants

- credential redemption, Bearer authentication, origin enforcement, network execution, durable append, projection, and checkpoint persistence remain in the trusted Go host
- credential values do not enter Rust worker metadata, receipts, fixtures, events, or logs
- the exact-family authority switch prevents simultaneous Go and Rust writers for droplets
- the other DigitalOcean families are unchanged

## Local validation

- `go test ./internal/sourceruntime/sourceworker ./internal/sourceruntime -count=1`
- `go test -race ./internal/sourceruntime/sourceworker/... ./internal/sourceruntime/... -count=1`
- `golangci-lint run ./internal/sourceruntime/sourceworker/...`
- `make check-structural check-arch`
- `git diff --check`

## Remaining proof

- terminal hosted checks on this exact head
- normal repository approval and protected merge after #2542
- exact deployed-revision receipt
- bounded authenticated DigitalOcean collection with at least two pages and interrupt/resume
- zero unexplained rejects plus append, projection, checkpoint, single-authority, and authenticated product-read receipts