### PR TITLE
Fix GRC summary test fixture

### DIFF
--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -99,13 +99,23 @@ describe("Home review links", () => {
   it("starts secondary Home queries after dashboard data arrives", async () => {
     const dashboardPath = grcDashboardPath({ limit: 12 });
     const dashboardData = {
-      summary: {},
+      summary: {
+        open_findings: 0,
+        critical_findings: 0,
+        high_findings: 0,
+        overdue_findings: 0,
+        unassigned: 0,
+        controls_failing: 0,
+        evidence_items: 0,
+        connectors: 0,
+        stale_connectors: 0,
+      },
       findings: [],
       controls: [],
       evidence: [],
       connectors: [],
       generated_at: "2026-08-25T00:00:00Z",
-    } as GRCDashboard;
+    } satisfies GRCDashboard;
     mocks.useGRCQuery.mockImplementation((path: string | null) => ({
       data: path === dashboardPath ? dashboardData : null,
       durationMs: null,


### PR DESCRIPTION
## State\n\nDraft forward repair for the current-main Portable Consumer Chain failure.\n\n## What changed\n\n- populate the complete zero-valued GRCSummary test fixture\n- replace the broad type assertion with satisfies GRCDashboard so future fixture drift fails at the changed line\n\n## Failure receipt\n\n- main: 034299fd40180796aaa9092357a5c1a5575e8687\n- workflow run: 32800615905\n- job: 97660555506\n- failing step: scripts/release/verify_portable_consumer_chain.sh\n- exact error: apps/web/src/app/page.test.tsx:101 rejected summary: {} because all nine GRCSummary fields were missing\n\n## Validation\n\n- git diff --check: pass\n- focused Vitest and Next production build: not run locally because this worktree has no installed web dependencies; vitest and next both exited 127 before execution\n- hosted Portable Consumer Chain and web build are the execution authority\n\n## Exact revision\n\n- base: 034299fd40180796aaa9092357a5c1a5575e8687\n- head: 6930ae64496099b0aad09f196afe1a58402f1dd4