### PR TITLE
Back vendor register with Rust graph data

### DIFF
--- a/apps/web/scripts/rust-product-demo.mjs
+++ b/apps/web/scripts/rust-product-demo.mjs
@@ -11,7 +11,7 @@ import { fileURLToPath } from "node:url";
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const webRoot = path.resolve(scriptDir, "..");
 const repositoryRoot = path.resolve(webRoot, "..", "..");
-const defaultTimeoutMs = 10 * 60_000;
+const defaultTimeoutMs = 20 * 60_000;
 const tenantID = "tenant-demo";
 const tenantAuthContext = Buffer.from(
   "cerebro-organizational-graph/tenant/v1\0",
@@ -423,6 +423,70 @@ async function browserProof(webBase, rootURN, expectedProof, workDir, deadlineAt
   }
 }
 
+async function vendorBrowserProof(webBase, workDir, deadlineAt) {
+  const { chromium } = await import("@playwright/test");
+  let browser;
+  try {
+    browser = await withDeadline(
+      chromium.launch({ headless: true }),
+      deadlineAt,
+      "Chromium launch",
+    );
+  } catch (error) {
+    if (!String(error?.message).includes("Executable doesn't exist")) throw error;
+    browser = await withDeadline(
+      chromium.launch({ channel: "chrome", headless: true }),
+      deadlineAt,
+      "installed Chrome launch",
+    );
+  }
+  try {
+    const page = await browser.newPage({ viewport: { height: 900, width: 1440 } });
+    const pageErrors = [];
+    page.on("pageerror", (error) => pageErrors.push(error));
+    const vendorsResponse = page.waitForResponse(
+      (candidate) => new URL(candidate.url()).pathname === "/api/cerebro/grc/vendors",
+      { timeout: Math.min(30_000, remaining(deadlineAt, "vendor browser request")) },
+    );
+    const navigation = await page.goto(`${webBase}/vendors?tenant_id=${tenantID}`, {
+      timeout: Math.min(30_000, remaining(deadlineAt, "vendor navigation")),
+      waitUntil: "domcontentloaded",
+    });
+    expect(navigation?.status() === 200, `Vendor page returned ${navigation?.status()}`);
+    const response = await vendorsResponse;
+    expect(response.status() === 200, `Vendor browser query returned ${response.status()}`);
+    expect(response.headers()["x-cerebro-fixture"] !== "true", "Vendor browser query used fixture data");
+    const payload = await response.json();
+    expect(payload.data_authority === "rust_graph", "Vendor response did not report Rust graph authority");
+    expect(
+      Number.isSafeInteger(payload.graph_revision) && payload.graph_revision > 0,
+      "Vendor response did not report a positive graph revision",
+    );
+    expect(payload.vendors?.length === 2, `Vendor response returned ${payload.vendors?.length ?? 0} rows; expected 2`);
+    await page.getByText("Identity Platform", { exact: true }).first().waitFor({
+      state: "visible",
+      timeout: Math.min(30_000, remaining(deadlineAt, "vendor row rendering")),
+    });
+    await page.getByText(`Rust graph revision ${payload.graph_revision}`, { exact: false }).waitFor({
+      state: "visible",
+      timeout: Math.min(30_000, remaining(deadlineAt, "vendor authority rendering")),
+    });
+    expect(pageErrors.length === 0, `Vendor page raised ${pageErrors[0]?.message}`);
+    const screenshot = path.join(workDir, "rust-product-vendors.png");
+    await page.screenshot({ fullPage: true, path: screenshot });
+    return {
+      endpoint_status: 200,
+      data_authority: payload.data_authority,
+      graph_revision: payload.graph_revision,
+      vendor_count: payload.vendors.length,
+      fixture_header: response.headers()["x-cerebro-fixture"] ?? "absent",
+      screenshot: path.basename(screenshot),
+    };
+  } finally {
+    await browser.close();
+  }
+}
+
 function waitForOperatorShutdown(children) {
   return new Promise((resolve, reject) => {
     const childListeners = new Map();
@@ -468,21 +532,37 @@ export async function runRustProductDemo(options = {}) {
   const processes = [];
   let failed = true;
   try {
-    const [rustPort, webPort] = await Promise.all([
+    const [rustPort, apiPort, webPort] = await Promise.all([
+      reserveLoopbackPort(),
       reserveLoopbackPort(),
       reserveLoopbackPort(),
     ]);
-    expect(rustPort !== webPort, "Reserved ports collided");
+    expect(new Set([rustPort, apiPort, webPort]).size === 3, "Reserved ports collided");
 
     const rustBinary = await cargoBinary(deadlineAt);
+    const eventAdmissionBinary = path.join(
+      path.dirname(rustBinary),
+      process.platform === "win32"
+        ? "cerebro-event-admission-worker.exe"
+        : "cerebro-event-admission-worker",
+    );
     await run(
       "cargo",
-      ["build", "--locked", "-p", "cerebro-platform"],
+      [
+        "build", "--locked",
+        "-p", "cerebro-platform",
+        "-p", "cerebro-sourceruntime-eventadmission",
+        "--bin", "cerebro-platform",
+        "--bin", "cerebro-event-admission-worker",
+      ],
       { cwd: repositoryRoot },
       deadlineAt,
     );
     await access(rustBinary).catch(() => {
       throw new Error(`Cargo did not produce the Rust platform binary at ${rustBinary}`);
+    });
+    await access(eventAdmissionBinary).catch(() => {
+      throw new Error(`Cargo did not produce the event admission binary at ${eventAdmissionBinary}`);
     });
     const { neighborhood, rootURN } = parseDemoNeighborhood(
       await run(
@@ -517,6 +597,43 @@ export async function runRustProductDemo(options = {}) {
       deadlineAt,
     );
 
+    const apiBinary = path.join(
+      workDir,
+      process.platform === "win32" ? "cerebro-demo-api.exe" : "cerebro-demo-api",
+    );
+    await run(
+      "go",
+      ["build", "-o", apiBinary, "./cmd/cerebro"],
+      { cwd: repositoryRoot },
+      deadlineAt,
+    );
+    const api = startLogged(
+      "go-api-adapter",
+      apiBinary,
+      ["serve"],
+      {
+        cwd: repositoryRoot,
+        env: portableEnvironment(process.env, {
+          CEREBRO_DEV_MODE: "1",
+          CEREBRO_DEV_MODE_ACK: "1",
+          CEREBRO_EVENT_ADMISSION_WORKER: eventAdmissionBinary,
+          CEREBRO_HTTP_ADDR: `127.0.0.1:${apiPort}`,
+          CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE: "authority",
+          CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL: `http://127.0.0.1:${rustPort}`,
+          CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET: sharedSecret,
+          CEREBRO_ORGANIZATIONAL_GRAPH_TIMEOUT: "30s",
+        }),
+      },
+      logDir,
+    );
+    processes.push(api);
+    await waitFor(
+      "Go product adapter",
+      async () => (await request(`http://127.0.0.1:${apiPort}/healthz`)).status === 200,
+      api,
+      deadlineAt,
+    );
+
     const graphQuery = `/platform/graph/neighborhood?root_urn=${encodeURIComponent(rootURN)}&limit=50`;
     const directGraphResponse = await request(
       `http://127.0.0.1:${rustPort}${graphQuery}`,
@@ -541,8 +658,7 @@ export async function runRustProductDemo(options = {}) {
       {
         cwd: webRoot,
         env: portableEnvironment(process.env, {
-          CEREBRO_API_BASE: `http://127.0.0.1:${rustPort}`,
-          CEREBRO_AUTHORIZATION: `Bearer ${bearer}`,
+          CEREBRO_API_BASE: `http://127.0.0.1:${apiPort}`,
           CEREBRO_FORWARD_AUTH_HEADERS: "false",
           CEREBRO_IDENTITY_REQUIRED: "false",
           CEREBRO_LOCAL_IDENTITY_FALLBACK: "true",
@@ -570,14 +686,16 @@ export async function runRustProductDemo(options = {}) {
     expect(proxiedGraph.root?.urn === rootURN, "Web proxy returned another graph root");
 
     const graphURL = `${webBase}/explore?root_urn=${encodeURIComponent(rootURN)}`;
+    const vendorsURL = `${webBase}/vendors?tenant_id=${tenantID}`;
     if (!options.check) {
       console.log(`[demo:rust] Graph explorer: ${graphURL}`);
+      console.log(`[demo:rust] Vendor register: ${vendorsURL}`);
       console.log("[demo:rust] Authority: Rust in-memory organizational graph");
       console.log("[demo:rust] Provider credentials: not required");
       console.log("[demo:rust] Press Ctrl-C to stop the Rust and web processes.");
       await waitForOperatorShutdown(processes);
       failed = false;
-      return { graphURL, workDir };
+      return { graphURL, vendorsURL, workDir };
     }
 
     const browser = await browserProof(
@@ -587,6 +705,7 @@ export async function runRustProductDemo(options = {}) {
       workDir,
       deadlineAt,
     );
+    const vendors = await vendorBrowserProof(webBase, workDir, deadlineAt);
     const revision = (
       process.env.GITHUB_SHA?.trim() ||
       (
@@ -608,6 +727,7 @@ export async function runRustProductDemo(options = {}) {
         command: "cerebro-platform serve-demo",
         graph_authority: "rust",
         persistence: "memory",
+        product_adapter: "go_http",
       },
       authentication: {
         kind: "ephemeral_hmac",
@@ -617,6 +737,7 @@ export async function runRustProductDemo(options = {}) {
       },
       contract: {
         path: "/platform/graph/neighborhood",
+        vendor_path: "/grc/vendors",
         root_urn: rootURN,
         tenant_selected_by_browser: false,
       },
@@ -624,6 +745,7 @@ export async function runRustProductDemo(options = {}) {
         direct_rust_status: 200,
         web_proxy_status: 200,
         browser,
+        vendors,
       },
     };
     await mkdir(path.dirname(receiptPath), { recursive: true });

--- a/apps/web/scripts/rust-product-demo.mjs
+++ b/apps/web/scripts/rust-product-demo.mjs
@@ -12,6 +12,7 @@ const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const webRoot = path.resolve(scriptDir, "..");
 const repositoryRoot = path.resolve(webRoot, "..", "..");
 const defaultTimeoutMs = 20 * 60_000;
+const browserStepTimeoutMs = 60_000;
 const tenantID = "tenant-demo";
 const tenantAuthContext = Buffer.from(
   "cerebro-organizational-graph/tenant/v1\0",
@@ -366,12 +367,12 @@ async function browserProof(webBase, rootURN, expectedProof, workDir, deadlineAt
       (candidate) =>
         new URL(candidate.url()).pathname ===
         "/api/cerebro/platform/graph/neighborhood",
-      { timeout: Math.min(30_000, remaining(deadlineAt, "graph browser request")) },
+      { timeout: Math.min(browserStepTimeoutMs, remaining(deadlineAt, "graph browser request")) },
     );
     const navigation = await page.goto(
       `${webBase}/explore?root_urn=${encodeURIComponent(rootURN)}`,
       {
-        timeout: Math.min(30_000, remaining(deadlineAt, "graph navigation")),
+        timeout: Math.min(browserStepTimeoutMs, remaining(deadlineAt, "graph navigation")),
         waitUntil: "domcontentloaded",
       },
     );
@@ -397,11 +398,11 @@ async function browserProof(webBase, rootURN, expectedProof, workDir, deadlineAt
       name: `Impact graph with ${expectedProof.node_count} nodes and ${expectedProof.relation_count} edges`,
     }).waitFor({
       state: "visible",
-      timeout: Math.min(30_000, remaining(deadlineAt, "graph rendering")),
+      timeout: Math.min(browserStepTimeoutMs, remaining(deadlineAt, "graph rendering")),
     });
     await page.getByText(expectedProof.root_label, { exact: true }).first().waitFor({
       state: "visible",
-      timeout: Math.min(30_000, remaining(deadlineAt, "graph root rendering")),
+      timeout: Math.min(browserStepTimeoutMs, remaining(deadlineAt, "graph root rendering")),
     });
     await page.getByRole("button", { name: "Fit", exact: true }).click();
     await page.waitForTimeout(250);
@@ -446,10 +447,10 @@ async function vendorBrowserProof(webBase, workDir, deadlineAt) {
     page.on("pageerror", (error) => pageErrors.push(error));
     const vendorsResponse = page.waitForResponse(
       (candidate) => new URL(candidate.url()).pathname === "/api/cerebro/grc/vendors",
-      { timeout: Math.min(30_000, remaining(deadlineAt, "vendor browser request")) },
+      { timeout: Math.min(browserStepTimeoutMs, remaining(deadlineAt, "vendor browser request")) },
     );
     const navigation = await page.goto(`${webBase}/vendors?tenant_id=${tenantID}`, {
-      timeout: Math.min(30_000, remaining(deadlineAt, "vendor navigation")),
+      timeout: Math.min(browserStepTimeoutMs, remaining(deadlineAt, "vendor navigation")),
       waitUntil: "domcontentloaded",
     });
     expect(navigation?.status() === 200, `Vendor page returned ${navigation?.status()}`);
@@ -465,11 +466,11 @@ async function vendorBrowserProof(webBase, workDir, deadlineAt) {
     expect(payload.vendors?.length === 2, `Vendor response returned ${payload.vendors?.length ?? 0} rows; expected 2`);
     await page.getByText("Identity Platform", { exact: true }).first().waitFor({
       state: "visible",
-      timeout: Math.min(30_000, remaining(deadlineAt, "vendor row rendering")),
+      timeout: Math.min(browserStepTimeoutMs, remaining(deadlineAt, "vendor row rendering")),
     });
     await page.getByText(`Rust graph revision ${payload.graph_revision}`, { exact: false }).waitFor({
       state: "visible",
-      timeout: Math.min(30_000, remaining(deadlineAt, "vendor authority rendering")),
+      timeout: Math.min(browserStepTimeoutMs, remaining(deadlineAt, "vendor authority rendering")),
     });
     expect(pageErrors.length === 0, `Vendor page raised ${pageErrors[0]?.message}`);
     const screenshot = path.join(workDir, "rust-product-vendors.png");

--- a/apps/web/src/app/vendors/page.tsx
+++ b/apps/web/src/app/vendors/page.tsx
@@ -1185,11 +1185,15 @@ function DiscoveryQueue({
 
 function VendorRegisterSection({
   assuranceItems,
+  dataAuthority,
+  graphRevision,
   meta,
   onOpenVendor,
   vendors,
 }: {
   assuranceItems: number;
+  dataAuthority?: GRCVendorsResponse["data_authority"];
+  graphRevision?: number;
   meta?: GRCVendorsResponse["meta"];
   onOpenVendor: (vendorURN: string) => void;
   vendors: GRCVendor[];
@@ -1274,10 +1278,15 @@ function VendorRegisterSection({
       ),
     },
   ], [onOpenVendor]);
+  const authorityLabel = dataAuthority === "rust_graph"
+    ? `Rust graph revision ${graphRevision?.toLocaleString() ?? "unknown"}`
+    : dataAuthority === "fixture"
+      ? "Local fixture data"
+      : "Data authority not reported";
   return (
     <WorklistTable
       title="Vendor status"
-      description={`${countLabel(vendors.length, "vendor")} in this view. ${assuranceItems.toLocaleString()} linked records.`}
+      description={`${countLabel(vendors.length, "vendor")} in this view. ${assuranceItems.toLocaleString()} linked records. ${authorityLabel}.`}
       rows={vendors}
       columns={vendorColumns}
       emptyMessage="No vendors match these filters."
@@ -2450,7 +2459,14 @@ export default function VendorsPage() {
       {activeSection === "register" && (vendorsQuery.loading && !vendorsQuery.data ? (
         <LoadingBlock label="Loading vendors..." />
       ) : (
-        <VendorRegisterSection assuranceItems={assuranceItems} meta={vendorMeta} onOpenVendor={openVendorDrawer} vendors={vendors} />
+        <VendorRegisterSection
+          assuranceItems={assuranceItems}
+          dataAuthority={vendorsQuery.data?.data_authority}
+          graphRevision={vendorsQuery.data?.graph_revision}
+          meta={vendorMeta}
+          onOpenVendor={openVendorDrawer}
+          vendors={vendors}
+        />
       ))}
     </main>
   );

--- a/apps/web/src/lib/cerebro-fixtures.test.ts
+++ b/apps/web/src/lib/cerebro-fixtures.test.ts
@@ -136,6 +136,8 @@ describe("cerebro fixture proxy responses", () => {
     expect(response?.status).toBe(200);
     expect(parseFixture(response!)).toMatchObject({
       summary: { total_vendors: 2, risk_queue_vendors: 1 },
+      data_authority: "fixture",
+      graph_revision: 0,
       vendors: [
         expect.objectContaining({ name: "Core SSO" }),
         expect.objectContaining({ name: "Payments Processor" }),

--- a/apps/web/src/lib/cerebro-fixtures.ts
+++ b/apps/web/src/lib/cerebro-fixtures.ts
@@ -4496,7 +4496,13 @@ export const cerebroFixtureResponseFor = ({
 
   if (normalizedPath === "grc/vendors") {
     const filteredVendors = filterVendors(searchParams);
-    return jsonFixture({ vendors: filteredVendors, summary: vendorSummary(filteredVendors), generated_at: generatedAt });
+    return jsonFixture({
+      vendors: filteredVendors,
+      summary: vendorSummary(filteredVendors),
+      data_authority: "fixture",
+      graph_revision: 0,
+      generated_at: generatedAt,
+    });
   }
 
   if (normalizedPath === "grc/questionnaire-runs") {

--- a/apps/web/src/lib/grc.ts
+++ b/apps/web/src/lib/grc.ts
@@ -1425,6 +1425,8 @@ export type GRCVendorsResponse = {
   summary?: GRCVendorSummary;
   meta?: GRCListMeta;
   vendors: GRCVendor[];
+  data_authority?: "rust_graph" | "fixture" | string;
+  graph_revision?: number;
   generated_at: string;
 };
 

--- a/crates/agent-context/src/lib.rs
+++ b/crates/agent-context/src/lib.rs
@@ -121,9 +121,10 @@ impl ContextEntity {
     /// Projects a domain entity into the bounded agent-facing representation.
     ///
     /// The stable agent key is also inserted as the `entity_urn` property. A
-    /// serialization failure for a domain kind or authority degrades only that
-    /// display projection to `provider` or JSON `null`; it does not change the
-    /// native entity identity.
+    /// validated `entity_type` presentation property preserves provider-specific
+    /// catalog kinds; otherwise the sealed domain kind is used. An authority
+    /// serialization failure degrades only that display projection to JSON
+    /// `null`; it does not change the native entity identity.
     pub fn from_domain(entity: &Entity) -> Self {
         let agent_key = entity.agent_key();
         let mut properties = entity.properties().clone();
@@ -131,10 +132,16 @@ impl ContextEntity {
         Self {
             entity_id: entity.id().clone(),
             agent_key,
-            entity_kind: serde_json::to_value(entity.kind())
-                .ok()
-                .and_then(|value| value.as_str().map(str::to_owned))
-                .unwrap_or_else(|| "provider".to_owned()),
+            entity_kind: entity
+                .properties()
+                .get("entity_type")
+                .filter(|value| {
+                    !value.is_empty()
+                        && value.trim() == value.as_str()
+                        && !value.chars().any(char::is_control)
+                })
+                .cloned()
+                .unwrap_or_else(|| entity.kind().as_str().to_owned()),
             authority: serde_json::to_value(entity.authority()).unwrap_or(serde_json::Value::Null),
             label: entity.label().to_owned(),
             properties,
@@ -1631,6 +1638,28 @@ mod tests {
             resolved.properties.get("entity_urn"),
             Some(&resolved.agent_key)
         );
+    }
+
+    #[test]
+    fn provider_extensions_keep_their_catalog_kind() {
+        let tenant = TenantId::parse("tenant-provider-kind").unwrap();
+        let vendor_kind = ProviderKind::parse("demo.vendor").unwrap();
+        let vendor = Entity::provider(
+            tenant,
+            SourceRuntimeId::parse("vendor-runtime").unwrap(),
+            vendor_kind.clone(),
+            "vendor-1",
+            EntityKind::Provider(vendor_kind),
+            "Vendor One",
+        )
+        .unwrap()
+        .with_property("entity_type", "vendor")
+        .unwrap();
+
+        let projected = ContextEntity::from_domain(&vendor);
+
+        assert_eq!(projected.entity_kind, "vendor");
+        assert_eq!(projected.authority["provider_kind"], "demo.vendor");
     }
 
     #[tokio::test]

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -7025,7 +7025,7 @@ mod tests {
             .await
             .unwrap();
         let response: serde_json::Value = serde_json::from_slice(&response).unwrap();
-        assert_eq!(response["graphRevision"], "1");
+        assert_eq!(response["graphRevision"], "2");
         assert_eq!(response["entities"].as_array().unwrap().len(), 4);
         assert!(
             response["entities"]

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -7026,7 +7026,7 @@ mod tests {
             .unwrap();
         let response: serde_json::Value = serde_json::from_slice(&response).unwrap();
         assert_eq!(response["graphRevision"], "2");
-        assert_eq!(response["entities"].as_array().unwrap().len(), 4);
+        assert_eq!(response["entities"].as_array().unwrap().len(), 6);
         assert!(
             response["entities"]
                 .as_array()
@@ -7101,7 +7101,7 @@ mod tests {
             .unwrap();
         let response: serde_json::Value = serde_json::from_slice(&response).unwrap();
         assert_eq!(response["tenantId"], "tenant-demo");
-        assert_eq!(response["graphRevision"], "1");
+        assert_eq!(response["graphRevision"], "2");
         assert_eq!(response["matches"].as_array().unwrap().len(), 1);
         assert_eq!(
             response["matches"][0]["edges"][0]["edge"]["relation"],

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -4552,6 +4552,62 @@ fn demo_graph() -> Result<(OrganizationalGraph, TenantId, EntityId), Box<dyn Err
 
     let mut graph = OrganizationalGraph::new();
     graph.apply(builder.build())?;
+
+    let vendor_runtime = SourceRuntimeId::parse("vendor-demo")?;
+    let vendor_collection = CompleteCollection::new(
+        tenant.clone(),
+        vendor_runtime.clone(),
+        CollectionId::parse("vendor-collection-demo")?,
+        "vendor.records",
+        1,
+    )?;
+    let vendor_kind = ProviderKind::parse("demo.vendor")?;
+    let identity_vendor = Entity::provider(
+        tenant.clone(),
+        vendor_runtime.clone(),
+        vendor_kind.clone(),
+        "identity-platform",
+        EntityKind::Provider(vendor_kind.clone()),
+        "Identity Platform",
+    )?
+    .with_property("entity_type", "vendor")?
+    .with_property(
+        "entity_urn",
+        "urn:cerebro:tenant-demo:vendor:identity-platform",
+    )?
+    .with_property("source_id", "rust-demo")?
+    .with_property("vendor_id", "identity-platform")?
+    .with_property("category", "identity")?
+    .with_property("services_provided", "Workforce identity and access")?
+    .with_property("security_owner_user_id", "identity-security")?
+    .with_property("lifecycle_state", "approved")?
+    .with_property("risk_level", "high")?
+    .with_property("security_review_status", "approved")?;
+    let collaboration_vendor = Entity::provider(
+        tenant.clone(),
+        vendor_runtime,
+        vendor_kind.clone(),
+        "collaboration-suite",
+        EntityKind::Provider(vendor_kind),
+        "Collaboration Suite",
+    )?
+    .with_property("entity_type", "vendor")?
+    .with_property(
+        "entity_urn",
+        "urn:cerebro:tenant-demo:vendor:collaboration-suite",
+    )?
+    .with_property("source_id", "rust-demo")?
+    .with_property("vendor_id", "collaboration-suite")?
+    .with_property("category", "productivity")?
+    .with_property("services_provided", "Documents and team collaboration")?
+    .with_property("security_owner_user_id", "security-operations")?
+    .with_property("lifecycle_state", "active")?
+    .with_property("risk_level", "medium")?
+    .with_property("security_review_status", "approved")?;
+    let mut vendor_builder = vendor_collection.begin_delta();
+    vendor_builder.add_entity(identity_vendor)?;
+    vendor_builder.add_entity(collaboration_vendor)?;
+    graph.apply(vendor_builder.build())?;
     Ok((graph, tenant, root_id))
 }
 

--- a/crates/cerebro-platform/src/rpc.rs
+++ b/crates/cerebro-platform/src/rpc.rs
@@ -1,4 +1,9 @@
-use std::{future::Future, sync::Arc, time::Duration};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    future::Future,
+    sync::Arc,
+    time::Duration,
+};
 
 use cerebro_agent_context::{
     AgentGraph, ContextEdge, ContextEntity, ContextError, FactQuery, GraphPath as ContextPath,
@@ -80,6 +85,7 @@ use service::cerebro::v1::{SecurityLifecycleService, SecurityLifecycleServiceExt
 // Bound every durable graph read independently of client-side deadlines.
 const GRAPH_RPC_TIMEOUT: Duration = Duration::from_secs(2);
 const MAX_SECURITY_LIFECYCLE_SCAN: usize = 500;
+const MAX_IN_MEMORY_CATALOG_SCAN: usize = 500;
 
 pub(crate) fn router(
     graph: Arc<dyn AgentGraph>,
@@ -233,6 +239,164 @@ impl GraphRpc {
             },
         )
         .map_err(|error| ConnectError::invalid_argument(error.to_string()))
+    }
+
+    async fn in_memory_catalog_page(
+        &self,
+        tenant: &TenantId,
+        filter: &StoreCatalogFilter,
+        limit: usize,
+        after_agent_key: &str,
+    ) -> Result<StoreCatalogPage, ConnectError> {
+        validate_in_memory_catalog_request(tenant, filter, after_agent_key)?;
+        let revision_before = self.graph_call(self.graph.revision(tenant)).await?;
+        if filter.expected_graph_revision != 0 && filter.expected_graph_revision != revision_before
+        {
+            return Err(ConnectError::unavailable(
+                "Entity catalog revision changed before continuation.",
+            ));
+        }
+
+        let mut entities = if filter.exact_agent_key.is_empty() {
+            let entities = self
+                .graph_call(
+                    self.graph
+                        .search(tenant, "", &[], MAX_IN_MEMORY_CATALOG_SCAN),
+                )
+                .await?;
+            if entities.len() == MAX_IN_MEMORY_CATALOG_SCAN {
+                return Err(ConnectError::unavailable(
+                    "The in-memory entity catalog exceeds its authoritative scan bound.",
+                ));
+            }
+            entities
+        } else {
+            match self
+                .graph_call(self.graph.resolve(tenant, &filter.exact_agent_key))
+                .await
+            {
+                Ok(entity) => vec![entity],
+                Err(error) if error.code == connectrpc::ErrorCode::NotFound => Vec::new(),
+                Err(error) => return Err(error),
+            }
+        };
+        entities.retain(|entity| {
+            entity.agent_key.as_str() > after_agent_key
+                && in_memory_catalog_entity_matches(entity, filter)
+        });
+        entities.sort_by(|left, right| left.agent_key.cmp(&right.agent_key));
+        let truncated = entities.len() > limit;
+        entities.truncate(limit);
+
+        let relation_counts = if let Some(count_filter) = filter.relation_counts.as_ref() {
+            self.in_memory_catalog_relation_counts(tenant, revision_before, &entities, count_filter)
+                .await?
+        } else {
+            Vec::new()
+        };
+        let revision_after = self.graph_call(self.graph.revision(tenant)).await?;
+        if revision_after != revision_before {
+            return Err(ConnectError::unavailable(
+                "Entity catalog revision changed during the read.",
+            ));
+        }
+        let next_after_agent_key = truncated
+            .then(|| entities.last().map(|entity| entity.agent_key.clone()))
+            .flatten()
+            .unwrap_or_default();
+        Ok(StoreCatalogPage {
+            tenant_id: tenant.as_str().to_owned(),
+            graph_revision: revision_before,
+            entities,
+            truncated,
+            next_after_agent_key,
+            relation_counts,
+        })
+    }
+
+    async fn in_memory_catalog_relation_counts(
+        &self,
+        tenant: &TenantId,
+        graph_revision: u64,
+        entities: &[ContextEntity],
+        filter: &StoreCatalogRelationCountFilter,
+    ) -> Result<Vec<cerebro_organizational_store::EntityCatalogRelationCount>, ConnectError> {
+        let mut grouped = BTreeMap::<(String, String, String, String), BTreeSet<EntityId>>::new();
+        for chunk in entities.chunks(100) {
+            let keys = chunk
+                .iter()
+                .map(|entity| entity.agent_key.clone())
+                .collect::<Vec<_>>();
+            let neighborhoods = self
+                .graph_call(self.graph.expand_many(tenant, &keys, 1, 500))
+                .await?;
+            for root_key in keys {
+                let neighborhood = neighborhoods.get(&root_key).ok_or_else(|| {
+                    ConnectError::unavailable("The in-memory catalog omitted a requested root.")
+                })?;
+                if neighborhood.graph_revision != graph_revision || neighborhood.truncated {
+                    return Err(ConnectError::unavailable(
+                        "The in-memory catalog could not produce complete revision-bound relation counts.",
+                    ));
+                }
+                let neighbors = neighborhood
+                    .entities
+                    .iter()
+                    .map(|entity| (entity.entity_id.clone(), entity))
+                    .collect::<BTreeMap<_, _>>();
+                for edge in &neighborhood.edges {
+                    let (direction, neighbor_id) = if edge.from == neighborhood.root.entity_id {
+                        (StoreCatalogDirection::Outgoing, &edge.to)
+                    } else if edge.to == neighborhood.root.entity_id {
+                        (StoreCatalogDirection::Incoming, &edge.from)
+                    } else {
+                        continue;
+                    };
+                    let Some(neighbor) = neighbors.get(neighbor_id) else {
+                        return Err(ConnectError::unavailable(
+                            "The in-memory catalog relation omitted its neighbor.",
+                        ));
+                    };
+                    if !filter.directions.contains(&direction)
+                        || !filter.relations.contains(&edge.relation)
+                        || !filter.neighbor_kinds.contains(&neighbor.entity_kind)
+                    {
+                        continue;
+                    }
+                    let direction_key = match direction {
+                        StoreCatalogDirection::Incoming => "incoming",
+                        StoreCatalogDirection::Outgoing => "outgoing",
+                    };
+                    grouped
+                        .entry((
+                            root_key.clone(),
+                            direction_key.to_owned(),
+                            edge.relation.clone(),
+                            neighbor.entity_kind.clone(),
+                        ))
+                        .or_default()
+                        .insert(neighbor.entity_id.clone());
+                }
+            }
+        }
+        Ok(grouped
+            .into_iter()
+            .map(
+                |((agent_key, direction, relation, neighbor_kind), neighbors)| {
+                    cerebro_organizational_store::EntityCatalogRelationCount {
+                        agent_key,
+                        direction: if direction == "incoming" {
+                            StoreCatalogDirection::Incoming
+                        } else {
+                            StoreCatalogDirection::Outgoing
+                        },
+                        relation,
+                        neighbor_kind,
+                        count: neighbors.len() as u64,
+                    }
+                },
+            )
+            .collect())
     }
 }
 
@@ -590,23 +754,26 @@ impl OrganizationalGraphService for GraphRpc {
             .as_option()
             .ok_or_else(|| ConnectError::invalid_argument("entity catalog filter is required"))?;
         let tenant = self.authorized_tenant(&context, filter.tenant_id)?;
-        let projection = self.lifecycle_projection.as_ref().ok_or_else(|| {
-            ConnectError::unavailable("The entity catalog projection is not loaded.")
-        })?;
         let limit = usize::try_from(request.limit)
             .map_err(|_| ConnectError::invalid_argument("limit exceeds usize"))?;
-        let result = tokio::time::timeout(
-            GRAPH_RPC_TIMEOUT,
-            projection.list_catalog_entities(
-                &tenant,
-                &catalog_filter(filter),
-                limit,
-                request.after_agent_key,
-            ),
-        )
-        .await
-        .map_err(|_| ConnectError::unavailable("Entity catalog read exceeded 2 seconds."))?
-        .map_err(catalog_store_error)?;
+        let mapped_filter = catalog_filter(filter);
+        let result = if let Some(projection) = self.lifecycle_projection.as_ref() {
+            tokio::time::timeout(
+                GRAPH_RPC_TIMEOUT,
+                projection.list_catalog_entities(
+                    &tenant,
+                    &mapped_filter,
+                    limit,
+                    request.after_agent_key,
+                ),
+            )
+            .await
+            .map_err(|_| ConnectError::unavailable("Entity catalog read exceeded 2 seconds."))?
+            .map_err(catalog_store_error)?
+        } else {
+            self.in_memory_catalog_page(&tenant, &mapped_filter, limit, request.after_agent_key)
+                .await?
+        };
         Response::ok(catalog_page_response(result))
     }
 
@@ -1265,6 +1432,99 @@ fn catalog_filter(filter: &__buffa::view::EntityCatalogFilterView<'_>) -> StoreC
     }
 }
 
+fn validate_in_memory_catalog_request(
+    tenant: &TenantId,
+    filter: &StoreCatalogFilter,
+    after_agent_key: &str,
+) -> Result<(), ConnectError> {
+    let tenant_prefix = format!("urn:cerebro:{}:", tenant.as_str());
+    if (!filter.exact_agent_key.is_empty() && !filter.exact_agent_key.starts_with(&tenant_prefix))
+        || (!after_agent_key.is_empty() && !after_agent_key.starts_with(&tenant_prefix))
+        || !catalog_values_are_closed(&filter.runtime_ids)
+        || !catalog_values_are_closed(&filter.include_kinds)
+        || !catalog_values_are_closed(&filter.include_kind_prefixes)
+        || !catalog_values_are_closed(&filter.exclude_kinds)
+        || !catalog_values_are_closed(&filter.exclude_kind_prefixes)
+        || filter.search.trim() != filter.search
+    {
+        return Err(ConnectError::invalid_argument(
+            "invalid in-memory entity catalog request",
+        ));
+    }
+    if let Some(counts) = filter.relation_counts.as_ref()
+        && (counts.directions.is_empty()
+            || counts.relations.is_empty()
+            || counts.neighbor_kinds.is_empty()
+            || counts.directions.iter().collect::<BTreeSet<_>>().len() != counts.directions.len()
+            || !catalog_values_are_closed(&counts.relations)
+            || !catalog_values_are_closed(&counts.neighbor_kinds))
+    {
+        return Err(ConnectError::invalid_argument(
+            "invalid in-memory entity catalog relation counts",
+        ));
+    }
+    Ok(())
+}
+
+fn catalog_values_are_closed(values: &[String]) -> bool {
+    values.len() <= 100
+        && values
+            .iter()
+            .all(|value| !value.is_empty() && value.trim() == value)
+        && values.iter().collect::<BTreeSet<_>>().len() == values.len()
+}
+
+fn in_memory_catalog_entity_matches(entity: &ContextEntity, filter: &StoreCatalogFilter) -> bool {
+    if !filter.exact_agent_key.is_empty() && entity.agent_key != filter.exact_agent_key {
+        return false;
+    }
+    if !filter.source_id.is_empty() && entity.properties.get("source_id") != Some(&filter.source_id)
+    {
+        return false;
+    }
+    if !filter.runtime_ids.is_empty() {
+        let runtime_id = entity
+            .properties
+            .get("runtime_id")
+            .map(String::as_str)
+            .or_else(|| {
+                entity
+                    .authority
+                    .get("source_runtime_id")
+                    .and_then(serde_json::Value::as_str)
+            })
+            .unwrap_or_default();
+        if !filter.runtime_ids.iter().any(|value| value == runtime_id) {
+            return false;
+        }
+    }
+    let included = filter.include_kinds.is_empty() && filter.include_kind_prefixes.is_empty()
+        || filter.include_kinds.contains(&entity.entity_kind)
+        || filter
+            .include_kind_prefixes
+            .iter()
+            .any(|prefix| entity.entity_kind.starts_with(prefix));
+    if !included
+        || filter.exclude_kinds.contains(&entity.entity_kind)
+        || filter
+            .exclude_kind_prefixes
+            .iter()
+            .any(|prefix| entity.entity_kind.starts_with(prefix))
+    {
+        return false;
+    }
+    if filter.search.is_empty() {
+        return true;
+    }
+    let query = filter.search.to_lowercase();
+    entity.agent_key.to_lowercase().contains(&query)
+        || entity.label.to_lowercase().contains(&query)
+        || (filter.search_attributes
+            && entity.properties.iter().any(|(key, value)| {
+                key.to_lowercase().contains(&query) || value.to_lowercase().contains(&query)
+            }))
+}
+
 fn catalog_store_error(error: StoreError) -> ConnectError {
     match error {
         StoreError::Conflict(message)
@@ -1634,6 +1894,43 @@ mod tests {
             error.message.as_deref(),
             Some("The graph backend exceeded its RPC deadline.")
         );
+    }
+
+    #[tokio::test]
+    async fn in_memory_catalog_lists_demo_vendors_at_one_revision() {
+        let (graph, tenant, _) = crate::demo_graph().unwrap();
+        let graph = Arc::new(cerebro_agent_context::MemoryAgentGraph::new(graph));
+        let service = GraphRpc {
+            graph,
+            lifecycle_projection: None,
+            catalog_summary: None,
+            tenant_auth: TenantRequestAuth::new(
+                "test-organizational-graph-secret-32-bytes".to_owned(),
+            )
+            .unwrap(),
+        };
+
+        let page = service
+            .in_memory_catalog_page(
+                &tenant,
+                &StoreCatalogFilter {
+                    include_kinds: vec!["vendor".to_owned()],
+                    ..Default::default()
+                },
+                100,
+                "",
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(page.graph_revision, 2);
+        assert_eq!(page.entities.len(), 2);
+        assert!(
+            page.entities
+                .iter()
+                .all(|entity| entity.entity_kind == "vendor")
+        );
+        assert!(!page.truncated);
     }
 
     #[test]

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -4131,6 +4131,45 @@ func TestGraphPackageImpactEndpointReturnsCanonicalPackageRoot(t *testing.T) {
 	}
 }
 
+func TestGRCVendorsReportsRustGraphAuthority(t *testing.T) {
+	graph := &stubGraphStore{cypherRows: [][]ports.CypherRow{{{
+		Values: map[string]any{
+			"urn":             "urn:cerebro:writer:vendor:one",
+			"tenant_id":       "writer",
+			"runtime_id":      "vendor-runtime",
+			"source_id":       "vendor-source",
+			"entity_type":     "vendor",
+			"label":           "Vendor One",
+			"attributes_json": `{"risk_level":"medium"}`,
+		},
+	}}}}
+	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph)}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/vendors?tenant_id=writer&limit=10")
+	if err != nil {
+		t.Fatalf("GET /grc/vendors error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /grc/vendors status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var body struct {
+		DataAuthority string `json:"data_authority"`
+		GraphRevision uint64 `json:"graph_revision"`
+		Vendors       []struct {
+			Name string `json:"name"`
+		} `json:"vendors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.DataAuthority != "rust_graph" || body.GraphRevision != 1 || len(body.Vendors) != 1 || body.Vendors[0].Name != "Vendor One" {
+		t.Fatalf("body = %#v, want one Rust graph vendor at revision 1", body)
+	}
+}
+
 func TestGraphImpactEndpointRejectsExplicitZeroBounds(t *testing.T) {
 	app := New(config.Config{}, Dependencies{GraphStore: &stubGraphStore{}}, nil)
 	server := httptest.NewServer(app.Handler())

--- a/internal/bootstrap/grc_vendor.go
+++ b/internal/bootstrap/grc_vendor.go
@@ -14,9 +14,9 @@ import (
 const maxGRCVendorDiscoveryDecisionBodyBytes = 32 << 10
 
 type grcVendorsResponse struct {
-	Summary     grcvendor.Summary  `json:"summary"`
-	Vendors     []grcvendor.Vendor `json:"vendors"`
-	GeneratedAt time.Time          `json:"generated_at"`
+	grcvendor.VendorPage
+	Summary     grcvendor.Summary `json:"summary"`
+	GeneratedAt time.Time         `json:"generated_at"`
 }
 
 type grcVendorDetailResponse struct {
@@ -70,7 +70,7 @@ func (a *App) handleGRCVendors(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	vendors, err := grcvendor.NewWithCapabilities(a.deps.GraphReads.Catalog, a.deps.GraphReads.Neighborhoods).ListVendors(r.Context(), grcvendor.ListVendorsRequest{
+	page, err := grcvendor.NewWithCapabilities(a.deps.GraphReads.Catalog, a.deps.GraphReads.Neighborhoods).ListVendorsPage(r.Context(), grcvendor.ListVendorsRequest{
 		TenantID:    scope.TenantID,
 		RuntimeID:   scope.RuntimeID,
 		RuntimeIDs:  scope.RuntimeIDs,
@@ -88,6 +88,7 @@ func (a *App) handleGRCVendors(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
+	vendors := page.Vendors
 	vendors, err = a.enrichGRCVendors(r, scope, vendors)
 	if err != nil {
 		writeGRCError(w, err)
@@ -96,10 +97,11 @@ func (a *App) handleGRCVendors(w http.ResponseWriter, r *http.Request) {
 	if queueOnly {
 		vendors = grcvendor.FilterVendorsByQueue(vendors)
 	}
-	vendors = grcvendor.SortAndLimitVendors(vendors, scope.Limit)
+	page.Vendors = grcvendor.SortAndLimitVendors(vendors, scope.Limit)
+	page.DataAuthority = "rust_graph"
 	writeJSON(w, http.StatusOK, grcVendorsResponse{
-		Summary:     grcvendor.Summarize(vendors),
-		Vendors:     vendors,
+		VendorPage:  page,
+		Summary:     grcvendor.Summarize(page.Vendors),
 		GeneratedAt: time.Now().UTC(),
 	})
 }

--- a/internal/grcvendor/service.go
+++ b/internal/grcvendor/service.go
@@ -393,6 +393,12 @@ type VendorDetail struct {
 	Graph         *ports.EntityNeighborhood `json:"graph,omitempty"`
 }
 
+type VendorPage struct {
+	Vendors       []Vendor `json:"vendors"`
+	DataAuthority string   `json:"data_authority"`
+	GraphRevision uint64   `json:"graph_revision"`
+}
+
 type VendorRelationships struct {
 	Contracts              []RelatedRecord `json:"contracts,omitempty"`
 	SecurityReviews        []RelatedRecord `json:"security_reviews,omitempty"`
@@ -499,8 +505,13 @@ func (s graphStoreCapabilities) ListEntityRelations(ctx context.Context, request
 }
 
 func (s *Service) ListVendors(ctx context.Context, request ListVendorsRequest) ([]Vendor, error) {
+	page, err := s.ListVendorsPage(ctx, request)
+	return page.Vendors, err
+}
+
+func (s *Service) ListVendorsPage(ctx context.Context, request ListVendorsRequest) (VendorPage, error) {
 	if s == nil || s.store == nil {
-		return nil, ErrRuntimeUnavailable
+		return VendorPage{}, ErrRuntimeUnavailable
 	}
 	limit := normalizeVendorLimit(request.Limit)
 	queryLimit := limit
@@ -509,23 +520,23 @@ func (s *Service) ListVendors(ctx context.Context, request ListVendorsRequest) (
 	}
 	tenantID := strings.TrimSpace(request.TenantID)
 	if tenantID == "" {
-		return nil, fmt.Errorf("%w: tenant_id is required", ErrInvalidRequest)
+		return VendorPage{}, fmt.Errorf("%w: tenant_id is required", ErrInvalidRequest)
 	}
 	store, ok := s.store.(ports.EntityCatalogStore)
 	if !ok {
-		return nil, ErrRuntimeUnavailable
+		return VendorPage{}, ErrRuntimeUnavailable
 	}
 	filter, possible := vendorCatalogFilter(tenantID, request.RuntimeID, request.RuntimeIDs, request.SourceID, request.Query, "vendor")
 	if !possible {
-		return []Vendor{}, nil
+		return VendorPage{Vendors: []Vendor{}}, nil
 	}
 	filter.RelationCounts = &ports.EntityRelationCountFilter{Directions: []ports.EntityRelationDirection{ports.EntityRelationIncoming}, Relations: []string{"associated_with"}, NeighborKinds: []string{"contract", "security.review", "security.questionnaire", "assurance.document"}}
 	page, err := store.ListEntities(ctx, ports.EntityCatalogPageRequest{Filter: filter, Limit: queryLimit})
 	if err != nil {
-		return nil, err
+		return VendorPage{}, err
 	}
 	if page == nil || page.TenantID != tenantID {
-		return nil, ErrRuntimeUnavailable
+		return VendorPage{}, ErrRuntimeUnavailable
 	}
 	vendors := make([]Vendor, 0, len(page.Entities))
 	for _, entity := range page.Entities {
@@ -542,7 +553,7 @@ func (s *Service) ListVendors(ctx context.Context, request ListVendorsRequest) (
 	if !request.DeferLimit && len(vendors) > limit {
 		vendors = vendors[:limit]
 	}
-	return vendors, nil
+	return VendorPage{Vendors: vendors, GraphRevision: page.GraphRevision}, nil
 }
 
 func (s *Service) ListDiscoveries(ctx context.Context, request ListDiscoveriesRequest) ([]VendorDiscovery, error) {

--- a/internal/grcvendor/service_test.go
+++ b/internal/grcvendor/service_test.go
@@ -12,12 +12,13 @@ import (
 )
 
 type stubGraphStore struct {
-	requests     []ports.CypherQueryRequest
-	rows         [][]ports.CypherRow
-	neighborhood *ports.EntityNeighborhood
-	rootURN      string
-	limit        int
-	err          error
+	requests      []ports.CypherQueryRequest
+	rows          [][]ports.CypherRow
+	neighborhood  *ports.EntityNeighborhood
+	rootURN       string
+	limit         int
+	graphRevision uint64
+	err           error
 }
 
 func (s *stubGraphStore) Ping(context.Context) error { return s.err }
@@ -40,7 +41,7 @@ func (s *stubGraphStore) ListEntities(_ context.Context, request ports.EntityCat
 		return nil, s.err
 	}
 	s.requests = append(s.requests, ports.CypherQueryRequest{Params: map[string]any{"tenant_id": request.Filter.TenantID, "limit": request.Limit}})
-	page := &ports.EntityCatalogPage{TenantID: request.Filter.TenantID}
+	page := &ports.EntityCatalogPage{TenantID: request.Filter.TenantID, GraphRevision: s.graphRevision}
 	if len(s.rows) == 0 {
 		return page, nil
 	}
@@ -177,6 +178,26 @@ func TestListVendorsDerivesPostureAndAppliesFilters(t *testing.T) {
 	}
 	if summary.OpenFindings != 2 || summary.CriticalFindings != 1 || summary.EvidenceItems != 3 {
 		t.Fatalf("summary finding counts = %#v", summary)
+	}
+}
+
+func TestListVendorsPagePreservesGraphRevision(t *testing.T) {
+	store := &stubGraphStore{
+		graphRevision: 42,
+		rows: [][]ports.CypherRow{{
+			vendorRow("urn:cerebro:writer:vendor:one", "Vendor One", `{"vendor_id":"one","risk_level":"medium"}`, 0, 0, 0, 0),
+		}},
+	}
+
+	page, err := New(store).ListVendorsPage(context.Background(), ListVendorsRequest{
+		TenantID: "writer",
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("ListVendorsPage() error = %v", err)
+	}
+	if page.GraphRevision != 42 || len(page.Vendors) != 1 {
+		t.Fatalf("page = %#v, want one vendor at graph revision 42", page)
 	}
 }
 


### PR DESCRIPTION
## Summary

- serve the vendor register from Rust organizational-graph entity data in the product demo
- preserve validated provider-specific entity kinds and expose graph authority plus revision through the existing Go HTTP adapter
- seed two tenant-scoped demo vendors and render the reported Rust graph revision in the vendor table
- extend the Rust product browser check through the vendor user path and fail if fixtures are used

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p cerebro-platform in_memory_catalog_lists_demo_vendors_at_one_revision -- --nocapture`
- `cargo test --locked -p cerebro-agent-context`
- `cargo clippy --locked -p cerebro-platform --all-targets -- -D warnings`
- `go test ./internal/grcvendor ./internal/sourcehttp/organizationalgraph ./internal/bootstrap -count=1`
- `npm test --workspace @writer/cerebro-web -- scripts/rust-product-demo.test.mjs src/lib/cerebro-fixtures.test.ts`
- focused Web ESLint and production build
- `make check-structural-test`
- `make check-arch`
- `npm run demo:rust:check --workspace @writer/cerebro-web` at `4cdb93413dd33f5f6225e663e89bf6378ee161e7`

The exact-head browser receipt reports `data_authority=rust_graph`, graph revision 2, two vendors, and no fixture header.

## Local capacity note

The repository-wide `check-structural` scan was killed twice on the 8 GiB development desk before producing a finding. Its linter build and unit suite passed; the hosted structural check remains authoritative for the full scan.