### PR TITLE
Render the compliance overview before enrichments finish

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1639,6 +1639,15 @@ paths:
             type: string
         - $ref: '#/components/parameters/responseViewQuery'
         - $ref: '#/components/parameters/coverageScopeQuery'
+        - name: enrichments
+          in: query
+          schema:
+            type: string
+            enum:
+              - inline
+              - deferred
+            default: inline
+          description: Use deferred to return findings, controls, evidence, and connectors without waiting for source health and coverage enrichment.
         - $ref: '#/components/parameters/limitQuery'
       responses:
         '200':

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -90,14 +90,14 @@ describe("Home review links", () => {
     });
 
     expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([
-      grcDashboardPath({ limit: 12 }),
+      grcDashboardPath({ limit: 12, enrichments: "deferred" }),
       null,
       null,
     ]);
   });
 
   it("starts secondary Home queries after dashboard data arrives", async () => {
-    const dashboardPath = grcDashboardPath({ limit: 12 });
+    const dashboardPath = grcDashboardPath({ limit: 12, enrichments: "deferred" });
     const dashboardData = {
       summary: {
         open_findings: 0,
@@ -140,5 +140,6 @@ describe("Home review links", () => {
         page_size: 3,
       }),
     ]);
+    expect(container.textContent).toContain("Loading source coverage.");
   });
 });

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -382,16 +382,20 @@ function HealthRow({
 }
 
 function ProgramHealthPanel({
+  coveragePending,
   coverageSourceCount,
   metrics,
   readinessLabel,
 }: {
+  coveragePending: boolean;
   coverageSourceCount: number;
   metrics: HomeMetrics;
   readinessLabel: string;
 }) {
   const sourceIssues = metrics.summary.stale_connectors + metrics.coverageBlindSpotCount;
-  const sourceDetail = `${countLabel(metrics.summary.stale_connectors, "stale source")}, ${countLabel(metrics.coverageBlindSpotCount, "coverage gap")} across ${countLabel(coverageSourceCount, "source")}`;
+  const sourceDetail = coveragePending
+    ? "Loading source coverage."
+    : `${countLabel(metrics.summary.stale_connectors, "stale source")}, ${countLabel(metrics.coverageBlindSpotCount, "coverage gap")} across ${countLabel(coverageSourceCount, "source")}`;
   return (
     <aside className="surface-panel p-5">
       <div className="flex items-start justify-between gap-3">
@@ -422,9 +426,9 @@ function ProgramHealthPanel({
         <HealthRow
           href="/connectors"
           label="Sources"
-          value={sourceIssues}
+          value={coveragePending ? "—" : sourceIssues}
           detail={sourceDetail}
-          tone={sourceIssues > 0 ? "warning" : "success"}
+          tone={coveragePending ? "neutral" : sourceIssues > 0 ? "warning" : "success"}
         />
       </div>
       <div className="mt-5 border-t border-[color:var(--border)] pt-4">
@@ -441,7 +445,7 @@ export default function Home() {
   const { preferences } = useUserPreferences();
   const visibleSections = preferences.homepage.sections;
   const compactHome = preferences.display.density === "compact";
-  const dashboard = useGRCQuery<GRCDashboard>(grcDashboardPath({ limit: HOME_DASHBOARD_FINDING_LIMIT }));
+  const dashboard = useGRCQuery<GRCDashboard>(grcDashboardPath({ limit: HOME_DASHBOARD_FINDING_LIMIT, enrichments: "deferred" }));
   const data = dashboard.data;
   const readinessQuery = useGRCQuery<GRCProgramReadiness>(data ? grcProgramReadinessPath() : null);
   const coverageQuery = useGRCQuery<{ blind_spots?: GRCSourceCoverageRecord[]; records?: GRCSourceCoverageRecord[] }>(
@@ -463,6 +467,7 @@ export default function Home() {
   );
   const coverageBlindSpotCount = readiness?.coverage_blind_spots ?? coverageSummaries.reduce((total, source) => total + source.blind_spots, 0);
   const coverageSourceCount = coverageSummaries.filter((source) => source.blind_spots > 0).length;
+  const coveragePending = !readinessQuery.data && !coverageQuery.data && (readinessQuery.loading || coverageQuery.loading);
   const missingEvidenceItems = (data?.controls ?? []).reduce((total, control) => total + (control.missing_evidence_items ?? 0), 0);
   const staleEvidenceItems = (data?.controls ?? []).reduce((total, control) => total + (control.stale_evidence_items ?? 0), 0);
   const primaryFrameworkRecord = readinessQuery.data?.frameworks?.[0];
@@ -535,6 +540,7 @@ export default function Home() {
               {visibleSections.reviewNow && <ReviewNowPanel items={queueItems} />}
               {visibleSections.programHealth && (
                 <ProgramHealthPanel
+                  coveragePending={coveragePending}
                   coverageSourceCount={coverageSourceCount}
                   metrics={homeMetrics}
                   readinessLabel={readinessLabel}

--- a/apps/web/src/lib/grc-client.test.tsx
+++ b/apps/web/src/lib/grc-client.test.tsx
@@ -72,6 +72,7 @@ describe("grc client paths", () => {
 
   it("requests compact dashboard and readiness responses", () => {
     expect(grcDashboardPath({ limit: 12 })).toBe("/grc/dashboard?limit=12&view=summary");
+    expect(grcDashboardPath({ limit: 12, enrichments: "deferred" })).toBe("/grc/dashboard?limit=12&enrichments=deferred&view=summary");
     expect(grcProgramReadinessPath({ tenant_id: "writer" })).toBe("/grc/program-readiness?tenant_id=writer&view=summary");
   });
 });

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -50,6 +50,13 @@ type grcScope struct {
 	Limit      uint32
 }
 
+type grcDashboardEnrichments string
+
+const (
+	grcDashboardEnrichmentsInline   grcDashboardEnrichments = "inline"
+	grcDashboardEnrichmentsDeferred grcDashboardEnrichments = "deferred"
+)
+
 type grcDashboardResponse struct {
 	Summary            grcSummary                   `json:"summary"`
 	Findings           []grcFindingItem             `json:"findings"`
@@ -120,6 +127,14 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, errors.Join(errInvalidHTTPRequest, err))
 		return
 	}
+	enrichments, err := grcDashboardEnrichmentsFromRequest(r)
+	if err != nil {
+		statusCode = http.StatusBadRequest
+		status, endAttrs = grcTelemetryError(endAttrs, err)
+		writeGRCError(w, errors.Join(errInvalidHTTPRequest, err))
+		return
+	}
+	endAttrs = endAttrs.WithField(telemetry.Field{Key: "enrichments", Value: string(enrichments)})
 	scope, err := grcScopeFromRequest(r)
 	if err != nil {
 		statusCode = grcHTTPStatusCode(err)
@@ -192,38 +207,44 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 			return attrs, err
 		})
 	})
-	group.Go(func() error {
-		runtimeHealthCtx, cancel := context.WithTimeout(groupCtx, grcRuntimeHealthEnrichmentTimeout)
-		defer cancel()
-		runtimeHealthErr = operationtelemetry.RunMainPhase(runtimeHealthCtx, "grc.dashboard.runtime_health", telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: len(runtimes)}), func(ctx context.Context) (telemetry.Attributes, error) {
+	if enrichments == grcDashboardEnrichmentsInline {
+		group.Go(func() error {
+			runtimeHealthCtx, cancel := context.WithTimeout(groupCtx, grcRuntimeHealthEnrichmentTimeout)
+			defer cancel()
+			runtimeHealthErr = operationtelemetry.RunMainPhase(runtimeHealthCtx, "grc.dashboard.runtime_health", telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: len(runtimes)}), func(ctx context.Context) (telemetry.Attributes, error) {
+				var err error
+				sourceSummaries, err = a.grcSourceRuntimeHealthSummaries(ctx, runtimes, generatedAt)
+				return telemetry.Attrs(telemetry.Field{Key: "source_summary_count", Value: len(sourceSummaries)}), err
+			})
+			if runtimeHealthErr != nil {
+				sourceSummaries = nil
+			}
+			return nil
+		})
+		group.Go(func() error {
 			var err error
-			sourceSummaries, err = a.grcSourceRuntimeHealthSummaries(ctx, runtimes, generatedAt)
-			return telemetry.Attrs(telemetry.Field{Key: "source_summary_count", Value: len(sourceSummaries)}), err
+			return operationtelemetry.RunMainPhase(groupCtx, "grc.dashboard.coverage", telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: len(runtimes)}), func(ctx context.Context) (telemetry.Attributes, error) {
+				coverage, err = a.sourceCoverageRecordsScoped(ctx, runtimes, ports.SourceRuntimeFilter{
+					RuntimeID: scope.RuntimeID, RuntimeIDs: scope.RuntimeIDs, TenantID: scope.TenantID,
+					SourceID: scope.SourceID, Limit: scope.Limit,
+				}, generatedAt, coverageScope)
+				return telemetry.Attrs(telemetry.Field{Key: "coverage_record_count", Value: len(coverage)}), err
+			})
 		})
-		if runtimeHealthErr != nil {
-			sourceSummaries = nil
-		}
-		return nil
-	})
-	group.Go(func() error {
-		var err error
-		return operationtelemetry.RunMainPhase(groupCtx, "grc.dashboard.coverage", telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: len(runtimes)}), func(ctx context.Context) (telemetry.Attributes, error) {
-			coverage, err = a.sourceCoverageRecordsScoped(ctx, runtimes, ports.SourceRuntimeFilter{
-				RuntimeID: scope.RuntimeID, RuntimeIDs: scope.RuntimeIDs, TenantID: scope.TenantID,
-				SourceID: scope.SourceID, Limit: scope.Limit,
-			}, generatedAt, coverageScope)
-			return telemetry.Attrs(telemetry.Field{Key: "coverage_record_count", Value: len(coverage)}), err
-		})
-	})
+	}
 	if err := group.Wait(); err != nil {
 		statusCode = grcHTTPStatusCode(err)
 		status, endAttrs = grcTelemetryError(endAttrs, err)
 		writeGRCError(w, err)
 		return
 	}
