### PR TITLE
Route remaining AI catalog sources through Rust authority

### DIFF
--- a/crates/source-runtime-next/Cargo.toml
+++ b/crates/source-runtime-next/Cargo.toml
@@ -26,13 +26,11 @@ prost-types.workspace = true
 reqwest = { workspace = true, features = ["form", "stream"] }
 serde.workspace = true
 serde_json.workspace = true
+serde-saphyr.workspace = true
 sha2.workspace = true
 time.workspace = true
 tokio = { workspace = true, features = ["time"] }
 zeroize.workspace = true
-
-[dev-dependencies]
-serde-saphyr.workspace = true
 
 [lints]
 workspace = true

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -52,6 +52,7 @@ mod okta;
 mod openai;
 mod page_publication;
 mod pagerduty;
+mod portable_ai;
 mod panopticon;
 mod protocol;
 mod provider_failure;

--- a/crates/source-runtime-next/src/portable_ai.rs
+++ b/crates/source-runtime-next/src/portable_ai.rs
@@ -2,6 +2,7 @@
 
 mod adapter;
 mod catalog;
+mod langfuse;
 mod normalize;
 
 pub(crate) use adapter::PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS;

--- a/crates/source-runtime-next/src/portable_ai.rs
+++ b/crates/source-runtime-next/src/portable_ai.rs
@@ -1,0 +1,10 @@
+//! Credential-free execution for catalog-defined AI provider families.
+
+mod adapter;
+mod catalog;
+mod normalize;
+
+pub(crate) use adapter::PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS;
+
+#[cfg(test)]
+mod tests;

