### PR TITLE
Serve cached GRC reads while data refreshes

### DIFF
--- a/apps/web/src/app/api/cerebro/[...path]/route.test.ts
+++ b/apps/web/src/app/api/cerebro/[...path]/route.test.ts
@@ -20,6 +20,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
   vi.unstubAllGlobals();
+  vi.useRealTimers();
 });
 
 describe("Cerebro proxy route", () => {
@@ -66,6 +67,48 @@ describe("Cerebro proxy route", () => {
     expect(firstResponse.headers.get("x-cerebro-web-trace-id")).toMatch(/^[0-9a-f]{32}$/);
     expect(secondResponse.headers.get("x-cerebro-web-trace-id")).toMatch(/^[0-9a-f]{32}$/);
     await expect(secondResponse.json()).resolves.toMatchObject({ error: "Unable to reach Cerebro API" });
+  });
+
+  it("serves stale GRC data immediately while one background refresh runs", async () => {
+    delete process.env.CEREBRO_WEB_FIXTURE_MODE;
+    vi.useFakeTimers();
+    const refreshed = Promise.withResolvers<Response>();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ version: 1 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }))
+      .mockImplementationOnce(() => refreshed.promise);
+    vi.stubGlobal("fetch", fetchMock);
+    const context = { params: Promise.resolve({ path: ["grc", "dashboard"] }) };
+    const requestURL = "http://localhost/api/cerebro/grc/dashboard?stale_while_refresh=test";
+
+    const first = await GET(new NextRequest(requestURL), context);
+    expect(await first.json()).toEqual({ version: 1 });
+    await vi.advanceTimersByTimeAsync(61_000);
+
+    const second = await GET(new NextRequest(requestURL), context);
+    expect(second.headers.get("x-cerebro-cache")).toBe("stale");
+    expect(await second.json()).toEqual({ version: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const third = await GET(new NextRequest(requestURL), context);
+    expect(third.headers.get("x-cerebro-cache")).toBe("stale");
+    expect(await third.json()).toEqual({ version: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    refreshed.resolve(new Response(JSON.stringify({ version: 2 }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }));
+    let fourth: Response | undefined;
+    await vi.waitFor(async () => {
+      fourth = await GET(new NextRequest(requestURL), context);
+      expect(fourth.headers.get("x-cerebro-cache")).toBe("hit");
+    });
+    if (!fourth) throw new Error("refreshed response was not observed");
+    expect(fourth.headers.get("x-cerebro-cache")).toBe("hit");
+    expect(await fourth.json()).toEqual({ version: 2 });
   });
 
   it("relays signed Rust-authority reads without deriving or stamping identity", async () => {

--- a/apps/web/src/app/api/cerebro/[...path]/route.ts
+++ b/apps/web/src/app/api/cerebro/[...path]/route.ts
@@ -105,6 +105,19 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
   const inflight = cacheKey ? readCerebroProxyInflight(cacheKey) : null;
   if (inflight) {
+    const stale = cacheKey ? readCerebroProxyCache(cacheKey, true) : null;
+    if (stale) {
+      span.increment("proxy.cache.stale.count");
+      span.end("completed", {
+        cache_state: "stale",
+        "http.response.status_code": stale.status,
+        ...responseSpanAttributes(stale.status, stale.headers, stale.body),
+      });
+      return new NextResponse(stale.body, {
+        status: stale.status,
+        headers: responseHeadersWithTrace(cachedResponseHeaders(stale, "stale"), span),
+      });
+    }
     let payload: ProxyResponsePayload;
     try {
       payload = await inflight;
@@ -123,19 +136,19 @@ export async function GET(request: NextRequest, context: RouteContext) {
     });
   }
 
-  const load = async (): Promise<ProxyResponsePayload> => {
+  const load = async (background = false): Promise<ProxyResponsePayload> => {
     let response: Response;
     try {
       response = await fetchCerebro(target, {
         method: "GET",
         headers: upstreamHeaders,
         cache: "no-store",
-        signal: request.signal,
+        signal: background ? undefined : request.signal,
       });
     } catch (error) {
       const stale = cacheKey ? readCerebroProxyCache(cacheKey, true) : null;
       if (stale) {
-        span.increment("proxy.cache.stale.count");
+        if (!background) span.increment("proxy.cache.stale.count");
         return {
           body: stale.body,
           headers: cachedResponseHeaders(stale, "stale"),
@@ -149,7 +162,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     if (cacheKey && [502, 503, 504].includes(response.status)) {
       const stale = readCerebroProxyCache(cacheKey, true);
       if (stale) {
-        span.increment("proxy.cache.stale.count");
+        if (!background) span.increment("proxy.cache.stale.count");
         return {
           body: stale.body,
           headers: cachedResponseHeaders(stale, "stale"),
@@ -166,7 +179,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     }
     if (cacheKey) {
       writeCerebroProxyCache(cacheKey, response, body, headers);
-      span.increment("proxy.cache.write.count");
+      if (!background) span.increment("proxy.cache.write.count");
     }
     return {
       body,
@@ -175,6 +188,21 @@ export async function GET(request: NextRequest, context: RouteContext) {
       status: response.status,
     };
   };
+
+  const stale = cacheKey ? readCerebroProxyCache(cacheKey, true) : null;
+  if (cacheKey && stale) {
+    void trackCerebroProxyInflight(cacheKey, load(true)).catch(() => undefined);
+    span.increment("proxy.cache.stale.count");
+    span.end("completed", {
+      cache_state: "stale",
+      "http.response.status_code": stale.status,
+      ...responseSpanAttributes(stale.status, stale.headers, stale.body),
+    });
+    return new NextResponse(stale.body, {
+      status: stale.status,
+      headers: responseHeadersWithTrace(cachedResponseHeaders(stale, "stale"), span),
+    });
+  }
 
   let payload: Awaited<ReturnType<typeof load>>;
   try {

--- a/internal/bootstrap/grc_cache.go
+++ b/internal/bootstrap/grc_cache.go
@@ -50,9 +50,9 @@ func (g *queryCacheRefreshGroup) Do(key string, fn func() (*capturedHTTPResponse
 	return response, nil
 }
 
-func (g *queryCacheRefreshGroup) Start(key string, fn func()) {
+func (g *queryCacheRefreshGroup) Start(ctx context.Context, key string, fn func(context.Context)) {
 	_ = g.group.DoChan(key, func() (any, error) {
-		fn()
+		fn(ctx)
 		return nil, nil
 	})
 }
@@ -109,9 +109,10 @@ func (a *App) cacheGRCJSON(policy grcCachePolicy, next http.HandlerFunc) http.Ha
 }
 
 func (a *App) refreshGRCJSONInBackground(key string, policy grcCachePolicy, next http.HandlerFunc, r *http.Request) {
-	request := r.Clone(context.WithoutCancel(r.Context()))
-	a.queryCacheGroup.Start(key, func() {
-		ctx, cancel := context.WithTimeout(request.Context(), grcCacheRefreshTimeout)
+	refreshContext := context.WithoutCancel(r.Context())
+	request := r.Clone(refreshContext)
+	a.queryCacheGroup.Start(refreshContext, key, func(parent context.Context) {
+		ctx, cancel := context.WithTimeout(parent, grcCacheRefreshTimeout)
 		defer cancel()
 		response := captureCacheResponse(next, request.Clone(ctx))
 		if response == nil || !response.cacheableJSON() {

--- a/internal/bootstrap/grc_cache.go
+++ b/internal/bootstrap/grc_cache.go
@@ -28,6 +28,7 @@ const (
 	grcCacheScopeRuntime   = "runtime"
 	grcCacheScopeGraph     = "graph"
 	grcCacheScopeInventory = "inventory"
+	grcCacheRefreshTimeout = 30 * time.Second
 )
 
 type queryCacheRefreshGroup struct {
@@ -47,6 +48,13 @@ func (g *queryCacheRefreshGroup) Do(key string, fn func() (*capturedHTTPResponse
 	}
 	response, _ := value.(*capturedHTTPResponse)
 	return response, nil
+}
+
+func (g *queryCacheRefreshGroup) Start(key string, fn func()) {
+	_ = g.group.DoChan(key, func() (any, error) {
+		fn()
+		return nil, nil
+	})
 }
 
 type grcCachePolicy struct {
@@ -73,19 +81,8 @@ func (a *App) cacheGRCJSON(policy grcCachePolicy, next http.HandlerFunc) http.Ha
 				writeCachedJSON(w, http.StatusOK, entry.Payload, "hit", policy)
 				return
 			case querycache.StateStale:
-				response, refreshErr := a.queryCacheGroup.Do(key, func() (*capturedHTTPResponse, error) {
-					return captureCacheResponse(next, r), nil
-				})
-				if refreshErr == nil && response.cacheableJSON() {
-					setErr := cache.Set(r.Context(), key, response.body.Bytes(), policy.TTL, policy.StaleTTL)
-					response.writeTo(w, queryCacheWriteState(r.Context(), setErr), policy)
-					return
-				}
-				if refreshErr != nil || response == nil || response.statusCode >= http.StatusInternalServerError {
-					writeCachedJSON(w, http.StatusOK, entry.Payload, "stale", policy)
-					return
-				}
-				response.writeTo(w, "bypass", policy)
+				writeCachedJSON(w, http.StatusOK, entry.Payload, "stale", policy)
+				a.refreshGRCJSONInBackground(key, policy, next, r)
 				return
 			}
 		} else if !errors.Is(err, querycache.ErrMiss) {
@@ -109,6 +106,24 @@ func (a *App) cacheGRCJSON(policy grcCachePolicy, next http.HandlerFunc) http.Ha
 		}
 		response.writeTo(w, "bypass", policy)
 	}
+}
+
+func (a *App) refreshGRCJSONInBackground(key string, policy grcCachePolicy, next http.HandlerFunc, r *http.Request) {
+	a.queryCacheGroup.Start(key, func() {
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), grcCacheRefreshTimeout)
+		defer cancel()
+		response := captureCacheResponse(next, r.Clone(ctx))
+		if response == nil || !response.cacheableJSON() {
+			telemetry.IncrementMain(ctx, "query_cache.refresh_error.count", 1)
+			return
+		}
+		if err := a.deps.QueryCache.Set(ctx, key, response.body.Bytes(), policy.TTL, policy.StaleTTL); err != nil {
+			_ = queryCacheWriteState(ctx, err)
+			telemetry.IncrementMain(ctx, "query_cache.refresh_error.count", 1)
+			return
+		}
+		telemetry.IncrementMain(ctx, "query_cache.refresh.count", 1)
+	})
 }
 
 func queryCacheWriteState(ctx context.Context, err error) string {
@@ -353,7 +368,7 @@ func setGRCQueryCacheHeaders(header http.Header, cacheState string, policy grcCa
 			if stale < 1 {
 				stale = 1
 			}
-			value += ", stale-if-error=" + strconv.Itoa(stale)
+			value += ", stale-while-revalidate=" + strconv.Itoa(stale) + ", stale-if-error=" + strconv.Itoa(stale)
 		}
 		header.Set("Cache-Control", value)
 	}

--- a/internal/bootstrap/grc_cache.go
+++ b/internal/bootstrap/grc_cache.go
@@ -109,10 +109,11 @@ func (a *App) cacheGRCJSON(policy grcCachePolicy, next http.HandlerFunc) http.Ha
 }
 
 func (a *App) refreshGRCJSONInBackground(key string, policy grcCachePolicy, next http.HandlerFunc, r *http.Request) {
+	request := r.Clone(context.WithoutCancel(r.Context()))
 	a.queryCacheGroup.Start(key, func() {
-		ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), grcCacheRefreshTimeout)
+		ctx, cancel := context.WithTimeout(request.Context(), grcCacheRefreshTimeout)
 		defer cancel()
-		response := captureCacheResponse(next, r.Clone(ctx))
+		response := captureCacheResponse(next, request.Clone(ctx))
 		if response == nil || !response.cacheableJSON() {
 			telemetry.IncrementMain(ctx, "query_cache.refresh_error.count", 1)
 			return

--- a/internal/bootstrap/grc_cache_test.go
+++ b/internal/bootstrap/grc_cache_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -42,6 +43,9 @@ func TestGRCQueryCacheServesFreshHit(t *testing.T) {
 	}
 	if first.Body.String() != second.Body.String() {
 		t.Fatalf("cached body = %q, want %q", second.Body.String(), first.Body.String())
+	}
+	if got := second.Header().Get("Cache-Control"); !strings.Contains(got, "stale-while-revalidate=60") {
+		t.Fatalf("Cache-Control = %q, want stale-while-revalidate=60", got)
 	}
 }
 
@@ -281,27 +285,43 @@ func TestGRCQueryCacheReportsOversizedResponseWithoutClientCacheHeaders(t *testi
 	}
 }
 
-func TestGRCQueryCacheServesStaleOnRefreshError(t *testing.T) {
+func TestGRCQueryCacheServesStaleWithoutWaitingForRefresh(t *testing.T) {
+	cache := querycache.NewMemory(querycache.Options{Namespace: "test"})
 	app := &App{
 		cfg:  config.Config{Cache: config.CacheConfig{DefaultTTL: time.Millisecond, StaleTTL: time.Minute}},
-		deps: Dependencies{QueryCache: querycache.NewMemory(querycache.Options{Namespace: "test"})},
+		deps: Dependencies{QueryCache: cache},
 	}
-	calls := 0
+	var calls atomic.Int32
+	refreshStarted := make(chan struct{})
+	releaseRefresh := make(chan struct{})
 	handler := app.cacheGRCJSON(app.grcCachePolicy("test", time.Millisecond), func(w http.ResponseWriter, _ *http.Request) {
-		calls++
-		if calls > 1 {
-			http.Error(w, "backend failed", http.StatusInternalServerError)
-			return
+		call := calls.Add(1)
+		if call > 1 {
+			close(refreshStarted)
+			<-releaseRefresh
 		}
-		writeJSON(w, http.StatusOK, map[string]any{"calls": calls})
+		writeJSON(w, http.StatusOK, map[string]any{"calls": call})
 	})
 
+	request := func() *http.Request {
+		return httptest.NewRequest(http.MethodGet, "/grc/dashboard?tenant_id=writer", nil)
+	}
 	first := httptest.NewRecorder()
-	handler(first, httptest.NewRequest(http.MethodGet, "/grc/dashboard?tenant_id=writer", nil))
+	handler(first, request())
 	time.Sleep(5 * time.Millisecond)
 
-	second := httptest.NewRecorder()
-	handler(second, httptest.NewRequest(http.MethodGet, "/grc/dashboard?tenant_id=writer", nil))
+	served := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		second := httptest.NewRecorder()
+		handler(second, request())
+		served <- second
+	}()
+	var second *httptest.ResponseRecorder
+	select {
+	case second = <-served:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("stale response waited for backend refresh")
+	}
 	if second.Header().Get("X-Cerebro-Cache") != "stale" {
 		t.Fatalf("second X-Cerebro-Cache = %q, want stale", second.Header().Get("X-Cerebro-Cache"))
 	}
@@ -311,4 +331,64 @@ func TestGRCQueryCacheServesStaleOnRefreshError(t *testing.T) {
 	if first.Body.String() != second.Body.String() {
 		t.Fatalf("stale body = %q, want %q", second.Body.String(), first.Body.String())
 	}
+	select {
+	case <-refreshStarted:
+	case <-time.After(time.Second):
+		t.Fatal("background refresh did not start")
+	}
+	close(releaseRefresh)
+
+	key := app.grcCacheKey(request(), app.grcCachePolicy("test", time.Millisecond))
+	deadline := time.Now().Add(time.Second)
+	for {
+		entry, err := cache.Get(t.Context(), key)
+		if err == nil && strings.Contains(string(entry.Payload), `"calls":2`) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("background refresh did not replace cached payload: calls=%d err=%v", calls.Load(), err)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestGRCQueryCacheCoalescesBackgroundRefreshes(t *testing.T) {
+	app := &App{
+		cfg:  config.Config{Cache: config.CacheConfig{DefaultTTL: time.Millisecond, StaleTTL: time.Minute}},
+		deps: Dependencies{QueryCache: querycache.NewMemory(querycache.Options{Namespace: "test"})},
+	}
+	var calls atomic.Int32
+	refreshStarted := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	handler := app.cacheGRCJSON(app.grcCachePolicy("test", time.Millisecond), func(w http.ResponseWriter, _ *http.Request) {
+		call := calls.Add(1)
+		if call > 1 {
+			close(refreshStarted)
+			<-releaseRefresh
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"calls": call})
+	})
+
+	request := func() *http.Request {
+		return httptest.NewRequest(http.MethodGet, "/grc/dashboard?tenant_id=writer", nil)
+	}
+	handler(httptest.NewRecorder(), request())
+	time.Sleep(5 * time.Millisecond)
+
+	for range 20 {
+		response := httptest.NewRecorder()
+		handler(response, request())
+		if got := response.Header().Get("X-Cerebro-Cache"); got != "stale" {
+			t.Fatalf("X-Cerebro-Cache = %q, want stale", got)
+		}
+	}
+	select {
+	case <-refreshStarted:
+	case <-time.After(time.Second):
+		t.Fatal("background refresh did not start")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("handler calls = %d, want one initial load and one coalesced refresh", got)
+	}
+	close(releaseRefresh)
 }


### PR DESCRIPTION
## Problem

Expired GRC cache entries currently block the request on a full backend refresh. The Compliance overview can therefore wait for the dashboard query even when a valid stale response is available.

## Change

- return valid stale GRC JSON immediately from the Go query cache and refresh it under a 30-second detached context
- coalesce concurrent Go refreshes by cache key
- return valid stale responses immediately from the Next proxy while one upstream refresh runs
- keep background refreshes independent from the completed browser request signal
- advertise the stale-while-revalidate cache policy and record refresh success/error telemetry

## Validation

DDESK readiness passed, but repository attachment timed out after 300 seconds while preparing Git state (`exit 124`). No DDESK test is claimed. The narrow change was validated in the disclosed Mac recovery environment and by hosted exact-head checks.

- `go test -race ./internal/bootstrap -run 'TestGRCQueryCache' -count=1`
- `go test ./internal/bootstrap -count=1`
- `make lint-bootstrap`
- `make lint-shard LINT_PACKAGES='./internal/...' LINT_SHARD_TOTAL=4 LINT_SHARD_INDEX=1` (`0 issues`)
- `make check-structural check-structural-test check-arch`
- `npm run check --workspace @writer/cerebro-web` (107 files, 653 tests)
- `npm run build --workspace @writer/cerebro-web`
- hosted `lint-internal-1` job `97672237558` on exact head `ec79ae9189e44f858d5ce67720c8b6462f4f0d77`

The focused tests keep the refresh unresolved, verify stale requests return before it completes, verify 20 stale requests produce one refresh, then verify the refreshed payload becomes the next cache hit.
