### PR TITLE
Move Anthropic source execution to Rust authority

### DIFF
--- a/crates/source-runtime-next/src/anthropic.rs
+++ b/crates/source-runtime-next/src/anthropic.rs
@@ -19,6 +19,7 @@ mod types;
 
 pub use error::AnthropicError;
 pub use family::{AnthropicAuthentication, AnthropicFamily};
+pub(crate) use source_execution::ANTHROPIC_SOURCE_EXECUTION_ADAPTERS;
 pub use types::{
     AnthropicKernel, AnthropicPage, AnthropicRecord, AnthropicRequest, AnthropicScope,
 };

--- a/crates/source-runtime-next/src/anthropic/source_execution.rs
+++ b/crates/source-runtime-next/src/anthropic/source_execution.rs
@@ -20,6 +20,7 @@ use crate::source_execution::{
 #[path = "source_execution/catalog.rs"]
 mod catalog;
 
+pub(crate) use catalog::ANTHROPIC_SOURCE_EXECUTION_ADAPTERS;
 use catalog::{AnthropicSourceExecutionAdapter, map_error, optional, timestamp, validated_kernel};
 
 impl SourceExecutionAdapter for AnthropicSourceExecutionAdapter {

--- a/crates/source-runtime-next/src/anthropic/source_execution/catalog.rs
+++ b/crates/source-runtime-next/src/anthropic/source_execution/catalog.rs
@@ -191,7 +191,12 @@ pub(super) fn validated_kernel(
         .query_parameters()
         .iter()
         .filter_map(|(_, name)| {
-            public_value(&metadata.public_config, name)
+            let public_name = if *name == "api_key_ids" {
+                "admin_key_ids"
+            } else {
+                *name
+            };
+            public_value(&metadata.public_config, public_name)
                 .map(|value| ((*name).to_owned(), value.to_owned()))
         })
         .collect::<BTreeMap<_, _>>();

--- a/crates/source-runtime-next/src/anthropic/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/anthropic/source_execution_tests.rs
@@ -49,7 +49,7 @@ fn adapter(family: AnthropicFamily) -> &'static super::AnthropicSourceExecutionA
 }
 
 #[test]
-fn provider_local_catalog_compiles_every_anthropic_family_without_authority() {
+fn shared_dispatcher_compiles_every_anthropic_family() {
     assert_eq!(
         ANTHROPIC_SOURCE_EXECUTION_ADAPTERS.len(),
         AnthropicFamily::ALL.len()
@@ -69,12 +69,14 @@ fn provider_local_catalog_compiles_every_anthropic_family_without_authority() {
         assert!(plan.required_attributes.contains(&"family".to_owned()));
 
         assert_eq!(
-            SourceExecutionDispatcher.compile_plan(&SourceExecutionSelectionRequestV1 {
-                source_id: "anthropic".to_owned(),
-                family_id: family.as_str().to_owned(),
-            }),
-            Err(SourceExecutionError::UnknownAdapter),
-            "{} must remain outside shared authority",
+            SourceExecutionDispatcher
+                .compile_plan(&SourceExecutionSelectionRequestV1 {
+                    source_id: "anthropic".to_owned(),
+                    family_id: family.as_str().to_owned(),
+                })
+                .unwrap_or_else(|error| panic!("{} compile: {error}", family.as_str())),
+            plan,
+            "{} shared plan mismatch",
             family.as_str()
         );
     }

--- a/crates/source-runtime-next/src/source_execution/dispatcher.rs
+++ b/crates/source-runtime-next/src/source_execution/dispatcher.rs
@@ -1,5 +1,6 @@
 use prost::Message;
 
+use crate::anthropic::ANTHROPIC_SOURCE_EXECUTION_ADAPTERS;
 use crate::asana::ASANA_SOURCE_EXECUTION_ADAPTERS;
 use crate::digitalocean::DIGITALOCEAN_SOURCE_EXECUTION_ADAPTERS;
 use crate::discord::DISCORD_SOURCE_EXECUTION_ADAPTERS;
@@ -129,6 +130,11 @@ impl SourceExecutionDispatcher {
         &self,
         request: &SourceExecutionSelectionRequestV1,
     ) -> Result<SourceExecutionPlanV1, SourceExecutionError> {
+        if let Some(adapter) = ANTHROPIC_SOURCE_EXECUTION_ADAPTERS.iter().find(|adapter| {
+            request.source_id == adapter.source_id() && request.family_id == adapter.family_id()
+        }) {
+            return Ok(adapter.compiled_plan());
+        }
         if let Some(adapter) = ASANA_SOURCE_EXECUTION_ADAPTERS.iter().find(|adapter| {
             request.source_id == adapter.source_id() && request.family_id == adapter.family_id()
         }) {
@@ -213,6 +219,13 @@ impl SourceExecutionDispatcher {
         &self,
         plan: &SourceExecutionPlanV1,
     ) -> Result<&'static dyn SourceExecutionAdapter, SourceExecutionError> {
+        if let Some(adapter) = ANTHROPIC_SOURCE_EXECUTION_ADAPTERS.iter().find(|adapter| {
+            plan.source_id == adapter.source_id()
+                && plan.family_id == adapter.family_id()
+                && plan.provider_kernel == adapter.provider_kernel()
+        }) {
+            return Ok(adapter);
+        }
         if let Some(adapter) = ASANA_SOURCE_EXECUTION_ADAPTERS.iter().find(|adapter| {
             plan.source_id == adapter.source_id()
                 && plan.family_id == adapter.family_id()

--- a/internal/sourceops/source_execution.go
+++ b/internal/sourceops/source_execution.go
@@ -45,7 +45,7 @@ func rustSourceFamily(sourceID string, config map[string]string) (string, bool) 
 	// runtime-authoritative provider must keep its existing sourceops path until
 	// its preview credential adapter and product-surface parity are ready.
 	switch sourceID {
-	case "asana", "azure", "digitalocean", "discord", "linode", "pagerduty", "sentinelone", "tailscale":
+	case "anthropic", "asana", "azure", "digitalocean", "discord", "linode", "pagerduty", "sentinelone", "tailscale":
 		return sourceworker.RustAuthoritativeFamily(sourceID, config["family"])
 	case "jumpcloud":
 		family := strings.TrimSpace(config["family"])
@@ -76,7 +76,7 @@ func (s *Service) executeRustSource(ctx context.Context, sourceID, family string
 		clear(credential)
 		return sourcecdk.Pull{}, sourceExecutionError(sourceID, family, err)
 	}
-	publicConfig := sourceworker.PublicExecutionConfig(config)
+	publicConfig := sourceworker.PublicExecutionConfigForSource(sourceID, config)
 	publicConfig["family"] = family
 	now := time.Now().UTC()
 	input := sourceworker.ExecutionInput{
@@ -151,6 +151,13 @@ func previewCredential(sourceID string, config map[string]string) string {
 			}
 		}
 		return ""
+	case "anthropic":
+		for _, key := range []string{"token", "api_token", "api_key", "access_token"} {
+			if credential := strings.TrimSpace(config[key]); credential != "" {
+				return credential
+			}
+		}
+		return ""
 	case "discord":
 		for _, key := range []string{"api_token", "api_key", "token"} {
 			if credential := strings.TrimSpace(config[key]); credential != "" {
@@ -168,6 +175,15 @@ func discoverURNs(pull sourcecdk.Pull) ([]sourcecdk.URN, error) {
 	for _, event := range pull.Events {
 		attributes := event.GetAttributes()
 		raw := strings.TrimSpace(attributes["resource_urn"])
+		if raw == "" && strings.TrimSpace(event.GetSourceId()) == "anthropic" {
+			family := strings.TrimSpace(attributes["family"])
+			stableID := strings.TrimSpace(attributes["external_id"])
+			urn, err := sourcecdk.URNFor(event.GetTenantId(), "anthropic_"+family, stableID)
+			if err != nil {
+				return nil, fmt.Errorf("%w: Anthropic discovery identity is invalid", sourceworker.ErrWorkerContract)
+			}
+			raw = urn.String()
+		}
 		if raw == "" && strings.TrimSpace(event.GetSourceId()) == "jumpcloud" {
 			family := strings.TrimSpace(attributes["family"])
 			if family == "" {

--- a/internal/sourceops/source_execution_test.go
+++ b/internal/sourceops/source_execution_test.go
@@ -20,6 +20,10 @@ func TestRustSourceFamilyPreviewAuthorityIsExact(t *testing.T) {
 	}{
 		"Azure authorization policy":  {"azure", "authorization_policy", "authorization_policy", true},
 		"other Azure family":          {"azure", "user", "user", false},
+		"Anthropic default":           {"anthropic", "", "user", true},
+		"Anthropic user":              {"anthropic", "user", "user", true},
+		"Anthropic compliance":        {"anthropic", "compliance_activity", "compliance_activity", true},
+		"unknown Anthropic family":    {"anthropic", "future-family", "future-family", true},
 		"Asana default":               {"asana", "", "users", true},
 		"Asana users":                 {"asana", "users", "users", true},
 		"Asana projects":              {"asana", "projects", "projects", true},
@@ -102,6 +106,54 @@ func TestAsanaCheckDiscoverAndReadUseOnlyClosedRustAuthority(t *testing.T) {
 			}
 			read, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{SourceId: "asana", Config: config})
 			if err != nil || len(read.GetEvents()) != 1 || read.GetEvents()[0].GetSourceId() != "asana" || read.GetCheckpoint().GetCursorOpaque() == "" {
+				t.Fatalf("Read() = %#v, %v", read, err)
+			}
+			if calls != 3 || legacy.checkCalls != 0 || legacy.discoverCalls != 0 || legacy.readCalls != 0 {
+				t.Fatalf("calls = Rust %d, Go check/discover/read %d/%d/%d", calls, legacy.checkCalls, legacy.discoverCalls, legacy.readCalls)
+			}
+		})
+	}
+}
+
+func TestAnthropicCheckDiscoverAndReadUseOnlyClosedRustAuthority(t *testing.T) {
+	const credentialFixture = "host-only-anthropic-secret" // #nosec G101 -- synthetic boundary-test sentinel, not credential material.
+	for _, family := range []string{"user", "compliance_activity"} {
+		t.Run(family, func(t *testing.T) {
+			legacy := &authorityProbeSource{sourceID: "anthropic"}
+			registry, err := sourcecdk.NewRegistry(legacy)
+			if err != nil {
+				t.Fatal(err)
+			}
+			service := New(registry)
+			service.sourceWorker = previewWorkerStub{}
+			calls := 0
+			service.runSourceExecution = func(_ context.Context, _ sourceworker.Worker, reference string, credential []byte, _ time.Time, input sourceworker.ExecutionInput) (*sourceworker.ExecutionOutput, error) {
+				calls++
+				if reference != previewCredentialReference || string(credential) != credentialFixture {
+					t.Fatal("Anthropic credential was not confined to the trusted runner boundary")
+				}
+				encoded, marshalErr := json.Marshal(input)
+				if marshalErr != nil || strings.Contains(string(encoded), credentialFixture) || input.Scope.PublicConfig["api_key"] != "" {
+					t.Fatalf("credential crossed the worker protocol: %s, %v", encoded, marshalErr)
+				}
+				if input.SourceID != "anthropic" || input.FamilyID != family || input.Scope.PublicConfig["auth_model"] != "api_key" || input.Scope.PublicConfig["per_page"] != "100" {
+					t.Fatalf("Rust selection = %s.%s, public config = %#v", input.SourceID, input.FamilyID, input.Scope.PublicConfig)
+				}
+				return anthropicPreviewOutput(family, input.Scope.PriorTerminalWatermarkUnixMillis), nil
+			}
+			config := map[string]string{
+				"family": family, "tenant_id": "tenant-1", "api_key": credentialFixture,
+				"auth_model": "api_key", "per_page": "100",
+			}
+			if _, err := service.Check(context.Background(), &cerebrov1.CheckSourceRequest{SourceId: "anthropic", Config: config}); err != nil {
+				t.Fatal(err)
+			}
+			discovered, err := service.Discover(context.Background(), &cerebrov1.DiscoverSourceRequest{SourceId: "anthropic", Config: config})
+			if err != nil || len(discovered.GetUrns()) != 1 || !strings.Contains(discovered.GetUrns()[0], ":anthropic_"+family+":") {
+				t.Fatalf("Discover() = %#v, %v", discovered, err)
+			}
+			read, err := service.Read(context.Background(), &cerebrov1.ReadSourceRequest{SourceId: "anthropic", Config: config})
+			if err != nil || len(read.GetEvents()) != 1 || read.GetEvents()[0].GetSourceId() != "anthropic" || read.GetCheckpoint().GetCursorOpaque() == "" {
 				t.Fatalf("Read() = %#v, %v", read, err)
 			}
 			if calls != 3 || legacy.checkCalls != 0 || legacy.discoverCalls != 0 || legacy.readCalls != 0 {
@@ -521,6 +573,25 @@ func TestJumpCloudPreviewCredentialAliases(t *testing.T) {
 	}
 }
 
+func TestAnthropicPreviewCredentialAliases(t *testing.T) {
+	for name, test := range map[string]struct {
+		config map[string]string
+		want   string
+	}{
+		"token precedence": {map[string]string{"token": "token", "api_key": "fallback"}, "token"},
+		"api token":        {map[string]string{"api_token": "api-token", "api_key": "fallback"}, "api-token"},
+		"api key":          {map[string]string{"api_key": "api-key"}, "api-key"},
+		"access token":     {map[string]string{"access_token": "access-token"}, "access-token"},
+		"missing":          {map[string]string{"graph_token": "wrong-provider"}, ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := previewCredential("anthropic", test.config); got != test.want {
+				t.Fatalf("previewCredential() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestTailscaleCheckDiscoverAndReadUseOnlyClosedRustAuthority(t *testing.T) {
 	for _, family := range []string{"device", "grant", "group", "service", "tag", "tailnet", "user"} {
 		t.Run(family, func(t *testing.T) {
@@ -889,6 +960,25 @@ func asanaPreviewOutput(family string, priorWatermark int64) *sourceworker.Execu
 			"resource_urn": "urn:cerebro:tenant-1:asana_" + family + ":" + providerID,
 		},
 		PayloadJson: []byte(`{"gid":"` + providerID + `"}`),
+	}
+	return &sourceworker.ExecutionOutput{
+		Plan: plan, Result: &cerebrov1.SourceWorkerDecodeResultV1{ResultDigestSha256: "result-digest"},
+		Program: &sourceworker.PageProgram{TransitionDigest: "transition", AdmittedRecords: []*cerebrov1.SourceWorkerRecordV1{record}, CheckpointCursor: providerID, CheckpointWatermarkUnixMillis: watermark},
+	}
+}
+
+func anthropicPreviewOutput(family string, priorWatermark int64) *sourceworker.ExecutionOutput {
+	watermark := max(priorWatermark, 1_725_000_000_000)
+	providerID := family + "-1"
+	plan := &cerebrov1.SourceExecutionPlanV1{
+		SourceId: "anthropic", FamilyId: family, EventKind: "anthropic." + family, SchemaRef: "anthropic/" + family + "/v1",
+	}
+	record := &cerebrov1.SourceWorkerRecordV1{
+		ProviderId: providerID, EventId: "anthropic-tenant-1-" + providerID, OccurredAtUnixMillis: watermark,
+		Attributes: map[string]string{
+			"external_id": providerID, "family": family, "provider": "anthropic", "source_provider": "anthropic",
+		},
+		PayloadJson: []byte(`{"id":"` + providerID + `"}`),
 	}
 	return &sourceworker.ExecutionOutput{
 		Plan: plan, Result: &cerebrov1.SourceWorkerDecodeResultV1{ResultDigestSha256: "result-digest"},

--- a/internal/sourceruntime/source_execution.go
+++ b/internal/sourceruntime/source_execution.go
@@ -28,14 +28,14 @@ func (s *Service) validateRustSourceRuntimePlan(ctx context.Context, runtime *ce
 	executionContext, err := s.sourceWorker.Context(ctx, sourceworker.ContextRequest{
 		TenantID: strings.TrimSpace(runtime.GetTenantId()), RuntimeID: strings.TrimSpace(runtime.GetId()),
 		PageNumber: 1, RuntimeGeneration: 1, LeaseGeneration: 1,
-		ObservedAtUnixMillis: now.UnixMilli(), PublicConfig: sourceworker.PublicExecutionConfig(config),
+		ObservedAtUnixMillis: now.UnixMilli(), PublicConfig: sourceworker.PublicExecutionConfigForSource(runtime.GetSourceId(), config),
 	})
 	if err != nil {
 		return fmt.Errorf("%w: validate Rust execution context: %w", ErrInvalidRequest, err)
 	}
 	_, err = s.sourceWorker.PlanV2(ctx, &cerebrov1.SourceWorkerPlanEnvelopeV2{
 		Request:  &cerebrov1.SourceWorkerPlanRequestV1{Plan: plan, Context: executionContext},
-		Metadata: &cerebrov1.SourceWorkerRuntimeMetadataV2{PublicConfig: sourceworker.PublicExecutionConfig(config)},
+		Metadata: &cerebrov1.SourceWorkerRuntimeMetadataV2{PublicConfig: sourceworker.PublicExecutionConfigForSource(runtime.GetSourceId(), config)},
 	})
 	if err != nil {
 		return fmt.Errorf("%w: validate Rust source plan: %w", ErrInvalidRequest, err)
@@ -69,7 +69,7 @@ func (s *Service) readSourcePull(ctx context.Context, runtime *cerebrov1.SourceR
 	if err != nil {
 		return sourcecdk.Pull{}, false, err
 	}
-	publicConfig := sourceworker.PublicExecutionConfig(cfg.Values())
+	publicConfig := sourceworker.PublicExecutionConfigForSource(runtime.GetSourceId(), cfg.Values())
 	priorWatermark := int64(0)
 	if watermark := checkpoint.GetWatermark(); watermark != nil && watermark.CheckValid() == nil {
 		priorWatermark = watermark.AsTime().UTC().UnixMilli()

--- a/internal/sourceruntime/source_execution_authority_test.go
+++ b/internal/sourceruntime/source_execution_authority_test.go
@@ -37,6 +37,62 @@ func TestPutTailscaleRuntimeValidatesWithRustWithoutCallingGoCheck(t *testing.T)
 	}
 }
 
+func TestPutAnthropicRuntimeValidatesWithRustWithoutCallingGoCheck(t *testing.T) {
+	legacy := &runtimeAuthorityProbe{sourceID: "anthropic"}
+	registry, err := sourcecdk.NewRegistry(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker := &runtimePlanWorker{}
+	service := New(registry, &runtimeStore{}, nil, nil)
+	service.sourceWorker = worker
+	_, err = service.Put(context.Background(), &cerebrov1.PutSourceRuntimeRequest{Runtime: &cerebrov1.SourceRuntime{
+		Id: "anthropic-user-runtime", SourceId: "anthropic", TenantId: "tenant-1",
+		Config: map[string]string{
+			"family": "user", "auth_model": "api_key", "per_page": "100",
+			"api_key": sourceconfig.CredentialReferenceValue("anthropic", "api_key"),
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy.checkCalls != 0 || worker.planCalls != 1 {
+		t.Fatalf("validation calls = Go %d, Rust %d", legacy.checkCalls, worker.planCalls)
+	}
+	if worker.selection.SourceID != "anthropic" || worker.selection.FamilyID != "user" {
+		t.Fatalf("Rust selection = %#v", worker.selection)
+	}
+	if worker.publicConfig["family"] != "user" || worker.publicConfig["auth_model"] != "api_key" || worker.publicConfig["per_page"] != "100" || worker.publicConfig["api_key"] != "" {
+		t.Fatalf("Rust public config = %#v", worker.publicConfig)
+	}
+}
+
+func TestAnthropicRuntimeNeverFallsBackToGoAuthority(t *testing.T) {
+	legacy := &runtimeAuthorityProbe{sourceID: "anthropic"}
+	worker := &runtimePlanWorker{compileErr: sourceworker.ErrWorkerUnsupported}
+	service := &Service{sourceWorker: worker}
+	runtime := &cerebrov1.SourceRuntime{
+		Id: "anthropic-user-runtime", SourceId: "anthropic", TenantId: "tenant-1",
+		Config: map[string]string{
+			"family": "user", "auth_model": "api_key",
+			"api_key": sourceconfig.CredentialReferenceValue("anthropic", "api_key"),
+		},
+	}
+	ctx := context.WithValue(context.Background(), sourceRuntimeLeaseFenceContextKey{}, sourceRuntimeLeaseAuthority{fence: ports.SourceRuntimeLeaseFence{
+		Owner: "owner-1", Generation: 1, ExpiresAt: time.Now().Add(time.Minute),
+	}})
+	resolved := sourcecdk.NewConfig(map[string]string{
+		"family": "user", "auth_model": "api_key", "api_key": "host-only-secret",
+	})
+
+	if _, _, err := service.readSourcePull(ctx, runtime, legacy, resolved, nil, nil, 1); !errors.Is(err, sourceworker.ErrWorkerUnsupported) {
+		t.Fatalf("readSourcePull() error = %v", err)
+	}
+	if legacy.readCalls != 0 || worker.selection.SourceID != "anthropic" || worker.selection.FamilyID != "user" {
+		t.Fatalf("authority calls = Go %d, Rust selection %#v", legacy.readCalls, worker.selection)
+	}
+}
+
 func TestTailscaleRuntimeFailsClosedWithoutRustWorker(t *testing.T) {
 	legacy := &runtimeAuthorityProbe{sourceID: "tailscale"}
 	registry, err := sourcecdk.NewRegistry(legacy)

--- a/internal/sourceruntime/sourceworker/host.go
+++ b/internal/sourceruntime/sourceworker/host.go
@@ -190,6 +190,10 @@ func credentialHeader(operation string, credential []byte) (string, []byte, erro
 	switch operation {
 	case "source.bearer":
 		return "Authorization", append([]byte("Bearer "), credential...), nil
+	case "anthropic.admin_x_api_key", "anthropic.compliance_x_api_key":
+		return "X-Api-Key", append([]byte(nil), credential...), nil
+	case "anthropic.org_admin_bearer":
+		return "Authorization", append([]byte("Bearer "), credential...), nil
 	case "jumpcloud.x_api_key":
 		return "X-Api-Key", append([]byte(nil), credential...), nil
 	case "sentinelone.api_token":

--- a/internal/sourceruntime/sourceworker/host_test.go
+++ b/internal/sourceruntime/sourceworker/host_test.go
@@ -218,6 +218,33 @@ func TestCredentialHeaderAppliesOnlyTheClosedSentinelOneScheme(t *testing.T) {
 	}
 }
 
+func TestCredentialHeaderAppliesOnlyClosedAnthropicSchemes(t *testing.T) {
+	for _, operation := range []string{"anthropic.admin_x_api_key", "anthropic.compliance_x_api_key"} {
+		header, value, err := credentialHeader(operation, []byte("synthetic-secret"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if header != "X-Api-Key" || string(value) != "synthetic-secret" {
+			t.Fatalf("%s header = %q, value = %q", operation, header, value)
+		}
+		clear(value)
+	}
+	header, value, err := credentialHeader("anthropic.org_admin_bearer", []byte("synthetic-secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clear(value)
+	if header != "Authorization" || string(value) != "Bearer synthetic-secret" {
+		t.Fatalf("Anthropic bearer header = %q, value = %q", header, value)
+	}
+	if err := validateDeclaredHeaders(map[string]string{"anthropic-version": "2023-06-01"}); err != nil {
+		t.Fatalf("Anthropic public version header was rejected: %v", err)
+	}
+	if _, _, err := credentialHeader("anthropic.api_key", []byte("synthetic-secret")); !errors.Is(err, ErrWorkerContract) {
+		t.Fatalf("unregistered Anthropic credential operation error = %v", err)
+	}
+}
+
 func TestCredentialHeaderAppliesOnlyTheClosedDiscordScheme(t *testing.T) {
 	header, value, err := credentialHeader("discord.bot_token", []byte("synthetic-secret"))
 	if err != nil {

--- a/internal/sourceruntime/sourceworker/pull.go
+++ b/internal/sourceruntime/sourceworker/pull.go
@@ -22,6 +22,13 @@ func RustAuthoritativeFamily(sourceID, familyID string) (string, bool) {
 	sourceID = strings.TrimSpace(sourceID)
 	familyID = strings.TrimSpace(familyID)
 	switch sourceID {
+	case "anthropic":
+		if familyID == "" {
+			familyID = "user"
+		}
+		// Every cataloged Anthropic family is closed in the Rust dispatcher.
+		// Unknown families fail there instead of restoring the retired Go path.
+		return familyID, true
 	case "asana":
 		if familyID == "" {
 			familyID = "users"
@@ -101,6 +108,9 @@ func CredentialBinding(sourceID string, references, resolved map[string]string) 
 		return passwordReference, encoded
 	}
 	keys := []string{"graph_token", "token"}
+	if strings.TrimSpace(sourceID) == "anthropic" {
+		keys = []string{"token", "api_token", "api_key", "access_token"}
+	}
 	if strings.TrimSpace(sourceID) == "discord" {
 		keys = []string{"api_token", "api_key", "token"}
 	}
@@ -142,6 +152,31 @@ func PublicExecutionConfig(values map[string]string) map[string]string {
 		if value, ok := values[key]; ok {
 			public[key] = strings.TrimSpace(value)
 		}
+	}
+	return public
+}
+
+// PublicExecutionConfigForSource adds provider-specific selectors that are
+// safe for the credential-free protocol. Secret-bearing aliases remain absent.
+func PublicExecutionConfigForSource(sourceID string, values map[string]string) map[string]string {
+	public := PublicExecutionConfig(values)
+	if strings.TrimSpace(sourceID) != "anthropic" {
+		return public
+	}
+	for _, key := range []string{
+		"activity_types", "actor_ids", "auth_model", "bucket_width", "context_windows",
+		"created_at_gt", "created_at_gte", "created_at_lt", "created_at_lte", "ending_at",
+		"group_by", "group_id", "include_archived", "inference_geos", "model", "models",
+		"organization_ids", "organization_uuid", "periods", "project_id", "role_id",
+		"service_tiers", "speeds", "starting_at", "status", "terminal_types", "user_ids",
+		"workspace_id", "workspace_ids",
+	} {
+		if value, ok := values[key]; ok {
+			public[key] = strings.TrimSpace(value)
+		}
+	}
+	if value, ok := values["api_key_ids"]; ok {
+		public["admin_key_ids"] = strings.TrimSpace(value)
 	}
 	return public
 }

--- a/internal/sourceruntime/sourceworker/pull_test.go
+++ b/internal/sourceruntime/sourceworker/pull_test.go
@@ -81,6 +81,21 @@ func TestPublicExecutionConfigNeverCarriesCredentialMaterial(t *testing.T) {
 	}
 }
 
+func TestAnthropicPublicExecutionConfigCarriesSelectorsWithoutCredentialMaterial(t *testing.T) {
+	public := PublicExecutionConfigForSource("anthropic", map[string]string{
+		"family": " usage_report_message ", "auth_model": " bearer_token ",
+		"organization_uuid": " org-1 ", "workspace_id": " workspace-1 ",
+		"api_key_ids": " key-1,key-2 ", "models": " model-1,model-2 ",
+		"api_key": "must-not-cross", "token": "must-not-cross-either",
+	})
+	if public["family"] != "usage_report_message" || public["auth_model"] != "bearer_token" || public["organization_uuid"] != "org-1" || public["workspace_id"] != "workspace-1" || public["admin_key_ids"] != "key-1,key-2" || public["models"] != "model-1,model-2" {
+		t.Fatalf("Anthropic public config lost declared selectors: %#v", public)
+	}
+	if public["api_key"] != "" || public["token"] != "" || public["api_key_ids"] != "" {
+		t.Fatalf("Anthropic public config leaked credential-shaped fields: %#v", public)
+	}
+}
+
 func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
 	for name, test := range map[string]struct {
 		source, family, wantFamily string
@@ -88,6 +103,10 @@ func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
 	}{
 		"Azure authorization policy":  {" azure ", " authorization_policy ", "authorization_policy", true},
 		"other Azure family":          {"azure", "user", "user", false},
+		"Anthropic default":           {" anthropic ", "", "user", true},
+		"Anthropic user":              {"anthropic", " user ", "user", true},
+		"Anthropic compliance":        {"anthropic", "compliance_activity", "compliance_activity", true},
+		"unknown Anthropic family":    {"anthropic", "future-family", "future-family", true},
 		"Asana default":               {" asana ", "", "users", true},
 		"Asana users":                 {"asana", " users ", "users", true},
 		"Asana projects":              {"asana", "projects", "projects", true},
@@ -167,6 +186,16 @@ func TestCredentialBindingUsesOnlyTheSelectedProviderAliases(t *testing.T) {
 			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.
 			source: "jumpcloud", references: map[string]string{"api_key": "credential:jumpcloud:api-key", "token": "credential:jumpcloud:fallback"},
 			resolved: map[string]string{"api_key": "resolved-api-key", "token": "resolved-fallback"}, wantReference: "credential:jumpcloud:api-key", wantResolved: "resolved-api-key",
+		},
+		"Anthropic token precedence": {
+			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.
+			source: "anthropic", references: map[string]string{"token": "credential:anthropic:token", "api_key": "credential:anthropic:api-key"},
+			resolved: map[string]string{"token": "resolved-token", "api_key": "resolved-api-key"}, wantReference: "credential:anthropic:token", wantResolved: "resolved-token",
+		},
+		"Anthropic api key": {
+			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.
+			source: "anthropic", references: map[string]string{"api_key": "credential:anthropic:api-key"},
+			resolved: map[string]string{"api_key": "resolved-api-key"}, wantReference: "credential:anthropic:api-key", wantResolved: "resolved-api-key",
 		},
 		"Twilio basic credentials": {
 			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.

--- a/internal/sourceruntime/sourceworker/validation.go
+++ b/internal/sourceruntime/sourceworker/validation.go
@@ -125,7 +125,7 @@ func validateHeaderMap(headers map[string]string, response bool) error {
 }
 
 func safeDeclaredHeaderName(name string) bool {
-	return name == "content-type" || name == "x-org-id"
+	return name == "anthropic-version" || name == "content-type" || name == "x-org-id"
 }
 
 func safeConfigKey(key string) bool {


### PR DESCRIPTION
Summary

- register all Anthropic source families in the closed Rust source-execution dispatcher
- apply Anthropic API-key, compliance-key, and organization-admin bearer authentication in the trusted host
- route durable runtime and preview operations through Rust without a Go provider fallback
- preserve credential-free public selectors, discovery identities, and restartable checkpoints

Validation

- go test ./internal/sourceruntime/sourceworker ./internal/sourceops ./internal/sourceruntime -count=1
- go test ./sources/anthropic -count=1
- make check-structural check-arch
- make source-fixture-check fixture-oracle-check
- rustfmt --edition 2024 --check on changed Rust files

Hosted Rust compilation and the full repository checks remain pending.