--- a/crates/source-runtime-next/src/portable_ai/adapter.rs
+++ b/crates/source-runtime-next/src/portable_ai/adapter.rs
@@ -66,7 +66,14 @@ impl PortableAiSourceExecutionAdapter {
         &self,
         metadata: &SourceWorkerRuntimeMetadataV2,
     ) -> Result<String, SourceExecutionError> {
-        let mut origin = self.source.origin_template.clone();
+        let mut origin = if self.source.id == "langfuse" {
+            public_value(&metadata.public_config, "base_url")
+                .ok_or(SourceExecutionError::MissingConfiguration)?
+                .trim_end_matches('/')
+                .to_owned()
+        } else {
+            self.source.origin_template.clone()
+        };
         for key in &self.source.required_config {
             let value = public_value(&metadata.public_config, key)
                 .ok_or(SourceExecutionError::MissingConfiguration)?;
@@ -99,8 +106,17 @@ impl PortableAiSourceExecutionAdapter {
         {
             return Err(SourceExecutionError::EgressDenied);
         }
-        if public_value(&metadata.public_config, "base_url")
-            .is_some_and(|base_url| base_url.trim_end_matches('/') != origin.trim_end_matches('/'))
+        if self.source.id == "aws_bedrock"
+            && (!parsed.host_str().is_some_and(|host| {
+                host.starts_with("bedrock.") && host.ends_with(".amazonaws.com")
+            }) || public_value(&metadata.public_config, "service") != Some("bedrock"))
+        {
+            return Err(SourceExecutionError::EgressDenied);
+        }
+        if self.source.id != "langfuse"
+            && public_value(&metadata.public_config, "base_url").is_some_and(|base_url| {
+                base_url.trim_end_matches('/') != origin.trim_end_matches('/')
+            })
         {
             return Err(SourceExecutionError::MissingConfiguration);
         }
@@ -120,7 +136,15 @@ impl PortableAiSourceExecutionAdapter {
                 path = path.replace(&placeholder, &path_component(value)?);
             }
         }
-        if !path.starts_with('/') || path.contains("${config.") {
+        for key in &self.source.allowed_config {
+            let placeholder = format!("{{{key}}}");
+            if path.contains(&placeholder) {
+                let value = public_value(&metadata.public_config, key)
+                    .ok_or(SourceExecutionError::MissingConfiguration)?;
+                path = path.replace(&placeholder, &path_component(value)?);
+            }
+        }
+        if !path.starts_with('/') || path.contains("${config.") || path.contains('{') {
             return Err(SourceExecutionError::MissingConfiguration);
         }
         Ok(path)
@@ -138,11 +162,21 @@ impl PortableAiSourceExecutionAdapter {
         {
             return Err(SourceExecutionError::MissingConfiguration);
         }
+        if self.source.id == "langfuse" && self.family.id == "metric" {
+            super::langfuse::validate_metrics_query(
+                public_value(&metadata.public_config, "metrics_query")
+                    .ok_or(SourceExecutionError::MissingConfiguration)?,
+            )?;
+        }
         for key in &self.source.required_config {
             public_value(&metadata.public_config, key)
                 .ok_or(SourceExecutionError::MissingConfiguration)?;
         }
         let origin = self.rendered_origin(metadata)?;
+        let continuation_url = matches!(
+            &self.family.pagination,
+            Pagination::NextUrl { .. } | Pagination::Link { .. }
+        ) && !context.prior_cursor.is_empty();
         let mut url = match &self.family.pagination {
             Pagination::NextUrl { .. } | Pagination::Link { .. }
                 if !context.prior_cursor.is_empty() =>
@@ -157,15 +191,15 @@ impl PortableAiSourceExecutionAdapter {
             ))
             .map_err(|_| SourceExecutionError::InvalidPlan)?,
         };
-        if context.prior_cursor.is_empty() {
+        if !continuation_url {
             let mut query = url.query_pairs_mut();
             for (key, value) in &self.family.static_query {
                 query.append_pair(key, value);
             }
             for (parameter, config_key) in &self.family.config_query {
-                let value = public_value(&metadata.public_config, config_key)
-                    .ok_or(SourceExecutionError::MissingConfiguration)?;
-                query.append_pair(parameter, value);
+                if let Some(value) = public_value(&metadata.public_config, config_key) {
+                    query.append_pair(parameter, value);
+                }
             }
             match &self.family.pagination {
                 Pagination::Cursor {
@@ -174,6 +208,15 @@ impl PortableAiSourceExecutionAdapter {
                     ..
                 }
                 | Pagination::Link {
+                    page_size_parameter,
+                    page_size,
+                    ..
+                } => {
+                    if let Some(parameter) = page_size_parameter {
+                        query.append_pair(parameter, &page_size.to_string());
+                    }
+                }
+                Pagination::Page {
                     page_size_parameter,
                     page_size,
                     ..
@@ -191,6 +234,24 @@ impl PortableAiSourceExecutionAdapter {
                 url.query_pairs_mut()
                     .append_pair(parameter, &context.prior_cursor);
             }
+        } else if let Pagination::Page {
+            parameter,
+            start_page,
+            ..
+        } = &self.family.pagination
+        {
+            let page = if context.prior_cursor.is_empty() {
+                *start_page
+            } else {
+                context
+                    .prior_cursor
+                    .parse::<usize>()
+                    .ok()
+                    .filter(|page| *page >= *start_page && *page <= 10_000_000)
+                    .ok_or(SourceExecutionError::InvalidCursor)?
+            };
+            url.query_pairs_mut()
+                .append_pair(parameter, &page.to_string());
         } else if matches!(&self.family.pagination, Pagination::None)
             && !context.prior_cursor.is_empty()
         {
@@ -199,7 +260,7 @@ impl PortableAiSourceExecutionAdapter {
         Ok((origin, url.to_string()))
     }
 
-    fn next_cursor(
+    pub(super) fn next_cursor(
         &self,
         body: &[u8],
         headers: &HashMap<String, String>,
@@ -212,6 +273,7 @@ impl PortableAiSourceExecutionAdapter {
             Pagination::Cursor { json_path, .. } => scalar_at(&document, &[json_path.clone()]),
             Pagination::NextUrl { json_path } => scalar_at(&document, &[json_path.clone()]),
             Pagination::Link { header, .. } => response_header(headers, header).and_then(link_next),
+            Pagination::Page { .. } => next_page(&document)?,
         };
         let Some(cursor) = cursor else {
             return Ok(String::new());
@@ -369,6 +431,7 @@ impl SourceExecutionAdapter for PortableAiSourceExecutionAdapter {
             &context.tenant_id,
             &request.response_body,
             context.observed_at_unix_millis,
+            &metadata.public_config,
         )?;
         let records = validate_and_deduplicate_records(records)?;
         let next_cursor =
@@ -481,4 +544,19 @@ fn link_next(value: &str) -> Option<String> {
             .map(str::to_owned)
             .filter(|target| !target.is_empty())
     })
+}
+
+fn next_page(document: &Value) -> Result<Option<String>, SourceExecutionError> {
+    let current = scalar_at(document, &["$.meta.page".to_owned()])
+        .ok_or(SourceExecutionError::MalformedResponse)?
+        .parse::<usize>()
+        .map_err(|_| SourceExecutionError::MalformedResponse)?;
+    let total = scalar_at(document, &["$.meta.totalPages".to_owned()])
+        .ok_or(SourceExecutionError::MalformedResponse)?
+        .parse::<usize>()
+        .map_err(|_| SourceExecutionError::MalformedResponse)?;
+    if current == 0 || total > 10_000_000 {
+        return Err(SourceExecutionError::InvalidCursor);
+    }
+    Ok((current < total).then(|| (current + 1).to_string()))
 }

--- a/crates/source-runtime-next/src/portable_ai/adapter.rs
+++ b/crates/source-runtime-next/src/portable_ai/adapter.rs
@@ -1,0 +1,484 @@
+use std::{collections::HashMap, sync::LazyLock};
+
+use reqwest::Url;
+use serde_json::Value;
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceExecutionPlanV1,
+    SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1,
+    SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2, SourceWorkerHttpRequestV1,
+    SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1, SourceWorkerRecordV1,
+    SourceWorkerRuntimeMetadataV2, canonical_http_execution_digest, canonical_plan_digest,
+    canonical_request_intent_digest, canonical_result_digest, validate_and_deduplicate_records,
+    validate_cursor, validate_execution_context, validate_runtime_metadata,
+};
+
+use super::{
+    catalog::{Family, Pagination, SOURCES, Source},
+    normalize::{expected_event_id, normalize_records, scalar_at},
+};
+
+const MAX_RESPONSE_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Credential-free adapter for one exact catalog-defined AI provider family.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PortableAiSourceExecutionAdapter {
+    pub(super) source: &'static Source,
+    pub(super) family: &'static Family,
+}
+
+impl PortableAiSourceExecutionAdapter {
+    fn new(source: &'static Source, family: &'static Family) -> Self {
+        Self { source, family }
+    }
+
+    pub(crate) fn compiled_plan(&self) -> SourceExecutionPlanV1 {
+        let mut plan = SourceExecutionPlanV1 {
+            plan_id: format!("source-plan-v1:{}:{}", self.source.id, self.family.id),
+            source_id: self.source.id.clone(),
+            family_id: self.family.id.clone(),
+            provider_kernel: self.family.kernel.clone(),
+            method: self.family.method.clone(),
+            origin: self.source.origin_template.clone(),
+            path: self.family.path.clone(),
+            record_selector: self.family.record_selector.clone(),
+            id_field: self.family.id_paths.join("|"),
+            singleton_fallback_id: String::new(),
+            max_response_bytes: MAX_RESPONSE_BYTES,
+            event_kind: self.family.kind.clone(),
+            schema_ref: self.family.schema_ref.clone(),
+            required_attributes: self.family.required_attributes.clone(),
+            required_payload_fields: self.family.required_payload_fields.clone(),
+            plan_digest_sha256: String::new(),
+        };
+        plan.plan_digest_sha256 = canonical_plan_digest(&plan);
+        plan
+    }
+
+    fn validate_plan(&self, plan: &SourceExecutionPlanV1) -> Result<(), SourceExecutionError> {
+        if plan != &self.compiled_plan() {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        Ok(())
+    }
+
+    fn rendered_origin(
+        &self,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<String, SourceExecutionError> {
+        let mut origin = self.source.origin_template.clone();
+        for key in &self.source.required_config {
+            let value = public_value(&metadata.public_config, key)
+                .ok_or(SourceExecutionError::MissingConfiguration)?;
+            let placeholder = format!("${{config.{key}}}");
+            if origin.contains(&placeholder) {
+                if !safe_dns_label(value) {
+                    return Err(SourceExecutionError::MissingConfiguration);
+                }
+                origin = origin.replace(&placeholder, value);
+            }
+        }
+        if origin.contains("${config.") {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        let parsed = Url::parse(&origin).map_err(|_| SourceExecutionError::MissingConfiguration)?;
+        if parsed.scheme() != "https"
+            || parsed.username() != ""
+            || parsed.password().is_some()
+            || parsed.port().is_some()
+            || parsed.query().is_some()
+            || parsed.fragment().is_some()
+            || parsed.host_str().is_none()
+        {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        if self.source.id == "google_vertex_ai"
+            && !parsed
+                .host_str()
+                .is_some_and(|host| host.ends_with("-aiplatform.googleapis.com"))
+        {
+            return Err(SourceExecutionError::EgressDenied);
+        }
+        if public_value(&metadata.public_config, "base_url")
+            .is_some_and(|base_url| base_url.trim_end_matches('/') != origin.trim_end_matches('/'))
+        {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        Ok(origin)
+    }
+
+    fn rendered_path(
+        &self,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<String, SourceExecutionError> {
+        let mut path = self.family.path.clone();
+        for key in &self.source.required_config {
+            let placeholder = format!("${{config.{key}}}");
+            if path.contains(&placeholder) {
+                let value = public_value(&metadata.public_config, key)
+                    .ok_or(SourceExecutionError::MissingConfiguration)?;
+                path = path.replace(&placeholder, &path_component(value)?);
+            }
+        }
+        if !path.starts_with('/') || path.contains("${config.") {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        Ok(path)
+    }
+
+    fn request_url(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(String, String), SourceExecutionError> {
+        validate_execution_context(context)?;
+        validate_runtime_metadata(metadata)?;
+        if public_value(&metadata.public_config, "family")
+            .is_some_and(|family| family != self.family.id.as_str())
+        {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        for key in &self.source.required_config {
+            public_value(&metadata.public_config, key)
+                .ok_or(SourceExecutionError::MissingConfiguration)?;
+        }
+        let origin = self.rendered_origin(metadata)?;
+        let mut url = match &self.family.pagination {
+            Pagination::NextUrl { .. } | Pagination::Link { .. }
+                if !context.prior_cursor.is_empty() =>
+            {
+                validate_cursor(&context.prior_cursor)?;
+                validated_continuation(&origin, &context.prior_cursor)?
+            }
+            _ => Url::parse(&format!(
+                "{}{}",
+                origin.trim_end_matches('/'),
+                self.rendered_path(metadata)?
+            ))
+            .map_err(|_| SourceExecutionError::InvalidPlan)?,
+        };
+        if context.prior_cursor.is_empty() {
+            let mut query = url.query_pairs_mut();
+            for (key, value) in &self.family.static_query {
+                query.append_pair(key, value);
+            }
+            for (parameter, config_key) in &self.family.config_query {
+                let value = public_value(&metadata.public_config, config_key)
+                    .ok_or(SourceExecutionError::MissingConfiguration)?;
+                query.append_pair(parameter, value);
+            }
+            match &self.family.pagination {
+                Pagination::Cursor {
+                    page_size_parameter,
+                    page_size,
+                    ..
+                }
+                | Pagination::Link {
+                    page_size_parameter,
+                    page_size,
+                    ..
+                } => {
+                    if let Some(parameter) = page_size_parameter {
+                        query.append_pair(parameter, &page_size.to_string());
+                    }
+                }
+                Pagination::None | Pagination::NextUrl { .. } => {}
+            }
+        }
+        if let Pagination::Cursor { parameter, .. } = &self.family.pagination {
+            if !context.prior_cursor.is_empty() {
+                validate_cursor(&context.prior_cursor)?;
+                url.query_pairs_mut()
+                    .append_pair(parameter, &context.prior_cursor);
+            }
+        } else if matches!(&self.family.pagination, Pagination::None)
+            && !context.prior_cursor.is_empty()
+        {
+            return Err(SourceExecutionError::InvalidCursor);
+        }
+        Ok((origin, url.to_string()))
+    }
+
+    fn next_cursor(
+        &self,
+        body: &[u8],
+        headers: &HashMap<String, String>,
+        origin: &str,
+    ) -> Result<String, SourceExecutionError> {
+        let document: Value =
+            serde_json::from_slice(body).map_err(|_| SourceExecutionError::MalformedResponse)?;
+        let cursor = match &self.family.pagination {
+            Pagination::None => None,
+            Pagination::Cursor { json_path, .. } => scalar_at(&document, &[json_path.clone()]),
+            Pagination::NextUrl { json_path } => scalar_at(&document, &[json_path.clone()]),
+            Pagination::Link { header, .. } => response_header(headers, header).and_then(link_next),
+        };
+        let Some(cursor) = cursor else {
+            return Ok(String::new());
+        };
+        validate_cursor(&cursor)?;
+        if matches!(
+            &self.family.pagination,
+            Pagination::NextUrl { .. } | Pagination::Link { .. }
+        ) {
+            validated_continuation(origin, &cursor)?;
+        }
+        Ok(cursor)
+    }
+
+    fn validate_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+    ) -> Result<(), SourceExecutionError> {
+        if record.event_id
+            != expected_event_id(
+                &context.tenant_id,
+                &self.source.id,
+                &self.family.id,
+                &record.provider_id,
+            )
+            || record.attributes.get("tenant_id") != Some(&context.tenant_id)
+            || record.attributes.get("source_event_id") != Some(&record.provider_id)
+            || record.attributes.get("family") != Some(&self.family.id)
+            || record.attributes.get("provider") != Some(&self.source.id)
+            || record.attributes.get("source_provider") != Some(&self.source.id)
+        {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        Ok(())
+    }
+}
+
+impl SourceExecutionAdapter for PortableAiSourceExecutionAdapter {
+    fn source_id(&self) -> &'static str {
+        &self.source.id
+    }
+
+    fn family_id(&self) -> &'static str {
+        &self.family.id
+    }
+
+    fn provider_kernel(&self) -> &'static str {
+        &self.family.kernel
+    }
+
+    fn validate_record_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+    ) -> Result<(), SourceExecutionError> {
+        self.validate_identity(context, record)
+    }
+
+    fn plan(
+        &self,
+        _request: &SourceWorkerPlanRequestV1,
+    ) -> Result<SourceWorkerHttpRequestV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn plan_v2(
+        &self,
+        envelope: &SourceWorkerPlanEnvelopeV2,
+    ) -> Result<SourceWorkerHttpExecutionV2, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (origin, url) = self.request_url(context, metadata)?;
+        let mut planned = SourceWorkerHttpRequestV1 {
+            plan_id: plan.plan_id.clone(),
+            method: plan.method.clone(),
+            url,
+            accept: "application/json".to_owned(),
+            max_response_bytes: plan.max_response_bytes,
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            request_intent_digest: String::new(),
+        };
+        planned.request_intent_digest = canonical_request_intent_digest(plan, context, &planned);
+        let mut execution = SourceWorkerHttpExecutionV2 {
+            request: Some(planned),
+            body: Vec::new(),
+            declared_headers: HashMap::new(),
+            execution_intent_digest_sha256: String::new(),
+            credential_operation: self.source.auth.host_operation().to_owned(),
+            allowed_origin: origin,
+        };
+        execution.execution_intent_digest_sha256 =
+            canonical_http_execution_digest(plan, context, metadata, &execution);
+        Ok(execution)
+    }
+
+    fn decode(
+        &self,
+        _request: &SourceWorkerDecodeRequestV1,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn decode_v2(
+        &self,
+        envelope: &SourceWorkerDecodeEnvelopeV2,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let receipt = request
+            .receipt
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        match request.status_code {
+            200..=299 => {}
+            401 => return Err(SourceExecutionError::AuthenticationRejected),
+            403 => return Err(SourceExecutionError::RequiredProviderScopeMissing),
+            429 => return Err(SourceExecutionError::ProviderRateLimit),
+            _ => return Err(SourceExecutionError::UnexpectedProviderStatus),
+        }
+        let origin = self.rendered_origin(metadata)?;
+        let records = normalize_records(
+            self.source,
+            self.family,
+            &context.tenant_id,
+            &request.response_body,
+            context.observed_at_unix_millis,
+        )?;
+        let records = validate_and_deduplicate_records(records)?;
+        let next_cursor =
+            self.next_cursor(&request.response_body, &envelope.response_headers, &origin)?;
+        let result_digest_sha256 = canonical_result_digest(receipt, &next_cursor, &records)?;
+        Ok(SourceWorkerDecodeResultV1 {
+            plan_id: plan.plan_id.clone(),
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: request.request_intent_digest.clone(),
+            records,
+            next_cursor,
+            result_digest_sha256,
+            tenant_id: context.tenant_id.clone(),
+            runtime_id: context.runtime_id.clone(),
+            runtime_generation: context.runtime_generation,
+            lease_generation: context.lease_generation,
+            observed_at_unix_millis: context.observed_at_unix_millis,
+        })
+    }
+}
+
+pub(crate) static PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS: LazyLock<
+    Vec<PortableAiSourceExecutionAdapter>,
+> = LazyLock::new(|| {
+    SOURCES
+        .iter()
+        .flat_map(|source| {
+            source
+                .families
+                .iter()
+                .map(|family| PortableAiSourceExecutionAdapter::new(source, family))
+        })
+        .collect()
+});
+
+fn public_value<'a>(config: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    config
+        .get(key)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn safe_dns_label(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 63
+        && !value.starts_with('-')
+        && !value.ends_with('-')
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}
+
+fn path_component(value: &str) -> Result<String, SourceExecutionError> {
+    if value.is_empty() || value.len() > 512 || value.chars().any(char::is_control) {
+        return Err(SourceExecutionError::MissingConfiguration);
+    }
+    Ok(value
+        .bytes()
+        .flat_map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                vec![char::from(byte)]
+            }
+            _ => format!("%{byte:02X}").chars().collect(),
+        })
+        .collect())
+}
+
+fn validated_continuation(origin: &str, value: &str) -> Result<Url, SourceExecutionError> {
+    let origin = Url::parse(origin).map_err(|_| SourceExecutionError::InvalidPlan)?;
+    let continuation = Url::parse(value).map_err(|_| SourceExecutionError::InvalidCursor)?;
+    let prefix = origin.path().trim_end_matches('/');
+    if continuation.scheme() != origin.scheme()
+        || continuation.host_str() != origin.host_str()
+        || continuation.port_or_known_default() != origin.port_or_known_default()
+        || continuation.username() != ""
+        || continuation.password().is_some()
+        || continuation.fragment().is_some()
+        || (!prefix.is_empty()
+            && continuation.path() != prefix
+            && !continuation.path().starts_with(&format!("{prefix}/")))
+    {
+        return Err(SourceExecutionError::EgressDenied);
+    }
+    Ok(continuation)
+}
+
+fn response_header<'a>(headers: &'a HashMap<String, String>, name: &str) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.trim())
+        .filter(|value| !value.is_empty())
+}
+
+fn link_next(value: &str) -> Option<String> {
+    value.split(',').find_map(|part| {
+        let part = part.trim();
+        let (target, parameters) = part.split_once('>')?;
+        if !parameters.split(';').any(|parameter| {
+            parameter.trim().eq_ignore_ascii_case("rel=\"next\"")
+                || parameter.trim().eq_ignore_ascii_case("rel=next")
+        }) {
+            return None;
+        }
+        target
+            .trim()
+            .strip_prefix('<')
+            .map(str::to_owned)
+            .filter(|target| !target.is_empty())
+    })
+}

--- a/crates/source-runtime-next/src/portable_ai/catalog.rs
+++ b/crates/source-runtime-next/src/portable_ai/catalog.rs
@@ -6,6 +6,8 @@ use serde::Deserialize;
 pub(super) enum AuthOperation {
     Bearer,
     ApiKeyHeader,
+    Basic,
+    AwsSigV4,
 }
 
 impl AuthOperation {
@@ -13,6 +15,8 @@ impl AuthOperation {
         match self {
             Self::Bearer => "source.bearer",
             Self::ApiKeyHeader => "google.api_key_header",
+            Self::Basic => "langfuse.basic",
+            Self::AwsSigV4 => "aws.sigv4",
         }
     }
 }
@@ -34,6 +38,12 @@ pub(super) enum Pagination {
         page_size_parameter: Option<String>,
         page_size: usize,
     },
+    Page {
+        parameter: String,
+        start_page: usize,
+        page_size_parameter: Option<String>,
+        page_size: usize,
+    },
 }
 
 #[derive(Debug)]
@@ -51,6 +61,8 @@ pub(super) struct Family {
     pub(super) required_attributes: Vec<String>,
     pub(super) required_payload_fields: Vec<String>,
     pub(super) projection_fields: BTreeMap<String, Vec<String>>,
+    pub(super) static_attributes: BTreeMap<String, String>,
+    pub(super) config_attributes: BTreeMap<String, String>,
     pub(super) config_query: BTreeMap<String, String>,
     pub(super) static_query: BTreeMap<String, String>,
     pub(super) pagination: Pagination,
@@ -62,6 +74,7 @@ pub(super) struct Source {
     pub(super) origin_template: String,
     pub(super) auth: AuthOperation,
     pub(super) required_config: Vec<String>,
+    pub(super) allowed_config: Vec<String>,
     pub(super) families: Vec<&'static Family>,
 }
 
@@ -114,6 +127,8 @@ struct FamilyWire {
     event: EventWire,
     projection: ProjectionWire,
     #[serde(default)]
+    config: FamilyConfigWire,
+    #[serde(default)]
     config_query: BTreeMap<String, String>,
     #[serde(default)]
     static_query: BTreeMap<String, String>,
@@ -134,6 +149,16 @@ struct EventWire {
 struct ProjectionWire {
     #[serde(default)]
     fields: BTreeMap<String, String>,
+    #[serde(default)]
+    static_fields: BTreeMap<String, String>,
+}
+
+#[derive(Default, Deserialize)]
+struct FamilyConfigWire {
+    #[serde(default)]
+    config_query: BTreeMap<String, String>,
+    #[serde(default)]
+    config_attributes: BTreeMap<String, String>,
 }
 
 #[derive(Default, Deserialize)]
@@ -152,6 +177,10 @@ struct PaginationWire {
     page_size_param: String,
     #[serde(default)]
     page_size: usize,
+    #[serde(default)]
+    page_param: String,
+    #[serde(default)]
+    start_page: usize,
 }
 
 #[derive(Deserialize)]
@@ -174,7 +203,13 @@ struct EmbeddedSource {
     catalog: &'static [u8],
 }
 
-const EMBEDDED: [EmbeddedSource; 8] = [
+const EMBEDDED: [EmbeddedSource; 10] = [
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/aws_bedrock.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/aws_bedrock/catalog.yaml"),
+    },
     EmbeddedSource {
         definition: include_bytes!(
             "../../../../internal/connectorcatalog/catalog/ai-governance/azure_openai.yaml"
@@ -210,6 +245,12 @@ const EMBEDDED: [EmbeddedSource; 8] = [
             "../../../../internal/connectorcatalog/catalog/ai-governance/huggingface.yaml"
         ),
         catalog: include_bytes!("../../../../sources/huggingface/catalog.yaml"),
+    },
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/langfuse.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/langfuse/catalog.yaml"),
     },
     EmbeddedSource {
         definition: include_bytes!(
@@ -250,6 +291,8 @@ fn compile_source(embedded: &EmbeddedSource) -> Result<&'static Source, String> 
     let auth = match definition.auth.model.as_str() {
         "bearer_token" => AuthOperation::Bearer,
         "api_key" if definition.source_id == "google_gemini" => AuthOperation::ApiKeyHeader,
+        "basic" if definition.source_id == "langfuse" => AuthOperation::Basic,
+        "aws_sigv4" if definition.source_id == "aws_bedrock" => AuthOperation::AwsSigV4,
         other => return Err(format!("unsupported {} auth {other}", definition.source_id)),
     };
     let families = definition
@@ -263,7 +306,14 @@ fn compile_source(embedded: &EmbeddedSource) -> Result<&'static Source, String> 
                 .get(&family.event.kind)
                 .ok_or_else(|| format!("{} contract is missing", family.event.kind))?;
             if contract.schema_ref != family.event.schema_ref
-                || contract.required_payload_fields != family.event.required_payload_fields
+                || contract.required_payload_fields.iter().any(|required| {
+                    !family.event.required_payload_fields.iter().any(|declared| {
+                        declared
+                            .split('|')
+                            .map(str::trim)
+                            .any(|candidate| candidate == required)
+                    })
+                })
             {
                 return Err(format!("{} event contracts drifted", family.event.kind));
             }
@@ -283,6 +333,8 @@ fn compile_source(embedded: &EmbeddedSource) -> Result<&'static Source, String> 
                     )
                 })
                 .collect();
+            let mut config_query = family.config_query;
+            config_query.extend(family.config.config_query);
             let compiled = Family {
                 kernel: format!("{}.{}", definition.source_id, family.id),
                 id: family.id,
@@ -295,9 +347,11 @@ fn compile_source(embedded: &EmbeddedSource) -> Result<&'static Source, String> 
                 schema_ref: family.event.schema_ref,
                 urn_kind: family.event.urn_kind,
                 required_attributes: contract.required_attributes.clone(),
-                required_payload_fields: contract.required_payload_fields.clone(),
+                required_payload_fields: family.event.required_payload_fields,
                 projection_fields,
-                config_query: family.config_query,
+                static_attributes: family.projection.static_fields,
+                config_attributes: family.config.config_attributes,
+                config_query,
                 static_query: family.static_query,
                 pagination: compile_pagination(family.pagination)?,
             };
@@ -307,16 +361,23 @@ fn compile_source(embedded: &EmbeddedSource) -> Result<&'static Source, String> 
     if families.is_empty() {
         return Err(format!("{} has no runtime families", definition.source_id));
     }
+    let required_config = definition
+        .config_fields
+        .iter()
+        .filter(|field| field.required)
+        .map(|field| field.key.clone())
+        .collect();
+    let allowed_config = definition
+        .config_fields
+        .iter()
+        .map(|field| field.key.clone())
+        .collect();
     Ok(&*Box::leak(Box::new(Source {
         id: definition.source_id,
         origin_template: definition.transport.base_url,
         auth,
-        required_config: definition
-            .config_fields
-            .into_iter()
-            .filter(|field| field.required)
-            .map(|field| field.key)
-            .collect(),
+        required_config,
+        allowed_config,
         families,
     })))
 }
@@ -342,6 +403,12 @@ fn compile_pagination(wire: PaginationWire) -> Result<Pagination, String> {
             } else {
                 wire.link_header
             },
+            page_size_parameter: (!wire.page_size_param.is_empty()).then_some(wire.page_size_param),
+            page_size: wire.page_size,
+        }),
+        "page" if !wire.page_param.is_empty() => Ok(Pagination::Page {
+            parameter: wire.page_param,
+            start_page: wire.start_page.max(1),
             page_size_parameter: (!wire.page_size_param.is_empty()).then_some(wire.page_size_param),
             page_size: wire.page_size,
         }),

--- a/crates/source-runtime-next/src/portable_ai/catalog.rs
+++ b/crates/source-runtime-next/src/portable_ai/catalog.rs
@@ -1,0 +1,359 @@
+use std::{collections::BTreeMap, sync::LazyLock};
+
+use serde::Deserialize;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum AuthOperation {
+    Bearer,
+    ApiKeyHeader,
+}
+
+impl AuthOperation {
+    pub(super) const fn host_operation(self) -> &'static str {
+        match self {
+            Self::Bearer => "source.bearer",
+            Self::ApiKeyHeader => "google.api_key_header",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) enum Pagination {
+    None,
+    Cursor {
+        parameter: String,
+        json_path: String,
+        page_size_parameter: Option<String>,
+        page_size: usize,
+    },
+    NextUrl {
+        json_path: String,
+    },
+    Link {
+        header: String,
+        page_size_parameter: Option<String>,
+        page_size: usize,
+    },
+}
+
+#[derive(Debug)]
+pub(super) struct Family {
+    pub(super) id: String,
+    pub(super) kernel: String,
+    pub(super) method: String,
+    pub(super) path: String,
+    pub(super) record_selector: String,
+    pub(super) id_paths: Vec<String>,
+    pub(super) name_paths: Vec<String>,
+    pub(super) kind: String,
+    pub(super) schema_ref: String,
+    pub(super) urn_kind: String,
+    pub(super) required_attributes: Vec<String>,
+    pub(super) required_payload_fields: Vec<String>,
+    pub(super) projection_fields: BTreeMap<String, Vec<String>>,
+    pub(super) config_query: BTreeMap<String, String>,
+    pub(super) static_query: BTreeMap<String, String>,
+    pub(super) pagination: Pagination,
+}
+
+#[derive(Debug)]
+pub(super) struct Source {
+    pub(super) id: String,
+    pub(super) origin_template: String,
+    pub(super) auth: AuthOperation,
+    pub(super) required_config: Vec<String>,
+    pub(super) families: Vec<&'static Family>,
+}
+
+#[derive(Deserialize)]
+struct DefinitionCatalog {
+    entries: Vec<DefinitionEntry>,
+}
+
+#[derive(Deserialize)]
+struct DefinitionEntry {
+    definition: DefinitionWire,
+}
+
+#[derive(Deserialize)]
+struct DefinitionWire {
+    source_id: String,
+    auth: AuthWire,
+    #[serde(default)]
+    config_fields: Vec<ConfigFieldWire>,
+    transport: TransportWire,
+    resource_families: Vec<FamilyWire>,
+}
+
+#[derive(Deserialize)]
+struct AuthWire {
+    model: String,
+}
+
+#[derive(Deserialize)]
+struct ConfigFieldWire {
+    key: String,
+    #[serde(default)]
+    required: bool,
+}
+
+#[derive(Deserialize)]
+struct TransportWire {
+    base_url: String,
+}
+
+#[derive(Deserialize)]
+struct FamilyWire {
+    id: String,
+    method: String,
+    path: String,
+    record_selector: String,
+    id_field: String,
+    #[serde(default)]
+    name_field: String,
+    event: EventWire,
+    projection: ProjectionWire,
+    #[serde(default)]
+    config_query: BTreeMap<String, String>,
+    #[serde(default)]
+    static_query: BTreeMap<String, String>,
+    #[serde(default)]
+    pagination: PaginationWire,
+}
+
+#[derive(Deserialize)]
+struct EventWire {
+    kind: String,
+    schema_ref: String,
+    urn_kind: String,
+    #[serde(default)]
+    required_payload_fields: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct ProjectionWire {
+    #[serde(default)]
+    fields: BTreeMap<String, String>,
+}
+
+#[derive(Default, Deserialize)]
+struct PaginationWire {
+    #[serde(rename = "type", default)]
+    kind: String,
+    #[serde(default)]
+    cursor_param: String,
+    #[serde(default)]
+    cursor_json_path: String,
+    #[serde(default, alias = "next_link_json_path")]
+    next_url_json_path: String,
+    #[serde(default)]
+    link_header: String,
+    #[serde(default)]
+    page_size_param: String,
+    #[serde(default)]
+    page_size: usize,
+}
+
+#[derive(Deserialize)]
+struct SourceCatalog {
+    event_contracts: Vec<EventContractWire>,
+}
+
+#[derive(Deserialize)]
+struct EventContractWire {
+    kind: String,
+    schema_ref: String,
+    #[serde(default)]
+    required_attributes: Vec<String>,
+    #[serde(default)]
+    required_payload_fields: Vec<String>,
+}
+
+struct EmbeddedSource {
+    definition: &'static [u8],
+    catalog: &'static [u8],
+}
+
+const EMBEDDED: [EmbeddedSource; 8] = [
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/azure_openai.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/azure_openai/catalog.yaml"),
+    },
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/cohere.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/cohere/catalog.yaml"),
+    },
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/google_gemini.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/google_gemini/catalog.yaml"),
+    },
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/google_vertex_ai.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/google_vertex_ai/catalog.yaml"),
+    },
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/groq.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/groq/catalog.yaml"),
+    },
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/huggingface.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/huggingface/catalog.yaml"),
+    },
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/mistral.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/mistral/catalog.yaml"),
+    },
+    EmbeddedSource {
+        definition: include_bytes!(
+            "../../../../internal/connectorcatalog/catalog/ai-governance/perplexity.yaml"
+        ),
+        catalog: include_bytes!("../../../../sources/perplexity/catalog.yaml"),
+    },
+];
+
+pub(super) static SOURCES: LazyLock<Vec<&'static Source>> = LazyLock::new(|| {
+    EMBEDDED
+        .iter()
+        .map(compile_source)
+        .collect::<Result<Vec<_>, _>>()
+        .expect("checked-in portable AI source catalogs must compile")
+});
+
+fn compile_source(embedded: &EmbeddedSource) -> Result<&'static Source, String> {
+    let mut definitions: DefinitionCatalog = serde_saphyr::from_slice(embedded.definition)
+        .map_err(|error| format!("definition YAML: {error}"))?;
+    if definitions.entries.len() != 1 {
+        return Err("definition catalog must contain one source".to_owned());
+    }
+    let definition = definitions.entries.remove(0).definition;
+    let source_catalog: SourceCatalog = serde_saphyr::from_slice(embedded.catalog)
+        .map_err(|error| format!("source catalog YAML: {error}"))?;
+    let contracts = source_catalog
+        .event_contracts
+        .into_iter()
+        .map(|contract| (contract.kind.clone(), contract))
+        .collect::<BTreeMap<_, _>>();
+    let auth = match definition.auth.model.as_str() {
+        "bearer_token" => AuthOperation::Bearer,
+        "api_key" if definition.source_id == "google_gemini" => AuthOperation::ApiKeyHeader,
+        other => return Err(format!("unsupported {} auth {other}", definition.source_id)),
+    };
+    let families = definition
+        .resource_families
+        .into_iter()
+        .map(|family| {
+            if family.method != "GET" {
+                return Err(format!("{}.{} is not GET", definition.source_id, family.id));
+            }
+            let contract = contracts
+                .get(&family.event.kind)
+                .ok_or_else(|| format!("{} contract is missing", family.event.kind))?;
+            if contract.schema_ref != family.event.schema_ref
+                || contract.required_payload_fields != family.event.required_payload_fields
+            {
+                return Err(format!("{} event contracts drifted", family.event.kind));
+            }
+            let projection_fields = family
+                .projection
+                .fields
+                .into_iter()
+                .map(|(key, paths)| {
+                    (
+                        key,
+                        paths
+                            .split('|')
+                            .map(str::trim)
+                            .filter(|value| !value.is_empty())
+                            .map(str::to_owned)
+                            .collect(),
+                    )
+                })
+                .collect();
+            let compiled = Family {
+                kernel: format!("{}.{}", definition.source_id, family.id),
+                id: family.id,
+                method: family.method,
+                path: family.path,
+                record_selector: family.record_selector,
+                id_paths: split_paths(&family.id_field),
+                name_paths: split_paths(&family.name_field),
+                kind: family.event.kind,
+                schema_ref: family.event.schema_ref,
+                urn_kind: family.event.urn_kind,
+                required_attributes: contract.required_attributes.clone(),
+                required_payload_fields: contract.required_payload_fields.clone(),
+                projection_fields,
+                config_query: family.config_query,
+                static_query: family.static_query,
+                pagination: compile_pagination(family.pagination)?,
+            };
+            Ok::<_, String>(&*Box::leak(Box::new(compiled)))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if families.is_empty() {
+        return Err(format!("{} has no runtime families", definition.source_id));
+    }
+    Ok(&*Box::leak(Box::new(Source {
+        id: definition.source_id,
+        origin_template: definition.transport.base_url,
+        auth,
+        required_config: definition
+            .config_fields
+            .into_iter()
+            .filter(|field| field.required)
+            .map(|field| field.key)
+            .collect(),
+        families,
+    })))
+}
+
+fn compile_pagination(wire: PaginationWire) -> Result<Pagination, String> {
+    match wire.kind.as_str() {
+        "" | "none" => Ok(Pagination::None),
+        "cursor" if !wire.cursor_param.is_empty() && !wire.cursor_json_path.is_empty() => {
+            Ok(Pagination::Cursor {
+                parameter: wire.cursor_param,
+                json_path: wire.cursor_json_path,
+                page_size_parameter: (!wire.page_size_param.is_empty())
+                    .then_some(wire.page_size_param),
+                page_size: wire.page_size,
+            })
+        }
+        "next_url" if !wire.next_url_json_path.is_empty() => Ok(Pagination::NextUrl {
+            json_path: wire.next_url_json_path,
+        }),
+        "link" => Ok(Pagination::Link {
+            header: if wire.link_header.is_empty() {
+                "Link".to_owned()
+            } else {
+                wire.link_header
+            },
+            page_size_parameter: (!wire.page_size_param.is_empty()).then_some(wire.page_size_param),
+            page_size: wire.page_size,
+        }),
+        other => Err(format!("unsupported pagination {other}")),
+    }
+}
+
+fn split_paths(value: &str) -> Vec<String> {
+    value
+        .split('|')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect()
+}

--- a/crates/source-runtime-next/src/portable_ai/langfuse.rs
+++ b/crates/source-runtime-next/src/portable_ai/langfuse.rs
@@ -1,0 +1,64 @@
+use serde::Deserialize;
+use time::{Duration, OffsetDateTime, format_description::well_known::Rfc3339};
+
+use crate::source_execution::SourceExecutionError;
+
+const MAX_QUERY_BYTES: usize = 16 * 1024;
+const MAX_METRICS: usize = 16;
+
+#[derive(Deserialize)]
+struct MetricsQuery {
+    view: String,
+    dimensions: Vec<Dimension>,
+    metrics: Vec<Metric>,
+    #[serde(rename = "fromTimestamp")]
+    from_timestamp: String,
+    #[serde(rename = "toTimestamp")]
+    to_timestamp: String,
+    #[serde(default)]
+    config: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+struct Dimension {
+    field: String,
+}
+
+#[derive(Deserialize)]
+struct Metric {
+    measure: String,
+    aggregation: String,
+}
+
+pub(super) fn validate_metrics_query(raw: &str) -> Result<(), SourceExecutionError> {
+    if raw.is_empty() || raw.len() > MAX_QUERY_BYTES {
+        return Err(SourceExecutionError::MissingConfiguration);
+    }
+    let query: MetricsQuery =
+        serde_json::from_str(raw).map_err(|_| SourceExecutionError::MissingConfiguration)?;
+    if !matches!(
+        query.view.as_str(),
+        "observations" | "scores-numeric" | "scores-boolean" | "scores-categorical"
+    ) || query.metrics.is_empty()
+        || query.metrics.len() > MAX_METRICS
+        || !query
+            .dimensions
+            .iter()
+            .any(|dimension| dimension.field == "name")
+        || query
+            .metrics
+            .iter()
+            .any(|metric| metric.measure.trim().is_empty() || metric.aggregation.trim().is_empty())
+        || !(query.config.is_null() || query.config.is_object())
+    {
+        return Err(SourceExecutionError::MissingConfiguration);
+    }
+    let from = OffsetDateTime::parse(&query.from_timestamp, &Rfc3339)
+        .map_err(|_| SourceExecutionError::MissingConfiguration)?;
+    let to = OffsetDateTime::parse(&query.to_timestamp, &Rfc3339)
+        .map_err(|_| SourceExecutionError::MissingConfiguration)?;
+    if to <= from || to - from > Duration::days(31) {
+        return Err(SourceExecutionError::MissingConfiguration);
+    }
+    Ok(())
+}

--- a/crates/source-runtime-next/src/portable_ai/normalize.rs
+++ b/crates/source-runtime-next/src/portable_ai/normalize.rs
@@ -1,0 +1,269 @@
+use std::collections::{BTreeMap, HashMap};
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use crate::source_execution::{SourceExecutionError, SourceWorkerRecordV1};
+
+use super::catalog::{Family, Source};
+
+const MAX_RECORDS: usize = 1_000;
+const MAX_DEPTH: usize = 32;
+
+pub(super) fn normalize_records(
+    source: &Source,
+    family: &Family,
+    tenant_id: &str,
+    body: &[u8],
+    observed_at_unix_millis: i64,
+) -> Result<Vec<SourceWorkerRecordV1>, SourceExecutionError> {
+    let document: Value =
+        serde_json::from_slice(body).map_err(|_| SourceExecutionError::MalformedResponse)?;
+    reject_untrusted(&document, 0)?;
+    let selected = select_records(&document, &family.record_selector)?;
+    if selected.len() > MAX_RECORDS {
+        return Err(SourceExecutionError::ResponseTooLarge);
+    }
+    let observed_at =
+        OffsetDateTime::from_unix_timestamp_nanos(i128::from(observed_at_unix_millis) * 1_000_000)
+            .map_err(|_| SourceExecutionError::InvalidExecutionContext)?;
+    selected
+        .into_iter()
+        .map(|raw| normalize_record(source, family, tenant_id, raw, observed_at))
+        .collect()
+}
+
+pub(super) fn expected_event_id(
+    tenant_id: &str,
+    source_id: &str,
+    family_id: &str,
+    provider_id: &str,
+) -> String {
+    let digest = Sha256::digest(format!(
+        "{tenant_id}\0{source_id}\0{family_id}\0{provider_id}"
+    ));
+    format!(
+        "{source_id}-{family_id}-{}",
+        digest[..12]
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>()
+    )
+}
+
+pub(super) fn value_at<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    let path = path
+        .trim()
+        .strip_prefix("$.")
+        .or_else(|| path.trim().strip_prefix('$'))
+        .unwrap_or(path.trim());
+    if path.is_empty() {
+        return Some(value);
+    }
+    path.split('.')
+        .try_fold(value, |current, part| current.as_object()?.get(part))
+}
+
+pub(super) fn scalar_at(value: &Value, paths: &[String]) -> Option<String> {
+    paths
+        .iter()
+        .find_map(|path| value_at(value, path).and_then(scalar))
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty() && value.len() <= 4_096)
+}
+
+fn normalize_record(
+    source: &Source,
+    family: &Family,
+    tenant_id: &str,
+    raw: Value,
+    observed_at: OffsetDateTime,
+) -> Result<SourceWorkerRecordV1, SourceExecutionError> {
+    let values = raw
+        .as_object()
+        .ok_or(SourceExecutionError::InvalidProviderRecord)?;
+    let external_id = scalar_at(&raw, &family.id_paths)
+        .filter(|value| value.len() <= 1_024)
+        .ok_or(SourceExecutionError::MissingStableIdentity)?;
+    let provider_id = family
+        .projection_fields
+        .get("resource_id")
+        .and_then(|paths| scalar_at(&raw, paths))
+        .filter(|value| value.len() <= 1_024)
+        .unwrap_or_else(|| external_id.clone());
+    let occurred_at = observed_timestamp(&raw, values).unwrap_or(observed_at);
+    let occurred_at_unix_millis = i64::try_from(occurred_at.unix_timestamp_nanos() / 1_000_000)
+        .map_err(|_| SourceExecutionError::InvalidProviderRecord)?;
+    let resource_urn = format!(
+        "urn:cerebro:{}:{}:{}",
+        urn_component(tenant_id)?,
+        family.urn_kind,
+        urn_component(&external_id)?
+    );
+    let resource_name = scalar_at(&raw, &family.name_paths).unwrap_or_else(|| provider_id.clone());
+    let mut attributes = BTreeMap::from([
+        ("external_id".to_owned(), external_id),
+        ("family".to_owned(), family.id.clone()),
+        ("provider".to_owned(), source.id.clone()),
+        ("resource_id".to_owned(), provider_id.clone()),
+        ("resource_name".to_owned(), resource_name),
+        ("resource_type".to_owned(), family.id.clone()),
+        ("resource_urn".to_owned(), resource_urn),
+        ("source_event_id".to_owned(), provider_id.clone()),
+        ("source_product".to_owned(), source.id.clone()),
+        ("source_provider".to_owned(), source.id.clone()),
+        ("source_system".to_owned(), source.id.clone()),
+        ("tenant_id".to_owned(), tenant_id.to_owned()),
+    ]);
+    for (attribute, paths) in &family.projection_fields {
+        if matches!(
+            attribute.as_str(),
+            "external_id"
+                | "family"
+                | "provider"
+                | "resource_urn"
+                | "source_event_id"
+                | "source_product"
+                | "source_provider"
+                | "source_system"
+                | "tenant_id"
+        ) {
+            continue;
+        }
+        if let Some(value) = scalar_at(&raw, paths) {
+            attributes.insert(attribute.clone(), value);
+        }
+    }
+    for required in &family.required_attributes {
+        if attributes.get(required).is_none_or(String::is_empty) {
+            return Err(SourceExecutionError::EventContractRejected);
+        }
+    }
+    for required in &family.required_payload_fields {
+        if value_at(&raw, required).is_none_or(Value::is_null) {
+            return Err(SourceExecutionError::EventContractRejected);
+        }
+    }
+    Ok(SourceWorkerRecordV1 {
+        provider_id: provider_id.clone(),
+        event_id: expected_event_id(tenant_id, &source.id, &family.id, &provider_id),
+        occurred_at_unix_millis,
+        attributes: attributes.into_iter().collect::<HashMap<_, _>>(),
+        payload_json: serde_json::to_vec(&raw)
+            .map_err(|_| SourceExecutionError::InternalRuntime)?,
+    })
+}
+
+fn select_records(document: &Value, selector: &str) -> Result<Vec<Value>, SourceExecutionError> {
+    let selector = selector.trim();
+    if selector == "$" {
+        return Ok(vec![document.clone()]);
+    }
+    let wildcard = selector.ends_with("[*]");
+    let path = selector.trim_end_matches("[*]");
+    let selected = value_at(document, path).ok_or(SourceExecutionError::MalformedResponse)?;
+    if wildcard || selected.is_array() {
+        return selected
+            .as_array()
+            .cloned()
+            .ok_or(SourceExecutionError::MalformedResponse);
+    }
+    Ok(vec![selected.clone()])
+}
+
+fn observed_timestamp(raw: &Value, values: &Map<String, Value>) -> Option<OffsetDateTime> {
+    let direct = [
+        "observed_at",
+        "updated_at",
+        "updatedAt",
+        "last_seen_at",
+        "created_at",
+        "createdAt",
+        "timestamp",
+    ]
+    .iter()
+    .find_map(|key| values.get(*key).and_then(scalar));
+    direct
+        .or_else(|| {
+            scalar_at(
+                raw,
+                &[
+                    "$.systemData.lastModifiedAt".to_owned(),
+                    "$.systemData.createdAt".to_owned(),
+                    "$.metadata.updated_at".to_owned(),
+                    "$.metadata.created_at".to_owned(),
+                ],
+            )
+        })
+        .and_then(|value| OffsetDateTime::parse(value.trim(), &Rfc3339).ok())
+}
+
+fn scalar(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) => Some(value.clone()),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn urn_component(value: &str) -> Result<String, SourceExecutionError> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > 1_024 || value.chars().any(char::is_control) {
+        return Err(SourceExecutionError::MissingStableIdentity);
+    }
+    Ok(value
+        .bytes()
+        .flat_map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'-' => {
+                vec![char::from(byte)]
+            }
+            _ => format!("%{byte:02X}").chars().collect(),
+        })
+        .collect())
+}
+
+fn reject_untrusted(value: &Value, depth: usize) -> Result<(), SourceExecutionError> {
+    if depth > MAX_DEPTH {
+        return Err(SourceExecutionError::InvalidProviderRecord);
+    }
+    match value {
+        Value::Object(values) => {
+            for (key, value) in values {
+                let normalized = key
+                    .chars()
+                    .filter(char::is_ascii_alphanumeric)
+                    .flat_map(char::to_lowercase)
+                    .collect::<String>();
+                if matches!(normalized.as_str(), "tenant" | "tenantid") {
+                    return Err(SourceExecutionError::TenantMismatch);
+                }
+                if matches!(
+                    normalized.as_str(),
+                    "authorization"
+                        | "accesstoken"
+                        | "refreshtoken"
+                        | "apikey"
+                        | "clientsecret"
+                        | "password"
+                        | "privatekey"
+                        | "sessioncookie"
+                ) {
+                    return Err(SourceExecutionError::InvalidProviderRecord);
+                }
+                reject_untrusted(value, depth + 1)?;
+            }
+        }
+        Value::Array(values) => {
+            if values.len() > MAX_RECORDS {
+                return Err(SourceExecutionError::ResponseTooLarge);
+            }
+            for value in values {
+                reject_untrusted(value, depth + 1)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}

--- a/crates/source-runtime-next/src/portable_ai/normalize.rs
+++ b/crates/source-runtime-next/src/portable_ai/normalize.rs
@@ -17,6 +17,7 @@ pub(super) fn normalize_records(
     tenant_id: &str,
     body: &[u8],
     observed_at_unix_millis: i64,
+    public_config: &HashMap<String, String>,
 ) -> Result<Vec<SourceWorkerRecordV1>, SourceExecutionError> {
     let document: Value =
         serde_json::from_slice(body).map_err(|_| SourceExecutionError::MalformedResponse)?;
@@ -30,7 +31,7 @@ pub(super) fn normalize_records(
             .map_err(|_| SourceExecutionError::InvalidExecutionContext)?;
     selected
         .into_iter()
-        .map(|raw| normalize_record(source, family, tenant_id, raw, observed_at))
+        .map(|raw| normalize_record(source, family, tenant_id, raw, observed_at, public_config))
         .collect()
 }
 
@@ -79,6 +80,7 @@ fn normalize_record(
     tenant_id: &str,
     raw: Value,
     observed_at: OffsetDateTime,
+    public_config: &HashMap<String, String>,
 ) -> Result<SourceWorkerRecordV1, SourceExecutionError> {
     let values = raw
         .as_object()
@@ -116,19 +118,25 @@ fn normalize_record(
         ("source_system".to_owned(), source.id.clone()),
         ("tenant_id".to_owned(), tenant_id.to_owned()),
     ]);
+    for (attribute, value) in &family.static_attributes {
+        if !protected_attribute(attribute) {
+            attributes.insert(attribute.clone(), value.clone());
+        }
+    }
+    for (attribute, config_key) in &family.config_attributes {
+        if !protected_attribute(attribute) {
+            if let Some(value) = public_config
+                .get(config_key)
+                .map(String::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                attributes.insert(attribute.clone(), value.to_owned());
+            }
+        }
+    }
     for (attribute, paths) in &family.projection_fields {
-        if matches!(
-            attribute.as_str(),
-            "external_id"
-                | "family"
-                | "provider"
-                | "resource_urn"
-                | "source_event_id"
-                | "source_product"
-                | "source_provider"
-                | "source_system"
-                | "tenant_id"
-        ) {
+        if protected_attribute(attribute) {
             continue;
         }
         if let Some(value) = scalar_at(&raw, paths) {
@@ -141,7 +149,11 @@ fn normalize_record(
         }
     }
     for required in &family.required_payload_fields {
-        if value_at(&raw, required).is_none_or(Value::is_null) {
+        if !required
+            .split('|')
+            .map(str::trim)
+            .any(|path| value_at(&raw, path).is_some_and(|value| !value.is_null()))
+        {
             return Err(SourceExecutionError::EventContractRejected);
         }
     }
@@ -153,6 +165,21 @@ fn normalize_record(
         payload_json: serde_json::to_vec(&raw)
             .map_err(|_| SourceExecutionError::InternalRuntime)?,
     })
+}
+
+fn protected_attribute(attribute: &str) -> bool {
+    matches!(
+        attribute,
+        "external_id"
+            | "family"
+            | "provider"
+            | "resource_urn"
+            | "source_event_id"
+            | "source_product"
+            | "source_provider"
+            | "source_system"
+            | "tenant_id"
+    )
 }
 
 fn select_records(document: &Value, selector: &str) -> Result<Vec<Value>, SourceExecutionError> {

--- a/crates/source-runtime-next/src/portable_ai/tests.rs
+++ b/crates/source-runtime-next/src/portable_ai/tests.rs
@@ -1,0 +1,262 @@
+use std::collections::HashMap;
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionDispatcher, SourceExecutionError,
+    SourceExecutionSelectionRequestV1, SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1,
+    SourceWorkerExecutionContextV1, SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1,
+    SourceWorkerRuntimeMetadataV2, SourceWorkerSafeReceiptV1, response_digest,
+};
+
+use super::{
+    PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS, adapter::PortableAiSourceExecutionAdapter,
+    catalog::SOURCES,
+};
+
+const OBSERVED_AT_MILLIS: i64 = 1_780_272_000_000;
+
+fn adapter(source: &str, family: &str) -> &'static PortableAiSourceExecutionAdapter {
+    PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS
+        .iter()
+        .find(|adapter| adapter.source_id() == source && adapter.family_id() == family)
+        .expect("portable AI adapter")
+}
+
+fn context(cursor: &str) -> SourceWorkerExecutionContextV1 {
+    SourceWorkerExecutionContextV1 {
+        tenant_id: "tenant".to_owned(),
+        runtime_id: "portable-ai-runtime".to_owned(),
+        logical_page_id: "source-page-v2:portable-ai-1".to_owned(),
+        prior_cursor: cursor.to_owned(),
+        runtime_generation: 7,
+        lease_generation: 11,
+        observed_at_unix_millis: OBSERVED_AT_MILLIS,
+    }
+}
+
+fn metadata(source: &str, family: &str) -> SourceWorkerRuntimeMetadataV2 {
+    let mut public_config = HashMap::from([("family".to_owned(), family.to_owned())]);
+    match source {
+        "azure_openai" => {
+            public_config.insert("subscription_id".to_owned(), "sub-1".to_owned());
+            public_config.insert("resource_group".to_owned(), "rg-ai".to_owned());
+            public_config.insert("account_name".to_owned(), "acct-openai".to_owned());
+            public_config.insert("location".to_owned(), "westus".to_owned());
+        }
+        "google_vertex_ai" => {
+            public_config.insert("project_id".to_owned(), "project-1".to_owned());
+            public_config.insert("location".to_owned(), "us-central1".to_owned());
+        }
+        "huggingface" => {
+            public_config.insert("organization".to_owned(), "writer".to_owned());
+        }
+        _ => {}
+    }
+    SourceWorkerRuntimeMetadataV2 {
+        public_config,
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    }
+}
+
+fn execution(
+    adapter: &PortableAiSourceExecutionAdapter,
+    context: SourceWorkerExecutionContextV1,
+    metadata: SourceWorkerRuntimeMetadataV2,
+) -> crate::source_execution::SourceWorkerHttpExecutionV2 {
+    adapter
+        .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(adapter.compiled_plan()),
+                context: Some(context),
+            }),
+            metadata: Some(metadata),
+        })
+        .expect("portable AI execution")
+}
+
+#[test]
+fn embedded_catalog_compiles_all_eight_sources_and_thirty_six_families() {
+    assert_eq!(SOURCES.len(), 8);
+    assert_eq!(PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS.len(), 36);
+    for adapter in PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS.iter() {
+        let plan = adapter.compiled_plan();
+        assert_eq!(plan.source_id, adapter.source_id());
+        assert_eq!(plan.family_id, adapter.family_id());
+        assert_eq!(plan.provider_kernel, adapter.provider_kernel());
+        assert!(!plan.required_attributes.is_empty());
+        assert!(!plan.required_payload_fields.is_empty());
+        assert_eq!(
+            SourceExecutionDispatcher
+                .compile_plan(&SourceExecutionSelectionRequestV1 {
+                    source_id: plan.source_id.clone(),
+                    family_id: plan.family_id.clone(),
+                })
+                .expect("dispatcher plan"),
+            plan
+        );
+    }
+}
+
+#[test]
+fn every_family_plans_an_origin_restricted_request_without_credentials() {
+    for adapter in PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS.iter() {
+        let execution = execution(
+            adapter,
+            context(""),
+            metadata(adapter.source_id(), adapter.family_id()),
+        );
+        let request = execution.request.expect("request");
+        let origin = reqwest::Url::parse(&execution.allowed_origin).expect("origin");
+        let url = reqwest::Url::parse(&request.url).expect("request URL");
+        assert_eq!(url.scheme(), "https");
+        assert_eq!(url.host_str(), origin.host_str());
+        assert!(url.username().is_empty());
+        assert!(url.password().is_none());
+        assert!(request.url.find("${config.").is_none());
+        assert!(execution.body.is_empty());
+        assert!(execution.declared_headers.is_empty());
+        assert!(url.query_pairs().all(|(key, _)| !matches!(
+            key.as_ref(),
+            "api_key" | "apikey" | "access_token" | "client_secret" | "token"
+        )));
+        let expected_operation = if adapter.source_id() == "google_gemini" {
+            "google.api_key_header"
+        } else {
+            "source.bearer"
+        };
+        assert_eq!(execution.credential_operation, expected_operation);
+    }
+}
+
+#[test]
+fn provider_specific_public_request_contracts_are_preserved() {
+    let azure = execution(
+        adapter("azure_openai", "deployments"),
+        context(""),
+        metadata("azure_openai", "deployments"),
+    );
+    let azure_url = reqwest::Url::parse(&azure.request.unwrap().url).unwrap();
+    assert_eq!(azure_url.host_str(), Some("management.azure.com"));
+    assert_eq!(
+        azure_url
+            .query_pairs()
+            .find(|(key, _)| key == "api-version")
+            .map(|(_, value)| value.into_owned()),
+        Some("2024-10-01".to_owned())
+    );
+
+    let vertex = execution(
+        adapter("google_vertex_ai", "models"),
+        context(""),
+        metadata("google_vertex_ai", "models"),
+    );
+    assert_eq!(
+        reqwest::Url::parse(&vertex.request.unwrap().url)
+            .unwrap()
+            .host_str(),
+        Some("us-central1-aiplatform.googleapis.com")
+    );
+
+    let huggingface = execution(
+        adapter("huggingface", "repositories"),
+        context(""),
+        metadata("huggingface", "repositories"),
+    );
+    let huggingface_url = reqwest::Url::parse(&huggingface.request.unwrap().url).unwrap();
+    let query = huggingface_url.query_pairs().collect::<HashMap<_, _>>();
+    assert_eq!(
+        query.get("author").map(|value| value.as_ref()),
+        Some("writer")
+    );
+    assert_eq!(query.get("limit").map(|value| value.as_ref()), Some("100"));
+}
+
+#[test]
+fn continuation_urls_cannot_escape_the_provider_origin() {
+    let error = adapter("azure_openai", "deployments")
+        .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(adapter("azure_openai", "deployments").compiled_plan()),
+                context: Some(context("https://attacker.example/next")),
+            }),
+            metadata: Some(metadata("azure_openai", "deployments")),
+        })
+        .unwrap_err();
+    assert_eq!(error, SourceExecutionError::EgressDenied);
+}
+
+#[test]
+fn gemini_decode_emits_tenant_scoped_records_and_a_valid_cursor() {
+    let adapter = adapter("google_gemini", "model_catalog");
+    let plan = adapter.compiled_plan();
+    let context = context("");
+    let metadata = metadata("google_gemini", "model_catalog");
+    let execution = execution(adapter, context.clone(), metadata.clone());
+    let planned = execution.request.as_ref().unwrap();
+    let body = br#"{"models":[{"name":"models/gemini-2.5-pro","displayName":"Gemini 2.5 Pro"}],"nextPageToken":"page-2"}"#;
+    let receipt = SourceWorkerSafeReceiptV1 {
+        plan_digest_sha256: plan.plan_digest_sha256.clone(),
+        logical_page_id: context.logical_page_id.clone(),
+        request_intent_digest: planned.request_intent_digest.clone(),
+        runtime_generation: context.runtime_generation,
+        lease_generation: context.lease_generation,
+        credential_operation: execution.credential_operation.clone(),
+        status_code: 200,
+        response_bytes: body.len() as u64,
+        response_sha256: response_digest(body),
+        tenant_id: context.tenant_id.clone(),
+        runtime_id: context.runtime_id.clone(),
+        observed_at_unix_millis: context.observed_at_unix_millis,
+    };
+    let result = adapter
+        .decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+            request: Some(SourceWorkerDecodeRequestV1 {
+                plan: Some(plan),
+                status_code: 200,
+                response_body: body.to_vec(),
+                logical_page_id: context.logical_page_id.clone(),
+                request_intent_digest: planned.request_intent_digest.clone(),
+                receipt: Some(receipt),
+                context: Some(context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+            response_headers: HashMap::new(),
+            response_headers_sha256: String::new(),
+            execution_intent_digest_sha256: execution.execution_intent_digest_sha256,
+        })
+        .unwrap();
+    assert_eq!(result.next_cursor, "page-2");
+    assert_eq!(result.records.len(), 1);
+    let record = &result.records[0];
+    assert_eq!(record.provider_id, "models/gemini-2.5-pro");
+    assert_eq!(record.attributes["tenant_id"], "tenant");
+    assert_eq!(
+        record.attributes["resource_urn"],
+        "urn:cerebro:tenant:google_gemini_model_catalog:models%2Fgemini-2.5-pro"
+    );
+    adapter
+        .validate_record_identity_v2(&context, record, &metadata)
+        .unwrap();
+}
+
+#[test]
+fn provider_payloads_cannot_supply_tenant_or_credential_material() {
+    let adapter = adapter("google_gemini", "model_catalog");
+    for body in [
+        br#"{"models":[{"name":"model-1","tenant_id":"other"}]}"#.as_slice(),
+        br#"{"models":[{"name":"model-1","apiKey":"secret"}]}"#.as_slice(),
+    ] {
+        let error = super::normalize::normalize_records(
+            adapter.source,
+            adapter.family,
+            "tenant",
+            body,
+            OBSERVED_AT_MILLIS,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            SourceExecutionError::TenantMismatch | SourceExecutionError::InvalidProviderRecord
+        ));
+    }
+}

