### PR TITLE
Promote SentinelOne threats to Rust authority

### DIFF
--- a/crates/source-runtime-next/src/sentinelone/source_execution_adapter/direct.rs
+++ b/crates/source-runtime-next/src/sentinelone/source_execution_adapter/direct.rs
@@ -57,11 +57,12 @@ impl SentinelOneDirectSourceExecutionAdapter {
 }
 
 pub(crate) static SENTINELONE_DIRECT_SOURCE_EXECUTION_ADAPTERS:
-    [SentinelOneDirectSourceExecutionAdapter; 4] = [
+    [SentinelOneDirectSourceExecutionAdapter; 5] = [
     SentinelOneDirectSourceExecutionAdapter::new(SentinelOneFamily::Activity),
     SentinelOneDirectSourceExecutionAdapter::new(SentinelOneFamily::Exclusion),
     SentinelOneDirectSourceExecutionAdapter::new(SentinelOneFamily::Group),
     SentinelOneDirectSourceExecutionAdapter::new(SentinelOneFamily::Site),
+    SentinelOneDirectSourceExecutionAdapter::new(SentinelOneFamily::Threat),
 ];
 
 impl SourceExecutionAdapter for SentinelOneDirectSourceExecutionAdapter {

--- a/crates/source-runtime-next/src/sentinelone/source_execution_adapter/normalization.rs
+++ b/crates/source-runtime-next/src/sentinelone/source_execution_adapter/normalization.rs
@@ -13,6 +13,9 @@ use crate::sentinelone::SentinelOneRecord;
 #[path = "normalization/direct.rs"]
 mod direct;
 pub(super) use direct::normalize_direct_record;
+#[path = "normalization/threat.rs"]
+mod threat;
+pub(super) use threat::normalize_threat_record;
 
 pub(super) fn normalize_agent_record(
     record: SentinelOneRecord,

--- a/crates/source-runtime-next/src/sentinelone/source_execution_adapter/normalization/direct.rs
+++ b/crates/source-runtime-next/src/sentinelone/source_execution_adapter/normalization/direct.rs
@@ -8,6 +8,7 @@ use crate::sentinelone::{SentinelOneFamily, SentinelOneRecord};
 use crate::source_execution::{SourceWorkerExecutionContextV1, SourceWorkerRecordV1};
 
 use super::super::{direct::direct_event_id, error::SentinelOneAgentAdapterError};
+use super::normalize_threat_record;
 use super::{
     bool_text, flexible_bool, flexible_string, insert_json_integer, insert_json_object,
     insert_json_string, insert_json_true, insert_nonblank, integer_text,
@@ -47,7 +48,8 @@ pub(crate) fn normalize_direct_record(
             site_payload(&record.payload, &context.tenant_id, provider_id),
             provider_occurred_at_millis_for(&record.payload, &["updatedAt", "createdAt"]),
         ),
-        SentinelOneFamily::Agent | SentinelOneFamily::Application | SentinelOneFamily::Threat => {
+        SentinelOneFamily::Threat => return normalize_threat_record(record, context),
+        SentinelOneFamily::Agent | SentinelOneFamily::Application => {
             return Err(SentinelOneAgentAdapterError::InvalidPlan);
         }
     };

--- a/crates/source-runtime-next/src/sentinelone/source_execution_adapter/normalization/threat.rs
+++ b/crates/source-runtime-next/src/sentinelone/source_execution_adapter/normalization/threat.rs
@@ -1,0 +1,526 @@
+//! Canonical SentinelOne threat event normalization.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::{Map, Value};
+
+use crate::sentinelone::SentinelOneRecord;
+use crate::source_execution::{SourceWorkerExecutionContextV1, SourceWorkerRecordV1};
+
+use super::super::{direct::direct_event_id, error::SentinelOneAgentAdapterError};
+use super::{
+    bool_text, insert_json_integer, insert_json_string, insert_nonblank,
+    provider_occurred_at_millis_for, remove_untrusted_tenant_fields, string_at,
+};
+use crate::sentinelone::SentinelOneFamily;
+
+pub(crate) fn normalize_threat_record(
+    record: SentinelOneRecord,
+    context: &SourceWorkerExecutionContextV1,
+) -> Result<SourceWorkerRecordV1, SentinelOneAgentAdapterError> {
+    let provider_id = record.provider_id.trim();
+    if provider_id.is_empty() {
+        return Err(SentinelOneAgentAdapterError::MissingProviderIdentity);
+    }
+    let threat_info = object_at(&record.payload, "threatInfo");
+    let detection = object_at(&record.payload, "agentDetectionInfo");
+    let realtime = object_at(&record.payload, "agentRealtimeInfo");
+    let indicators = indicator_summary(&record.payload);
+    let occurred_at_unix_millis =
+        provider_occurred_at_millis_for(threat_info, &["updatedAt", "identifiedAt", "createdAt"])
+            .unwrap_or(context.observed_at_unix_millis);
+    let attributes = threat_attributes(
+        threat_info,
+        detection,
+        realtime,
+        &indicators,
+        &context.tenant_id,
+        provider_id,
+    );
+    let payload = threat_payload(
+        &record.payload,
+        threat_info,
+        detection,
+        realtime,
+        indicators,
+        &context.tenant_id,
+        provider_id,
+    );
+    Ok(SourceWorkerRecordV1 {
+        provider_id: provider_id.to_owned(),
+        event_id: direct_event_id(SentinelOneFamily::Threat, &context.tenant_id, provider_id)?,
+        occurred_at_unix_millis,
+        attributes: attributes.into_iter().collect(),
+        payload_json: serde_json::to_vec(&payload)
+            .map_err(|_| SentinelOneAgentAdapterError::InvalidProviderResponse)?,
+    })
+}
+
+#[derive(Default)]
+struct IndicatorSummary {
+    categories: Vec<String>,
+    tactics: Vec<String>,
+    techniques: Vec<String>,
+    descriptions: Vec<String>,
+}
+
+fn threat_attributes(
+    threat_info: &Value,
+    detection: &Value,
+    realtime: &Value,
+    indicators: &IndicatorSummary,
+    tenant_id: &str,
+    provider_id: &str,
+) -> BTreeMap<String, String> {
+    let mut attributes = BTreeMap::from([
+        ("family".to_owned(), "threat".to_owned()),
+        ("threat_id".to_owned(), provider_id.to_owned()),
+        ("tenant_host".to_owned(), tenant_id.to_owned()),
+        ("is_active".to_owned(), bool_text(realtime, "agentIsActive")),
+        (
+            "is_decommissioned".to_owned(),
+            bool_text(realtime, "agentIsDecommissioned"),
+        ),
+        (
+            "is_infected".to_owned(),
+            bool_text(realtime, "agentInfected"),
+        ),
+        (
+            "is_fileless".to_owned(),
+            bool_text(threat_info, "isFileless"),
+        ),
+        (
+            "automatically_resolved".to_owned(),
+            bool_text(threat_info, "automaticallyResolved"),
+        ),
+    ]);
+    for (name, value) in [
+        ("classification", string_at(threat_info, "classification")),
+        (
+            "classification_source",
+            string_at(threat_info, "classificationSource"),
+        ),
+        ("analyst_verdict", string_at(threat_info, "analystVerdict")),
+        ("incident_status", string_at(threat_info, "incidentStatus")),
+        (
+            "confidence_level",
+            string_at(threat_info, "confidenceLevel"),
+        ),
+        (
+            "mitigation_status",
+            string_at(threat_info, "mitigationStatus"),
+        ),
+        ("detection_type", string_at(threat_info, "detectionType")),
+        ("threat_name", string_at(threat_info, "threatName")),
+        ("file_path", string_at(threat_info, "filePath")),
+        ("sha256", string_at(threat_info, "sha256")),
+        (
+            "agent_id",
+            first_nonempty(&[
+                string_at(realtime, "agentId"),
+                string_at(detection, "agentUuid"),
+            ]),
+        ),
+        ("agent_uuid", string_at(detection, "agentUuid")),
+        ("agent_name", string_at(realtime, "agentComputerName")),
+        ("computer_name", string_at(realtime, "agentComputerName")),
+        ("hostname", string_at(realtime, "agentComputerName")),
+        (
+            "site_id",
+            first_nonempty(&[
+                string_at(detection, "siteId"),
+                string_at(realtime, "siteId"),
+            ]),
+        ),
+        (
+            "group_id",
+            first_nonempty(&[
+                string_at(detection, "groupId"),
+                string_at(realtime, "groupId"),
+            ]),
+        ),
+        (
+            "site_name",
+            first_nonempty(&[
+                string_at(detection, "siteName"),
+                string_at(realtime, "siteName"),
+            ]),
+        ),
+        (
+            "group_name",
+            first_nonempty(&[
+                string_at(detection, "groupName"),
+                string_at(realtime, "groupName"),
+            ]),
+        ),
+        (
+            "account_id",
+            first_nonempty(&[
+                string_at(detection, "accountId"),
+                string_at(realtime, "accountId"),
+            ]),
+        ),
+        (
+            "account_name",
+            first_nonempty(&[
+                string_at(detection, "accountName"),
+                string_at(realtime, "accountName"),
+            ]),
+        ),
+        (
+            "agent_os_name",
+            first_nonempty(&[
+                string_at(detection, "agentOsName"),
+                string_at(realtime, "agentOsName"),
+            ]),
+        ),
+        ("agent_os_type", string_at(realtime, "agentOsType")),
+        ("agent_ip_v4", string_at(detection, "agentIpV4")),
+        ("agent_ip_v6", string_at(detection, "agentIpV6")),
+        ("external_ip", string_at(detection, "externalIp")),
+        (
+            "ip",
+            first_nonempty(&[
+                string_at(detection, "agentIpV4"),
+                string_at(detection, "externalIp"),
+                string_at(detection, "agentIpV6"),
+            ]),
+        ),
+        (
+            "ip_addresses",
+            distinct_join(&[
+                string_at(detection, "agentIpV4"),
+                string_at(detection, "agentIpV6"),
+                string_at(detection, "externalIp"),
+            ]),
+        ),
+        (
+            "user_mail",
+            string_at(detection, "agentLastLoggedInUserMail"),
+        ),
+        (
+            "user_name",
+            string_at(detection, "agentLastLoggedInUserName"),
+        ),
+    ] {
+        insert_nonblank(&mut attributes, name, value);
+    }
+    for (name, provider_name) in [
+        ("classification_norm", "classification"),
+        ("analyst_verdict_norm", "analystVerdict"),
+        ("incident_status_norm", "incidentStatus"),
+        ("mitigation_status_norm", "mitigationStatus"),
+    ] {
+        insert_nonblank(
+            &mut attributes,
+            name,
+            normalize_posture(&string_at(threat_info, provider_name)),
+        );
+    }
+    for (name, values) in [
+        ("mitre_tactics", &indicators.tactics),
+        ("mitre_techniques", &indicators.techniques),
+        ("indicator_categories", &indicators.categories),
+    ] {
+        if !values.is_empty() {
+            attributes.insert(name.to_owned(), values.join(","));
+        }
+    }
+    attributes
+}
+
+fn threat_payload(
+    raw: &Value,
+    threat_info: &Value,
+    detection: &Value,
+    realtime: &Value,
+    indicators: IndicatorSummary,
+    tenant_id: &str,
+    provider_id: &str,
+) -> Value {
+    let mut payload = Map::new();
+    payload.insert("id".to_owned(), Value::String(provider_id.to_owned()));
+    payload.insert(
+        "tenant_host".to_owned(),
+        Value::String(tenant_id.to_owned()),
+    );
+    payload.insert("threat_info".to_owned(), threat_info_payload(threat_info));
+    payload.insert("agent_detection".to_owned(), detection_payload(detection));
+    payload.insert("agent_realtime".to_owned(), realtime_payload(realtime));
+    payload.insert("indicators".to_owned(), indicators_payload(indicators));
+    if let Some(actions) = mitigation_payload(raw) {
+        payload.insert("mitigation_actions".to_owned(), actions);
+    }
+    if let Some(values) = nonempty_array(raw.get("whiteningOptions")) {
+        payload.insert("whitening_options".to_owned(), values);
+    }
+    let mut sanitized_raw = raw.clone();
+    remove_untrusted_tenant_fields(&mut sanitized_raw);
+    payload.insert("raw".to_owned(), sanitized_raw);
+    Value::Object(payload)
+}
+
+fn threat_info_payload(raw: &Value) -> Value {
+    let mut output = Map::new();
+    for (name, provider_name) in [
+        ("analyst_verdict", "analystVerdict"),
+        ("classification", "classification"),
+        ("classification_source", "classificationSource"),
+        ("confidence_level", "confidenceLevel"),
+        ("incident_status", "incidentStatus"),
+        ("mitigation_status", "mitigationStatus"),
+        ("threat_name", "threatName"),
+        ("detection_type", "detectionType"),
+        ("created_at", "createdAt"),
+        ("identified_at", "identifiedAt"),
+        ("updated_at", "updatedAt"),
+        ("initiated_by", "initiatedBy"),
+        ("initiated_by_description", "initiatedByDescription"),
+        ("initiating_user_id", "initiatingUserId"),
+        ("initiating_username", "initiatingUsername"),
+        ("originator_process", "originatorProcess"),
+        ("storyline_id", "storyline"),
+        ("external_ticket_id", "externalTicketId"),
+        ("file_path", "filePath"),
+        ("file_extension", "fileExtension"),
+        ("file_extension_type", "fileExtensionType"),
+        ("sha1", "sha1"),
+        ("sha256", "sha256"),
+        ("md5", "md5"),
+    ] {
+        insert_json_string(&mut output, name, string_at(raw, provider_name));
+    }
+    insert_json_integer(&mut output, "file_size", raw, "fileSize");
+    for (name, provider_name) in [
+        ("is_fileless", "isFileless"),
+        ("automatically_resolved", "automaticallyResolved"),
+    ] {
+        if raw.get(provider_name).and_then(Value::as_bool) == Some(true) {
+            output.insert(name.to_owned(), Value::Bool(true));
+        }
+    }
+    Value::Object(output)
+}
+
+fn detection_payload(raw: &Value) -> Value {
+    let mut output = Map::new();
+    for (name, provider_name) in [
+        ("account_id", "accountId"),
+        ("account_name", "accountName"),
+        ("domain", "agentDomain"),
+        ("ip_v4", "agentIpV4"),
+        ("ip_v6", "agentIpV6"),
+        ("os_name", "agentOsName"),
+        ("os_revision", "agentOsRevision"),
+        ("registered_at", "agentRegisteredAt"),
+        ("uuid", "agentUuid"),
+        ("version", "agentVersion"),
+        ("external_ip", "externalIp"),
+        ("group_id", "groupId"),
+        ("group_name", "groupName"),
+        ("site_id", "siteId"),
+        ("site_name", "siteName"),
+        ("user_mail", "agentLastLoggedInUserMail"),
+        ("user_name", "agentLastLoggedInUserName"),
+    ] {
+        insert_json_string(&mut output, name, string_at(raw, provider_name));
+    }
+    insert_json_string(
+        &mut output,
+        "ip_addresses",
+        distinct_join(&[
+            string_at(raw, "agentIpV4"),
+            string_at(raw, "agentIpV6"),
+            string_at(raw, "externalIp"),
+        ]),
+    );
+    Value::Object(output)
+}
+
+fn realtime_payload(raw: &Value) -> Value {
+    let mut output = Map::new();
+    for (name, provider_name) in [
+        ("agent_id", "agentId"),
+        ("computer_name", "agentComputerName"),
+        ("hostname", "agentComputerName"),
+        ("os_name", "agentOsName"),
+        ("os_type", "agentOsType"),
+        ("os_revision", "agentOsRevision"),
+        ("network_status", "agentNetworkStatus"),
+        ("operational_state", "operationalState"),
+        ("scan_status", "scanStatus"),
+        ("mitigation_mode", "agentMitigationMode"),
+        ("uuid", "agentUuid"),
+        ("version", "agentVersion"),
+        ("group_id", "groupId"),
+        ("group_name", "groupName"),
+        ("site_id", "siteId"),
+        ("site_name", "siteName"),
+    ] {
+        insert_json_string(&mut output, name, string_at(raw, provider_name));
+    }
+    for (name, provider_name) in [
+        ("is_active", "agentIsActive"),
+        ("is_decommissioned", "agentIsDecommissioned"),
+        ("is_infected", "agentInfected"),
+    ] {
+        output.insert(
+            name.to_owned(),
+            Value::Bool(
+                raw.get(provider_name)
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+            ),
+        );
+    }
+    output.insert(
+        "active_threats".to_owned(),
+        Value::Number(
+            raw.get("activeThreats")
+                .and_then(Value::as_i64)
+                .unwrap_or(0)
+                .into(),
+        ),
+    );
+    for (name, provider_name) in [("reboot_required", "rebootRequired")] {
+        if raw.get(provider_name).and_then(Value::as_bool) == Some(true) {
+            output.insert(name.to_owned(), Value::Bool(true));
+        }
+    }
+    Value::Object(output)
+}
+
+fn indicator_summary(raw: &Value) -> IndicatorSummary {
+    let mut categories = BTreeSet::new();
+    let mut tactics = BTreeSet::new();
+    let mut techniques = BTreeSet::new();
+    let mut descriptions = BTreeSet::new();
+    for indicator in raw
+        .get("indicators")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        insert_set(&mut categories, string_at(indicator, "category"));
+        for value in indicator
+            .get("categories")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            if let Some(value) = value.as_str() {
+                insert_set(&mut categories, value.to_owned());
+            }
+        }
+        insert_set(&mut descriptions, string_at(indicator, "description"));
+        for tactic in indicator
+            .get("tactics")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            insert_set(&mut tactics, string_at(tactic, "name"));
+            for technique in tactic
+                .get("techniques")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                insert_set(&mut techniques, string_at(technique, "name"));
+            }
+        }
+    }
+    IndicatorSummary {
+        categories: categories.into_iter().collect(),
+        tactics: tactics.into_iter().collect(),
+        techniques: techniques.into_iter().collect(),
+        descriptions: descriptions.into_iter().collect(),
+    }
+}
+
+fn indicators_payload(summary: IndicatorSummary) -> Value {
+    let mut output = Map::new();
+    for (name, values) in [
+        ("categories", summary.categories),
+        ("mitre_tactics", summary.tactics),
+        ("mitre_techniques", summary.techniques),
+        ("descriptions", summary.descriptions),
+    ] {
+        if !values.is_empty() {
+            output.insert(
+                name.to_owned(),
+                Value::Array(values.into_iter().map(Value::String).collect()),
+            );
+        }
+    }
+    Value::Object(output)
+}
+
+fn mitigation_payload(raw: &Value) -> Option<Value> {
+    let actions = raw.get("mitigationStatus")?.as_array()?;
+    if actions.is_empty() {
+        return None;
+    }
+    let values = actions
+        .iter()
+        .map(|action| {
+            let mut output = Map::new();
+            output.insert(
+                "action".to_owned(),
+                Value::String(string_at(action, "action")),
+            );
+            for (name, provider_name) in [
+                ("status", "status"),
+                ("started_at", "mitigationStartedAt"),
+                ("ended_at", "mitigationEndedAt"),
+                ("last_update", "lastUpdate"),
+                ("report_id", "reportId"),
+            ] {
+                insert_json_string(&mut output, name, string_at(action, provider_name));
+            }
+            Value::Object(output)
+        })
+        .collect();
+    Some(Value::Array(values))
+}
+
+fn object_at<'a>(raw: &'a Value, name: &str) -> &'a Value {
+    raw.get(name)
+        .filter(|value| value.is_object())
+        .unwrap_or(&Value::Null)
+}
+
+fn nonempty_array(value: Option<&Value>) -> Option<Value> {
+    let values = value?.as_array()?;
+    (!values.is_empty()).then(|| Value::Array(values.clone()))
+}
+
+fn insert_set(values: &mut BTreeSet<String>, value: String) {
+    let value = value.trim();
+    if !value.is_empty() {
+        values.insert(value.to_owned());
+    }
+}
+
+fn first_nonempty(values: &[String]) -> String {
+    values
+        .iter()
+        .find(|value| !value.trim().is_empty())
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn distinct_join(values: &[String]) -> String {
+    let mut output = Vec::new();
+    for value in values {
+        let value = value.trim();
+        if !value.is_empty() && !output.contains(&value) {
+            output.push(value);
+        }
+    }
+    output.join(",")
+}
+
+fn normalize_posture(value: &str) -> String {
+    value.trim().to_ascii_lowercase().replace(['-', ' '], "_")
+}

--- a/crates/source-runtime-next/src/sentinelone/source_execution_adapter_tests.rs
+++ b/crates/source-runtime-next/src/sentinelone/source_execution_adapter_tests.rs
@@ -474,6 +474,58 @@ fn closed_dispatcher_executes_promoted_direct_families_with_go_identity_and_shap
                 ("is_default", Value::from(true)),
             ],
         },
