### PR TITLE
Route connector runtime health to the Rust platform

### DIFF
--- a/apps/web/src/app/api/cerebro/[...path]/route.test.ts
+++ b/apps/web/src/app/api/cerebro/[...path]/route.test.ts
@@ -18,6 +18,7 @@ afterEach(() => {
   if (originalLocalIdentityFallback === undefined) delete process.env.CEREBRO_LOCAL_IDENTITY_FALLBACK;
   else process.env.CEREBRO_LOCAL_IDENTITY_FALLBACK = originalLocalIdentityFallback;
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
   vi.unstubAllGlobals();
 });
 
@@ -95,6 +96,38 @@ describe("Cerebro proxy route", () => {
     expect(upstreamHeaders.get("x-cerebro-api-key")).toBeNull();
     expect(upstreamHeaders.get("x-cerebro-user-id")).toBeNull();
     expect(upstreamHeaders.get("x-cerebro-user-subject")).toBeNull();
+  });
+
+  it("routes runtime health to Rust with server-owned tenant authentication", async () => {
+    vi.stubEnv("CEREBRO_RUST_PLATFORM_API_BASE", "http://rust-platform.internal:8080");
+    vi.stubEnv("CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID", "tenant-a");
+    vi.stubEnv(
+      "CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET",
+      "test-organizational-graph-secret-32-bytes",
+    );
+    let upstreamURL = "";
+    let upstreamHeaders = new Headers();
+    vi.stubGlobal("fetch", vi.fn(async (url: URL | RequestInfo, init?: RequestInit) => {
+      upstreamURL = url.toString();
+      upstreamHeaders = new Headers(init?.headers);
+      return new Response(JSON.stringify({ runtimes: [], source_summaries: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }));
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/cerebro/v1/source-runtimes/health?limit=500"),
+      { params: Promise.resolve({ path: ["v1", "source-runtimes", "health"] }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(upstreamURL).toBe("http://rust-platform.internal:8080/v1/source-runtimes/health?limit=500");
+    expect(upstreamHeaders.get("x-cerebro-tenant")).toBe("tenant-a");
+    expect(upstreamHeaders.get("authorization")).toBe(
+      "Bearer 34b1625abbaa7a28cbca5f0a4803c1ba5360a998e5cc2f5b28d37bd32ba131d6",
+    );
+    expect(upstreamHeaders.get("x-cerebro-api-key")).toBeNull();
   });
 
   it("relays signed Rust-authority writes without authorizing or stamping in Next", async () => {

--- a/apps/web/src/lib/cerebro-proxy.test.ts
+++ b/apps/web/src/lib/cerebro-proxy.test.ts
@@ -7,10 +7,12 @@ import {
   cachedResponseHeaders,
   cerebroProxyCacheKey,
   configuredOrganizationalGraphTenant,
+  configuredRustPlatformApiBase,
   fetchCerebro,
   getCerebroPublicConfig,
   isCacheableCerebroPath,
   responseHeadersFor,
+  rustTenantAuthHeaders,
   rustOwnsWebAuthority,
   shouldRetryUpstreamResponse,
   shouldBypassCerebroProxyCache,
@@ -59,11 +61,53 @@ describe("cerebro proxy cache headers", () => {
     expect(new Headers(authHeadersFor(request, "user/preferences")).get("x-cerebro-tenant")).toBeNull();
   });
 
+  it("routes only runtime health to the configured Rust platform origin", () => {
+    vi.stubEnv("CEREBRO_RUST_PLATFORM_API_BASE", "http://rust-platform.internal:8080");
+
+    expect(buildCerebroUrl("/v1/source-runtimes/health", "?limit=500").toString()).toBe(
+      "http://rust-platform.internal:8080/v1/source-runtimes/health?limit=500",
+    );
+    expect(buildCerebroUrl("/grc/dashboard").origin).not.toBe("http://rust-platform.internal:8080");
+  });
+
+  it("matches the shared Go and Rust tenant-auth test vector", () => {
+    const headers = new Headers(rustTenantAuthHeaders(
+      "tenant-a",
+      "test-organizational-graph-secret-32-bytes",
+    ));
+
+    expect(headers.get("x-cerebro-tenant")).toBe("tenant-a");
+    expect(headers.get("authorization")).toBe(
+      "Bearer 34b1625abbaa7a28cbca5f0a4803c1ba5360a998e5cc2f5b28d37bd32ba131d6",
+    );
+  });
+
+  it("uses only server-owned Rust tenant auth for runtime health", () => {
+    vi.stubEnv("CEREBRO_RUST_PLATFORM_API_BASE", "http://rust-platform.internal:8080");
+    vi.stubEnv("CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID", "tenant-a");
+    vi.stubEnv(
+      "CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET",
+      "test-organizational-graph-secret-32-bytes",
+    );
+    const headers = new Headers(authHeadersFor(new NextRequest("http://localhost"), "v1/source-runtimes/health"));
+
+    expect(headers.get("x-cerebro-tenant")).toBe("tenant-a");
+    expect(headers.get("authorization")).toMatch(/^Bearer [0-9a-f]{64}$/);
+    expect(headers.get("x-cerebro-api-key")).toBeNull();
+  });
+
   it("rejects an invalid server-owned tenant header", () => {
     expect(() => configuredOrganizationalGraphTenant("tenant-demo\nforged")).toThrow(
       "is not a valid header value",
     );
     expect(configuredOrganizationalGraphTenant("   ")).toBeUndefined();
+  });
+
+  it("rejects credential-bearing Rust platform origins and short shared secrets", () => {
+    expect(() => configuredRustPlatformApiBase("https://user:pass@rust.example.com")).toThrow(
+      "without credentials",
+    );
+    expect(() => rustTenantAuthHeaders("tenant-a", "too-short")).toThrow("at least 32 bytes");
   });
 
   it("enables Rust authority only through an explicit deployment mode", () => {

--- a/apps/web/src/lib/cerebro-proxy.ts
+++ b/apps/web/src/lib/cerebro-proxy.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createHash } from "crypto";
+import { createHash, createHmac } from "crypto";
 
 import { headersWithTrace, startWebSpan } from "./observability";
 import { normalizeProxyPath } from "./identity-write-stamp";
@@ -8,6 +8,13 @@ const API_BASE =
   process.env.CEREBRO_API_BASE ??
   process.env.NEXT_PUBLIC_CEREBRO_API_BASE ??
   "http://localhost:8080";
+
+const RUST_RUNTIME_HEALTH_PATH = "v1/source-runtimes/health";
+const RUST_TENANT_AUTH_CONTEXT = Buffer.from(
+  "cerebro-organizational-graph/tenant/v1\0",
+  "utf8",
+);
+const MIN_RUST_SHARED_SECRET_BYTES = 32;
 
 const firstConfiguredApiKey = (value?: string) =>
   value
@@ -56,6 +63,45 @@ export const configuredOrganizationalGraphTenant = (
   }
   return tenantID;
 };
+
+export const configuredRustPlatformApiBase = (
+  value = process.env.CEREBRO_RUST_PLATFORM_API_BASE,
+) => {
+  const configured = value?.trim();
+  if (!configured) return undefined;
+  const base = new URL(configured);
+  if (!["http:", "https:"].includes(base.protocol) || base.username || base.password || base.search || base.hash) {
+    throw new Error("CEREBRO_RUST_PLATFORM_API_BASE must be an HTTP(S) origin without credentials, query, or fragment");
+  }
+  return base.toString();
+};
+
+export const rustTenantAuthHeaders = (tenantID: string, sharedSecret: string): HeadersInit => {
+  const tenant = configuredOrganizationalGraphTenant(tenantID);
+  if (!tenant) {
+    throw new Error("CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID is required for Rust runtime health");
+  }
+  if (Buffer.byteLength(sharedSecret, "utf8") < MIN_RUST_SHARED_SECRET_BYTES) {
+    throw new Error(
+      `CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET must be at least ${MIN_RUST_SHARED_SECRET_BYTES} bytes for Rust runtime health`,
+    );
+  }
+  const tenantBytes = Buffer.from(tenant, "utf8");
+  const tenantLength = Buffer.alloc(8);
+  tenantLength.writeBigUInt64BE(BigInt(tenantBytes.length));
+  const token = createHmac("sha256", sharedSecret)
+    .update(RUST_TENANT_AUTH_CONTEXT)
+    .update(tenantLength)
+    .update(tenantBytes)
+    .digest("hex");
+  return {
+    Authorization: `Bearer ${token}`,
+    "X-Cerebro-Tenant": tenant,
+  };
+};
+
+const isRustRuntimeHealthPath = (path: string) =>
+  normalizeProxyPath(path) === RUST_RUNTIME_HEALTH_PATH;
 
 const forwardRequestAuth =
   parseBooleanEnv(process.env.CEREBRO_FORWARD_AUTH_HEADERS) ??
@@ -112,9 +158,14 @@ export const rustOwnsWebAuthority = () =>
   process.env.CEREBRO_AUTHORITY_MODE?.trim().toLowerCase() === "rust";
 
 export const buildCerebroUrl = (path: string, search = "") => {
-  const base = new URL(API_BASE.endsWith("/") ? API_BASE : `${API_BASE}/`);
+  const normalizedPath = normalizeProxyPath(path);
+  const rustPlatformBase = configuredRustPlatformApiBase();
+  const apiBase = rustPlatformBase && normalizedPath === RUST_RUNTIME_HEALTH_PATH
+    ? rustPlatformBase
+    : API_BASE;
+  const base = new URL(apiBase.endsWith("/") ? apiBase : `${apiBase}/`);
   const basePath = base.pathname.endsWith("/") ? base.pathname.slice(0, -1) : base.pathname;
-  const pathSegments = normalizeProxyPath(path)
+  const pathSegments = normalizedPath
     .split("/")
     .filter(Boolean)
     .map((segment) => encodeURIComponent(segment));
@@ -125,6 +176,15 @@ export const buildCerebroUrl = (path: string, search = "") => {
 
 export const authHeadersFor = (request: NextRequest, upstreamPath = ""): HeadersInit => {
   const headers: Record<string, string> = { Accept: "application/json, text/plain;q=0.9, */*;q=0.8" };
+  if (configuredRustPlatformApiBase() && isRustRuntimeHealthPath(upstreamPath)) {
+    return {
+      ...headers,
+      ...rustTenantAuthHeaders(
+        process.env.CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID ?? "",
+        process.env.CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET ?? "",
+      ),
+    };
+  }
   const requestApiKey =
     request.headers.get("x-cerebro-api-key") ?? request.headers.get("x-api-key");
   const requestAuthorization = request.headers.get("authorization");


### PR DESCRIPTION
## Summary
- route only the connector runtime-health read to the configured Rust platform origin
- authenticate that internal request with the existing tenant-bound Go/Rust HMAC contract
- keep the shared secret server-only and keep all other web proxy traffic on the configured API origin

## Validation
- `npm run lint`
- `NODE_OPTIONS=--localstorage-file=/tmp/cerebro-web-vitest-localstorage npm test -- --reporter=dot` (651 tests)
- `npm run build`
- `bash scripts/leak_check.sh staged`
- focused route, proxy, UI contract, and connector-runtime tests