### PR TITLE
Promote SentinelOne applications to Rust authority

### DIFF
--- a/crates/source-runtime-next/src/sentinelone.rs
+++ b/crates/source-runtime-next/src/sentinelone.rs
@@ -3,8 +3,8 @@
 //! SentinelOne exposes six directly paginated collection endpoints and one
 //! application inventory endpoint that must first enumerate agents. This
 //! module owns that credential-free provider state machine. Its normalized
-//! records still require the shared source-execution adapter, compiler mapping,
-//! event admission, and projection path before they can reach the graph.
+//! records pass through the shared source-execution contract, event admission,
+//! and projection path before they reach the graph.
 
 mod cursor;
 mod kernel;
@@ -13,8 +13,8 @@ mod response;
 mod source_execution_adapter;
 
 pub(crate) use source_execution_adapter::{
-    SENTINELONE_DIRECT_SOURCE_EXECUTION_ADAPTERS, SentinelOneAgentSourceExecutionAdapter,
-    durable_checkpoint_cursor,
+    SENTINELONE_APPLICATION_SOURCE_EXECUTION_ADAPTER, SENTINELONE_DIRECT_SOURCE_EXECUTION_ADAPTERS,
+    SentinelOneAgentSourceExecutionAdapter, durable_checkpoint_cursor,
 };
 
 pub use kernel::SentinelOneKernel;

--- a/crates/source-runtime-next/src/sentinelone/cursor.rs
+++ b/crates/source-runtime-next/src/sentinelone/cursor.rs
@@ -4,7 +4,7 @@ use super::model::{ApplicationCursor, SentinelOneError};
 
 pub(super) const APPLICATION_CURSOR_PREFIX: &str = "cerebro-sentinelone-application-v1:";
 pub(super) const MAX_PROVIDER_CURSOR_BYTES: usize = 4_096;
-pub(super) const MAX_APPLICATION_CURSOR_BYTES: usize = 17_000;
+pub(super) const MAX_APPLICATION_CURSOR_BYTES: usize = 4_096;
 const MAX_CURSOR_COMPONENT_BYTES: usize = 4_096;
 
 pub(super) fn bounded_provider_cursor(

--- a/crates/source-runtime-next/src/sentinelone/model.rs
+++ b/crates/source-runtime-next/src/sentinelone/model.rs
@@ -146,6 +146,13 @@ impl SentinelOneRequest {
     pub const fn accept(&self) -> &'static str {
         "application/json"
     }
+
+    pub(crate) fn continuation_cursor(&self) -> Result<Option<String>, SentinelOneError> {
+        self.application_state
+            .as_ref()
+            .map(super::cursor::encode_application_cursor)
+            .transpose()
+    }
 }
 
 /// One normalized provider record produced by the SentinelOne kernel.

--- a/crates/source-runtime-next/src/sentinelone/source_execution_adapter.rs
+++ b/crates/source-runtime-next/src/sentinelone/source_execution_adapter.rs
@@ -1,8 +1,8 @@
 //! SentinelOne adapters for the canonical source-execution protocol.
 //!
