### PR TITLE
Fix Rust-only catalog census gate

### DIFF
--- a/.github/workflows/rust-only-candidate.yml
+++ b/.github/workflows/rust-only-candidate.yml
@@ -177,8 +177,8 @@ jobs:
             test -x /usr/local/bin/cerebro-event-admission-worker
           '
           summary="$(docker run --rm "${CANDIDATE_IMAGE}" catalog-summary)"
-          test "$(jq -r .sources <<<"${summary}")" -eq 799
-          test "$(jq -r .families <<<"${summary}")" -eq 4016
+          test "$(jq -r .sources <<<"${summary}")" -eq 800
+          test "$(jq -r .families <<<"${summary}")" -eq 4019
       - name: Start disposable PostgreSQL, Neo4j, and JetStream
         run: |
           set -euo pipefail
@@ -246,7 +246,7 @@ jobs:
             | .checks += [
                 {name:"rust_entrypoint",status:"passed",evidence:"image starts cerebro-platform directly"},
                 {name:"go_binary_absent",status:"passed",evidence:"/usr/local/bin/cerebro is absent"},
-                {name:"source_catalog",status:"passed",evidence:"799 sources and 4016 families loaded"}
+                {name:"source_catalog",status:"passed",evidence:"800 sources and 4019 families loaded"}
               ]
           ' .dist/rust-only-e2e/rust-only-e2e-receipt.json \
             > .dist/rust-only-e2e/receipt.tmp

--- a/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
+++ b/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
@@ -107,9 +107,9 @@ fn rust_candidate_build_never_invokes_go_or_emulation() {
         "Run the candidate through its declared Rust entrypoint",
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- seed",
         "cargo +1.93.1 run --locked -p cerebro-platform --example organizational_graph_e2e -- verify",
-        r#"test "$(jq -r .sources <<<"${summary}")" -eq 799"#,
-        r#"test "$(jq -r .families <<<"${summary}")" -eq 4016"#,
-        r#"evidence:"799 sources and 4016 families loaded""#,
+        r#"test "$(jq -r .sources <<<"${summary}")" -eq 800"#,
+        r#"test "$(jq -r .families <<<"${summary}")" -eq 4019"#,
+        r#"evidence:"800 sources and 4019 families loaded""#,
         "cerebro.rust-only-e2e/v1",
         "cerebro.rust-only-candidate/v1",
     ] {


### PR DESCRIPTION
## Problem

The Rust-only candidate for merge commit `8e27a4953a485bc5b1848e22fe629cfc14a9fd74` built both architecture images and the manifest, then failed the catalog e2e assertion. The Twilio catalog registration raised the compiled Rust catalog from 799 sources / 4,016 families to 800 sources / 4,019 families, but the workflow still asserted and recorded the old census.

## Fix

- assert the current compiled catalog census: 800 sources and 4,019 families
- record the same immutable census in the Rust-only e2e receipt

## Validation

- `cargo run --locked -p cerebro-platform -- catalog-summary` -> `sources: 800`, `families: 4019`
- `actionlint .github/workflows/rust-only-candidate.yml`
- `git diff --check`

DDESK readiness was healthy, but this isolated worktree was blocked on a new billable disk allocation. Validation used the Mac recovery path with the repository-managed Cargo cache.