+        Case {
+            family: "threat",
+            path: "/web/api/v2.1/threats",
+            provider_id: "threat-fixture-1",
+            body: serde_json::json!({"data": [{
+                "id": "threat-fixture-1",
+                "threatInfo": {
+                    "analystVerdict": "true_positive",
+                    "classification": "Malware",
+                    "classificationSource": "Engine",
+                    "confidenceLevel": "malicious",
+                    "incidentStatus": "unresolved",
+                    "mitigationStatus": "not_mitigated",
+                    "identifiedAt": "2026-04-23T01:00:00Z",
+                    "sha256": "feedfacecafebeef"
+                },
+                "agentDetectionInfo": {
+                    "agentIpV4": "203.0.113.20",
+                    "agentIpV6": "2001:db8::20",
+                    "externalIp": "198.51.100.20",
+                    "agentUuid": "agent-uuid-1",
+                    "siteId": "site-fixture-1",
+                    "groupId": "group-fixture-1"
+                },
+                "agentRealtimeInfo": {
+                    "agentId": "agent-fixture-1",
+                    "agentComputerName": "host-fixture-1",
+                    "agentIsActive": true,
+                    "agentInfected": true,
+                    "activeThreats": 1
+                },
+                "indicators": [{
+                    "category": "Malware",
+                    "tactics": [{"name": "Execution"}]
+                }],
+                "tenantId": "provider-controlled-tenant"
+            }], "pagination": {}}),
+            identity_attribute: "threat_id",
+            expected_attributes: vec![
+                ("classification", "Malware"),
+                ("classification_norm", "malware"),
+                ("analyst_verdict_norm", "true_positive"),
+                ("incident_status_norm", "unresolved"),
+                ("mitigation_status_norm", "not_mitigated"),
+                ("agent_id", "agent-fixture-1"),
+                ("hostname", "host-fixture-1"),
+                ("ip", "203.0.113.20"),
+                ("ip_addresses", "203.0.113.20,2001:db8::20,198.51.100.20"),
+                ("mitre_tactics", "Execution"),
+            ],
+            expected_payload: vec![],
+        },
     ];
 
     let dispatcher = crate::source_execution::SourceExecutionDispatcher;
