### PR TITLE
Prioritize the Compliance overview cold path

### DIFF
--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -5,7 +5,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { GRCProgramReadiness } from "@/lib/grc";
+import type { GRCDashboard, GRCProgramReadiness } from "@/lib/grc";
 import { defaultUserPreferences } from "@/lib/user-preferences";
 
 const mocks = vi.hoisted(() => ({
@@ -84,13 +84,44 @@ describe("Home review links", () => {
     expect(links.map((link) => link.getAttribute("href"))).toContain("/controls?framework=SOC%202&control=CC6.6");
   });
 
-  it("starts independent Home queries on the initial render", async () => {
+  it("starts the dashboard before secondary Home queries", async () => {
     await act(async () => {
       root.render(<Home />);
     });
 
     expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([
       grcDashboardPath({ limit: 12 }),
+      null,
+      null,
+    ]);
+  });
+
+  it("starts secondary Home queries after dashboard data arrives", async () => {
+    const dashboardPath = grcDashboardPath({ limit: 12 });
+    const dashboardData = {
+      summary: {},
+      findings: [],
+      controls: [],
+      evidence: [],
+      connectors: [],
+      generated_at: "2026-08-25T00:00:00Z",
+    } as GRCDashboard;
+    mocks.useGRCQuery.mockImplementation((path: string | null) => ({
+      data: path === dashboardPath ? dashboardData : null,
+      durationMs: null,
+      error: null,
+      lastSuccessfulAt: null,
+      loading: Boolean(path),
+      reload: mocks.reload,
+      state: path ? "loading" : "empty",
+    }));
+
+    await act(async () => {
+      root.render(<Home />);
+    });
+
+    expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([
+      dashboardPath,
       grcProgramReadinessPath(),
       grcPath("/connectors/coverage", {
         coverage_scope: "configured",

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -443,9 +443,11 @@ export default function Home() {
   const compactHome = preferences.display.density === "compact";
   const dashboard = useGRCQuery<GRCDashboard>(grcDashboardPath({ limit: HOME_DASHBOARD_FINDING_LIMIT }));
   const data = dashboard.data;
-  const readinessQuery = useGRCQuery<GRCProgramReadiness>(grcProgramReadinessPath());
+  const readinessQuery = useGRCQuery<GRCProgramReadiness>(data ? grcProgramReadinessPath() : null);
   const coverageQuery = useGRCQuery<{ blind_spots?: GRCSourceCoverageRecord[]; records?: GRCSourceCoverageRecord[] }>(
-    grcPath("/connectors/coverage", { coverage_scope: "configured", coverage_view: "page", blind_spots_only: "true", page_size: 3 }),
+    data
+      ? grcPath("/connectors/coverage", { coverage_scope: "configured", coverage_view: "page", blind_spots_only: "true", page_size: 3 })
+      : null,
   );
   const readiness = readinessQuery.data?.summary;
   const priorityFindings = useMemo(() => (data?.findings ?? []).slice().sort(riskSort), [data?.findings]);
@@ -498,6 +500,7 @@ export default function Home() {
   const reload = () => {
     void dashboard.reload();
     void readinessQuery.reload();
+    void coverageQuery.reload();
   };
 
   return (

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -63,6 +63,7 @@ import (
 	"github.com/writer/cerebro/internal/resourcescope"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
+	"github.com/writer/cerebro/internal/sourcecoverage"
 	httpcompression "github.com/writer/cerebro/internal/sourcehttp/compression"
 	"github.com/writer/cerebro/internal/sourcehttp/organizationalgraph"
 	"github.com/writer/cerebro/internal/sourceops"
@@ -199,6 +200,11 @@ func newWithOptions(cfg config.Config, deps Dependencies, sources *sourcecdk.Reg
 	app := &App{cfg: cfg, deps: deps, sources: sources}
 	if err := grcfindings.ValidateBuiltinFindingProfileIndex(); err != nil {
 		return nil, fmt.Errorf("GRC finding profile bootstrap failed: %w", err)
+	}
+	if options.eventAdmissionContext != nil {
+		if err := sourcecoverage.WarmEvaluator(options.eventAdmissionContext); err != nil {
+			return nil, fmt.Errorf("source coverage evaluator bootstrap failed: %w", err)
+		}
 	}
 	transitKey, err := connectorTransitKeyFromConfig(cfg.ConnectorCredentials)
 	if err != nil {

--- a/internal/sourcecoverage/evaluator.go
+++ b/internal/sourcecoverage/evaluator.go
@@ -50,19 +50,32 @@ type coverageEvaluationResponse struct {
 	Records []Record `json:"records"`
 }
 
-var coverageEvaluator = wasmjson.New(wasmjson.Config{
-	Name:              "embedded source coverage evaluator",
-	Module:            coverageEvaluatorWasm,
-	ABIVersion:        coverageEvaluatorABIVersion,
-	ABIVersionExport:  "cerebro_sourcecoverage_abi_version",
-	AllocateExport:    "cerebro_sourcecoverage_alloc",
-	EvaluateExport:    "cerebro_sourcecoverage_evaluate",
-	MemoryLimitPages:  1024,
-	MaxInputBytes:     coverageEvaluatorMaxInput,
-	MaxOutputBytes:    coverageEvaluatorMaxOutput,
-	InitializeTimeout: 30 * time.Second,
-	CallTimeout:       2 * time.Second,
-})
+func newCoverageEvaluator() *wasmjson.Evaluator {
+	return wasmjson.New(wasmjson.Config{
+		Name:              "embedded source coverage evaluator",
+		Module:            coverageEvaluatorWasm,
+		ABIVersion:        coverageEvaluatorABIVersion,
+		ABIVersionExport:  "cerebro_sourcecoverage_abi_version",
+		AllocateExport:    "cerebro_sourcecoverage_alloc",
+		EvaluateExport:    "cerebro_sourcecoverage_evaluate",
+		MemoryLimitPages:  1024,
+		MaxInputBytes:     coverageEvaluatorMaxInput,
+		MaxOutputBytes:    coverageEvaluatorMaxOutput,
+		InitializeTimeout: 30 * time.Second,
+		CallTimeout:       2 * time.Second,
+	})
+}
+
+var coverageEvaluator = newCoverageEvaluator()
+
+// WarmEvaluator compiles and validates the embedded coverage module before a
+// user request reaches a coverage-backed GRC route.
+func WarmEvaluator(ctx context.Context) error {
+	if err := coverageEvaluator.Warm(ctx); err != nil {
+		return fmt.Errorf("%w: %w", ErrEvaluatorUnavailable, err)
+	}
+	return nil
+}
 
 func evaluateCoverage(ctx context.Context, contracts []sourcecdk.CoverageContract, observations []RuntimeObservation, options Options) ([]Record, error) {
 	if contracts == nil {

--- a/internal/sourcecoverage/evaluator_parity_test.go
+++ b/internal/sourcecoverage/evaluator_parity_test.go
@@ -27,6 +27,19 @@ func TestCoverageEvaluatorReportsCanceledDiagnostic(t *testing.T) {
 	}
 }
 
+func TestWarmCoverageEvaluatorPreparesEvaluation(t *testing.T) {
+	if err := WarmEvaluator(context.Background()); err != nil {
+		t.Fatalf("WarmEvaluator() error = %v", err)
+	}
+	records, err := Evaluate(context.Background(), nil, nil, Options{})
+	if err != nil {
+		t.Fatalf("Evaluate() after WarmEvaluator() error = %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("Evaluate() after WarmEvaluator() records = %#v, want empty", records)
+	}
+}
+
 //go:embed testdata/wasmjson/*.json
 var coverageEvaluatorCorpus embed.FS
 
@@ -98,6 +111,21 @@ func BenchmarkCoverageEvaluator(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		if _, err := runCoverageEvaluator(ctx, payload); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkCoverageEvaluatorColdRequest(b *testing.B) {
+	ctx := context.Background()
+	payload := []byte(`{"contracts":[{"source_id":"aws","dimensions":[{"id":"users","type":"entity_family","title":"Users","families":["user"],"support":"supported"}]}],"observations":[{"runtime_id":"runtime-a","source_id":"aws","family":"user","status":"healthy"}],"options":{}}`)
+	b.ReportAllocs()
+	for b.Loop() {
+		evaluator := newCoverageEvaluator()
+		if _, err := evaluator.Evaluate(ctx, payload); err != nil {
+			b.Fatal(err)
+		}
+		if err := evaluator.Close(ctx); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/internal/wasmhost/runtime.go
+++ b/internal/wasmhost/runtime.go
@@ -61,6 +61,21 @@ func New(config Config) *Runtime {
 	return &Runtime{config: config}
 }
 
+// Warm compiles and validates the embedded module without instantiating a call module.
+// Subsequent Run calls reuse the compiled module and only pay per-call instantiation cost.
+func (r *Runtime) Warm(ctx context.Context) error {
+	if r == nil {
+		return Diagnose(DiagnosticInvalidInput, fmt.Errorf("%w: runtime is required", ErrInvalidConfig))
+	}
+	if ctx == nil {
+		return Diagnose(DiagnosticInvalidInput, r.errorfWith(ErrInvalidConfig, "context is required"))
+	}
+	r.once.Do(func() {
+		r.initialize(ctx)
+	})
+	return r.err
+}
+
 // Run invokes call with a fresh module instance governed by the configured timeout.
 func (r *Runtime) Run(ctx context.Context, call func(context.Context, api.Module) error) error {
 	if r == nil {
@@ -72,11 +87,8 @@ func (r *Runtime) Run(ctx context.Context, call func(context.Context, api.Module
 	if call == nil {
 		return Diagnose(DiagnosticInvalidInput, r.errorfWith(ErrInvalidConfig, "call function is required"))
 	}
-	r.once.Do(func() {
-		r.initialize(ctx)
-	})
-	if r.err != nil {
-		return r.err
+	if err := r.Warm(ctx); err != nil {
+		return err
 	}
 
 	callCtx, cancel := context.WithTimeout(ctx, r.config.CallTimeout)

--- a/internal/wasmhost/runtime_test.go
+++ b/internal/wasmhost/runtime_test.go
@@ -210,6 +210,27 @@ func BenchmarkRuntimeRun(b *testing.B) {
 	}
 }
 
+func TestRuntimeWarmPreparesRun(t *testing.T) {
+	runtime := New(testRuntimeConfig())
+	ctx := context.Background()
+	if err := runtime.Warm(ctx); err != nil {
+		t.Fatalf("Warm() error = %v", err)
+	}
+	if runtime.compiled == nil {
+		t.Fatal("Warm() compiled module = nil")
+	}
+	called := false
+	if err := runtime.Run(ctx, func(context.Context, api.Module) error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("Run() after Warm() error = %v", err)
+	}
+	if !called {
+		t.Fatal("Run() after Warm() did not invoke callback")
+	}
+}
+
 func testRuntimeConfig() Config {
 	return Config{
 		Name:             "test module",

--- a/internal/wasmjson/evaluator.go
+++ b/internal/wasmjson/evaluator.go
@@ -71,6 +71,17 @@ func New(config Config) *Evaluator {
 	return evaluator
 }
 
+// Warm compiles and validates the embedded module without evaluating a payload.
+func (e *Evaluator) Warm(ctx context.Context) error {
+	if e == nil {
+		return wasmhost.Diagnose(wasmhost.DiagnosticInvalidInput, fmt.Errorf("%w: evaluator is required", ErrInvalidConfig))
+	}
+	if e.configErr != nil {
+		return e.configErr
+	}
+	return e.runtime.Warm(ctx)
+}
+
 // Evaluate passes one bounded JSON payload through the embedded module.
 func (e *Evaluator) Evaluate(ctx context.Context, payload []byte) ([]byte, error) {
 	if e.configErr != nil {

--- a/internal/wasmjson/evaluator_test.go
+++ b/internal/wasmjson/evaluator_test.go
@@ -23,6 +23,17 @@ func TestEvaluatorRejectsInvalidConfiguration(t *testing.T) {
 	}
 }
 
+func TestEvaluatorWarmRejectsInvalidConfiguration(t *testing.T) {
+	evaluator := New(Config{})
+	err := evaluator.Warm(context.Background())
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("Warm() error = %v, want %v", err, ErrInvalidConfig)
+	}
+	if !errors.Is(err, wasmhost.ErrInvalidInput) {
+		t.Fatalf("Warm() error = %v, want typed invalid input", err)
+	}
+}
+
 func TestEvaluatorBoundsInputWithoutExposingPayload(t *testing.T) {
 	t.Parallel()
 	config := testConfig()


### PR DESCRIPTION
## Summary

- compile and validate the embedded source-coverage module during production bootstrap
- let the Compliance overview dashboard finish before starting secondary readiness and coverage queries
- keep secondary data refreshable after the dashboard has loaded

## Performance evidence

- prewarmed coverage evaluation: 0.17-0.29 ms per operation in the focused benchmark
- cold evaluator construction plus evaluation: 28.9-47.8 ms per operation
- request-order tests prove secondary Home queries remain disabled until dashboard data exists

## Validation

- `go test ./internal/wasmhost ./internal/wasmjson ./internal/sourcecoverage ./internal/bootstrap -count=1`
- `make lint-bootstrap`
- `NODE_OPTIONS=--localstorage-file=<task-cache> npm run check --workspace @writer/cerebro-web` (107 files, 652 tests)
- `make check-structural check-structural-test check-arch`
- `git diff --check`