--- a/crates/source-runtime-next/src/portable_ai/tests.rs
+++ b/crates/source-runtime-next/src/portable_ai/tests.rs
@@ -36,6 +36,10 @@ fn context(cursor: &str) -> SourceWorkerExecutionContextV1 {
 fn metadata(source: &str, family: &str) -> SourceWorkerRuntimeMetadataV2 {
     let mut public_config = HashMap::from([("family".to_owned(), family.to_owned())]);
     match source {
+        "aws_bedrock" => {
+            public_config.insert("region".to_owned(), "us-east-1".to_owned());
+            public_config.insert("service".to_owned(), "bedrock".to_owned());
+        }
         "azure_openai" => {
             public_config.insert("subscription_id".to_owned(), "sub-1".to_owned());
             public_config.insert("resource_group".to_owned(), "rg-ai".to_owned());
@@ -48,6 +52,19 @@ fn metadata(source: &str, family: &str) -> SourceWorkerRuntimeMetadataV2 {
         }
         "huggingface" => {
             public_config.insert("organization".to_owned(), "writer".to_owned());
+        }
+        "langfuse" => {
+            public_config.insert(
+                "base_url".to_owned(),
+                "https://cloud.langfuse.com".to_owned(),
+            );
+            public_config.insert("project_id".to_owned(), "project-1".to_owned());
+            if family == "metric" {
+                public_config.insert(
+                    "metrics_query".to_owned(),
+                    r#"{"view":"observations","dimensions":[{"field":"name"}],"metrics":[{"measure":"count","aggregation":"count"}],"fromTimestamp":"2026-08-01T00:00:00Z","toTimestamp":"2026-08-02T00:00:00Z"}"#.to_owned(),
+                );
+            }
         }
         _ => {}
     }
@@ -75,9 +92,9 @@ fn execution(
 }
 
 #[test]
-fn embedded_catalog_compiles_all_eight_sources_and_thirty_six_families() {
-    assert_eq!(SOURCES.len(), 8);
-    assert_eq!(PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS.len(), 36);
+fn embedded_catalog_compiles_all_ten_sources_and_fifty_one_families() {
+    assert_eq!(SOURCES.len(), 10);
+    assert_eq!(PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS.len(), 51);
     for adapter in PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS.iter() {
         let plan = adapter.compiled_plan();
         assert_eq!(plan.source_id, adapter.source_id());
@@ -119,10 +136,11 @@ fn every_family_plans_an_origin_restricted_request_without_credentials() {
             key.as_ref(),
             "api_key" | "apikey" | "access_token" | "client_secret" | "token"
         )));
-        let expected_operation = if adapter.source_id() == "google_gemini" {
-            "google.api_key_header"
-        } else {
-            "source.bearer"
+        let expected_operation = match adapter.source_id() {
+            "google_gemini" => "google.api_key_header",
+            "langfuse" => "langfuse.basic",
+            "aws_bedrock" => "aws.sigv4",
+            _ => "source.bearer",
         };
         assert_eq!(execution.credential_operation, expected_operation);
     }
@@ -252,6 +270,7 @@ fn provider_payloads_cannot_supply_tenant_or_credential_material() {
             "tenant",
             body,
             OBSERVED_AT_MILLIS,
+            &HashMap::new(),
         )
         .unwrap_err();
         assert!(matches!(
@@ -259,4 +278,116 @@ fn provider_payloads_cannot_supply_tenant_or_credential_material() {
             SourceExecutionError::TenantMismatch | SourceExecutionError::InvalidProviderRecord
         ));
     }
+}
+
+#[test]
+fn aws_bedrock_and_langfuse_preserve_provider_specific_request_contracts() {
+    let aws = execution(
+        adapter("aws_bedrock", "foundation_models"),
+        context(""),
+        metadata("aws_bedrock", "foundation_models"),
+    );
+    assert_eq!(aws.credential_operation, "aws.sigv4");
+    assert_eq!(
+        aws.request.unwrap().url,
+        "https://bedrock.us-east-1.amazonaws.com/foundation-models"
+    );
+
+    let member = execution(
+        adapter("langfuse", "project_member"),
+        context(""),
+        metadata("langfuse", "project_member"),
+    );
+    assert_eq!(member.credential_operation, "langfuse.basic");
+    assert_eq!(
+        member.request.unwrap().url,
+        "https://cloud.langfuse.com/api/public/projects/project-1/members"
+    );
+}
+
+#[test]
+fn langfuse_page_cursor_is_bounded_and_preserves_public_filters() {
+    let adapter = adapter("langfuse", "trace");
+    let runtime_metadata = metadata("langfuse", "trace");
+    let first = execution(adapter, context(""), runtime_metadata.clone());
+    let first_url = reqwest::Url::parse(&first.request.unwrap().url).unwrap();
+    assert_eq!(
+        first_url
+            .query_pairs()
+            .find(|(key, _)| key == "page")
+            .map(|(_, value)| value.into_owned()),
+        Some("1".to_owned())
+    );
+    assert_eq!(
+        adapter
+            .next_cursor(
+                br#"{"meta":{"page":1,"totalPages":2}}"#,
+                &HashMap::new(),
+                "https://cloud.langfuse.com",
+            )
+            .unwrap(),
+        "2"
+    );
+    let second = execution(adapter, context("2"), runtime_metadata);
+    let second_url = reqwest::Url::parse(&second.request.unwrap().url).unwrap();
+    assert_eq!(
+        second_url
+            .query_pairs()
+            .find(|(key, _)| key == "page")
+            .map(|(_, value)| value.into_owned()),
+        Some("2".to_owned())
+    );
+    assert_eq!(
+        adapter
+            .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+                request: Some(SourceWorkerPlanRequestV1 {
+                    plan: Some(adapter.compiled_plan()),
+                    context: Some(context("10000001")),
+                }),
+                metadata: Some(metadata("langfuse", "trace")),
+            })
+            .unwrap_err(),
+        SourceExecutionError::InvalidCursor
+    );
+}
+
+#[test]
+fn langfuse_metric_query_fails_closed_before_request_planning() {
+    let adapter = adapter("langfuse", "metric");
+    let mut metadata = metadata("langfuse", "metric");
+    metadata.public_config.insert(
+        "metrics_query".to_owned(),
+        r#"{"view":"unknown"}"#.to_owned(),
+    );
+    assert_eq!(
+        adapter
+            .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+                request: Some(SourceWorkerPlanRequestV1 {
+                    plan: Some(adapter.compiled_plan()),
+                    context: Some(context("")),
+                }),
+                metadata: Some(metadata),
+            })
+            .unwrap_err(),
+        SourceExecutionError::MissingConfiguration
+    );
+}
+
+#[test]
+fn langfuse_alternative_identity_and_public_project_context_normalize_deterministically() {
+    let adapter = adapter("langfuse", "project_member");
+    let metadata = metadata("langfuse", "project_member");
+    let records = super::normalize::normalize_records(
+        adapter.source,
+        adapter.family,
+        "tenant",
+        br#"{"memberships":[{"email":"operator@example.com","status":"active"}]}"#,
+        OBSERVED_AT_MILLIS,
+        &metadata.public_config,
+    )
+    .unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].provider_id, "operator@example.com");
+    assert_eq!(records[0].attributes["project_id"], "project-1");
+    assert_eq!(records[0].attributes["tenant_id"], "tenant");
 }

