### PR TITLE
feat(sources): route catalog AI providers through Rust

### DIFF
--- a/crates/source-runtime-next/Cargo.toml
+++ b/crates/source-runtime-next/Cargo.toml
@@ -26,13 +26,11 @@ prost-types.workspace = true
 reqwest = { workspace = true, features = ["form", "stream"] }
 serde.workspace = true
 serde_json.workspace = true
+serde-saphyr.workspace = true
 sha2.workspace = true
 time.workspace = true
 tokio = { workspace = true, features = ["time"] }
 zeroize.workspace = true
-
-[dev-dependencies]
-serde-saphyr.workspace = true
 
 [lints]
 workspace = true

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -51,6 +51,7 @@ mod mapper;
 mod okta;
 mod openai;
 mod pagerduty;
+mod portable_ai;
 mod panopticon;
 mod protocol;
 mod provider_failure;

--- a/crates/source-runtime-next/src/portable_ai.rs
+++ b/crates/source-runtime-next/src/portable_ai.rs
@@ -1,0 +1,10 @@
+//! Credential-free execution for catalog-defined AI provider families.
+
+mod adapter;
+mod catalog;
+mod normalize;
+
+pub(crate) use adapter::PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS;
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/portable_ai/adapter.rs
+++ b/crates/source-runtime-next/src/portable_ai/adapter.rs
@@ -1,0 +1,484 @@
+use std::{collections::HashMap, sync::LazyLock};
+
+use reqwest::Url;
+use serde_json::Value;
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceExecutionPlanV1,
+    SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1,
+    SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2, SourceWorkerHttpRequestV1,
+    SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1, SourceWorkerRecordV1,
+    SourceWorkerRuntimeMetadataV2, canonical_http_execution_digest, canonical_plan_digest,
+    canonical_request_intent_digest, canonical_result_digest, validate_and_deduplicate_records,
+    validate_cursor, validate_execution_context, validate_runtime_metadata,
+};
+
+use super::{
+    catalog::{Family, Pagination, SOURCES, Source},
+    normalize::{expected_event_id, normalize_records, scalar_at},
+};
+
+const MAX_RESPONSE_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Credential-free adapter for one exact catalog-defined AI provider family.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PortableAiSourceExecutionAdapter {
+    pub(super) source: &'static Source,
+    pub(super) family: &'static Family,
+}
+
+impl PortableAiSourceExecutionAdapter {
+    fn new(source: &'static Source, family: &'static Family) -> Self {
+        Self { source, family }
+    }
+
+    pub(crate) fn compiled_plan(&self) -> SourceExecutionPlanV1 {
+        let mut plan = SourceExecutionPlanV1 {
+            plan_id: format!("source-plan-v1:{}:{}", self.source.id, self.family.id),
+            source_id: self.source.id.clone(),
+            family_id: self.family.id.clone(),
+            provider_kernel: self.family.kernel.clone(),
+            method: self.family.method.clone(),
+            origin: self.source.origin_template.clone(),
+            path: self.family.path.clone(),
+            record_selector: self.family.record_selector.clone(),
+            id_field: self.family.id_paths.join("|"),
+            singleton_fallback_id: String::new(),
+            max_response_bytes: MAX_RESPONSE_BYTES,
+            event_kind: self.family.kind.clone(),
+            schema_ref: self.family.schema_ref.clone(),
+            required_attributes: self.family.required_attributes.clone(),
+            required_payload_fields: self.family.required_payload_fields.clone(),
+            plan_digest_sha256: String::new(),
+        };
+        plan.plan_digest_sha256 = canonical_plan_digest(&plan);
+        plan
+    }
+
+    fn validate_plan(&self, plan: &SourceExecutionPlanV1) -> Result<(), SourceExecutionError> {
+        if plan != &self.compiled_plan() {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        Ok(())
+    }
+
+    fn rendered_origin(
+        &self,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<String, SourceExecutionError> {
+        let mut origin = self.source.origin_template.clone();
+        for key in &self.source.required_config {
+            let value = public_value(&metadata.public_config, key)
+                .ok_or(SourceExecutionError::MissingConfiguration)?;
+            let placeholder = format!("${{config.{key}}}");
+            if origin.contains(&placeholder) {
+                if !safe_dns_label(value) {
+                    return Err(SourceExecutionError::MissingConfiguration);
+                }
+                origin = origin.replace(&placeholder, value);
+            }
+        }
+        if origin.contains("${config.") {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        let parsed = Url::parse(&origin).map_err(|_| SourceExecutionError::MissingConfiguration)?;
+        if parsed.scheme() != "https"
+            || parsed.username() != ""
+            || parsed.password().is_some()
+            || parsed.port().is_some()
+            || parsed.query().is_some()
+            || parsed.fragment().is_some()
+            || parsed.host_str().is_none()
+        {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        if self.source.id == "google_vertex_ai"
+            && !parsed
+                .host_str()
+                .is_some_and(|host| host.ends_with("-aiplatform.googleapis.com"))
+        {
+            return Err(SourceExecutionError::EgressDenied);
+        }
+        if public_value(&metadata.public_config, "base_url")
+            .is_some_and(|base_url| base_url.trim_end_matches('/') != origin.trim_end_matches('/'))
+        {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        Ok(origin)
+    }
+
+    fn rendered_path(
+        &self,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<String, SourceExecutionError> {
+        let mut path = self.family.path.clone();
+        for key in &self.source.required_config {
+            let placeholder = format!("${{config.{key}}}");
+            if path.contains(&placeholder) {
+                let value = public_value(&metadata.public_config, key)
+                    .ok_or(SourceExecutionError::MissingConfiguration)?;
+                path = path.replace(&placeholder, &path_component(value)?);
+            }
+        }
+        if !path.starts_with('/') || path.contains("${config.") {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        Ok(path)
+    }
+
+    fn request_url(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(String, String), SourceExecutionError> {
+        validate_execution_context(context)?;
+        validate_runtime_metadata(metadata)?;
+        if public_value(&metadata.public_config, "family")
+            .is_some_and(|family| family != self.family.id.as_str())
+        {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        for key in &self.source.required_config {
+            public_value(&metadata.public_config, key)
+                .ok_or(SourceExecutionError::MissingConfiguration)?;
+        }
+        let origin = self.rendered_origin(metadata)?;
+        let mut url = match &self.family.pagination {
+            Pagination::NextUrl { .. } | Pagination::Link { .. }
+                if !context.prior_cursor.is_empty() =>
+            {
+                validate_cursor(&context.prior_cursor)?;
+                validated_continuation(&origin, &context.prior_cursor)?
+            }
+            _ => Url::parse(&format!(
+                "{}{}",
+                origin.trim_end_matches('/'),
+                self.rendered_path(metadata)?
+            ))
+            .map_err(|_| SourceExecutionError::InvalidPlan)?,
+        };
+        if context.prior_cursor.is_empty() {
+            let mut query = url.query_pairs_mut();
+            for (key, value) in &self.family.static_query {
+                query.append_pair(key, value);
+            }
+            for (parameter, config_key) in &self.family.config_query {
+                let value = public_value(&metadata.public_config, config_key)
+                    .ok_or(SourceExecutionError::MissingConfiguration)?;
+                query.append_pair(parameter, value);
+            }
+            match &self.family.pagination {
+                Pagination::Cursor {
+                    page_size_parameter,
+                    page_size,
+                    ..
+                }
+                | Pagination::Link {
+                    page_size_parameter,
+                    page_size,
+                    ..
+                } => {
+                    if let Some(parameter) = page_size_parameter {
+                        query.append_pair(parameter, &page_size.to_string());
+                    }
+                }
+                Pagination::None | Pagination::NextUrl { .. } => {}
+            }
+        }
+        if let Pagination::Cursor { parameter, .. } = &self.family.pagination {
+            if !context.prior_cursor.is_empty() {
+                validate_cursor(&context.prior_cursor)?;
+                url.query_pairs_mut()
+                    .append_pair(parameter, &context.prior_cursor);
+            }
+        } else if matches!(&self.family.pagination, Pagination::None)
+            && !context.prior_cursor.is_empty()
+        {
+            return Err(SourceExecutionError::InvalidCursor);
+        }
+        Ok((origin, url.to_string()))
+    }
+
+    fn next_cursor(
+        &self,
+        body: &[u8],
+        headers: &HashMap<String, String>,
+        origin: &str,
+    ) -> Result<String, SourceExecutionError> {
+        let document: Value =
+            serde_json::from_slice(body).map_err(|_| SourceExecutionError::MalformedResponse)?;
+        let cursor = match &self.family.pagination {
+            Pagination::None => None,
+            Pagination::Cursor { json_path, .. } => scalar_at(&document, &[json_path.clone()]),
+            Pagination::NextUrl { json_path } => scalar_at(&document, &[json_path.clone()]),
+            Pagination::Link { header, .. } => response_header(headers, header).and_then(link_next),
+        };
+        let Some(cursor) = cursor else {
+            return Ok(String::new());
+        };
+        validate_cursor(&cursor)?;
+        if matches!(
+            &self.family.pagination,
+            Pagination::NextUrl { .. } | Pagination::Link { .. }
+        ) {
+            validated_continuation(origin, &cursor)?;
+        }
+        Ok(cursor)
+    }
+
+    fn validate_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+    ) -> Result<(), SourceExecutionError> {
+        if record.event_id
+            != expected_event_id(
+                &context.tenant_id,
+                &self.source.id,
+                &self.family.id,
+                &record.provider_id,
+            )
+            || record.attributes.get("tenant_id") != Some(&context.tenant_id)
+            || record.attributes.get("source_event_id") != Some(&record.provider_id)
+            || record.attributes.get("family") != Some(&self.family.id)
+            || record.attributes.get("provider") != Some(&self.source.id)
+            || record.attributes.get("source_provider") != Some(&self.source.id)
+        {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        Ok(())
+    }
+}
+
+impl SourceExecutionAdapter for PortableAiSourceExecutionAdapter {
+    fn source_id(&self) -> &'static str {
+        &self.source.id
+    }
+
+    fn family_id(&self) -> &'static str {
+        &self.family.id
+    }
+
+    fn provider_kernel(&self) -> &'static str {
+        &self.family.kernel
+    }
+
+    fn validate_record_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+    ) -> Result<(), SourceExecutionError> {
+        self.validate_identity(context, record)
+    }
+
+    fn plan(
+        &self,
+        _request: &SourceWorkerPlanRequestV1,
+    ) -> Result<SourceWorkerHttpRequestV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn plan_v2(
+        &self,
+        envelope: &SourceWorkerPlanEnvelopeV2,
+    ) -> Result<SourceWorkerHttpExecutionV2, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (origin, url) = self.request_url(context, metadata)?;
+        let mut planned = SourceWorkerHttpRequestV1 {
+            plan_id: plan.plan_id.clone(),
+            method: plan.method.clone(),
+            url,
+            accept: "application/json".to_owned(),
+            max_response_bytes: plan.max_response_bytes,
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            request_intent_digest: String::new(),
+        };
+        planned.request_intent_digest = canonical_request_intent_digest(plan, context, &planned);
+        let mut execution = SourceWorkerHttpExecutionV2 {
+            request: Some(planned),
+            body: Vec::new(),
+            declared_headers: HashMap::new(),
+            execution_intent_digest_sha256: String::new(),
+            credential_operation: self.source.auth.host_operation().to_owned(),
+            allowed_origin: origin,
+        };
+        execution.execution_intent_digest_sha256 =
+            canonical_http_execution_digest(plan, context, metadata, &execution);
+        Ok(execution)
+    }
+
+    fn decode(
+        &self,
+        _request: &SourceWorkerDecodeRequestV1,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn decode_v2(
+        &self,
+        envelope: &SourceWorkerDecodeEnvelopeV2,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let receipt = request
+            .receipt
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        match request.status_code {
+            200..=299 => {}
+            401 => return Err(SourceExecutionError::AuthenticationRejected),
+            403 => return Err(SourceExecutionError::RequiredProviderScopeMissing),
+            429 => return Err(SourceExecutionError::ProviderRateLimit),
+            _ => return Err(SourceExecutionError::UnexpectedProviderStatus),
+        }
+        let origin = self.rendered_origin(metadata)?;
+        let records = normalize_records(
+            self.source,
+            self.family,
+            &context.tenant_id,
+            &request.response_body,
+            context.observed_at_unix_millis,
+        )?;
+        let records = validate_and_deduplicate_records(records)?;
+        let next_cursor =
+            self.next_cursor(&request.response_body, &envelope.response_headers, &origin)?;
+        let result_digest_sha256 = canonical_result_digest(receipt, &next_cursor, &records)?;
+        Ok(SourceWorkerDecodeResultV1 {
+            plan_id: plan.plan_id.clone(),
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: request.request_intent_digest.clone(),
+            records,
+            next_cursor,
+            result_digest_sha256,
+            tenant_id: context.tenant_id.clone(),
+            runtime_id: context.runtime_id.clone(),
+            runtime_generation: context.runtime_generation,
+            lease_generation: context.lease_generation,
+            observed_at_unix_millis: context.observed_at_unix_millis,
+        })
+    }
+}
+
+pub(crate) static PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS: LazyLock<
+    Vec<PortableAiSourceExecutionAdapter>,
+> = LazyLock::new(|| {
+    SOURCES
+        .iter()
+        .flat_map(|source| {
+            source
+                .families
+                .iter()
+                .map(|family| PortableAiSourceExecutionAdapter::new(source, family))
+        })
+        .collect()
+});
+
+fn public_value<'a>(config: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    config
+        .get(key)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn safe_dns_label(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 63
+        && !value.starts_with('-')
+        && !value.ends_with('-')
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}
+
+fn path_component(value: &str) -> Result<String, SourceExecutionError> {
+    if value.is_empty() || value.len() > 512 || value.chars().any(char::is_control) {
+        return Err(SourceExecutionError::MissingConfiguration);
+    }
+    Ok(value
+        .bytes()
+        .flat_map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                vec![char::from(byte)]
+            }
+            _ => format!("%{byte:02X}").chars().collect(),
+        })
+        .collect())
+}
+
+fn validated_continuation(origin: &str, value: &str) -> Result<Url, SourceExecutionError> {
+    let origin = Url::parse(origin).map_err(|_| SourceExecutionError::InvalidPlan)?;
+    let continuation = Url::parse(value).map_err(|_| SourceExecutionError::InvalidCursor)?;
+    let prefix = origin.path().trim_end_matches('/');
+    if continuation.scheme() != origin.scheme()
+        || continuation.host_str() != origin.host_str()
+        || continuation.port_or_known_default() != origin.port_or_known_default()
+        || continuation.username() != ""
+        || continuation.password().is_some()
+        || continuation.fragment().is_some()
+        || (!prefix.is_empty()
+            && continuation.path() != prefix
+            && !continuation.path().starts_with(&format!("{prefix}/")))
+    {
+        return Err(SourceExecutionError::EgressDenied);
+    }
+    Ok(continuation)
+}
+
+fn response_header<'a>(headers: &'a HashMap<String, String>, name: &str) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.trim())
+        .filter(|value| !value.is_empty())
+}
+
+fn link_next(value: &str) -> Option<String> {
+    value.split(',').find_map(|part| {
+        let part = part.trim();
+        let (target, parameters) = part.split_once('>')?;
+        if !parameters.split(';').any(|parameter| {
+            parameter.trim().eq_ignore_ascii_case("rel=\"next\"")
+                || parameter.trim().eq_ignore_ascii_case("rel=next")
+        }) {
+            return None;
+        }
+        target
+            .trim()
+            .strip_prefix('<')
+            .map(str::to_owned)
+            .filter(|target| !target.is_empty())
+    })
+}