-//! The agent adapter remains the representative compatibility oracle. Direct
-//! family adapters live in a focused sibling module and reuse this module's
-//! request, receipt, status, identity, and checkpoint invariants.
+//! The agent adapter remains the representative event-contract oracle. Direct
+//! and application-fanout adapters live in focused sibling modules and reuse
+//! this module's request, receipt, status, identity, and checkpoint invariants.
 
 use crate::source_execution::{
     SourceExecutionAdapter, SourceExecutionError, SourceExecutionPlanV1,
@@ -18,6 +18,8 @@ use super::{
     SentinelOneError, SentinelOneFamily, SentinelOneFilters, SentinelOneKernel, SentinelOneOutcome,
 };
 
+#[path = "source_execution_adapter/application.rs"]
+mod application;
 #[path = "source_execution_adapter/direct.rs"]
 mod direct;
 #[path = "source_execution_adapter/error.rs"]
@@ -30,6 +32,7 @@ mod runtime;
 use error::SentinelOneAgentAdapterError;
 use normalization::normalize_agent_record;
 
+pub(crate) use application::SENTINELONE_APPLICATION_SOURCE_EXECUTION_ADAPTER;
 pub(crate) use direct::SENTINELONE_DIRECT_SOURCE_EXECUTION_ADAPTERS;
 
 const SOURCE_ID: &str = "sentinelone";
@@ -288,8 +291,10 @@ fn validate_provider_request(
     allowed_origin: &str,
     request: &super::SentinelOneRequest,
 ) -> Result<(), SentinelOneAgentAdapterError> {
+    let application_path = plan.family_id == SentinelOneFamily::Application.as_str()
+        && request.url().path() == SentinelOneFamily::Application.path();
     if request.url().origin().ascii_serialization() != allowed_origin
-        || request.url().path() != plan.path
+        || (request.url().path() != plan.path && !application_path)
         || request.authorization_scheme() != "ApiToken"
         || request.accept() != "application/json"
     {
@@ -360,7 +365,15 @@ pub(crate) fn durable_checkpoint_cursor(
                 && plan.family_id == adapter.family_id()
                 && plan.provider_kernel == adapter.provider_kernel()
         });
-    if !direct_family && (plan.source_id != SOURCE_ID || plan.family_id != FAMILY_ID) {
+    let application_family = plan.source_id
+        == SENTINELONE_APPLICATION_SOURCE_EXECUTION_ADAPTER.source_id()
+        && plan.family_id == SENTINELONE_APPLICATION_SOURCE_EXECUTION_ADAPTER.family_id()
+        && plan.provider_kernel
+            == SENTINELONE_APPLICATION_SOURCE_EXECUTION_ADAPTER.provider_kernel();
+    if !direct_family
+        && !application_family
+        && (plan.source_id != SOURCE_ID || plan.family_id != FAMILY_ID)
+    {
         return None;
     }
     if !result.next_cursor.is_empty() {

--- a/crates/source-runtime-next/src/sentinelone/source_execution_adapter/application.rs
+++ b/crates/source-runtime-next/src/sentinelone/source_execution_adapter/application.rs
@@ -1,0 +1,283 @@
+//! Closed source-execution adapter for SentinelOne application fanout.
+
+use crate::sentinelone::{
+    SentinelOneFamily, SentinelOneFilters, SentinelOneKernel, SentinelOneOutcome,
+};
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceExecutionPlanV1,
+    SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1,
+    SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2, SourceWorkerHttpRequestV1,
+    SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1, SourceWorkerRecordV1,
+    canonical_plan_digest, canonical_result_digest, validate_and_deduplicate_records,
+    validate_decode_result, validate_execution_context, validate_http_request,
+    validate_safe_receipt,
+};
+
+use super::error::SentinelOneAgentAdapterError;
+use super::{
+    COMPILED_ORIGIN, MAX_RESPONSE_BYTES, METHOD, PAGE_SIZE, RECORD_SELECTOR, SOURCE_ID,
+    classify_status, map_kernel_error,
+    normalization::{application_event_id, normalize_application_record},
+    optional_cursor, plan_with_kernel, runtime, validate_agent_tenant, validate_provider_request,
+};
+
+const FAMILY: SentinelOneFamily = SentinelOneFamily::Application;
+const PLAN_ID: &str = "source-plan-v1:sentinelone:application";
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct SentinelOneApplicationSourceExecutionAdapter;
+
+pub(crate) static SENTINELONE_APPLICATION_SOURCE_EXECUTION_ADAPTER:
+    SentinelOneApplicationSourceExecutionAdapter = SentinelOneApplicationSourceExecutionAdapter;
+
+impl SentinelOneApplicationSourceExecutionAdapter {
+    pub(crate) fn compiled_plan(&self) -> SourceExecutionPlanV1 {
+        let mut plan = SourceExecutionPlanV1 {
+            plan_id: PLAN_ID.to_owned(),
+            source_id: SOURCE_ID.to_owned(),
+            family_id: FAMILY.as_str().to_owned(),
+            provider_kernel: FAMILY.provider_kind().to_owned(),
+            method: METHOD.to_owned(),
+            origin: COMPILED_ORIGIN.to_owned(),
+            path: SentinelOneFamily::Agent.path().to_owned(),
+            record_selector: RECORD_SELECTOR.to_owned(),
+            id_field: String::new(),
+            singleton_fallback_id: String::new(),
+            max_response_bytes: MAX_RESPONSE_BYTES,
+            event_kind: FAMILY.provider_kind().to_owned(),
+            schema_ref: FAMILY.schema_ref().to_owned(),
+            required_attributes: vec!["family".to_owned(), "agent_id".to_owned()],
+            required_payload_fields: vec!["agent_id".to_owned()],
+            plan_digest_sha256: String::new(),
+        };
+        plan.plan_digest_sha256 = canonical_plan_digest(&plan);
+        plan
+    }
+}
+
+impl SourceExecutionAdapter for SentinelOneApplicationSourceExecutionAdapter {
+    fn source_id(&self) -> &'static str {
+        SOURCE_ID
+    }
+
+    fn family_id(&self) -> &'static str {
+        FAMILY.as_str()
+    }
+
+    fn provider_kernel(&self) -> &'static str {
+        FAMILY.provider_kind()
+    }
+
+    fn validate_record_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+    ) -> Result<(), SourceExecutionError> {
+        let payload: serde_json::Value = serde_json::from_slice(&record.payload_json)
+            .map_err(|_| SourceExecutionError::MalformedResponse)?;
+        let agent_id = payload
+            .get("agent_id")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        let application_id = application_identity(&payload);
+        let expected = application_event_id(&context.tenant_id, agent_id, &application_id)
+            .map_err(SourceExecutionError::from)?;
+        if record.event_id != expected
+            || record.attributes.get("agent_id").map(String::as_str) != Some(agent_id)
+            || record.provider_id != format!("{agent_id}::{application_id}")
+        {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        Ok(())
+    }
+
+    fn plan(
+        &self,
+        request: &SourceWorkerPlanRequestV1,
+    ) -> Result<SourceWorkerHttpRequestV1, SourceExecutionError> {
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        validate_application_plan(plan).map_err(SourceExecutionError::from)?;
+        validate_execution_context(context)?;
+        validate_agent_tenant(&context.tenant_id).map_err(SourceExecutionError::from)?;
+        let kernel = application_kernel(plan, None)?;
+        let result = plan_with_kernel(plan, context, &kernel, &plan.origin)?;
+        validate_http_request(plan, context, &result)?;
+        Ok(result)
+    }
+
+    fn plan_v2(
+        &self,
+        envelope: &SourceWorkerPlanEnvelopeV2,
+    ) -> Result<SourceWorkerHttpExecutionV2, SourceExecutionError> {
+        runtime::plan_application_v2(envelope)
+    }
+
+    fn decode(
+        &self,
+        request: &SourceWorkerDecodeRequestV1,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let kernel = application_kernel(plan, None)?;
+        let expected = plan_with_kernel(plan, context, &kernel, &plan.origin)?;
+        decode_application_response_with_kernel(request, self, &kernel, &plan.origin, &expected)
+    }
+
+    fn decode_v2(
+        &self,
+        envelope: &SourceWorkerDecodeEnvelopeV2,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        runtime::decode_application_v2(envelope, self)
+    }
+}
+
+pub(super) fn decode_application_response_with_kernel(
+    request: &SourceWorkerDecodeRequestV1,
+    adapter: &SentinelOneApplicationSourceExecutionAdapter,
+    kernel: &SentinelOneKernel,
+    allowed_origin: &str,
+    expected: &SourceWorkerHttpRequestV1,
+) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+    let plan = request
+        .plan
+        .as_ref()
+        .ok_or(SourceExecutionError::InvalidPlan)?;
+    let context = request
+        .context
+        .as_ref()
+        .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+    let receipt = request
+        .receipt
+        .as_ref()
+        .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+    validate_application_plan(plan).map_err(SourceExecutionError::from)?;
+    validate_execution_context(context)?;
+    validate_agent_tenant(&context.tenant_id).map_err(SourceExecutionError::from)?;
+    classify_status(request.status_code).map_err(SourceExecutionError::from)?;
+    if request.response_body.len() as u64 > plan.max_response_bytes {
+        return Err(SourceExecutionError::ResponseTooLarge);
+    }
+    if request.logical_page_id != context.logical_page_id {
+        return Err(SourceExecutionError::MissingExecutionIdentity);
+    }
+    validate_safe_receipt(
+        receipt,
+        plan,
+        context,
+        &request.response_body,
+        request.status_code,
+        &request.request_intent_digest,
+    )?;
+    if request.request_intent_digest != expected.request_intent_digest {
+        return Err(SourceExecutionError::InvalidDigest);
+    }
+    let provider_request = kernel
+        .plan(optional_cursor(&context.prior_cursor))
+        .map_err(map_kernel_error)
+        .map_err(SourceExecutionError::from)?;
+    validate_provider_request(plan, allowed_origin, &provider_request)
+        .map_err(SourceExecutionError::from)?;
+
+    let outcome = kernel
+        .decode(&provider_request, &request.response_body)
+        .map_err(map_kernel_error)
+        .map_err(SourceExecutionError::from)?;
+    let (records, next_cursor) = match outcome {
+        SentinelOneOutcome::Request(followup) => {
+            validate_provider_request(plan, allowed_origin, &followup)
+                .map_err(SourceExecutionError::from)?;
+            let cursor = followup
+                .continuation_cursor()
+                .map_err(map_kernel_error)
+                .map_err(SourceExecutionError::from)?
+                .ok_or(SourceExecutionError::InvalidCursor)?;
+            (Vec::new(), cursor)
+        }
+        SentinelOneOutcome::Page(page) => {
+            let records = page
+                .records
+                .into_iter()
+                .map(|record| normalize_application_record(record, context))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(SourceExecutionError::from)?;
+            (
+                validate_and_deduplicate_records(records)?,
+                page.next_cursor.unwrap_or_default(),
+            )
+        }
+    };
+    let result_digest_sha256 = canonical_result_digest(receipt, &next_cursor, &records)?;
+    let result = SourceWorkerDecodeResultV1 {
+        plan_id: plan.plan_id.clone(),
+        plan_digest_sha256: plan.plan_digest_sha256.clone(),
+        logical_page_id: context.logical_page_id.clone(),
+        request_intent_digest: request.request_intent_digest.clone(),
+        records,
+        next_cursor,
+        result_digest_sha256,
+        tenant_id: context.tenant_id.clone(),
+        runtime_id: context.runtime_id.clone(),
+        runtime_generation: context.runtime_generation,
+        lease_generation: context.lease_generation,
+        observed_at_unix_millis: context.observed_at_unix_millis,
+    };
+    validate_decode_result(request, &result)?;
+    for record in &result.records {
+        adapter.validate_record_identity(context, record)?;
+    }
+    Ok(result)
+}
+
+pub(super) fn validate_application_plan(
+    plan: &SourceExecutionPlanV1,
+) -> Result<(), SentinelOneAgentAdapterError> {
+    if plan != &SENTINELONE_APPLICATION_SOURCE_EXECUTION_ADAPTER.compiled_plan() {
+        return Err(SentinelOneAgentAdapterError::InvalidPlan);
+    }
+    Ok(())
+}
+
+fn application_kernel(
+    plan: &SourceExecutionPlanV1,
+    agent_id: Option<String>,
+) -> Result<SentinelOneKernel, SourceExecutionError> {
+    SentinelOneKernel::new(
+        &plan.origin,
+        FAMILY,
+        SentinelOneFilters {
+            agent_id,
+            ..SentinelOneFilters::default()
+        },
+        Some(PAGE_SIZE),
+    )
+    .map_err(map_kernel_error)
+    .map_err(SourceExecutionError::from)
+}
+
+fn application_identity(payload: &serde_json::Value) -> String {
+    let parts = ["publisher", "name", "version"]
+        .into_iter()
+        .filter_map(|name| payload.get(name).and_then(serde_json::Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.replace(' ', "_"))
+        .collect::<Vec<_>>();
+    if parts.is_empty() {
+        "unknown".to_owned()
+    } else {
+        parts.join("::")
+    }
+}

--- a/crates/source-runtime-next/src/sentinelone/source_execution_adapter/normalization.rs
+++ b/crates/source-runtime-next/src/sentinelone/source_execution_adapter/normalization.rs
@@ -13,6 +13,9 @@ use crate::sentinelone::SentinelOneRecord;
 #[path = "normalization/direct.rs"]
 mod direct;
 pub(super) use direct::normalize_direct_record;
+#[path = "normalization/application.rs"]
+mod application;
+pub(crate) use application::{application_event_id, normalize_application_record};
 #[path = "normalization/threat.rs"]
 mod threat;
 pub(super) use threat::normalize_threat_record;

--- a/crates/source-runtime-next/src/sentinelone/source_execution_adapter/normalization/application.rs
+++ b/crates/source-runtime-next/src/sentinelone/source_execution_adapter/normalization/application.rs
@@ -1,0 +1,116 @@
+//! Canonical SentinelOne application-inventory event normalization.
+
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Value};
+
+use crate::sentinelone::SentinelOneRecord;
+use crate::source_execution::{SourceWorkerExecutionContextV1, SourceWorkerRecordV1};
+
+use super::super::error::SentinelOneAgentAdapterError;
+use super::{
+    insert_json_integer, insert_json_string, insert_nonblank, provider_occurred_at_millis_for,
+    remove_untrusted_tenant_fields, string_at,
+};
+
+pub(crate) fn normalize_application_record(
+    record: SentinelOneRecord,
+    context: &SourceWorkerExecutionContextV1,
+) -> Result<SourceWorkerRecordV1, SentinelOneAgentAdapterError> {
+    let provider_id = record.provider_id.trim();
+    let agent_id = record
+        .fields
+        .get("agent_id")
+        .map(String::as_str)
+        .map(str::trim)
+        .unwrap_or_default();
+    let application_id = record
+        .fields
+        .get("application_id")
+        .map(String::as_str)
+        .map(str::trim)
+        .unwrap_or_default();
+    if provider_id.is_empty()
+        || agent_id.is_empty()
+        || application_id.is_empty()
+        || provider_id != format!("{agent_id}::{application_id}")
+    {
+        return Err(SentinelOneAgentAdapterError::MissingProviderIdentity);
+    }
+    let occurred_at_unix_millis =
+        provider_occurred_at_millis_for(&record.payload, &["installedDate"])
+            .unwrap_or(context.observed_at_unix_millis);
+
+    let mut attributes = BTreeMap::from([
+        ("family".to_owned(), "application".to_owned()),
+        ("agent_id".to_owned(), agent_id.to_owned()),
+        ("tenant_host".to_owned(), context.tenant_id.clone()),
+    ]);
+    for (name, provider_name) in [
+        ("application_name", "name"),
+        ("publisher", "publisher"),
+        ("version", "version"),
+        ("installed_date", "installedDate"),
+    ] {
+        insert_nonblank(
+            &mut attributes,
+            name,
+            string_at(&record.payload, provider_name),
+        );
+    }
+
+    let mut payload = Map::new();
+    payload.insert("agent_id".to_owned(), Value::String(agent_id.to_owned()));
+    payload.insert(
+        "tenant_host".to_owned(),
+        Value::String(context.tenant_id.clone()),
+    );
+    for (name, provider_name) in [
+        ("name", "name"),
+        ("publisher", "publisher"),
+        ("version", "version"),
+        ("installed_date", "installedDate"),
+    ] {
+        insert_json_string(
+            &mut payload,
+            name,
+            string_at(&record.payload, provider_name),
+        );
+    }
+    insert_json_integer(&mut payload, "size_bytes", &record.payload, "size");
+    let mut raw = record.payload;
+    remove_untrusted_tenant_fields(&mut raw);
+    payload.insert("raw".to_owned(), raw);
+
+    Ok(SourceWorkerRecordV1 {
+        provider_id: provider_id.to_owned(),
+        event_id: application_event_id(&context.tenant_id, agent_id, application_id)?,
+        occurred_at_unix_millis,
+        attributes: attributes.into_iter().collect(),
+        payload_json: serde_json::to_vec(&Value::Object(payload))
+            .map_err(|_| SentinelOneAgentAdapterError::InvalidProviderResponse)?,
+    })
+}
+
+pub(crate) fn application_event_id(
+    tenant_id: &str,
+    agent_id: &str,
+    application_id: &str,
+) -> Result<String, SentinelOneAgentAdapterError> {
+    let event_id = format!(
+        "sentinelone-application-{}-{}-{}",
+        tenant_id.trim(),
+        agent_id.trim(),
+        application_id.trim()
+    );
+    if tenant_id.trim().is_empty()
+        || agent_id.trim().is_empty()
+        || application_id.trim().is_empty()
+        || event_id.len() > 256
+        || event_id != event_id.trim()
+        || event_id.chars().any(char::is_control)
+    {
+        return Err(SentinelOneAgentAdapterError::InvalidEventIdentity);
+    }
+    Ok(event_id)
+}

