### PR TITLE
Use family-valid OpenAI plan metadata

### DIFF
--- a/crates/source-runtime-next/src/openai/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/openai/source_execution_tests.rs
@@ -24,11 +24,8 @@ fn context(cursor: &str) -> SourceWorkerExecutionContextV1 {
     }
 }
 
-fn metadata(family: OpenAiFamily) -> SourceWorkerRuntimeMetadataV2 {
-    let mut public_config = HashMap::from([
-        ("family".to_owned(), family.id().to_owned()),
-        ("per_page".to_owned(), "2".to_owned()),
-    ]);
+fn initial_metadata(family: OpenAiFamily) -> SourceWorkerRuntimeMetadataV2 {
+    let mut public_config = HashMap::from([("family".to_owned(), family.id().to_owned())]);
     for parameter in family.spec().path_parameters {
         public_config.insert((*parameter).to_owned(), format!("{parameter}-1"));
     }
@@ -78,7 +75,7 @@ fn every_family_plans_one_origin_restricted_credential_free_request() {
                     plan: Some(adapter(family).compiled_plan()),
                     context: Some(context("")),
                 }),
-                metadata: Some(metadata(family)),
+                metadata: Some(initial_metadata(family)),
             })
             .unwrap_or_else(|error| panic!("{} plan: {error}", family.id()));
         assert_eq!(execution.allowed_origin, ORIGIN);
@@ -106,7 +103,7 @@ fn user_decode_preserves_cursor_and_tenant_scoped_identity() {
     let adapter = adapter(family);
     let plan = adapter.compiled_plan();
     let context = context("");
-    let metadata = metadata(family);
+    let metadata = initial_metadata(family);
     let execution = adapter
         .plan_v2(&SourceWorkerPlanEnvelopeV2 {
             request: Some(SourceWorkerPlanRequestV1 {


### PR DESCRIPTION
## State\n\nDraft forward repair for the exact OpenAI deterministic-review failure observed on unrelated PR #2592.\n\n## Diagnosis\n\nThe failure is deterministic, not order-dependent. The test context uses an empty prior cursor, but its shared metadata helper injected per_page=2 for all 39 families. Singleton families such as data_retention reject any pagination input, so request planning returned source_worker.invalid_cursor.\n\n## What changed\n\n- rename the fixture helper to initial_metadata\n- omit explicit page size from the cross-family initial-request fixture\n- retain exact family and required path parameters\n- keep focused pagination and cursor behavior covered by the provider-specific tests\n\n## Failure receipt\n\n- unrelated PR: #2592\n- head: 72c59993d81f03fb5eac8b2bb9fe0f9ecb16d9c6\n- run: 32800774872\n- job: 97660995625\n- test: openai::source_execution::tests::every_family_plans_one_origin_restricted_credential_free_request\n- failing family: data_retention\n\n## Local validation\n\n- rustfmt --edition 2024 --check crates/source-runtime-next/src/openai/source_execution_tests.rs\n- git diff --check\n- cargo test -p cerebro-source-runtime-next every_family_plans_one_origin_restricted_credential_free_request --lib\n\nFormatting and diff checks passed. Managed Cargo exited 75 before compilation because safe capacity is short by 31,853,427,302 bytes. Hosted Rust tests and warnings-denied Clippy are the compilation authority.\n\n## Exact revision\n\n- base: 034299fd40180796aaa9092357a5c1a5575e8687\n- head: 25e7350d99ff8efccc2d7b96aa551396a3ba7823