### PR TITLE
Add Langfuse runtime catalog fixtures

### DIFF
--- a/sources/langfuse/testdata/discover_api_key.json
+++ b/sources/langfuse/testdata/discover_api_key.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:writer:langfuse_api_key:key_123"
+]

--- a/sources/langfuse/testdata/discover_project_member.json
+++ b/sources/langfuse/testdata/discover_project_member.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:writer:langfuse_project_member:member_123"
+]

--- a/sources/langfuse/testdata/read_api_key.json
+++ b/sources/langfuse/testdata/read_api_key.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "langfuse-writer-40fd2d487aef-api_key-key_123",
+    "tenant_id": "writer",
+    "source_id": "langfuse",
+    "kind": "langfuse.api_key",
+    "occurred_at": "2026-06-24T12:00:00Z",
+    "schema_ref": "langfuse/api_key/v1",
+    "payload": {
+      "createdAt": "2026-06-24T12:00:00Z",
+      "id": "key_123",
+      "project_id": "project_123",
+      "publicKey": "pk-lf-key"
+    },
+    "attributes": {
+      "api_key_id": "key_123",
+      "created_at": "2026-06-24T12:00:00Z",
+      "credential_id": "key_123",
+      "credential_type": "langfuse_project_api_key",
+      "external_id": "key_123",
+      "family": "api_key",
+      "project_id": "project_123",
+      "provider": "langfuse",
+      "public_key": "pk-lf-key",
+      "source_product": "langfuse",
+      "source_provider": "langfuse"
+    }
+  }
+]

--- a/sources/langfuse/testdata/read_project_member.json
+++ b/sources/langfuse/testdata/read_project_member.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "langfuse-writer-96a6417383e6-project_member-member_123",
+    "tenant_id": "writer",
+    "source_id": "langfuse",
+    "kind": "langfuse.project_member",
+    "occurred_at": "2026-06-24T12:00:00Z",
+    "schema_ref": "langfuse/project_member/v1",
+    "payload": {
+      "createdAt": "2026-06-24T12:00:00Z",
+      "email": "owner@example.com",
+      "id": "member_123",
+      "project_id": "project_123",
+      "role": "OWNER",
+      "userId": "user_123"
+    },
+    "attributes": {
+      "created_at": "2026-06-24T12:00:00Z",
+      "email": "owner@example.com",
+      "external_id": "member_123",
+      "family": "project_member",
+      "principal_id": "user_123",
+      "principal_type": "user",
+      "project_id": "project_123",
+      "provider": "langfuse",
+      "role": "OWNER",
+      "source_product": "langfuse",
+      "source_provider": "langfuse",
+      "user_id": "user_123"
+    }
+  }
+]


### PR DESCRIPTION
## Summary

- add deterministic runtime fixtures for the Langfuse `api_key` family
- add deterministic runtime fixtures for the Langfuse `project_member` family
- satisfy the catalog contract for every declared Langfuse runtime family

## Validation

- `make catalog-check`
- `go test ./sources/langfuse -count=1`
- `git diff --check`

The fixtures were generated through the existing Langfuse source adapters from their provider-shaped access-family test responses. No credentials or secret values are included.