### PR TITLE
Promote Linode issue to Rust runtime authority

### DIFF
--- a/internal/sourceops/source_execution.go
+++ b/internal/sourceops/source_execution.go
@@ -45,7 +45,7 @@ func rustSourceFamily(sourceID string, config map[string]string) (string, bool) 
 	// runtime-authoritative provider must keep its existing sourceops path until
 	// its preview credential adapter and product-surface parity are ready.
 	switch sourceID {
-	case "azure", "sentinelone", "tailscale":
+	case "azure", "linode", "sentinelone", "tailscale":
 		return sourceworker.RustAuthoritativeFamily(sourceID, config["family"])
 	case "jumpcloud":
 		family := strings.TrimSpace(config["family"])

--- a/internal/sourceops/source_execution_test.go
+++ b/internal/sourceops/source_execution_test.go
@@ -24,6 +24,10 @@ func TestRustSourceFamilyPreviewAuthorityIsExact(t *testing.T) {
 		"JumpCloud default":          {"jumpcloud", "", "users", true},
 		"JumpCloud family":           {"jumpcloud", "group_members", "group_members", true},
 		"unknown JumpCloud family":   {"jumpcloud", "future-family", "future-family", true},
+		"Linode default":             {"linode", "", "issue", true},
+		"Linode issue":               {"linode", "issue", "issue", true},
+		"other Linode family":        {"linode", "event", "event", false},
+		"unknown Linode family":      {"linode", "future-family", "future-family", false},
 		"SentinelOne threat":         {"sentinelone", "threat", "threat", true},
 		"SentinelOne application":    {"sentinelone", "application", "application", true},
 		"unknown SentinelOne family": {"sentinelone", "future-family", "future-family", false},
@@ -80,6 +84,47 @@ func TestSentinelOneCheckDiscoverAndReadUseOnlyClosedRustAuthority(t *testing.T)
 				t.Fatalf("calls = Rust %d, Go check/discover/read %d/%d/%d", calls, legacy.checkCalls, legacy.discoverCalls, legacy.readCalls)
 			}
 		})
+	}
+}
+
+func TestLinodeIssueCheckDiscoverAndReadUseOnlyClosedRustAuthority(t *testing.T) {
+	const credentialFixture = "host-only-linode-secret" // #nosec G101 -- synthetic boundary-test sentinel, not credential material.
+	legacy := &authorityProbeSource{sourceID: "linode"}
+	registry, err := sourcecdk.NewRegistry(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := New(registry)
+	service.sourceWorker = previewWorkerStub{}
+	calls := 0
+	service.runSourceExecution = func(_ context.Context, _ sourceworker.Worker, reference string, credential []byte, _ time.Time, input sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+		calls++
+		if reference != previewCredentialReference || string(credential) != credentialFixture {
+			t.Fatal("Linode credential was not confined to the trusted runner boundary")
+		}
+		encoded, marshalErr := json.Marshal(input)
+		if marshalErr != nil || strings.Contains(string(encoded), credentialFixture) || input.Scope.PublicConfig["token"] != "" {
+			t.Fatalf("credential crossed the worker protocol: %s, %v", encoded, marshalErr)
+		}
+		if input.SourceID != "linode" || input.FamilyID != "issue" || input.Scope.PublicConfig["page_size"] != "100" {
+			t.Fatalf("Rust selection = %s.%s, public config = %#v", input.SourceID, input.FamilyID, input.Scope.PublicConfig)
+		}
+		return linodeIssuePreviewOutput(input.Scope.PriorTerminalWatermarkUnixMillis), nil
+	}
+	config := map[string]string{"family": "issue", "tenant_id": "tenant-1", "token": credentialFixture, "page_size": "100"}
+	if _, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{SourceId: "linode", Config: config}); err != nil {
+		t.Fatal(err)
+	}
+	discovered, err := service.Discover(context.Background(), &cerebrov1.DiscoverSourceRequest{SourceId: "linode", Config: config})
+	if err != nil || len(discovered.GetUrns()) != 1 || discovered.GetUrns()[0] != "urn:cerebro:tenant-1:linode_issue:823" {
+		t.Fatalf("Discover() = %#v, %v", discovered, err)
+	}
+	read, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{SourceId: "linode", Config: config})
+	if err != nil || len(read.GetEvents()) != 1 || read.GetEvents()[0].GetSourceId() != "linode" || read.GetCheckpoint().GetCursorOpaque() == "" {
+		t.Fatalf("Read() = %#v, %v", read, err)
+	}
+	if calls != 3 || legacy.checkCalls != 0 || legacy.discoverCalls != 0 || legacy.readCalls != 0 {
+		t.Fatalf("calls = Rust %d, Go check/discover/read %d/%d/%d", calls, legacy.checkCalls, legacy.discoverCalls, legacy.readCalls)
 	}
 }
 