--- a/crates/source-runtime-next/src/portable_ai/catalog.rs
+++ b/crates/source-runtime-next/src/portable_ai/catalog.rs
@@ -1,0 +1,359 @@
+use std::{collections::BTreeMap, sync::LazyLock};
+
+use serde::Deserialize;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum AuthOperation {
+    Bearer,
+    ApiKeyHeader,
+}
+
+impl AuthOperation {
+    pub(super) const fn host_operation(self) -> &'static str {
+        match self {
+            Self::Bearer => "source.bearer",
+            Self::ApiKeyHeader => "google.api_key_header",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) enum Pagination {
+    None,
+    Cursor {
+        parameter: String,
+        json_path: String,
+        page_size_parameter: Option<String>,
+        page_size: usize,
+    },
+    NextUrl {
+        json_path: String,
+    },
+    Link {
+        header: String,
+        page_size_parameter: Option<String>,
+        page_size: usize,
+    },
+}
+
+#[derive(Debug)]
+pub(super) struct Family {
+    pub(super) id: String,
+    pub(super) kernel: String,
+    pub(super) method: String,
+    pub(super) path: String,
+    pub(super) record_selector: String,
+    pub(super) id_paths: Vec<String>,
+    pub(super) name_paths: Vec<String>,
+    pub(super) kind: String,
+    pub(super) schema_ref: String,
+    pub(super) urn_kind: String,
+    pub(super) required_attributes: Vec<String>,
+    pub(super) required_payload_fields: Vec<String>,
+    pub(super) projection_fields: BTreeMap<String, Vec<String>>,
+    pub(super) config_query: BTreeMap<String, String>,
+    pub(super) static_query: BTreeMap<String, String>,
+    pub(super) pagination: Pagination,
+}
+
+#[derive(Debug)]
+pub(super) struct Source {
+    pub(super) id: String,
+    pub(super) origin_template: String,
+    pub(super) auth: AuthOperation,
+    pub(super) required_config: Vec<String>,
+    pub(super) families: Vec<&'static Family>,
+}
+
+#[derive(Deserialize)]
+struct DefinitionCatalog {
+    entries: Vec<DefinitionEntry>,
+}
+
+#[derive(Deserialize)]
+struct DefinitionEntry {
+    definition: DefinitionWire,
+}
+
+#[derive(Deserialize)]
+struct DefinitionWire {
+    source_id: String,
+    auth: AuthWire,
+    #[serde(default)]
+    config_fields: Vec<ConfigFieldWire>,
+    transport: TransportWire,
+    resource_families: Vec<FamilyWire>,
+}
+
+#[derive(Deserialize)]
+struct AuthWire {
+    model: String,
+}
+
+#[derive(Deserialize)]
+struct ConfigFieldWire {
+    key: String,
+    #[serde(default)]
+    required: bool,
+}
+
+#[derive(Deserialize)]
+struct TransportWire {
+    base_url: String,
+}
+
+#[derive(Deserialize)]
+struct FamilyWire {
+    id: String,
+    method: String,
+    path: String,
+    record_selector: String,
+    id_field: String,
+    #[serde(default)]
+    name_field: String,
+    event: EventWire,
+    projection: ProjectionWire,
+    #[serde(default)]
+    config_query: BTreeMap<String, String>,
+    #[serde(default)]
+    static_query: BTreeMap<String, String>,
+    #[serde(default)]
+    pagination: PaginationWire,
+}
+
+#[derive(Deserialize)]
+struct EventWire {
+    kind: String,
+    schema_ref: String,
+    urn_kind: String,
+    #[serde(default)]
+    required_payload_fields: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct ProjectionWire {
+    #[serde(default)]
+    fields: BTreeMap<String, String>,
+}
+
+#[derive(Default, Deserialize)]
+struct PaginationWire {
+    #[serde(rename = "type", default)]
+    kind: String,
+    #[serde(default)]
+    cursor_param: String,
+    #[serde(default)]
+    cursor_json_path: String,
+    #[serde(default, alias = "next_link_json_path")]
+    next_url_json_path: String,
+    #[serde(default)]
+    link_header: String,
+    #[serde(default)]
+    page_size_param: String,
+    #[serde(default)]
+    page_size: usize,
+}
+
+#[derive(Deserialize)]
+struct SourceCatalog {
+    event_contracts: Vec<EventContractWire>,
+}
+
+#[derive(Deserialize)]
+struct EventContractWire {
+    kind: String,
+    schema_ref: String,
+    #[serde(default)]
+    required_attributes: Vec<String>,
+    #[serde(default)]
+    required_payload_fields: Vec<String>,
+}
+
+struct EmbeddedSource {
+    definition: &'static [u8],
+    catalog: &'static [u8],
+}
+
+const EMBEDDED: [EmbeddedSource; 8] = [
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/azure_openai.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/azure_openai/catalog.yaml"),
+    },
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/cohere.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/cohere/catalog.yaml"),
+    },
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/google_gemini.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/google_gemini/catalog.yaml"),
+    },
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/google_vertex_ai.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/google_vertex_ai/catalog.yaml"),
+    },
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/groq.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/groq/catalog.yaml"),
+    },
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/huggingface.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/huggingface/catalog.yaml"),
+    },
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/mistral.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/mistral/catalog.yaml"),
+    },
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/perplexity.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/perplexity/catalog.yaml"),
+    },
+];
+
+pub(super) static SOURCES: LazyLock<Vec<&'static Source>> = LazyLock::new(|| {
+    EMBEDDED
+        .iter()
+        .map(compile_source)
+        .collect::<Result<Vec<_>, _>>()
+        .expect("checked-in portable AI source catalogs must compile")
+});
+
+fn compile_source(embedded: &EmbeddedSource) -> Result<&'static Source, String> {
+    let mut definitions: DefinitionCatalog = serde_saphyr::from_slice(embedded.definition)
+        .map_err(|error| format!("definition YAML: {error}"))?;
+    if definitions.entries.len() != 1 {
+        return Err("definition catalog must contain one source".to_owned());
+    }
+    let definition = definitions.entries.remove(0).definition;
+    let source_catalog: SourceCatalog = serde_saphyr::from_slice(embedded.catalog)
+        .map_err(|error| format!("source catalog YAML: {error}"))?;
+    let contracts = source_catalog
+        .event_contracts
+        .into_iter()
+        .map(|contract| (contract.kind.clone(), contract))
+        .collect::<BTreeMap<_, _>>();
+    let auth = match definition.auth.model.as_str() {
+        "bearer_token" => AuthOperation::Bearer,
+        "api_key" if definition.source_id == "google_gemini" => AuthOperation::ApiKeyHeader,
+        other => return Err(format!("unsupported {} auth {other}", definition.source_id)),
+    };
+    let families = definition
+        .resource_families
+        .into_iter()
+        .map(|family| {
+            if family.method != "GET" {
+                return Err(format!("{}.{} is not GET", definition.source_id, family.id));
+            }
+            let contract = contracts
+                .get(&family.event.kind)
+                .ok_or_else(|| format!("{} contract is missing", family.event.kind))?;
+            if contract.schema_ref != family.event.schema_ref
+                || contract.required_payload_fields != family.event.required_payload_fields
+            {
+                return Err(format!("{} event contracts drifted", family.event.kind));
+            }
+            let projection_fields = family
+                .projection
+                .fields
+                .into_iter()
+                .map(|(key, paths)| {
+                    (
+                        key,
+                        paths
+                            .split('|')
+                            .map(str::trim)
+                            .filter(|value| !value.is_empty())
+                            .map(str::to_owned)
+                            .collect(),
+                    )
+                })
+                .collect();
+            let compiled = Family {
+                kernel: format!("{}.{}", definition.source_id, family.id),
+                id: family.id,
+                method: family.method,
+                path: family.path,
+                record_selector: family.record_selector,
+                id_paths: split_paths(&family.id_field),
+                name_paths: split_paths(&family.name_field),
+                kind: family.event.kind,
+                schema_ref: family.event.schema_ref,
+                urn_kind: family.event.urn_kind,
+                required_attributes: contract.required_attributes.clone(),
+                required_payload_fields: contract.required_payload_fields.clone(),
+                projection_fields,
+                config_query: family.config_query,
+                static_query: family.static_query,
+                pagination: compile_pagination(family.pagination)?,
+            };
+            Ok::<_, String>(&*Box::leak(Box::new(compiled)))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if families.is_empty() {
+        return Err(format!("{} has no runtime families", definition.source_id));
+    }
+    Ok(&*Box::leak(Box::new(Source {
+        id: definition.source_id,
+        origin_template: definition.transport.base_url,
+        auth,
+        required_config: definition
+            .config_fields
+            .into_iter()
+            .filter(|field| field.required)
+            .map(|field| field.key)
+            .collect(),
+        families,
+    })))
+}
+
+fn compile_pagination(wire: PaginationWire) -> Result<Pagination, String> {
+    match wire.kind.as_str() {
+        "" | "none" => Ok(Pagination::None),
+        "cursor" if !wire.cursor_param.is_empty() && !wire.cursor_json_path.is_empty() => {
+            Ok(Pagination::Cursor {
+                parameter: wire.cursor_param,
+                json_path: wire.cursor_json_path,
+                page_size_parameter: (!wire.page_size_param.is_empty())
+                    .then_some(wire.page_size_param),
+                page_size: wire.page_size,
+            })
+        }
+        "next_url" if !wire.next_url_json_path.is_empty() => Ok(Pagination::NextUrl {
+            json_path: wire.next_url_json_path,
+        }),
+        "link" => Ok(Pagination::Link {
+            header: if wire.link_header.is_empty() {
+                "Link".to_owned()
+            } else {
+                wire.link_header
+            },
+            page_size_parameter: (!wire.page_size_param.is_empty()).then_some(wire.page_size_param),
+            page_size: wire.page_size,
+        }),
+        other => Err(format!("unsupported pagination {other}")),
+    }
+}
+
+fn split_paths(value: &str) -> Vec<String> {
+    value
+        .split('|')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect()
+}

--- a/crates/source-runtime-next/src/portable_ai/normalize.rs
+++ b/crates/source-runtime-next/src/portable_ai/normalize.rs
@@ -1,0 +1,269 @@
+use std::collections::{BTreeMap, HashMap};
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use crate::source_execution::{SourceExecutionError, SourceWorkerRecordV1};
+
+use super::catalog::{Family, Source};
+
+const MAX_RECORDS: usize = 1_000;
+const MAX_DEPTH: usize = 32;
+
+pub(super) fn normalize_records(
+    source: &Source,
+    family: &Family,
+    tenant_id: &str,
+    body: &[u8],
+    observed_at_unix_millis: i64,
+) -> Result<Vec<SourceWorkerRecordV1>, SourceExecutionError> {
+    let document: Value =
+        serde_json::from_slice(body).map_err(|_| SourceExecutionError::MalformedResponse)?;
+    reject_untrusted(&document, 0)?;
+    let selected = select_records(&document, &family.record_selector)?;
+    if selected.len() > MAX_RECORDS {
+        return Err(SourceExecutionError::ResponseTooLarge);
+    }
+    let observed_at =
+        OffsetDateTime::from_unix_timestamp_nanos(i128::from(observed_at_unix_millis) * 1_000_000)
+            .map_err(|_| SourceExecutionError::InvalidExecutionContext)?;
+    selected
+        .into_iter()
+        .map(|raw| normalize_record(source, family, tenant_id, raw, observed_at))
+        .collect()
+}
+
+pub(super) fn expected_event_id(
+    tenant_id: &str,
+    source_id: &str,
+    family_id: &str,
+    provider_id: &str,
+) -> String {
+    let digest = Sha256::digest(format!(
+        "{tenant_id}\0{source_id}\0{family_id}\0{provider_id}"
+    ));
+    format!(
+        "{source_id}-{family_id}-{}",
+        digest[..12]
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>()
+    )
+}
+
+pub(super) fn value_at<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    let path = path
+        .trim()
+        .strip_prefix("$.")
+        .or_else(|| path.trim().strip_prefix('$'))
+        .unwrap_or(path.trim());
+    if path.is_empty() {
+        return Some(value);
+    }
+    path.split('.')
+        .try_fold(value, |current, part| current.as_object()?.get(part))
+}
+
+pub(super) fn scalar_at(value: &Value, paths: &[String]) -> Option<String> {
+    paths
+        .iter()
+        .find_map(|path| value_at(value, path).and_then(scalar))
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty() && value.len() <= 4_096)
+}
+
+fn normalize_record(
+    source: &Source,
+    family: &Family,
+    tenant_id: &str,
+    raw: Value,
+    observed_at: OffsetDateTime,
+) -> Result<SourceWorkerRecordV1, SourceExecutionError> {
+    let values = raw
+        .as_object()
+        .ok_or(SourceExecutionError::InvalidProviderRecord)?;
+    let external_id = scalar_at(&raw, &family.id_paths)
+        .filter(|value| value.len() <= 1_024)
+        .ok_or(SourceExecutionError::MissingStableIdentity)?;
+    let provider_id = family
+        .projection_fields
+        .get("resource_id")
+        .and_then(|paths| scalar_at(&raw, paths))
+        .filter(|value| value.len() <= 1_024)
+        .unwrap_or_else(|| external_id.clone());
+    let occurred_at = observed_timestamp(&raw, values).unwrap_or(observed_at);
+    let occurred_at_unix_millis = i64::try_from(occurred_at.unix_timestamp_nanos() / 1_000_000)
+        .map_err(|_| SourceExecutionError::InvalidProviderRecord)?;
+    let resource_urn = format!(
+        "urn:cerebro:{}:{}:{}",
+        urn_component(tenant_id)?,
+        family.urn_kind,
+        urn_component(&external_id)?
+    );
+    let resource_name = scalar_at(&raw, &family.name_paths).unwrap_or_else(|| provider_id.clone());
+    let mut attributes = BTreeMap::from([
+        ("external_id".to_owned(), external_id),
+        ("family".to_owned(), family.id.clone()),
+        ("provider".to_owned(), source.id.clone()),
+        ("resource_id".to_owned(), provider_id.clone()),
+        ("resource_name".to_owned(), resource_name),
+        ("resource_type".to_owned(), family.id.clone()),
+        ("resource_urn".to_owned(), resource_urn),
+        ("source_event_id".to_owned(), provider_id.clone()),
+        ("source_product".to_owned(), source.id.clone()),
+        ("source_provider".to_owned(), source.id.clone()),
+        ("source_system".to_owned(), source.id.clone()),
+        ("tenant_id".to_owned(), tenant_id.to_owned()),
+    ]);
+    for (attribute, paths) in &family.projection_fields {
+        if matches!(
+            attribute.as_str(),
+            "external_id"
+                | "family"
+                | "provider"
+                | "resource_urn"
+                | "source_event_id"
+                | "source_product"
+                | "source_provider"
+                | "source_system"
+                | "tenant_id"
+        ) {
+            continue;
+        }
+        if let Some(value) = scalar_at(&raw, paths) {
+            attributes.insert(attribute.clone(), value);
+        }
+    }
+    for required in &family.required_attributes {
+        if attributes.get(required).is_none_or(String::is_empty) {
+            return Err(SourceExecutionError::EventContractRejected);
+        }
+    }
+    for required in &family.required_payload_fields {
+        if value_at(&raw, required).is_none_or(Value::is_null) {
+            return Err(SourceExecutionError::EventContractRejected);
+        }
+    }
+    Ok(SourceWorkerRecordV1 {
+        provider_id: provider_id.clone(),
+        event_id: expected_event_id(tenant_id, &source.id, &family.id, &provider_id),
+        occurred_at_unix_millis,
+        attributes: attributes.into_iter().collect::<HashMap<_, _>>(),
+        payload_json: serde_json::to_vec(&raw)
+            .map_err(|_| SourceExecutionError::InternalRuntime)?,
+    })
+}
+
+fn select_records(document: &Value, selector: &str) -> Result<Vec<Value>, SourceExecutionError> {
+    let selector = selector.trim();
+    if selector == "$" {
+        return Ok(vec![document.clone()]);
+    }
+    let wildcard = selector.ends_with("[*]");
+    let path = selector.trim_end_matches("[*]");
+    let selected = value_at(document, path).ok_or(SourceExecutionError::MalformedResponse)?;
+    if wildcard || selected.is_array() {
+        return selected
+            .as_array()
+            .cloned()
+            .ok_or(SourceExecutionError::MalformedResponse);
+    }
+    Ok(vec![selected.clone()])
+}
+
+fn observed_timestamp(raw: &Value, values: &Map<String, Value>) -> Option<OffsetDateTime> {
+    let direct = [
+        "observed_at",
+        "updated_at",
+        "updatedAt",
+        "last_seen_at",
+        "created_at",
+        "createdAt",
+        "timestamp",
+    ]
+    .iter()
+    .find_map(|key| values.get(*key).and_then(scalar));
+    direct
+        .or_else(|| {
+            scalar_at(
+                raw,
+                &[
+                    "$.systemData.lastModifiedAt".to_owned(),
+                    "$.systemData.createdAt".to_owned(),
+                    "$.metadata.updated_at".to_owned(),
+                    "$.metadata.created_at".to_owned(),
+                ],
+            )
+        })
+        .and_then(|value| OffsetDateTime::parse(value.trim(), &Rfc3339).ok())
+}
+
+fn scalar(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) => Some(value.clone()),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn urn_component(value: &str) -> Result<String, SourceExecutionError> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > 1_024 || value.chars().any(char::is_control) {
+        return Err(SourceExecutionError::MissingStableIdentity);
+    }
+    Ok(value
+        .bytes()
+        .flat_map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'-' => {
+                vec![char::from(byte)]
+            }
+            _ => format!("%{byte:02X}").chars().collect(),
+        })
+        .collect())
+}
+
+fn reject_untrusted(value: &Value, depth: usize) -> Result<(), SourceExecutionError> {
+    if depth > MAX_DEPTH {
+        return Err(SourceExecutionError::InvalidProviderRecord);
+    }
+    match value {
+        Value::Object(values) => {
+            for (key, value) in values {
+                let normalized = key
+                    .chars()
+                    .filter(char::is_ascii_alphanumeric)
+                    .flat_map(char::to_lowercase)
+                    .collect::<String>();
+                if matches!(normalized.as_str(), "tenant" | "tenantid") {
+                    return Err(SourceExecutionError::TenantMismatch);
+                }
+                if matches!(
+                    normalized.as_str(),
+                    "authorization"
+                        | "accesstoken"
+                        | "refreshtoken"
+                        | "apikey"
+                        | "clientsecret"
+                        | "password"
+                        | "privatekey"
+                        | "sessioncookie"
+                ) {
+                    return Err(SourceExecutionError::InvalidProviderRecord);
+                }
+                reject_untrusted(value, depth + 1)?;
+            }
+        }
+        Value::Array(values) => {
+            if values.len() > MAX_RECORDS {
+                return Err(SourceExecutionError::ResponseTooLarge);
+            }
+            for value in values {
+                reject_untrusted(value, depth + 1)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}

--- a/crates/source-runtime-next/src/portable_ai/tests.rs
+++ b/crates/source-runtime-next/src/portable_ai/tests.rs
@@ -1,0 +1,262 @@
+use std::collections::HashMap;
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionDispatcher, SourceExecutionError,
+    SourceExecutionSelectionRequestV1, SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1,
+    SourceWorkerExecutionContextV1, SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1,
+    SourceWorkerRuntimeMetadataV2, SourceWorkerSafeReceiptV1, response_digest,
+};
+
+use super::{
+    PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS, adapter::PortableAiSourceExecutionAdapter,
+    catalog::SOURCES,
+};
+
+const OBSERVED_AT_MILLIS: i64 = 1_780_272_000_000;
+
+fn adapter(source: &str, family: &str) -> &'static PortableAiSourceExecutionAdapter {
+    PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS
+        .iter()
+        .find(|adapter| adapter.source_id() == source && adapter.family_id() == family)
+        .expect("portable AI adapter")
+}
+
+fn context(cursor: &str) -> SourceWorkerExecutionContextV1 {
+    SourceWorkerExecutionContextV1 {
+        tenant_id: "tenant".to_owned(),
+        runtime_id: "portable-ai-runtime".to_owned(),
+        logical_page_id: "source-page-v2:portable-ai-1".to_owned(),
+        prior_cursor: cursor.to_owned(),
+        runtime_generation: 7,
+        lease_generation: 11,
+        observed_at_unix_millis: OBSERVED_AT_MILLIS,
+    }
+}
+
+fn metadata(source: &str, family: &str) -> SourceWorkerRuntimeMetadataV2 {
+    let mut public_config = HashMap::from([("family".to_owned(), family.to_owned())]);
+    match source {
+        "azure_openai" => {
+            public_config.insert("subscription_id".to_owned(), "sub-1".to_owned());
+            public_config.insert("resource_group".to_owned(), "rg-ai".to_owned());
+            public_config.insert("account_name".to_owned(), "acct-openai".to_owned());
+            public_config.insert("location".to_owned(), "westus".to_owned());
+        }
+        "google_vertex_ai" => {
+            public_config.insert("project_id".to_owned(), "project-1".to_owned());
+            public_config.insert("location".to_owned(), "us-central1".to_owned());
+        }
+        "huggingface" => {
+            public_config.insert("organization".to_owned(), "writer".to_owned());
+        }
+        _ => {}
+    }
+    SourceWorkerRuntimeMetadataV2 {
+        public_config,
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    }
+}
+
+fn execution(
+    adapter: &PortableAiSourceExecutionAdapter,
+    context: SourceWorkerExecutionContextV1,
+    metadata: SourceWorkerRuntimeMetadataV2,
+) -> crate::source_execution::SourceWorkerHttpExecutionV2 {
+    adapter
+        .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(adapter.compiled_plan()),
+                context: Some(context),
+            }),
+            metadata: Some(metadata),
+        })
+        .expect("portable AI execution")
+}
+
+#[test]
+fn embedded_catalog_compiles_all_eight_sources_and_thirty_six_families() {
+    assert_eq!(SOURCES.len(), 8);
+    assert_eq!(PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS.len(), 36);
+    for adapter in PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS.iter() {
+        let plan = adapter.compiled_plan();
+        assert_eq!(plan.source_id, adapter.source_id());
+        assert_eq!(plan.family_id, adapter.family_id());
+        assert_eq!(plan.provider_kernel, adapter.provider_kernel());
+        assert!(!plan.required_attributes.is_empty());
+        assert!(!plan.required_payload_fields.is_empty());
+        assert_eq!(
+            SourceExecutionDispatcher
+                .compile_plan(&SourceExecutionSelectionRequestV1 {
+                    source_id: plan.source_id.clone(),
+                    family_id: plan.family_id.clone(),
+                })
+                .expect("dispatcher plan"),
+            plan
+        );
+    }
+}
+
+#[test]
+fn every_family_plans_an_origin_restricted_request_without_credentials() {
+    for adapter in PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS.iter() {
+        let execution = execution(
+            adapter,
+            context(""),
+            metadata(adapter.source_id(), adapter.family_id()),
+        );
+        let request = execution.request.expect("request");
+        let origin = reqwest::Url::parse(&execution.allowed_origin).expect("origin");
+        let url = reqwest::Url::parse(&request.url).expect("request URL");
+        assert_eq!(url.scheme(), "https");
+        assert_eq!(url.host_str(), origin.host_str());
+        assert!(url.username().is_empty());
+        assert!(url.password().is_none());
+        assert!(request.url.find("${config.").is_none());
+        assert!(execution.body.is_empty());
+        assert!(execution.declared_headers.is_empty());
+        assert!(url.query_pairs().all(|(key, _)| !matches!(
+            key.as_ref(),
+            "api_key" | "apikey" | "access_token" | "client_secret" | "token"
+        )));
+        let expected_operation = if adapter.source_id() == "google_gemini" {
+            "google.api_key_header"
+        } else {
+            "source.bearer"
+        };
+        assert_eq!(execution.credential_operation, expected_operation);
+    }
+}
+
+#[test]
+fn provider_specific_public_request_contracts_are_preserved() {
+    let azure = execution(
+        adapter("azure_openai", "deployments"),
+        context(""),
+        metadata("azure_openai", "deployments"),
+    );
+    let azure_url = reqwest::Url::parse(&azure.request.unwrap().url).unwrap();
+    assert_eq!(azure_url.host_str(), Some("management.azure.com"));
+    assert_eq!(
+        azure_url
+            .query_pairs()
+            .find(|(key, _)| key == "api-version")
+            .map(|(_, value)| value.into_owned()),
+        Some("2024-10-01".to_owned())
+    );
+
+    let vertex = execution(
+        adapter("google_vertex_ai", "models"),
+        context(""),
+        metadata("google_vertex_ai", "models"),
+    );
+    assert_eq!(
+        reqwest::Url::parse(&vertex.request.unwrap().url)
+            .unwrap()
+            .host_str(),
+        Some("us-central1-aiplatform.googleapis.com")
+    );
+
+    let huggingface = execution(
+        adapter("huggingface", "repositories"),
+        context(""),
+        metadata("huggingface", "repositories"),
+    );
+    let huggingface_url = reqwest::Url::parse(&huggingface.request.unwrap().url).unwrap();
+    let query = huggingface_url.query_pairs().collect::<HashMap<_, _>>();
+    assert_eq!(
+        query.get("author").map(|value| value.as_ref()),
+        Some("writer")
+    );
+    assert_eq!(query.get("limit").map(|value| value.as_ref()), Some("100"));
+}
+
+#[test]
+fn continuation_urls_cannot_escape_the_provider_origin() {
+    let error = adapter("azure_openai", "deployments")
+        .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(adapter("azure_openai", "deployments").compiled_plan()),
+                context: Some(context("https://attacker.example/next")),
+            }),
+            metadata: Some(metadata("azure_openai", "deployments")),
+        })
+        .unwrap_err();
+    assert_eq!(error, SourceExecutionError::EgressDenied);
+}
+
+#[test]
+fn gemini_decode_emits_tenant_scoped_records_and_a_valid_cursor() {
+    let adapter = adapter("google_gemini", "model_catalog");
+    let plan = adapter.compiled_plan();
+    let context = context("");
+    let metadata = metadata("google_gemini", "model_catalog");
+    let execution = execution(adapter, context.clone(), metadata.clone());
+    let planned = execution.request.as_ref().unwrap();
+    let body = br#"{"models":[{"name":"models/gemini-2.5-pro","displayName":"Gemini 2.5 Pro"}],"nextPageToken":"page-2"}"#;
+    let receipt = SourceWorkerSafeReceiptV1 {
+        plan_digest_sha256: plan.plan_digest_sha256.clone(),
+        logical_page_id: context.logical_page_id.clone(),
+        request_intent_digest: planned.request_intent_digest.clone(),
+        runtime_generation: context.runtime_generation,
+        lease_generation: context.lease_generation,
+        credential_operation: execution.credential_operation.clone(),
+        status_code: 200,
+        response_bytes: body.len() as u64,
+        response_sha256: response_digest(body),
+        tenant_id: context.tenant_id.clone(),
+        runtime_id: context.runtime_id.clone(),
+        observed_at_unix_millis: context.observed_at_unix_millis,
+    };
+    let result = adapter
+        .decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+            request: Some(SourceWorkerDecodeRequestV1 {
+                plan: Some(plan),
+                status_code: 200,
+                response_body: body.to_vec(),
+                logical_page_id: context.logical_page_id.clone(),
+                request_intent_digest: planned.request_intent_digest.clone(),
+                receipt: Some(receipt),
+                context: Some(context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+            response_headers: HashMap::new(),
+            response_headers_sha256: String::new(),
+            execution_intent_digest_sha256: execution.execution_intent_digest_sha256,
+        })
+        .unwrap();
+    assert_eq!(result.next_cursor, "page-2");
+    assert_eq!(result.records.len(), 1);
+    let record = &result.records[0];
+    assert_eq!(record.provider_id, "models/gemini-2.5-pro");
+    assert_eq!(record.attributes["tenant_id"], "tenant");
+    assert_eq!(
+        record.attributes["resource_urn"],
+        "urn:cerebro:tenant:google_gemini_model_catalog:models%2Fgemini-2.5-pro"
+    );
+    adapter
+        .validate_record_identity_v2(&context, record, &metadata)
+        .unwrap();
+}
+
+#[test]
+fn provider_payloads_cannot_supply_tenant_or_credential_material() {
+    let adapter = adapter("google_gemini", "model_catalog");
+    for body in [
+        br#"{"models":[{"name":"model-1","tenant_id":"other"}]}"#.as_slice(),
+        br#"{"models":[{"name":"model-1","apiKey":"secret"}]}"#.as_slice(),
+    ] {
+        let error = super::normalize::normalize_records(
+            adapter.source,
+            adapter.family,
+            "tenant",
+            body,
+            OBSERVED_AT_MILLIS,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            SourceExecutionError::TenantMismatch | SourceExecutionError::InvalidProviderRecord
+        ));
+    }
+}

