### PR TITLE
Add Google Workspace user source execution adapter

### DIFF
--- a/crates/source-runtime-next/src/google_workspace.rs
+++ b/crates/source-runtime-next/src/google_workspace.rs
@@ -16,14 +16,20 @@ use serde_json::Value;
 mod error;
 mod materialization;
 mod normalization;
+mod source_execution;
 mod user_adapter;
 
 #[cfg(test)]
 mod tests;
 #[cfg(test)]
 mod user_adapter_tests;
+#[cfg(test)]
+mod source_execution_tests;
 
 pub use error::GoogleWorkspaceError;
+pub(crate) use source_execution::{
+    GOOGLE_WORKSPACE_USER_SOURCE_EXECUTION_ADAPTER, durable_checkpoint_cursor,
+};
 use normalization::*;
 
 const SOURCE_ID: &str = "google_workspace";

--- a/crates/source-runtime-next/src/google_workspace.rs
+++ b/crates/source-runtime-next/src/google_workspace.rs
@@ -16,6 +16,9 @@ use serde_json::Value;
 mod error;
 mod materialization;
 mod normalization;
+// Shared dispatcher registration lands separately so this provider slice does
+// not collide with another branch that currently owns the shared registry.
+#[allow(dead_code)]
 mod source_execution;
 mod user_adapter;
 
@@ -28,6 +31,7 @@ mod user_adapter_tests;
 
 pub use error::GoogleWorkspaceError;
 use normalization::*;
+#[allow(unused_imports)]
 pub(crate) use source_execution::{
     GOOGLE_WORKSPACE_USER_SOURCE_EXECUTION_ADAPTER, durable_checkpoint_cursor,
 };

--- a/crates/source-runtime-next/src/google_workspace.rs
+++ b/crates/source-runtime-next/src/google_workspace.rs
@@ -20,17 +20,17 @@ mod source_execution;
 mod user_adapter;
 
 #[cfg(test)]
+mod source_execution_tests;
+#[cfg(test)]
 mod tests;
 #[cfg(test)]
 mod user_adapter_tests;
-#[cfg(test)]
-mod source_execution_tests;
 
 pub use error::GoogleWorkspaceError;
+use normalization::*;
 pub(crate) use source_execution::{
     GOOGLE_WORKSPACE_USER_SOURCE_EXECUTION_ADAPTER, durable_checkpoint_cursor,
 };
-use normalization::*;
 
 const SOURCE_ID: &str = "google_workspace";
 const DEFAULT_CUSTOMER_ID: &str = "my_customer";