--- a/crates/source-runtime-next/src/source_execution/contract.rs
+++ b/crates/source-runtime-next/src/source_execution/contract.rs
@@ -155,6 +155,8 @@ pub fn validate_http_execution(
             execution.credential_operation.as_str(),
             "source.bearer"
                 | "google.api_key_header"
+                | "langfuse.basic"
+                | "aws.sigv4"
                 | "jumpcloud.x_api_key"
                 | "sentinelone.api_token"
                 | "twilio.basic"

--- a/crates/source-runtime-next/src/source_execution/contract.rs
+++ b/crates/source-runtime-next/src/source_execution/contract.rs
@@ -154,6 +154,7 @@ pub fn validate_http_execution(
         || !matches!(
             execution.credential_operation.as_str(),
             "source.bearer"
+                | "google.api_key_header"
                 | "jumpcloud.x_api_key"
                 | "sentinelone.api_token"
                 | "twilio.basic"

--- a/crates/source-runtime-next/src/source_execution/dispatcher.rs
+++ b/crates/source-runtime-next/src/source_execution/dispatcher.rs
@@ -8,6 +8,7 @@ use crate::discord::DISCORD_SOURCE_EXECUTION_ADAPTERS;
 use crate::linode::LINODE_ISSUE_SOURCE_EXECUTION_ADAPTER;
 use crate::openai::OPENAI_SOURCE_EXECUTION_ADAPTERS;
 use crate::pagerduty::PAGERDUTY_SOURCE_EXECUTION_ADAPTERS;
+use crate::portable_ai::PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS;
 use crate::sentinelone::{
     SENTINELONE_APPLICATION_SOURCE_EXECUTION_ADAPTER, SENTINELONE_DIRECT_SOURCE_EXECUTION_ADAPTERS,
     SentinelOneAgentSourceExecutionAdapter,
@@ -152,6 +153,14 @@ impl SourceExecutionDispatcher {
         }) {
             return Ok(adapter.compiled_plan());
         }
+        if let Some(adapter) = PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS
+            .iter()
+            .find(|adapter| {
+                request.source_id == adapter.source_id() && request.family_id == adapter.family_id()
+            })
+        {
+            return Ok(adapter.compiled_plan());
+        }
         if request.source_id == AZURE_AUTHORIZATION_POLICY.source_id()
             && request.family_id == AZURE_AUTHORIZATION_POLICY.family_id()
         {
@@ -257,6 +266,16 @@ impl SourceExecutionDispatcher {
                 && plan.family_id == adapter.family_id()
                 && plan.provider_kernel == adapter.provider_kernel()
         }) {
+            return Ok(adapter);
+        }
+        if let Some(adapter) = PORTABLE_AI_SOURCE_EXECUTION_ADAPTERS
+            .iter()
+            .find(|adapter| {
+                plan.source_id == adapter.source_id()
+                    && plan.family_id == adapter.family_id()
+                    && plan.provider_kernel == adapter.provider_kernel()
+            })
+        {
             return Ok(adapter);
         }
         if plan.source_id == AZURE_AUTHORIZATION_POLICY.source_id()

--- a/internal/connectorcatalog/catalog/ai-governance/azure_openai.yaml
+++ b/internal/connectorcatalog/catalog/ai-governance/azure_openai.yaml
@@ -83,14 +83,14 @@ entries:
           event:
             kind: azure_openai.model_catalog
             required_payload_fields:
-              - name
+              - model
             schema_ref: azure_openai/model_catalog/v1
             urn_kind: azure_openai_model_catalog
           id: model_catalog
-          id_field: name
+          id_field: model.name
           label: Model catalog
           method: GET
-          name_field: name
+          name_field: model.name
           pagination:
             disable_page_size: true
             next_url_json_path: $.nextLink
@@ -98,9 +98,9 @@ entries:
           path: /subscriptions/${config.subscription_id}/providers/Microsoft.CognitiveServices/locations/${config.location}/models
           projection:
             fields:
-              resource_id: name
-              resource_name: name
-              resource_type: resource_type|type|kind
+              resource_id: model.name
+              resource_name: model.name
+              resource_type: model.format|kind|resource_type|type
               resource_urn: resource_urn|urn|metadata.resource_urn
             template: asset
           record_selector: $.value[*]

--- a/internal/connectorcatalog/catalog/ai-governance/langfuse.yaml
+++ b/internal/connectorcatalog/catalog/ai-governance/langfuse.yaml
@@ -42,7 +42,7 @@ entries:
           pagination: {type: none, disable_page_size: true}
           projection: &project_asset
             template: asset
-            fields: {resource_id: "id|projectId|project_id", resource_name: name, resource_type: type}
+            fields: {project_id: "id|projectId|project_id", resource_id: "id|projectId|project_id", resource_name: name, resource_type: type}
             static_fields: {source_product: langfuse}
           coverage:
             - {id: projects, type: entity_family, title: Langfuse projects, families: [project], support: supported, high_value: true, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
@@ -76,7 +76,7 @@ entries:
             config_attributes: {project_id: project_id}
           projection:
             template: secret
-            fields: {secret_id: "id|apiKeyId|publicKey", secret_name: "name|label|note", secret_status: status, secret_type: credential_type}
+            fields: {api_key_id: "id|apiKeyId|publicKey", secret_id: "id|apiKeyId|publicKey", secret_name: "name|label|note", secret_status: status, secret_type: credential_type}
             static_fields: {source_product: langfuse, credential_type: langfuse_project_api_key}
           coverage:
             - {id: project_api_keys, type: app_entitlement, title: Langfuse project API keys, families: [api_key], support: supported, high_value: true, evidence_types: [identity_configuration], control_domains: [identity_access]}
@@ -93,24 +93,24 @@ entries:
             config_query: {fromTimestamp: from_timestamp, toTimestamp: to_timestamp, name: name, userId: user_id, sessionId: session_id, release: release, version: version, tags: tags, filter: filter}
           projection:
             template: audit_event
-            fields: {event_id: "id|traceId", event_type: name, actor_id: "userId|user_id", resource_id: "sessionId|session_id", resource_type: trace, created_at: "timestamp|createdAt|created_at"}
+            fields: {trace_id: "id|traceId", event_id: "id|traceId", event_type: name, actor_id: "userId|user_id", resource_id: "sessionId|session_id", resource_type: trace, created_at: "timestamp|createdAt|created_at"}
             static_fields: {source_product: langfuse}
           coverage:
             - {id: traces, type: audit_event, title: Langfuse traces, families: [trace], support: supported, high_value: true, evidence_types: [logging_configuration], control_domains: [logging_monitoring]}
         - id: observation
           label: Observations
           method: GET
-          path: /api/public/v2/observations
+          path: /api/public/observations
           record_selector: $.data[*]
           id_field: id|observationId
           name_field: name
           event: {kind: langfuse.observation, schema_ref: langfuse/observation/v1, urn_kind: langfuse_observation, required_payload_fields: [id|observationId]}
-          pagination: {type: cursor, cursor_param: cursor, cursor_json_path: $.meta.cursor, page_size_param: limit, page_size: 100}
+          pagination: *langfuse_page
           config:
             config_query: {fromStartTime: from_start_time, toStartTime: to_start_time, traceId: trace_id, userId: user_id, name: name, type: type, fields: fields, filter: filter}
           projection:
             template: audit_event
-            fields: {event_id: "id|observationId", event_type: "type|name", actor_id: "userId|user_id", resource_id: "traceId|trace_id", resource_type: observation, created_at: "startTime|createdAt|created_at"}
+            fields: {observation_id: "id|observationId", event_id: "id|observationId", event_type: "type|name", actor_id: "userId|user_id", resource_id: "traceId|trace_id", resource_type: observation, created_at: "startTime|createdAt|created_at"}
             static_fields: {source_product: langfuse}
           coverage:
             - {id: observations, type: audit_event, title: Langfuse observations, families: [observation], support: supported, high_value: true, evidence_types: [logging_configuration], control_domains: [logging_monitoring]}
@@ -127,7 +127,7 @@ entries:
             config_query: {traceId: trace_id, userId: user_id, name: name, fromTimestamp: from_timestamp, toTimestamp: to_timestamp}
           projection:
             template: audit_event
-            fields: {event_id: "id|scoreId", event_type: "dataType|scoreType|type|name", actor_id: "userId|user_id", resource_id: "observationId|observation_id|traceId|trace_id", resource_type: score, created_at: "createdAt|created_at|timestamp"}
+            fields: {score_id: "id|scoreId", event_id: "id|scoreId", event_type: "dataType|scoreType|type|name", actor_id: "userId|user_id", resource_id: "observationId|observation_id|traceId|trace_id", resource_type: score, created_at: "createdAt|created_at|timestamp"}
             static_fields: {source_product: langfuse}
           coverage:
             - {id: scores, type: audit_event, title: Langfuse scores, families: [score], support: supported, high_value: true, evidence_types: [logging_configuration], control_domains: [logging_monitoring]}
@@ -144,7 +144,7 @@ entries:
             config_query: {name: name, label: label, tag: tag}
           projection:
             template: asset
-            fields: {resource_id: name, resource_name: name, resource_type: type, versions: versions, last_updated_at: lastUpdatedAt, last_config: lastConfig}
+            fields: {prompt_id: name, resource_id: name, resource_name: name, resource_type: type, versions: versions, last_updated_at: lastUpdatedAt, last_config: lastConfig}
             static_fields: {source_product: langfuse}
           coverage:
             - {id: prompts, type: entity_family, title: Langfuse prompts, families: [prompt], support: supported, high_value: true, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
@@ -161,14 +161,14 @@ entries:
             config_query: {fromTimestamp: from_timestamp, toTimestamp: to_timestamp, userId: user_id}
           projection:
             template: asset
-            fields: {resource_id: "id|sessionId", resource_name: name, resource_type: type}
+            fields: {session_id: "id|sessionId", resource_id: "id|sessionId", resource_name: name, resource_type: type}
             static_fields: {source_product: langfuse}
           coverage:
             - {id: sessions, type: entity_family, title: Langfuse sessions, families: [session], support: supported, high_value: true, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
         - id: metric
           label: Metrics
           method: GET
-          path: /api/public/v2/metrics
+          path: /api/public/metrics
           record_selector: $.data[*]
           id_field: name|metric
           name_field: name|metric
@@ -178,7 +178,7 @@ entries:
             config_query: {query: metrics_query}
           projection:
             template: asset
-            fields: {resource_id: "id|name|metric", resource_name: "name|metric", resource_type: "type|metric"}
+            fields: {metric_id: "id|name|metric", resource_id: "id|name|metric", resource_name: "name|metric", resource_type: "type|metric"}
             static_fields: {source_product: langfuse}
           coverage:
             - {id: metrics, type: entity_family, title: Langfuse metrics, families: [metric], support: supported, high_value: true, evidence_types: [source_snapshot], control_domains: [asset_inventory]}
@@ -193,7 +193,7 @@ entries:
           pagination: *langfuse_page
           projection:
             template: asset
-            fields: {resource_id: "id|queueId|name", resource_name: name, resource_type: type}
+            fields: {queue_id: "id|queueId|name", resource_id: "id|queueId|name", resource_name: name, resource_type: type}
             static_fields: {source_product: langfuse}
           coverage:
             - {id: annotation_queues, type: entity_family, title: Langfuse annotation queues, families: [annotation_queue], support: supported, high_value: true, evidence_types: [source_snapshot], control_domains: [asset_inventory]}

--- a/internal/sourceops/source_execution.go
+++ b/internal/sourceops/source_execution.go
@@ -2,6 +2,7 @@ package sourceops
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -45,7 +46,7 @@ func rustSourceFamily(sourceID string, config map[string]string) (string, bool) 
 	// runtime-authoritative provider must keep its existing sourceops path until
 	// its preview credential adapter and product-surface parity are ready.
 	switch sourceID {
-	case "anthropic", "asana", "azure", "azure_openai", "cohere", "deepseek", "digitalocean", "discord", "google_gemini", "google_vertex_ai", "groq", "huggingface", "linode", "mistral", "openai", "pagerduty", "perplexity", "sentinelone", "tailscale":
+	case "anthropic", "asana", "aws_bedrock", "azure", "azure_openai", "cohere", "deepseek", "digitalocean", "discord", "google_gemini", "google_vertex_ai", "groq", "huggingface", "langfuse", "linode", "mistral", "openai", "pagerduty", "perplexity", "sentinelone", "tailscale":
 		return sourceworker.RustAuthoritativeFamily(sourceID, config["family"])
 	case "jumpcloud":
 		family := strings.TrimSpace(config["family"])
@@ -140,6 +141,26 @@ func (s *Service) discoverRustSource(ctx context.Context, sourceID, family strin
 
 func previewCredential(sourceID string, config map[string]string) string {
 	switch strings.TrimSpace(sourceID) {
+	case "aws_bedrock":
+		accessKey := firstNonEmpty(config, "access_key", "access_key_id")
+		secretKey := firstNonEmpty(config, "secret_key", "secret_access_key")
+		if accessKey == "" || secretKey == "" {
+			return ""
+		}
+		return sourceworker.EncodeAWSHostCredential(accessKey, secretKey)
+	case "langfuse":
+		publicKey := strings.TrimSpace(config["public_key"])
+		secretKey := strings.TrimSpace(config["secret_key"])
+		if publicKey == "" || secretKey == "" {
+			return ""
+		}
+		basic := make([]byte, 0, len(publicKey)+1+len(secretKey))
+		basic = append(basic, publicKey...)
+		basic = append(basic, ':')
+		basic = append(basic, secretKey...)
+		encoded := base64.StdEncoding.EncodeToString(basic)
+		clear(basic)
+		return encoded
 	case "azure":
 		if credential := strings.TrimSpace(config["graph_token"]); credential != "" {
 			return credential

--- a/internal/sourceops/source_execution.go
+++ b/internal/sourceops/source_execution.go
@@ -45,7 +45,7 @@ func rustSourceFamily(sourceID string, config map[string]string) (string, bool) 
 	// runtime-authoritative provider must keep its existing sourceops path until
 	// its preview credential adapter and product-surface parity are ready.
 	switch sourceID {
-	case "anthropic", "asana", "azure", "deepseek", "digitalocean", "discord", "linode", "openai", "pagerduty", "sentinelone", "tailscale":
+	case "anthropic", "asana", "azure", "azure_openai", "cohere", "deepseek", "digitalocean", "discord", "google_gemini", "google_vertex_ai", "groq", "huggingface", "linode", "mistral", "openai", "pagerduty", "perplexity", "sentinelone", "tailscale":
 		return sourceworker.RustAuthoritativeFamily(sourceID, config["family"])
 	case "jumpcloud":
 		family := strings.TrimSpace(config["family"])
@@ -166,6 +166,13 @@ func previewCredential(sourceID string, config map[string]string) string {
 		}
 		return ""
 	case "deepseek":
+		for _, key := range []string{"token", "api_token", "api_key", "access_token"} {
+			if credential := strings.TrimSpace(config[key]); credential != "" {
+				return credential
+			}
+		}
+		return ""
+	case "azure_openai", "cohere", "google_gemini", "google_vertex_ai", "groq", "huggingface", "mistral", "perplexity":
 		for _, key := range []string{"token", "api_token", "api_key", "access_token"} {
 			if credential := strings.TrimSpace(config[key]); credential != "" {
 				return credential

--- a/internal/sourceops/source_execution_test.go
+++ b/internal/sourceops/source_execution_test.go
@@ -32,6 +32,15 @@ func TestRustSourceFamilyPreviewAuthorityIsExact(t *testing.T) {
 		"DeepSeek model catalog":      {"deepseek", "model_catalog", "model_catalog", true},
 		"DeepSeek account balances":   {"deepseek", "account_balances", "account_balances", true},
 		"unknown DeepSeek family":     {"deepseek", "future-family", "future-family", true},
+		"Azure OpenAI default":        {"azure_openai", "", "deployments", true},
+		"Cohere default":              {"cohere", "", "model_catalog", true},
+		"Gemini default":              {"google_gemini", "", "model_catalog", true},
+		"Vertex default":              {"google_vertex_ai", "", "models", true},
+		"Groq default":                {"groq", "", "model_catalog", true},
+		"Hugging Face default":        {"huggingface", "", "organization_members", true},
+		"Mistral default":             {"mistral", "", "workspaces", true},
+		"Perplexity default":          {"perplexity", "", "api_groups", true},
+		"unknown portable AI family":  {"mistral", "future-family", "future-family", true},
 		"Asana default":               {"asana", "", "users", true},
 		"Asana users":                 {"asana", "users", "users", true},
 		"Asana projects":              {"asana", "projects", "projects", true},
@@ -721,6 +730,19 @@ func TestDeepSeekPreviewCredentialAliases(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			if got := previewCredential("deepseek", test.config); got != test.want {
 				t.Fatalf("previewCredential() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestPortableAIPreviewCredentialAliasesStayInsideTheTrustedRunner(t *testing.T) {
+	for _, sourceID := range []string{"azure_openai", "cohere", "google_gemini", "google_vertex_ai", "groq", "huggingface", "mistral", "perplexity"} {
+		t.Run(sourceID, func(t *testing.T) {
+			if got := previewCredential(sourceID, map[string]string{"api_key": "api-key", "token": "token"}); got != "token" {
+				t.Fatalf("previewCredential() = %q, want token precedence", got)
+			}
+			if got := previewCredential(sourceID, map[string]string{"api_key": "api-key"}); got != "api-key" {
+				t.Fatalf("previewCredential() = %q, want api-key compatibility", got)
 			}
 		})
 	}

--- a/internal/sourceops/source_execution_test.go
+++ b/internal/sourceops/source_execution_test.go
@@ -40,6 +40,8 @@ func TestRustSourceFamilyPreviewAuthorityIsExact(t *testing.T) {
 		"Hugging Face default":        {"huggingface", "", "organization_members", true},
 		"Mistral default":             {"mistral", "", "workspaces", true},
 		"Perplexity default":          {"perplexity", "", "api_groups", true},
+		"AWS Bedrock default":         {"aws_bedrock", "", "foundation_models", true},
+		"Langfuse default":            {"langfuse", "", "project", true},
 		"unknown portable AI family":  {"mistral", "future-family", "future-family", true},
 		"Asana default":               {"asana", "", "users", true},
 		"Asana users":                 {"asana", "users", "users", true},
@@ -745,6 +747,20 @@ func TestPortableAIPreviewCredentialAliasesStayInsideTheTrustedRunner(t *testing
 				t.Fatalf("previewCredential() = %q, want api-key compatibility", got)
 			}
 		})
+	}
+}
+
+func TestSpecialAIPreviewCredentialsStayInsideTheTrustedRunner(t *testing.T) {
+	aws := previewCredential("aws_bedrock", map[string]string{"access_key": "AKIDEXAMPLE", "secret_key": "synthetic-secret"}) // #nosec G101 -- synthetic fixture.
+	if aws != sourceworker.EncodeAWSHostCredential("AKIDEXAMPLE", "synthetic-secret") {
+		t.Fatal("AWS preview credential was not encoded for the trusted host")
+	}
+	langfuse := previewCredential("langfuse", map[string]string{"public_key": "pk-example", "secret_key": "synthetic-secret"}) // #nosec G101 -- synthetic fixture.
+	if langfuse != "cGstZXhhbXBsZTpzeW50aGV0aWMtc2VjcmV0" {
+		t.Fatal("Langfuse preview credential was not encoded for Basic auth inside the trusted host")
+	}
+	if previewCredential("aws_bedrock", map[string]string{"access_key": "AKIDEXAMPLE"}) != "" || previewCredential("langfuse", map[string]string{"public_key": "pk-example"}) != "" {
+		t.Fatal("incomplete compound credentials must fail closed")
 	}
 }
 

--- a/internal/sourceruntime/sourceworker/host.go
+++ b/internal/sourceruntime/sourceworker/host.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/subtle"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -14,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	awsv4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"google.golang.org/protobuf/proto"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -149,13 +152,25 @@ func (h *Host) get(ctx context.Context, endpoint *url.URL, method, accept string
 	for name, value := range declaredHeaders {
 		req.Header.Set(name, value)
 	}
-	authHeader, authValue, err := credentialHeader(credentialOperation, credential)
-	if err != nil {
-		return nil, nil, 0, err
+	authHeader := ""
+	var authValue []byte
+	if credentialOperation == "aws.sigv4" {
+		if err := signAWSBedrockRequest(ctx, req, credential, h.now().UTC()); err != nil {
+			return nil, nil, 0, err
+		}
+	} else {
+		authHeader, authValue, err = credentialHeader(credentialOperation, credential)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+		req.Header.Set(authHeader, string(authValue))
 	}
-	req.Header.Set(authHeader, string(authValue))
 	response, err := h.client.Do(req)
-	req.Header.Del(authHeader)
+	if authHeader != "" {
+		req.Header.Del(authHeader)
+	}
+	req.Header.Del("Authorization")
+	req.Header.Del("X-Amz-Date")
 	clear(authValue)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -198,6 +213,8 @@ func credentialHeader(operation string, credential []byte) (string, []byte, erro
 		return "Authorization", append([]byte("Bearer "), credential...), nil
 	case "google.api_key_header":
 		return "X-Goog-Api-Key", append([]byte(nil), credential...), nil
+	case "langfuse.basic":
+		return "Authorization", append([]byte("Basic "), credential...), nil
 	case "jumpcloud.x_api_key":
 		return "X-Api-Key", append([]byte(nil), credential...), nil
 	case "sentinelone.api_token":
@@ -211,6 +228,48 @@ func credentialHeader(operation string, credential []byte) (string, []byte, erro
 	default:
 		return "", nil, fmt.Errorf("%w: credential operation is not registered", ErrWorkerContract)
 	}
+}
+
+func signAWSBedrockRequest(ctx context.Context, req *http.Request, credential []byte, now time.Time) error {
+	accessKey, secretKey, err := decodeAWSHostCredential(credential)
+	if err != nil {
+		return err
+	}
+	defer clear(accessKey)
+	defer clear(secretKey)
+	host := strings.ToLower(req.URL.Hostname())
+	parts := strings.Split(host, ".")
+	if len(parts) != 4 || parts[0] != "bedrock" || parts[2] != "amazonaws" || parts[3] != "com" || !safeAWSRegion(parts[1]) {
+		return fmt.Errorf("%w: AWS Bedrock origin is invalid", ErrProviderEgress)
+	}
+	return awsv4.NewSigner().SignHTTP(ctx, awssdk.Credentials{
+		AccessKeyID: string(accessKey), SecretAccessKey: string(secretKey), Source: "cerebro-source-host",
+	}, req, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "bedrock", parts[1], now)
+}
+
+func decodeAWSHostCredential(value []byte) ([]byte, []byte, error) {
+	parts := bytes.SplitN(value, []byte("."), 2)
+	if len(parts) != 2 {
+		return nil, nil, ErrCredentialUnavailable
+	}
+	accessKey, err := base64.RawStdEncoding.DecodeString(string(parts[0]))
+	if err != nil || len(accessKey) == 0 {
+		clear(accessKey)
+		return nil, nil, ErrCredentialUnavailable
+	}
+	secretKey, err := base64.RawStdEncoding.DecodeString(string(parts[1]))
+	if err != nil || len(secretKey) == 0 {
+		clear(accessKey)
+		clear(secretKey)
+		return nil, nil, ErrCredentialUnavailable
+	}
+	return accessKey, secretKey, nil
+}
+
+func safeAWSRegion(value string) bool {
+	return value != "" && len(value) <= 63 && !strings.HasPrefix(value, "-") && !strings.HasSuffix(value, "-") && strings.IndexFunc(value, func(character rune) bool {
+		return (character < 'a' || character > 'z') && (character < '0' || character > '9') && character != '-'
+	}) == -1
 }
 
 func runtimeMetadata(scope CredentialScope) *cerebrov1.SourceWorkerRuntimeMetadataV2 {

--- a/internal/sourceruntime/sourceworker/host.go
+++ b/internal/sourceruntime/sourceworker/host.go
@@ -196,6 +196,8 @@ func credentialHeader(operation string, credential []byte) (string, []byte, erro
 		return "Authorization", append([]byte("Bearer "), credential...), nil
 	case "openai.admin_api_key_bearer":
 		return "Authorization", append([]byte("Bearer "), credential...), nil
+	case "google.api_key_header":
+		return "X-Goog-Api-Key", append([]byte(nil), credential...), nil
 	case "jumpcloud.x_api_key":
 		return "X-Api-Key", append([]byte(nil), credential...), nil
 	case "sentinelone.api_token":

--- a/internal/sourceruntime/sourceworker/host_test.go
+++ b/internal/sourceruntime/sourceworker/host_test.go
@@ -3,6 +3,7 @@ package sourceworker
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -312,6 +313,42 @@ func TestCredentialHeaderAppliesGeminiKeyOnlyInsideTheTrustedHost(t *testing.T) 
 	}
 	if _, _, err := credentialHeader("google.api_key_query", []byte("synthetic-api-key")); !errors.Is(err, ErrWorkerContract) {
 		t.Fatalf("query credential operation error = %v, want ErrWorkerContract", err)
+	}
+}
+
+func TestCredentialHeaderAppliesLangfuseBasicOnlyInsideTheTrustedHost(t *testing.T) {
+	header, value, err := credentialHeader("langfuse.basic", []byte("synthetic-basic-value"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clear(value)
+	if header != "Authorization" || string(value) != "Basic synthetic-basic-value" {
+		t.Fatalf("Langfuse header = %q, value = %q", header, value)
+	}
+}
+
+func TestAWSBedrockSigningStaysInsideTheTrustedHostAndBindsTheOrigin(t *testing.T) {
+	credential := []byte(base64.RawStdEncoding.EncodeToString([]byte("AKIDEXAMPLE")) + "." + base64.RawStdEncoding.EncodeToString([]byte("synthetic-secret"))) // #nosec G101 -- synthetic signer fixture.
+	request, err := http.NewRequest(http.MethodGet, "https://bedrock.us-east-1.amazonaws.com/foundation-models", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := signAWSBedrockRequest(context.Background(), request, credential, time.Date(2026, time.August, 24, 12, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatal(err)
+	}
+	authorization := request.Header.Get("Authorization")
+	if !strings.Contains(authorization, "AWS4-HMAC-SHA256") || !strings.Contains(authorization, "Credential=AKIDEXAMPLE/20260824/us-east-1/bedrock/aws4_request") {
+		t.Fatalf("AWS authorization scope = %q", authorization)
+	}
+	if strings.Contains(request.URL.String(), "AKIDEXAMPLE") || strings.Contains(request.URL.String(), "synthetic-secret") {
+		t.Fatal("AWS credential entered the request URL")
+	}
+	wrongOrigin, _ := http.NewRequest(http.MethodGet, "https://s3.us-east-1.amazonaws.com/", nil)
+	if err := signAWSBedrockRequest(context.Background(), wrongOrigin, credential, time.Now()); !errors.Is(err, ErrProviderEgress) {
+		t.Fatalf("wrong AWS origin error = %v, want ErrProviderEgress", err)
+	}
+	if err := signAWSBedrockRequest(context.Background(), request, []byte("malformed"), time.Now()); !errors.Is(err, ErrCredentialUnavailable) {
+		t.Fatalf("malformed AWS credential error = %v, want ErrCredentialUnavailable", err)
 	}
 }
 

--- a/internal/sourceruntime/sourceworker/host_test.go
+++ b/internal/sourceruntime/sourceworker/host_test.go
@@ -301,6 +301,20 @@ func TestCredentialHeaderAppliesOnlyTheClosedPagerDutyScheme(t *testing.T) {
 	}
 }
 
+func TestCredentialHeaderAppliesGeminiKeyOnlyInsideTheTrustedHost(t *testing.T) {
+	header, value, err := credentialHeader("google.api_key_header", []byte("synthetic-api-key"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clear(value)
+	if header != "X-Goog-Api-Key" || string(value) != "synthetic-api-key" {
+		t.Fatal("Gemini credential operation did not produce the exact provider header")
+	}
+	if _, _, err := credentialHeader("google.api_key_query", []byte("synthetic-api-key")); !errors.Is(err, ErrWorkerContract) {
+		t.Fatalf("query credential operation error = %v, want ErrWorkerContract", err)
+	}
+}
+
 func TestSafeResponseHeadersRedactsAndBounds(t *testing.T) {
 	headers := http.Header{
 		"X-Result-Count": {"2"}, "X-Limit": {"2"}, "X-Search_after": {`{"id":"event-2"}`}, "Retry-After": {"30"},

--- a/internal/sourceruntime/sourceworker/pull.go
+++ b/internal/sourceruntime/sourceworker/pull.go
@@ -83,6 +83,16 @@ func RustAuthoritativeFamily(sourceID, familyID string) (string, bool) {
 			familyID = "api_groups"
 		}
 		return familyID, true
+	case "aws_bedrock":
+		if familyID == "" {
+			familyID = "foundation_models"
+		}
+		return familyID, true
+	case "langfuse":
+		if familyID == "" {
+			familyID = "project"
+		}
+		return familyID, true
 	case "asana":
 		if familyID == "" {
 			familyID = "users"
@@ -146,6 +156,32 @@ func RustAuthoritativeFamily(sourceID, familyID string) (string, bool) {
 // to the Go host; callers must never include the resolved value in worker
 // metadata, receipts, or errors.
 func CredentialBinding(sourceID string, references, resolved map[string]string) (string, string) {
+	if strings.TrimSpace(sourceID) == "aws_bedrock" {
+		accessReference := firstCredentialValue(references, "access_key", "access_key_id")
+		secretReference := firstCredentialValue(references, "secret_key", "secret_access_key")
+		accessKey := firstCredentialValue(resolved, "access_key", "access_key_id")
+		secretKey := firstCredentialValue(resolved, "secret_key", "secret_access_key")
+		if accessReference == "" || secretReference == "" || accessKey == "" || secretKey == "" {
+			return "", ""
+		}
+		return secretReference, EncodeAWSHostCredential(accessKey, secretKey)
+	}
+	if strings.TrimSpace(sourceID) == "langfuse" {
+		publicReference := strings.TrimSpace(references["public_key"])
+		secretReference := strings.TrimSpace(references["secret_key"])
+		publicKey := strings.TrimSpace(resolved["public_key"])
+		secretKey := strings.TrimSpace(resolved["secret_key"])
+		if publicReference == "" || secretReference == "" || publicKey == "" || secretKey == "" {
+			return "", ""
+		}
+		basic := make([]byte, 0, len(publicKey)+1+len(secretKey))
+		basic = append(basic, publicKey...)
+		basic = append(basic, ':')
+		basic = append(basic, secretKey...)
+		encoded := base64.StdEncoding.EncodeToString(basic)
+		clear(basic)
+		return secretReference, encoded
+	}
 	if strings.TrimSpace(sourceID) == "twilio" {
 		username := strings.TrimSpace(resolved["username"])
 		passwordReference := strings.TrimSpace(references["password"])
@@ -259,10 +295,37 @@ func PublicExecutionConfigForSource(sourceID string, values map[string]string) m
 		copyPublicValue(public, values, "organization")
 	case "cohere", "google_gemini", "groq", "mistral", "perplexity":
 		// These catalog-defined families need no public provider selectors.
+	case "aws_bedrock":
+		for _, key := range []string{"region", "service"} {
+			copyPublicValue(public, values, key)
+		}
+	case "langfuse":
+		for _, key := range []string{
+			"project_id", "from_timestamp", "to_timestamp", "from_start_time", "to_start_time",
+			"trace_id", "user_id", "session_id", "name", "type", "release", "version", "tags",
+			"fields", "filter", "label", "tag", "metrics_query",
+		} {
+			copyPublicValue(public, values, key)
+		}
 	default:
 		return public
 	}
 	return public
+}
+
+func firstCredentialValue(values map[string]string, keys ...string) string {
+	for _, key := range keys {
+		if value := strings.TrimSpace(values[key]); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+// EncodeAWSHostCredential binds an AWS access-key pair for one trusted-host
+// redemption. The opaque value must never enter worker metadata or receipts.
+func EncodeAWSHostCredential(accessKey, secretKey string) string {
+	return base64.RawStdEncoding.EncodeToString([]byte(accessKey)) + "." + base64.RawStdEncoding.EncodeToString([]byte(secretKey))
 }
 
 func copyPublicValue(public, values map[string]string, key string) {

--- a/internal/sourceruntime/sourceworker/pull.go
+++ b/internal/sourceruntime/sourceworker/pull.go
@@ -43,6 +43,46 @@ func RustAuthoritativeFamily(sourceID, familyID string) (string, bool) {
 		// Both cataloged DeepSeek families are closed in the Rust dispatcher.
 		// Unknown families fail there instead of restoring the retired Go path.
 		return familyID, true
+	case "azure_openai":
+		if familyID == "" {
+			familyID = "deployments"
+		}
+		return familyID, true
+	case "cohere":
+		if familyID == "" {
+			familyID = "model_catalog"
+		}
+		return familyID, true
+	case "google_gemini":
+		if familyID == "" {
+			familyID = "model_catalog"
+		}
+		return familyID, true
+	case "google_vertex_ai":
+		if familyID == "" {
+			familyID = "models"
+		}
+		return familyID, true
+	case "groq":
+		if familyID == "" {
+			familyID = "model_catalog"
+		}
+		return familyID, true
+	case "huggingface":
+		if familyID == "" {
+			familyID = "organization_members"
+		}
+		return familyID, true
+	case "mistral":
+		if familyID == "" {
+			familyID = "workspaces"
+		}
+		return familyID, true
+	case "perplexity":
+		if familyID == "" {
+			familyID = "api_groups"
+		}
+		return familyID, true
 	case "asana":
 		if familyID == "" {
 			familyID = "users"
@@ -131,6 +171,10 @@ func CredentialBinding(sourceID string, references, resolved map[string]string) 
 	if strings.TrimSpace(sourceID) == "deepseek" {
 		keys = []string{"token", "api_token", "api_key", "access_token"}
 	}
+	switch strings.TrimSpace(sourceID) {
+	case "azure_openai", "cohere", "google_gemini", "google_vertex_ai", "groq", "huggingface", "mistral", "perplexity":
+		keys = []string{"token", "api_token", "api_key", "access_token"}
+	}
 	if strings.TrimSpace(sourceID) == "discord" {
 		keys = []string{"api_token", "api_key", "token"}
 	}
@@ -203,6 +247,18 @@ func PublicExecutionConfigForSource(sourceID string, values map[string]string) m
 			copyPublicValue(public, values, key)
 		}
 		copyPublicAlias(public, values, "api_key_ids", "admin_key_ids")
+	case "azure_openai":
+		for _, key := range []string{"subscription_id", "resource_group", "account_name", "location"} {
+			copyPublicValue(public, values, key)
+		}
+	case "google_vertex_ai":
+		for _, key := range []string{"project_id", "location"} {
+			copyPublicValue(public, values, key)
+		}
+	case "huggingface":
+		copyPublicValue(public, values, "organization")
+	case "cohere", "google_gemini", "groq", "mistral", "perplexity":
+		// These catalog-defined families need no public provider selectors.
 	default:
 		return public
 	}

--- a/internal/sourceruntime/sourceworker/pull_test.go
+++ b/internal/sourceruntime/sourceworker/pull_test.go
@@ -110,6 +110,28 @@ func TestOpenAIPublicExecutionConfigCarriesSelectorsWithoutCredentialMaterial(t 
 	}
 }
 
+func TestPortableAIPublicExecutionConfigCarriesOnlyProviderSelectors(t *testing.T) {
+	azure := PublicExecutionConfigForSource("azure_openai", map[string]string{
+		"family": " deployments ", "subscription_id": " sub-1 ", "resource_group": " rg-ai ",
+		"account_name": " acct-openai ", "location": " westus ", "api_key": "must-not-cross",
+	})
+	if azure["subscription_id"] != "sub-1" || azure["resource_group"] != "rg-ai" || azure["account_name"] != "acct-openai" || azure["location"] != "westus" || azure["api_key"] != "" {
+		t.Fatalf("Azure OpenAI public config = %#v", azure)
+	}
+	vertex := PublicExecutionConfigForSource("google_vertex_ai", map[string]string{
+		"project_id": " project-1 ", "location": " us-central1 ", "token": "must-not-cross",
+	})
+	if vertex["project_id"] != "project-1" || vertex["location"] != "us-central1" || vertex["token"] != "" {
+		t.Fatalf("Vertex public config = %#v", vertex)
+	}
+	huggingface := PublicExecutionConfigForSource("huggingface", map[string]string{
+		"organization": " writer ", "token": "must-not-cross",
+	})
+	if huggingface["organization"] != "writer" || huggingface["token"] != "" {
+		t.Fatalf("Hugging Face public config = %#v", huggingface)
+	}
+}
+
 func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
 	for name, test := range map[string]struct {
 		source, family, wantFamily string
@@ -129,6 +151,15 @@ func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
 		"DeepSeek model catalog":      {"deepseek", " model_catalog ", "model_catalog", true},
 		"DeepSeek account balances":   {"deepseek", "account_balances", "account_balances", true},
 		"unknown DeepSeek family":     {"deepseek", "future-family", "future-family", true},
+		"Azure OpenAI default":        {"azure_openai", "", "deployments", true},
+		"Cohere default":              {"cohere", "", "model_catalog", true},
+		"Gemini default":              {"google_gemini", "", "model_catalog", true},
+		"Vertex default":              {"google_vertex_ai", "", "models", true},
+		"Groq default":                {"groq", "", "model_catalog", true},
+		"Hugging Face default":        {"huggingface", "", "organization_members", true},
+		"Mistral default":             {"mistral", "", "workspaces", true},
+		"Perplexity default":          {"perplexity", "", "api_groups", true},
+		"unknown portable AI family":  {"google_gemini", "future-family", "future-family", true},
 		"Asana default":               {" asana ", "", "users", true},
 		"Asana users":                 {"asana", " users ", "users", true},
 		"Asana projects":              {"asana", "projects", "projects", true},
@@ -228,6 +259,11 @@ func TestCredentialBindingUsesOnlyTheSelectedProviderAliases(t *testing.T) {
 			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.
 			source: "deepseek", references: map[string]string{"api_key": "credential:deepseek:api-key"},
 			resolved: map[string]string{"api_key": "resolved-api-key"}, wantReference: "credential:deepseek:api-key", wantResolved: "resolved-api-key",
+		},
+		"Gemini api key": {
+			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.
+			source: "google_gemini", references: map[string]string{"api_key": "credential:gemini:api-key"},
+			resolved: map[string]string{"api_key": "resolved-api-key"}, wantReference: "credential:gemini:api-key", wantResolved: "resolved-api-key",
 		},
 		"Twilio basic credentials": {
 			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.

--- a/internal/sourceruntime/sourceworker/pull_test.go
+++ b/internal/sourceruntime/sourceworker/pull_test.go
@@ -159,6 +159,8 @@ func TestRustAuthoritativeFamilyIsAnExactClosedAllowlist(t *testing.T) {
 		"Hugging Face default":        {"huggingface", "", "organization_members", true},
 		"Mistral default":             {"mistral", "", "workspaces", true},
 		"Perplexity default":          {"perplexity", "", "api_groups", true},
+		"AWS Bedrock default":         {"aws_bedrock", "", "foundation_models", true},
+		"Langfuse default":            {"langfuse", "", "project", true},
 		"unknown portable AI family":  {"google_gemini", "future-family", "future-family", true},
 		"Asana default":               {" asana ", "", "users", true},
 		"Asana users":                 {"asana", " users ", "users", true},
@@ -264,6 +266,16 @@ func TestCredentialBindingUsesOnlyTheSelectedProviderAliases(t *testing.T) {
 			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.
 			source: "google_gemini", references: map[string]string{"api_key": "credential:gemini:api-key"},
 			resolved: map[string]string{"api_key": "resolved-api-key"}, wantReference: "credential:gemini:api-key", wantResolved: "resolved-api-key",
+		},
+		"AWS Bedrock compound host credential": {
+			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.
+			source: "aws_bedrock", references: map[string]string{"access_key": "credential:aws:access", "secret_key": "credential:aws:secret"},
+			resolved: map[string]string{"access_key": "AKIDEXAMPLE", "secret_key": "synthetic-secret"}, wantReference: "credential:aws:secret", wantResolved: EncodeAWSHostCredential("AKIDEXAMPLE", "synthetic-secret"),
+		},
+		"Langfuse basic host credential": {
+			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.
+			source: "langfuse", references: map[string]string{"public_key": "credential:langfuse:public", "secret_key": "credential:langfuse:secret"},
+			resolved: map[string]string{"public_key": "pk-example", "secret_key": "synthetic-secret"}, wantReference: "credential:langfuse:secret", wantResolved: "cGstZXhhbXBsZTpzeW50aGV0aWMtc2VjcmV0",
 		},
 		"Twilio basic credentials": {
 			// #nosec G101 -- synthetic credential-reference and resolved-value fixtures.

--- a/sources/langfuse/catalog.yaml
+++ b/sources/langfuse/catalog.yaml
@@ -14,6 +14,8 @@ emitted_kinds:
   - langfuse.annotation_queue
 runtime_families:
   - project
+  - project_member
+  - api_key
   - trace
   - observation
   - score


### PR DESCRIPTION
Transfers the remaining catalog-backed AI sources to the credential-free Rust runtime.

Scope:
- Azure OpenAI, Cohere, Google Gemini, Google Vertex AI, Groq, Hugging Face, Mistral, and Perplexity
- AWS Bedrock with SigV4 applied only by the trusted Go host
- Langfuse with Basic auth applied only by the trusted Go host
- 51 catalog-compiled source families with bounded request planning, pagination, deterministic tenant-scoped normalization, event admission, and existing durable page sealing/checkpoint ordering

Security and authority invariants:
- Credential bytes never enter Rust worker metadata, requests, receipts, fixtures, events, or graph attributes
- Provider origins, continuations, page cursors, response sizes, record counts, and metrics queries fail closed
- Go routes each cataloged family to the closed Rust dispatcher without fallback after Rust failure

Local validation on exact head:
- go test ./internal/sourceruntime/sourceworker ./internal/sourceops ./internal/connectorcatalog ./internal/sourcegen
- make check-arch source-fixture-check fixture-oracle-check check-structural check-structural-test
- direct rustfmt on changed Rust modules and git diff --check

DDESK repository preparation timed out after a healthy doctor result, and managed local Cargo blocked before ENOSPC due capacity. Hosted Rust build, test, Clippy, graph-action, codegen, and security jobs are therefore the compile authority before this PR is readied.