### PR TITLE
Register Asana Rust source adapters

### DIFF
--- a/apps/web/src/app/api/cerebro/[...path]/route.test.ts
+++ b/apps/web/src/app/api/cerebro/[...path]/route.test.ts
@@ -18,6 +18,7 @@ afterEach(() => {
   if (originalLocalIdentityFallback === undefined) delete process.env.CEREBRO_LOCAL_IDENTITY_FALLBACK;
   else process.env.CEREBRO_LOCAL_IDENTITY_FALLBACK = originalLocalIdentityFallback;
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
   vi.unstubAllGlobals();
 });
 
@@ -95,6 +96,38 @@ describe("Cerebro proxy route", () => {
     expect(upstreamHeaders.get("x-cerebro-api-key")).toBeNull();
     expect(upstreamHeaders.get("x-cerebro-user-id")).toBeNull();
     expect(upstreamHeaders.get("x-cerebro-user-subject")).toBeNull();
+  });
+
+  it("routes runtime health to Rust with server-owned tenant authentication", async () => {
+    vi.stubEnv("CEREBRO_RUST_PLATFORM_API_BASE", "http://rust-platform.internal:8080");
+    vi.stubEnv("CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID", "tenant-a");
+    vi.stubEnv(
+      "CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET",
+      "test-organizational-graph-secret-32-bytes",
+    );
+    let upstreamURL = "";
+    let upstreamHeaders = new Headers();
+    vi.stubGlobal("fetch", vi.fn(async (url: URL | RequestInfo, init?: RequestInit) => {
+      upstreamURL = url.toString();
+      upstreamHeaders = new Headers(init?.headers);
+      return new Response(JSON.stringify({ runtimes: [], source_summaries: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }));
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/cerebro/v1/source-runtimes/health?limit=500"),
+      { params: Promise.resolve({ path: ["v1", "source-runtimes", "health"] }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(upstreamURL).toBe("http://rust-platform.internal:8080/v1/source-runtimes/health?limit=500");
+    expect(upstreamHeaders.get("x-cerebro-tenant")).toBe("tenant-a");
+    expect(upstreamHeaders.get("authorization")).toBe(
+      "Bearer 34b1625abbaa7a28cbca5f0a4803c1ba5360a998e5cc2f5b28d37bd32ba131d6",
+    );
+    expect(upstreamHeaders.get("x-cerebro-api-key")).toBeNull();
   });
 
   it("relays signed Rust-authority writes without authorizing or stamping in Next", async () => {

--- a/apps/web/src/lib/cerebro-proxy.test.ts
+++ b/apps/web/src/lib/cerebro-proxy.test.ts
@@ -7,10 +7,12 @@ import {
   cachedResponseHeaders,
   cerebroProxyCacheKey,
   configuredOrganizationalGraphTenant,
+  configuredRustPlatformApiBase,
   fetchCerebro,
   getCerebroPublicConfig,
   isCacheableCerebroPath,
   responseHeadersFor,
+  rustTenantAuthHeaders,
   rustOwnsWebAuthority,
   shouldRetryUpstreamResponse,
   shouldBypassCerebroProxyCache,
@@ -59,11 +61,53 @@ describe("cerebro proxy cache headers", () => {
     expect(new Headers(authHeadersFor(request, "user/preferences")).get("x-cerebro-tenant")).toBeNull();
   });
 
+  it("routes only runtime health to the configured Rust platform origin", () => {
+    vi.stubEnv("CEREBRO_RUST_PLATFORM_API_BASE", "http://rust-platform.internal:8080");
+
+    expect(buildCerebroUrl("/v1/source-runtimes/health", "?limit=500").toString()).toBe(
+      "http://rust-platform.internal:8080/v1/source-runtimes/health?limit=500",
+    );
+    expect(buildCerebroUrl("/grc/dashboard").origin).not.toBe("http://rust-platform.internal:8080");
+  });
+
+  it("matches the shared Go and Rust tenant-auth test vector", () => {
+    const headers = new Headers(rustTenantAuthHeaders(
+      "tenant-a",
+      "test-organizational-graph-secret-32-bytes",
+    ));
+
+    expect(headers.get("x-cerebro-tenant")).toBe("tenant-a");
+    expect(headers.get("authorization")).toBe(
+      "Bearer 34b1625abbaa7a28cbca5f0a4803c1ba5360a998e5cc2f5b28d37bd32ba131d6",
+    );
+  });
+
+  it("uses only server-owned Rust tenant auth for runtime health", () => {
+    vi.stubEnv("CEREBRO_RUST_PLATFORM_API_BASE", "http://rust-platform.internal:8080");
+    vi.stubEnv("CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID", "tenant-a");
+    vi.stubEnv(
+      "CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET",
+      "test-organizational-graph-secret-32-bytes",
+    );
+    const headers = new Headers(authHeadersFor(new NextRequest("http://localhost"), "v1/source-runtimes/health"));
+
+    expect(headers.get("x-cerebro-tenant")).toBe("tenant-a");
+    expect(headers.get("authorization")).toMatch(/^Bearer [0-9a-f]{64}$/);
+    expect(headers.get("x-cerebro-api-key")).toBeNull();
+  });
+
   it("rejects an invalid server-owned tenant header", () => {
     expect(() => configuredOrganizationalGraphTenant("tenant-demo\nforged")).toThrow(
       "is not a valid header value",
     );
     expect(configuredOrganizationalGraphTenant("   ")).toBeUndefined();
+  });
+
+  it("rejects credential-bearing Rust platform origins and short shared secrets", () => {
+    expect(() => configuredRustPlatformApiBase("https://user:pass@rust.example.com")).toThrow(
+      "without credentials",
+    );
+    expect(() => rustTenantAuthHeaders("tenant-a", "too-short")).toThrow("at least 32 bytes");
   });
 
   it("enables Rust authority only through an explicit deployment mode", () => {

--- a/apps/web/src/lib/cerebro-proxy.ts
+++ b/apps/web/src/lib/cerebro-proxy.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createHash } from "crypto";
+import { createHash, createHmac } from "crypto";
 
 import { headersWithTrace, startWebSpan } from "./observability";
 import { normalizeProxyPath } from "./identity-write-stamp";
@@ -8,6 +8,13 @@ const API_BASE =
   process.env.CEREBRO_API_BASE ??
   process.env.NEXT_PUBLIC_CEREBRO_API_BASE ??
   "http://localhost:8080";
+
+const RUST_RUNTIME_HEALTH_PATH = "v1/source-runtimes/health";
+const RUST_TENANT_AUTH_CONTEXT = Buffer.from(
+  "cerebro-organizational-graph/tenant/v1\0",
+  "utf8",
+);
+const MIN_RUST_SHARED_SECRET_BYTES = 32;
 
 const firstConfiguredApiKey = (value?: string) =>
   value
@@ -56,6 +63,45 @@ export const configuredOrganizationalGraphTenant = (
   }
   return tenantID;
 };
+
+export const configuredRustPlatformApiBase = (
+  value = process.env.CEREBRO_RUST_PLATFORM_API_BASE,
+) => {
+  const configured = value?.trim();
+  if (!configured) return undefined;
+  const base = new URL(configured);
+  if (!["http:", "https:"].includes(base.protocol) || base.username || base.password || base.search || base.hash) {
+    throw new Error("CEREBRO_RUST_PLATFORM_API_BASE must be an HTTP(S) origin without credentials, query, or fragment");
+  }
+  return base.toString();
+};
+
+export const rustTenantAuthHeaders = (tenantID: string, sharedSecret: string): HeadersInit => {
+  const tenant = configuredOrganizationalGraphTenant(tenantID);
+  if (!tenant) {
+    throw new Error("CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID is required for Rust runtime health");
+  }
+  if (Buffer.byteLength(sharedSecret, "utf8") < MIN_RUST_SHARED_SECRET_BYTES) {
+    throw new Error(
+      `CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET must be at least ${MIN_RUST_SHARED_SECRET_BYTES} bytes for Rust runtime health`,
+    );
+  }
+  const tenantBytes = Buffer.from(tenant, "utf8");
+  const tenantLength = Buffer.alloc(8);
+  tenantLength.writeBigUInt64BE(BigInt(tenantBytes.length));
+  const token = createHmac("sha256", sharedSecret)
+    .update(RUST_TENANT_AUTH_CONTEXT)
+    .update(tenantLength)
+    .update(tenantBytes)
+    .digest("hex");
+  return {
+    Authorization: `Bearer ${token}`,
+    "X-Cerebro-Tenant": tenant,
+  };
+};
+
+const isRustRuntimeHealthPath = (path: string) =>
+  normalizeProxyPath(path) === RUST_RUNTIME_HEALTH_PATH;
 
 const forwardRequestAuth =
   parseBooleanEnv(process.env.CEREBRO_FORWARD_AUTH_HEADERS) ??
@@ -112,9 +158,14 @@ export const rustOwnsWebAuthority = () =>
   process.env.CEREBRO_AUTHORITY_MODE?.trim().toLowerCase() === "rust";
 
 export const buildCerebroUrl = (path: string, search = "") => {
-  const base = new URL(API_BASE.endsWith("/") ? API_BASE : `${API_BASE}/`);
+  const normalizedPath = normalizeProxyPath(path);
+  const rustPlatformBase = configuredRustPlatformApiBase();
+  const apiBase = rustPlatformBase && normalizedPath === RUST_RUNTIME_HEALTH_PATH
+    ? rustPlatformBase
+    : API_BASE;
+  const base = new URL(apiBase.endsWith("/") ? apiBase : `${apiBase}/`);
   const basePath = base.pathname.endsWith("/") ? base.pathname.slice(0, -1) : base.pathname;
-  const pathSegments = normalizeProxyPath(path)
+  const pathSegments = normalizedPath
     .split("/")
     .filter(Boolean)
     .map((segment) => encodeURIComponent(segment));
@@ -125,6 +176,15 @@ export const buildCerebroUrl = (path: string, search = "") => {
 
 export const authHeadersFor = (request: NextRequest, upstreamPath = ""): HeadersInit => {
   const headers: Record<string, string> = { Accept: "application/json, text/plain;q=0.9, */*;q=0.8" };
+  if (configuredRustPlatformApiBase() && isRustRuntimeHealthPath(upstreamPath)) {
+    return {
+      ...headers,
+      ...rustTenantAuthHeaders(
+        process.env.CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID ?? "",
+        process.env.CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET ?? "",
+      ),
+    };
+  }
   const requestApiKey =
     request.headers.get("x-cerebro-api-key") ?? request.headers.get("x-api-key");
   const requestAuthorization = request.headers.get("authorization");

--- a/crates/source-runtime-next/src/asana.rs
+++ b/crates/source-runtime-next/src/asana.rs
@@ -13,7 +13,10 @@ mod origin;
 mod projection;
 mod request;
 mod response;
+mod source_execution;
 mod types;
+
+pub(crate) use source_execution::ASANA_SOURCE_EXECUTION_ADAPTERS;
 
 pub use catalog::{AsanaEventContract, AsanaRuntimeDefinition};
 pub use error::AsanaError;

--- a/crates/source-runtime-next/src/asana/normalize.rs
+++ b/crates/source-runtime-next/src/asana/normalize.rs
@@ -39,19 +39,9 @@ pub(super) fn normalize(
     {
         return Err(AsanaError::EventContractRejection);
     }
-    let digest = Sha256::digest(format!(
-        "{}\0{}\0{}",
-        kernel.tenant_id,
-        kernel.family.as_str(),
-        provider_id
-    ));
-    let suffix = digest[..10]
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect::<String>();
     Ok(AsanaRecord {
         tenant_id: kernel.tenant_id.clone(),
-        event_id: format!("asana-{}-{suffix}", kernel.family.as_str()),
+        event_id: event_id(&kernel.tenant_id, kernel.family, &provider_id),
         provider_id,
         family: kernel.family,
         kind: kernel.family.event_kind().to_owned(),
@@ -60,6 +50,15 @@ pub(super) fn normalize(
         attributes,
         payload,
     })
+}
+
+pub(super) fn event_id(tenant_id: &str, family: AsanaFamily, provider_id: &str) -> String {
+    let digest = Sha256::digest(format!("{tenant_id}\0{}\0{provider_id}", family.as_str()));
+    let suffix = digest[..10]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!("asana-{}-{suffix}", family.as_str())
 }
 
 fn normalize_user(

--- a/crates/source-runtime-next/src/asana/source_execution.rs
+++ b/crates/source-runtime-next/src/asana/source_execution.rs
@@ -1,0 +1,438 @@
+//! Asana family bridges into the closed source-execution dispatcher.
+//!
+//! The adapters consume authenticated tenant context, public configuration,
+//! and bounded provider response bytes. The trusted Go host retains credential
+//! redemption, Bearer authentication, network I/O, durable append, projection,
+//! and checkpoint ownership.
+
+use std::collections::HashMap;
+
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceExecutionPlanV1,
+    SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1,
+    SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2, SourceWorkerHttpRequestV1,
+    SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1, SourceWorkerRecordV1,
+    SourceWorkerRuntimeMetadataV2, canonical_http_execution_digest, canonical_plan_digest,
+    canonical_request_intent_digest, canonical_result_digest, validate_and_deduplicate_records,
+    validate_execution_context, validate_runtime_metadata,
+};
+
+use super::{
+    AsanaError, AsanaFamily, AsanaKernel, AsanaRuntimeDefinition, normalize::event_id,
+    origin::validate_origin, request::MAX_RESPONSE_BYTES,
+};
+
+const SOURCE_ID: &str = "asana";
+const DEFAULT_BASE_URL: &str = "https://app.asana.com/api/1.0";
+const METHOD: &str = "GET";
+const RECORD_SELECTOR: &str = "$.data[*]";
+const ID_FIELD: &str = "gid";
+
+/// Credential-free adapter for one closed Asana family.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AsanaSourceExecutionAdapter {
+    family: AsanaFamily,
+}
+
+impl AsanaSourceExecutionAdapter {
+    const fn new(family: AsanaFamily) -> Self {
+        Self { family }
+    }
+
+    pub(crate) const fn family(&self) -> AsanaFamily {
+        self.family
+    }
+
+    pub(crate) fn compiled_plan(&self) -> Result<SourceExecutionPlanV1, SourceExecutionError> {
+        let definition = AsanaRuntimeDefinition::compile(self.family).map_err(map_error)?;
+        let contract = definition.event_contract;
+        let mut plan = SourceExecutionPlanV1 {
+            plan_id: format!("source-plan-v1:asana:{}", self.family.as_str()),
+            source_id: SOURCE_ID.to_owned(),
+            family_id: self.family.as_str().to_owned(),
+            provider_kernel: self.family.event_kind().to_owned(),
+            method: METHOD.to_owned(),
+            origin: DEFAULT_BASE_URL.to_owned(),
+            path: family_path(self.family, "{workspace_gid}"),
+            record_selector: RECORD_SELECTOR.to_owned(),
+            id_field: ID_FIELD.to_owned(),
+            singleton_fallback_id: String::new(),
+            max_response_bytes: MAX_RESPONSE_BYTES as u64,
+            event_kind: contract.kind.to_owned(),
+            schema_ref: contract.schema_ref.to_owned(),
+            required_attributes: contract
+                .required_attributes
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
+            required_payload_fields: contract
+                .required_payload_fields
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
+            plan_digest_sha256: String::new(),
+        };
+        plan.plan_digest_sha256 = canonical_plan_digest(&plan);
+        Ok(plan)
+    }
+
+    fn validate_plan(&self, plan: &SourceExecutionPlanV1) -> Result<(), SourceExecutionError> {
+        if plan != &self.compiled_plan()? {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        Ok(())
+    }
+
+    fn kernel(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(AsanaKernel, String), SourceExecutionError> {
+        validate_execution_context(context)?;
+        validate_runtime_metadata(metadata)?;
+        if public_value(&metadata.public_config, "family")
+            .is_some_and(|value| value != self.family.as_str())
+        {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        let base_url =
+            public_value(&metadata.public_config, "base_url").unwrap_or(DEFAULT_BASE_URL);
+        let normalized = validate_origin(base_url).map_err(map_error)?;
+        let allowed_origin = normalized.to_string().trim_end_matches('/').to_owned();
+        let workspace_gid = public_value(&metadata.public_config, "workspace_gid")
+            .ok_or(SourceExecutionError::MissingConfiguration)?;
+        let page_size = public_value(&metadata.public_config, "page_size")
+            .map(|value| {
+                value
+                    .parse::<usize>()
+                    .map_err(|_| SourceExecutionError::MissingConfiguration)
+            })
+            .transpose()?;
+        let kernel = AsanaKernel::new(
+            base_url,
+            &context.tenant_id,
+            workspace_gid,
+            self.family,
+            page_size,
+        )
+        .map_err(map_error)?;
+        Ok((kernel, allowed_origin))
+    }
+
+    fn validate_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+    ) -> Result<(), SourceExecutionError> {
+        let expected = event_id(&context.tenant_id, self.family, &record.provider_id);
+        if record.event_id != expected
+            || record.attributes.get("tenant_id") != Some(&context.tenant_id)
+            || record.attributes.get("source_event_id") != Some(&record.provider_id)
+            || (self.family == AsanaFamily::Users
+                && record.attributes.get("user_id") != Some(&record.provider_id))
+            || (self.family == AsanaFamily::Projects
+                && record.attributes.get("resource_id") != Some(&record.provider_id))
+        {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        Ok(())
+    }
+}
+
+impl SourceExecutionAdapter for AsanaSourceExecutionAdapter {
+    fn source_id(&self) -> &'static str {
+        SOURCE_ID
+    }
+
+    fn family_id(&self) -> &'static str {
+        self.family.as_str()
+    }
+
+    fn provider_kernel(&self) -> &'static str {
+        self.family.event_kind()
+    }
+
+    fn validate_record_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+    ) -> Result<(), SourceExecutionError> {
+        self.validate_identity(context, record)
+    }
+
+    fn plan(
+        &self,
+        _request: &SourceWorkerPlanRequestV1,
+    ) -> Result<SourceWorkerHttpRequestV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn plan_v2(
+        &self,
+        envelope: &SourceWorkerPlanEnvelopeV2,
+    ) -> Result<SourceWorkerHttpExecutionV2, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, allowed_origin) = self.kernel(context, metadata)?;
+        let provider_request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        if provider_request.url().path()
+            != family_path(
+                self.family,
+                public_value(&metadata.public_config, "workspace_gid").unwrap_or_default(),
+            )
+            || provider_request.method() != plan.method
+            || provider_request.authorization_header() != "Authorization"
+            || provider_request.authorization_scheme() != "Bearer"
+            || provider_request.contains_credentials()
+            || provider_request.allows_redirects()
+        {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        let mut planned = SourceWorkerHttpRequestV1 {
+            plan_id: plan.plan_id.clone(),
+            method: provider_request.method().to_owned(),
+            url: provider_request.url().to_string(),
+            accept: provider_request.accept().to_owned(),
+            max_response_bytes: u64::try_from(provider_request.max_response_bytes())
+                .map_err(|_| SourceExecutionError::InvalidPlan)?,
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            request_intent_digest: String::new(),
+        };
+        planned.request_intent_digest = canonical_request_intent_digest(plan, context, &planned);
+        let mut execution = SourceWorkerHttpExecutionV2 {
+            request: Some(planned),
+            body: Vec::new(),
+            declared_headers: HashMap::new(),
+            execution_intent_digest_sha256: String::new(),
+            credential_operation: "source.bearer".to_owned(),
+            allowed_origin,
+        };
+        execution.execution_intent_digest_sha256 =
+            canonical_http_execution_digest(plan, context, metadata, &execution);
+        Ok(execution)
+    }
+
+    fn decode(
+        &self,
+        _request: &SourceWorkerDecodeRequestV1,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn decode_v2(
+        &self,
+        envelope: &SourceWorkerDecodeEnvelopeV2,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let receipt = request
+            .receipt
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, _) = self.kernel(context, metadata)?;
+        let provider_request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        let retry_after_seconds = response_header(&envelope.response_headers, "retry-after")
+            .map(|value| {
+                value
+                    .parse::<u64>()
+                    .map_err(|_| SourceExecutionError::UnexpectedProviderStatus)
+            })
+            .transpose()?;
+        let status = u16::try_from(request.status_code)
+            .map_err(|_| SourceExecutionError::UnexpectedProviderStatus)?;
+        let observed_at = timestamp(context.observed_at_unix_millis)?;
+        let page = kernel
+            .decode_http(
+                &provider_request,
+                status,
+                retry_after_seconds,
+                &request.response_body,
+                &observed_at,
+            )
+            .map_err(map_error)?;
+        let checkpoint = kernel
+            .checkpoint_candidate(
+                &provider_request,
+                &page,
+                optional_watermark(metadata)?.as_deref(),
+            )
+            .map_err(map_error)?;
+        let next_cursor = checkpoint.cursor.unwrap_or_default();
+        let records = page
+            .records
+            .into_iter()
+            .map(|record| {
+                if record.tenant_id != context.tenant_id
+                    || record.family != self.family
+                    || record.kind != plan.event_kind
+                    || record.schema_ref != plan.schema_ref
+                {
+                    return Err(SourceExecutionError::TenantMismatch);
+                }
+                Ok(SourceWorkerRecordV1 {
+                    provider_id: record.provider_id,
+                    event_id: record.event_id,
+                    occurred_at_unix_millis: parse_timestamp(&record.occurred_at)?,
+                    attributes: record.attributes.into_iter().collect(),
+                    payload_json: serde_json::to_vec(&record.payload)
+                        .map_err(|_| SourceExecutionError::InternalRuntime)?,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let records = validate_and_deduplicate_records(records)?;
+        let result_digest_sha256 = canonical_result_digest(receipt, &next_cursor, &records)?;
+        Ok(SourceWorkerDecodeResultV1 {
+            plan_id: plan.plan_id.clone(),
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: request.request_intent_digest.clone(),
+            records,
+            next_cursor,
+            result_digest_sha256,
+            tenant_id: context.tenant_id.clone(),
+            runtime_id: context.runtime_id.clone(),
+            runtime_generation: context.runtime_generation,
+            lease_generation: context.lease_generation,
+            observed_at_unix_millis: context.observed_at_unix_millis,
+        })
+    }
+}
+
+pub(crate) static ASANA_SOURCE_EXECUTION_ADAPTERS: [AsanaSourceExecutionAdapter; 3] = [
+    AsanaSourceExecutionAdapter::new(AsanaFamily::Users),
+    AsanaSourceExecutionAdapter::new(AsanaFamily::Projects),
+    AsanaSourceExecutionAdapter::new(AsanaFamily::AuditEvents),
+];
+
+fn family_path(family: AsanaFamily, workspace_gid: &str) -> String {
+    match family {
+        AsanaFamily::Users => "/api/1.0/users".to_owned(),
+        AsanaFamily::Projects => "/api/1.0/projects".to_owned(),
+        AsanaFamily::AuditEvents => {
+            format!("/api/1.0/workspaces/{workspace_gid}/audit_log_events")
+        }
+    }
+}
+
+fn public_value<'a>(config: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    config
+        .get(key)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn response_header<'a>(headers: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    headers
+        .get(key)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn optional(value: &str) -> Option<&str> {
+    (!value.is_empty()).then_some(value)
+}
+
+fn optional_watermark(
+    metadata: &SourceWorkerRuntimeMetadataV2,
+) -> Result<Option<String>, SourceExecutionError> {
+    (metadata.prior_terminal_watermark_unix_millis > 0)
+        .then(|| timestamp(metadata.prior_terminal_watermark_unix_millis))
+        .transpose()
+}
+
+fn timestamp(unix_millis: i64) -> Result<String, SourceExecutionError> {
+    OffsetDateTime::from_unix_timestamp_nanos(i128::from(unix_millis) * 1_000_000)
+        .map_err(|_| SourceExecutionError::InvalidExecutionContext)?
+        .format(&Rfc3339)
+        .map_err(|_| SourceExecutionError::InternalRuntime)
+}
+
+fn parse_timestamp(value: &str) -> Result<i64, SourceExecutionError> {
+    let nanos = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| SourceExecutionError::InvalidProviderRecord)?
+        .unix_timestamp_nanos();
+    i64::try_from(nanos / 1_000_000).map_err(|_| SourceExecutionError::InvalidProviderRecord)
+}
+
+fn map_error(error: AsanaError) -> SourceExecutionError {
+    match error {
+        AsanaError::InvalidFamily => SourceExecutionError::UnknownAdapter,
+        AsanaError::MissingConfiguration(_)
+        | AsanaError::InvalidConfiguration(_)
+        | AsanaError::InvalidBaseUrl
+        | AsanaError::UnsafeOrigin => SourceExecutionError::MissingConfiguration,
+        AsanaError::InvalidTenantId => SourceExecutionError::InvalidExecutionContext,
+        AsanaError::MissingCredentialReference => SourceExecutionError::MissingCredentialReference,
+        AsanaError::CredentialUnavailable => SourceExecutionError::CredentialUnavailable,
+        AsanaError::InvalidCursor => SourceExecutionError::InvalidCursor,
+        AsanaError::RequestScopeMismatch => SourceExecutionError::InvalidPlan,
+        AsanaError::AuthenticationRejected => SourceExecutionError::AuthenticationRejected,
+        AsanaError::RequiredScopeMissing => SourceExecutionError::RequiredProviderScopeMissing,
+        AsanaError::EgressDenied => SourceExecutionError::EgressDenied,
+        AsanaError::DnsFailure | AsanaError::ConnectionFailure => {
+            SourceExecutionError::ConnectionFailure
+        }
+        AsanaError::ProviderTimeout => SourceExecutionError::ProviderTimeout,
+        AsanaError::RateLimited { .. } => SourceExecutionError::ProviderRateLimit,
+        AsanaError::ProviderUnavailable { .. }
+        | AsanaError::UnexpectedStatus { .. }
+        | AsanaError::InvalidRetryAfter => SourceExecutionError::UnexpectedProviderStatus,
+        AsanaError::ResponseTooLarge => SourceExecutionError::ResponseTooLarge,
+        AsanaError::TooManyRecords => SourceExecutionError::ResultTooLarge,
+        AsanaError::MalformedResponse => SourceExecutionError::MalformedResponse,
+        AsanaError::InvalidProviderRecord | AsanaError::CredentialMaterial => {
+            SourceExecutionError::InvalidProviderRecord
+        }
+        AsanaError::MissingStableIdentity => SourceExecutionError::MissingStableIdentity,
+        AsanaError::TenantMismatch => SourceExecutionError::TenantMismatch,
+        AsanaError::ConflictingDuplicate => SourceExecutionError::DuplicateConflict,
+        AsanaError::EventContractRejection => SourceExecutionError::EventContractRejected,
+        AsanaError::AppendFailure => SourceExecutionError::AppendFailed,
+        AsanaError::ProjectionFailure => SourceExecutionError::ProjectionFailed,
+        AsanaError::LeaseLoss => SourceExecutionError::LeaseLost,
+        AsanaError::StaleAuthority => SourceExecutionError::StaleAuthority,
+        AsanaError::InternalRuntimeFailure => SourceExecutionError::InternalRuntime,
+    }
+}
+
+#[cfg(test)]
+#[path = "source_execution_tests.rs"]
+mod tests;

--- a/crates/source-runtime-next/src/asana/source_execution.rs
+++ b/crates/source-runtime-next/src/asana/source_execution.rs
@@ -41,10 +41,6 @@ impl AsanaSourceExecutionAdapter {
         Self { family }
     }
 
-    pub(crate) const fn family(&self) -> AsanaFamily {
-        self.family
-    }
-
     pub(crate) fn compiled_plan(&self) -> Result<SourceExecutionPlanV1, SourceExecutionError> {
         let definition = AsanaRuntimeDefinition::compile(self.family).map_err(map_error)?;
         let contract = definition.event_contract;

--- a/crates/source-runtime-next/src/asana/source_execution.rs
+++ b/crates/source-runtime-next/src/asana/source_execution.rs
@@ -59,7 +59,8 @@ impl AsanaSourceExecutionAdapter {
             record_selector: RECORD_SELECTOR.to_owned(),
             id_field: ID_FIELD.to_owned(),
             singleton_fallback_id: String::new(),
-            max_response_bytes: MAX_RESPONSE_BYTES as u64,
+            max_response_bytes: u64::try_from(MAX_RESPONSE_BYTES)
+                .map_err(|_| SourceExecutionError::InvalidPlan)?,
             event_kind: contract.kind.to_owned(),
             schema_ref: contract.schema_ref.to_owned(),
             required_attributes: contract

--- a/crates/source-runtime-next/src/asana/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/asana/source_execution_tests.rs
@@ -1,0 +1,189 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::source_execution::{
+    SourceExecutionDispatcher, SourceExecutionError, SourceExecutionLifecycleEnvelopeV2,
+    SourceExecutionLifecycleRequestV1, SourceExecutionSelectionRequestV1,
+    SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1, SourceWorkerExecutionContextV1,
+    SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1, SourceWorkerRuntimeMetadataV2,
+    seal_page_program_v2,
+};
+
+use super::{ASANA_SOURCE_EXECUTION_ADAPTERS, AsanaFamily, DEFAULT_BASE_URL};
+
+const OBSERVED_AT_MILLIS: i64 = 1_780_272_000_000;
+
+fn context(cursor: &str, page: u32) -> SourceWorkerExecutionContextV1 {
+    SourceWorkerExecutionContextV1 {
+        tenant_id: "tenant".to_owned(),
+        runtime_id: "asana-runtime".to_owned(),
+        logical_page_id: format!("source-page-v2:asana-{page}"),
+        prior_cursor: cursor.to_owned(),
+        runtime_generation: 7,
+        lease_generation: 11,
+        observed_at_unix_millis: OBSERVED_AT_MILLIS,
+    }
+}
+
+fn metadata(family: AsanaFamily) -> SourceWorkerRuntimeMetadataV2 {
+    SourceWorkerRuntimeMetadataV2 {
+        public_config: HashMap::from([
+            ("family".to_owned(), family.as_str().to_owned()),
+            ("workspace_gid".to_owned(), "workspace-1".to_owned()),
+            ("page_size".to_owned(), "2".to_owned()),
+        ]),
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    }
+}
+
+#[test]
+fn closed_dispatcher_compiles_every_asana_family() {
+    let dispatcher = SourceExecutionDispatcher;
+    assert_eq!(
+        ASANA_SOURCE_EXECUTION_ADAPTERS.len(),
+        AsanaFamily::ALL.len()
+    );
+    for adapter in &ASANA_SOURCE_EXECUTION_ADAPTERS {
+        let family = adapter.family();
+        let plan = dispatcher
+            .compile_plan(&SourceExecutionSelectionRequestV1 {
+                source_id: "asana".to_owned(),
+                family_id: family.as_str().to_owned(),
+            })
+            .unwrap();
+        assert_eq!(plan, adapter.compiled_plan().unwrap());
+        assert_eq!(plan.provider_kernel, family.event_kind());
+        assert_eq!(plan.origin, DEFAULT_BASE_URL);
+        assert_eq!(plan.record_selector, "$.data[*]");
+        assert_eq!(plan.id_field, "gid");
+        assert_eq!(plan.event_kind, family.event_kind());
+        assert_eq!(plan.schema_ref, family.schema_ref());
+    }
+    assert_eq!(
+        dispatcher.compile_plan(&SourceExecutionSelectionRequestV1 {
+            source_id: "asana".to_owned(),
+            family_id: "tasks".to_owned(),
+        }),
+        Err(SourceExecutionError::UnknownAdapter)
+    );
+}
+
+#[test]
+fn plans_all_families_without_credentials_and_requires_workspace_scope() {
+    let dispatcher = SourceExecutionDispatcher;
+    for adapter in &ASANA_SOURCE_EXECUTION_ADAPTERS {
+        let family = adapter.family();
+        let plan = adapter.compiled_plan().unwrap();
+        let execution = dispatcher
+            .dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+                request: Some(SourceWorkerPlanRequestV1 {
+                    plan: Some(plan),
+                    context: Some(context("", 1)),
+                }),
+                metadata: Some(metadata(family)),
+            })
+            .unwrap();
+        assert_eq!(execution.credential_operation, "source.bearer");
+        assert_eq!(execution.allowed_origin, DEFAULT_BASE_URL);
+        assert!(execution.body.is_empty());
+        assert!(execution.declared_headers.is_empty());
+        let request = execution.request.unwrap();
+        assert_eq!(request.method, "GET");
+        assert!(request.url.starts_with(DEFAULT_BASE_URL));
+        assert!(request.url.contains("limit=2"));
+        assert!(!request.url.contains("token"));
+        match family {
+            AsanaFamily::Users | AsanaFamily::Projects => {
+                assert!(request.url.contains("workspace=workspace-1"));
+            }
+            AsanaFamily::AuditEvents => {
+                assert!(
+                    request
+                        .url
+                        .contains("/workspaces/workspace-1/audit_log_events?")
+                );
+            }
+        }
+    }
+
+    let adapter = &ASANA_SOURCE_EXECUTION_ADAPTERS[0];
+    let mut missing = metadata(adapter.family());
+    missing.public_config.remove("workspace_gid");
+    assert_eq!(
+        dispatcher.dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(adapter.compiled_plan().unwrap()),
+                context: Some(context("", 1)),
+            }),
+            metadata: Some(missing),
+        }),
+        Err(SourceExecutionError::MissingConfiguration)
+    );
+}
+
+#[test]
+fn users_page_decodes_and_seals_a_restartable_cursor() {
+    let dispatcher = SourceExecutionDispatcher;
+    let family = AsanaFamily::Users;
+    let plan = dispatcher
+        .compile_plan(&SourceExecutionSelectionRequestV1 {
+            source_id: "asana".to_owned(),
+            family_id: family.as_str().to_owned(),
+        })
+        .unwrap();
+    let context = context("", 1);
+    let metadata = metadata(family);
+    let execution = dispatcher
+        .dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+        })
+        .unwrap();
+    let request = execution.request.as_ref().unwrap();
+    let output = dispatcher
+        .dispatch_decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+            request: Some(SourceWorkerDecodeRequestV1 {
+                plan: Some(plan.clone()),
+                status_code: 200,
+                response_body: br#"{"data":[{"gid":"user-1","name":"User One","email":"user@example.test"}],"next_page":{"offset":"cursor-2"}}"#.to_vec(),
+                logical_page_id: context.logical_page_id.clone(),
+                request_intent_digest: request.request_intent_digest.clone(),
+                receipt: None,
+                context: Some(context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+            response_headers: HashMap::new(),
+            response_headers_sha256: String::new(),
+            execution_intent_digest_sha256: execution.execution_intent_digest_sha256.clone(),
+        })
+        .unwrap();
+    let result = output.result.as_ref().unwrap();
+    assert_eq!(result.next_cursor, "cursor-2");
+    assert_eq!(result.records.len(), 1);
+    let record = &result.records[0];
+    assert_eq!(record.provider_id, "user-1");
+    assert_eq!(record.attributes["tenant_id"], "tenant");
+    assert_eq!(record.attributes["user_id"], "user-1");
+    let payload: Value = serde_json::from_slice(&record.payload_json).unwrap();
+    assert_eq!(payload["gid"], "user-1");
+    assert!(!record.event_id.contains("tenant"));
+
+    let decision = seal_page_program_v2(&SourceExecutionLifecycleEnvelopeV2 {
+        request: Some(SourceExecutionLifecycleRequestV1 {
+            plan: Some(plan),
+            context: Some(context),
+            receipt: output.receipt,
+            result: output.result,
+            current_lease_generation: 11,
+        }),
+        metadata: Some(metadata),
+    })
+    .unwrap();
+    assert_eq!(decision.checkpoint_cursor, "cursor-2");
+    assert_eq!(decision.admitted_records.len(), 1);
+}

--- a/crates/source-runtime-next/src/asana/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/asana/source_execution_tests.rs
@@ -46,7 +46,7 @@ fn closed_dispatcher_compiles_every_asana_family() {
         AsanaFamily::ALL.len()
     );
     for adapter in &ASANA_SOURCE_EXECUTION_ADAPTERS {
-        let family = adapter.family();
+        let family = adapter.family;
         let plan = dispatcher
             .compile_plan(&SourceExecutionSelectionRequestV1 {
                 source_id: "asana".to_owned(),
@@ -74,7 +74,7 @@ fn closed_dispatcher_compiles_every_asana_family() {
 fn plans_all_families_without_credentials_and_requires_workspace_scope() {
     let dispatcher = SourceExecutionDispatcher;
     for adapter in &ASANA_SOURCE_EXECUTION_ADAPTERS {
-        let family = adapter.family();
+        let family = adapter.family;
         let plan = adapter.compiled_plan().unwrap();
         let execution = dispatcher
             .dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {
@@ -109,7 +109,7 @@ fn plans_all_families_without_credentials_and_requires_workspace_scope() {
     }
 
     let adapter = &ASANA_SOURCE_EXECUTION_ADAPTERS[0];
-    let mut missing = metadata(adapter.family());
+    let mut missing = metadata(adapter.family);
     missing.public_config.remove("workspace_gid");
     assert_eq!(
         dispatcher.dispatch_plan_v2(&SourceWorkerPlanEnvelopeV2 {

--- a/crates/source-runtime-next/src/source_execution/dispatcher.rs
+++ b/crates/source-runtime-next/src/source_execution/dispatcher.rs
@@ -1,5 +1,6 @@
 use prost::Message;
 
+use crate::asana::ASANA_SOURCE_EXECUTION_ADAPTERS;
 use crate::digitalocean::DIGITALOCEAN_DROPLETS_SOURCE_EXECUTION_ADAPTER;
 use crate::linode::LINODE_ISSUE_SOURCE_EXECUTION_ADAPTER;
 use crate::pagerduty::PAGERDUTY_USER_SOURCE_EXECUTION_ADAPTER;
@@ -127,6 +128,11 @@ impl SourceExecutionDispatcher {
         &self,
         request: &SourceExecutionSelectionRequestV1,
     ) -> Result<SourceExecutionPlanV1, SourceExecutionError> {
+        if let Some(adapter) = ASANA_SOURCE_EXECUTION_ADAPTERS.iter().find(|adapter| {
+            request.source_id == adapter.source_id() && request.family_id == adapter.family_id()
+        }) {
+            return adapter.compiled_plan();
+        }
         if request.source_id == AZURE_AUTHORIZATION_POLICY.source_id()
             && request.family_id == AZURE_AUTHORIZATION_POLICY.family_id()
         {
@@ -198,6 +204,13 @@ impl SourceExecutionDispatcher {
         &self,
         plan: &SourceExecutionPlanV1,
     ) -> Result<&'static dyn SourceExecutionAdapter, SourceExecutionError> {
+        if let Some(adapter) = ASANA_SOURCE_EXECUTION_ADAPTERS.iter().find(|adapter| {
+            plan.source_id == adapter.source_id()
+                && plan.family_id == adapter.family_id()
+                && plan.provider_kernel == adapter.provider_kernel()
+        }) {
+            return Ok(adapter);
+        }
         if plan.source_id == AZURE_AUTHORIZATION_POLICY.source_id()
             && plan.family_id == AZURE_AUTHORIZATION_POLICY.family_id()
             && plan.provider_kernel == AZURE_AUTHORIZATION_POLICY.provider_kernel()


### PR DESCRIPTION
## Scope

- register credential-free Rust source-execution adapters for Asana `users`, `projects`, and `audit_events`
- compile exact catalog event contracts, base-path-restricted request plans, bounded pagination, and tenant-scoped identities
- decode bounded provider responses, classify typed failures, deduplicate records, and propose restartable cursors
- require public `workspace_gid` configuration before any family can plan a request

## Stack and authority boundary

- stacked on #2561 so the shared dispatcher changes remain linear
- Go remains production authority for every Asana family in this pull request
- the trusted Go host retains credential redemption, Bearer authentication, network I/O, durable append, projection, lease fencing, and checkpoint persistence
- later exact-family authority changes must add the trusted-host public-config mapping and prove fail-closed behavior independently

## Local validation

- `rustfmt --edition 2024 --check` on every changed Rust file
- `go test ./internal/sourceruntime/sourceworker ./tools/archtests -count=1`
- `make check-structural check-structural-test check-arch`
- `git diff --check`

The managed Cargo wrapper blocked `cargo test -p cerebro-source-runtime-next asana::source_execution` before compilation because safe DDESK capacity was short by 11,563,362,918 bytes. Hosted checks are required to supply the exact-head Rust compile, test, and Clippy receipt; no unmanaged Cargo path or checkout-local target was used.

## Review state

- draft until exact-head hosted checks are terminal
- no human reviewers assigned
