### PR TITLE
Compile Anthropic source execution adapters

### DIFF
--- a/crates/source-runtime-next/src/anthropic.rs
+++ b/crates/source-runtime-next/src/anthropic.rs
@@ -11,6 +11,9 @@ mod mappings;
 mod normalize;
 mod request;
 mod response;
+// Provider-local adapters remain intentionally unreachable from the shared
+// dispatcher until a later authority change qualifies each family.
+#[cfg_attr(not(test), allow(dead_code))]
 mod source_execution;
 mod types;
 

--- a/crates/source-runtime-next/src/anthropic.rs
+++ b/crates/source-runtime-next/src/anthropic.rs
@@ -11,6 +11,7 @@ mod mappings;
 mod normalize;
 mod request;
 mod response;
+mod source_execution;
 mod types;
 
 pub use error::AnthropicError;

--- a/crates/source-runtime-next/src/anthropic/normalize.rs
+++ b/crates/source-runtime-next/src/anthropic/normalize.rs
@@ -119,7 +119,7 @@ fn canonical_timestamp(value: &str) -> Option<String> {
         .ok()
 }
 
-fn event_id(
+pub(super) fn event_id(
     tenant_id: &str,
     base_url: &str,
     operation_path: &str,

--- a/crates/source-runtime-next/src/anthropic/source_execution.rs
+++ b/crates/source-runtime-next/src/anthropic/source_execution.rs
@@ -20,8 +20,6 @@ use crate::source_execution::{
 #[path = "source_execution/catalog.rs"]
 mod catalog;
 
-pub(crate) use catalog::ANTHROPIC_SOURCE_EXECUTION_ADAPTERS;
-
 use catalog::{AnthropicSourceExecutionAdapter, map_error, optional, timestamp, validated_kernel};
 
 impl SourceExecutionAdapter for AnthropicSourceExecutionAdapter {

--- a/crates/source-runtime-next/src/anthropic/source_execution.rs
+++ b/crates/source-runtime-next/src/anthropic/source_execution.rs
@@ -1,0 +1,235 @@
+//! Anthropic family bridges for the credential-free source-execution protocol.
+//!
+//! These adapters compile public family contracts and consume bounded provider
+//! bytes. The trusted host retains credential redemption, authentication,
+//! network I/O, durable append, projection, lease fencing, and checkpoints.
+
+use std::collections::HashMap;
+
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceWorkerDecodeEnvelopeV2,
+    SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1, SourceWorkerExecutionContextV1,
+    SourceWorkerHttpExecutionV2, SourceWorkerHttpRequestV1, SourceWorkerPlanEnvelopeV2,
+    SourceWorkerPlanRequestV1, SourceWorkerRecordV1, SourceWorkerRuntimeMetadataV2,
+    canonical_http_execution_digest, canonical_request_intent_digest, canonical_result_digest,
+    validate_and_deduplicate_records,
+};
+
+#[path = "source_execution/catalog.rs"]
+mod catalog;
+
+pub(crate) use catalog::ANTHROPIC_SOURCE_EXECUTION_ADAPTERS;
+
+use catalog::{AnthropicSourceExecutionAdapter, map_error, optional, timestamp, validated_kernel};
+
+impl SourceExecutionAdapter for AnthropicSourceExecutionAdapter {
+    fn source_id(&self) -> &'static str {
+        "anthropic"
+    }
+
+    fn family_id(&self) -> &'static str {
+        self.family().as_str()
+    }
+
+    fn provider_kernel(&self) -> &'static str {
+        self.family().as_str()
+    }
+
+    fn validate_record_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+    ) -> Result<(), SourceExecutionError> {
+        let metadata = SourceWorkerRuntimeMetadataV2 {
+            public_config: HashMap::from([
+                ("family".to_owned(), self.family().as_str().to_owned()),
+                ("base_url".to_owned(), catalog::DEFAULT_BASE_URL.to_owned()),
+            ]),
+            prior_terminal_watermark_unix_millis: 0,
+            prior_checkpoint: String::new(),
+        };
+        self.validate_identity(context, record, &metadata)
+    }
+
+    fn validate_record_identity_v2(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(), SourceExecutionError> {
+        self.validate_identity(context, record, metadata)
+    }
+
+    fn plan(
+        &self,
+        _request: &SourceWorkerPlanRequestV1,
+    ) -> Result<SourceWorkerHttpRequestV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn plan_v2(
+        &self,
+        envelope: &SourceWorkerPlanEnvelopeV2,
+    ) -> Result<SourceWorkerHttpExecutionV2, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, allowed_origin) = validated_kernel(self.family(), context, metadata)?;
+        let provider_request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        let expected_path = format!("/v1{}", provider_request.operation_path);
+        if provider_request.url().path() != expected_path
+            || provider_request.method() != plan.method
+            || provider_request.contains_credentials()
+            || provider_request.allows_redirects()
+            || provider_request.api_version_header() != ("anthropic-version", "2023-06-01")
+        {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        let mut planned = SourceWorkerHttpRequestV1 {
+            plan_id: plan.plan_id.clone(),
+            method: provider_request.method().to_owned(),
+            url: provider_request.url().to_string(),
+            accept: "application/json".to_owned(),
+            max_response_bytes: u64::try_from(provider_request.max_response_bytes())
+                .map_err(|_| SourceExecutionError::InvalidPlan)?,
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            request_intent_digest: String::new(),
+        };
+        planned.request_intent_digest = canonical_request_intent_digest(plan, context, &planned);
+        let mut execution = SourceWorkerHttpExecutionV2 {
+            request: Some(planned),
+            body: Vec::new(),
+            declared_headers: HashMap::from([(
+                "anthropic-version".to_owned(),
+                "2023-06-01".to_owned(),
+            )]),
+            execution_intent_digest_sha256: String::new(),
+            credential_operation: catalog::credential_operation(
+                provider_request.authentication(),
+                &metadata.public_config,
+            )?
+            .to_owned(),
+            allowed_origin,
+        };
+        execution.execution_intent_digest_sha256 =
+            canonical_http_execution_digest(plan, context, metadata, &execution);
+        Ok(execution)
+    }
+
+    fn decode(
+        &self,
+        _request: &SourceWorkerDecodeRequestV1,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn decode_v2(
+        &self,
+        envelope: &SourceWorkerDecodeEnvelopeV2,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let receipt = request
+            .receipt
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, _) = validated_kernel(self.family(), context, metadata)?;
+        let provider_request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        let status = u16::try_from(request.status_code)
+            .map_err(|_| SourceExecutionError::UnexpectedProviderStatus)?;
+        let observed_at = timestamp(context.observed_at_unix_millis)?;
+        let page = kernel
+            .decode_http(
+                &provider_request,
+                status,
+                &request.response_body,
+                &observed_at
+                    .format(&Rfc3339)
+                    .map_err(|_| SourceExecutionError::InvalidExecutionContext)?,
+            )
+            .map_err(map_error)?;
+        let next_cursor = page.next_cursor.unwrap_or_default();
+        let records = page
+            .records
+            .into_iter()
+            .map(|record| {
+                if record.tenant_id != context.tenant_id
+                    || record.provider_kind != plan.event_kind
+                    || record.schema_ref != plan.schema_ref
+                {
+                    return Err(SourceExecutionError::TenantMismatch);
+                }
+                Ok(SourceWorkerRecordV1 {
+                    provider_id: record.provider_id,
+                    event_id: record.event_id,
+                    occurred_at_unix_millis: parse_timestamp(&record.occurred_at)?,
+                    attributes: record.fields.into_iter().collect(),
+                    payload_json: serde_json::to_vec(&record.payload)
+                        .map_err(|_| SourceExecutionError::InternalRuntime)?,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let records = validate_and_deduplicate_records(records)?;
+        let result_digest_sha256 = canonical_result_digest(receipt, &next_cursor, &records)?;
+        Ok(SourceWorkerDecodeResultV1 {
+            plan_id: plan.plan_id.clone(),
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: request.request_intent_digest.clone(),
+            records,
+            next_cursor,
+            result_digest_sha256,
+            tenant_id: context.tenant_id.clone(),
+            runtime_id: context.runtime_id.clone(),
+            runtime_generation: context.runtime_generation,
+            lease_generation: context.lease_generation,
+            observed_at_unix_millis: context.observed_at_unix_millis,
+        })
+    }
+}
+
+fn parse_timestamp(value: &str) -> Result<i64, SourceExecutionError> {
+    let nanos = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| SourceExecutionError::InvalidProviderRecord)?
+        .unix_timestamp_nanos();
+    i64::try_from(nanos / 1_000_000).map_err(|_| SourceExecutionError::InvalidProviderRecord)
+}
+
+#[cfg(test)]
+#[path = "source_execution_tests.rs"]
+mod tests;

--- a/crates/source-runtime-next/src/anthropic/source_execution/catalog.rs
+++ b/crates/source-runtime-next/src/anthropic/source_execution/catalog.rs
@@ -1,0 +1,278 @@
+//! Closed Anthropic adapter catalog and public execution configuration.
+
+use std::collections::{BTreeMap, HashMap};
+
+use time::OffsetDateTime;
+
+use crate::source_execution::{
+    SourceExecutionError, SourceExecutionPlanV1, SourceWorkerExecutionContextV1,
+    SourceWorkerRecordV1, SourceWorkerRuntimeMetadataV2, canonical_plan_digest,
+    validate_execution_context, validate_runtime_metadata,
+};
+
+use super::super::{
+    AnthropicAuthentication, AnthropicError, AnthropicFamily, AnthropicKernel, AnthropicScope,
+    normalize::event_id,
+};
+
+const SOURCE_ID: &str = "anthropic";
+pub(super) const DEFAULT_BASE_URL: &str = "https://api.anthropic.com/v1";
+const ALLOWED_ORIGIN: &str = "https://api.anthropic.com";
+const METHOD: &str = "GET";
+const MAX_RESPONSE_BYTES: u64 = 8 << 20;
+
+/// One credential-free adapter for a closed Anthropic family.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AnthropicSourceExecutionAdapter {
+    family: AnthropicFamily,
+}
+
+impl AnthropicSourceExecutionAdapter {
+    const fn new(family: AnthropicFamily) -> Self {
+        Self { family }
+    }
+
+    pub(super) const fn family(&self) -> AnthropicFamily {
+        self.family
+    }
+
+    pub(crate) fn compiled_plan(&self) -> SourceExecutionPlanV1 {
+        let family_id = self.family.as_str();
+        let mut required_attributes = [
+            "external_id",
+            "family",
+            "provider",
+            "source_product",
+            "source_provider",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+        for attribute in self.family.required_attributes() {
+            if !required_attributes.iter().any(|value| value == attribute) {
+                required_attributes.push((*attribute).to_owned());
+            }
+        }
+        let record_selector = match self.family {
+            AnthropicFamily::Organization => "$",
+            AnthropicFamily::ComplianceOrganizationSetting => "$.settings[*]",
+            _ => "$.data[*]",
+        };
+        let mut plan = SourceExecutionPlanV1 {
+            plan_id: format!("source-plan-v1:anthropic:{family_id}"),
+            source_id: SOURCE_ID.to_owned(),
+            family_id: family_id.to_owned(),
+            provider_kernel: family_id.to_owned(),
+            method: METHOD.to_owned(),
+            origin: DEFAULT_BASE_URL.to_owned(),
+            path: format!("/v1{}", self.family.path()),
+            record_selector: record_selector.to_owned(),
+            id_field: self.family.id_paths().join("|"),
+            singleton_fallback_id: String::new(),
+            max_response_bytes: MAX_RESPONSE_BYTES,
+            event_kind: self.family.provider_kind(),
+            schema_ref: self.family.schema_ref(),
+            required_attributes,
+            required_payload_fields: self
+                .family
+                .required_payload_fields()
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
+            plan_digest_sha256: String::new(),
+        };
+        plan.plan_digest_sha256 = canonical_plan_digest(&plan);
+        plan
+    }
+
+    pub(super) fn validate_plan(
+        &self,
+        plan: &SourceExecutionPlanV1,
+    ) -> Result<(), SourceExecutionError> {
+        if plan != &self.compiled_plan() {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        Ok(())
+    }
+
+    pub(super) fn validate_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(), SourceExecutionError> {
+        let (kernel, _) = validated_kernel(self.family, context, metadata)?;
+        let request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        let expected = event_id(
+            &context.tenant_id,
+            DEFAULT_BASE_URL,
+            &request.operation_path,
+            self.family,
+            &record.provider_id,
+        );
+        if record.event_id != expected
+            || record.attributes.get("external_id") != Some(&record.provider_id)
+            || record.attributes.get("family").map(String::as_str) != Some(self.family.as_str())
+            || record.attributes.get("provider").map(String::as_str) != Some("anthropic")
+            || record.attributes.get("source_provider").map(String::as_str) != Some("anthropic")
+        {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        Ok(())
+    }
+}
+
+pub(crate) static ANTHROPIC_SOURCE_EXECUTION_ADAPTERS: [AnthropicSourceExecutionAdapter; 28] = [
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::AnalyticsCost),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::ApiKey),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::ComplianceActivity),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::ComplianceGroup),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::ComplianceGroupMember),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::ComplianceOrganization),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::ComplianceOrganizationSetting),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::ComplianceOrganizationUser),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::ComplianceProject),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::ComplianceProjectCollaborator),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::ComplianceRole),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::ComplianceRolePermission),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::CostReport),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::ExternalKey),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::FederationIssuer),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::FederationRule),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::Invite),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::Organization),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::RateLimit),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::ServiceAccount),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::SpendLimit),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::SpendLimitIncreaseRequest),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::UsageReportClaudeCode),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::UsageReportMessage),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::User),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::Workspace),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::WorkspaceMember),
+    AnthropicSourceExecutionAdapter::new(AnthropicFamily::WorkspaceRateLimit),
+];
+
+pub(super) fn validated_kernel(
+    family: AnthropicFamily,
+    context: &SourceWorkerExecutionContextV1,
+    metadata: &SourceWorkerRuntimeMetadataV2,
+) -> Result<(AnthropicKernel, String), SourceExecutionError> {
+    validate_execution_context(context)?;
+    validate_runtime_metadata(metadata)?;
+    if public_value(&metadata.public_config, "family").is_some_and(|value| value != family.as_str())
+    {
+        return Err(SourceExecutionError::MissingConfiguration);
+    }
+    if public_value(&metadata.public_config, "base_url")
+        .is_some_and(|value| value.trim_end_matches('/') != DEFAULT_BASE_URL)
+    {
+        return Err(SourceExecutionError::MissingConfiguration);
+    }
+    let page_size = public_value(&metadata.public_config, "per_page")
+        .or_else(|| public_value(&metadata.public_config, "page_size"))
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .map_err(|_| SourceExecutionError::MissingConfiguration)
+        })
+        .transpose()?;
+    let path_parameters = family
+        .path_parameters()
+        .iter()
+        .filter_map(|name| {
+            public_value(&metadata.public_config, name)
+                .map(|value| ((*name).to_owned(), value.to_owned()))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let query_parameters = family
+        .query_parameters()
+        .iter()
+        .filter_map(|(_, name)| {
+            public_value(&metadata.public_config, name)
+                .map(|value| ((*name).to_owned(), value.to_owned()))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let kernel = AnthropicKernel::new(
+        DEFAULT_BASE_URL,
+        &context.tenant_id,
+        family,
+        AnthropicScope {
+            path_parameters,
+            query_parameters,
+        },
+        page_size,
+    )
+    .map_err(map_error)?;
+    Ok((kernel, ALLOWED_ORIGIN.to_owned()))
+}
+
+pub(super) fn credential_operation(
+    authentication: AnthropicAuthentication,
+    config: &HashMap<String, String>,
+) -> Result<&'static str, SourceExecutionError> {
+    let auth_model = public_value(config, "auth_model");
+    match authentication {
+        AnthropicAuthentication::AdminKeyOrOrgAdminBearer => match auth_model {
+            None | Some("api_key" | "legacy_token") => Ok("anthropic.admin_x_api_key"),
+            Some("bearer_token") => Ok("anthropic.org_admin_bearer"),
+            Some(_) => Err(SourceExecutionError::MissingConfiguration),
+        },
+        AnthropicAuthentication::OrgAdminBearer => match auth_model {
+            None | Some("bearer_token") => Ok("anthropic.org_admin_bearer"),
+            Some(_) => Err(SourceExecutionError::MissingConfiguration),
+        },
+        AnthropicAuthentication::ComplianceAccessKey => match auth_model {
+            None | Some("api_key" | "legacy_token") => Ok("anthropic.compliance_x_api_key"),
+            Some(_) => Err(SourceExecutionError::MissingConfiguration),
+        },
+    }
+}
+
+pub(super) fn timestamp(unix_millis: i64) -> Result<OffsetDateTime, SourceExecutionError> {
+    OffsetDateTime::from_unix_timestamp_nanos(i128::from(unix_millis) * 1_000_000)
+        .map_err(|_| SourceExecutionError::InvalidExecutionContext)
+}
+
+pub(super) fn optional(value: &str) -> Option<&str> {
+    (!value.is_empty()).then_some(value)
+}
+
+fn public_value<'a>(config: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    config
+        .get(key)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+pub(super) fn map_error(error: AnthropicError) -> SourceExecutionError {
+    match error {
+        AnthropicError::InvalidFamily => SourceExecutionError::UnknownAdapter,
+        AnthropicError::InvalidBaseUrl
+        | AnthropicError::MissingPathParameter
+        | AnthropicError::InvalidParameter
+        | AnthropicError::InvalidPageSize => SourceExecutionError::MissingConfiguration,
+        AnthropicError::MissingTenantId | AnthropicError::InvalidObservedAt => {
+            SourceExecutionError::InvalidExecutionContext
+        }
+        AnthropicError::InvalidCursor => SourceExecutionError::InvalidCursor,
+        AnthropicError::RequestScopeMismatch => SourceExecutionError::InvalidPlan,
+        AnthropicError::AuthenticationRejected => SourceExecutionError::AuthenticationRejected,
+        AnthropicError::RequiredProviderScopeMissing => {
+            SourceExecutionError::RequiredProviderScopeMissing
+        }
+        AnthropicError::ProviderRateLimit => SourceExecutionError::ProviderRateLimit,
+        AnthropicError::ProviderUnavailable | AnthropicError::UnexpectedProviderStatus => {
+            SourceExecutionError::UnexpectedProviderStatus
+        }
+        AnthropicError::ResponseTooLarge => SourceExecutionError::ResponseTooLarge,
+        AnthropicError::MalformedResponse => SourceExecutionError::MalformedResponse,
+        AnthropicError::InvalidRecord => SourceExecutionError::InvalidProviderRecord,
+        AnthropicError::MissingStableIdentity => SourceExecutionError::MissingStableIdentity,
+        AnthropicError::EventContractRejected => SourceExecutionError::EventContractRejected,
+        AnthropicError::DuplicateConflict => SourceExecutionError::DuplicateConflict,
+    }
+}

--- a/crates/source-runtime-next/src/anthropic/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/anthropic/source_execution_tests.rs
@@ -9,7 +9,7 @@ use crate::source_execution::{
     SourceWorkerRuntimeMetadataV2, SourceWorkerSafeReceiptV1, response_digest,
 };
 
-use super::{ANTHROPIC_SOURCE_EXECUTION_ADAPTERS, DEFAULT_BASE_URL};
+use super::catalog::{ANTHROPIC_SOURCE_EXECUTION_ADAPTERS, DEFAULT_BASE_URL};
 use crate::anthropic::{AnthropicAuthentication, AnthropicFamily};
 
 const OBSERVED_AT_MILLIS: i64 = 1_780_272_000_000;

--- a/crates/source-runtime-next/src/anthropic/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/anthropic/source_execution_tests.rs
@@ -125,8 +125,13 @@ fn every_family_plans_one_origin_restricted_credential_free_request() {
         let request = execution.request.expect("planned request");
         assert_eq!(request.method, "GET");
         assert!(request.url.starts_with(DEFAULT_BASE_URL));
-        assert!(!request.url.contains("api_key"));
-        assert!(!request.url.contains("token"));
+        let url = reqwest::Url::parse(&request.url).expect("planned URL");
+        assert!(url.username().is_empty());
+        assert!(url.password().is_none());
+        assert!(url.query_pairs().all(|(key, _)| !matches!(
+            key.as_ref(),
+            "api_key" | "api_token" | "access_token" | "token"
+        )));
     }
 }
 

--- a/crates/source-runtime-next/src/anthropic/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/anthropic/source_execution_tests.rs
@@ -1,0 +1,305 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionDispatcher, SourceExecutionError,
+    SourceExecutionSelectionRequestV1, SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1,
+    SourceWorkerExecutionContextV1, SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1,
+    SourceWorkerRuntimeMetadataV2, SourceWorkerSafeReceiptV1, response_digest,
+};
+
+use super::{ANTHROPIC_SOURCE_EXECUTION_ADAPTERS, DEFAULT_BASE_URL};
+use crate::anthropic::{AnthropicAuthentication, AnthropicFamily};
+
+const OBSERVED_AT_MILLIS: i64 = 1_780_272_000_000;
+
+fn context(cursor: &str, page: u32) -> SourceWorkerExecutionContextV1 {
+    SourceWorkerExecutionContextV1 {
+        tenant_id: "tenant".to_owned(),
+        runtime_id: "anthropic-runtime".to_owned(),
+        logical_page_id: format!("source-page-v2:anthropic-{page}"),
+        prior_cursor: cursor.to_owned(),
+        runtime_generation: 7,
+        lease_generation: 11,
+        observed_at_unix_millis: OBSERVED_AT_MILLIS,
+    }
+}
+
+fn metadata(family: AnthropicFamily) -> SourceWorkerRuntimeMetadataV2 {
+    let mut public_config = HashMap::from([
+        ("family".to_owned(), family.as_str().to_owned()),
+        ("per_page".to_owned(), "2".to_owned()),
+    ]);
+    for parameter in family.path_parameters() {
+        public_config.insert((*parameter).to_owned(), format!("{parameter}-1"));
+    }
+    SourceWorkerRuntimeMetadataV2 {
+        public_config,
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    }
+}
+
+fn adapter(family: AnthropicFamily) -> &'static super::AnthropicSourceExecutionAdapter {
+    ANTHROPIC_SOURCE_EXECUTION_ADAPTERS
+        .iter()
+        .find(|adapter| adapter.family() == family)
+        .expect("Anthropic adapter")
+}
+
+#[test]
+fn provider_local_catalog_compiles_every_anthropic_family_without_authority() {
+    assert_eq!(
+        ANTHROPIC_SOURCE_EXECUTION_ADAPTERS.len(),
+        AnthropicFamily::ALL.len()
+    );
+    for family in AnthropicFamily::ALL {
+        let adapter = adapter(family);
+        let plan = adapter.compiled_plan();
+        assert_eq!(plan.source_id, "anthropic");
+        assert_eq!(plan.family_id, family.as_str());
+        assert_eq!(plan.provider_kernel, family.as_str());
+        assert_eq!(plan.origin, DEFAULT_BASE_URL);
+        assert_eq!(plan.path, format!("/v1{}", family.path()));
+        assert_eq!(plan.id_field, family.id_paths().join("|"));
+        assert_eq!(plan.event_kind, family.provider_kind());
+        assert_eq!(plan.schema_ref, family.schema_ref());
+        assert!(plan.required_attributes.contains(&"external_id".to_owned()));
+        assert!(plan.required_attributes.contains(&"family".to_owned()));
+
+        assert_eq!(
+            SourceExecutionDispatcher.compile_plan(&SourceExecutionSelectionRequestV1 {
+                source_id: "anthropic".to_owned(),
+                family_id: family.as_str().to_owned(),
+            }),
+            Err(SourceExecutionError::UnknownAdapter),
+            "{} must remain outside shared authority",
+            family.as_str()
+        );
+    }
+}
+
+#[test]
+fn every_family_plans_one_origin_restricted_credential_free_request() {
+    for family in AnthropicFamily::ALL {
+        let adapter = adapter(family);
+        let plan = adapter.compiled_plan();
+        let mut metadata = metadata(family);
+        if family
+            .query_parameters()
+            .iter()
+            .any(|(_, name)| *name == "models")
+        {
+            metadata
+                .public_config
+                .insert("models".to_owned(), "model-a,model-b".to_owned());
+        }
+        let execution = adapter
+            .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+                request: Some(SourceWorkerPlanRequestV1 {
+                    plan: Some(plan),
+                    context: Some(context("", 1)),
+                }),
+                metadata: Some(metadata),
+            })
+            .unwrap_or_else(|error| panic!("{} plan: {error}", family.as_str()));
+        assert_eq!(execution.allowed_origin, "https://api.anthropic.com");
+        assert!(execution.body.is_empty());
+        assert_eq!(
+            execution.declared_headers.get("anthropic-version"),
+            Some(&"2023-06-01".to_owned())
+        );
+        assert_eq!(
+            execution.credential_operation,
+            match family.authentication() {
+                AnthropicAuthentication::AdminKeyOrOrgAdminBearer => {
+                    "anthropic.admin_x_api_key"
+                }
+                AnthropicAuthentication::OrgAdminBearer => "anthropic.org_admin_bearer",
+                AnthropicAuthentication::ComplianceAccessKey => {
+                    "anthropic.compliance_x_api_key"
+                }
+            }
+        );
+        let request = execution.request.expect("planned request");
+        assert_eq!(request.method, "GET");
+        assert!(request.url.starts_with(DEFAULT_BASE_URL));
+        assert!(!request.url.contains("api_key"));
+        assert!(!request.url.contains("token"));
+    }
+}
+
+#[test]
+fn auth_model_is_explicit_and_family_scoped() {
+    let user = adapter(AnthropicFamily::User);
+    let user_plan = user.compiled_plan();
+    let mut bearer = metadata(AnthropicFamily::User);
+    bearer
+        .public_config
+        .insert("auth_model".to_owned(), "bearer_token".to_owned());
+    let execution = user
+        .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(user_plan),
+                context: Some(context("", 1)),
+            }),
+            metadata: Some(bearer),
+        })
+        .unwrap();
+    assert_eq!(execution.credential_operation, "anthropic.org_admin_bearer");
+
+    let compliance = adapter(AnthropicFamily::ComplianceActivity);
+    let mut invalid = metadata(AnthropicFamily::ComplianceActivity);
+    invalid
+        .public_config
+        .insert("auth_model".to_owned(), "bearer_token".to_owned());
+    assert_eq!(
+        compliance.plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(compliance.compiled_plan()),
+                context: Some(context("", 1)),
+            }),
+            metadata: Some(invalid),
+        }),
+        Err(SourceExecutionError::MissingConfiguration)
+    );
+}
+
+#[test]
+fn user_decode_preserves_cursor_identity_and_provider_failures() {
+    let adapter = adapter(AnthropicFamily::User);
+    let plan = adapter.compiled_plan();
+    let context = context("", 1);
+    let metadata = metadata(AnthropicFamily::User);
+    let execution = adapter
+        .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+        })
+        .unwrap();
+    let planned = execution.request.as_ref().unwrap();
+    let body = br#"{"data":[{"id":"user_1","email":"person@example.test","role":"admin","status":"active"}],"has_more":true,"last_id":"user_1"}"#;
+    let receipt = SourceWorkerSafeReceiptV1 {
+        plan_digest_sha256: plan.plan_digest_sha256.clone(),
+        logical_page_id: context.logical_page_id.clone(),
+        request_intent_digest: planned.request_intent_digest.clone(),
+        runtime_generation: context.runtime_generation,
+        lease_generation: context.lease_generation,
+        credential_operation: execution.credential_operation.clone(),
+        status_code: 200,
+        response_bytes: body.len() as u64,
+        response_sha256: response_digest(body),
+        tenant_id: context.tenant_id.clone(),
+        runtime_id: context.runtime_id.clone(),
+        observed_at_unix_millis: context.observed_at_unix_millis,
+    };
+    let result = adapter
+        .decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+            request: Some(SourceWorkerDecodeRequestV1 {
+                plan: Some(plan.clone()),
+                status_code: 200,
+                response_body: body.to_vec(),
+                logical_page_id: context.logical_page_id.clone(),
+                request_intent_digest: planned.request_intent_digest.clone(),
+                receipt: Some(receipt),
+                context: Some(context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+            response_headers: HashMap::new(),
+            response_headers_sha256: String::new(),
+            execution_intent_digest_sha256: execution.execution_intent_digest_sha256,
+        })
+        .unwrap();
+    assert_eq!(result.next_cursor, "user_1");
+    assert_eq!(result.records.len(), 1);
+    let record = &result.records[0];
+    assert_eq!(record.provider_id, "user_1");
+    assert_eq!(record.attributes["user_id"], "user_1");
+    assert_eq!(record.attributes["source_provider"], "anthropic");
+    adapter
+        .validate_record_identity_v2(&context, record, &metadata)
+        .unwrap();
+    let payload: Value = serde_json::from_slice(&record.payload_json).unwrap();
+    assert_eq!(payload["id"], "user_1");
+
+    for (status, expected) in [
+        (401, SourceExecutionError::AuthenticationRejected),
+        (403, SourceExecutionError::RequiredProviderScopeMissing),
+        (429, SourceExecutionError::ProviderRateLimit),
+        (503, SourceExecutionError::UnexpectedProviderStatus),
+    ] {
+        let receipt = SourceWorkerSafeReceiptV1 {
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: planned.request_intent_digest.clone(),
+            runtime_generation: context.runtime_generation,
+            lease_generation: context.lease_generation,
+            credential_operation: execution.credential_operation.clone(),
+            status_code: status,
+            response_bytes: 2,
+            response_sha256: response_digest(b"{}"),
+            tenant_id: context.tenant_id.clone(),
+            runtime_id: context.runtime_id.clone(),
+            observed_at_unix_millis: context.observed_at_unix_millis,
+        };
+        assert_eq!(
+            adapter.decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+                request: Some(SourceWorkerDecodeRequestV1 {
+                    plan: Some(plan.clone()),
+                    status_code: status,
+                    response_body: b"{}".to_vec(),
+                    logical_page_id: context.logical_page_id.clone(),
+                    request_intent_digest: planned.request_intent_digest.clone(),
+                    receipt: Some(receipt),
+                    context: Some(context.clone()),
+                }),
+                metadata: Some(metadata.clone()),
+                response_headers: HashMap::new(),
+                response_headers_sha256: String::new(),
+                execution_intent_digest_sha256: String::new(),
+            }),
+            Err(expected)
+        );
+    }
+}
+
+#[test]
+fn base_url_family_path_scope_and_identity_fail_closed() {
+    let user = adapter(AnthropicFamily::User);
+    let mut wrong_origin = metadata(AnthropicFamily::User);
+    wrong_origin.public_config.insert(
+        "base_url".to_owned(),
+        "https://example.invalid/v1".to_owned(),
+    );
+    assert_eq!(
+        user.plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(user.compiled_plan()),
+                context: Some(context("", 1)),
+            }),
+            metadata: Some(wrong_origin),
+        }),
+        Err(SourceExecutionError::MissingConfiguration)
+    );
+
+    let member = adapter(AnthropicFamily::WorkspaceMember);
+    let missing_scope = SourceWorkerRuntimeMetadataV2 {
+        public_config: HashMap::from([("family".to_owned(), "workspace_member".to_owned())]),
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    };
+    assert_eq!(
+        member.plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(member.compiled_plan()),
+                context: Some(context("", 1)),
+            }),
+            metadata: Some(missing_scope),
+        }),
+        Err(SourceExecutionError::MissingConfiguration)
+    );
+}


### PR DESCRIPTION
## Summary

- compile credential-free source-execution adapters for all 28 Anthropic Admin and Compliance API families
- bind each family to its closed request path, selector, stable identity, event contract, pagination model, and public authentication operation
- keep credential redemption, authentication, network execution, append, projection, checkpoint, and authority in the trusted host
- keep every Anthropic family outside the shared dispatcher in this slice, so the existing Go collector remains authoritative

## Validation

- `rustfmt --edition 2024 --check crates/source-runtime-next/src/anthropic.rs crates/source-runtime-next/src/anthropic/normalize.rs crates/source-runtime-next/src/anthropic/source_execution.rs crates/source-runtime-next/src/anthropic/source_execution/catalog.rs crates/source-runtime-next/src/anthropic/source_execution_tests.rs`
- `go test ./sources/anthropic -count=1`
- `make source-fixture-check`
- `make check-structural check-structural-test check-arch`
- `git diff --check`

Managed Cargo capacity blocked local Rust compilation before build output was created. This draft requires exact-head hosted Rust tests and Clippy before it can be readied.

## Authority boundary

This pull request adds provider-local request/response adapters only. It does not register Anthropic with the shared dispatcher, change source authority, remove the Go collector, redeem credentials, or add environment-specific configuration.
