### PR TITLE
Add deterministic Langfuse runtime fixtures

### DIFF
--- a/sources/langfuse/source_test.go
+++ b/sources/langfuse/source_test.go
@@ -341,14 +341,15 @@ func TestReadProjectAPIKeysUsesBasicAuthAndProjectScope(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 	source.inner.AllowLoopbackBaseURL = true
-	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test-only placeholder secret.
+	cfg := sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test-only placeholder secret.
 		"base_url":   server.URL,
 		"family":     "api_key",
 		"project_id": "project_123",
 		"public_key": "pk-lf",
 		"secret_key": "test-secret",
 		"tenant_id":  "writer",
-	}), nil)
+	})
+	pull, err := source.Read(context.Background(), cfg, nil)
 	if err != nil {
 		t.Fatalf("Read() error = %v", err)
 	}
@@ -369,6 +370,7 @@ func TestReadProjectAPIKeysUsesBasicAuthAndProjectScope(t *testing.T) {
 			t.Fatalf("%s = %q, want %q", key, got, want)
 		}
 	}
+	compareSyntheticProviderOutputs(t, source, cfg, "api_key", pull)
 }
 
 func TestReadProjectMemberEmitsStaticPrincipalType(t *testing.T) {
@@ -396,14 +398,15 @@ func TestReadProjectMemberEmitsStaticPrincipalType(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 	source.inner.AllowLoopbackBaseURL = true
-	pull, err := source.Read(context.Background(), sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test-only placeholder secret.
+	cfg := sourcecdk.NewConfig(map[string]string{ // #nosec G101 -- test-only placeholder secret.
 		"base_url":   server.URL,
 		"family":     "project_member",
 		"project_id": "project_123",
 		"public_key": "pk-lf",
 		"secret_key": "test-secret",
 		"tenant_id":  "writer",
-	}), nil)
+	})
+	pull, err := source.Read(context.Background(), cfg, nil)
 	if err != nil {
 		t.Fatalf("Read() error = %v", err)
 	}
@@ -416,6 +419,26 @@ func TestReadProjectMemberEmitsStaticPrincipalType(t *testing.T) {
 	}
 	if got := event.Attributes["principal_type"]; got != "user" {
 		t.Fatalf("principal_type = %q, want user", got)
+	}
+	compareSyntheticProviderOutputs(t, source, cfg, "project_member", pull)
+}
+
+func compareSyntheticProviderOutputs(t *testing.T, source *Source, cfg sourcecdk.Config, family string, pull sourcecdk.Pull) {
+	t.Helper()
+	stableFixture := sourcefixture.Bundle{Manifest: sourcefixture.Manifest{
+		SourceID: "langfuse",
+		Family:   family,
+		Response: sourcefixture.Response{CapturedAt: "2026-06-24T12:00:00Z"},
+	}}
+	if err := sourcefixture.StabilizeEvents(stableFixture, pull.Events, false); err != nil {
+		t.Fatalf("StabilizeEvents(%s) error = %v", family, err)
+	}
+	urns, err := source.Discover(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Discover(%s) error = %v", family, err)
+	}
+	if err := sourcefixture.CompareOrUpdateSourceOutputs(".", family, pull.Events, urns, strings.TrimSpace(os.Getenv("CEREBRO_UPDATE_SOURCE_FIXTURES")) == "1"); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/sources/langfuse/testdata/discover_api_key.json
+++ b/sources/langfuse/testdata/discover_api_key.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:writer:langfuse_api_key:key_123"
+]

--- a/sources/langfuse/testdata/discover_project_member.json
+++ b/sources/langfuse/testdata/discover_project_member.json
@@ -1,0 +1,3 @@
+[
+  "urn:cerebro:writer:langfuse_project_member:member_123"
+]

--- a/sources/langfuse/testdata/read_api_key.json
+++ b/sources/langfuse/testdata/read_api_key.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "langfuse-writer-api_key-1470bfd40fd536f4",
+    "tenant_id": "writer",
+    "source_id": "langfuse",
+    "kind": "langfuse.api_key",
+    "occurred_at": "2026-06-24T12:00:00Z",
+    "schema_ref": "langfuse/api_key/v1",
+    "payload": {
+      "createdAt": "2026-06-24T12:00:00Z",
+      "id": "key_123",
+      "project_id": "project_123",
+      "publicKey": "pk-lf-key"
+    },
+    "attributes": {
+      "api_key_id": "key_123",
+      "created_at": "2026-06-24T12:00:00Z",
+      "credential_id": "key_123",
+      "credential_type": "langfuse_project_api_key",
+      "external_id": "key_123",
+      "family": "api_key",
+      "project_id": "project_123",
+      "provider": "langfuse",
+      "public_key": "pk-lf-key",
+      "source_product": "langfuse",
+      "source_provider": "langfuse"
+    }
+  }
+]

--- a/sources/langfuse/testdata/read_project_member.json
+++ b/sources/langfuse/testdata/read_project_member.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "langfuse-writer-project_member-0f1c99c3c0a90909",
+    "tenant_id": "writer",
+    "source_id": "langfuse",
+    "kind": "langfuse.project_member",
+    "occurred_at": "2026-06-24T12:00:00Z",
+    "schema_ref": "langfuse/project_member/v1",
+    "payload": {
+      "createdAt": "2026-06-24T12:00:00Z",
+      "email": "owner@example.com",
+      "id": "member_123",
+      "project_id": "project_123",
+      "role": "OWNER",
+      "userId": "user_123"
+    },
+    "attributes": {
+      "created_at": "2026-06-24T12:00:00Z",
+      "email": "owner@example.com",
+      "external_id": "member_123",
+      "family": "project_member",
+      "principal_id": "user_123",
+      "principal_type": "user",
+      "project_id": "project_123",
+      "provider": "langfuse",
+      "role": "OWNER",
+      "source_product": "langfuse",
+      "source_provider": "langfuse",
+      "user_id": "user_123"
+    }
+  }
+]


### PR DESCRIPTION
## What changed

- add deterministic discover/read fixtures for Langfuse `api_key` and `project_member`
- derive the checked-in fixtures from the existing scoped provider-response tests
- stabilize event identities so loopback ports cannot change fixture output

## Why

Current `main` `7e93eb293046fbf5d8962e6da9356972ef436137` fails `make catalog-check` because PR #2597 registered both runtime families without their required source fixtures. Fresh receipts:

- main CI run `32802029844`, `catalog-source-catalog` job `97664956658`
- PR #2592 merge-tree CI run `32802041074`, job `97664792891`

Both report the same four missing files. This PR does not touch #2592 or Google Workspace. The pre-existing remote branch `codex/langfuse-runtime-fixtures` remains untouched; it has no pull request and contains only generated files with loopback-dependent event IDs.

## Local validation

- `go test ./sources/langfuse -count=1`
- `go test ./tools/catalogcheck -count=1`
- `go test ./internal/connectorcatalog -count=1`
- `make catalog-check`
- `git diff --check`

All pass on macOS. The managed Cargo wrapper blocked the Rust-side focused test and Clippy before compilation because safe capacity is short by 33,545,345,638 bytes; no Rust test failed. Hosted checks are the Rust validation authority for this fixture-only repair.

No reviewer was assigned.