### PR TITLE
Compile Discord source execution adapters

### DIFF
--- a/crates/source-runtime-next/src/discord.rs
+++ b/crates/source-runtime-next/src/discord.rs
@@ -10,6 +10,10 @@ mod family;
 mod normalize;
 mod request;
 mod response;
+// Provider-local adapters remain intentionally unreachable from the shared
+// dispatcher until a later authority change qualifies each family.
+#[cfg_attr(not(test), allow(dead_code))]
+mod source_execution;
 mod types;
 mod wire;
 

--- a/crates/source-runtime-next/src/discord/normalize.rs
+++ b/crates/source-runtime-next/src/discord/normalize.rs
@@ -90,7 +90,7 @@ fn snowflake_unix_millis(value: &str) -> Result<i64, DiscordError> {
     i64::try_from(milliseconds).map_err(|_| DiscordError::InvalidRecord)
 }
 
-fn event_id(
+pub(super) fn event_id(
     tenant_id: &str,
     base_url: &str,
     operation_path: &str,

--- a/crates/source-runtime-next/src/discord/source_execution.rs
+++ b/crates/source-runtime-next/src/discord/source_execution.rs
@@ -1,0 +1,228 @@
+//! Discord family bridges for the credential-free source-execution protocol.
+//!
+//! These adapters compile public family contracts and consume bounded provider
+//! bytes. The trusted host retains bot-token redemption, authentication,
+//! network I/O, durable append, projection, lease fencing, and checkpoints.
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceWorkerDecodeEnvelopeV2,
+    SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1, SourceWorkerExecutionContextV1,
+    SourceWorkerHttpExecutionV2, SourceWorkerHttpRequestV1, SourceWorkerPlanEnvelopeV2,
+    SourceWorkerPlanRequestV1, SourceWorkerRecordV1, SourceWorkerRuntimeMetadataV2,
+    canonical_http_execution_digest, canonical_request_intent_digest, canonical_result_digest,
+    validate_and_deduplicate_records,
+};
+
+#[path = "source_execution/catalog.rs"]
+mod catalog;
+
+use catalog::{DiscordSourceExecutionAdapter, map_error, optional, validated_kernel};
+
+impl SourceExecutionAdapter for DiscordSourceExecutionAdapter {
+    fn source_id(&self) -> &'static str {
+        "discord"
+    }
+
+    fn family_id(&self) -> &'static str {
+        self.family().as_str()
+    }
+
+    fn provider_kernel(&self) -> &'static str {
+        self.family().provider_kind()
+    }
+
+    fn validate_record_identity(
+        &self,
+        _context: &SourceWorkerExecutionContextV1,
+        _record: &SourceWorkerRecordV1,
+    ) -> Result<(), SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn validate_record_identity_v2(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(), SourceExecutionError> {
+        self.validate_identity(context, record, metadata)
+    }
+
+    fn plan(
+        &self,
+        _request: &SourceWorkerPlanRequestV1,
+    ) -> Result<SourceWorkerHttpRequestV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn plan_v2(
+        &self,
+        envelope: &SourceWorkerPlanEnvelopeV2,
+    ) -> Result<SourceWorkerHttpExecutionV2, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, allowed_origin) = validated_kernel(self.family(), context, metadata)?;
+        let provider_request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        let expected_path = format!("/api/v10{}", provider_request.operation_path);
+        if provider_request.url().path() != expected_path
+            || provider_request.method() != plan.method
+            || provider_request.authorization_header() != "Authorization"
+            || provider_request.authorization_scheme() != "Bot"
+            || provider_request.contains_credentials()
+            || provider_request.allows_redirects()
+        {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        let mut planned = SourceWorkerHttpRequestV1 {
+            plan_id: plan.plan_id.clone(),
+            method: provider_request.method().to_owned(),
+            url: provider_request.url().to_string(),
+            accept: provider_request.accept().to_owned(),
+            max_response_bytes: u64::try_from(provider_request.max_response_bytes())
+                .map_err(|_| SourceExecutionError::InvalidPlan)?,
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            request_intent_digest: String::new(),
+        };
+        planned.request_intent_digest = canonical_request_intent_digest(plan, context, &planned);
+        let mut execution = SourceWorkerHttpExecutionV2 {
+            request: Some(planned),
+            body: Vec::new(),
+            declared_headers: Default::default(),
+            execution_intent_digest_sha256: String::new(),
+            credential_operation: "discord.bot_token".to_owned(),
+            allowed_origin,
+        };
+        execution.execution_intent_digest_sha256 =
+            canonical_http_execution_digest(plan, context, metadata, &execution);
+        Ok(execution)
+    }
+
+    fn decode(
+        &self,
+        _request: &SourceWorkerDecodeRequestV1,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn decode_v2(
+        &self,
+        envelope: &SourceWorkerDecodeEnvelopeV2,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let receipt = request
+            .receipt
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, _) = validated_kernel(self.family(), context, metadata)?;
+        let provider_request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        let retry_after_seconds = response_header(&envelope.response_headers, "retry-after")
+            .map(|value| {
+                value
+                    .parse::<u64>()
+                    .map_err(|_| SourceExecutionError::UnexpectedProviderStatus)
+            })
+            .transpose()?;
+        let status = u16::try_from(request.status_code)
+            .map_err(|_| SourceExecutionError::UnexpectedProviderStatus)?;
+        let page = kernel
+            .decode_http(
+                &provider_request,
+                status,
+                retry_after_seconds,
+                &request.response_body,
+            )
+            .map_err(map_error)?;
+        let next_cursor = page.next_cursor.unwrap_or_default();
+        let records = page
+            .records
+            .into_iter()
+            .map(|mut record| {
+                if record.tenant_id != context.tenant_id
+                    || record.source_id != plan.source_id
+                    || record.family != plan.family_id
+                    || record.provider_kind != plan.event_kind
+                    || record.schema_ref != plan.schema_ref
+                {
+                    return Err(SourceExecutionError::TenantMismatch);
+                }
+                record
+                    .fields
+                    .insert("tenant_id".to_owned(), context.tenant_id.clone());
+                Ok(SourceWorkerRecordV1 {
+                    provider_id: record.provider_id,
+                    event_id: record.event_id,
+                    occurred_at_unix_millis: record.occurred_at_unix_millis,
+                    attributes: record.fields.into_iter().collect(),
+                    payload_json: serde_json::to_vec(&record.payload)
+                        .map_err(|_| SourceExecutionError::InternalRuntime)?,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let records = validate_and_deduplicate_records(records)?;
+        let result_digest_sha256 = canonical_result_digest(receipt, &next_cursor, &records)?;
+        Ok(SourceWorkerDecodeResultV1 {
+            plan_id: plan.plan_id.clone(),
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: request.request_intent_digest.clone(),
+            records,
+            next_cursor,
+            result_digest_sha256,
+            tenant_id: context.tenant_id.clone(),
+            runtime_id: context.runtime_id.clone(),
+            runtime_generation: context.runtime_generation,
+            lease_generation: context.lease_generation,
+            observed_at_unix_millis: context.observed_at_unix_millis,
+        })
+    }
+}
+
+fn response_header<'a>(
+    headers: &'a std::collections::HashMap<String, String>,
+    name: &str,
+) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.trim())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+#[path = "source_execution_tests.rs"]
+mod tests;

--- a/crates/source-runtime-next/src/discord/source_execution/catalog.rs
+++ b/crates/source-runtime-next/src/discord/source_execution/catalog.rs
@@ -1,0 +1,245 @@
+//! Closed Discord adapter catalog and public execution configuration.
+
+use std::collections::HashMap;
+
+use crate::source_execution::{
+    SourceExecutionError, SourceExecutionPlanV1, SourceWorkerExecutionContextV1,
+    SourceWorkerRecordV1, SourceWorkerRuntimeMetadataV2, canonical_plan_digest,
+    validate_execution_context, validate_runtime_metadata,
+};
+
+use super::super::{DiscordError, DiscordFamily, DiscordKernel, normalize::event_id};
+
+const SOURCE_ID: &str = "discord";
+pub(super) const DEFAULT_BASE_URL: &str = "https://discord.com/api/v10";
+const METHOD: &str = "GET";
+const MAX_RESPONSE_BYTES: u64 = 4 << 20;
+
+/// One credential-free adapter for a closed Discord family.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct DiscordSourceExecutionAdapter {
+    family: DiscordFamily,
+}
+
+impl DiscordSourceExecutionAdapter {
+    const fn new(family: DiscordFamily) -> Self {
+        Self { family }
+    }
+
+    pub(super) const fn family(&self) -> DiscordFamily {
+        self.family
+    }
+
+    pub(crate) fn compiled_plan(&self) -> SourceExecutionPlanV1 {
+        let family_id = self.family.as_str();
+        let mut plan = SourceExecutionPlanV1 {
+            plan_id: format!("source-plan-v1:discord:{family_id}"),
+            source_id: SOURCE_ID.to_owned(),
+            family_id: family_id.to_owned(),
+            provider_kernel: self.family.provider_kind().to_owned(),
+            method: METHOD.to_owned(),
+            origin: DEFAULT_BASE_URL.to_owned(),
+            path: family_path(self.family).to_owned(),
+            record_selector: record_selector(self.family).to_owned(),
+            id_field: id_field(self.family).to_owned(),
+            singleton_fallback_id: String::new(),
+            max_response_bytes: MAX_RESPONSE_BYTES,
+            event_kind: self.family.provider_kind().to_owned(),
+            schema_ref: format!("discord/{family_id}/v1"),
+            required_attributes: required_attributes(self.family)
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
+            required_payload_fields: required_payload_fields(self.family)
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
+            plan_digest_sha256: String::new(),
+        };
+        plan.plan_digest_sha256 = canonical_plan_digest(&plan);
+        plan
+    }
+
+    pub(super) fn validate_plan(
+        &self,
+        plan: &SourceExecutionPlanV1,
+    ) -> Result<(), SourceExecutionError> {
+        if plan != &self.compiled_plan() {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        Ok(())
+    }
+
+    pub(super) fn validate_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(), SourceExecutionError> {
+        let (kernel, _) = validated_kernel(self.family, context, metadata)?;
+        let request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        let expected = event_id(
+            &context.tenant_id,
+            DEFAULT_BASE_URL,
+            &request.operation_path,
+            self.family,
+            &record.provider_id,
+        );
+        if record.event_id != expected
+            || record.attributes.get("external_id") != Some(&record.provider_id)
+            || record.attributes.get("family").map(String::as_str) != Some(self.family.as_str())
+            || record.attributes.get("provider").map(String::as_str) != Some(SOURCE_ID)
+            || record.attributes.get("source_provider").map(String::as_str) != Some(SOURCE_ID)
+            || record.attributes.get("tenant_id") != Some(&context.tenant_id)
+        {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        Ok(())
+    }
+}
+
+pub(crate) static DISCORD_SOURCE_EXECUTION_ADAPTERS: [DiscordSourceExecutionAdapter; 4] = [
+    DiscordSourceExecutionAdapter::new(DiscordFamily::AuditLog),
+    DiscordSourceExecutionAdapter::new(DiscordFamily::Member),
+    DiscordSourceExecutionAdapter::new(DiscordFamily::Role),
+    DiscordSourceExecutionAdapter::new(DiscordFamily::Permission),
+];
+
+pub(super) fn validated_kernel(
+    family: DiscordFamily,
+    context: &SourceWorkerExecutionContextV1,
+    metadata: &SourceWorkerRuntimeMetadataV2,
+) -> Result<(DiscordKernel, String), SourceExecutionError> {
+    validate_execution_context(context)?;
+    validate_runtime_metadata(metadata)?;
+    if public_value(&metadata.public_config, "family").is_some_and(|value| value != family.as_str())
+    {
+        return Err(SourceExecutionError::MissingConfiguration);
+    }
+    if public_value(&metadata.public_config, "base_url")
+        .is_some_and(|value| value.trim_end_matches('/') != DEFAULT_BASE_URL)
+    {
+        return Err(SourceExecutionError::MissingConfiguration);
+    }
+    let guild_id = public_value(&metadata.public_config, "guild_id")
+        .ok_or(SourceExecutionError::MissingConfiguration)?;
+    let application_id = public_value(&metadata.public_config, "application_id");
+    let page_size = if matches!(family, DiscordFamily::AuditLog | DiscordFamily::Member) {
+        public_value(&metadata.public_config, "per_page")
+            .map(|value| {
+                value
+                    .parse::<usize>()
+                    .map_err(|_| SourceExecutionError::MissingConfiguration)
+            })
+            .transpose()?
+    } else {
+        None
+    };
+    let kernel = DiscordKernel::new(
+        DEFAULT_BASE_URL,
+        &context.tenant_id,
+        guild_id,
+        application_id,
+        family,
+        page_size,
+    )
+    .map_err(map_error)?;
+    Ok((kernel, DEFAULT_BASE_URL.to_owned()))
+}
+
+pub(super) const fn family_path(family: DiscordFamily) -> &'static str {
+    match family {
+        DiscordFamily::AuditLog => "/guilds/{guild_id}/audit-logs",
+        DiscordFamily::Member => "/guilds/{guild_id}/members",
+        DiscordFamily::Role => "/guilds/{guild_id}/roles",
+        DiscordFamily::Permission => {
+            "/applications/{application_id}/guilds/{guild_id}/commands/permissions"
+        }
+    }
+}
+
+const fn record_selector(family: DiscordFamily) -> &'static str {
+    match family {
+        DiscordFamily::AuditLog => "$.audit_log_entries[*]",
+        DiscordFamily::Member | DiscordFamily::Role | DiscordFamily::Permission => "$[*]",
+    }
+}
+
+const fn id_field(family: DiscordFamily) -> &'static str {
+    match family {
+        DiscordFamily::Member => "user.id",
+        DiscordFamily::AuditLog | DiscordFamily::Role | DiscordFamily::Permission => "id",
+    }
+}
+
+const fn required_attributes(family: DiscordFamily) -> &'static [&'static str] {
+    match family {
+        DiscordFamily::AuditLog => &["tenant_id", "source_event_id", "event_type"],
+        DiscordFamily::Member => &["tenant_id", "source_event_id", "user_id"],
+        DiscordFamily::Role => &["tenant_id", "source_event_id", "group_id"],
+        DiscordFamily::Permission => &[
+            "tenant_id",
+            "source_event_id",
+            "resource_urn",
+            "resource_type",
+            "resource_id",
+        ],
+    }
+}
+
+const fn required_payload_fields(family: DiscordFamily) -> &'static [&'static str] {
+    match family {
+        DiscordFamily::Member => &["avatar"],
+        DiscordFamily::AuditLog | DiscordFamily::Role | DiscordFamily::Permission => &["id"],
+    }
+}
+
+pub(super) fn optional(value: &str) -> Option<&str> {
+    (!value.is_empty()).then_some(value)
+}
+
+fn public_value<'a>(config: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    config
+        .get(key)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+pub(super) fn map_error(error: DiscordError) -> SourceExecutionError {
+    match error {
+        DiscordError::InvalidFamily => SourceExecutionError::UnknownAdapter,
+        DiscordError::InvalidBaseUrl
+        | DiscordError::UnsafeOrigin
+        | DiscordError::InvalidGuildId
+        | DiscordError::InvalidApplicationId
+        | DiscordError::MissingApplicationId
+        | DiscordError::InvalidPageSize
+        | DiscordError::UnsupportedPageSize => SourceExecutionError::MissingConfiguration,
+        DiscordError::InvalidTenantId => SourceExecutionError::InvalidExecutionContext,
+        DiscordError::InvalidCursor | DiscordError::UnsupportedCursor => {
+            SourceExecutionError::InvalidCursor
+        }
+        DiscordError::InvalidResponse => SourceExecutionError::MalformedResponse,
+        DiscordError::ResponseTooLarge => SourceExecutionError::ResponseTooLarge,
+        DiscordError::TooManyRecords | DiscordError::TooManyNestedRecords => {
+            SourceExecutionError::ResultTooLarge
+        }
+        DiscordError::InvalidRecord | DiscordError::CredentialMaterial => {
+            SourceExecutionError::InvalidProviderRecord
+        }
+        DiscordError::MissingProviderId => SourceExecutionError::MissingStableIdentity,
+        DiscordError::InvalidPageOrder => SourceExecutionError::InvalidProviderRecord,
+        DiscordError::RequestScopeMismatch => SourceExecutionError::InvalidPlan,
+        DiscordError::ConflictingDuplicate => SourceExecutionError::DuplicateConflict,
+        DiscordError::AuthenticationRejected => SourceExecutionError::AuthenticationRejected,
+        DiscordError::RequiredScopeMissing => SourceExecutionError::RequiredProviderScopeMissing,
+        DiscordError::RateLimited { .. } => SourceExecutionError::ProviderRateLimit,
+        DiscordError::ProviderUnavailable { .. } | DiscordError::UnexpectedStatus { .. } => {
+            SourceExecutionError::UnexpectedProviderStatus
+        }
+        DiscordError::InvalidRetryAfter => SourceExecutionError::UnexpectedProviderStatus,
+    }
+}