--- a/crates/source-runtime-next/src/sentinelone/source_execution_adapter/runtime.rs
+++ b/crates/source-runtime-next/src/sentinelone/source_execution_adapter/runtime.rs
@@ -9,6 +9,10 @@ use crate::source_execution::{
     validate_runtime_metadata,
 };
 
+use super::application::{
+    SentinelOneApplicationSourceExecutionAdapter, decode_application_response_with_kernel,
+    validate_application_plan,
+};
 use super::direct::{
     SentinelOneDirectSourceExecutionAdapter, decode_direct_response_with_kernel,
     validate_direct_plan,
@@ -149,6 +153,69 @@ pub(super) fn decode_direct_v2(
     )
 }
 
+pub(super) fn plan_application_v2(
+    envelope: &SourceWorkerPlanEnvelopeV2,
+) -> Result<SourceWorkerHttpExecutionV2, SourceExecutionError> {
+    let request = envelope
+        .request
+        .as_ref()
+        .ok_or(SourceExecutionError::InvalidPlan)?;
+    let plan = request
+        .plan
+        .as_ref()
+        .ok_or(SourceExecutionError::InvalidPlan)?;
+    let context = request
+        .context
+        .as_ref()
+        .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+    let metadata = envelope
+        .metadata
+        .as_ref()
+        .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+    validate_application_plan(plan).map_err(SourceExecutionError::from)?;
+    let (kernel, allowed_origin) =
+        kernel_for_family(context, metadata, SentinelOneFamily::Application)?;
+    let planned = plan_with_kernel(plan, context, &kernel, &allowed_origin)?;
+    let mut execution = SourceWorkerHttpExecutionV2 {
+        request: Some(planned),
+        body: Vec::new(),
+        declared_headers: HashMap::new(),
+        execution_intent_digest_sha256: String::new(),
+        credential_operation: CREDENTIAL_OPERATION.to_owned(),
+        allowed_origin,
+    };
+    execution.execution_intent_digest_sha256 =
+        canonical_http_execution_digest(plan, context, metadata, &execution);
+    Ok(execution)
+}
+
+pub(super) fn decode_application_v2(
+    envelope: &SourceWorkerDecodeEnvelopeV2,
+    adapter: &SentinelOneApplicationSourceExecutionAdapter,
+) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+    let request = envelope
+        .request
+        .as_ref()
+        .ok_or(SourceExecutionError::InvalidPlan)?;
+    let plan = request
+        .plan
+        .as_ref()
+        .ok_or(SourceExecutionError::InvalidPlan)?;
+    let context = request
+        .context
+        .as_ref()
+        .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+    let metadata = envelope
+        .metadata
+        .as_ref()
+        .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+    validate_application_plan(plan).map_err(SourceExecutionError::from)?;
+    let (kernel, allowed_origin) =
+        kernel_for_family(context, metadata, SentinelOneFamily::Application)?;
+    let expected = plan_with_kernel(plan, context, &kernel, &allowed_origin)?;
+    decode_application_response_with_kernel(request, adapter, &kernel, &allowed_origin, &expected)
+}
+
 fn kernel(
     context: &SourceWorkerExecutionContextV1,
     metadata: &SourceWorkerRuntimeMetadataV2,
@@ -179,7 +246,7 @@ fn kernel_for_family(
         since: public_owned(&metadata.public_config, "since"),
         until: public_owned(&metadata.public_config, "until"),
         activity_type: public_owned(&metadata.public_config, "activity_type"),
-        ..SentinelOneFilters::default()
+        agent_id: public_owned(&metadata.public_config, "agent_id"),
     };
     let kernel = SentinelOneKernel::new(base_url, family, filters, page_size)
         .map_err(map_kernel_error)

--- a/crates/source-runtime-next/src/sentinelone/source_execution_adapter_tests.rs
+++ b/crates/source-runtime-next/src/sentinelone/source_execution_adapter_tests.rs
@@ -11,6 +11,14 @@ use super::*;
 
 const AGENT_PAGE: &[u8] = include_bytes!("fixtures/agent_page.json");
 const GO_PARITY: &str = include_str!("fixtures/agent_go_parity.json");
+const APPLICATION_RESPONSE: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../sources/sentinelone/testdata/api/application/list_applications/response.json"
+));
+const APPLICATION_GO_PARITY: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../sources/sentinelone/testdata/read_application.json"
+));
 
 fn context(cursor: &str) -> SourceWorkerExecutionContextV1 {
     SourceWorkerExecutionContextV1 {
@@ -778,6 +786,241 @@ fn threat_runtime_preserves_go_event_shape_and_strips_nested_secret_fields() {
             .payload_json
             .windows(b"provider-secret-shape".len())
             .any(|window| window == b"provider-secret-shape")
+    );
+}
+
+#[test]
+fn application_runtime_resumes_between_agent_discovery_and_inventory_fetch() {
+    let dispatcher = crate::source_execution::SourceExecutionDispatcher;
+    let plan = dispatcher
+        .compile_plan(
+            &crate::source_execution::SourceExecutionSelectionRequestV1 {
+                source_id: SOURCE_ID.to_owned(),
+                family_id: "application".to_owned(),
+            },
+        )
+        .unwrap();
+    assert_eq!(plan.path, "/web/api/v2.1/agents");
+    assert_eq!(plan.event_kind, "sentinelone.application_inventory");
+    assert_eq!(plan.required_payload_fields, ["agent_id"]);
+    let metadata = SourceWorkerRuntimeMetadataV2 {
+        public_config: HashMap::from([
+            (
+                "base_url".to_owned(),
+                "https://sentinelone.example.test".to_owned(),
+            ),
+            ("per_page".to_owned(), "10".to_owned()),
+        ]),
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    };
+
+    let discovery_context = SourceWorkerExecutionContextV1 {
+        tenant_id: "sentinelone.example.test".to_owned(),
+        runtime_id: "sentinelone-application-runtime".to_owned(),
+        logical_page_id: "application-discovery-page".to_owned(),
+        prior_cursor: String::new(),
+        runtime_generation: 7,
+        lease_generation: 11,
+        observed_at_unix_millis: 1_776_906_123_456,
+    };
+    let discovery = dispatcher
+        .dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(discovery_context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+        })
+        .unwrap();
+    assert_eq!(
+        discovery.request.as_ref().unwrap().url,
+        "https://sentinelone.example.test/web/api/v2.1/agents?limit=1"
+    );
+    let discovery_result = dispatcher
+        .dispatch_decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+            request: Some(SourceWorkerDecodeRequestV1 {
+                plan: Some(plan.clone()),
+                status_code: 200,
+                response_body: br#"{"data":[{"id":"agent-fixture-1"}],"pagination":{"nextCursor":"agent-next"}}"#.to_vec(),
+                logical_page_id: discovery_context.logical_page_id.clone(),
+                request_intent_digest: discovery
+                    .request
+                    .as_ref()
+                    .unwrap()
+                    .request_intent_digest
+                    .clone(),
+                receipt: None,
+                context: Some(discovery_context),
+            }),
+            metadata: Some(metadata.clone()),
+            response_headers: HashMap::new(),
+            execution_intent_digest_sha256: discovery.execution_intent_digest_sha256,
+            response_headers_sha256: String::new(),
+        })
+        .unwrap()
+        .result
+        .unwrap();
+    assert!(discovery_result.records.is_empty());
+    assert!(
+        discovery_result
+            .next_cursor
+            .starts_with("cerebro-sentinelone-application-v1:")
+    );
+    assert_eq!(
+        durable_checkpoint_cursor(&plan, &discovery_result),
+        Some(discovery_result.next_cursor.clone())
+    );
+
+    let inventory_context = SourceWorkerExecutionContextV1 {
+        logical_page_id: "application-inventory-page".to_owned(),
+        prior_cursor: discovery_result.next_cursor,
+        ..context("")
+    };
+    let inventory = dispatcher
+        .dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(inventory_context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+        })
+        .unwrap();
+    assert_eq!(
+        inventory.request.as_ref().unwrap().url,
+        "https://sentinelone.example.test/web/api/v2.1/agents/applications?ids=agent-fixture-1"
+    );
+    let inventory_result = dispatcher
+        .dispatch_decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+            request: Some(SourceWorkerDecodeRequestV1 {
+                plan: Some(plan.clone()),
+                status_code: 200,
+                response_body: APPLICATION_RESPONSE.to_vec(),
+                logical_page_id: inventory_context.logical_page_id.clone(),
+                request_intent_digest: inventory
+                    .request
+                    .as_ref()
+                    .unwrap()
+                    .request_intent_digest
+                    .clone(),
+                receipt: None,
+                context: Some(inventory_context),
+            }),
+            metadata: Some(metadata.clone()),
+            response_headers: HashMap::new(),
+            execution_intent_digest_sha256: inventory.execution_intent_digest_sha256,
+            response_headers_sha256: String::new(),
+        })
+        .unwrap()
+        .result
+        .unwrap();
+    assert_eq!(inventory_result.next_cursor, "agent-next");
+    assert_eq!(inventory_result.records.len(), 1);
+    let record = &inventory_result.records[0];
+    assert_eq!(
+        record.event_id,
+        "sentinelone-application-sentinelone.example.test-agent-fixture-1-Example_Inc::Example_App::1.0.0"
+    );
+    assert_eq!(record.occurred_at_unix_millis, 1_776_643_200_000);
+    let expected: Value = serde_json::from_str(APPLICATION_GO_PARITY).unwrap();
+    assert_eq!(
+        serde_json::to_value(&record.attributes).unwrap(),
+        expected[0]["attributes"]
+    );
+    assert_eq!(
+        serde_json::from_slice::<Value>(&record.payload_json).unwrap(),
+        expected[0]["payload"]
+    );
+
+    let resumed_context = SourceWorkerExecutionContextV1 {
+        logical_page_id: "application-next-agent-page".to_owned(),
+        prior_cursor: inventory_result.next_cursor,
+        ..context("")
+    };
+    let resumed = dispatcher
+        .dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan),
+                context: Some(resumed_context),
+            }),
+            metadata: Some(metadata),
+        })
+        .unwrap();
+    assert_eq!(
+        resumed.request.unwrap().url,
+        "https://sentinelone.example.test/web/api/v2.1/agents?limit=1&cursor=agent-next"
+    );
+}
+
+#[test]
+fn configured_application_identity_preserves_the_bounded_go_compatibility_tail() {
+    let dispatcher = crate::source_execution::SourceExecutionDispatcher;
+    let plan = dispatcher
+        .compile_plan(
+            &crate::source_execution::SourceExecutionSelectionRequestV1 {
+                source_id: SOURCE_ID.to_owned(),
+                family_id: "application".to_owned(),
+            },
+        )
+        .unwrap();
+    let execution_context = context("");
+    let metadata = SourceWorkerRuntimeMetadataV2 {
+        public_config: HashMap::from([
+            (
+                "base_url".to_owned(),
+                "https://sentinelone.example.test".to_owned(),
+            ),
+            ("agent_id".to_owned(), "agent-fixture-1".to_owned()),
+        ]),
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    };
+    let planned = dispatcher
+        .dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(execution_context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+        })
+        .unwrap();
+    assert!(
+        planned
+            .request
+            .as_ref()
+            .unwrap()
+            .url
+            .ends_with("/web/api/v2.1/agents/applications?ids=agent-fixture-1")
+    );
+    let body = br#"{"data":[{"name":"(Example App)"}]}"#;
+    let decoded = dispatcher
+        .dispatch_decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+            request: Some(SourceWorkerDecodeRequestV1 {
+                plan: Some(plan),
+                status_code: 200,
+                response_body: body.to_vec(),
+                logical_page_id: execution_context.logical_page_id.clone(),
+                request_intent_digest: planned
+                    .request
+                    .as_ref()
+                    .unwrap()
+                    .request_intent_digest
+                    .clone(),
+                receipt: None,
+                context: Some(execution_context),
+            }),
+            metadata: Some(metadata),
+            response_headers: HashMap::new(),
+            execution_intent_digest_sha256: planned.execution_intent_digest_sha256,
+            response_headers_sha256: String::new(),
+        })
+        .unwrap()
+        .result
+        .unwrap();
+    assert_eq!(decoded.records.len(), 1);
+    assert_eq!(
+        decoded.records[0].event_id,
+        "sentinelone-application-sentinelone.example.test-agent-fixture-1-(Example_App)"
     );
 }
 