+	sourceSummariesStatus := grcTelemetryStatus(runtimeHealthErr)
+	if enrichments == grcDashboardEnrichmentsDeferred {
+		sourceSummariesStatus = string(grcDashboardEnrichmentsDeferred)
+	}
 	endAttrs = endAttrs.With(
 		telemetry.Attrs(
-			telemetry.Field{Key: "source_summaries_status", Value: grcTelemetryStatus(runtimeHealthErr)},
+			telemetry.Field{Key: "source_summaries_status", Value: sourceSummariesStatus},
 			telemetry.Field{Key: "source_summary_count", Value: len(sourceSummaries)},
 		),
 	)
@@ -241,7 +262,10 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	controls := grcControlItems(findingItems, evidenceItems)
 	coverageBlindSpots := sourcecoverage.BlindSpots(coverage)
 	serializedCoverageBlindSpots := coverageBlindSpots
-	productAreas := grcproductareas.BuildCoverageViews(coverage)
+	var productAreas []grcproductareas.View
+	if enrichments == grcDashboardEnrichmentsInline {
+		productAreas = grcproductareas.BuildCoverageViews(coverage)
+	}
 	if view == responseview.Summary {
 		serializedCoverageBlindSpots = nil
 		productAreas = responseview.CompactProductAreas(productAreas)
@@ -261,6 +285,20 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		ProductAreas:       productAreas,
 		GeneratedAt:        generatedAt,
 	})