@@ -590,6 +642,143 @@ fn closed_dispatcher_executes_promoted_direct_families_with_go_identity_and_shap
             Some(case.provider_id)
         );
     }
+}
+
+#[test]
+fn threat_runtime_preserves_go_event_shape_and_strips_nested_secret_fields() {
+    let dispatcher = crate::source_execution::SourceExecutionDispatcher;
+    let adapter = SENTINELONE_DIRECT_SOURCE_EXECUTION_ADAPTERS
+        .iter()
+        .find(|adapter| adapter.family_id() == "threat")
+        .unwrap();
+    let plan = adapter.compiled_plan();
+    let execution_context = context("");
+    let metadata = SourceWorkerRuntimeMetadataV2 {
+        public_config: HashMap::from([
+            (
+                "base_url".to_owned(),
+                "https://sentinelone.example.test".to_owned(),
+            ),
+            ("site_id".to_owned(), "site-fixture-1".to_owned()),
+            ("since".to_owned(), "2026-04-01T00:00:00Z".to_owned()),
+            ("until".to_owned(), "2026-04-30T00:00:00Z".to_owned()),
+        ]),
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    };
+    let planned = adapter
+        .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(execution_context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+        })
+        .unwrap();
+    let url = &planned.request.as_ref().unwrap().url;
+    for expected in [
+        "siteIds=site-fixture-1",
+        "createdAt__gte=2026-04-01T00%3A00%3A00Z",
+        "createdAt__lte=2026-04-30T00%3A00%3A00Z",
+    ] {
+        assert!(url.contains(expected), "missing {expected} in {url}");
+    }
+    let body = serde_json::to_vec(&serde_json::json!({
+        "data": [{
+            "id": "threat-fixture-1",
+            "threatInfo": {
+                "analystVerdict": "true_positive",
+                "classification": "Malware",
+                "classificationSource": "Engine",
+                "confidenceLevel": "malicious",
+                "incidentStatus": "unresolved",
+                "mitigationStatus": "not_mitigated",
+                "identifiedAt": "2026-04-23T01:00:00Z",
+                "sha256": "feedfacecafebeef"
+            },
+            "agentDetectionInfo": {
+                "agentIpV4": "203.0.113.20",
+                "agentIpV6": "2001:db8::20",
+                "externalIp": "198.51.100.20",
+                "agentUuid": "agent-uuid-1",
+                "siteId": "site-fixture-1",
+                "groupId": "group-fixture-1"
+            },
+            "agentRealtimeInfo": {
+                "agentId": "agent-fixture-1",
+                "agentComputerName": "host-fixture-1",
+                "agentIsActive": true,
+                "agentInfected": true,
+                "activeThreats": 1
+            },
+            "indicators": [{
+                "category": "Malware",
+                "description": "Observed execution",
+                "tactics": [{
+                    "name": "Execution",
+                    "techniques": [
+                        {"name": "Native API"},
+                        {"name": "Native API"}
+                    ]
+                }]
+            }],
+            "mitigationStatus": [{
+                "action": "kill",
+                "status": "success",
+                "reportId": "report-1"
+            }],
+            "whiteningOptions": ["path"],
+            "nested": {"apiToken": "provider-secret-shape"},
+            "tenantId": "provider-controlled-tenant"
+        }],
+        "pagination": {"nextCursor": "cursor-2"}
+    }))
+    .unwrap();
+    let decoded = dispatcher
+        .dispatch_decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+            request: Some(SourceWorkerDecodeRequestV1 {
+                plan: Some(plan.clone()),
+                status_code: 200,
+                response_body: body,
+                logical_page_id: execution_context.logical_page_id.clone(),
+                request_intent_digest: planned
+                    .request
+                    .as_ref()
+                    .unwrap()
+                    .request_intent_digest
+                    .clone(),
+                receipt: None,
+                context: Some(execution_context),
+            }),
+            metadata: Some(metadata),
+            response_headers: HashMap::new(),
+            execution_intent_digest_sha256: planned.execution_intent_digest_sha256,
+            response_headers_sha256: String::new(),
+        })
+        .unwrap()
+        .result
+        .unwrap();
+    assert_eq!(decoded.next_cursor, "cursor-2");
+    assert_eq!(decoded.records.len(), 1);
+    let record = &decoded.records[0];
+    assert_eq!(record.occurred_at_unix_millis, 1_776_906_000_000);
+    assert_eq!(record.attributes["mitre_tactics"], "Execution");
+    assert_eq!(record.attributes["mitre_techniques"], "Native API");
+    let payload: Value = serde_json::from_slice(&record.payload_json).unwrap();
+    assert_eq!(payload["tenant_host"], "sentinelone.example.test");
+    assert_eq!(payload["threat_info"]["classification"], "Malware");
+    assert_eq!(payload["agent_realtime"]["is_decommissioned"], false);
+    assert_eq!(payload["indicators"]["mitre_techniques"][0], "Native API");
+    assert_eq!(payload["mitigation_actions"][0]["action"], "kill");
+    assert_eq!(payload["whitening_options"][0], "path");
+    assert!(payload["raw"].get("tenantId").is_none());
+    assert!(payload["raw"]["nested"].get("apiToken").is_none());
+    assert!(
+        !record
+            .payload_json
+            .windows(b"provider-secret-shape".len())
+            .any(|window| window == b"provider-secret-shape")
+    );
 }
 
 #[test]