--- a/crates/source-runtime-next/src/source_execution/contract.rs
+++ b/crates/source-runtime-next/src/source_execution/contract.rs
@@ -154,6 +154,7 @@ pub fn validate_http_execution(
         || !matches!(
             execution.credential_operation.as_str(),
             "source.bearer"
+                | "google.api_key_header"
                 | "jumpcloud.x_api_key"
                 | "sentinelone.api_token"
                 | "twilio.basic"

--- a/crates/source-runtime-next/src/source_execution/dispatcher.rs
+++ b/crates/source-runtime-next/src/source_execution/dispatcher.rs
@@ -8,6 +8,7 @@ use crate::discord::DISCORD_SOURCE_EXECUTION_ADAPTERS;
 use crate::linode::LINODE_ISSUE_SOURCE_EXECUTION_ADAPTER;
 use crate::openai::OPENAI_SOURCE_EXECUTION_ADAPTERS;
 use crate::pagerduty::PAGERDUTY_SOURCE_EXECUTION_ADAPTERS;
+use crate::portable_ai::PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS;
 use crate::sentinelone::{
     SENTINELONE_APPLICATION_SOURCE_EXECUTION_ADAPTER, SENTINELONE_DIRECT_SOURCE_EXECUTION_ADAPTERS,
     SentinelOneAgentSourceExecutionAdapter,
@@ -152,6 +153,14 @@ impl SourceExecutionDispatcher {
         }) {
             return Ok(adapter.compiled_plan());
         }
+        if let Some(adapter) = PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS
+            .iter()
+            .find(|adapter| {
+                request.source_id == adapter.source_id() && request.family_id == adapter.family_id()
+            })
+        {
+            return Ok(adapter.compiled_plan());
+        }
         if request.source_id == AZURE_AUTHORIZATION_POLICY.source_id()
             && request.family_id == AZURE_AUTHORIZATION_POLICY.family_id()
         {
@@ -257,6 +266,16 @@ impl SourceExecutionDispatcher {
                 && plan.family_id == adapter.family_id()
                 && plan.provider_kernel == adapter.provider_kernel()
         }) {
+            return Ok(adapter);
+        }
+        if let Some(adapter) = PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS
+            .iter()
+            .find(|adapter| {
+                plan.source_id == adapter.source_id()
+                    && plan.family_id == adapter.family_id()
+                    && plan.provider_kernel == adapter.provider_kernel()
+            })
+        {
             return Ok(adapter);
         }
         if plan.source_id == AZURE_AUTHORIZATION_POLICY.source_id()

--- a/internal/connectorcatalog/catalog/ai-governance/azure_openai.yaml
+++ b/internal/connectorcatalog/catalog/ai-governance/azure_openai.yaml
@@ -83,14 +83,14 @@ entries:
           event:
             kind: azure_openai.model_catalog
             required_payload_fields:
-              - name
+              - model
             schema_ref: azure_openai/model_catalog/v1
             urn_kind: azure_openai_model_catalog
           id: model_catalog
-          id_field: name
+          id_field: model.name
           label: Model catalog
           method: GET
-          name_field: name
+          name_field: model.name
           pagination:
             disable_page_size: true
             next_url_json_path: $.nextLink
@@ -98,9 +98,9 @@ entries:
           path: /subscriptions/${config.subscription_id}/providers/Microsoft.CognitiveServices/locations/${config.location}/models
           projection:
             fields:
-              resource_id: name
-              resource_name: name
-              resource_type: resource_type|type|kind
+              resource_id: model.name
+              resource_name: model.name
+              resource_type: model.format|kind|resource_type|type
               resource_urn: resource_urn|urn|metadata.resource_urn
             template: asset
           record_selector: $.value[*]

--- a/internal/sourceops/source_execution.go
+++ b/internal/sourceops/source_execution.go
@@ -45,7 +45,7 @@ func rustSourceFamily(sourceID string, config map[string]string) (string, bool) 
 	// runtime-authoritative provider must keep its existing sourceops path until
 	// its preview credential adapter and product-surface parity are ready.
 	switch sourceID {
-	case "anthropic", "asana", "azure", "deepseek", "digitalocean", "discord", "linode", "openai", "pagerduty", "sentinelone", "tailscale":
+	case "anthropic", "asana", "azure", "azure_openai", "cohere", "deepseek", "digitalocean", "discord", "google_gemini", "google_vertex_ai", "groq", "huggingface", "linode", "mistral", "openai", "pagerduty", "perplexity", "sentinelone", "tailscale":
 		return sourceworker.RustAuthoritativeFamily(sourceID, config["family"])
 	case "jumpcloud":
 		family := strings.TrimSpace(config["family"])
@@ -166,6 +166,13 @@ func previewCredential(sourceID string, config map[string]string) string {
 		}
 		return ""
 	case "deepseek":
+		for _, key := range []string{"token", "api_token", "api_key", "access_token"} {
+			if credential := strings.TrimSpace(config[key]); credential != "" {
+				return credential
+			}
+		}
+		return ""
+	case "azure_openai", "cohere", "google_gemini", "google_vertex_ai", "groq", "huggingface", "mistral", "perplexity":
 		for _, key := range []string{"token", "api_token", "api_key", "access_token"} {
 			if credential := strings.TrimSpace(config[key]); credential != "" {
 				return credential

--- a/internal/sourceops/source_execution_test.go
+++ b/internal/sourceops/source_execution_test.go
@@ -32,6 +32,15 @@ func TestRustSourceFamilyPreviewAuthorityIsExact(t *testing.T) {
 		"DeepSeek model catalog":      {"deepseek", "model_catalog", "model_catalog", true},
 		"DeepSeek account balances":   {"deepseek", "account_balances", "account_balances", true},
 		"unknown DeepSeek family":     {"deepseek", "future-family", "future-family", true},
+		"Azure OpenAI default":        {"azure_openai", "", "deployments", true},
+		"Cohere default":              {"cohere", "", "model_catalog", true},
+		"Gemini default":              {"google_gemini", "", "model_catalog", true},
+		"Vertex default":              {"google_vertex_ai", "", "models", true},
+		"Groq default":                {"groq", "", "model_catalog", true},
+		"Hugging Face default":        {"huggingface", "", "organization_members", true},
+		"Mistral default":             {"mistral", "", "workspaces", true},
+		"Perplexity default":          {"perplexity", "", "api_groups", true},
+		"unknown portable AI family":  {"mistral", "future-family", "future-family", true},
 		"Asana default":               {"asana", "", "users", true},
 		"Asana users":                 {"asana", "users", "users", true},
 		"Asana projects":              {"asana", "projects", "projects", true},
@@ -721,6 +730,19 @@ func TestDeepSeekPreviewCredentialAliases(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			if got := previewCredential("deepseek", test.config); got != test.want {
 				t.Fatalf("previewCredential() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestPortableAIPreviewCredentialAliasesStayInsideTheTrustedRunner(t *testing.T) {
+	for _, sourceID := range []string{"azure_openai", "cohere", "google_gemini", "google_vertex_ai", "groq", "huggingface", "mistral", "perplexity"} {
+		t.Run(sourceID, func(t *testing.T) {
+			if got := previewCredential(sourceID, map[string]string{"api_key": "api-key", "token": "token"}); got != "token" {
+				t.Fatalf("previewCredential() = %q, want token precedence", got)
+			}
+			if got := previewCredential(sourceID, map[string]string{"api_key": "api-key"}); got != "api-key" {
+				t.Fatalf("previewCredential() = %q, want api-key compatibility", got)
 			}
 		})
 	}

--- a/internal/sourceruntime/sourceworker/host.go
+++ b/internal/sourceruntime/sourceworker/host.go
@@ -196,6 +196,8 @@ func credentialHeader(operation string, credential []byte) (string, []byte, erro
 		return "Authorization", append([]byte("Bearer "), credential...), nil
 	case "openai.admin_api_key_bearer":
 		return "Authorization", append([]byte("Bearer "), credential...), nil
+	case "google.api_key_header":
+		return "X-Goog-Api-Key", append([]byte(nil), credential...), nil
 	case "jumpcloud.x_api_key":
 		return "X-Api-Key", append([]byte(nil), credential...), nil
 	case "sentinelone.api_token":

--- a/internal/sourceruntime/sourceworker/host_test.go
+++ b/internal/sourceruntime/sourceworker/host_test.go
@@ -301,6 +301,20 @@ func TestCredentialHeaderAppliesOnlyTheClosedPagerDutyScheme(t *testing.T) {
 	}
 }
 
+func TestCredentialHeaderAppliesGeminiKeyOnlyInsideTheTrustedHost(t *testing.T) {
+	header, value, err := credentialHeader("google.api_key_header", []byte("synthetic-api-key"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clear(value)
+	if header != "X-Goog-Api-Key" || string(value) != "synthetic-api-key" {
+		t.Fatal("Gemini credential operation did not produce the exact provider header")
+	}
+	if _, _, err := credentialHeader("google.api_key_query", []byte("synthetic-api-key")); !errors.Is(err, ErrWorkerContract) {
+		t.Fatalf("query credential operation error = %v, want ErrWorkerContract", err)
+	}
+}
+
 func TestSafeResponseHeadersRedactsAndBounds(t *testing.T) {
 	headers := http.Header{
 		"X-Result-Count": {"2"}, "X-Limit": {"2"}, "X-Search_after": {`{"id":"event-2"}`}, "Retry-After": {"30"},

--- a/internal/sourceruntime/sourceworker/pull.go
+++ b/internal/sourceruntime/sourceworker/pull.go
@@ -43,6 +43,46 @@ func RustAuthoritativeFamily(sourceID, familyID string) (string, bool) {
 		// Both cataloged DeepSeek families are closed in the Rust dispatcher.
 		// Unknown families fail there instead of restoring the retired Go path.
 		return familyID, true
+	case "azure_openai":
+		if familyID == "" {
+			familyID = "deployments"
+		}
+		return familyID, true
+	case "cohere":
+		if familyID == "" {
+			familyID = "model_catalog"
+		}
+		return familyID, true
+	case "google_gemini":
+		if familyID == "" {
+			familyID = "model_catalog"
+		}
+		return familyID, true
+	case "google_vertex_ai":
+		if familyID == "" {
+			familyID = "models"
+		}
+		return familyID, true
+	case "groq":
+		if familyID == "" {
+			familyID = "model_catalog"
+		}
+		return familyID, true
+	case "huggingface":
+		if familyID == "" {
+			familyID = "organization_members"
+		}
+		return familyID, true
+	case "mistral":
+		if familyID == "" {
+			familyID = "workspaces"
+		}
+		return familyID, true
+	case "perplexity":
+		if familyID == "" {
+			familyID = "api_groups"
+		}
+		return familyID, true
 	case "asana":
 		if familyID == "" {
 			familyID = "users"
@@ -131,6 +171,10 @@ func CredentialBinding(sourceID string, references, resolved map[string]string) 
 	if strings.TrimSpace(sourceID) == "deepseek" {
 		keys = []string{"token", "api_token", "api_key", "access_token"}
 	}
+	switch strings.TrimSpace(sourceID) {
+	case "azure_openai", "cohere", "google_gemini", "google_vertex_ai", "groq", "huggingface", "mistral", "perplexity":
+		keys = []string{"token", "api_token", "api_key", "access_token"}
+	}
 	if strings.TrimSpace(sourceID) == "discord" {
 		keys = []string{"api_token", "api_key", "token"}
 	}
@@ -203,6 +247,18 @@ func PublicExecutionConfigForSource(sourceID string, values map[string]string) m
 			copyPublicValue(public, values, key)
 		}
 		copyPublicAlias(public, values, "api_key_ids", "admin_key_ids")
+	case "azure_openai":
+		for _, key := range []string{"subscription_id", "resource_group", "account_name", "location"} {
+			copyPublicValue(public, values, key)
+		}
+	case "google_vertex_ai":
+		for _, key := range []string{"project_id", "location"} {
+			copyPublicValue(public, values, key)
+		}
+	case "huggingface":
+		copyPublicValue(public, values, "organization")
+	case "cohere", "google_gemini", "groq", "mistral", "perplexity":
+		// These catalog-defined families need no public provider selectors.
 	default:
 		return public
 	}

--- a/internal/sourceruntime/sourceworker/pull_test.go
+++ b/internal/sourceruntime/sourceworker/pull_test.go
@@ -110,6 +110,28 @@ func TestOpenAIPublicExecutionConfigCarriesSelectorsWithoutCredentialMaterial(t 
 	}
 }
 
+func TestPortableAIPublicExecutionConfigCarriesOnlyProviderSelectors(t *testing.T) {
+	azure := PublicExecutionConfigForSource("azure_openai", map[string]string{
+		"family": " deployments ", "subscription_id": " sub-1 ", "resource_group": " rg-ai ",
+		"account_name": " acct-openai ", "location": " westus ", "api_key": "must-not-cross",
+	})
+	if azure["subscription_id"] != "sub-1" || azure["resource_group"] != "rg-ai" || azure["account_name"] != "acct-openai" || azure["location"] != "westus" || azure["api_key"] != "" {
+		t.Fatalf("Azure OpenAI public config = %#v", azure)
+	}
+	vertex := PublicExecutionConfigForSource("google_vertex_ai", map[string]string{
+		"project_id": " project-1 ", "location": " us-central1 ", "token": "must-not-cross",
+	})
+	if vertex["project_id"] != "project-1" || vertex["location"] != "us-central1" || vertex["token"] != "" {
+		t.Fatalf("Vertex public config = %#v", vertex)
+	}
+	huggingface := PublicExecutionConfigForSource("huggingface", map[string]string{
+		"organization": " writer ", "token": "must-not-cross",
+	})
+	if huggingface["organization"] != "writer" || huggingface["token"] != "" {
+		t.Fatalf("Hugging Face public config = %#v", huggingface)
+	}
+}
+
 func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
 	for name, test := range map[string]struct {
 		source, family, wantFamily string
@@ -129,6 +151,15 @@ func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
 		"DeepSeek model catalog":      {"deepseek", " model_catalog ", "model_catalog", true},
 		"DeepSeek account balances":   {"deepseek", "account_balances", "account_balances", true},
 		"unknown DeepSeek family":     {"deepseek", "future-family", "future-family", true},
+		"Azure OpenAI default":        {"azure_openai", "", "deployments", true},
+		"Cohere default":              {"cohere", "", "model_catalog", true},
+		"Gemini default":              {"google_gemini", "", "model_catalog", true},
+		"Vertex default":              {"google_vertex_ai", "", "models", true},
+		"Groq default":                {"groq", "", "model_catalog", true},
+		"Hugging Face default":        {"huggingface", "", "organization_members", true},
+		"Mistral default":             {"mistral", "", "workspaces", true},
+		"Perplexity default":          {"perplexity", "", "api_groups", true},
+		"unknown portable AI family":  {"google_gemini", "future-family", "future-family", true},
 		"Asana default":               {" asana ", "", "users", true},
 		"Asana users":                 {"asana", " users ", "users", true},
 		"Asana projects":              {"asana", "projects", "projects", true},
@@ -228,6 +259,11 @@ func TestCredentialBindingUsesOnlyTheSelectedProviderAliases(t *testing.T) {
 			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.
 			source: "deepseek", references: map[string]string{"api_key": "credential:deepseek:api-key"},
 			resolved: map[string]string{"api_key": "resolved-api-key"}, wantReference: "credential:deepseek:api-key", wantResolved: "resolved-api-key",
+		},
+		"Gemini api key": {
+			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.
+			source: "google_gemini", references: map[string]string{"api_key": "credential:gemini:api-key"},
+			resolved: map[string]string{"api_key": "resolved-api-key"}, wantReference: "credential:gemini:api-key", wantResolved: "resolved-api-key",
 		},
 		"Twilio basic credentials": {
 			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.


### PR DESCRIPTION
## Scope

Routes 36 catalog-defined families through one credential-free Rust source adapter:

- Azure OpenAI: 5 families
- Cohere: 4 families
- Google Gemini: 5 families
- Google Vertex AI: 6 families
- Groq: 4 families
- Hugging Face: 4 families
- Mistral: 4 families
- Perplexity: 4 families

Rust now compiles the checked-in provider and event contracts, renders bounded requests, validates provider origins and continuations, normalizes tenant-scoped records, enforces event contracts, and emits durable provider cursors. The trusted Go host retains credential redemption, authentication, network execution, append, projection, and checkpoint ordering. Gemini API keys are applied only by the trusted host using `X-Goog-Api-Key`.

This also repairs the Azure OpenAI model-catalog definition to use the provider-shaped `model.name` identity and the existing `model` payload contract.

## Invariants

- No credential value crosses into Rust metadata, fixtures, receipts, events, URLs, or logs.
- Redirects remain disabled and continuation URLs cannot change provider origin.
- Provider payloads cannot supply tenant identity or credential-shaped fields.
- Unknown families fail closed after Rust authority selection; Go does not regain write authority.
- Cursor advancement remains after append and projection through the existing durable page program.

## Local validation

- `go test ./internal/sourceruntime/sourceworker ./internal/sourceops ./internal/sourceruntime -count=1`
- `go test ./internal/connectorcatalog ./internal/connectorvalidation/... ./internal/sourcegen/... -count=1`
- `make check-arch source-fixture-check fixture-oracle-check`
- `rustfmt --edition 2024 --check` on all changed Rust files
- `git diff --check`

`make check-structural` reaches the current target and fails only on the pre-existing default-branch `VendorRegisterRow` 32-field violation, tracked by #2587. Local Cargo compilation is blocked by the managed DDESK capacity gate before build startup; hosted exact-head checks are the current Rust compilation authority.

## Stack

Draft stacked on #2584 (DeepSeek Rust authority). It will be rebased to `main` after the lower stack lands.
