### PR TITLE
Register PagerDuty user in the Rust dispatcher

### DIFF
--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -50,6 +50,7 @@ mod linode;
 mod mapper;
 mod okta;
 mod openai;
+mod pagerduty;
 mod panopticon;
 mod protocol;
 mod provider_failure;
@@ -255,6 +256,11 @@ pub use okta::{
 pub use openai::{
     OpenAiAuthRequirement, OpenAiCheckpoint, OpenAiError, OpenAiFamily, OpenAiKernel, OpenAiPage,
     OpenAiRecord, OpenAiRequest, OpenAiRequestInput,
+};
+pub use pagerduty::{
+    PagerDutyEntityFact, PagerDutyError, PagerDutyFamily, PagerDutyFilters, PagerDutyKernel,
+    PagerDutyPage, PagerDutyPlan, PagerDutyProjectionFacts, PagerDutyRecord, PagerDutyRelationFact,
+    PagerDutyRequest, project_pagerduty_records,
 };
 pub use panopticon::{
     PanopticonError, PanopticonFamily, PanopticonKernel, PanopticonOutcome, PanopticonPage,

--- a/crates/source-runtime-next/src/pagerduty/mod.rs
+++ b/crates/source-runtime-next/src/pagerduty/mod.rs
@@ -8,6 +8,7 @@ mod origin;
 mod projection;
 mod request;
 mod response;
+mod source_execution;
 
 pub use error::PagerDutyError;
 pub use model::{PagerDutyFamily, PagerDutyFilters, PagerDutyPage, PagerDutyPlan, PagerDutyRecord};
@@ -15,6 +16,10 @@ pub use projection::{
     PagerDutyEntityFact, PagerDutyProjectionFacts, PagerDutyRelationFact, project_pagerduty_records,
 };
 pub use request::{PagerDutyKernel, PagerDutyRequest};
+
+pub(crate) use source_execution::{
+    PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER, durable_checkpoint_cursor,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/source-runtime-next/src/pagerduty/normalize.rs
+++ b/crates/source-runtime-next/src/pagerduty/normalize.rs
@@ -270,7 +270,7 @@ fn provider_time(
     })
 }
 
-fn event_id(
+pub(super) fn event_id(
     tenant_id: &str,
     origin: &str,
     path: &str,

--- a/crates/source-runtime-next/src/pagerduty/source_execution.rs
+++ b/crates/source-runtime-next/src/pagerduty/source_execution.rs
@@ -1,0 +1,404 @@
+//! PagerDuty `user` bridge into the closed source-execution dispatcher.
+//!
+//! The adapter consumes authenticated tenant context, public configuration, and
+//! bounded provider response bytes. The trusted Go host retains credential
+//! redemption, PagerDuty authentication, network I/O, durable append,
+//! projection, and checkpoint ownership.
+
+use std::collections::HashMap;
+
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceExecutionPlanV1,
+    SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1,
+    SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2, SourceWorkerHttpRequestV1,
+    SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1, SourceWorkerRecordV1,
+    SourceWorkerRuntimeMetadataV2, canonical_http_execution_digest, canonical_plan_digest,
+    canonical_request_intent_digest, canonical_result_digest, validate_and_deduplicate_records,
+    validate_execution_context, validate_runtime_metadata,
+};
+
+use super::{
+    PagerDutyError, PagerDutyFamily, PagerDutyFilters, PagerDutyKernel,
+    normalize::event_id,
+    origin::{DEFAULT_BASE_URL, origin_string, validate_origin},
+};
+
+const SOURCE_ID: &str = "pagerduty";
+const FAMILY_ID: &str = "user";
+const PROVIDER_KERNEL: &str = "pagerduty.user";
+const PLAN_ID: &str = "source-plan-v1:pagerduty:user";
+const METHOD: &str = "GET";
+const PATH: &str = "/users";
+const RECORD_SELECTOR: &str = "$.users[*]";
+const ID_FIELD: &str = "id";
+const MAX_RESPONSE_BYTES: u64 = 8 << 20;
+const EVENT_KIND: &str = "pagerduty.user";
+const SCHEMA_REF: &str = "pagerduty/user/v1";
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct PagerDutyUserSourceExecutionAdapter;
+
+pub(crate) static PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER: PagerDutyUserSourceExecutionAdapter =
+    PagerDutyUserSourceExecutionAdapter;
+
+impl PagerDutyUserSourceExecutionAdapter {
+    pub(crate) fn compiled_plan(&self) -> SourceExecutionPlanV1 {
+        let mut plan = SourceExecutionPlanV1 {
+            plan_id: PLAN_ID.to_owned(),
+            source_id: SOURCE_ID.to_owned(),
+            family_id: FAMILY_ID.to_owned(),
+            provider_kernel: PROVIDER_KERNEL.to_owned(),
+            method: METHOD.to_owned(),
+            origin: DEFAULT_BASE_URL.to_owned(),
+            path: PATH.to_owned(),
+            record_selector: RECORD_SELECTOR.to_owned(),
+            id_field: ID_FIELD.to_owned(),
+            singleton_fallback_id: String::new(),
+            max_response_bytes: MAX_RESPONSE_BYTES,
+            event_kind: EVENT_KIND.to_owned(),
+            schema_ref: SCHEMA_REF.to_owned(),
+            required_attributes: [
+                "external_id",
+                "family",
+                "source_provider",
+                "source_product",
+                "user_id",
+            ]
+            .into_iter()
+            .map(str::to_owned)
+            .collect(),
+            required_payload_fields: vec!["id".to_owned()],
+            plan_digest_sha256: String::new(),
+        };
+        plan.plan_digest_sha256 = canonical_plan_digest(&plan);
+        plan
+    }
+
+    fn validate_plan(&self, plan: &SourceExecutionPlanV1) -> Result<(), SourceExecutionError> {
+        if plan != &self.compiled_plan() {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        Ok(())
+    }
+
+    fn kernel(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(PagerDutyKernel, String), SourceExecutionError> {
+        validate_execution_context(context)?;
+        validate_runtime_metadata(metadata)?;
+        if public_value(&metadata.public_config, "family").is_some_and(|value| value != FAMILY_ID) {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        let base_url = public_value(&metadata.public_config, "base_url");
+        let allowed_origin = origin_string(&validate_origin(base_url).map_err(map_error)?);
+        let page_size = public_value(&metadata.public_config, "per_page")
+            .map(|value| {
+                value
+                    .parse::<usize>()
+                    .map_err(|_| SourceExecutionError::MissingConfiguration)
+            })
+            .transpose()?;
+        let kernel = PagerDutyKernel::new(
+            base_url,
+            &context.tenant_id,
+            PagerDutyFamily::User,
+            PagerDutyFilters::default(),
+            page_size,
+        )
+        .map_err(map_error)?;
+        Ok((kernel, allowed_origin))
+    }
+}
+
+impl SourceExecutionAdapter for PagerDutyUserSourceExecutionAdapter {
+    fn source_id(&self) -> &'static str {
+        SOURCE_ID
+    }
+
+    fn family_id(&self) -> &'static str {
+        FAMILY_ID
+    }
+
+    fn provider_kernel(&self) -> &'static str {
+        PROVIDER_KERNEL
+    }
+
+    fn validate_record_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+    ) -> Result<(), SourceExecutionError> {
+        let expected = event_id(
+            &context.tenant_id,
+            DEFAULT_BASE_URL,
+            PATH,
+            PagerDutyFamily::User,
+            &record.provider_id,
+        );
+        if record.event_id != expected
+            || record.attributes.get("external_id") != Some(&record.provider_id)
+            || record.attributes.get("user_id") != Some(&record.provider_id)
+        {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        Ok(())
+    }
+
+    fn validate_record_identity_v2(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(), SourceExecutionError> {
+        let origin = origin_string(
+            &validate_origin(public_value(&metadata.public_config, "base_url"))
+                .map_err(map_error)?,
+        );
+        let expected = event_id(
+            &context.tenant_id,
+            &origin,
+            PATH,
+            PagerDutyFamily::User,
+            &record.provider_id,
+        );
+        if record.event_id != expected
+            || record.attributes.get("external_id") != Some(&record.provider_id)
+            || record.attributes.get("user_id") != Some(&record.provider_id)
+        {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        Ok(())
+    }
+
+    fn plan(
+        &self,
+        _request: &SourceWorkerPlanRequestV1,
+    ) -> Result<SourceWorkerHttpRequestV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn plan_v2(
+        &self,
+        envelope: &SourceWorkerPlanEnvelopeV2,
+    ) -> Result<SourceWorkerHttpExecutionV2, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, allowed_origin) = self.kernel(context, metadata)?;
+        let provider_request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        if provider_request.url().path() != plan.path
+            || provider_request.method() != plan.method
+            || provider_request.authorization_header() != "Authorization"
+            || provider_request.authorization_scheme() != "Token token="
+            || provider_request.contains_credentials()
+            || provider_request.allows_redirects()
+        {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        let mut planned = SourceWorkerHttpRequestV1 {
+            plan_id: plan.plan_id.clone(),
+            method: provider_request.method().to_owned(),
+            url: provider_request.url().to_string(),
+            accept: provider_request.accept().to_owned(),
+            max_response_bytes: u64::try_from(provider_request.max_response_bytes())
+                .map_err(|_| SourceExecutionError::InvalidPlan)?,
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            request_intent_digest: String::new(),
+        };
+        planned.request_intent_digest = canonical_request_intent_digest(plan, context, &planned);
+        let mut execution = SourceWorkerHttpExecutionV2 {
+            request: Some(planned),
+            body: Vec::new(),
+            declared_headers: HashMap::new(),
+            execution_intent_digest_sha256: String::new(),
+            credential_operation: "pagerduty.token".to_owned(),
+            allowed_origin,
+        };
+        execution.execution_intent_digest_sha256 =
+            canonical_http_execution_digest(plan, context, metadata, &execution);
+        Ok(execution)
+    }
+
+    fn decode(
+        &self,
+        _request: &SourceWorkerDecodeRequestV1,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn decode_v2(
+        &self,
+        envelope: &SourceWorkerDecodeEnvelopeV2,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let receipt = request
+            .receipt
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, _) = self.kernel(context, metadata)?;
+        let provider_request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        let status = u16::try_from(request.status_code)
+            .map_err(|_| SourceExecutionError::UnexpectedProviderStatus)?;
+        let observed_at = timestamp(context.observed_at_unix_millis)?;
+        let page = kernel
+            .decode(
+                &provider_request,
+                status,
+                &request.response_body,
+                observed_at,
+            )
+            .map_err(map_error)?;
+        let next_cursor = page.next_cursor.unwrap_or_default();
+        let records = page
+            .records
+            .into_iter()
+            .map(|record| {
+                if record.tenant_id != context.tenant_id
+                    || record.family != PagerDutyFamily::User
+                    || record.event_kind != plan.event_kind
+                    || record.schema_ref != plan.schema_ref
+                {
+                    return Err(SourceExecutionError::TenantMismatch);
+                }
+                Ok(SourceWorkerRecordV1 {
+                    provider_id: record.provider_id,
+                    event_id: record.event_id,
+                    occurred_at_unix_millis: parse_timestamp(&record.occurred_at)?,
+                    attributes: record.attributes.into_iter().collect(),
+                    payload_json: serde_json::to_vec(&record.payload)
+                        .map_err(|_| SourceExecutionError::InternalRuntime)?,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let records = validate_and_deduplicate_records(records)?;
+        let result_digest_sha256 = canonical_result_digest(receipt, &next_cursor, &records)?;
+        Ok(SourceWorkerDecodeResultV1 {
+            plan_id: plan.plan_id.clone(),
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: request.request_intent_digest.clone(),
+            records,
+            next_cursor,
+            result_digest_sha256,
+            tenant_id: context.tenant_id.clone(),
+            runtime_id: context.runtime_id.clone(),
+            runtime_generation: context.runtime_generation,
+            lease_generation: context.lease_generation,
+            observed_at_unix_millis: context.observed_at_unix_millis,
+        })
+    }
+}
+
+pub(crate) fn durable_checkpoint_cursor(
+    plan: &SourceExecutionPlanV1,
+    result: &SourceWorkerDecodeResultV1,
+) -> Option<String> {
+    if plan.source_id != SOURCE_ID
+        || plan.family_id != FAMILY_ID
+        || plan.provider_kernel != PROVIDER_KERNEL
+    {
+        return None;
+    }
+    if !result.next_cursor.is_empty() {
+        return Some(result.next_cursor.clone());
+    }
+    Some(
+        result
+            .records
+            .last()
+            .map(|record| record.provider_id.clone())
+            .unwrap_or_default(),
+    )
+}
+
+fn public_value<'a>(config: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    config
+        .get(key)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn optional(value: &str) -> Option<&str> {
+    (!value.is_empty()).then_some(value)
+}
+
+fn timestamp(unix_millis: i64) -> Result<OffsetDateTime, SourceExecutionError> {
+    OffsetDateTime::from_unix_timestamp_nanos(i128::from(unix_millis) * 1_000_000)
+        .map_err(|_| SourceExecutionError::InvalidExecutionContext)
+}
+
+fn parse_timestamp(value: &str) -> Result<i64, SourceExecutionError> {
+    let nanos = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| SourceExecutionError::InvalidProviderRecord)?
+        .unix_timestamp_nanos();
+    i64::try_from(nanos / 1_000_000).map_err(|_| SourceExecutionError::InvalidProviderRecord)
+}
+
+fn map_error(error: PagerDutyError) -> SourceExecutionError {
+    match error {
+        PagerDutyError::InvalidFamily => SourceExecutionError::UnknownAdapter,
+        PagerDutyError::InvalidBaseUrl
+        | PagerDutyError::MissingServiceId
+        | PagerDutyError::InvalidServiceId
+        | PagerDutyError::InvalidPageSize => SourceExecutionError::MissingConfiguration,
+        PagerDutyError::MissingTenantId => SourceExecutionError::InvalidExecutionContext,
+        PagerDutyError::InvalidCursor => SourceExecutionError::InvalidCursor,
+        PagerDutyError::RequestScopeMismatch => SourceExecutionError::InvalidPlan,
+        PagerDutyError::AuthenticationRejected => SourceExecutionError::AuthenticationRejected,
+        PagerDutyError::PermissionDenied => SourceExecutionError::RequiredProviderScopeMissing,
+        PagerDutyError::RateLimited => SourceExecutionError::ProviderRateLimit,
+        PagerDutyError::ProviderUnavailable | PagerDutyError::UnexpectedProviderStatus => {
+            SourceExecutionError::UnexpectedProviderStatus
+        }
+        PagerDutyError::ResponseTooLarge => SourceExecutionError::ResponseTooLarge,
+        PagerDutyError::TooManyRecords => SourceExecutionError::ResultTooLarge,
+        PagerDutyError::MalformedResponse => SourceExecutionError::MalformedResponse,
+        PagerDutyError::MissingProviderIdentity => SourceExecutionError::MissingStableIdentity,
+        PagerDutyError::InvalidProviderIdentity => SourceExecutionError::InvalidProviderRecord,
+        PagerDutyError::ConflictingProviderIdentity => SourceExecutionError::DuplicateConflict,
+        PagerDutyError::EventContractRejected => SourceExecutionError::EventContractRejected,
+    }
+}
+
+#[cfg(test)]
+#[path = "source_execution_tests.rs"]
+mod tests;

--- a/crates/source-runtime-next/src/pagerduty/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/pagerduty/source_execution_tests.rs
@@ -1,0 +1,309 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::source_execution::{
+    SourceExecutionDispatcher, SourceExecutionError, SourceExecutionLifecycleEnvelopeV2,
+    SourceExecutionLifecycleRequestV1, SourceExecutionPlanV1, SourceExecutionSelectionRequestV1,
+    SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeOutputV2, SourceWorkerDecodeRequestV1,
+    SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2, SourceWorkerPlanEnvelopeV2,
+    SourceWorkerPlanRequestV1, SourceWorkerRuntimeMetadataV2, seal_page_program_v2,
+};
+
+use super::{DEFAULT_BASE_URL, PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER};
+
+const OBSERVED_AT_MILLIS: i64 = 1_780_272_000_000;
+
+fn context(cursor: &str, page: u32) -> SourceWorkerExecutionContextV1 {
+    SourceWorkerExecutionContextV1 {
+        tenant_id: "tenant".to_owned(),
+        runtime_id: "pagerduty-runtime".to_owned(),
+        logical_page_id: format!("source-page-v2:pagerduty-{page}"),
+        prior_cursor: cursor.to_owned(),
+        runtime_generation: 7,
+        lease_generation: 11,
+        observed_at_unix_millis: OBSERVED_AT_MILLIS,
+    }
+}
+
+fn metadata() -> SourceWorkerRuntimeMetadataV2 {
+    SourceWorkerRuntimeMetadataV2 {
+        public_config: HashMap::from([
+            ("family".to_owned(), "user".to_owned()),
+            ("per_page".to_owned(), "2".to_owned()),
+        ]),
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    }
+}
+
+fn plan(dispatcher: SourceExecutionDispatcher) -> SourceExecutionPlanV1 {
+    dispatcher
+        .compile_plan(&SourceExecutionSelectionRequestV1 {
+            source_id: "pagerduty".to_owned(),
+            family_id: "user".to_owned(),
+        })
+        .unwrap()
+}
+
+fn plan_page(
+    dispatcher: SourceExecutionDispatcher,
+    plan: &SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    metadata: &SourceWorkerRuntimeMetadataV2,
+) -> SourceWorkerHttpExecutionV2 {
+    dispatcher
+        .dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+        })
+        .unwrap()
+}
+
+fn decode_page(
+    dispatcher: SourceExecutionDispatcher,
+    plan: &SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    metadata: &SourceWorkerRuntimeMetadataV2,
+    execution: &SourceWorkerHttpExecutionV2,
+    status_code: u32,
+    body: &[u8],
+) -> Result<SourceWorkerDecodeOutputV2, SourceExecutionError> {
+    let planned = execution.request.as_ref().unwrap();
+    dispatcher.dispatch_decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+        request: Some(SourceWorkerDecodeRequestV1 {
+            plan: Some(plan.clone()),
+            status_code,
+            response_body: body.to_vec(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: planned.request_intent_digest.clone(),
+            receipt: None,
+            context: Some(context.clone()),
+        }),
+        metadata: Some(metadata.clone()),
+        response_headers: HashMap::new(),
+        response_headers_sha256: String::new(),
+        execution_intent_digest_sha256: execution.execution_intent_digest_sha256.clone(),
+    })
+}
+
+#[test]
+fn closed_dispatcher_registers_only_pagerduty_user() {
+    let dispatcher = SourceExecutionDispatcher;
+    let plan = plan(dispatcher);
+    assert_eq!(plan.plan_id, "source-plan-v1:pagerduty:user");
+    assert_eq!(plan.provider_kernel, "pagerduty.user");
+    assert_eq!(plan.origin, DEFAULT_BASE_URL);
+    assert_eq!(plan.path, "/users");
+    assert_eq!(plan.record_selector, "$.users[*]");
+    assert_eq!(plan.event_kind, "pagerduty.user");
+    assert_eq!(plan.schema_ref, "pagerduty/user/v1");
+
+    for family in ["team", "service", "schedule", "", "future"] {
+        assert_eq!(
+            dispatcher.compile_plan(&SourceExecutionSelectionRequestV1 {
+                source_id: "pagerduty".to_owned(),
+                family_id: family.to_owned(),
+            }),
+            Err(SourceExecutionError::UnknownAdapter),
+            "{family}"
+        );
+    }
+}
+
+#[test]
+fn plan_and_decode_are_credential_free_and_go_compatible() {
+    let dispatcher = SourceExecutionDispatcher;
+    let plan = plan(dispatcher);
+    let context = context("", 1);
+    let metadata = metadata();
+    let execution = plan_page(dispatcher, &plan, &context, &metadata);
+    assert_eq!(execution.credential_operation, "pagerduty.token");
+    assert_eq!(execution.allowed_origin, DEFAULT_BASE_URL);
+    assert!(execution.body.is_empty());
+    assert!(execution.declared_headers.is_empty());
+    let request = execution.request.as_ref().unwrap();
+    assert_eq!(request.method, "GET");
+    assert_eq!(request.url, "https://api.pagerduty.com/users?limit=2");
+    assert!(!request.url.contains("token"));
+
+    let output = decode_page(
+        dispatcher,
+        &plan,
+        &context,
+        &metadata,
+        &execution,
+        200,
+        br#"{"users":[{"id":"PU1","name":"Alice","email":"alice@example.test"}],"limit":2,"offset":0,"more":false}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        output.receipt.as_ref().unwrap().credential_operation,
+        "pagerduty.token"
+    );
+    let result = output.result.as_ref().unwrap();
+    assert!(result.next_cursor.is_empty());
+    assert_eq!(result.records.len(), 1);
+    let record = &result.records[0];
+    assert_eq!(record.provider_id, "PU1");
+    assert_eq!(record.attributes["user_id"], "PU1");
+    assert_eq!(record.attributes["source_provider"], "pagerduty");
+    assert!(record.event_id.starts_with("pagerduty-tenant-"));
+    let payload: Value = serde_json::from_slice(&record.payload_json).unwrap();
+    assert_eq!(payload["id"], "PU1");
+
+    let decision = seal_page_program_v2(&SourceExecutionLifecycleEnvelopeV2 {
+        request: Some(SourceExecutionLifecycleRequestV1 {
+            plan: Some(plan),
+            context: Some(context),
+            receipt: output.receipt,
+            result: output.result,
+            current_lease_generation: 11,
+        }),
+        metadata: Some(metadata),
+    })
+    .unwrap();
+    assert_eq!(decision.admitted_records.len(), 1);
+    assert_eq!(decision.checkpoint_cursor, "PU1");
+}
+
+#[test]
+fn provider_offset_and_durable_checkpoint_remain_separate() {
+    let dispatcher = SourceExecutionDispatcher;
+    let plan = plan(dispatcher);
+    let metadata = metadata();
+    let first_context = context("", 1);
+    let first_execution = plan_page(dispatcher, &plan, &first_context, &metadata);
+    let first = decode_page(
+        dispatcher,
+        &plan,
+        &first_context,
+        &metadata,
+        &first_execution,
+        200,
+        br#"{"users":[{"id":"PU1"},{"id":"PU2"}],"limit":2,"offset":0,"more":true}"#,
+    )
+    .unwrap();
+    assert_eq!(first.result.as_ref().unwrap().next_cursor, "2");
+    let first_decision = seal_page_program_v2(&SourceExecutionLifecycleEnvelopeV2 {
+        request: Some(SourceExecutionLifecycleRequestV1 {
+            plan: Some(plan.clone()),
+            context: Some(first_context),
+            receipt: first.receipt,
+            result: first.result,
+            current_lease_generation: 11,
+        }),
+        metadata: Some(metadata.clone()),
+    })
+    .unwrap();
+    assert_eq!(first_decision.checkpoint_cursor, "2");
+
+    let second_context = context("2", 2);
+    let second_execution = plan_page(dispatcher, &plan, &second_context, &metadata);
+    assert_eq!(
+        second_execution.request.as_ref().unwrap().url,
+        "https://api.pagerduty.com/users?limit=2&offset=2"
+    );
+    let second = decode_page(
+        dispatcher,
+        &plan,
+        &second_context,
+        &metadata,
+        &second_execution,
+        200,
+        br#"{"users":[{"id":"PU3"}],"limit":2,"offset":2,"more":false}"#,
+    )
+    .unwrap();
+    assert!(second.result.as_ref().unwrap().next_cursor.is_empty());
+    let second_decision = seal_page_program_v2(&SourceExecutionLifecycleEnvelopeV2 {
+        request: Some(SourceExecutionLifecycleRequestV1 {
+            plan: Some(plan),
+            context: Some(second_context),
+            receipt: second.receipt,
+            result: second.result,
+            current_lease_generation: 11,
+        }),
+        metadata: Some(metadata),
+    })
+    .unwrap();
+    assert_eq!(second_decision.checkpoint_cursor, "PU3");
+}
+
+#[test]
+fn origin_cursor_status_and_identity_fail_closed() {
+    let dispatcher = SourceExecutionDispatcher;
+    let plan = plan(dispatcher);
+    let execution_context = context("", 1);
+
+    let mut wrong_origin = metadata();
+    wrong_origin
+        .public_config
+        .insert("base_url".to_owned(), "https://other.invalid".to_owned());
+    assert_eq!(
+        dispatcher
+            .dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+                request: Some(SourceWorkerPlanRequestV1 {
+                    plan: Some(plan.clone()),
+                    context: Some(execution_context.clone()),
+                }),
+                metadata: Some(wrong_origin),
+            })
+            .unwrap_err(),
+        SourceExecutionError::MissingConfiguration
+    );
+
+    let invalid_cursor = context("PU1", 2);
+    assert_eq!(
+        dispatcher
+            .dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+                request: Some(SourceWorkerPlanRequestV1 {
+                    plan: Some(plan.clone()),
+                    context: Some(invalid_cursor),
+                }),
+                metadata: Some(metadata()),
+            })
+            .unwrap_err(),
+        SourceExecutionError::InvalidCursor
+    );
+
+    let metadata = metadata();
+    let execution = plan_page(dispatcher, &plan, &execution_context, &metadata);
+    assert_eq!(
+        decode_page(
+            dispatcher,
+            &plan,
+            &execution_context,
+            &metadata,
+            &execution,
+            401,
+            b"{}",
+        )
+        .unwrap_err(),
+        SourceExecutionError::AuthenticationRejected
+    );
+
+    let mut output = decode_page(
+        dispatcher,
+        &plan,
+        &execution_context,
+        &metadata,
+        &execution,
+        200,
+        br#"{"users":[{"id":"PU1"}],"limit":2,"offset":0,"more":false}"#,
+    )
+    .unwrap();
+    let mut record = output.result.take().unwrap().records.remove(0);
+    record.event_id = "pagerduty-other-identity".to_owned();
+    assert_eq!(
+        crate::source_execution::SourceExecutionAdapter::validate_record_identity_v2(
+            &PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER,
+            &execution_context,
+            &record,
+            &metadata,
+        ),
+        Err(SourceExecutionError::TenantMismatch)
+    );
+}