+}
+
+func grcDashboardEnrichmentsFromRequest(r *http.Request) (grcDashboardEnrichments, error) {
+	if r == nil || r.URL == nil {
+		return grcDashboardEnrichmentsInline, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(r.URL.Query().Get("enrichments"))) {
+	case "", string(grcDashboardEnrichmentsInline):
+		return grcDashboardEnrichmentsInline, nil
+	case string(grcDashboardEnrichmentsDeferred):
+		return grcDashboardEnrichmentsDeferred, nil
+	default:
+		return grcDashboardEnrichmentsInline, errors.New("enrichments must be inline or deferred when provided")
+	}
 }
 
 func (a *App) grcSourceRuntimeHealthSummaries(ctx context.Context, runtimes []*cerebrov1.SourceRuntime, generatedAt time.Time) ([]sourceRuntimeHealthSummary, error) {

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -335,6 +335,7 @@ func TestGRCDashboardEmitsLatencyTelemetry(t *testing.T) {
 		"status":         "completed",
 		"route":          "/grc/dashboard",
 		"dashboard":      "grc",
+		"enrichments":    "inline",
 		"status_code":    float64(http.StatusOK),
 		"limit":          float64(1),
 		"preview_limit":  float64(1),
@@ -362,6 +363,85 @@ func TestGRCDashboardEmitsLatencyTelemetry(t *testing.T) {
 		if _, ok := phasePayload["duration_ms"].(float64); !ok {
 			t.Fatalf("%s duration_ms = %#v, want number; payload=%#v", name, phasePayload["duration_ms"], phasePayload)
 		}
+	}
+}
+
+func TestGRCDashboardDeferredEnrichmentsReturnCoreData(t *testing.T) {
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"runtime-1": {
+				Id:       "runtime-1",
+				SourceId: "source-1",
+				TenantId: "tenant-1",
+			},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"finding-1": {
+				ID:        "finding-1",
+				RuntimeID: "runtime-1",
+				TenantID:  "tenant-1",
+				Title:     "Finding",
+				Severity:  "HIGH",
+				Status:    "open",
+			},
+		},
+		findingEvidence: map[string]*cerebrov1.FindingEvidence{},
+	}
+	app := New(
+		config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second},
+		Dependencies{
+			StateStore: store,
+			GraphStore: &stubGraphStore{err: errors.New("deferred runtime health must not run")},
+		},
+		nil,
+	)
+	server := httptest.NewServer(app.Handler())
+
+	stderr := captureBootstrapStderr(t, func() {
+		defer server.Close()
+		resp, err := server.Client().Get(server.URL + "/grc/dashboard?tenant_id=tenant-1&limit=1&view=summary&enrichments=deferred")
+		if err != nil {
+			t.Fatalf("GET deferred /grc/dashboard error = %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET deferred /grc/dashboard status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		var payload grcDashboardResponse
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode deferred /grc/dashboard: %v", err)
+		}
+		if payload.Summary.OpenFindings != 1 || len(payload.Findings) != 1 || len(payload.Connectors) != 1 {
+			t.Fatalf("deferred core payload = summary %+v, findings %d, connectors %d", payload.Summary, len(payload.Findings), len(payload.Connectors))
+		}
+		if len(payload.SourceSummaries) != 0 || len(payload.CoverageSummaries) != 0 || len(payload.ProductAreas) != 0 {
+			t.Fatalf("deferred enrichments = source summaries %d, coverage summaries %d, product areas %d, want 0/0/0", len(payload.SourceSummaries), len(payload.CoverageSummaries), len(payload.ProductAreas))
+		}
+	})
+
+	for _, phase := range []string{"grc.dashboard.runtime_health", "grc.dashboard.coverage"} {
+		if strings.Contains(stderr, `"name":"`+phase+`"`) {
+			t.Fatalf("deferred dashboard emitted %s telemetry: %s", phase, stderr)
+		}
+	}
+	payload := decodeBootstrapTelemetryPayload(t, stderr, "grc.dashboard")
+	if payload["enrichments"] != "deferred" || payload["source_summaries_status"] != "deferred" {
+		t.Fatalf("deferred dashboard telemetry = %#v", payload)
+	}
+}
+
+func TestGRCDashboardRejectsUnknownEnrichments(t *testing.T) {
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{StateStore: &stubRuntimeStore{}}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/dashboard?enrichments=eventually")
+	if err != nil {
+		t.Fatalf("GET /grc/dashboard with invalid enrichments error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("GET /grc/dashboard with invalid enrichments status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
 	}
 }
 


### PR DESCRIPTION
## Problem

The compliance overview waits for source-health and coverage enrichment before it can render core findings, controls, evidence, and connector data. The page already loads readiness and coverage through separate bounded requests after the dashboard becomes available.

## Change

- add an explicit `enrichments=deferred` dashboard request mode while preserving the existing inline default
- make the overview request core dashboard data first, then load readiness and coverage
- keep source coverage in a loading state until a coverage response arrives instead of briefly showing a zero
- reject unsupported enrichment modes and expose the selected mode in dashboard telemetry

## Validation

- `go test ./internal/bootstrap -count=1`
- `go test -race ./internal/bootstrap -run 'TestGRCDashboard' -count=1`
- `make lint-bootstrap`
- `make check-structural check-structural-test check-arch`
- `npm run check --workspace @writer/cerebro-web`
- `npm run build --workspace @writer/cerebro-web`
- `make openapi-check openapi-lint openapi-ts-check`
- `make oss-audit`

The focused dashboard test verifies that deferred requests retain core data and never launch runtime-health or coverage phases.
