### PR TITLE
Add Amplitude source execution adapters

### DIFF
--- a/crates/source-runtime-next/src/amplitude.rs
+++ b/crates/source-runtime-next/src/amplitude.rs
@@ -5,6 +5,18 @@
 //! without owning credentials, egress policy, deployment routes, or tenant
 //! authorization.
 
+// Shared dispatcher registration lands separately so this provider-local slice
+// does not collide with another branch that owns the closed registry.
+#[allow(dead_code)]
+#[path = "amplitude/source_execution.rs"]
+mod source_execution;
+#[cfg(test)]
+#[path = "amplitude/source_execution_tests.rs"]
+mod source_execution_tests;
+
+#[allow(unused_imports)]
+pub(crate) use source_execution::AMPLITUDE_SOURCE_EXECUTION_ADAPTERS;
+
 use std::{collections::BTreeMap, error::Error, fmt, net::IpAddr, str::FromStr};
 
 use reqwest::Url;

--- a/crates/source-runtime-next/src/amplitude/source_execution.rs
+++ b/crates/source-runtime-next/src/amplitude/source_execution.rs
@@ -1,0 +1,422 @@
+//! Amplitude SCIM bridge for the closed source-execution protocol.
+//!
+//! The adapters receive authenticated tenant context, public SCIM selectors,
+//! and bounded provider response bytes. The trusted host retains credential
+//! redemption, Bearer authentication, origin-constrained network I/O, durable
+//! append, projection, and checkpoint ownership.
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceExecutionPlanV1,
+    SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1,
+    SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2, SourceWorkerHttpRequestV1,
+    SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1, SourceWorkerRecordV1,
+    SourceWorkerRuntimeMetadataV2, canonical_http_execution_digest, canonical_plan_digest,
+    canonical_request_intent_digest, canonical_result_digest, tenant_scoped_event_id,
+    validate_and_deduplicate_records, validate_execution_context, validate_runtime_metadata,
+};
+
+use super::{AmplitudeError, AmplitudeFamily, AmplitudeKernel};
+
+const SOURCE_ID: &str = "amplitude";
+const DEFAULT_BASE_URL: &str = "https://core.amplitude.com";
+const METHOD: &str = "GET";
+const RECORD_SELECTOR: &str = "$.Resources[*]";
+const ID_FIELD: &str = "id";
+const MAX_RESPONSE_BYTES: u64 = 8 << 20;
+
+/// Credential-free adapter for one Amplitude SCIM family.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AmplitudeSourceExecutionAdapter {
+    family: AmplitudeFamily,
+}
+
+/// Provider-local adapter set. Shared dispatcher registration and authority
+/// promotion are intentionally separate delivery steps.
+pub(crate) static AMPLITUDE_SOURCE_EXECUTION_ADAPTERS: [AmplitudeSourceExecutionAdapter; 2] = [
+    AmplitudeSourceExecutionAdapter::new(AmplitudeFamily::Users),
+    AmplitudeSourceExecutionAdapter::new(AmplitudeFamily::Groups),
+];
+
+impl AmplitudeSourceExecutionAdapter {
+    const fn new(family: AmplitudeFamily) -> Self {
+        Self { family }
+    }
+
+    pub(crate) fn compiled_plan(&self) -> SourceExecutionPlanV1 {
+        let family_id = self.family.as_str();
+        let mut plan = SourceExecutionPlanV1 {
+            plan_id: format!("source-plan-v1:{SOURCE_ID}:{family_id}"),
+            source_id: SOURCE_ID.to_owned(),
+            family_id: family_id.to_owned(),
+            provider_kernel: self.family.provider_kind().to_owned(),
+            method: METHOD.to_owned(),
+            origin: DEFAULT_BASE_URL.to_owned(),
+            path: family_path(self.family).to_owned(),
+            record_selector: RECORD_SELECTOR.to_owned(),
+            id_field: ID_FIELD.to_owned(),
+            singleton_fallback_id: String::new(),
+            max_response_bytes: MAX_RESPONSE_BYTES,
+            event_kind: self.family.provider_kind().to_owned(),
+            schema_ref: schema_ref(self.family).to_owned(),
+            required_attributes: required_attributes(self.family)
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
+            required_payload_fields: vec!["id".to_owned()],
+            plan_digest_sha256: String::new(),
+        };
+        plan.plan_digest_sha256 = canonical_plan_digest(&plan);
+        plan
+    }
+
+    fn validate_plan(&self, plan: &SourceExecutionPlanV1) -> Result<(), SourceExecutionError> {
+        if plan != &self.compiled_plan() {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        Ok(())
+    }
+
+    fn kernel(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(AmplitudeKernel, String), SourceExecutionError> {
+        validate_execution_context(context)?;
+        validate_runtime_metadata(metadata)?;
+        if public_value(&metadata.public_config, "family")
+            .is_some_and(|value| value != self.family.as_str())
+        {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        let base_url =
+            public_value(&metadata.public_config, "base_url").unwrap_or(DEFAULT_BASE_URL);
+        let page_size = public_value(&metadata.public_config, "per_page")
+            .map(|value| {
+                value
+                    .parse::<usize>()
+                    .map_err(|_| SourceExecutionError::MissingConfiguration)
+            })
+            .transpose()?;
+        let kernel = AmplitudeKernel::new(base_url, self.family, page_size).map_err(map_error)?;
+        let allowed_origin = kernel
+            .plan(None)
+            .map_err(map_error)?
+            .url()
+            .origin()
+            .ascii_serialization();
+        Ok((kernel, allowed_origin))
+    }
+}
+
+impl SourceExecutionAdapter for AmplitudeSourceExecutionAdapter {
+    fn source_id(&self) -> &'static str {
+        SOURCE_ID
+    }
+
+    fn family_id(&self) -> &'static str {
+        self.family.as_str()
+    }
+
+    fn provider_kernel(&self) -> &'static str {
+        self.family.provider_kind()
+    }
+
+    fn validate_record_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+    ) -> Result<(), SourceExecutionError> {
+        let expected_event_id = tenant_scoped_event_id(
+            SOURCE_ID,
+            self.family.as_str(),
+            &context.tenant_id,
+            &record.provider_id,
+        )?;
+        if record.event_id != expected_event_id
+            || record.attributes.get("tenant_id") != Some(&context.tenant_id)
+            || record.attributes.get("source_event_id") != Some(&record.provider_id)
+            || record.attributes.get("family").map(String::as_str) != Some(self.family.as_str())
+        {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        match self.family {
+            AmplitudeFamily::Users => {
+                if record
+                    .attributes
+                    .get("user_id")
+                    .is_none_or(|value| value.trim().is_empty())
+                {
+                    return Err(SourceExecutionError::EventContractRejected);
+                }
+            }
+            AmplitudeFamily::Groups => {
+                if record.attributes.get("group_id") != Some(&record.provider_id)
+                    || record
+                        .attributes
+                        .get("group_name")
+                        .is_none_or(|value| value.trim().is_empty())
+                {
+                    return Err(SourceExecutionError::EventContractRejected);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn plan(
+        &self,
+        _request: &SourceWorkerPlanRequestV1,
+    ) -> Result<SourceWorkerHttpRequestV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn plan_v2(
+        &self,
+        envelope: &SourceWorkerPlanEnvelopeV2,
+    ) -> Result<SourceWorkerHttpExecutionV2, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, allowed_origin) = self.kernel(context, metadata)?;
+        let provider_request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        if provider_request.url().path() != plan.path
+            || provider_request.authorization_scheme() != "Bearer"
+            || !provider_request.url().username().is_empty()
+            || provider_request.url().password().is_some()
+        {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        let mut planned = SourceWorkerHttpRequestV1 {
+            plan_id: plan.plan_id.clone(),
+            method: METHOD.to_owned(),
+            url: provider_request.url().to_string(),
+            accept: provider_request.accept().to_owned(),
+            max_response_bytes: MAX_RESPONSE_BYTES,
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            request_intent_digest: String::new(),
+        };
+        planned.request_intent_digest = canonical_request_intent_digest(plan, context, &planned);
+        let mut execution = SourceWorkerHttpExecutionV2 {
+            request: Some(planned),
+            body: Vec::new(),
+            declared_headers: HashMap::new(),
+            execution_intent_digest_sha256: String::new(),
+            credential_operation: "source.bearer".to_owned(),
+            allowed_origin,
+        };
+        execution.execution_intent_digest_sha256 =
+            canonical_http_execution_digest(plan, context, metadata, &execution);
+        Ok(execution)
+    }
+
+    fn decode(
+        &self,
+        _request: &SourceWorkerDecodeRequestV1,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn decode_v2(
+        &self,
+        envelope: &SourceWorkerDecodeEnvelopeV2,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let receipt = request
+            .receipt
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, _) = self.kernel(context, metadata)?;
+        let provider_request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        let page = match request.status_code {
+            200 => kernel
+                .decode(&provider_request, &request.response_body)
+                .map_err(map_error)?,
+            401 => return Err(SourceExecutionError::AuthenticationRejected),
+            403 => return Err(SourceExecutionError::RequiredProviderScopeMissing),
+            429 => return Err(SourceExecutionError::ProviderRateLimit),
+            _ => return Err(SourceExecutionError::UnexpectedProviderStatus),
+        };
+        let next_cursor = page.next_cursor.unwrap_or_default();
+        let records = page
+            .records
+            .into_iter()
+            .map(|record| {
+                if record.family != self.family.as_str()
+                    || record.provider_kind != plan.event_kind
+                    || record.provider_id.trim().is_empty()
+                {
+                    return Err(SourceExecutionError::InvalidProviderRecord);
+                }
+                let provider_id = record.provider_id;
+                let mut attributes = record.fields.into_iter().collect::<HashMap<_, _>>();
+                attributes.insert("tenant_id".to_owned(), context.tenant_id.clone());
+                attributes.insert("source_event_id".to_owned(), provider_id.clone());
+                attributes.insert("external_id".to_owned(), provider_id.clone());
+                attributes.insert("family".to_owned(), self.family.as_str().to_owned());
+                attributes.insert("provider".to_owned(), SOURCE_ID.to_owned());
+                attributes.insert("source_provider".to_owned(), SOURCE_ID.to_owned());
+                attributes.insert("source_system".to_owned(), SOURCE_ID.to_owned());
+                let event_id = tenant_scoped_event_id(
+                    SOURCE_ID,
+                    self.family.as_str(),
+                    &context.tenant_id,
+                    &provider_id,
+                )?;
+                Ok(SourceWorkerRecordV1 {
+                    provider_id,
+                    event_id,
+                    occurred_at_unix_millis: context.observed_at_unix_millis,
+                    attributes,
+                    payload_json: serde_json::to_vec(&sanitize_payload(record.payload))
+                        .map_err(|_| SourceExecutionError::InternalRuntime)?,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let records = validate_and_deduplicate_records(records)?;
+        for record in &records {
+            self.validate_record_identity(context, record)?;
+        }
+        let result_digest_sha256 = canonical_result_digest(receipt, &next_cursor, &records)?;
+        Ok(SourceWorkerDecodeResultV1 {
+            plan_id: plan.plan_id.clone(),
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: request.request_intent_digest.clone(),
+            records,
+            next_cursor,
+            result_digest_sha256,
+            tenant_id: context.tenant_id.clone(),
+            runtime_id: context.runtime_id.clone(),
+            runtime_generation: context.runtime_generation,
+            lease_generation: context.lease_generation,
+            observed_at_unix_millis: context.observed_at_unix_millis,
+        })
+    }
+}
+
+const fn family_path(family: AmplitudeFamily) -> &'static str {
+    match family {
+        AmplitudeFamily::Users => "/scim/1/Users",
+        AmplitudeFamily::Groups => "/scim/1/Groups",
+    }
+}
+
+const fn schema_ref(family: AmplitudeFamily) -> &'static str {
+    match family {
+        AmplitudeFamily::Users => "amplitude/users/v1",
+        AmplitudeFamily::Groups => "amplitude/groups/v1",
+    }
+}
+
+const fn required_attributes(family: AmplitudeFamily) -> &'static [&'static str] {
+    match family {
+        AmplitudeFamily::Users => &["tenant_id", "source_event_id", "user_id"],
+        AmplitudeFamily::Groups => &["tenant_id", "source_event_id", "group_id", "group_name"],
+    }
+}
+
+fn public_value<'a>(config: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    config
+        .get(key)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn optional(value: &str) -> Option<&str> {
+    (!value.is_empty()).then_some(value)
+}
+
+fn sanitize_payload(value: Value) -> Value {
+    match value {
+        Value::Object(object) => Value::Object(
+            object
+                .into_iter()
+                .filter(|(key, _)| !restricted_payload_field(key))
+                .map(|(key, value)| (key, sanitize_payload(value)))
+                .collect(),
+        ),
+        Value::Array(values) => Value::Array(values.into_iter().map(sanitize_payload).collect()),
+        other => other,
+    }
+}
+
+fn restricted_payload_field(key: &str) -> bool {
+    let normalized = key
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect::<String>();
+    matches!(
+        normalized.as_str(),
+        "token"
+            | "accesstoken"
+            | "refreshtoken"
+            | "sessiontoken"
+            | "apikey"
+            | "apitoken"
+            | "authorization"
+            | "cookie"
+            | "setcookie"
+            | "password"
+            | "passcode"
+            | "secret"
+            | "clientsecret"
+            | "privatekey"
+            | "tenant"
+            | "tenantid"
+            | "runtimeid"
+            | "sourceruntimeid"
+    )
+}
+
+fn map_error(error: AmplitudeError) -> SourceExecutionError {
+    match error {
+        AmplitudeError::InvalidBaseUrl | AmplitudeError::InvalidPageSize => {
+            SourceExecutionError::MissingConfiguration
+        }
+        AmplitudeError::InvalidFamily => SourceExecutionError::UnknownAdapter,
+        AmplitudeError::InvalidCursor => SourceExecutionError::InvalidCursor,
+        AmplitudeError::InvalidResponse => SourceExecutionError::MalformedResponse,
+        AmplitudeError::MissingIdentity => SourceExecutionError::MissingStableIdentity,
+        AmplitudeError::RequestScopeMismatch => SourceExecutionError::InvalidPlan,
+    }
+}

--- a/crates/source-runtime-next/src/amplitude/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/amplitude/source_execution_tests.rs
@@ -1,0 +1,325 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceExecutionLifecycleEnvelopeV2,
+    SourceExecutionLifecycleRequestV1, SourceExecutionPlanV1, SourceWorkerDecodeEnvelopeV2,
+    SourceWorkerDecodeRequestV1, SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2,
+    SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1, SourceWorkerRuntimeMetadataV2,
+    SourceWorkerSafeReceiptV1, response_digest, seal_page_program_v2, tenant_scoped_event_id,
+};
+
+use super::source_execution::{
+    AMPLITUDE_SOURCE_EXECUTION_ADAPTERS, AmplitudeSourceExecutionAdapter,
+};
+
+const OBSERVED_AT_MILLIS: i64 = 1_780_272_000_000;
+const USERS_FIXTURE: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../sources/amplitude/testdata/read_users.json"
+));
+const GROUPS_FIXTURE: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../sources/amplitude/testdata/read_groups.json"
+));
+
+fn adapter(family: &str) -> &'static AmplitudeSourceExecutionAdapter {
+    AMPLITUDE_SOURCE_EXECUTION_ADAPTERS
+        .iter()
+        .find(|adapter| adapter.family_id() == family)
+        .unwrap()
+}
+
+fn context(cursor: &str, page: u32) -> SourceWorkerExecutionContextV1 {
+    SourceWorkerExecutionContextV1 {
+        tenant_id: "tenant-1".to_owned(),
+        runtime_id: "amplitude-runtime".to_owned(),
+        logical_page_id: format!("source-page-v2:amplitude-{page}"),
+        prior_cursor: cursor.to_owned(),
+        runtime_generation: 7,
+        lease_generation: 11,
+        observed_at_unix_millis: OBSERVED_AT_MILLIS,
+    }
+}
+
+fn metadata(family: &str) -> SourceWorkerRuntimeMetadataV2 {
+    SourceWorkerRuntimeMetadataV2 {
+        public_config: HashMap::from([
+            ("family".to_owned(), family.to_owned()),
+            ("per_page".to_owned(), "100".to_owned()),
+        ]),
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    }
+}
+
+fn plan_page(
+    adapter: &AmplitudeSourceExecutionAdapter,
+    plan: &SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    metadata: &SourceWorkerRuntimeMetadataV2,
+) -> SourceWorkerHttpExecutionV2 {
+    adapter
+        .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+        })
+        .unwrap()
+}
+
+fn receipt(
+    plan: &SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    execution: &SourceWorkerHttpExecutionV2,
+    status_code: u32,
+    body: &[u8],
+) -> SourceWorkerSafeReceiptV1 {
+    let request = execution.request.as_ref().unwrap();
+    SourceWorkerSafeReceiptV1 {
+        plan_digest_sha256: plan.plan_digest_sha256.clone(),
+        logical_page_id: context.logical_page_id.clone(),
+        request_intent_digest: request.request_intent_digest.clone(),
+        runtime_generation: context.runtime_generation,
+        lease_generation: context.lease_generation,
+        credential_operation: execution.credential_operation.clone(),
+        status_code,
+        response_bytes: body.len() as u64,
+        response_sha256: response_digest(body),
+        tenant_id: context.tenant_id.clone(),
+        runtime_id: context.runtime_id.clone(),
+        observed_at_unix_millis: context.observed_at_unix_millis,
+    }
+}
+
+fn decode_page(
+    adapter: &AmplitudeSourceExecutionAdapter,
+    plan: &SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    metadata: &SourceWorkerRuntimeMetadataV2,
+    execution: &SourceWorkerHttpExecutionV2,
+    status_code: u32,
+    body: &[u8],
+) -> Result<crate::source_execution::SourceWorkerDecodeResultV1, SourceExecutionError> {
+    let safe_receipt = receipt(plan, context, execution, status_code, body);
+    adapter.decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+        request: Some(SourceWorkerDecodeRequestV1 {
+            plan: Some(plan.clone()),
+            status_code,
+            response_body: body.to_vec(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: execution
+                .request
+                .as_ref()
+                .unwrap()
+                .request_intent_digest
+                .clone(),
+            receipt: Some(safe_receipt),
+            context: Some(context.clone()),
+        }),
+        metadata: Some(metadata.clone()),
+        response_headers: HashMap::new(),
+        response_headers_sha256: String::new(),
+        execution_intent_digest_sha256: execution.execution_intent_digest_sha256.clone(),
+    })
+}
+
+#[test]
+fn amplitude_plans_both_scim_families_without_credentials() {
+    for (family, path, kind, schema) in [
+        (
+            "users",
+            "/scim/1/Users",
+            "amplitude.users",
+            "amplitude/users/v1",
+        ),
+        (
+            "groups",
+            "/scim/1/Groups",
+            "amplitude.groups",
+            "amplitude/groups/v1",
+        ),
+    ] {
+        let adapter = adapter(family);
+        let plan = adapter.compiled_plan();
+        assert_eq!(plan.plan_id, format!("source-plan-v1:amplitude:{family}"));
+        assert_eq!(plan.source_id, "amplitude");
+        assert_eq!(plan.family_id, family);
+        assert_eq!(plan.provider_kernel, kind);
+        assert_eq!(plan.origin, "https://core.amplitude.com");
+        assert_eq!(plan.path, path);
+        assert_eq!(plan.record_selector, "$.Resources[*]");
+        assert_eq!(plan.id_field, "id");
+        assert_eq!(plan.event_kind, kind);
+        assert_eq!(plan.schema_ref, schema);
+
+        let context = context("101", 2);
+        let metadata = metadata(family);
+        let execution = plan_page(adapter, &plan, &context, &metadata);
+        assert_eq!(execution.credential_operation, "source.bearer");
+        assert_eq!(execution.allowed_origin, "https://core.amplitude.com");
+        assert!(execution.body.is_empty());
+        assert!(execution.declared_headers.is_empty());
+        let request = execution.request.unwrap();
+        assert_eq!(request.method, "GET");
+        assert_eq!(
+            request.url,
+            format!("https://core.amplitude.com{path}?startIndex=101&itemsPerPage=100")
+        );
+        assert!(!request.url.to_ascii_lowercase().contains("authorization"));
+        assert!(!request.url.to_ascii_lowercase().contains("bearer"));
+        assert!(!request.url.to_ascii_lowercase().contains("token"));
+    }
+}
+
+#[test]
+fn amplitude_decodes_fixtures_with_tenant_scoped_identity_and_seals() {
+    for (family, body, provider_id) in [
+        ("users", USERS_FIXTURE, "datamonster@example.com"),
+        ("groups", GROUPS_FIXTURE, "632"),
+    ] {
+        let adapter = adapter(family);
+        let plan = adapter.compiled_plan();
+        let context = context("", 1);
+        let metadata = metadata(family);
+        let execution = plan_page(adapter, &plan, &context, &metadata);
+        let safe_receipt = receipt(&plan, &context, &execution, 200, body);
+        let result =
+            decode_page(adapter, &plan, &context, &metadata, &execution, 200, body).unwrap();
+        assert!(result.next_cursor.is_empty());
+        assert_eq!(result.records.len(), 1);
+        let record = &result.records[0];
+        assert_eq!(record.provider_id, provider_id);
+        assert_eq!(
+            record.event_id,
+            tenant_scoped_event_id("amplitude", family, "tenant-1", provider_id).unwrap()
+        );
+        assert_eq!(record.attributes["tenant_id"], "tenant-1");
+        assert_eq!(record.attributes["source_event_id"], provider_id);
+        assert_eq!(record.attributes["family"], family);
+        let payload: Value = serde_json::from_slice(&record.payload_json).unwrap();
+        assert_eq!(payload["id"], provider_id);
+        adapter.validate_record_identity(&context, record).unwrap();
+
+        let decision = seal_page_program_v2(&SourceExecutionLifecycleEnvelopeV2 {
+            request: Some(SourceExecutionLifecycleRequestV1 {
+                plan: Some(plan),
+                context: Some(context),
+                receipt: Some(safe_receipt),
+                result: Some(result),
+                current_lease_generation: 11,
+            }),
+            metadata: Some(metadata),
+        })
+        .unwrap();
+        assert_eq!(decision.admitted_records.len(), 1);
+        assert!(decision.checkpoint_cursor.is_empty());
+    }
+}
+
+#[test]
+fn amplitude_pagination_and_typed_provider_failures_fail_closed() {
+    let adapter = adapter("users");
+    let plan = adapter.compiled_plan();
+    let context = context("", 1);
+    let metadata = metadata("users");
+    let execution = plan_page(adapter, &plan, &context, &metadata);
+    let mut page: Value = serde_json::from_slice(USERS_FIXTURE).unwrap();
+    page["totalResults"] = Value::from(200);
+    let body = serde_json::to_vec(&page).unwrap();
+    let result = decode_page(adapter, &plan, &context, &metadata, &execution, 200, &body).unwrap();
+    assert_eq!(result.next_cursor, "101");
+
+    for (status, expected) in [
+        (401, SourceExecutionError::AuthenticationRejected),
+        (403, SourceExecutionError::RequiredProviderScopeMissing),
+        (429, SourceExecutionError::ProviderRateLimit),
+        (503, SourceExecutionError::UnexpectedProviderStatus),
+    ] {
+        assert_eq!(
+            decode_page(
+                adapter, &plan, &context, &metadata, &execution, status, b"{}",
+            ),
+            Err(expected)
+        );
+    }
+
+    let bad_context = context("0", 2);
+    assert_eq!(
+        adapter.plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(bad_context),
+            }),
+            metadata: Some(metadata.clone()),
+        }),
+        Err(SourceExecutionError::InvalidCursor)
+    );
+
+    let mut wrong_family = metadata;
+    wrong_family
+        .public_config
+        .insert("family".to_owned(), "groups".to_owned());
+    assert_eq!(
+        adapter.plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan),
+                context: Some(context),
+            }),
+            metadata: Some(wrong_family),
+        }),
+        Err(SourceExecutionError::MissingConfiguration)
+    );
+}
+
+#[test]
+fn amplitude_rejects_duplicate_conflicts_and_scrubs_untrusted_scope_and_credentials() {
+    let adapter = adapter("users");
+    let plan = adapter.compiled_plan();
+    let context = context("", 1);
+    let metadata = metadata("users");
+    let execution = plan_page(adapter, &plan, &context, &metadata);
+    let mut page: Value = serde_json::from_slice(USERS_FIXTURE).unwrap();
+    let resource = page["Resources"][0].as_object_mut().unwrap();
+    resource.insert("tenant_id".to_owned(), Value::from("foreign-tenant"));
+    resource.insert(
+        "access_token".to_owned(),
+        Value::from("credential-material"),
+    );
+    resource.insert(
+        "nested".to_owned(),
+        serde_json::json!({"client_secret": "credential-material"}),
+    );
+    let body = serde_json::to_vec(&page).unwrap();
+    let result = decode_page(adapter, &plan, &context, &metadata, &execution, 200, &body).unwrap();
+    let record = &result.records[0];
+    assert_eq!(record.attributes["tenant_id"], "tenant-1");
+    let payload: Value = serde_json::from_slice(&record.payload_json).unwrap();
+    assert!(payload.get("tenant_id").is_none());
+    assert!(payload.get("access_token").is_none());
+    assert!(payload["nested"].get("client_secret").is_none());
+    assert!(!String::from_utf8_lossy(&record.payload_json).contains("credential-material"));
+
+    let first = page["Resources"][0].clone();
+    let mut duplicate = first.clone();
+    duplicate["displayName"] = Value::from("Conflicting display name");
+    page["Resources"] = Value::Array(vec![first, duplicate]);
+    page["itemsPerPage"] = Value::from(2);
+    page["totalResults"] = Value::from(2);
+    let conflicting_body = serde_json::to_vec(&page).unwrap();
+    assert_eq!(
+        decode_page(
+            adapter,
+            &plan,
+            &context,
+            &metadata,
+            &execution,
+            200,
+            &conflicting_body,
+        ),
+        Err(SourceExecutionError::DuplicateConflict)
+    );
+}