--- a/crates/source-runtime-next/src/source_execution/contract.rs
+++ b/crates/source-runtime-next/src/source_execution/contract.rs
@@ -153,7 +153,11 @@ pub fn validate_http_execution(
         || !matches!(request.method.as_str(), "GET" | "POST")
         || !matches!(
             execution.credential_operation.as_str(),
-            "source.bearer" | "jumpcloud.x_api_key" | "sentinelone.api_token" | "twilio.basic"
+            "source.bearer"
+                | "jumpcloud.x_api_key"
+                | "sentinelone.api_token"
+                | "twilio.basic"
+                | "pagerduty.token"
         )
     {
         return Err(SourceExecutionError::InvalidPlan);

--- a/crates/source-runtime-next/src/source_execution/dispatcher.rs
+++ b/crates/source-runtime-next/src/source_execution/dispatcher.rs
@@ -1,6 +1,7 @@
 use prost::Message;
 
 use crate::digitalocean::DIGITALOCEAN_DROPLETS_SOURCE_EXECUTION_ADAPTER;
+use crate::pagerduty::PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER;
 use crate::sentinelone::SentinelOneAgentSourceExecutionAdapter;
 use crate::twilio::adapter::{
     TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER, TWILIO_AUDIT_EVENTS_SOURCE_EXECUTION_ADAPTER,
@@ -137,6 +138,11 @@ impl SourceExecutionDispatcher {
         {
             return Ok(DIGITALOCEAN_DROPLETS_SOURCE_EXECUTION_ADAPTER.compiled_plan());
         }
+        if request.source_id == PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER.source_id()
+            && request.family_id == PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER.family_id()
+        {
+            return Ok(PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER.compiled_plan());
+        }
         if request.source_id == TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER.source_id()
             && request.family_id == TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER.family_id()
         {
@@ -188,6 +194,12 @@ impl SourceExecutionDispatcher {
                 == DIGITALOCEAN_DROPLETS_SOURCE_EXECUTION_ADAPTER.provider_kernel()
         {
             return Ok(&DIGITALOCEAN_DROPLETS_SOURCE_EXECUTION_ADAPTER);
+        }
+        if plan.source_id == PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER.source_id()
+            && plan.family_id == PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER.family_id()
+            && plan.provider_kernel == PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER.provider_kernel()
+        {
+            return Ok(&PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER);
         }
         if plan.source_id == TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER.source_id()
             && plan.family_id == TWILIO_ACCOUNTS_SOURCE_EXECUTION_ADAPTER.family_id()

--- a/crates/source-runtime-next/src/source_execution/runtime.rs
+++ b/crates/source-runtime-next/src/source_execution/runtime.rs
@@ -107,6 +107,9 @@ fn seal_page_program_inner(
         "tailscale" => {
             super::tailscale::durable_checkpoint_cursor(plan, result).unwrap_or_default()
         }
+        "pagerduty" => {
+            crate::pagerduty::durable_checkpoint_cursor(plan, result).unwrap_or_default()
+        }
         _ => result.next_cursor.clone(),
     };
 

--- a/crates/source-runtime-next/tests/pagerduty_provider.rs
+++ b/crates/source-runtime-next/tests/pagerduty_provider.rs
@@ -1,2 +1,0 @@
-#[path = "../src/pagerduty/mod.rs"]
-mod pagerduty;

--- a/internal/sourceruntime/sourceworker/host.go
+++ b/internal/sourceruntime/sourceworker/host.go
@@ -196,6 +196,8 @@ func credentialHeader(operation string, credential []byte) (string, []byte, erro
 		return "Authorization", append([]byte("ApiToken "), credential...), nil
 	case "twilio.basic":
 		return "Authorization", append([]byte("Basic "), credential...), nil
+	case "pagerduty.token":
+		return "Authorization", append([]byte("Token token="), credential...), nil
 	default:
 		return "", nil, fmt.Errorf("%w: credential operation is not registered", ErrWorkerContract)
 	}

--- a/internal/sourceruntime/sourceworker/host_test.go
+++ b/internal/sourceruntime/sourceworker/host_test.go
@@ -232,6 +232,20 @@ func TestCredentialHeaderAppliesOnlyTheClosedTwilioScheme(t *testing.T) {
 	}
 }
 
+func TestCredentialHeaderAppliesOnlyTheClosedPagerDutyScheme(t *testing.T) {
+	header, value, err := credentialHeader("pagerduty.token", []byte("synthetic-token"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clear(value)
+	if header != "Authorization" || string(value) != "Token token=synthetic-token" {
+		t.Fatal("PagerDuty credential operation did not produce the exact provider scheme")
+	}
+	if _, _, err := credentialHeader("pagerduty.bearer", []byte("synthetic-token")); !errors.Is(err, ErrWorkerContract) {
+		t.Fatalf("unregistered credential operation error = %v, want ErrWorkerContract", err)
+	}
+}
+
 func TestSafeResponseHeadersRedactsAndBounds(t *testing.T) {
 	headers := http.Header{
 		"X-Result-Count": {"2"}, "X-Limit": {"2"}, "X-Search_after": {`{"id":"event-2"}`}, "Retry-After": {"30"},


### PR DESCRIPTION
Registers the existing credential-free PagerDuty `user` kernel in the closed source-execution dispatcher.

Scope
- compiles only `pagerduty.user` into the shared Rust plan/decode boundary
- adds the trusted-host `pagerduty.token` operation for the exact `Authorization: Token token=` provider scheme
- keeps provider offset continuation separate from the terminal durable last-record checkpoint
- promotes the existing PagerDuty module into the crate and replaces the path-only test harness with unit coverage

Authority and safety
- Go remains production authority in this PR
- the Rust kernel receives no token bytes and cannot emit credentials in requests, records, fixtures, receipts, or errors
- tenant identity comes from the execution context; origins, redirects, response bytes, record counts, cursors, and duplicate identities fail closed

Exact-head validation (`a2fd774998de7091f4eed85c92d27b73171e120d`)
- DDESK `cargo fmt --all -- --check`: passed
- DDESK `cargo test -p cerebro-source-runtime-next pagerduty -- --nocapture`: 15 passed
- DDESK `cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings`: passed
- DDESK `go test ./internal/sourceruntime/sourceworker`: passed
- local focused Rust, Clippy, and Go runs also passed before publication.