### PR TITLE
Compile PagerDuty family source adapters

### DIFF
--- a/crates/source-runtime-next/src/pagerduty/source_execution.rs
+++ b/crates/source-runtime-next/src/pagerduty/source_execution.rs
@@ -1,4 +1,4 @@
-//! PagerDuty `user` bridge into the closed source-execution dispatcher.
+//! PagerDuty family bridges into the closed source-execution dispatcher.
 //!
 //! The adapter consumes authenticated tenant context, public configuration, and
 //! bounded provider response bytes. The trusted Go host retains credential
@@ -14,117 +14,32 @@ use crate::source_execution::{
     SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1,
     SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2, SourceWorkerHttpRequestV1,
     SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1, SourceWorkerRecordV1,
-    SourceWorkerRuntimeMetadataV2, canonical_http_execution_digest, canonical_plan_digest,
+    SourceWorkerRuntimeMetadataV2, canonical_http_execution_digest,
     canonical_request_intent_digest, canonical_result_digest, validate_and_deduplicate_records,
-    validate_execution_context, validate_runtime_metadata,
 };
 
-use super::{
-    PagerDutyError, PagerDutyFamily, PagerDutyFilters, PagerDutyKernel,
-    normalize::event_id,
-    origin::{DEFAULT_BASE_URL, origin_string, validate_origin},
+use super::PagerDutyFamily;
+
+#[path = "source_execution/catalog.rs"]
+mod catalog;
+
+pub(crate) use catalog::{
+    PAGERDUTY_SOURCE_EXECUTION_ADAPTERS, PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER,
 };
 
-const SOURCE_ID: &str = "pagerduty";
-const FAMILY_ID: &str = "user";
-const PROVIDER_KERNEL: &str = "pagerduty.user";
-const PLAN_ID: &str = "source-plan-v1:pagerduty:user";
-const METHOD: &str = "GET";
-const PATH: &str = "/users";
-const RECORD_SELECTOR: &str = "$.users[*]";
-const ID_FIELD: &str = "id";
-const MAX_RESPONSE_BYTES: u64 = 8 << 20;
-const EVENT_KIND: &str = "pagerduty.user";
-const SCHEMA_REF: &str = "pagerduty/user/v1";
+use catalog::{DEFAULT_BASE_URL, PagerDutySourceExecutionAdapter, map_error, optional};
 
-#[derive(Clone, Copy, Debug, Default)]
-pub(crate) struct PagerDutyUserSourceExecutionAdapter;
-
-pub(crate) static PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER: PagerDutyUserSourceExecutionAdapter =
-    PagerDutyUserSourceExecutionAdapter;
-
-impl PagerDutyUserSourceExecutionAdapter {
-    pub(crate) fn compiled_plan(&self) -> SourceExecutionPlanV1 {
-        let mut plan = SourceExecutionPlanV1 {
-            plan_id: PLAN_ID.to_owned(),
-            source_id: SOURCE_ID.to_owned(),
-            family_id: FAMILY_ID.to_owned(),
-            provider_kernel: PROVIDER_KERNEL.to_owned(),
-            method: METHOD.to_owned(),
-            origin: DEFAULT_BASE_URL.to_owned(),
-            path: PATH.to_owned(),
-            record_selector: RECORD_SELECTOR.to_owned(),
-            id_field: ID_FIELD.to_owned(),
-            singleton_fallback_id: String::new(),
-            max_response_bytes: MAX_RESPONSE_BYTES,
-            event_kind: EVENT_KIND.to_owned(),
-            schema_ref: SCHEMA_REF.to_owned(),
-            required_attributes: [
-                "external_id",
-                "family",
-                "source_provider",
-                "source_product",
-                "user_id",
-            ]
-            .into_iter()
-            .map(str::to_owned)
-            .collect(),
-            required_payload_fields: vec!["id".to_owned()],
-            plan_digest_sha256: String::new(),
-        };
-        plan.plan_digest_sha256 = canonical_plan_digest(&plan);
-        plan
-    }
-
-    fn validate_plan(&self, plan: &SourceExecutionPlanV1) -> Result<(), SourceExecutionError> {
-        if plan != &self.compiled_plan() {
-            return Err(SourceExecutionError::InvalidPlan);
-        }
-        Ok(())
-    }
-
-    fn kernel(
-        &self,
-        context: &SourceWorkerExecutionContextV1,
-        metadata: &SourceWorkerRuntimeMetadataV2,
-    ) -> Result<(PagerDutyKernel, String), SourceExecutionError> {
-        validate_execution_context(context)?;
-        validate_runtime_metadata(metadata)?;
-        if public_value(&metadata.public_config, "family").is_some_and(|value| value != FAMILY_ID) {
-            return Err(SourceExecutionError::MissingConfiguration);
-        }
-        let base_url = public_value(&metadata.public_config, "base_url");
-        let allowed_origin = origin_string(&validate_origin(base_url).map_err(map_error)?);
-        let page_size = public_value(&metadata.public_config, "per_page")
-            .map(|value| {
-                value
-                    .parse::<usize>()
-                    .map_err(|_| SourceExecutionError::MissingConfiguration)
-            })
-            .transpose()?;
-        let kernel = PagerDutyKernel::new(
-            base_url,
-            &context.tenant_id,
-            PagerDutyFamily::User,
-            PagerDutyFilters::default(),
-            page_size,
-        )
-        .map_err(map_error)?;
-        Ok((kernel, allowed_origin))
-    }
-}
-
-impl SourceExecutionAdapter for PagerDutyUserSourceExecutionAdapter {
+impl SourceExecutionAdapter for PagerDutySourceExecutionAdapter {
     fn source_id(&self) -> &'static str {
-        SOURCE_ID
+        "pagerduty"
     }
 
     fn family_id(&self) -> &'static str {
-        FAMILY_ID
+        self.family().as_str()
     }
 
     fn provider_kernel(&self) -> &'static str {
-        PROVIDER_KERNEL
+        self.family().event_kind()
     }
 
     fn validate_record_identity(
@@ -132,20 +47,15 @@ impl SourceExecutionAdapter for PagerDutyUserSourceExecutionAdapter {
         context: &SourceWorkerExecutionContextV1,
         record: &SourceWorkerRecordV1,
     ) -> Result<(), SourceExecutionError> {
-        let expected = event_id(
-            &context.tenant_id,
-            DEFAULT_BASE_URL,
-            PATH,
-            PagerDutyFamily::User,
-            &record.provider_id,
-        );
-        if record.event_id != expected
-            || record.attributes.get("external_id") != Some(&record.provider_id)
-            || record.attributes.get("user_id") != Some(&record.provider_id)
-        {
-            return Err(SourceExecutionError::TenantMismatch);
-        }
-        Ok(())
+        let metadata = SourceWorkerRuntimeMetadataV2 {
+            public_config: HashMap::from([
+                ("family".to_owned(), self.family().as_str().to_owned()),
+                ("base_url".to_owned(), DEFAULT_BASE_URL.to_owned()),
+            ]),
+            prior_terminal_watermark_unix_millis: 0,
+            prior_checkpoint: String::new(),
+        };
+        self.validate_identity(context, record, &metadata)
     }
 
     fn validate_record_identity_v2(
@@ -154,24 +64,7 @@ impl SourceExecutionAdapter for PagerDutyUserSourceExecutionAdapter {
         record: &SourceWorkerRecordV1,
         metadata: &SourceWorkerRuntimeMetadataV2,
     ) -> Result<(), SourceExecutionError> {
-        let origin = origin_string(
-            &validate_origin(public_value(&metadata.public_config, "base_url"))
-                .map_err(map_error)?,
-        );
-        let expected = event_id(
-            &context.tenant_id,
-            &origin,
-            PATH,
-            PagerDutyFamily::User,
-            &record.provider_id,
-        );
-        if record.event_id != expected
-            || record.attributes.get("external_id") != Some(&record.provider_id)
-            || record.attributes.get("user_id") != Some(&record.provider_id)
-        {
-            return Err(SourceExecutionError::TenantMismatch);
-        }
-        Ok(())
+        self.validate_identity(context, record, metadata)
     }
 
     fn plan(
@@ -206,7 +99,8 @@ impl SourceExecutionAdapter for PagerDutyUserSourceExecutionAdapter {
         let provider_request = kernel
             .plan(optional(&context.prior_cursor))
             .map_err(map_error)?;
-        if provider_request.url().path() != plan.path
+        if (self.family() != PagerDutyFamily::Integration
+            && provider_request.url().path() != plan.path)
             || provider_request.method() != plan.method
             || provider_request.authorization_header() != "Authorization"
             || provider_request.authorization_scheme() != "Token token="
@@ -292,7 +186,7 @@ impl SourceExecutionAdapter for PagerDutyUserSourceExecutionAdapter {
             .into_iter()
             .map(|record| {
                 if record.tenant_id != context.tenant_id
-                    || record.family != PagerDutyFamily::User
+                    || record.family != self.family()
                     || record.event_kind != plan.event_kind
                     || record.schema_ref != plan.schema_ref
                 {
@@ -331,12 +225,11 @@ pub(crate) fn durable_checkpoint_cursor(
     plan: &SourceExecutionPlanV1,
     result: &SourceWorkerDecodeResultV1,
 ) -> Option<String> {
-    if plan.source_id != SOURCE_ID
-        || plan.family_id != FAMILY_ID
-        || plan.provider_kernel != PROVIDER_KERNEL
-    {
-        return None;
-    }
+    PAGERDUTY_SOURCE_EXECUTION_ADAPTERS.iter().find(|adapter| {
+        plan.source_id == adapter.source_id()
+            && plan.family_id == adapter.family_id()
+            && plan.provider_kernel == adapter.provider_kernel()
+    })?;
     if !result.next_cursor.is_empty() {
         return Some(result.next_cursor.clone());
     }
@@ -349,18 +242,6 @@ pub(crate) fn durable_checkpoint_cursor(
     )
 }
 
-fn public_value<'a>(config: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
-    config
-        .get(key)
-        .map(String::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-}
-
-fn optional(value: &str) -> Option<&str> {
-    (!value.is_empty()).then_some(value)
-}
-
 fn timestamp(unix_millis: i64) -> Result<OffsetDateTime, SourceExecutionError> {
     OffsetDateTime::from_unix_timestamp_nanos(i128::from(unix_millis) * 1_000_000)
         .map_err(|_| SourceExecutionError::InvalidExecutionContext)
@@ -371,32 +252,6 @@ fn parse_timestamp(value: &str) -> Result<i64, SourceExecutionError> {
         .map_err(|_| SourceExecutionError::InvalidProviderRecord)?
         .unix_timestamp_nanos();
     i64::try_from(nanos / 1_000_000).map_err(|_| SourceExecutionError::InvalidProviderRecord)
-}
-
-fn map_error(error: PagerDutyError) -> SourceExecutionError {
-    match error {
-        PagerDutyError::InvalidFamily => SourceExecutionError::UnknownAdapter,
-        PagerDutyError::InvalidBaseUrl
-        | PagerDutyError::MissingServiceId
-        | PagerDutyError::InvalidServiceId
-        | PagerDutyError::InvalidPageSize => SourceExecutionError::MissingConfiguration,
-        PagerDutyError::MissingTenantId => SourceExecutionError::InvalidExecutionContext,
-        PagerDutyError::InvalidCursor => SourceExecutionError::InvalidCursor,
-        PagerDutyError::RequestScopeMismatch => SourceExecutionError::InvalidPlan,
-        PagerDutyError::AuthenticationRejected => SourceExecutionError::AuthenticationRejected,
-        PagerDutyError::PermissionDenied => SourceExecutionError::RequiredProviderScopeMissing,
-        PagerDutyError::RateLimited => SourceExecutionError::ProviderRateLimit,
-        PagerDutyError::ProviderUnavailable | PagerDutyError::UnexpectedProviderStatus => {
-            SourceExecutionError::UnexpectedProviderStatus
-        }
-        PagerDutyError::ResponseTooLarge => SourceExecutionError::ResponseTooLarge,
-        PagerDutyError::TooManyRecords => SourceExecutionError::ResultTooLarge,
-        PagerDutyError::MalformedResponse => SourceExecutionError::MalformedResponse,
-        PagerDutyError::MissingProviderIdentity => SourceExecutionError::MissingStableIdentity,
-        PagerDutyError::InvalidProviderIdentity => SourceExecutionError::InvalidProviderRecord,
-        PagerDutyError::ConflictingProviderIdentity => SourceExecutionError::DuplicateConflict,
-        PagerDutyError::EventContractRejected => SourceExecutionError::EventContractRejected,
-    }
 }
 
 #[cfg(test)]

--- a/crates/source-runtime-next/src/pagerduty/source_execution/catalog.rs
+++ b/crates/source-runtime-next/src/pagerduty/source_execution/catalog.rs
@@ -205,10 +205,10 @@ fn service_ids(config: &HashMap<String, String>) -> Vec<String> {
         .filter(|value| !value.is_empty())
         .map(str::to_owned)
         .collect::<Vec<_>>();
-    if values.is_empty() {
-        if let Some(value) = public_value(config, "service_id") {
-            values.push(value.to_owned());
-        }
+    if values.is_empty()
+        && let Some(value) = public_value(config, "service_id")
+    {
+        values.push(value.to_owned());
     }
     values
 }

--- a/crates/source-runtime-next/src/pagerduty/source_execution/catalog.rs
+++ b/crates/source-runtime-next/src/pagerduty/source_execution/catalog.rs
@@ -1,0 +1,214 @@
+//! Closed PagerDuty source-execution adapter catalog and public configuration.
+
+use std::collections::HashMap;
+
+use crate::source_execution::{
+    SourceExecutionError, SourceExecutionPlanV1, SourceWorkerExecutionContextV1,
+    SourceWorkerRecordV1, SourceWorkerRuntimeMetadataV2, canonical_plan_digest,
+    validate_execution_context, validate_runtime_metadata,
+};
+
+use super::super::{
+    PagerDutyError, PagerDutyFamily, PagerDutyFilters, PagerDutyKernel,
+    normalize::event_id,
+    origin::{origin_string, validate_origin},
+};
+
+const SOURCE_ID: &str = "pagerduty";
+pub(super) const DEFAULT_BASE_URL: &str = "https://api.pagerduty.com";
+const METHOD: &str = "GET";
+const ID_FIELD: &str = "id";
+const MAX_RESPONSE_BYTES: u64 = 8 << 20;
+
+/// One credential-free adapter for a closed PagerDuty family.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PagerDutySourceExecutionAdapter {
+    family: PagerDutyFamily,
+}
+
+impl PagerDutySourceExecutionAdapter {
+    const fn new(family: PagerDutyFamily) -> Self {
+        Self { family }
+    }
+
+    pub(super) const fn family(&self) -> PagerDutyFamily {
+        self.family
+    }
+
+    pub(crate) fn compiled_plan(&self) -> SourceExecutionPlanV1 {
+        let family_id = self.family.as_str();
+        let mut required_attributes = vec![
+            "external_id".to_owned(),
+            "family".to_owned(),
+            "source_provider".to_owned(),
+            "source_product".to_owned(),
+            self.family.identity_attribute().to_owned(),
+        ];
+        if self.family == PagerDutyFamily::Integration {
+            required_attributes.push("service_id".to_owned());
+        }
+        let mut plan = SourceExecutionPlanV1 {
+            plan_id: format!("source-plan-v1:pagerduty:{family_id}"),
+            source_id: SOURCE_ID.to_owned(),
+            family_id: family_id.to_owned(),
+            provider_kernel: self.family.event_kind().to_owned(),
+            method: METHOD.to_owned(),
+            origin: DEFAULT_BASE_URL.to_owned(),
+            path: self.family.path_template().to_owned(),
+            record_selector: format!("$.{}[*]", self.family.response_key()),
+            id_field: ID_FIELD.to_owned(),
+            singleton_fallback_id: String::new(),
+            max_response_bytes: MAX_RESPONSE_BYTES,
+            event_kind: self.family.event_kind().to_owned(),
+            schema_ref: self.family.schema_ref().to_owned(),
+            required_attributes,
+            required_payload_fields: vec!["id".to_owned()],
+            plan_digest_sha256: String::new(),
+        };
+        plan.plan_digest_sha256 = canonical_plan_digest(&plan);
+        plan
+    }
+
+    pub(super) fn validate_plan(
+        &self,
+        plan: &SourceExecutionPlanV1,
+    ) -> Result<(), SourceExecutionError> {
+        if plan != &self.compiled_plan() {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        Ok(())
+    }
+
+    pub(super) fn kernel(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(PagerDutyKernel, String), SourceExecutionError> {
+        validate_execution_context(context)?;
+        validate_runtime_metadata(metadata)?;
+        if public_value(&metadata.public_config, "family")
+            .is_some_and(|value| value != self.family.as_str())
+        {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        let base_url = public_value(&metadata.public_config, "base_url");
+        let allowed_origin = origin_string(&validate_origin(base_url).map_err(map_error)?);
+        let page_size = public_value(&metadata.public_config, "per_page")
+            .map(|value| {
+                value
+                    .parse::<usize>()
+                    .map_err(|_| SourceExecutionError::MissingConfiguration)
+            })
+            .transpose()?;
+        let filters = PagerDutyFilters {
+            service_ids: service_ids(&metadata.public_config),
+        };
+        let kernel = PagerDutyKernel::new(
+            base_url,
+            &context.tenant_id,
+            self.family,
+            filters,
+            page_size,
+        )
+        .map_err(map_error)?;
+        Ok((kernel, allowed_origin))
+    }
+
+    pub(super) fn validate_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(), SourceExecutionError> {
+        let (kernel, origin) = self.kernel(context, metadata)?;
+        let request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        let expected = event_id(
+            &context.tenant_id,
+            &origin,
+            request.url().path(),
+            self.family,
+            &record.provider_id,
+        );
+        if record.event_id != expected
+            || record.attributes.get("external_id") != Some(&record.provider_id)
+            || record.attributes.get(self.family.identity_attribute()) != Some(&record.provider_id)
+            || (self.family == PagerDutyFamily::Integration
+                && record
+                    .attributes
+                    .get("service_id")
+                    .is_none_or(String::is_empty))
+        {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        Ok(())
+    }
+}
+
+pub(crate) static PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER: PagerDutySourceExecutionAdapter =
+    PagerDutySourceExecutionAdapter::new(PagerDutyFamily::User);
+
+pub(crate) static PAGERDUTY_SOURCE_EXECUTION_ADAPTERS: [PagerDutySourceExecutionAdapter; 7] = [
+    PagerDutySourceExecutionAdapter::new(PagerDutyFamily::User),
+    PagerDutySourceExecutionAdapter::new(PagerDutyFamily::Team),
+    PagerDutySourceExecutionAdapter::new(PagerDutyFamily::Service),
+    PagerDutySourceExecutionAdapter::new(PagerDutyFamily::Schedule),
+    PagerDutySourceExecutionAdapter::new(PagerDutyFamily::EscalationPolicy),
+    PagerDutySourceExecutionAdapter::new(PagerDutyFamily::Integration),
+    PagerDutySourceExecutionAdapter::new(PagerDutyFamily::Vendor),
+];
+
+pub(super) fn public_value<'a>(config: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    config
+        .get(key)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+pub(super) fn optional(value: &str) -> Option<&str> {
+    (!value.is_empty()).then_some(value)
+}
+
+pub(super) fn map_error(error: PagerDutyError) -> SourceExecutionError {
+    match error {
+        PagerDutyError::InvalidFamily => SourceExecutionError::UnknownAdapter,
+        PagerDutyError::InvalidBaseUrl
+        | PagerDutyError::MissingServiceId
+        | PagerDutyError::InvalidServiceId
+        | PagerDutyError::InvalidPageSize => SourceExecutionError::MissingConfiguration,
+        PagerDutyError::MissingTenantId => SourceExecutionError::InvalidExecutionContext,
+        PagerDutyError::InvalidCursor => SourceExecutionError::InvalidCursor,
+        PagerDutyError::RequestScopeMismatch => SourceExecutionError::InvalidPlan,
+        PagerDutyError::AuthenticationRejected => SourceExecutionError::AuthenticationRejected,
+        PagerDutyError::PermissionDenied => SourceExecutionError::RequiredProviderScopeMissing,
+        PagerDutyError::RateLimited => SourceExecutionError::ProviderRateLimit,
+        PagerDutyError::ProviderUnavailable | PagerDutyError::UnexpectedProviderStatus => {
+            SourceExecutionError::UnexpectedProviderStatus
+        }
+        PagerDutyError::ResponseTooLarge => SourceExecutionError::ResponseTooLarge,
+        PagerDutyError::TooManyRecords => SourceExecutionError::ResultTooLarge,
+        PagerDutyError::MalformedResponse => SourceExecutionError::MalformedResponse,
+        PagerDutyError::MissingProviderIdentity => SourceExecutionError::MissingStableIdentity,
+        PagerDutyError::InvalidProviderIdentity => SourceExecutionError::InvalidProviderRecord,
+        PagerDutyError::ConflictingProviderIdentity => SourceExecutionError::DuplicateConflict,
+        PagerDutyError::EventContractRejected => SourceExecutionError::EventContractRejected,
+    }
+}
+
+fn service_ids(config: &HashMap<String, String>) -> Vec<String> {
+    let mut values = public_value(config, "service_ids")
+        .into_iter()
+        .flat_map(|value| value.split(','))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    if values.is_empty() {
+        if let Some(value) = public_value(config, "service_id") {
+            values.push(value.to_owned());
+        }
+    }
+    values
+}

--- a/crates/source-runtime-next/src/pagerduty/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/pagerduty/source_execution_tests.rs
@@ -10,7 +10,9 @@ use crate::source_execution::{
     SourceWorkerPlanRequestV1, SourceWorkerRuntimeMetadataV2, seal_page_program_v2,
 };
 
-use super::{DEFAULT_BASE_URL, PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER};
+use super::{
+    DEFAULT_BASE_URL, PAGERDUTY_SOURCE_EXECUTION_ADAPTERS, PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER,
+};
 
 const OBSERVED_AT_MILLIS: i64 = 1_780_272_000_000;
 
@@ -112,6 +114,99 @@ fn closed_dispatcher_registers_only_pagerduty_user() {
             "{family}"
         );
     }
+}
+
+#[test]
+fn provider_local_catalog_compiles_and_plans_every_pagerduty_family() {
+    let execution_context = context("", 1);
+    assert_eq!(
+        PAGERDUTY_SOURCE_EXECUTION_ADAPTERS.len(),
+        crate::pagerduty::PagerDutyFamily::ALL.len()
+    );
+
+    for adapter in &PAGERDUTY_SOURCE_EXECUTION_ADAPTERS {
+        let family = adapter.family();
+        let plan = adapter.compiled_plan();
+        assert_eq!(plan.source_id, "pagerduty");
+        assert_eq!(plan.family_id, family.as_str());
+        assert_eq!(plan.provider_kernel, family.event_kind());
+        assert_eq!(plan.path, family.path_template());
+        assert_eq!(
+            plan.record_selector,
+            format!("$.{}[*]", family.response_key())
+        );
+        assert_eq!(plan.event_kind, family.event_kind());
+        assert_eq!(plan.schema_ref, family.schema_ref());
+        assert!(
+            plan.required_attributes
+                .contains(&family.identity_attribute().to_owned())
+        );
+
+        let mut metadata = SourceWorkerRuntimeMetadataV2 {
+            public_config: HashMap::from([
+                ("family".to_owned(), family.as_str().to_owned()),
+                ("per_page".to_owned(), "2".to_owned()),
+            ]),
+            prior_terminal_watermark_unix_millis: 0,
+            prior_checkpoint: String::new(),
+        };
+        if family == crate::pagerduty::PagerDutyFamily::Integration {
+            metadata
+                .public_config
+                .insert("service_ids".to_owned(), "PS1, PS2".to_owned());
+            assert!(plan.required_attributes.contains(&"service_id".to_owned()));
+        }
+        let execution = crate::source_execution::SourceExecutionAdapter::plan_v2(
+            adapter,
+            &SourceWorkerPlanEnvelopeV2 {
+                request: Some(SourceWorkerPlanRequestV1 {
+                    plan: Some(plan.clone()),
+                    context: Some(execution_context.clone()),
+                }),
+                metadata: Some(metadata),
+            },
+        )
+        .unwrap();
+        assert_eq!(execution.credential_operation, "pagerduty.token");
+        assert_eq!(execution.allowed_origin, DEFAULT_BASE_URL);
+        let request = execution.request.unwrap();
+        assert_eq!(request.method, "GET");
+        assert!(request.url.starts_with(DEFAULT_BASE_URL));
+        assert!(request.url.ends_with("limit=2"));
+        if family == crate::pagerduty::PagerDutyFamily::Integration {
+            assert!(request.url.contains("/services/PS1/integrations?"));
+        }
+    }
+}
+
+#[test]
+fn integration_adapter_requires_bounded_service_scope() {
+    let adapter = PAGERDUTY_SOURCE_EXECUTION_ADAPTERS
+        .iter()
+        .find(|adapter| adapter.family() == crate::pagerduty::PagerDutyFamily::Integration)
+        .unwrap();
+    let plan = adapter.compiled_plan();
+    let metadata = SourceWorkerRuntimeMetadataV2 {
+        public_config: HashMap::from([
+            ("family".to_owned(), "integration".to_owned()),
+            ("per_page".to_owned(), "2".to_owned()),
+        ]),
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    };
+    assert_eq!(
+        crate::source_execution::SourceExecutionAdapter::plan_v2(
+            adapter,
+            &SourceWorkerPlanEnvelopeV2 {
+                request: Some(SourceWorkerPlanRequestV1 {
+                    plan: Some(plan),
+                    context: Some(context("", 1)),
+                }),
+                metadata: Some(metadata),
+            },
+        ),
+        Err(SourceExecutionError::MissingConfiguration)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Scope

- compile provider-local Rust source-execution adapters for PagerDuty `user`, `team`, `service`, `schedule`, `escalation_policy`, `integration`, and `vendor`
- preserve the existing `PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER` compatibility symbol
- require an explicit bounded service scope before planning PagerDuty integration requests
- share family plan, kernel, identity, and error mapping without exposing credentials to Rust

## Authority boundary

- the closed shared dispatcher remains `user`-only in this pull request
- no PagerDuty family changes runtime authority in this pull request
- the trusted Go host still owns credential redemption, authentication, network I/O, durable append, projection, and checkpointing
- a later scoped pull request can register qualified families after this provider-local surface is merged

## Local validation

- `rustfmt --edition 2024 --check crates/source-runtime-next/src/pagerduty/source_execution.rs crates/source-runtime-next/src/pagerduty/source_execution/catalog.rs crates/source-runtime-next/src/pagerduty/source_execution_tests.rs`
- `go test ./internal/sourceruntime/sourceworker ./tools/archtests -count=1`
- `make check-structural check-structural-test check-arch`
- `git diff --check`

The managed Cargo wrapper blocked `cargo test -p cerebro-source-runtime-next pagerduty::source_execution` before compilation because safe DDESK capacity was unavailable. No local target directory or unmanaged Cargo path was used.

## Hosted validation

- exact head: `f3175ceb3901d002f791dd77954f922de1f7e716`
- 81 checks passed, 9 checks skipped, and no check failed
- `Seeded Go and Rust graph` completed successfully
- zero unresolved review threads

## Delivery state

- ready for protected review; repository approval remains required
- no human reviewers assigned