--- a/crates/source-runtime-next/src/google_workspace/source_execution.rs
+++ b/crates/source-runtime-next/src/google_workspace/source_execution.rs
@@ -1,0 +1,399 @@
+//! Google Workspace `user` bridge for the closed source-execution protocol.
+//!
+//! The adapter receives only authenticated execution context, public Directory
+//! selectors, and bounded provider response bytes. The trusted host retains
+//! OAuth credential redemption, Bearer authentication, origin-constrained
+//! network I/O, durable append, projection, and checkpoint ownership.
+
+use std::collections::HashMap;
+
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceExecutionPlanV1,
+    SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1,
+    SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2, SourceWorkerHttpRequestV1,
+    SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1, SourceWorkerRecordV1,
+    SourceWorkerRuntimeMetadataV2, canonical_http_execution_digest, canonical_plan_digest,
+    canonical_request_intent_digest, canonical_result_digest, validate_and_deduplicate_records,
+    validate_execution_context, validate_runtime_metadata,
+};
+
+use super::{GoogleWorkspaceError, GoogleWorkspaceKernel};
+
+const SOURCE_ID: &str = "google_workspace";
+const FAMILY_ID: &str = "user";
+const PROVIDER_KERNEL: &str = "google_workspace.user";
+const PLAN_ID: &str = "source-plan-v1:google_workspace:user";
+const DEFAULT_BASE_URL: &str = "https://admin.googleapis.com";
+const METHOD: &str = "GET";
+const PATH: &str = "/admin/directory/v1/users";
+const RECORD_SELECTOR: &str = "$.users[*]";
+const ID_FIELD: &str = "id";
+const MAX_RESPONSE_BYTES: u64 = 8 << 20;
+const EVENT_KIND: &str = "google_workspace.user";
+const SCHEMA_REF: &str = "google_workspace/user/v1";
+
+/// Credential-free adapter for the Google Workspace users family.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct GoogleWorkspaceUserSourceExecutionAdapter;
+
+/// Shared instance ready for closed-dispatcher registration.
+pub(crate) static GOOGLE_WORKSPACE_USER_SOURCE_EXECUTION_ADAPTER:
+    GoogleWorkspaceUserSourceExecutionAdapter = GoogleWorkspaceUserSourceExecutionAdapter;
+
+impl GoogleWorkspaceUserSourceExecutionAdapter {
+    pub(crate) fn compiled_plan(&self) -> SourceExecutionPlanV1 {
+        let mut plan = SourceExecutionPlanV1 {
+            plan_id: PLAN_ID.to_owned(),
+            source_id: SOURCE_ID.to_owned(),
+            family_id: FAMILY_ID.to_owned(),
+            provider_kernel: PROVIDER_KERNEL.to_owned(),
+            method: METHOD.to_owned(),
+            origin: DEFAULT_BASE_URL.to_owned(),
+            path: PATH.to_owned(),
+            record_selector: RECORD_SELECTOR.to_owned(),
+            id_field: ID_FIELD.to_owned(),
+            singleton_fallback_id: String::new(),
+            max_response_bytes: MAX_RESPONSE_BYTES,
+            event_kind: EVENT_KIND.to_owned(),
+            schema_ref: SCHEMA_REF.to_owned(),
+            required_attributes: ["domain", "family", "user_id"]
+                .into_iter()
+                .map(str::to_owned)
+                .collect(),
+            required_payload_fields: vec!["id".to_owned(), "domain".to_owned()],
+            plan_digest_sha256: String::new(),
+        };
+        plan.plan_digest_sha256 = canonical_plan_digest(&plan);
+        plan
+    }
+
+    fn validate_plan(&self, plan: &SourceExecutionPlanV1) -> Result<(), SourceExecutionError> {
+        if plan != &self.compiled_plan() {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        Ok(())
+    }
+
+    fn kernel(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(GoogleWorkspaceKernel, String), SourceExecutionError> {
+        validate_execution_context(context)?;
+        validate_runtime_metadata(metadata)?;
+        if public_value(&metadata.public_config, "family").is_some_and(|value| value != FAMILY_ID) {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        let domain = public_value(&metadata.public_config, "domain")
+            .ok_or(SourceExecutionError::MissingConfiguration)?;
+        let base_url =
+            public_value(&metadata.public_config, "base_url").unwrap_or(DEFAULT_BASE_URL);
+        let customer_id = public_value(&metadata.public_config, "customer_id").map(str::to_owned);
+        let page_size = public_value(&metadata.public_config, "per_page")
+            .map(|value| {
+                value
+                    .parse::<usize>()
+                    .map_err(|_| SourceExecutionError::MissingConfiguration)
+            })
+            .transpose()?;
+        let kernel =
+            GoogleWorkspaceKernel::new_user_adapter(base_url, domain, customer_id, page_size)
+                .map_err(map_error)?;
+        let origin = kernel
+            .plan_user_page(None)
+            .map_err(map_error)?
+            .url()
+            .origin()
+            .ascii_serialization();
+        Ok((kernel, origin))
+    }
+}
+
+impl SourceExecutionAdapter for GoogleWorkspaceUserSourceExecutionAdapter {
+    fn source_id(&self) -> &'static str {
+        SOURCE_ID
+    }
+
+    fn family_id(&self) -> &'static str {
+        FAMILY_ID
+    }
+
+    fn provider_kernel(&self) -> &'static str {
+        PROVIDER_KERNEL
+    }
+
+    fn validate_record_identity(
+        &self,
+        _context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+    ) -> Result<(), SourceExecutionError> {
+        if record.event_id != format!("google-workspace-user-{}", record.provider_id)
+            || record.attributes.get("user_id") != Some(&record.provider_id)
+            || record.attributes.get("family").map(String::as_str) != Some(FAMILY_ID)
+        {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        Ok(())
+    }
+
+    fn validate_record_identity_v2(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(), SourceExecutionError> {
+        self.validate_record_identity(context, record)?;
+        let domain = public_value(&metadata.public_config, "domain")
+            .ok_or(SourceExecutionError::MissingConfiguration)?;
+        if record.attributes.get("domain").map(String::as_str) != Some(domain) {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        Ok(())
+    }
+
+    fn plan(
+        &self,
+        _request: &SourceWorkerPlanRequestV1,
+    ) -> Result<SourceWorkerHttpRequestV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn plan_v2(
+        &self,
+        envelope: &SourceWorkerPlanEnvelopeV2,
+    ) -> Result<SourceWorkerHttpExecutionV2, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, allowed_origin) = self.kernel(context, metadata)?;
+        let provider_request = kernel
+            .plan_user_page(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        if provider_request.url().path() != plan.path
+            || provider_request.method() != plan.method
+            || provider_request.authorization_scheme() != "Bearer"
+            || provider_request.url().username() != ""
+            || provider_request.url().password().is_some()
+        {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        let mut planned = SourceWorkerHttpRequestV1 {
+            plan_id: plan.plan_id.clone(),
+            method: provider_request.method().to_owned(),
+            url: provider_request.url().to_string(),
+            accept: provider_request.accept().to_owned(),
+            max_response_bytes: MAX_RESPONSE_BYTES,
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            request_intent_digest: String::new(),
+        };
+        planned.request_intent_digest = canonical_request_intent_digest(plan, context, &planned);
+        let mut execution = SourceWorkerHttpExecutionV2 {
+            request: Some(planned),
+            body: Vec::new(),
+            declared_headers: HashMap::new(),
+            execution_intent_digest_sha256: String::new(),
+            credential_operation: "source.bearer".to_owned(),
+            allowed_origin,
+        };
+        execution.execution_intent_digest_sha256 =
+            canonical_http_execution_digest(plan, context, metadata, &execution);
+        Ok(execution)
+    }
+
+    fn decode(
+        &self,
+        _request: &SourceWorkerDecodeRequestV1,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn decode_v2(
+        &self,
+        envelope: &SourceWorkerDecodeEnvelopeV2,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let receipt = request
+            .receipt
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, _) = self.kernel(context, metadata)?;
+        let provider_request = kernel
+            .plan_user_page(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        let status = u16::try_from(request.status_code)
+            .ok()
+            .and_then(|value| reqwest::StatusCode::from_u16(value).ok())
+            .ok_or(SourceExecutionError::UnexpectedProviderStatus)?;
+        let observed_at = observed_at(context.observed_at_unix_millis)?;
+        let page = kernel
+            .decode_user_response(
+                &provider_request,
+                status,
+                &request.response_body,
+                &observed_at,
+            )
+            .map_err(map_error)?;
+        let next_cursor = page.next_cursor.unwrap_or_default();
+        let records = page
+            .events
+            .into_iter()
+            .map(|event| {
+                if event.source_id != SOURCE_ID
+                    || event.provider_kind != plan.event_kind
+                    || event.schema_ref != plan.schema_ref
+                {
+                    return Err(SourceExecutionError::TenantMismatch);
+                }
+                let provider_id = event
+                    .attributes
+                    .get("user_id")
+                    .cloned()
+                    .filter(|value| !value.trim().is_empty())
+                    .ok_or(SourceExecutionError::MissingStableIdentity)?;
+                Ok(SourceWorkerRecordV1 {
+                    provider_id,
+                    event_id: event.event_id,
+                    occurred_at_unix_millis: parse_timestamp(&event.occurred_at)?,
+                    attributes: event.attributes.into_iter().collect(),
+                    payload_json: serde_json::to_vec(&event.payload)
+                        .map_err(|_| SourceExecutionError::InternalRuntime)?,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let records = validate_and_deduplicate_records(records)?;
+        let result_digest_sha256 = canonical_result_digest(receipt, &next_cursor, &records)?;
+        Ok(SourceWorkerDecodeResultV1 {
+            plan_id: plan.plan_id.clone(),
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: request.request_intent_digest.clone(),
+            records,
+            next_cursor,
+            result_digest_sha256,
+            tenant_id: context.tenant_id.clone(),
+            runtime_id: context.runtime_id.clone(),
+            runtime_generation: context.runtime_generation,
+            lease_generation: context.lease_generation,
+            observed_at_unix_millis: context.observed_at_unix_millis,
+        })
+    }
+}
+
+/// Returns the Go-compatible durable users checkpoint without conflating it
+/// with same-run provider continuation.
+pub(crate) fn durable_checkpoint_cursor(
+    plan: &SourceExecutionPlanV1,
+    result: &SourceWorkerDecodeResultV1,
+) -> Option<String> {
+    if plan.source_id != SOURCE_ID
+        || plan.family_id != FAMILY_ID
+        || plan.provider_kernel != PROVIDER_KERNEL
+    {
+        return None;
+    }
+    if !result.next_cursor.is_empty() {
+        return Some(result.next_cursor.clone());
+    }
+    Some(
+        result
+            .records
+            .last()
+            .map(|record| record.event_id.clone())
+            .unwrap_or_default(),
+    )
+}
+
+fn public_value<'a>(config: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    config
+        .get(key)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn optional(value: &str) -> Option<&str> {
+    (!value.is_empty()).then_some(value)
+}
+
+fn observed_at(unix_millis: i64) -> Result<String, SourceExecutionError> {
+    OffsetDateTime::from_unix_timestamp_nanos(i128::from(unix_millis) * 1_000_000)
+        .map_err(|_| SourceExecutionError::InvalidExecutionContext)?
+        .format(&Rfc3339)
+        .map_err(|_| SourceExecutionError::InvalidExecutionContext)
+}
+
+fn parse_timestamp(value: &str) -> Result<i64, SourceExecutionError> {
+    let nanos = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| SourceExecutionError::InvalidProviderRecord)?
+        .unix_timestamp_nanos();
+    i64::try_from(nanos / 1_000_000).map_err(|_| SourceExecutionError::InvalidProviderRecord)
+}
+
+fn map_error(error: GoogleWorkspaceError) -> SourceExecutionError {
+    match error {
+        GoogleWorkspaceError::InvalidFamily => SourceExecutionError::UnknownAdapter,
+        GoogleWorkspaceError::InvalidBaseUrl
+        | GoogleWorkspaceError::MissingDomain
+        | GoogleWorkspaceError::MissingGroupKey
+        | GoogleWorkspaceError::InvalidPageSize
+        | GoogleWorkspaceError::InvalidTenantIdentity
+        | GoogleWorkspaceError::InvalidCustomerId => SourceExecutionError::MissingConfiguration,
+        GoogleWorkspaceError::InvalidCursor => SourceExecutionError::InvalidCursor,
+        GoogleWorkspaceError::ResponseTooLarge => SourceExecutionError::ResponseTooLarge,
+        GoogleWorkspaceError::TooManyUserRecords => SourceExecutionError::ResultTooLarge,
+        GoogleWorkspaceError::ConflictingUserIdentity => SourceExecutionError::DuplicateConflict,
+        GoogleWorkspaceError::AuthenticationRejected => {
+            SourceExecutionError::AuthenticationRejected
+        }
+        GoogleWorkspaceError::RequiredUserScopeMissing | GoogleWorkspaceError::PermissionDenied => {
+            SourceExecutionError::RequiredProviderScopeMissing
+        }
+        GoogleWorkspaceError::RateLimited => SourceExecutionError::ProviderRateLimit,
+        GoogleWorkspaceError::ProviderUnavailable(_)
+        | GoogleWorkspaceError::UnexpectedProviderStatus(_) => {
+            SourceExecutionError::UnexpectedProviderStatus
+        }
+        GoogleWorkspaceError::InvalidResponse => SourceExecutionError::MalformedResponse,
+        GoogleWorkspaceError::InvalidRecord => SourceExecutionError::InvalidProviderRecord,
+        GoogleWorkspaceError::MissingRecordIdentity
+        | GoogleWorkspaceError::MissingDiscoveryIdentity => {
+            SourceExecutionError::MissingStableIdentity
+        }
+        GoogleWorkspaceError::MissingRoleState
+        | GoogleWorkspaceError::RequestScopeMismatch
+        | GoogleWorkspaceError::UserFamilyRequired => SourceExecutionError::InvalidPlan,
+        GoogleWorkspaceError::InvalidObservedAt => SourceExecutionError::InvalidExecutionContext,
+    }
+}

--- a/crates/source-runtime-next/src/google_workspace/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/google_workspace/source_execution_tests.rs
@@ -1,0 +1,267 @@
+use std::collections::HashMap;
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceExecutionLifecycleEnvelopeV2,
+    SourceExecutionLifecycleRequestV1, SourceExecutionPlanV1, SourceWorkerDecodeEnvelopeV2,
+    SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1, SourceWorkerExecutionContextV1,
+    SourceWorkerHttpExecutionV2, SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1,
+    SourceWorkerRuntimeMetadataV2, SourceWorkerSafeReceiptV1, response_digest,
+    seal_page_program_v2,
+};
+
+use super::{GOOGLE_WORKSPACE_USER_SOURCE_EXECUTION_ADAPTER, durable_checkpoint_cursor};
+
+const OBSERVED_AT_MILLIS: i64 = 1_780_272_000_000;
+const USERS_PAGE_1: &[u8] = include_bytes!("fixtures/users_page_1.json");
+const USERS_PAGE_2: &[u8] = include_bytes!("fixtures/users_page_2.json");
+
+fn context(cursor: &str, page: u32) -> SourceWorkerExecutionContextV1 {
+    SourceWorkerExecutionContextV1 {
+        tenant_id: "tenant-1".to_owned(),
+        runtime_id: "google-workspace-runtime".to_owned(),
+        logical_page_id: format!("source-page-v2:google-workspace-{page}"),
+        prior_cursor: cursor.to_owned(),
+        runtime_generation: 7,
+        lease_generation: 11,
+        observed_at_unix_millis: OBSERVED_AT_MILLIS,
+    }
+}
+
+fn metadata() -> SourceWorkerRuntimeMetadataV2 {
+    SourceWorkerRuntimeMetadataV2 {
+        public_config: HashMap::from([
+            ("family".to_owned(), "user".to_owned()),
+            ("domain".to_owned(), "writer.com".to_owned()),
+            ("customer_id".to_owned(), "C01".to_owned()),
+            ("per_page".to_owned(), "2".to_owned()),
+        ]),
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    }
+}
+
+fn plan() -> SourceExecutionPlanV1 {
+    GOOGLE_WORKSPACE_USER_SOURCE_EXECUTION_ADAPTER.compiled_plan()
+}
+
+fn plan_page(
+    plan: &SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    metadata: &SourceWorkerRuntimeMetadataV2,
+) -> SourceWorkerHttpExecutionV2 {
+    GOOGLE_WORKSPACE_USER_SOURCE_EXECUTION_ADAPTER
+        .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+        })
+        .unwrap()
+}
+
+fn decode_page(
+    plan: &SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    metadata: &SourceWorkerRuntimeMetadataV2,
+    execution: &SourceWorkerHttpExecutionV2,
+    status_code: u32,
+    body: &[u8],
+) -> Result<(SourceWorkerSafeReceiptV1, SourceWorkerDecodeResultV1), SourceExecutionError> {
+    let request = execution.request.as_ref().unwrap();
+    let receipt = SourceWorkerSafeReceiptV1 {
+        plan_digest_sha256: plan.plan_digest_sha256.clone(),
+        logical_page_id: context.logical_page_id.clone(),
+        request_intent_digest: request.request_intent_digest.clone(),
+        runtime_generation: context.runtime_generation,
+        lease_generation: context.lease_generation,
+        credential_operation: execution.credential_operation.clone(),
+        status_code,
+        response_bytes: body.len() as u64,
+        response_sha256: response_digest(body),
+        tenant_id: context.tenant_id.clone(),
+        runtime_id: context.runtime_id.clone(),
+        observed_at_unix_millis: context.observed_at_unix_millis,
+    };
+    let result = GOOGLE_WORKSPACE_USER_SOURCE_EXECUTION_ADAPTER.decode_v2(
+        &SourceWorkerDecodeEnvelopeV2 {
+            request: Some(SourceWorkerDecodeRequestV1 {
+                plan: Some(plan.clone()),
+                status_code,
+                response_body: body.to_vec(),
+                logical_page_id: context.logical_page_id.clone(),
+                request_intent_digest: request.request_intent_digest.clone(),
+                receipt: Some(receipt.clone()),
+                context: Some(context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+            response_headers: HashMap::new(),
+            response_headers_sha256: String::new(),
+            execution_intent_digest_sha256: execution.execution_intent_digest_sha256.clone(),
+        },
+    )?;
+    Ok((receipt, result))
+}
+
+#[test]
+fn users_plan_is_exact_and_credential_free() {
+    let plan = plan();
+    assert_eq!(plan.plan_id, "source-plan-v1:google_workspace:user");
+    assert_eq!(plan.source_id, "google_workspace");
+    assert_eq!(plan.family_id, "user");
+    assert_eq!(plan.provider_kernel, "google_workspace.user");
+    assert_eq!(plan.origin, "https://admin.googleapis.com");
+    assert_eq!(plan.path, "/admin/directory/v1/users");
+    assert_eq!(plan.record_selector, "$.users[*]");
+    assert_eq!(plan.event_kind, "google_workspace.user");
+    assert_eq!(plan.schema_ref, "google_workspace/user/v1");
+
+    let context = context("page-2", 2);
+    let execution = plan_page(&plan, &context, &metadata());
+    assert_eq!(execution.credential_operation, "source.bearer");
+    assert_eq!(execution.allowed_origin, "https://admin.googleapis.com");
+    assert!(execution.body.is_empty());
+    assert!(execution.declared_headers.is_empty());
+    let request = execution.request.unwrap();
+    assert_eq!(request.method, "GET");
+    assert_eq!(
+        request.url,
+        "https://admin.googleapis.com/admin/directory/v1/users?customer=C01&maxResults=2&pageToken=page-2"
+    );
+    assert!(!request.url.to_ascii_lowercase().contains("authorization"));
+    assert!(!request.url.to_ascii_lowercase().contains("bearer"));
+}
+
+#[test]
+fn users_run_two_pages_with_go_compatible_identity_and_checkpoint() {
+    let plan = plan();
+    let metadata = metadata();
+    let first_context = context("", 1);
+    let first_execution = plan_page(&plan, &first_context, &metadata);
+    let (first_receipt, first) = decode_page(
+        &plan,
+        &first_context,
+        &metadata,
+        &first_execution,
+        200,
+        USERS_PAGE_1,
+    )
+    .unwrap();
+    assert_eq!(first.next_cursor, "page-2");
+    assert_eq!(first.records.len(), 1);
+    assert_eq!(first.records[0].provider_id, "1001");
+    assert_eq!(first.records[0].event_id, "google-workspace-user-1001");
+    assert_eq!(first.records[0].attributes["domain"], "writer.com");
+    assert_eq!(
+        durable_checkpoint_cursor(&plan, &first).as_deref(),
+        Some("page-2")
+    );
+    let decision = seal_page_program_v2(&SourceExecutionLifecycleEnvelopeV2 {
+        request: Some(SourceExecutionLifecycleRequestV1 {
+            plan: Some(plan.clone()),
+            context: Some(first_context),
+            receipt: Some(first_receipt),
+            result: Some(first),
+            current_lease_generation: 11,
+        }),
+        metadata: Some(metadata.clone()),
+    })
+    .unwrap();
+    assert_eq!(decision.admitted_records.len(), 1);
+    assert_eq!(decision.checkpoint_cursor, "page-2");
+
+    let second_context = context("page-2", 2);
+    let second_execution = plan_page(&plan, &second_context, &metadata);
+    let (_, second) = decode_page(
+        &plan,
+        &second_context,
+        &metadata,
+        &second_execution,
+        200,
+        USERS_PAGE_2,
+    )
+    .unwrap();
+    assert!(second.next_cursor.is_empty());
+    assert_eq!(second.records.len(), 1);
+    assert_eq!(second.records[0].provider_id, "1002");
+    assert_eq!(second.records[0].event_id, "google-workspace-user-1002");
+    assert_eq!(
+        durable_checkpoint_cursor(&plan, &second).as_deref(),
+        Some("google-workspace-user-1002")
+    );
+}
+
+#[test]
+fn users_fail_closed_on_config_cursor_provider_and_identity_errors() {
+    let plan = plan();
+    let execution_context = context("", 1);
+    let mut missing_domain = metadata();
+    missing_domain.public_config.remove("domain");
+    assert_eq!(
+        GOOGLE_WORKSPACE_USER_SOURCE_EXECUTION_ADAPTER
+            .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+                request: Some(SourceWorkerPlanRequestV1 {
+                    plan: Some(plan.clone()),
+                    context: Some(execution_context.clone()),
+                }),
+                metadata: Some(missing_domain),
+            })
+            .unwrap_err(),
+        SourceExecutionError::MissingConfiguration
+    );
+
+    let invalid_cursor = context(&"x".repeat((4 << 10) + 1), 1);
+    assert_eq!(
+        GOOGLE_WORKSPACE_USER_SOURCE_EXECUTION_ADAPTER
+            .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+                request: Some(SourceWorkerPlanRequestV1 {
+                    plan: Some(plan.clone()),
+                    context: Some(invalid_cursor),
+                }),
+                metadata: Some(metadata()),
+            })
+            .unwrap_err(),
+        SourceExecutionError::InvalidCursor
+    );
+
+    let metadata = metadata();
+    let execution = plan_page(&plan, &execution_context, &metadata);
+    assert_eq!(
+        decode_page(&plan, &execution_context, &metadata, &execution, 401, b"{}",).unwrap_err(),
+        SourceExecutionError::AuthenticationRejected
+    );
+    assert_eq!(
+        decode_page(
+            &plan,
+            &execution_context,
+            &metadata,
+            &execution,
+            403,
+            br#"{"error":{"status":"PERMISSION_DENIED","message":"Request had insufficient authentication scopes."}}"#,
+        )
+        .unwrap_err(),
+        SourceExecutionError::RequiredProviderScopeMissing
+    );
+
+    let (_, mut output) = decode_page(
+        &plan,
+        &execution_context,
+        &metadata,
+        &execution,
+        200,
+        br#"{"users":[{"id":"1001","primaryEmail":"admin@writer.com"}]}"#,
+    )
+    .unwrap();
+    let mut record = output.records.remove(0);
+    record
+        .attributes
+        .insert("domain".to_owned(), "other.example".to_owned());
+    assert_eq!(
+        GOOGLE_WORKSPACE_USER_SOURCE_EXECUTION_ADAPTER.validate_record_identity_v2(
+            &execution_context,
+            &record,
+            &metadata,
+        ),
+        Err(SourceExecutionError::TenantMismatch)
+    );
+}


### PR DESCRIPTION
## Summary
- add a credential-free Google Workspace users adapter for the shared source-execution protocol
- bind the exact Directory users request, public domain/customer selectors, opaque pagination, response bounds, stable identity, and Go-compatible event/checkpoint semantics
- keep OAuth credentials, Bearer application, egress, append, projection, and durable checkpoint ownership outside the kernel

This provider-local slice does not register the adapter in the shared dispatcher or change runtime authority. Those shared-path changes will follow after the current dispatcher owner lands.

## Validation
Exact head: `3a4da285236621803941cb96ae30a279091b0c25`

DDESK:
- `cargo fmt --all -- --check`
- `cargo test -p cerebro-source-runtime-next google_workspace::source_execution_tests -- --nocapture` — 3 passed
- `cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings`

Hosted:
- 81 successful checks
- zero failures
- zero unresolved review threads