@@ -583,5 +628,24 @@ func sentinelOnePreviewOutput(family string, priorWatermark int64) *sourceworker
 	return &sourceworker.ExecutionOutput{
 		Plan: plan, Result: &cerebrov1.SourceWorkerDecodeResultV1{ResultDigestSha256: "result-digest"},
 		Program: &sourceworker.PageProgram{TransitionDigest: "transition", AdmittedRecords: []*cerebrov1.SourceWorkerRecordV1{record}, CheckpointCursor: providerID, CheckpointWatermarkUnixMillis: watermark},
+	}
+}
+
+func linodeIssuePreviewOutput(priorWatermark int64) *sourceworker.ExecutionOutput {
+	watermark := max(priorWatermark, 1_725_000_000_000)
+	plan := &cerebrov1.SourceExecutionPlanV1{
+		SourceId: "linode", FamilyId: "issue", EventKind: "linode.issue", SchemaRef: "linode/issue/v1",
+	}
+	record := &cerebrov1.SourceWorkerRecordV1{
+		ProviderId: "823", EventId: "linode-tenant-1-c9ca572ccbf1-issue-823", OccurredAtUnixMillis: watermark,
+		Attributes: map[string]string{
+			"tenant_id": "tenant-1", "source_event_id": "823", "finding_id": "823",
+			"resource_urn": "urn:cerebro:tenant-1:linode_issue:823", "severity": "medium", "status": "open",
+		},
+		PayloadJson: []byte(`{"id":823}`),
+	}
+	return &sourceworker.ExecutionOutput{
+		Plan: plan, Result: &cerebrov1.SourceWorkerDecodeResultV1{ResultDigestSha256: "result-digest"},
+		Program: &sourceworker.PageProgram{TransitionDigest: "transition", AdmittedRecords: []*cerebrov1.SourceWorkerRecordV1{record}, CheckpointCursor: "823", CheckpointWatermarkUnixMillis: watermark},
 	}
 }

--- a/internal/sourceruntime/source_execution_authority_test.go
+++ b/internal/sourceruntime/source_execution_authority_test.go
@@ -235,6 +235,82 @@ func TestOtherDigitalOceanFamilyRemainsGoCompatible(t *testing.T) {
 	}
 }
 