--- a/docs/domains/source-runtime-guide.md
+++ b/docs/domains/source-runtime-guide.md
@@ -44,10 +44,10 @@ The production package includes the credential-free `source_worker` binary.
 `CEREBRO_SOURCE_WORKER` selects its absolute path; when unset, Cerebro uses the
 `source_worker` sibling next to the Go executable. Closed production dispatch
 includes `azure` with `family=authorization_policy` and SentinelOne with
-`family=agent`, `activity`, `exclusion`, `group`, or `site`. Those runtimes must
-store an opaque `env:` or `credential:` reference. The trusted host resolves
-and redeems it once; raw credential bytes are never sent to the Rust worker.
-SentinelOne threat and application inventory remain on the Go compatibility
+`family=agent`, `activity`, `exclusion`, `group`, `site`, or `threat`. Those
+runtimes must store an opaque `env:` or `credential:` reference. The trusted
+host resolves and redeems it once; raw credential bytes are never sent to the
+Rust worker. SentinelOne application inventory remains on the Go compatibility
 path. SentinelOne source preview also remains on its compatibility path until
 the preview credential adapter is promoted separately.
 

--- a/docs/engineering/rust-source-runtime-adr.md
+++ b/docs/engineering/rust-source-runtime-adr.md
@@ -182,11 +182,12 @@ process restarts, while tenant-scoped event identity makes a refetched singleton
 idempotent. A stale generation is rejected before append and by the final
 Postgres checkpoint transaction. The closed Rust dispatcher and durable runtime
 authority also own `sentinelone.agent`, `sentinelone.activity`,