--- a/crates/source-runtime-next/src/discord/source_execution/catalog.rs
+++ b/crates/source-runtime-next/src/discord/source_execution/catalog.rs
@@ -125,7 +125,14 @@ pub(super) fn validated_kernel(
     }
     let guild_id = public_value(&metadata.public_config, "guild_id")
         .ok_or(SourceExecutionError::MissingConfiguration)?;
-    let application_id = public_value(&metadata.public_config, "application_id");
+    let application_id = if family == DiscordFamily::Permission {
+        Some(
+            public_value(&metadata.public_config, "application_id")
+                .ok_or(SourceExecutionError::MissingConfiguration)?,
+        )
+    } else {
+        None
+    };
     let page_size = if matches!(family, DiscordFamily::AuditLog | DiscordFamily::Member) {
         public_value(&metadata.public_config, "per_page")
             .map(|value| {

--- a/crates/source-runtime-next/src/discord/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/discord/source_execution_tests.rs
@@ -231,7 +231,7 @@ fn decode_envelope(
     metadata: &SourceWorkerRuntimeMetadataV2,
     request_intent_digest: String,
     execution_intent_digest_sha256: String,
-    status_code: i32,
+    status_code: u32,
     body: &[u8],
     response_headers: HashMap<String, String>,
 ) -> SourceWorkerDecodeEnvelopeV2 {

--- a/crates/source-runtime-next/src/discord/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/discord/source_execution_tests.rs
@@ -1,0 +1,267 @@
+use std::collections::HashMap;
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionDispatcher, SourceExecutionError,
+    SourceExecutionSelectionRequestV1, SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1,
+    SourceWorkerExecutionContextV1, SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1,
+    SourceWorkerRuntimeMetadataV2, SourceWorkerSafeReceiptV1, response_digest,
+};
+
+use super::catalog::{DEFAULT_BASE_URL, DISCORD_SOURCE_EXECUTION_ADAPTERS};
+use crate::discord::DiscordFamily;
+
+const GUILD_ID: &str = "100000000000000000";
+const APPLICATION_ID: &str = "200000000000000000";
+const OBSERVED_AT_MILLIS: i64 = 1_787_865_600_000;
+
+fn families() -> [DiscordFamily; 4] {
+    [
+        DiscordFamily::AuditLog,
+        DiscordFamily::Member,
+        DiscordFamily::Role,
+        DiscordFamily::Permission,
+    ]
+}
+
+fn adapter(family: DiscordFamily) -> &'static super::DiscordSourceExecutionAdapter {
+    DISCORD_SOURCE_EXECUTION_ADAPTERS
+        .iter()
+        .find(|adapter| adapter.family() == family)
+        .expect("Discord adapter")
+}
+
+fn context(cursor: &str, page: u32) -> SourceWorkerExecutionContextV1 {
+    SourceWorkerExecutionContextV1 {
+        tenant_id: "tenant".to_owned(),
+        runtime_id: "discord-runtime".to_owned(),
+        logical_page_id: format!("source-page-v2:discord-{page}"),
+        prior_cursor: cursor.to_owned(),
+        runtime_generation: 7,
+        lease_generation: 11,
+        observed_at_unix_millis: OBSERVED_AT_MILLIS,
+    }
+}
+
+fn metadata(family: DiscordFamily) -> SourceWorkerRuntimeMetadataV2 {
+    SourceWorkerRuntimeMetadataV2 {
+        public_config: HashMap::from([
+            ("family".to_owned(), family.as_str().to_owned()),
+            ("guild_id".to_owned(), GUILD_ID.to_owned()),
+            ("application_id".to_owned(), APPLICATION_ID.to_owned()),
+            ("per_page".to_owned(), "2".to_owned()),
+        ]),
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    }
+}
+
+#[test]
+fn provider_local_catalog_compiles_all_families_without_shared_authority() {
+    assert_eq!(DISCORD_SOURCE_EXECUTION_ADAPTERS.len(), families().len());
+    for family in families() {
+        let plan = adapter(family).compiled_plan();
+        assert_eq!(plan.source_id, "discord");
+        assert_eq!(plan.family_id, family.as_str());
+        assert_eq!(plan.provider_kernel, family.provider_kind());
+        assert_eq!(plan.origin, DEFAULT_BASE_URL);
+        assert_eq!(plan.event_kind, family.provider_kind());
+        assert_eq!(plan.schema_ref, format!("discord/{}/v1", family.as_str()));
+        assert!(plan.required_attributes.contains(&"tenant_id".to_owned()));
+        assert!(
+            plan.required_attributes
+                .contains(&"source_event_id".to_owned())
+        );
+        assert_eq!(
+            SourceExecutionDispatcher.compile_plan(&SourceExecutionSelectionRequestV1 {
+                source_id: "discord".to_owned(),
+                family_id: family.as_str().to_owned(),
+            }),
+            Err(SourceExecutionError::UnknownAdapter)
+        );
+    }
+}
+
+#[test]
+fn every_family_plans_one_origin_restricted_bot_request() {
+    for family in families() {
+        let adapter = adapter(family);
+        let plan = adapter.compiled_plan();
+        let execution = adapter
+            .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+                request: Some(SourceWorkerPlanRequestV1 {
+                    plan: Some(plan),
+                    context: Some(context("", 1)),
+                }),
+                metadata: Some(metadata(family)),
+            })
+            .unwrap_or_else(|error| panic!("{} plan: {error}", family.as_str()));
+        assert_eq!(execution.allowed_origin, DEFAULT_BASE_URL);
+        assert_eq!(execution.credential_operation, "discord.bot_token");
+        assert!(execution.body.is_empty());
+        assert!(execution.declared_headers.is_empty());
+        let request = execution.request.expect("planned request");
+        assert_eq!(request.method, "GET");
+        assert!(request.url.starts_with(DEFAULT_BASE_URL));
+        assert!(request.url.contains(GUILD_ID));
+        assert!(!request.url.contains("api_key"));
+        assert!(!request.url.contains("token"));
+        if matches!(family, DiscordFamily::AuditLog | DiscordFamily::Member) {
+            assert!(request.url.contains("after=0"));
+            assert!(request.url.contains("limit=2"));
+        } else {
+            assert!(!request.url.contains('?'));
+        }
+        if family == DiscordFamily::Permission {
+            assert!(request.url.contains(APPLICATION_ID));
+        }
+    }
+}
+
+#[test]
+fn audit_decode_preserves_scope_cursor_identity_and_typed_failures() {
+    let adapter = adapter(DiscordFamily::AuditLog);
+    let plan = adapter.compiled_plan();
+    let context = context("", 1);
+    let metadata = metadata(DiscordFamily::AuditLog);
+    let execution = adapter
+        .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+        })
+        .unwrap();
+    let planned = execution.request.as_ref().unwrap();
+    let body = br#"{"audit_log_entries":[{"id":"100000000000000001","user_id":"400000000000000001","action_type":10,"target_id":"300000000000000001"},{"id":"100000000000000002","user_id":null,"action_type":20,"target_id":null}]}"#;
+    let result = adapter
+        .decode_v2(&decode_envelope(
+            &plan,
+            &context,
+            &metadata,
+            planned.request_intent_digest.clone(),
+            execution.execution_intent_digest_sha256,
+            200,
+            body,
+            HashMap::new(),
+        ))
+        .unwrap();
+    assert_eq!(result.next_cursor, "100000000000000002");
+    assert_eq!(result.records.len(), 2);
+    let record = &result.records[0];
+    assert_eq!(record.provider_id, "100000000000000001");
+    assert_eq!(record.attributes["tenant_id"], "tenant");
+    assert_eq!(record.attributes["guild_id"], GUILD_ID);
+    assert_eq!(record.attributes["event_type"], "10");
+    adapter
+        .validate_record_identity_v2(&context, record, &metadata)
+        .unwrap();
+
+    for (status, expected) in [
+        (401, SourceExecutionError::AuthenticationRejected),
+        (403, SourceExecutionError::RequiredProviderScopeMissing),
+        (429, SourceExecutionError::ProviderRateLimit),
+        (503, SourceExecutionError::UnexpectedProviderStatus),
+    ] {
+        let headers = if status == 429 {
+            HashMap::from([("Retry-After".to_owned(), "2".to_owned())])
+        } else {
+            HashMap::new()
+        };
+        assert_eq!(
+            adapter.decode_v2(&decode_envelope(
+                &plan,
+                &context,
+                &metadata,
+                planned.request_intent_digest.clone(),
+                String::new(),
+                status,
+                b"{}",
+                headers,
+            )),
+            Err(expected)
+        );
+    }
+}
+
+#[test]
+fn origin_family_and_required_scope_fail_closed() {
+    let member = adapter(DiscordFamily::Member);
+    let mut wrong_origin = metadata(DiscordFamily::Member);
+    wrong_origin.public_config.insert(
+        "base_url".to_owned(),
+        "https://example.invalid/api/v10".to_owned(),
+    );
+    assert_eq!(
+        member.plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(member.compiled_plan()),
+                context: Some(context("", 1)),
+            }),
+            metadata: Some(wrong_origin),
+        }),
+        Err(SourceExecutionError::MissingConfiguration)
+    );
+
+    let permission = adapter(DiscordFamily::Permission);
+    let missing_application = SourceWorkerRuntimeMetadataV2 {
+        public_config: HashMap::from([
+            ("family".to_owned(), "permission".to_owned()),
+            ("guild_id".to_owned(), GUILD_ID.to_owned()),
+        ]),
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    };
+    assert_eq!(
+        permission.plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(permission.compiled_plan()),
+                context: Some(context("", 1)),
+            }),
+            metadata: Some(missing_application),
+        }),
+        Err(SourceExecutionError::MissingConfiguration)
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn decode_envelope(
+    plan: &crate::source_execution::SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    metadata: &SourceWorkerRuntimeMetadataV2,
+    request_intent_digest: String,
+    execution_intent_digest_sha256: String,
+    status_code: i32,
+    body: &[u8],
+    response_headers: HashMap<String, String>,
+) -> SourceWorkerDecodeEnvelopeV2 {
+    let receipt = SourceWorkerSafeReceiptV1 {
+        plan_digest_sha256: plan.plan_digest_sha256.clone(),
+        logical_page_id: context.logical_page_id.clone(),
+        request_intent_digest: request_intent_digest.clone(),
+        runtime_generation: context.runtime_generation,
+        lease_generation: context.lease_generation,
+        credential_operation: "discord.bot_token".to_owned(),
+        status_code,
+        response_bytes: body.len() as u64,
+        response_sha256: response_digest(body),
+        tenant_id: context.tenant_id.clone(),
+        runtime_id: context.runtime_id.clone(),
+        observed_at_unix_millis: context.observed_at_unix_millis,
+    };
+    SourceWorkerDecodeEnvelopeV2 {
+        request: Some(SourceWorkerDecodeRequestV1 {
+            plan: Some(plan.clone()),
+            status_code,
+            response_body: body.to_vec(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest,
+            receipt: Some(receipt),
+            context: Some(context.clone()),
+        }),
+        metadata: Some(metadata.clone()),
+        response_headers,
+        response_headers_sha256: String::new(),
+        execution_intent_digest_sha256,
+    }
+}


### PR DESCRIPTION
## Summary

- compile credential-free source-execution adapters for Discord `audit_log`, `member`, `role`, and `permission`
- bind each family to its closed guild or application request scope, event contract, stable identity, and pagination behavior
- expose only the `discord.bot_token` credential operation; bot-token bytes remain outside Rust requests, records, receipts, and logs
- preserve exact provider status classes for authentication, missing audit-log permission, rate limiting, provider failures, and malformed records

## Validation

- `rustfmt --edition 2024 --check crates/source-runtime-next/src/discord.rs crates/source-runtime-next/src/discord/normalize.rs crates/source-runtime-next/src/discord/source_execution.rs crates/source-runtime-next/src/discord/source_execution/catalog.rs crates/source-runtime-next/src/discord/source_execution_tests.rs`
- `go test ./sources/discord -count=1`
- `make source-fixture-check`
- `make check-structural check-structural-test check-arch`
- `git diff --check`

Managed Cargo capacity blocked local Rust compilation before build output was created. This draft requires exact-head hosted Rust tests and Clippy before it can be readied.

## Authority boundary

This pull request adds provider-local request/response adapters only. It does not register Discord with the shared dispatcher, change source authority, remove the Go collector, redeem credentials, or add environment-specific configuration.