+func TestPutLinodeIssueRuntimeValidatesWithRustWithoutCallingGoCheck(t *testing.T) {
+	legacy := &runtimeAuthorityProbe{sourceID: "linode"}
+	registry, err := sourcecdk.NewRegistry(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker := &runtimePlanWorker{}
+	service := New(registry, &runtimeStore{}, nil, nil)
+	service.sourceWorker = worker
+	_, err = service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{Runtime: &cerebrov1.SourceRuntime{
+		Id: "linode-issue-runtime", SourceId: "linode", TenantId: "tenant-1",
+		Config: map[string]string{
+			"family": "issue", "page_size": "100",
+			"token": sourceconfig.CredentialReferenceValue("linode", "token"),
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy.checkCalls != 0 || worker.planCalls != 1 {
+		t.Fatalf("validation calls = Go %d, Rust %d", legacy.checkCalls, worker.planCalls)
+	}
+	if worker.selection.SourceID != "linode" || worker.selection.FamilyID != "issue" {
+		t.Fatalf("Rust selection = %#v", worker.selection)
+	}
+	if worker.publicConfig["family"] != "issue" || worker.publicConfig["page_size"] != "100" || worker.publicConfig["token"] != "" {
+		t.Fatalf("Rust public config = %#v", worker.publicConfig)
+	}
+}
+
+func TestLinodeIssueNeverFallsBackToGoAuthority(t *testing.T) {
+	legacy := &runtimeAuthorityProbe{sourceID: "linode"}
+	worker := &runtimePlanWorker{compileErr: sourceworker.ErrWorkerUnsupported}
+	service := &Service{sourceWorker: worker}
+	runtime := &cerebrov1.SourceRuntime{
+		Id: "linode-issue-runtime", SourceId: "linode", TenantId: "tenant-1",
+		Config: map[string]string{
+			"family": "issue", "page_size": "100",
+			"token": sourceconfig.CredentialReferenceValue("linode", "token"),
+		},
+	}
+	ctx := context.WithValue(context.Background(), sourceRuntimeLeaseFenceContextKey{}, sourceRuntimeLeaseAuthority{fence: ports.SourceRuntimeLeaseFence{
+		Owner: "owner-1", Generation: 1, ExpiresAt: time.Now().Add(time.Minute),
+	}})
+	resolved := sourcecdk.NewConfig(map[string]string{
+		"family": "issue", "page_size": "100", "token": "host-only-secret",
+	})
+
+	if _, _, err := service.readSourcePull(ctx, runtime, legacy, resolved, nil, nil, 1); !errors.Is(err, sourceworker.ErrWorkerUnsupported) {
+		t.Fatalf("readSourcePull() error = %v", err)
+	}
+	if legacy.readCalls != 0 || worker.selection.SourceID != "linode" || worker.selection.FamilyID != "issue" {
+		t.Fatalf("authority calls = Go %d, Rust selection %#v", legacy.readCalls, worker.selection)
+	}
+}
+
+func TestOtherLinodeFamiliesRemainGoCompatible(t *testing.T) {
+	for _, family := range []string{"event", "credential", "user", "future-family"} {
+		t.Run(family, func(t *testing.T) {
+			legacy := &runtimeAuthorityProbe{sourceID: "linode"}
+			service := &Service{sourceWorker: &runtimePlanWorker{}}
+			runtime := &cerebrov1.SourceRuntime{Id: "linode-" + family + "-runtime", SourceId: "linode", TenantId: "tenant-1"}
+			config := sourcecdk.NewConfig(map[string]string{"family": family})
+
+			if _, rustPage, err := service.readSourcePull(context.Background(), runtime, legacy, config, nil, nil, 1); err != nil {
+				t.Fatalf("readSourcePull() error = %v", err)
+			} else if rustPage {
+				t.Fatal("readSourcePull() reported a Rust page for a Go-authoritative Linode family")
+			}
+			if legacy.readCalls != 1 {
+				t.Fatalf("Go Read calls = %d, want 1", legacy.readCalls)
+			}
+		})
+	}
+}
+
 func TestPutTwilioAccountsRuntimeValidatesWithRustWithoutCallingGoCheck(t *testing.T) {
 	legacy := &runtimeAuthorityProbe{sourceID: "twilio"}
 	registry, err := sourcecdk.NewRegistry(legacy)

--- a/internal/sourceruntime/source_execution_test.go
+++ b/internal/sourceruntime/source_execution_test.go
@@ -13,16 +13,18 @@ func TestPublicSourceExecutionConfigCarriesTailscaleScopeWithoutSecrets(t *testi
 	got := sourceworker.PublicExecutionConfig(map[string]string{
 		"base_url":    " https://api.tailscale.com/api/v2 ",
 		"family":      " user ",
+		"page_size":   " 100 ",
 		"per_page":    " 100 ",
 		"tailnet":     " example.test ",
 		"token":       "must-not-cross",
 		"graph_token": "must-not-cross-either",
 	})
 	want := map[string]string{
-		"base_url": "https://api.tailscale.com/api/v2",
-		"family":   "user",
-		"per_page": "100",
-		"tailnet":  "example.test",
+		"base_url":  "https://api.tailscale.com/api/v2",
+		"family":    "user",
+		"page_size": "100",
+		"per_page":  "100",
+		"tailnet":   "example.test",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("PublicExecutionConfig() = %#v, want %#v", got, want)

--- a/internal/sourceruntime/sourceworker/pull.go
+++ b/internal/sourceruntime/sourceworker/pull.go
@@ -36,6 +36,11 @@ func RustAuthoritativeFamily(sourceID, familyID string) (string, bool) {
 		// Every public JumpCloud family is closed in the Rust dispatcher. An
 		// unknown future family must fail there instead of restoring Go authority.
 		return familyID, true
+	case "linode":
+		if familyID == "" {
+			familyID = "issue"
+		}
+		return familyID, familyID == "issue"
 	case "sentinelone":
 		switch familyID {
 		case "activity", "agent", "application", "exclusion", "group", "site", "threat":
@@ -105,7 +110,7 @@ func PublicExecutionConfig(values map[string]string) map[string]string {
 	public := make(map[string]string)
 	for _, key := range []string{
 		"account_sid", "activity_type", "agent_id", "audit_end_time", "audit_services", "audit_sort", "audit_start_time", "base_url",
-		"family", "group_id", "group_ids", "insights_base_url", "org_id", "per_page",
+		"family", "group_id", "group_ids", "insights_base_url", "org_id", "page_size", "per_page",
 		"since", "site_id", "tailnet", "until", "user_group_id", "user_group_ids",
 	} {
 		if value, ok := values[key]; ok {

--- a/internal/sourceruntime/sourceworker/pull_test.go
+++ b/internal/sourceruntime/sourceworker/pull_test.go
@@ -72,9 +72,10 @@ func TestPublicExecutionConfigNeverCarriesCredentialMaterial(t *testing.T) {
 	public := PublicExecutionConfig(map[string]string{
 		"account_sid": " AC123 ", "family": "user", "tailnet": "example.com", "base_url": "https://api.tailscale.com/api/v2",
 		"site_id": "site-1", "agent_id": "agent-1", "since": "2026-01-01T00:00:00Z", "until": "2026-02-01T00:00:00Z", "activity_type": "27",
-		"token": "secret-token", "graph_token": "secret-graph-token", "tenant_id": "tenant-1",
+		"page_size": " 100 ",
+		"token":     "secret-token", "graph_token": "secret-graph-token", "tenant_id": "tenant-1",
 	})
-	if len(public) != 9 || public["account_sid"] != "AC123" || public["site_id"] != "site-1" || public["agent_id"] != "agent-1" || public["since"] == "" || public["until"] == "" || public["activity_type"] != "27" || public["token"] != "" || public["graph_token"] != "" || public["tenant_id"] != "" {
+	if len(public) != 10 || public["account_sid"] != "AC123" || public["site_id"] != "site-1" || public["agent_id"] != "agent-1" || public["since"] == "" || public["until"] == "" || public["activity_type"] != "27" || public["page_size"] != "100" || public["token"] != "" || public["graph_token"] != "" || public["tenant_id"] != "" {
 		t.Fatalf("public config leaked private fields: %#v", public)
 	}
 }
@@ -92,6 +93,10 @@ func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
 		"JumpCloud default":          {"jumpcloud", "", "users", true},
 		"JumpCloud family":           {"jumpcloud", "group_members", "group_members", true},
 		"unknown JumpCloud family":   {"jumpcloud", "future-family", "future-family", true},
+		"Linode default":             {" linode ", "", "issue", true},
+		"Linode issue":               {"linode", " issue ", "issue", true},
+		"other Linode family":        {"linode", "event", "event", false},
+		"unknown Linode family":      {"linode", "future-family", "future-family", false},
 		"SentinelOne agent":          {" sentinelone ", " agent ", "agent", true},
 		"SentinelOne activity":       {"sentinelone", "activity", "activity", true},
 		"SentinelOne exclusion":      {"sentinelone", "exclusion", "exclusion", true},


### PR DESCRIPTION
## Summary

- promote only the Linode `issue` family to the closed Rust source-execution path
- route durable collection and Check/Discover/Read preview through the registered `linode.issue` adapter
- admit `page_size` as bounded public configuration while keeping the token in the trusted host
- preserve Go compatibility for Linode `event`, `credential`, and `user`

## Authority invariants

- omitted Linode family normalizes to `issue`; only `issue` is Rust-authoritative
- a missing or unsupported Rust worker fails `issue` closed without calling the Go loader
- unknown and non-promoted Linode families remain on the existing Go path
- durable checkpoints use the Rust provider cursor envelope only for the promoted family
- preview credentials do not enter public worker metadata, events, checkpoints, or errors

## Local validation

- `go test ./internal/sourceops ./internal/sourceruntime/sourceworker ./internal/sourceruntime -count=1`
- `go test -race ./internal/sourceops ./internal/sourceruntime/sourceworker ./internal/sourceruntime -count=1`
- `make check-structural check-structural-test check-arch`
- `git diff --check`

All listed checks passed on commit `dfadf7d609719c016e340801a5f1338b6b0a6375`.

## Hosted validation

- exact head: `dfadf7d609719c016e340801a5f1338b6b0a6375`
- terminal checks: 81 successful, 8 skipped
- failures and nonterminal checks: 0

## Stack and remaining work

- this pull request is stacked on #2561 and must follow its adapter through normal protection
- the Go Linode loader remains because `event`, `credential`, and `user` are not registered in Rust yet
- deleting the Go loader requires Rust adapters and authority for those three families plus worker-only catalog metadata

No human reviewers are assigned.
