### PR TITLE
Serve vendor detail core from Rust

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -4198,6 +4198,30 @@ func TestGRCVendorsReportsRustGraphAuthority(t *testing.T) {
 	}
 }
 
+func TestGRCVendorDetailSelectsExactRustRegisterRow(t *testing.T) {
+	const vendorURN = "urn:cerebro:writer:vendor:one"
+	graph := &stubGraphStore{cypherRows: [][]ports.CypherRow{{{
+		Values: map[string]any{
+			"urn": vendorURN, "tenant_id": "writer", "runtime_id": "vendor-runtime",
+			"source_id": "vendor-source", "entity_type": "vendor", "label": "Vendor One",
+			"attributes_json": `{"risk_level":"high","security_owner_user_id":"alice"}`,
+		},
+	}}}}
+	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph)}, nil)
+	request := httptest.NewRequest(http.MethodGet, "/grc/vendors/"+url.PathEscape(vendorURN), nil)
+
+	row, page, err := app.grcVendorRegisterDetail(request, grcScope{TenantID: "writer", Limit: 10}, vendorURN, "")
+	if err != nil {
+		t.Fatalf("grcVendorRegisterDetail() error = %v", err)
+	}
+	if row.URN != vendorURN || row.Name != "Vendor One" || row.RiskLevel != "high" || row.Owner != "alice" {
+		t.Fatalf("row = %#v, want exact Rust register vendor", row)
+	}
+	if page.GraphRevision != 1 || page.DataAuthority != "rust_graph" {
+		t.Fatalf("page = %#v, want Rust graph revision 1", page)
+	}
+}
+
 func TestGraphImpactEndpointRejectsExplicitZeroBounds(t *testing.T) {
 	app := New(config.Config{}, Dependencies{GraphStore: &stubGraphStore{}}, nil)
 	server := httptest.NewServer(app.Handler())

--- a/internal/bootstrap/grc_vendor.go
+++ b/internal/bootstrap/grc_vendor.go
@@ -28,6 +28,8 @@ type grcVendorDetailResponse struct {
 	Graph         any                           `json:"graph,omitempty"`
 	Findings      []grcFindingItem              `json:"findings"`
 	Evidence      []grcEvidenceItem             `json:"evidence"`
+	GraphRevision uint64                        `json:"graph_revision"`
+	DataAuthority string                        `json:"data_authority"`
 	GeneratedAt   time.Time                     `json:"generated_at"`
 }
 
@@ -134,9 +136,12 @@ func (a *App) grcVendorDetailResponse(r *http.Request) (grcVendorDetailResponse,
 	if err != nil {
 		return grcVendorDetailResponse{}, err
 	}
+	registerRow, registerPage, err := a.grcVendorRegisterDetail(r, scope, urn, vendorID)
+	if err != nil {
+		return grcVendorDetailResponse{}, err
+	}
 	detail, err := grcvendor.NewWithCapabilities(a.deps.GraphReads.Catalog, a.deps.GraphReads.Neighborhoods).GetVendor(r.Context(), grcvendor.VendorDetailRequest{
-		URN:        urn,
-		VendorID:   vendorID,
+		URN:        registerRow.URN,
 		TenantID:   scope.TenantID,
 		RuntimeID:  scope.RuntimeID,
 		RuntimeIDs: scope.RuntimeIDs,
@@ -146,6 +151,7 @@ func (a *App) grcVendorDetailResponse(r *http.Request) (grcVendorDetailResponse,
 	if err != nil {
 		return grcVendorDetailResponse{}, err
 	}
+	detail.Vendor = grcvendor.VendorFromRegisterRow(registerRow, time.Now().UTC())
 	urn = detail.Vendor.URN
 	questionnaireRollups, err := grcvendor.QuestionnaireVendorRollups(r.Context(), grcQuestionnaireRunStore(a.deps.StateStore), scope.TenantID, []string{urn}, time.Now().UTC())
 	if err != nil {
@@ -187,8 +193,50 @@ func (a *App) grcVendorDetailResponse(r *http.Request) (grcVendorDetailResponse,
 		Graph:         detail.Graph,
 		Findings:      findingItems,
 		Evidence:      evidenceItems,
+		GraphRevision: registerPage.GraphRevision,
+		DataAuthority: registerPage.DataAuthority,
 		GeneratedAt:   time.Now().UTC(),
 	}, nil
+}
+
+func (a *App) grcVendorRegisterDetail(r *http.Request, scope grcScope, urn string, vendorID string) (ports.VendorRegisterRow, *ports.VendorRegisterPage, error) {
+	if a.deps.GraphReads.VendorRegister == nil {
+		return ports.VendorRegisterRow{}, nil, grcvendor.ErrRuntimeUnavailable
+	}
+	runtimeIDs := append([]string{}, scope.RuntimeIDs...)
+	if scope.RuntimeID != "" {
+		runtimeIDs = []string{scope.RuntimeID}
+	}
+	query := strings.TrimSpace(urn)
+	if query == "" {
+		query = strings.TrimSpace(vendorID)
+	}
+	page, err := a.deps.GraphReads.VendorRegister.ListVendorRegister(r.Context(), ports.VendorRegisterFilter{
+		TenantID: scope.TenantID, SourceID: scope.SourceID, RuntimeIDs: runtimeIDs, Query: query, Limit: int(scope.Limit),
+	})
+	if err != nil {
+		return ports.VendorRegisterRow{}, nil, err
+	}
+	if page == nil || page.TenantID != scope.TenantID || page.DataAuthority != "rust_graph" {
+		return ports.VendorRegisterRow{}, nil, grcvendor.ErrRuntimeUnavailable
+	}
+	matched := make([]ports.VendorRegisterRow, 0, 1)
+	for _, row := range page.Vendors {
+		if urn != "" && row.URN == urn {
+			matched = append(matched, row)
+			continue
+		}
+		if urn == "" && (strings.EqualFold(row.VendorID, vendorID) || strings.EqualFold(row.Name, vendorID) || strings.HasSuffix(strings.ToLower(row.URN), ":"+strings.ToLower(vendorID))) {
+			matched = append(matched, row)
+		}
+	}
+	if len(matched) == 0 {
+		return ports.VendorRegisterRow{}, nil, ports.ErrGraphEntityNotFound
+	}
+	if len(matched) != 1 {
+		return ports.VendorRegisterRow{}, nil, grcvendor.ErrRuntimeUnavailable
+	}
+	return matched[0], page, nil
 }
 
 func (a *App) handleGRCVendorRiskVendors(w http.ResponseWriter, r *http.Request) {

--- a/internal/grcvendor/service.go
+++ b/internal/grcvendor/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"strings"
@@ -922,6 +923,70 @@ func (s *Service) vendorFromRow(row ports.CypherRow) Vendor {
 	vendor.VendorAssessmentPosture = vendorAssessmentPosture(vendor, now)
 	vendor.VendorCommercialPosture = vendorCommercialPosture(attrs, now)
 	return RefreshVendorQueuePosture(vendor, now)
+}
+
+// VendorFromRegisterRow adapts the Rust-owned vendor register contract to the
+// existing HTTP product shape without re-reading or re-deriving its canonical
+// identity, posture, counts, or queue state in Go.
+func VendorFromRegisterRow(row ports.VendorRegisterRow, now time.Time) Vendor {
+	attributes, _ := json.Marshal(row.Attributes)
+	service := &Service{now: func() time.Time { return now }}
+	vendor := service.vendorFromRow(ports.CypherRow{Values: map[string]any{
+		"urn":                      row.URN,
+		"label":                    row.Name,
+		"source_id":                row.SourceID,
+		"runtime_id":               row.RuntimeID,
+		"attributes_json":          string(attributes),
+		"contract_count":           int64(registerCount(row.ContractCount)),
+		"security_review_count":    int64(registerCount(row.SecurityReviewCount)),
+		"questionnaire_count":      int64(registerCount(row.QuestionnaireCount)),
+		"assurance_document_count": int64(registerCount(row.AssuranceDocumentCount)),
+	}})
+	vendor.VendorIdentity = VendorIdentity{
+		URN: row.URN, VendorID: row.VendorID, Name: row.Name, SourceID: row.SourceID,
+		RuntimeID: row.RuntimeID, Provider: row.Provider, Status: row.Status,
+		Category: row.Category, WebsiteURL: row.WebsiteURL, ServicesProvided: row.ServicesProvided,
+	}
+	vendor.LifecycleState = row.LifecycleState
+	vendor.Owner = row.Owner
+	vendor.OwnerState = row.OwnerState
+	vendor.RiskLevel = row.RiskLevel
+	vendor.RiskScore = int(row.RiskScore)
+	vendor.RiskScoreLevel = row.RiskScoreLevel
+	vendor.ReviewState = row.ReviewState
+	vendor.ReviewDueAt = parseDateAttribute(map[string]string{"review_due_at": row.ReviewDueAt}, "review_due_at")
+	vendor.EvidenceFreshnessState = row.EvidenceFreshnessState
+	vendor.PacketState = row.PacketState
+	vendor.VendorRecordCounts = VendorRecordCounts{
+		ContractCount:          registerCount(row.ContractCount),
+		SecurityReviewCount:    registerCount(row.SecurityReviewCount),
+		QuestionnaireCount:     registerCount(row.QuestionnaireCount),
+		AssuranceDocumentCount: registerCount(row.AssuranceDocumentCount),
+	}
+	vendor.VendorFindingCounts = VendorFindingCounts{
+		OpenFindings: registerCount(row.OpenFindings), CriticalFindings: registerCount(row.CriticalFindings),
+		HighFindings: registerCount(row.HighFindings), EvidenceItems: registerCount(row.EvidenceItems),
+	}
+	vendor.RiskQueueRank = int(row.RiskQueueRank)
+	vendor.QueueReasons = append([]string{}, row.QueueReasons...)
+	vendor.NextActions = make([]VendorAction, 0, len(row.NextActions))
+	for index, action := range row.NextActions {
+		reason := ""
+		if index < len(row.QueueReasons) {
+			reason = row.QueueReasons[index]
+		}
+		vendor.NextActions = append(vendor.NextActions, VendorAction{ID: action.ID, Label: action.Label, Reason: reason})
+	}
+	vendor.Attributes = maps.Clone(row.Attributes)
+	return vendor
+}
+
+func registerCount(value uint64) int {
+	maximum := int(^uint(0) >> 1)
+	if value > uint64(maximum) {
+		return maximum
+	}
+	return int(value) // #nosec G115 -- bounded to the native int maximum above.
 }
 
 func discoveryFromRow(row ports.CypherRow) VendorDiscovery {

--- a/internal/grcvendor/service_test.go
+++ b/internal/grcvendor/service_test.go
@@ -733,3 +733,40 @@ func relatedRow(urn string, entityType string, label string, relation string) po
 		"attributes_json": "{}",
 	}}
 }
+
+func TestVendorFromRegisterRowPreservesRustProductState(t *testing.T) {
+	row := ports.VendorRegisterRow{
+		VendorRegisterIdentity: ports.VendorRegisterIdentity{
+			URN: "urn:cerebro:writer:vendor:acme", VendorID: "acme", Name: "Acme",
+			SourceID: "grc", RuntimeID: "writer-vrm", Provider: "manual", Status: "active",
+			Category: "payments", WebsiteURL: "https://acme.example", ServicesProvided: "Payments",
+			LifecycleState: "active", Owner: "alice", OwnerState: "assigned",
+		},
+		VendorRegisterAssessment: ports.VendorRegisterAssessment{
+			RiskLevel: "high", RiskScore: 78, RiskScoreLevel: "high", ReviewState: "due_soon",
+			ReviewDueAt: "2026-09-01", EvidenceFreshnessState: "current", PacketState: "ready",
+		},
+		VendorRegisterSignals: ports.VendorRegisterSignals{
+			ContractCount: 2, SecurityReviewCount: 3, QuestionnaireCount: 4,
+			AssuranceDocumentCount: 5, OpenFindings: 6, CriticalFindings: 1,
+			HighFindings: 2, EvidenceItems: 7, RiskQueueRank: 42,
+			QueueReasons: []string{"Complete the review"},
+			NextActions:  []ports.VendorRegisterAction{{ID: "complete_review", Label: "Complete the review"}},
+		},
+		Attributes: map[string]string{"data_sensitivity": "restricted", "business_unit": "Finance"},
+	}
+
+	vendor := VendorFromRegisterRow(row, time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC))
+	if vendor.URN != row.URN || vendor.Name != "Acme" || vendor.LifecycleState != "active" || vendor.Owner != "alice" {
+		t.Fatalf("identity or ownership = %#v", vendor)
+	}
+	if vendor.RiskScore != 78 || vendor.ReviewState != "due_soon" || vendor.PacketState != "ready" {
+		t.Fatalf("assessment = %#v", vendor)
+	}
+	if vendor.ContractCount != 2 || vendor.OpenFindings != 6 || vendor.EvidenceItems != 7 || vendor.RiskQueueRank != 42 {
+		t.Fatalf("counts or queue = %#v", vendor)
+	}
+	if len(vendor.NextActions) != 1 || vendor.NextActions[0].ID != "complete_review" || vendor.DataSensitivity != "restricted" || vendor.BusinessUnit != "Finance" {
+		t.Fatalf("actions or attributes = %#v", vendor)
+	}
+}


### PR DESCRIPTION
## Scope
- select the vendor detail record through the Rust vendor-register capability and fail closed on unavailable, cross-tenant, missing, or ambiguous authority
- preserve the existing HTTP JSON shape while binding core identity, posture, counts, queue state, and attributes to the Rust-owned row
- expose `graph_revision` and `data_authority` on vendor detail responses
- keep the existing relationship, questionnaire, finding, evidence, and packet enrichments unchanged for the next bounded migration slice

## Local validation
- `go test ./internal/grcvendor ./internal/bootstrap ./internal/sourcehttp/organizationalgraph ./internal/ports`
- `git diff --check origin/main...HEAD`

No reviewers requested.