-`sentinelone.exclusion`, `sentinelone.group`, and `sentinelone.site`. The trusted
-host still owns SentinelOne credential redemption and origin-constrained HTTP;
-Go still owns durable append, projection, and checkpoint transactions. Threat
-and application inventory remain on compatibility execution until their richer
-normalization and fanout contracts earn the same authority receipts.
+`sentinelone.exclusion`, `sentinelone.group`, `sentinelone.site`, and
+`sentinelone.threat`. The trusted host still owns SentinelOne credential
+redemption and origin-constrained HTTP; Go still owns durable append, projection,
+and checkpoint transactions. Application inventory remains on compatibility
+execution until its multi-request fanout contract earns the same authority
+receipts.
 
 ## Why Rust, and where Rust is not the reason
 

--- a/internal/sourceruntime/source_execution_authority_test.go
+++ b/internal/sourceruntime/source_execution_authority_test.go
@@ -460,7 +460,7 @@ func TestSentinelOneAgentNeverFallsBackToGoAuthority(t *testing.T) {
 }
 
 func TestPromotedSentinelOneDirectFamiliesNeverFallBackToGoAuthority(t *testing.T) {
-	for _, family := range []string{"activity", "exclusion", "group", "site"} {
+	for _, family := range []string{"activity", "exclusion", "group", "site", "threat"} {
 		t.Run(family, func(t *testing.T) {
 			legacy := &runtimeAuthorityProbe{sourceID: "sentinelone"}
 			worker := &runtimePlanWorker{compileErr: sourceworker.ErrWorkerUnsupported}
@@ -489,8 +489,8 @@ func TestPromotedSentinelOneDirectFamiliesNeverFallBackToGoAuthority(t *testing.
 	}
 }
 
-func TestRemainingSentinelOneFamiliesStayGoCompatible(t *testing.T) {
-	for _, family := range []string{"application", "threat"} {
+func TestSentinelOneApplicationStaysGoCompatible(t *testing.T) {
+	for _, family := range []string{"application"} {
 		t.Run(family, func(t *testing.T) {
 			legacy := &runtimeAuthorityProbe{sourceID: "sentinelone"}
 			service := &Service{sourceWorker: &runtimePlanWorker{}}

--- a/internal/sourceruntime/sourceworker/pull.go
+++ b/internal/sourceruntime/sourceworker/pull.go
@@ -38,7 +38,7 @@ func RustAuthoritativeFamily(sourceID, familyID string) (string, bool) {
 		return familyID, true
 	case "sentinelone":
 		switch familyID {
-		case "activity", "agent", "exclusion", "group", "site":
+		case "activity", "agent", "exclusion", "group", "site", "threat":
 			return familyID, true
 		default:
 			return familyID, false

--- a/internal/sourceruntime/sourceworker/pull_test.go
+++ b/internal/sourceruntime/sourceworker/pull_test.go
@@ -98,7 +98,7 @@ func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
 		"SentinelOne group":          {"sentinelone", "group", "group", true},
 		"SentinelOne site":           {"sentinelone", "site", "site", true},
 		"SentinelOne default":        {"sentinelone", "", "", false},
-		"SentinelOne threat":         {"sentinelone", "threat", "threat", false},
+		"SentinelOne threat":         {"sentinelone", "threat", "threat", true},
 		"SentinelOne application":    {"sentinelone", "application", "application", false},
 		"Tailscale default":          {"tailscale", "", "device", true},
 		"unknown Tailscale family":   {"tailscale", "future-family", "future-family", true},


### PR DESCRIPTION
## Summary

- add SentinelOne `threat` to the closed Rust source-execution dispatcher and durable authority allowlist
- normalize the full Go-compatible threat event shape in a focused provider module
- preserve tenant-scoped identity, typed response validation, bounded pagination, public filters, deduplication, and credential-field stripping
- leave application inventory and source preview outside this PR

## Source boundary

- source: `sentinelone`
- family: `threat`
- request owner: credential-free Rust kernel
- network/auth owner: trusted host using the existing `sentinelone.api_token` operation
- continuation owner: bounded provider cursor returned by Rust and durably committed by the host
- event: `sentinelone.threat` / `sentinelone/threat/v1`
- durable append, projection, and checkpoint transactions remain in the current host plane

## Validation

Validated on the threat commit before merging current `main`:

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p cerebro-source-runtime-next --all-targets -- -D warnings`
- `cargo test --locked -p cerebro-source-runtime-next sentinelone -- --nocapture` — 33 passed
- `cargo test --locked -p cerebro-source-runtime-next source_execution -- --nocapture` — 51 passed

Validated on the exact PR head after merging current `main`:

- focused Go source-runtime authority tests
- docs drift, architecture, and structural checks
- source generation, provider fixtures, catalog, and connector-contract checks
- `git diff --check origin/main...HEAD`

The exact-head local Rust rerun is blocked before compilation because the managed DDESK Cargo cache is 848,550,502 bytes below its safe-capacity threshold. The merge added only the landed Rust-only census workflow and its paired contract test; hosted CI is the exact-head Rust receipt for this PR.

## Security and failure behavior

- no credential values enter Rust requests, responses, fixtures, event payloads, attributes, or errors
- trusted execution context owns tenant identity
- provider origin, redirect boundary, response size, record identity, cursor size, status classification, and duplicate conflicts fail closed
- nested credential- and tenant-shaped fields are removed from retained raw provider data

## Remaining boundary

SentinelOne application inventory remains the final persisted-runtime family outside this PR because it uses a two-request agent-discovery fanout contract. Source preview remains on its existing compatibility path.