--- a/crates/source-runtime-next/src/source_execution/contract.rs
+++ b/crates/source-runtime-next/src/source_execution/contract.rs
@@ -576,7 +576,7 @@ fn required_payload_value<'a>(
 
 fn validate_record(record: &SourceWorkerRecordV1) -> Result<(), SourceExecutionError> {
     if !bounded_text(&record.provider_id, MAX_CONTEXT_IDENTIFIER_BYTES)
-        || !safe_identifier(&record.event_id, 512)
+        || !safe_event_identifier(&record.event_id)
         || record.occurred_at_unix_millis <= 0
     {
         return Err(SourceExecutionError::MissingStableIdentity);
@@ -587,6 +587,14 @@ fn validate_record(record: &SourceWorkerRecordV1) -> Result<(), SourceExecutionE
     serde_json::from_slice::<serde_json::Value>(&record.payload_json)
         .map_err(|_| SourceExecutionError::MalformedResponse)?;
     Ok(())
+}
+
+fn safe_event_identifier(value: &str) -> bool {
+    safe_identifier(value, 512)
+        || (value.starts_with("sentinelone-application-")
+            && value == value.trim()
+            && value.len() <= 256
+            && !value.chars().any(char::is_control))
 }
 
 fn update_record_digest(hasher: &mut Sha256, record: &SourceWorkerRecordV1) {

--- a/crates/source-runtime-next/src/source_execution/dispatcher.rs
+++ b/crates/source-runtime-next/src/source_execution/dispatcher.rs
@@ -2,7 +2,8 @@ use prost::Message;
 
 use crate::digitalocean::DIGITALOCEAN_DROPLETS_SOURCE_EXECUTION_ADAPTER;
 use crate::sentinelone::{
-    SENTINELONE_DIRECT_SOURCE_EXECUTION_ADAPTERS, SentinelOneAgentSourceExecutionAdapter,
+    SENTINELONE_APPLICATION_SOURCE_EXECUTION_ADAPTER, SENTINELONE_DIRECT_SOURCE_EXECUTION_ADAPTERS,
+    SentinelOneAgentSourceExecutionAdapter,
 };
 use crate::twilio::adapter::{
     TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER, TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER,
@@ -142,6 +143,11 @@ impl SourceExecutionDispatcher {
         {
             return Ok(adapter.compiled_plan());
         }
+        if request.source_id == SENTINELONE_APPLICATION_SOURCE_EXECUTION_ADAPTER.source_id()
+            && request.family_id == SENTINELONE_APPLICATION_SOURCE_EXECUTION_ADAPTER.family_id()
+        {
+            return Ok(SENTINELONE_APPLICATION_SOURCE_EXECUTION_ADAPTER.compiled_plan());
+        }
         if request.source_id == DIGITALOCEAN_DROPLETS_SOURCE_EXECUTION_ADAPTER.source_id()
             && request.family_id == DIGITALOCEAN_DROPLETS_SOURCE_EXECUTION_ADAPTER.family_id()
         {
@@ -201,6 +207,13 @@ impl SourceExecutionDispatcher {
             })
         {
             return Ok(adapter);
+        }
+        if plan.source_id == SENTINELONE_APPLICATION_SOURCE_EXECUTION_ADAPTER.source_id()
+            && plan.family_id == SENTINELONE_APPLICATION_SOURCE_EXECUTION_ADAPTER.family_id()
+            && plan.provider_kernel
+                == SENTINELONE_APPLICATION_SOURCE_EXECUTION_ADAPTER.provider_kernel()
+        {
+            return Ok(&SENTINELONE_APPLICATION_SOURCE_EXECUTION_ADAPTER);
         }
         if plan.source_id == DIGITALOCEAN_DROPLETS_SOURCE_EXECUTION_ADAPTER.source_id()
             && plan.family_id == DIGITALOCEAN_DROPLETS_SOURCE_EXECUTION_ADAPTER.family_id()

--- a/docs/domains/source-runtime-guide.md
+++ b/docs/domains/source-runtime-guide.md
@@ -44,12 +44,13 @@ The production package includes the credential-free `source_worker` binary.
 `CEREBRO_SOURCE_WORKER` selects its absolute path; when unset, Cerebro uses the
 `source_worker` sibling next to the Go executable. Closed production dispatch
 includes `azure` with `family=authorization_policy` and SentinelOne with
-`family=agent`, `activity`, `exclusion`, `group`, `site`, or `threat`. Those
-runtimes must store an opaque `env:` or `credential:` reference. The trusted
-host resolves and redeems it once; raw credential bytes are never sent to the
-Rust worker. SentinelOne application inventory remains on the Go compatibility
-path. SentinelOne source preview also remains on its compatibility path until
-the preview credential adapter is promoted separately.
+`family=agent`, `activity`, `application`, `exclusion`, `group`, `site`, or
+`threat`. Those runtimes must store an opaque `env:` or `credential:` reference.
+The trusted host resolves and redeems it once; raw credential bytes are never
+sent to the Rust worker. Application inventory resumes across its agent-discovery
+and inventory-fetch requests with one bounded opaque cursor. SentinelOne source
+preview remains on its compatibility path until the preview credential adapter
+is promoted separately.
 
 ## Source preview
 

--- a/docs/engineering/rust-source-runtime-adr.md
+++ b/docs/engineering/rust-source-runtime-adr.md
@@ -181,13 +181,14 @@ owner and generation remain current. The logical page identity is stable across
 process restarts, while tenant-scoped event identity makes a refetched singleton
 idempotent. A stale generation is rejected before append and by the final
 Postgres checkpoint transaction. The closed Rust dispatcher and durable runtime
-authority also own `sentinelone.agent`, `sentinelone.activity`,
+authority own all seven SentinelOne families: `sentinelone.agent`,
+`sentinelone.activity`, `sentinelone.application_inventory`,
 `sentinelone.exclusion`, `sentinelone.group`, `sentinelone.site`, and
-`sentinelone.threat`. The trusted host still owns SentinelOne credential
+`sentinelone.threat`. Application inventory persists a bounded continuation
+between agent discovery and the per-agent inventory request, so interruption
+cannot skip an agent. The trusted host still owns SentinelOne credential
 redemption and origin-constrained HTTP; Go still owns durable append, projection,
-and checkpoint transactions. Application inventory remains on compatibility
-execution until its multi-request fanout contract earns the same authority
-receipts.
+and checkpoint transactions.
 
 ## Why Rust, and where Rust is not the reason
 

--- a/internal/sourceruntime/source_execution_authority_test.go
+++ b/internal/sourceruntime/source_execution_authority_test.go
@@ -459,8 +459,8 @@ func TestSentinelOneAgentNeverFallsBackToGoAuthority(t *testing.T) {
 	}
 }
 
-func TestPromotedSentinelOneDirectFamiliesNeverFallBackToGoAuthority(t *testing.T) {
-	for _, family := range []string{"activity", "exclusion", "group", "site", "threat"} {
+func TestPromotedSentinelOneNonAgentFamiliesNeverFallBackToGoAuthority(t *testing.T) {
+	for _, family := range []string{"activity", "application", "exclusion", "group", "site", "threat"} {
 		t.Run(family, func(t *testing.T) {
 			legacy := &runtimeAuthorityProbe{sourceID: "sentinelone"}
 			worker := &runtimePlanWorker{compileErr: sourceworker.ErrWorkerUnsupported}
@@ -484,26 +484,6 @@ func TestPromotedSentinelOneDirectFamiliesNeverFallBackToGoAuthority(t *testing.
 			}
 			if legacy.readCalls != 0 || worker.selection.SourceID != "sentinelone" || worker.selection.FamilyID != family {
 				t.Fatalf("authority calls = Go %d, Rust selection %#v", legacy.readCalls, worker.selection)
-			}
-		})
-	}
-}
-
-func TestSentinelOneApplicationStaysGoCompatible(t *testing.T) {
-	for _, family := range []string{"application"} {
-		t.Run(family, func(t *testing.T) {
-			legacy := &runtimeAuthorityProbe{sourceID: "sentinelone"}
-			service := &Service{sourceWorker: &runtimePlanWorker{}}
-			runtime := &cerebrov1.SourceRuntime{Id: "sentinelone-" + family + "-runtime", SourceId: "sentinelone", TenantId: "tenant-1"}
-			config := sourcecdk.NewConfig(map[string]string{"family": family})
-
-			if _, rustPage, err := service.readSourcePull(context.Background(), runtime, legacy, config, nil, nil, 1); err != nil {
-				t.Fatalf("readSourcePull() error = %v", err)
-			} else if rustPage {
-				t.Fatal("readSourcePull() reported a Rust page for a Go-authoritative SentinelOne family")
-			}
-			if legacy.readCalls != 1 {
-				t.Fatalf("Go Read calls = %d, want 1", legacy.readCalls)
 			}
 		})
 	}

--- a/internal/sourceruntime/sourceworker/pull.go
+++ b/internal/sourceruntime/sourceworker/pull.go
@@ -38,7 +38,7 @@ func RustAuthoritativeFamily(sourceID, familyID string) (string, bool) {
 		return familyID, true
 	case "sentinelone":
 		switch familyID {
-		case "activity", "agent", "exclusion", "group", "site", "threat":
+		case "activity", "agent", "application", "exclusion", "group", "site", "threat":
 			return familyID, true
 		default:
 			return familyID, false
@@ -104,7 +104,7 @@ func TailscaleFamily(sourceID, familyID string) (string, bool) {
 func PublicExecutionConfig(values map[string]string) map[string]string {
 	public := make(map[string]string)
 	for _, key := range []string{
-		"account_sid", "activity_type", "audit_end_time", "audit_services", "audit_sort", "audit_start_time", "base_url",
+		"account_sid", "activity_type", "agent_id", "audit_end_time", "audit_services", "audit_sort", "audit_start_time", "base_url",
 		"family", "group_id", "group_ids", "insights_base_url", "org_id", "per_page",
 		"since", "site_id", "tailnet", "until", "user_group_id", "user_group_ids",
 	} {

--- a/internal/sourceruntime/sourceworker/pull_test.go
+++ b/internal/sourceruntime/sourceworker/pull_test.go
@@ -71,10 +71,10 @@ func TestProviderResumeFailsClosedForMalformedAndCrossFamilyCheckpoints(t *testi
 func TestPublicExecutionConfigNeverCarriesCredentialMaterial(t *testing.T) {
 	public := PublicExecutionConfig(map[string]string{
 		"account_sid": " AC123 ", "family": "user", "tailnet": "example.com", "base_url": "https://api.tailscale.com/api/v2",
-		"site_id": "site-1", "since": "2026-01-01T00:00:00Z", "until": "2026-02-01T00:00:00Z", "activity_type": "27",
+		"site_id": "site-1", "agent_id": "agent-1", "since": "2026-01-01T00:00:00Z", "until": "2026-02-01T00:00:00Z", "activity_type": "27",
 		"token": "secret-token", "graph_token": "secret-graph-token", "tenant_id": "tenant-1",
 	})
-	if len(public) != 8 || public["account_sid"] != "AC123" || public["site_id"] != "site-1" || public["since"] == "" || public["until"] == "" || public["activity_type"] != "27" || public["token"] != "" || public["graph_token"] != "" || public["tenant_id"] != "" {
+	if len(public) != 9 || public["account_sid"] != "AC123" || public["site_id"] != "site-1" || public["agent_id"] != "agent-1" || public["since"] == "" || public["until"] == "" || public["activity_type"] != "27" || public["token"] != "" || public["graph_token"] != "" || public["tenant_id"] != "" {
 		t.Fatalf("public config leaked private fields: %#v", public)
 	}
 }
@@ -99,7 +99,7 @@ func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
 		"SentinelOne site":           {"sentinelone", "site", "site", true},
 		"SentinelOne default":        {"sentinelone", "", "", false},
 		"SentinelOne threat":         {"sentinelone", "threat", "threat", true},
-		"SentinelOne application":    {"sentinelone", "application", "application", false},
+		"SentinelOne application":    {"sentinelone", "application", "application", true},
 		"Tailscale default":          {"tailscale", "", "device", true},
 		"unknown Tailscale family":   {"tailscale", "future-family", "future-family", true},
 		"Twilio accounts":            {"twilio", "accounts", "accounts", true},


### PR DESCRIPTION
## Summary

- add the final SentinelOne persisted-runtime family, `application`, to the closed Rust dispatcher and durable authority allowlist
- execute agent discovery and per-agent application inventory as two bounded requests separated by a durable opaque continuation
- normalize exact Go-compatible application identities, attributes, payloads, and occurrence times
- preserve legacy application IDs that contain bounded punctuation without widening other provider identities

## Dependency

This PR is stacked on #2553 because its local branch was built after the SentinelOne threat authority slice. The application implementation is isolated to its own adapter and normalization modules. Retarget this PR to `main` after #2553 merges.

## Source boundary

- source: `sentinelone`
- family: `application`
- request owner: credential-free Rust kernel
- network/auth owner: trusted host using `sentinelone.api_token`
- first request: one bounded `/web/api/v2.1/agents` discovery page
- durable handoff: versioned cursor containing the selected agent and next-agent cursor, capped at 4 KiB
- second request: origin-constrained `/web/api/v2.1/agents/applications?ids=<agent>`
- event: `sentinelone.application_inventory` / `sentinelone/application_inventory/v1`
- durable append, projection, and checkpoint transactions remain in the current host plane

## Validation

Validated on the application commit before merging the current #2553 head:

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p cerebro-source-runtime-next --all-targets -- -D warnings`
- `cargo test --locked -p cerebro-source-runtime-next sentinelone -- --nocapture` — 35 passed
- `cargo test --locked -p cerebro-source-runtime-next source_execution -- --nocapture` — 53 passed
- focused Go source-runtime authority tests
- docs drift, architecture, and structural checks
- source generation, provider fixtures, catalog, and connector-contract checks

Validated on exact head `f83a02d5ffc7f2254266dff5edfa9d20aead3df4` after merging #2553:

- focused Go source-runtime authority tests
- docs drift, architecture, and structural checks
- `git diff --check origin/codex/sentinelone-threat-rust-authority...HEAD`

The exact-head local Rust rerun is blocked before compilation by the same managed DDESK Cargo safe-capacity gate. The merge added only the landed Rust-only census workflow and its paired contract test; hosted CI is the exact-head Rust receipt.

## Proved behavior

- interruption after agent discovery resumes at the exact per-agent inventory request
- completion advances to the next provider-owned agent cursor
- configured-agent reads skip discovery without accepting an unrelated provider cursor
- duplicate application identities fail closed
- tenant identity comes only from the trusted execution context
- credential- and tenant-shaped raw fields are removed before event admission
- application events match the checked-in Go fixture, including agent-scoped stable IDs

## Remaining boundary

After this PR, all seven persisted SentinelOne runtime families are Rust-authoritative. The provider-local Go package still owns source preview and is retired separately once preview uses the Rust credential adapter.
