### PR TITLE
Persist fenced Rust source pages

### DIFF
--- a/crates/organizational-store/src/lib.rs
+++ b/crates/organizational-store/src/lib.rs
@@ -27,6 +27,7 @@
 mod credential_vault;
 mod cutover;
 mod neo4j;
+mod page_publication;
 mod parity;
 mod postgres;
 

--- a/crates/organizational-store/src/lib.rs
+++ b/crates/organizational-store/src/lib.rs
@@ -47,6 +47,7 @@ pub use neo4j::{
     LegacyRootCoverage, LegacyRootCoverageKind, Neo4jProjector, PersonAccessPath,
     PersonAccessPathPage, ResolvedLifecycleFinding, SourceRuntimeGraphObservation,
 };
+pub use page_publication::PagePublicationOutbox;
 pub use parity::{
     MismatchSide, ParityError, ParityReceipt, ParityStatus, SemanticFact, SemanticFactKind,
     SemanticMismatch, SemanticSnapshot,

--- a/crates/organizational-store/src/page_publication.rs
+++ b/crates/organizational-store/src/page_publication.rs
@@ -3,16 +3,47 @@
 use cerebro_organizational_model::TenantId;
 use cerebro_source_runtime_next::{PagePublication, PagePublicationState};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use tokio_postgres::{Row, Transaction};
 
 use crate::{PostgresLedger, StoreError};
 
 const PAGE_COLUMNS: &str = "tenant_id, logical_page_id, source_runtime_id, source_id, family_id, state, revision, publication_json";
+const MAX_EVENT_ENVELOPE_BYTES: usize = 16 << 20;
+const MAX_PAGE_OUTBOX_BYTES: usize = 32 << 20;
+
+/// One validated page and the exact secret-free envelope bytes required to
+/// resume its ordered append publication without recollecting provider data.
+pub struct PagePublicationOutbox {
+    page: PagePublication,
+    envelopes: Vec<Vec<u8>>,
+}
+
+impl PagePublicationOutbox {
+    /// Returns the validated publication state and ordered event intents.
+    pub fn page(&self) -> &PagePublication {
+        &self.page
+    }
+
+    /// Returns canonical envelope bytes in the exact order of `page.events()`.
+    pub fn envelopes(&self) -> &[Vec<u8>] {
+        &self.envelopes
+    }
+
+    /// Consumes the outbox into its validated state and ordered envelopes.
+    pub fn into_parts(self) -> (PagePublication, Vec<Vec<u8>>) {
+        (self.page, self.envelopes)
+    }
+}
 
 impl PostgresLedger {
     /// Inserts a newly prepared page. Repeating the exact snapshot is
     /// idempotent; reusing its identity for different content fails closed.
-    pub async fn prepare_page_publication(&self, page: &PagePublication) -> Result<(), StoreError> {
+    pub async fn prepare_page_publication(
+        &self,
+        page: &PagePublication,
+        envelopes: Vec<Vec<u8>>,
+    ) -> Result<(), StoreError> {
         if page.state() != PagePublicationState::Prepared || page.revision() != 1 {
             return Err(StoreError::Conflict(
                 "only a newly prepared page can enter the publication ledger".to_owned(),
@@ -21,6 +52,7 @@ impl PostgresLedger {
         let revision = storage_revision(page.revision())?;
         let state = state_name(page.state());
         let snapshot = serde_json::to_value(page)?;
+        validate_envelopes(page, &envelopes)?;
         let mut client = self.client.lock().await;
         let transaction = client.transaction().await?;
         set_tenant(&transaction, page.tenant_id().as_str()).await?;
@@ -62,6 +94,68 @@ RETURNING revision
         if stored.is_none() {
             return Err(StoreError::Conflict(
                 "logical page identity already belongs to different publication content".to_owned(),
+            ));
+        }
+        let ordinals = page
+            .events()
+            .iter()
+            .map(|event| {
+                i32::try_from(event.ordinal())
+                    .map_err(|_| StoreError::Conflict("page event ordinal overflow".to_owned()))
+            })
+            .collect::<Result<Vec<_>, StoreError>>()?;
+        let event_ids = page
+            .events()
+            .iter()
+            .map(|event| event.event_id().as_str().to_owned())
+            .collect::<Vec<_>>();
+        let envelope_digests = page
+            .events()
+            .iter()
+            .map(|event| event.envelope_sha256().to_owned())
+            .collect::<Vec<_>>();
+        let message_ids = page
+            .events()
+            .iter()
+            .map(|event| event.message_id().to_owned())
+            .collect::<Vec<_>>();
+        let event_rows = transaction
+            .query(
+                r#"
+INSERT INTO source_runtime_page_events (
+  tenant_id,
+  logical_page_id,
+  ordinal,
+  event_id,
+  envelope_sha256,
+  message_id,
+  envelope
+)
+SELECT $1, $2, input.ordinal, input.event_id, input.envelope_sha256, input.message_id, input.envelope
+FROM UNNEST($3::INTEGER[], $4::TEXT[], $5::TEXT[], $6::TEXT[], $7::BYTEA[])
+  AS input(ordinal, event_id, envelope_sha256, message_id, envelope)
+ON CONFLICT (tenant_id, logical_page_id, ordinal) DO UPDATE
+SET ordinal = EXCLUDED.ordinal
+WHERE source_runtime_page_events.event_id = EXCLUDED.event_id
+  AND source_runtime_page_events.envelope_sha256 = EXCLUDED.envelope_sha256
+  AND source_runtime_page_events.message_id = EXCLUDED.message_id
+  AND source_runtime_page_events.envelope = EXCLUDED.envelope
+RETURNING ordinal
+"#,
+                &[
+                    &page.tenant_id().as_str(),
+                    &page.logical_page_id(),
+                    &ordinals,
+                    &event_ids,
+                    &envelope_digests,
+                    &message_ids,
+                    &envelopes,
+                ],
+            )
+            .await?;
+        if event_rows.len() != page.events().len() {
+            return Err(StoreError::Conflict(
+                "logical page outbox already contains different event bytes".to_owned(),
             ));
         }
         transaction.commit().await?;
@@ -170,6 +264,37 @@ WHERE tenant_id = $1
         row.map(decode_page_publication).transpose()
     }
 
+    /// Loads one page and the exact envelope outbox needed for publication.
+    pub async fn load_page_publication_outbox(
+        &self,
+        tenant_id: &TenantId,
+        logical_page_id: &str,
+    ) -> Result<Option<PagePublicationOutbox>, StoreError> {
+        if logical_page_id.trim().is_empty() {
+            return Err(StoreError::Conflict(
+                "logical page id is required".to_owned(),
+            ));
+        }
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        set_tenant(&transaction, tenant_id.as_str()).await?;
+        let query = format!(
+            "SELECT {PAGE_COLUMNS} FROM source_runtime_page_publications WHERE tenant_id = $1 AND logical_page_id = $2"
+        );
+        let row = transaction
+            .query_opt(&query, &[&tenant_id.as_str(), &logical_page_id])
+            .await?;
+        let outbox = match row {
+            Some(row) => {
+                let page = decode_page_publication(row)?;
+                Some(load_outbox(&transaction, page).await?)
+            }
+            None => None,
+        };
+        transaction.commit().await?;
+        Ok(outbox)
+    }
+
     /// Lists recoverable pages for one tenant in stable oldest-first order.
     /// Terminal and quarantined pages remain queryable by exact identity but
     /// are never admitted to automatic recovery.
@@ -177,7 +302,7 @@ WHERE tenant_id = $1
         &self,
         tenant_id: &TenantId,
         limit: usize,
-    ) -> Result<Vec<PagePublication>, StoreError> {
+    ) -> Result<Vec<PagePublicationOutbox>, StoreError> {
         if limit == 0 || limit > 500 {
             return Err(StoreError::Conflict(
                 "page publication recovery limit is invalid".to_owned(),
@@ -194,9 +319,51 @@ WHERE tenant_id = $1
         let rows = transaction
             .query(&query, &[&tenant_id.as_str(), &limit])
             .await?;
+        let mut outboxes = Vec::with_capacity(rows.len());
+        for row in rows {
+            let page = decode_page_publication(row)?;
+            outboxes.push(load_outbox(&transaction, page).await?);
+        }
         transaction.commit().await?;
-        rows.into_iter().map(decode_page_publication).collect()
+        Ok(outboxes)
     }
+}
+
+async fn load_outbox(
+    transaction: &Transaction<'_>,
+    page: PagePublication,
+) -> Result<PagePublicationOutbox, StoreError> {
+    let rows = transaction
+        .query(
+            "SELECT ordinal, event_id, envelope_sha256, message_id, envelope FROM source_runtime_page_events WHERE tenant_id = $1 AND logical_page_id = $2 ORDER BY ordinal",
+            &[&page.tenant_id().as_str(), &page.logical_page_id()],
+        )
+        .await?;
+    if rows.len() != page.events().len() {
+        return Err(StoreError::Conflict(
+            "stored page publication outbox is incomplete".to_owned(),
+        ));
+    }
+    let mut envelopes = Vec::with_capacity(rows.len());
+    for (expected, row) in page.events().iter().zip(rows) {
+        let ordinal: i32 = row.get(0);
+        let event_id: String = row.get(1);
+        let envelope_sha256: String = row.get(2);
+        let message_id: String = row.get(3);
+        let envelope: Vec<u8> = row.get(4);
+        if i64::from(ordinal) != i64::from(expected.ordinal())
+            || event_id != expected.event_id().as_str()
+            || envelope_sha256 != expected.envelope_sha256()
+            || message_id != expected.message_id()
+        {
+            return Err(StoreError::Conflict(
+                "stored page event metadata does not match its intent".to_owned(),
+            ));
+        }
+        envelopes.push(envelope);
+    }
+    validate_envelopes(&page, &envelopes)?;
+    Ok(PagePublicationOutbox { page, envelopes })
 }
 
 fn decode_page_publication(row: Row) -> Result<PagePublication, StoreError> {
@@ -226,6 +393,47 @@ fn decode_page_publication(row: Row) -> Result<PagePublication, StoreError> {
         ));
     }
     Ok(page)
+}
+
+fn validate_envelopes(page: &PagePublication, envelopes: &[Vec<u8>]) -> Result<(), StoreError> {
+    if envelopes.len() != page.events().len() {
+        return Err(StoreError::Conflict(
+            "page publication outbox does not match its event count".to_owned(),
+        ));
+    }
+    let mut total_bytes = 0_usize;
+    for (event, envelope) in page.events().iter().zip(envelopes) {
+        if envelope.is_empty() || envelope.len() > MAX_EVENT_ENVELOPE_BYTES {
+            return Err(StoreError::Conflict(
+                "page event envelope size is invalid".to_owned(),
+            ));
+        }
+        total_bytes = total_bytes.checked_add(envelope.len()).ok_or_else(|| {
+            StoreError::Conflict("page publication outbox size overflow".to_owned())
+        })?;
+        if total_bytes > MAX_PAGE_OUTBOX_BYTES {
+            return Err(StoreError::Conflict(
+                "page publication outbox exceeds its byte limit".to_owned(),
+            ));
+        }
+        if digest_bytes(envelope) != event.envelope_sha256() {
+            return Err(StoreError::Conflict(
+                "page event envelope does not match its digest".to_owned(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn digest_bytes(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let digest = Sha256::digest(bytes);
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+        encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    encoded
 }
 
 fn state_name(state: PagePublicationState) -> &'static str {
@@ -283,5 +491,13 @@ mod tests {
         assert!(storage_revision(0).is_err());
         assert!(storage_revision(u64::MAX).is_err());
         assert_eq!(storage_revision(1).unwrap(), 1);
+    }
+
+    #[test]
+    fn envelope_digest_is_lowercase_sha256() {
+        assert_eq!(
+            digest_bytes(b"event"),
+            "b8e1f80bd70ae0784c7855a451731b745fddb67749d23f637be9082b75e9575b"
+        );
     }
 }

--- a/crates/organizational-store/src/page_publication.rs
+++ b/crates/organizational-store/src/page_publication.rs
@@ -1,0 +1,287 @@
+//! PostgreSQL persistence for fenced source-page publication.
+
+use cerebro_organizational_model::TenantId;
+use cerebro_source_runtime_next::{PagePublication, PagePublicationState};
+use serde_json::Value;
+use tokio_postgres::{Row, Transaction};
+
+use crate::{PostgresLedger, StoreError};
+
+const PAGE_COLUMNS: &str = "tenant_id, logical_page_id, source_runtime_id, source_id, family_id, state, revision, publication_json";
+
+impl PostgresLedger {
+    /// Inserts a newly prepared page. Repeating the exact snapshot is
+    /// idempotent; reusing its identity for different content fails closed.
+    pub async fn prepare_page_publication(&self, page: &PagePublication) -> Result<(), StoreError> {
+        if page.state() != PagePublicationState::Prepared || page.revision() != 1 {
+            return Err(StoreError::Conflict(
+                "only a newly prepared page can enter the publication ledger".to_owned(),
+            ));
+        }
+        let revision = storage_revision(page.revision())?;
+        let state = state_name(page.state());
+        let snapshot = serde_json::to_value(page)?;
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        set_tenant(&transaction, page.tenant_id().as_str()).await?;
+        let stored = transaction
+            .query_opt(
+                r#"
+INSERT INTO source_runtime_page_publications (
+  tenant_id,
+  logical_page_id,
+  source_runtime_id,
+  source_id,
+  family_id,
+  state,
+  revision,
+  publication_json
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (tenant_id, logical_page_id) DO UPDATE
+SET updated_at = NOW()
+WHERE source_runtime_page_publications.source_runtime_id = EXCLUDED.source_runtime_id
+  AND source_runtime_page_publications.source_id = EXCLUDED.source_id
+  AND source_runtime_page_publications.family_id = EXCLUDED.family_id
+  AND source_runtime_page_publications.state = EXCLUDED.state
+  AND source_runtime_page_publications.revision = EXCLUDED.revision
+  AND source_runtime_page_publications.publication_json = EXCLUDED.publication_json
+RETURNING revision
+"#,
+                &[
+                    &page.tenant_id().as_str(),
+                    &page.logical_page_id(),
+                    &page.source_runtime_id().as_str(),
+                    &page.source_id(),
+                    &page.family_id(),
+                    &state,
+                    &revision,
+                    &snapshot,
+                ],
+            )
+            .await?;
+        if stored.is_none() {
+            return Err(StoreError::Conflict(
+                "logical page identity already belongs to different publication content".to_owned(),
+            ));
+        }
+        transaction.commit().await?;
+        Ok(())
+    }
+
+    /// Persists exactly one state-machine revision using compare-and-swap.
+    /// An exact retry is idempotent; a stale or skipped revision fails closed.
+    pub async fn persist_page_publication(
+        &self,
+        expected_revision: u64,
+        page: &PagePublication,
+    ) -> Result<(), StoreError> {
+        let next_revision = expected_revision
+            .checked_add(1)
+            .ok_or_else(|| StoreError::Conflict("page publication revision overflow".to_owned()))?;
+        if page.revision() != next_revision {
+            return Err(StoreError::Conflict(
+                "page publication persistence must advance exactly one revision".to_owned(),
+            ));
+        }
+        let expected_revision = storage_revision(expected_revision)?;
+        let revision = storage_revision(page.revision())?;
+        let state = state_name(page.state());
+        let snapshot = serde_json::to_value(page)?;
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        set_tenant(&transaction, page.tenant_id().as_str()).await?;
+        let changed = transaction
+            .execute(
+                r#"
+UPDATE source_runtime_page_publications
+SET state = $6,
+    revision = $7,
+    publication_json = $8,
+    updated_at = NOW()
+WHERE tenant_id = $1
+  AND logical_page_id = $2
+  AND source_runtime_id = $3
+  AND source_id = $4
+  AND family_id = $5
+  AND revision = $9
+"#,
+                &[
+                    &page.tenant_id().as_str(),
+                    &page.logical_page_id(),
+                    &page.source_runtime_id().as_str(),
+                    &page.source_id(),
+                    &page.family_id(),
+                    &state,
+                    &revision,
+                    &snapshot,
+                    &expected_revision,
+                ],
+            )
+            .await?;
+        if changed == 0 {
+            let exact_retry = transaction
+                .query_opt(
+                    "SELECT 1 FROM source_runtime_page_publications WHERE tenant_id = $1 AND logical_page_id = $2 AND source_runtime_id = $3 AND source_id = $4 AND family_id = $5 AND state = $6 AND revision = $7 AND publication_json = $8",
+                    &[
+                        &page.tenant_id().as_str(),
+                        &page.logical_page_id(),
+                        &page.source_runtime_id().as_str(),
+                        &page.source_id(),
+                        &page.family_id(),
+                        &state,
+                        &revision,
+                        &snapshot,
+                    ],
+                )
+                .await?
+                .is_some();
+            if !exact_retry {
+                return Err(StoreError::Conflict(
+                    "page publication revision is stale or missing".to_owned(),
+                ));
+            }
+        }
+        transaction.commit().await?;
+        Ok(())
+    }
+
+    /// Loads one page through tenant row-level security and revalidates its
+    /// entire snapshot before returning it to recovery code.
+    pub async fn load_page_publication(
+        &self,
+        tenant_id: &TenantId,
+        logical_page_id: &str,
+    ) -> Result<Option<PagePublication>, StoreError> {
+        if logical_page_id.trim().is_empty() {
+            return Err(StoreError::Conflict(
+                "logical page id is required".to_owned(),
+            ));
+        }
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        set_tenant(&transaction, tenant_id.as_str()).await?;
+        let query = format!(
+            "SELECT {PAGE_COLUMNS} FROM source_runtime_page_publications WHERE tenant_id = $1 AND logical_page_id = $2"
+        );
+        let row = transaction
+            .query_opt(&query, &[&tenant_id.as_str(), &logical_page_id])
+            .await?;
+        transaction.commit().await?;
+        row.map(decode_page_publication).transpose()
+    }
+
+    /// Lists recoverable pages for one tenant in stable oldest-first order.
+    /// Terminal and quarantined pages remain queryable by exact identity but
+    /// are never admitted to automatic recovery.
+    pub async fn recoverable_page_publications(
+        &self,
+        tenant_id: &TenantId,
+        limit: usize,
+    ) -> Result<Vec<PagePublication>, StoreError> {
+        if limit == 0 || limit > 500 {
+            return Err(StoreError::Conflict(
+                "page publication recovery limit is invalid".to_owned(),
+            ));
+        }
+        let limit = i64::try_from(limit)
+            .map_err(|_| StoreError::Conflict("page recovery limit overflow".to_owned()))?;
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        set_tenant(&transaction, tenant_id.as_str()).await?;
+        let query = format!(
+            "SELECT {PAGE_COLUMNS} FROM source_runtime_page_publications WHERE tenant_id = $1 AND state IN ('prepared', 'publishing', 'published', 'projected') ORDER BY updated_at, logical_page_id LIMIT $2"
+        );
+        let rows = transaction
+            .query(&query, &[&tenant_id.as_str(), &limit])
+            .await?;
+        transaction.commit().await?;
+        rows.into_iter().map(decode_page_publication).collect()
+    }
+}
+
+fn decode_page_publication(row: Row) -> Result<PagePublication, StoreError> {
+    let tenant_id: String = row.get(0);
+    let logical_page_id: String = row.get(1);
+    let source_runtime_id: String = row.get(2);
+    let source_id: String = row.get(3);
+    let family_id: String = row.get(4);
+    let state: String = row.get(5);
+    let revision: i64 = row.get(6);
+    let snapshot: Value = row.get(7);
+    let page = PagePublication::restore_snapshot(snapshot).map_err(|_| {
+        StoreError::Conflict("stored page publication failed invariant validation".to_owned())
+    })?;
+    let revision = u64::try_from(revision)
+        .map_err(|_| StoreError::Conflict("stored page revision is invalid".to_owned()))?;
+    if page.tenant_id().as_str() != tenant_id
+        || page.logical_page_id() != logical_page_id
+        || page.source_runtime_id().as_str() != source_runtime_id
+        || page.source_id() != source_id
+        || page.family_id() != family_id
+        || state_name(page.state()) != state
+        || page.revision() != revision
+    {
+        return Err(StoreError::Conflict(
+            "stored page publication metadata does not match its snapshot".to_owned(),
+        ));
+    }
+    Ok(page)
+}
+
+fn state_name(state: PagePublicationState) -> &'static str {
+    match state {
+        PagePublicationState::Prepared => "prepared",
+        PagePublicationState::Publishing => "publishing",
+        PagePublicationState::Published => "published",
+        PagePublicationState::Projected => "projected",
+        PagePublicationState::Committed => "committed",
+        PagePublicationState::Superseded => "superseded",
+        PagePublicationState::Quarantined => "quarantined",
+    }
+}
+
+fn storage_revision(revision: u64) -> Result<i64, StoreError> {
+    if revision == 0 {
+        return Err(StoreError::Conflict(
+            "page publication revision must be positive".to_owned(),
+        ));
+    }
+    i64::try_from(revision)
+        .map_err(|_| StoreError::Conflict("page publication revision overflow".to_owned()))
+}
+
+async fn set_tenant(
+    transaction: &Transaction<'_>,
+    tenant_id: &str,
+) -> Result<(), tokio_postgres::Error> {
+    transaction
+        .query_one(
+            "SELECT set_config('cerebro.tenant_id', $1, true)",
+            &[&tenant_id],
+        )
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_names_match_the_database_contract() {
+        assert_eq!(state_name(PagePublicationState::Prepared), "prepared");
+        assert_eq!(state_name(PagePublicationState::Publishing), "publishing");
+        assert_eq!(state_name(PagePublicationState::Published), "published");
+        assert_eq!(state_name(PagePublicationState::Projected), "projected");
+        assert_eq!(state_name(PagePublicationState::Committed), "committed");
+        assert_eq!(state_name(PagePublicationState::Superseded), "superseded");
+        assert_eq!(state_name(PagePublicationState::Quarantined), "quarantined");
+    }
+
+    #[test]
+    fn storage_revision_rejects_zero_and_overflow() {
+        assert!(storage_revision(0).is_err());
+        assert!(storage_revision(u64::MAX).is_err());
+        assert_eq!(storage_revision(1).unwrap(), 1);
+    }
+}

--- a/crates/organizational-store/src/postgres.rs
+++ b/crates/organizational-store/src/postgres.rs
@@ -234,6 +234,21 @@ CREATE TABLE IF NOT EXISTS source_runtime_page_publications (
 CREATE INDEX IF NOT EXISTS source_runtime_page_publications_recovery_idx
   ON source_runtime_page_publications
     (tenant_id, source_runtime_id, state, updated_at, logical_page_id);
+CREATE TABLE IF NOT EXISTS source_runtime_page_events (
+  tenant_id TEXT NOT NULL,
+  logical_page_id TEXT NOT NULL,
+  ordinal INTEGER NOT NULL CHECK (ordinal >= 0),
+  event_id TEXT NOT NULL,
+  envelope_sha256 TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  envelope BYTEA NOT NULL,
+  PRIMARY KEY (tenant_id, logical_page_id, ordinal),
+  UNIQUE (tenant_id, logical_page_id, event_id),
+  UNIQUE (tenant_id, logical_page_id, message_id),
+  FOREIGN KEY (tenant_id, logical_page_id)
+    REFERENCES source_runtime_page_publications (tenant_id, logical_page_id)
+    ON DELETE CASCADE
+);
 CREATE TABLE IF NOT EXISTS organizational_entities (
   tenant_id TEXT NOT NULL,
   entity_id TEXT NOT NULL,
@@ -411,6 +426,8 @@ ALTER TABLE organizational_source_collection_receipts ENABLE ROW LEVEL SECURITY;
 ALTER TABLE organizational_source_collection_receipts FORCE ROW LEVEL SECURITY;
 ALTER TABLE source_runtime_page_publications ENABLE ROW LEVEL SECURITY;
 ALTER TABLE source_runtime_page_publications FORCE ROW LEVEL SECURITY;
+ALTER TABLE source_runtime_page_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE source_runtime_page_events FORCE ROW LEVEL SECURITY;
 ALTER TABLE organizational_entities ENABLE ROW LEVEL SECURITY;
 ALTER TABLE organizational_entities FORCE ROW LEVEL SECURITY;
 ALTER TABLE organizational_assertions ENABLE ROW LEVEL SECURITY;
@@ -436,6 +453,7 @@ BEGIN
     'organizational_legacy_projection_receipts',
     'organizational_source_collection_receipts',
     'source_runtime_page_publications',
+    'source_runtime_page_events',
     'organizational_entities',
     'organizational_assertions',
     'organizational_identity_bindings',
@@ -3240,6 +3258,7 @@ mod tests {
             "organizational_source_collection_receipts",
             "source_runtime_page_publications",
             "source_runtime_page_publications_recovery_idx",
+            "source_runtime_page_events",
             "organizational_source_collection_latest_idx",
             "organizational_consumer_runs",
             "organizational_consumer_family_progress",

--- a/crates/organizational-store/src/postgres.rs
+++ b/crates/organizational-store/src/postgres.rs
@@ -210,6 +210,30 @@ CREATE TABLE IF NOT EXISTS organizational_source_collection_receipts (
   manifest_json JSONB NOT NULL,
   PRIMARY KEY (tenant_id, collection_id)
 );
+CREATE TABLE IF NOT EXISTS source_runtime_page_publications (
+  tenant_id TEXT NOT NULL,
+  logical_page_id TEXT NOT NULL,
+  source_runtime_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  family_id TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN (
+    'prepared',
+    'publishing',
+    'published',
+    'projected',
+    'committed',
+    'superseded',
+    'quarantined'
+  )),
+  revision BIGINT NOT NULL CHECK (revision > 0),
+  publication_json JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tenant_id, logical_page_id)
+);
+CREATE INDEX IF NOT EXISTS source_runtime_page_publications_recovery_idx
+  ON source_runtime_page_publications
+    (tenant_id, source_runtime_id, state, updated_at, logical_page_id);
 CREATE TABLE IF NOT EXISTS organizational_entities (
   tenant_id TEXT NOT NULL,
   entity_id TEXT NOT NULL,
@@ -385,6 +409,8 @@ ALTER TABLE organizational_legacy_projection_receipts ENABLE ROW LEVEL SECURITY;
 ALTER TABLE organizational_legacy_projection_receipts FORCE ROW LEVEL SECURITY;
 ALTER TABLE organizational_source_collection_receipts ENABLE ROW LEVEL SECURITY;
 ALTER TABLE organizational_source_collection_receipts FORCE ROW LEVEL SECURITY;
+ALTER TABLE source_runtime_page_publications ENABLE ROW LEVEL SECURITY;
+ALTER TABLE source_runtime_page_publications FORCE ROW LEVEL SECURITY;
 ALTER TABLE organizational_entities ENABLE ROW LEVEL SECURITY;
 ALTER TABLE organizational_entities FORCE ROW LEVEL SECURITY;
 ALTER TABLE organizational_assertions ENABLE ROW LEVEL SECURITY;
@@ -409,6 +435,7 @@ BEGIN
     'organizational_source_event_receipts',
     'organizational_legacy_projection_receipts',
     'organizational_source_collection_receipts',
+    'source_runtime_page_publications',
     'organizational_entities',
     'organizational_assertions',
     'organizational_identity_bindings',
@@ -918,7 +945,7 @@ struct StoredSourceCheckpointWire {
 }
 
 pub struct PostgresLedger {
-    client: Mutex<Client>,
+    pub(crate) client: Mutex<Client>,
 }
 
 impl PostgresLedger {
@@ -3211,6 +3238,8 @@ mod tests {
             "organizational_source_event_receipts",
             "organizational_legacy_projection_receipts",
             "organizational_source_collection_receipts",
+            "source_runtime_page_publications",
+            "source_runtime_page_publications_recovery_idx",
             "organizational_source_collection_latest_idx",
             "organizational_consumer_runs",
             "organizational_consumer_family_progress",

--- a/crates/source-runtime-next/src/page_publication.rs
+++ b/crates/source-runtime-next/src/page_publication.rs
@@ -8,7 +8,8 @@
 use std::{collections::BTreeSet, error::Error, fmt};
 
 use cerebro_organizational_model::{ObservationId, SourceRuntimeId, TenantId};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 const MAX_PAGE_EVENTS: usize = 100_000;
@@ -160,6 +161,7 @@ pub enum PagePublicationState {
 /// Credential-free state required to resume or finish one logical page.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct PagePublication {
+    revision: u64,
     logical_page_id: String,
     tenant_id: TenantId,
     source_runtime_id: SourceRuntimeId,
@@ -177,6 +179,57 @@ pub struct PagePublication {
     projection_receipt: Option<PageProjectionReceipt>,
     state: PagePublicationState,
     quarantine_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct PagePublicationSnapshot {
+    revision: u64,
+    logical_page_id: String,
+    tenant_id: String,
+    source_runtime_id: String,
+    source_id: String,
+    family_id: String,
+    lease_generation: u64,
+    authority_epoch: u64,
+    request_intent_sha256: String,
+    input_progress_sha256: String,
+    target_progress_sha256: String,
+    result_sha256: String,
+    events: Vec<PageEventIntentSnapshot>,
+    append_receipts: Vec<PageAppendReceiptSnapshot>,
+    publish_claim: Option<PublishClaimSnapshot>,
+    projection_receipt: Option<PageProjectionReceiptSnapshot>,
+    state: String,
+    quarantine_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct PageEventIntentSnapshot {
+    ordinal: u32,
+    event_id: String,
+    envelope_sha256: String,
+    message_id: String,
+}
+
+#[derive(Deserialize)]
+struct PageAppendReceiptSnapshot {
+    ordinal: u32,
+    event_id: String,
+    message_id: String,
+    stream: String,
+    stream_sequence: u64,
+}
+
+#[derive(Deserialize)]
+struct PublishClaimSnapshot {
+    owner: String,
+    generation: u64,
+}
+
+#[derive(Deserialize)]
+struct PageProjectionReceiptSnapshot {
+    delta_sha256: String,
+    graph_revision: u64,
 }
 
 impl PagePublication {
@@ -219,6 +272,7 @@ impl PagePublication {
             });
         }
         Ok(Self {
+            revision: 1,
             logical_page_id,
             tenant_id: input.tenant_id,
             source_runtime_id: input.source_runtime_id,
@@ -244,6 +298,31 @@ impl PagePublication {
         &self.logical_page_id
     }
 
+    /// Returns the tenant that owns the page and every durable transition.
+    pub fn tenant_id(&self) -> &TenantId {
+        &self.tenant_id
+    }
+
+    /// Returns the stored runtime that collected the page.
+    pub fn source_runtime_id(&self) -> &SourceRuntimeId {
+        &self.source_runtime_id
+    }
+
+    /// Returns the catalog source identifier.
+    pub fn source_id(&self) -> &str {
+        &self.source_id
+    }
+
+    /// Returns the catalog family identifier.
+    pub fn family_id(&self) -> &str {
+        &self.family_id
+    }
+
+    /// Returns the monotonic persistence revision.
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
     /// Returns the current terminal or recovery state.
     pub fn state(&self) -> PagePublicationState {
         self.state
@@ -259,10 +338,142 @@ impl PagePublication {
         &self.append_receipts
     }
 
+    /// Restores a persisted snapshot through the same constructors and
+    /// transitions used for live execution.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invariant error when stored JSON is malformed, internally
+    /// inconsistent, or could not have been produced by the state machine.
+    pub fn restore_snapshot(value: Value) -> Result<Self, PagePublicationError> {
+        let snapshot: PagePublicationSnapshot = serde_json::from_value(value)
+            .map_err(|_| PagePublicationError::Invalid("page publication snapshot"))?;
+        let tenant_id = TenantId::parse(snapshot.tenant_id)
+            .map_err(|_| PagePublicationError::Invalid("page publication tenant"))?;
+        let source_runtime_id = SourceRuntimeId::parse(snapshot.source_runtime_id)
+            .map_err(|_| PagePublicationError::Invalid("page publication runtime"))?;
+        let event_inputs = snapshot
+            .events
+            .iter()
+            .map(|event| {
+                Ok(PageEventInput {
+                    event_id: ObservationId::parse(event.event_id.clone())
+                        .map_err(|_| PagePublicationError::Invalid("page event id"))?,
+                    envelope_sha256: event.envelope_sha256.clone(),
+                })
+            })
+            .collect::<Result<Vec<_>, PagePublicationError>>()?;
+        let mut page = Self::prepare(
+            PagePublicationInput {
+                logical_page_id: snapshot.logical_page_id,
+                tenant_id,
+                source_runtime_id,
+                source_id: snapshot.source_id,
+                family_id: snapshot.family_id,
+                lease_generation: snapshot.lease_generation,
+                authority_epoch: snapshot.authority_epoch,
+                request_intent_sha256: snapshot.request_intent_sha256,
+                input_progress_sha256: snapshot.input_progress_sha256,
+                target_progress_sha256: snapshot.target_progress_sha256,
+                result_sha256: snapshot.result_sha256,
+            },
+            event_inputs,
+        )?;
+        if page.events.len() != snapshot.events.len()
+            || page
+                .events
+                .iter()
+                .zip(&snapshot.events)
+                .any(|(actual, stored)| {
+                    actual.ordinal != stored.ordinal
+                        || actual.event_id.as_str() != stored.event_id
+                        || actual.envelope_sha256 != stored.envelope_sha256
+                        || actual.message_id != stored.message_id
+                })
+        {
+            return Err(PagePublicationError::ReceiptMismatch);
+        }
+        let claim = snapshot
+            .publish_claim
+            .map(|claim| PublishClaim::new(claim.owner, claim.generation))
+            .transpose()?;
+        if let Some(claim) = &claim {
+            page.begin_publishing(claim.clone())?;
+        }
+        for receipt in snapshot.append_receipts {
+            let claim = claim.as_ref().ok_or(PagePublicationError::StaleClaim)?;
+            page.record_append(
+                claim,
+                PageAppendReceipt {
+                    ordinal: receipt.ordinal,
+                    event_id: ObservationId::parse(receipt.event_id)
+                        .map_err(|_| PagePublicationError::Invalid("append event id"))?,
+                    message_id: receipt.message_id,
+                    stream: receipt.stream,
+                    stream_sequence: receipt.stream_sequence,
+                },
+            )?;
+        }
+        let projection = snapshot
+            .projection_receipt
+            .map(|receipt| PageProjectionReceipt {
+                delta_sha256: receipt.delta_sha256,
+                graph_revision: receipt.graph_revision,
+            });
+        let stored_state = parse_state(&snapshot.state)?;
+        match stored_state {
+            PagePublicationState::Prepared
+            | PagePublicationState::Publishing
+            | PagePublicationState::Published => {}
+            PagePublicationState::Projected | PagePublicationState::Committed => {
+                let claim = claim.as_ref().ok_or(PagePublicationError::StaleClaim)?;
+                page.record_projection(
+                    claim,
+                    projection
+                        .clone()
+                        .ok_or(PagePublicationError::Invalid("projection receipt"))?,
+                )?;
+                if stored_state == PagePublicationState::Committed {
+                    page.commit(claim)?;
+                }
+            }
+            PagePublicationState::Superseded => page.supersede()?,
+            PagePublicationState::Quarantined => {
+                if let Some(receipt) = projection.clone() {
+                    let claim = claim.as_ref().ok_or(PagePublicationError::StaleClaim)?;
+                    page.record_projection(claim, receipt)?;
+                }
+                page.quarantine(
+                    snapshot
+                        .quarantine_reason
+                        .clone()
+                        .ok_or(PagePublicationError::Invalid("quarantine reason"))?,
+                )?;
+            }
+        }
+        if page.state != stored_state
+            || (stored_state == PagePublicationState::Prepared && snapshot.revision != 1)
+            || (stored_state != PagePublicationState::Quarantined
+                && snapshot.quarantine_reason.is_some())
+            || (stored_state != PagePublicationState::Projected
+                && stored_state != PagePublicationState::Committed
+                && stored_state != PagePublicationState::Quarantined
+                && projection.is_some())
+            || snapshot.revision < page.revision
+        {
+            return Err(PagePublicationError::Invalid(
+                "page publication snapshot state",
+            ));
+        }
+        page.revision = snapshot.revision;
+        Ok(page)
+    }
+
     /// Grants a publisher the first monotonic claim on a prepared page.
     pub fn begin_publishing(&mut self, claim: PublishClaim) -> Result<(), PagePublicationError> {
         match self.state {
             PagePublicationState::Prepared => {
+                self.bump_revision()?;
                 self.publish_claim = Some(claim);
                 self.state = if self.events.is_empty() {
                     PagePublicationState::Published
@@ -300,6 +511,7 @@ impl PagePublication {
                 operation: "transfer publish claim",
             });
         }
+        self.bump_revision()?;
         self.publish_claim = Some(successor);
         Ok(())
     }
@@ -353,6 +565,7 @@ impl PagePublication {
                 "append acknowledgements must be recorded in page order",
             ));
         }
+        self.bump_revision()?;
         self.append_receipts.push(receipt);
         if self.append_receipts.len() == self.events.len() {
             self.state = PagePublicationState::Published;
@@ -387,6 +600,7 @@ impl PagePublication {
                 operation: "record projection",
             });
         }
+        self.bump_revision()?;
         self.projection_receipt = Some(receipt);
         self.state = PagePublicationState::Projected;
         Ok(())
@@ -404,6 +618,7 @@ impl PagePublication {
                 operation: "commit runtime progress",
             });
         }
+        self.bump_revision()?;
         self.state = PagePublicationState::Committed;
         Ok(())
     }
@@ -423,6 +638,7 @@ impl PagePublication {
                 operation: "supersede page",
             });
         }
+        self.bump_revision()?;
         self.state = PagePublicationState::Superseded;
         Ok(())
     }
@@ -438,12 +654,23 @@ impl PagePublication {
                 operation: "quarantine page",
             });
         }
-        self.quarantine_reason = Some(bounded_text(
-            reason.into(),
-            "quarantine reason",
-            MAX_REASON_BYTES,
-        )?);
+        let reason = bounded_text(reason.into(), "quarantine reason", MAX_REASON_BYTES)?;
+        if self.state == PagePublicationState::Quarantined
+            && self.quarantine_reason.as_ref() == Some(&reason)
+        {
+            return Ok(());
+        }
+        self.bump_revision()?;
+        self.quarantine_reason = Some(reason);
         self.state = PagePublicationState::Quarantined;
+        Ok(())
+    }
+
+    fn bump_revision(&mut self) -> Result<(), PagePublicationError> {
+        self.revision = self
+            .revision
+            .checked_add(1)
+            .ok_or(PagePublicationError::Invalid("page revision overflow"))?;
         Ok(())
     }
 
@@ -453,6 +680,19 @@ impl PagePublication {
         } else {
             Err(PagePublicationError::StaleClaim)
         }
+    }
+}
+
+fn parse_state(value: &str) -> Result<PagePublicationState, PagePublicationError> {
+    match value {
+        "prepared" => Ok(PagePublicationState::Prepared),
+        "publishing" => Ok(PagePublicationState::Publishing),
+        "published" => Ok(PagePublicationState::Published),
+        "projected" => Ok(PagePublicationState::Projected),
+        "committed" => Ok(PagePublicationState::Committed),
+        "superseded" => Ok(PagePublicationState::Superseded),
+        "quarantined" => Ok(PagePublicationState::Quarantined),
+        _ => Err(PagePublicationError::Invalid("page publication state")),
     }
 }
 
@@ -720,6 +960,33 @@ mod tests {
         assert_eq!(
             first.events()[0].message_id(),
             second.events()[0].message_id()
+        );
+    }
+
+    #[test]
+    fn persisted_snapshot_replays_validated_transitions_and_revision() {
+        let mut page = prepared(&["event-a", "event-b"]);
+        let first = PublishClaim::new("worker-a", 1).unwrap();
+        page.begin_publishing(first.clone()).unwrap();
+        let append = receipt(&page, 0, 10);
+        page.record_append(&first, append).unwrap();
+        let successor = PublishClaim::new("worker-b", 2).unwrap();
+        page.transfer_claim(&first, successor).unwrap();
+
+        let snapshot = serde_json::to_value(&page).unwrap();
+        let restored = PagePublication::restore_snapshot(snapshot).unwrap();
+        assert_eq!(restored, page);
+        assert_eq!(restored.revision(), 4);
+    }
+
+    #[test]
+    fn persisted_snapshot_rejects_tampered_message_identity() {
+        let page = prepared(&["event-a"]);
+        let mut snapshot = serde_json::to_value(&page).unwrap();
+        snapshot["events"][0]["message_id"] = Value::String("tampered".to_owned());
+        assert_eq!(
+            PagePublication::restore_snapshot(snapshot),
+            Err(PagePublicationError::ReceiptMismatch)
         );
     }
 }


### PR DESCRIPTION
## Runtime scope

- persist the credential-free Rust source-page publication state in PostgreSQL
- atomically retain the exact canonical envelope bytes required for restart-safe publication
- enforce tenant row-level security for every page read and write
- admit only newly prepared revision 1 pages, then require one-revision compare-and-swap transitions
- make exact insert and transition retries idempotent while rejecting reused identities, stale writers, and skipped revisions
- reconstruct stored snapshots through validated constructors and state transitions before recovery
- verify every restored envelope against its ordinal, event identity, stable message identity, and SHA-256 digest
- enumerate only prepared, publishing, published, and projected pages for automatic recovery

This is stacked on #2577 because it persists the fenced publication state machine introduced there. It does not add provider sources or expose a second collection/commit path.

## Invariants

- publication snapshots contain identifiers, digests, ordered append receipts, projection receipts, and fencing claims; no credential bytes or private routes
- the byte outbox is committed atomically with the prepared page and is bounded to 16 MiB per envelope and 32 MiB per page
- PostgreSQL metadata must exactly match the validated snapshot
- committed, superseded, and quarantined pages are excluded from automatic recovery
- durable state cannot skip a revision or overwrite a successor

## Validation

- `rustfmt --edition 2024 crates/source-runtime-next/src/page_publication.rs crates/organizational-store/src/page_publication.rs crates/organizational-store/src/lib.rs crates/organizational-store/src/postgres.rs`
- `git diff --check`
- focused Cargo tests were attempted through the managed wrapper but compilation was blocked before execution: DDESK has no project disk and the safe Cargo capacity gate is short by 24,532,560,486 bytes
- hosted checks on the exact head are required for Rust compilation, unit tests, Clippy, schema checks, and the wider repository suite

## Follow-up boundary

The next runtime slice will wire JetStream publication and restart recovery through this ledger. Rust source sync remains unexposed as a service until append, projection, and checkpoint ordering all use this path.