--- a/crates/source-runtime-next/src/amplitude/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/amplitude/source_execution_tests.rs
@@ -224,13 +224,22 @@ fn amplitude_decodes_fixtures_with_tenant_scoped_identity_and_seals() {
 fn amplitude_pagination_and_typed_provider_failures_fail_closed() {
     let adapter = adapter("users");
     let plan = adapter.compiled_plan();
-    let context = context("", 1);
+    let execution_context = context("", 1);
     let metadata = metadata("users");
-    let execution = plan_page(adapter, &plan, &context, &metadata);
+    let execution = plan_page(adapter, &plan, &execution_context, &metadata);
     let mut page: Value = serde_json::from_slice(USERS_FIXTURE).unwrap();
     page["totalResults"] = Value::from(200);
     let body = serde_json::to_vec(&page).unwrap();
-    let result = decode_page(adapter, &plan, &context, &metadata, &execution, 200, &body).unwrap();
+    let result = decode_page(
+        adapter,
+        &plan,
+        &execution_context,
+        &metadata,
+        &execution,
+        200,
+        &body,
+    )
+    .unwrap();
     assert_eq!(result.next_cursor, "101");
 
     for (status, expected) in [
@@ -241,7 +250,13 @@ fn amplitude_pagination_and_typed_provider_failures_fail_closed() {
     ] {
         assert_eq!(
             decode_page(
-                adapter, &plan, &context, &metadata, &execution, status, b"{}",
+                adapter,
+                &plan,
+                &execution_context,
+                &metadata,
+                &execution,
+                status,
+                b"{}",
             ),
             Err(expected)
         );
@@ -267,7 +282,7 @@ fn amplitude_pagination_and_typed_provider_failures_fail_closed() {
         adapter.plan_v2(&SourceWorkerPlanEnvelopeV2 {
             request: Some(SourceWorkerPlanRequestV1 {
                 plan: Some(plan),
-                context: Some(context),
+                context: Some(execution_context),
             }),
             metadata: Some(wrong_family),
         }),


### PR DESCRIPTION
## Scope

Adds provider-local, credential-free source-execution adapters for the two cataloged Amplitude SCIM families: `users` and `groups`. This draft is stacked on #2602 exact base `1dc39eb471fead18f374ac2d9b95b962dd0f1a32` so hosted checks include the shared Langfuse and Rust-format repair. It will be retargeted to `main` after #2602 lands.

This PR does not register Amplitude in the shared dispatcher, change Go/Rust authority, retire compatibility code, deploy, or claim live-provider proof.

## Preserved boundaries

- The trusted host owns bearer credential resolution/application, origin enforcement, network I/O, durable append/projection ordering, and checkpoint persistence.
- Rust receives only public base URL/family/page-size configuration, trusted tenant/runtime context, prior cursor, and bounded response bytes.
- Requests are GET-only, origin-bound, cursor-bounded, and contain no credential material.
- Event identities bind source, family, tenant, and provider ID. Provider payload tenant/runtime fields cannot override trusted context.
- Credential-shaped and untrusted tenant/runtime payload keys are recursively removed before event serialization.
- Duplicate identities with conflicting payloads fail closed.
- Authentication, provider scope, rate-limit, malformed response, cursor, configuration, and unexpected status failures remain typed.

## Validation

- `rustfmt --edition 2024 --check crates/source-runtime-next/src/amplitude.rs crates/source-runtime-next/src/amplitude/source_execution.rs crates/source-runtime-next/src/amplitude/source_execution_tests.rs` — pass
- `git diff --check origin/codex/rust-module-order-format...HEAD` — pass
- `cargo test --locked -p cerebro-source-runtime-next amplitude::source_execution_tests` — blocked before compilation by the managed Cargo capacity gate; latest safe-capacity shortfall was 38,157,617,766 bytes. No local Rust test result is claimed.

Hosted exact-head Rust tests and warnings-denied Clippy are the next compile authority. The PR stays draft until they pass and the stacked base lands.