### PR TITLE
feat(sources): add Abnormal Security Rust adapters

### DIFF
--- a/crates/source-runtime-next/src/abnormal_security.rs
+++ b/crates/source-runtime-next/src/abnormal_security.rs
@@ -13,6 +13,9 @@ mod origin;
 mod projection;
 mod request;
 mod response;
+#[allow(dead_code)]
+#[path = "abnormal_security/source_execution.rs"]
+mod source_execution;
 mod types;
 
 pub use catalog::{AbnormalSecurityEventContract, AbnormalSecurityRuntimeDefinition};
@@ -25,6 +28,13 @@ pub use types::{
     AbnormalSecurityCheckpointCandidate, AbnormalSecurityKernel, AbnormalSecurityPage,
     AbnormalSecurityRecord, AbnormalSecurityRequest,
 };
+
+#[allow(unused_imports)]
+pub(crate) use source_execution::ABNORMAL_SECURITY_SOURCE_EXECUTION_ADAPTERS;
+
+#[cfg(test)]
+#[path = "abnormal_security/source_execution_tests.rs"]
+mod source_execution_tests;
 
 #[cfg(test)]
 mod tests;

--- a/crates/source-runtime-next/src/abnormal_security/normalize.rs
+++ b/crates/source-runtime-next/src/abnormal_security/normalize.rs
@@ -162,7 +162,7 @@ fn admit(record: &AbnormalSecurityRecord) -> Result<(), AbnormalSecurityError> {
     Ok(())
 }
 
-fn event_id(kernel: &AbnormalSecurityKernel, provider_id: &str) -> String {
+pub(super) fn event_id(kernel: &AbnormalSecurityKernel, provider_id: &str) -> String {
     let scope = Sha256::digest(format!(
         "{}\0{}",
         kernel.base_url.as_str(),
@@ -263,14 +263,25 @@ fn reject_protected(value: &Value, depth: usize) -> Result<(), AbnormalSecurityE
             }
             for (key, value) in values {
                 let key = key.to_ascii_lowercase().replace(['-', '.'], "_");
-                if key == "tenant_id" {
+                if ["tenant", "tenant_id", "runtime_id", "source_runtime_id"]
+                    .contains(&key.as_str())
+                {
                     return Err(AbnormalSecurityError::TenantMismatch);
                 }
                 if [
                     "token",
+                    "access_token",
+                    "refresh_token",
+                    "session_token",
                     "api_key",
+                    "api_token",
                     "authorization",
+                    "cookie",
+                    "set_cookie",
                     "password",
+                    "passcode",
+                    "secret",
+                    "client_secret",
                     "private_key",
                 ]
                 .contains(&key.as_str())

--- a/crates/source-runtime-next/src/abnormal_security/source_execution.rs
+++ b/crates/source-runtime-next/src/abnormal_security/source_execution.rs
@@ -1,0 +1,453 @@
+//! Abnormal Security bridge for the closed source-execution protocol.
+//!
+//! These adapters receive authenticated tenant context, public provider
+//! configuration, and bounded provider response bytes. The trusted host owns
+//! credential redemption, Bearer authentication, origin-constrained network
+//! I/O, durable append, projection, and checkpoint persistence.
+
+use std::collections::HashMap;
+
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceExecutionPlanV1,
+    SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1,
+    SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2, SourceWorkerHttpRequestV1,
+    SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1, SourceWorkerRecordV1,
+    SourceWorkerRuntimeMetadataV2, canonical_http_execution_digest, canonical_plan_digest,
+    canonical_request_intent_digest, canonical_result_digest, validate_and_deduplicate_records,
+    validate_execution_context, validate_runtime_metadata,
+};
+
+use super::{
+    AbnormalSecurityError, AbnormalSecurityFamily, AbnormalSecurityKernel,
+    AbnormalSecurityRuntimeDefinition, normalize::event_id,
+};
+
+const SOURCE_ID: &str = "abnormal_security";
+const DEFAULT_BASE_URL: &str = "https://api.abnormalplatform.com/v1";
+const METHOD: &str = "GET";
+const ACCEPT: &str = "application/json";
+const MAX_RESPONSE_BYTES: u64 = 8 << 20;
+
+/// Credential-free adapter for one cataloged Abnormal Security family.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AbnormalSecuritySourceExecutionAdapter {
+    family: AbnormalSecurityFamily,
+}
+
+/// Provider-local adapter set. Shared dispatcher registration and authority
+/// promotion remain separate delivery steps.
+pub(crate) static ABNORMAL_SECURITY_SOURCE_EXECUTION_ADAPTERS:
+    [AbnormalSecuritySourceExecutionAdapter; 5] = [
+    AbnormalSecuritySourceExecutionAdapter::new(AbnormalSecurityFamily::Resources),
+    AbnormalSecuritySourceExecutionAdapter::new(AbnormalSecurityFamily::AuditEvents),
+    AbnormalSecuritySourceExecutionAdapter::new(AbnormalSecurityFamily::Cases),
+    AbnormalSecuritySourceExecutionAdapter::new(AbnormalSecurityFamily::PostureCatalog),
+    AbnormalSecuritySourceExecutionAdapter::new(AbnormalSecurityFamily::Threats),
+];
+
+impl AbnormalSecuritySourceExecutionAdapter {
+    const fn new(family: AbnormalSecurityFamily) -> Self {
+        Self { family }
+    }
+
+    pub(crate) fn compiled_plan(&self) -> SourceExecutionPlanV1 {
+        let family_id = self.family.as_str();
+        let definition = AbnormalSecurityRuntimeDefinition::compile(self.family)
+            .expect("closed Abnormal Security family must compile");
+        let mut plan = SourceExecutionPlanV1 {
+            plan_id: format!("source-plan-v1:{SOURCE_ID}:{family_id}"),
+            source_id: SOURCE_ID.to_owned(),
+            family_id: family_id.to_owned(),
+            provider_kernel: self.family.event_kind().to_owned(),
+            method: METHOD.to_owned(),
+            origin: DEFAULT_BASE_URL.to_owned(),
+            path: format!("/v1{}", self.family.path()),
+            record_selector: record_selector(self.family).to_owned(),
+            id_field: self.family.id_field().to_owned(),
+            singleton_fallback_id: String::new(),
+            max_response_bytes: MAX_RESPONSE_BYTES,
+            event_kind: definition.event_contract.kind.to_owned(),
+            schema_ref: definition.event_contract.schema_ref.to_owned(),
+            required_attributes: definition
+                .event_contract
+                .required_attributes
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
+            required_payload_fields: definition
+                .event_contract
+                .required_payload_fields
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
+            plan_digest_sha256: String::new(),
+        };
+        plan.plan_digest_sha256 = canonical_plan_digest(&plan);
+        plan
+    }
+
+    fn validate_plan(&self, plan: &SourceExecutionPlanV1) -> Result<(), SourceExecutionError> {
+        if plan != &self.compiled_plan() {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        Ok(())
+    }
+
+    fn kernel(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(AbnormalSecurityKernel, String), SourceExecutionError> {
+        validate_execution_context(context)?;
+        validate_runtime_metadata(metadata)?;
+        if public_value(&metadata.public_config, "family")
+            .is_some_and(|value| value != self.family.as_str())
+        {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        let base_url =
+            public_value(&metadata.public_config, "base_url").unwrap_or(DEFAULT_BASE_URL);
+        let observed_at = timestamp(context.observed_at_unix_millis)?;
+        let kernel =
+            AbnormalSecurityKernel::new(base_url, &context.tenant_id, self.family, &observed_at)
+                .map_err(map_error)?;
+        let mut allowed_origin = kernel.plan(None).map_err(map_error)?.url().clone();
+        allowed_origin.set_path("/v1");
+        allowed_origin.set_query(None);
+        Ok((
+            kernel,
+            allowed_origin.to_string().trim_end_matches('/').to_owned(),
+        ))
+    }
+
+    fn validate_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+        metadata: Option<&SourceWorkerRuntimeMetadataV2>,
+    ) -> Result<(), SourceExecutionError> {
+        let default_metadata;
+        let metadata = match metadata {
+            Some(metadata) => metadata,
+            None => {
+                default_metadata = SourceWorkerRuntimeMetadataV2 {
+                    public_config: HashMap::new(),
+                    prior_terminal_watermark_unix_millis: 0,
+                    prior_checkpoint: String::new(),
+                };
+                &default_metadata
+            }
+        };
+        let (kernel, _) = self.kernel(context, metadata)?;
+        if record.event_id != event_id(&kernel, &record.provider_id)
+            || record.attributes.get("tenant_id") != Some(&context.tenant_id)
+            || record.attributes.get("source_event_id") != Some(&record.provider_id)
+        {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        Ok(())
+    }
+}
+
+impl SourceExecutionAdapter for AbnormalSecuritySourceExecutionAdapter {
+    fn source_id(&self) -> &'static str {
+        SOURCE_ID
+    }
+
+    fn family_id(&self) -> &'static str {
+        self.family.as_str()
+    }
+
+    fn provider_kernel(&self) -> &'static str {
+        self.family.event_kind()
+    }
+
+    fn validate_record_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+    ) -> Result<(), SourceExecutionError> {
+        self.validate_identity(context, record, None)
+    }
+
+    fn validate_record_identity_v2(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(), SourceExecutionError> {
+        self.validate_identity(context, record, Some(metadata))
+    }
+
+    fn plan(
+        &self,
+        _request: &SourceWorkerPlanRequestV1,
+    ) -> Result<SourceWorkerHttpRequestV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn plan_v2(
+        &self,
+        envelope: &SourceWorkerPlanEnvelopeV2,
+    ) -> Result<SourceWorkerHttpExecutionV2, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, allowed_origin) = self.kernel(context, metadata)?;
+        let provider_request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        if provider_request.method() != plan.method
+            || provider_request.url().path() != plan.path
+            || provider_request.authentication_header() != "Authorization"
+            || provider_request.authentication_scheme() != "Bearer"
+            || provider_request.contains_credentials()
+            || provider_request.allows_redirects()
+        {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        let mut planned = SourceWorkerHttpRequestV1 {
+            plan_id: plan.plan_id.clone(),
+            method: provider_request.method().to_owned(),
+            url: provider_request.url().to_string(),
+            accept: ACCEPT.to_owned(),
+            max_response_bytes: u64::try_from(provider_request.max_response_bytes())
+                .map_err(|_| SourceExecutionError::InvalidPlan)?,
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            request_intent_digest: String::new(),
+        };
+        planned.request_intent_digest = canonical_request_intent_digest(plan, context, &planned);
+        let mut execution = SourceWorkerHttpExecutionV2 {
+            request: Some(planned),
+            body: Vec::new(),
+            declared_headers: HashMap::new(),
+            execution_intent_digest_sha256: String::new(),
+            credential_operation: "source.bearer".to_owned(),
+            allowed_origin,
+        };
+        execution.execution_intent_digest_sha256 =
+            canonical_http_execution_digest(plan, context, metadata, &execution);
+        Ok(execution)
+    }
+
+    fn decode(
+        &self,
+        _request: &SourceWorkerDecodeRequestV1,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn decode_v2(
+        &self,
+        envelope: &SourceWorkerDecodeEnvelopeV2,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let receipt = request
+            .receipt
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, _) = self.kernel(context, metadata)?;
+        let provider_request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        let retry_after_seconds = response_header(&envelope.response_headers, "retry-after")
+            .map(|value| {
+                value
+                    .parse::<u64>()
+                    .map_err(|_| SourceExecutionError::UnexpectedProviderStatus)
+            })
+            .transpose()?;
+        let status = u16::try_from(request.status_code)
+            .map_err(|_| SourceExecutionError::UnexpectedProviderStatus)?;
+        let page = kernel
+            .decode(
+                &provider_request,
+                status,
+                retry_after_seconds,
+                &request.response_body,
+            )
+            .map_err(map_error)?;
+        let checkpoint = kernel
+            .checkpoint_candidate(
+                &provider_request,
+                &page,
+                optional_watermark(metadata)?.as_deref(),
+            )
+            .map_err(map_error)?;
+        let next_cursor = checkpoint.cursor.unwrap_or_default();
+        let records = page
+            .records
+            .into_iter()
+            .map(|record| {
+                if record.tenant_id != context.tenant_id
+                    || record.family != self.family
+                    || record.kind != plan.event_kind
+                    || record.schema_ref != plan.schema_ref
+                {
+                    return Err(SourceExecutionError::TenantMismatch);
+                }
+                Ok(SourceWorkerRecordV1 {
+                    provider_id: record.provider_id,
+                    event_id: record.event_id,
+                    occurred_at_unix_millis: parse_timestamp(&record.occurred_at)?,
+                    attributes: record.attributes.into_iter().collect(),
+                    payload_json: serde_json::to_vec(&record.payload)
+                        .map_err(|_| SourceExecutionError::InternalRuntime)?,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let records = validate_and_deduplicate_records(records)?;
+        for record in &records {
+            self.validate_record_identity_v2(context, record, metadata)?;
+        }
+        let result_digest_sha256 = canonical_result_digest(receipt, &next_cursor, &records)?;
+        Ok(SourceWorkerDecodeResultV1 {
+            plan_id: plan.plan_id.clone(),
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: request.request_intent_digest.clone(),
+            records,
+            next_cursor,
+            result_digest_sha256,
+            tenant_id: context.tenant_id.clone(),
+            runtime_id: context.runtime_id.clone(),
+            runtime_generation: context.runtime_generation,
+            lease_generation: context.lease_generation,
+            observed_at_unix_millis: context.observed_at_unix_millis,
+        })
+    }
+}
+
+const fn record_selector(family: AbnormalSecurityFamily) -> &'static str {
+    match family {
+        AbnormalSecurityFamily::Resources => "$.resources[*]",
+        AbnormalSecurityFamily::AuditEvents => "$.auditLogs[*]",
+        AbnormalSecurityFamily::Cases => "$.cases[*]",
+        AbnormalSecurityFamily::PostureCatalog => "$.data[*]",
+        AbnormalSecurityFamily::Threats => "$.threats[*]",
+    }
+}
+
+fn public_value<'a>(config: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    config
+        .get(key)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn response_header<'a>(headers: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    headers
+        .get(key)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn optional(value: &str) -> Option<&str> {
+    (!value.is_empty()).then_some(value)
+}
+
+fn optional_watermark(
+    metadata: &SourceWorkerRuntimeMetadataV2,
+) -> Result<Option<String>, SourceExecutionError> {
+    (metadata.prior_terminal_watermark_unix_millis > 0)
+        .then(|| timestamp(metadata.prior_terminal_watermark_unix_millis))
+        .transpose()
+}
+
+fn timestamp(unix_millis: i64) -> Result<String, SourceExecutionError> {
+    OffsetDateTime::from_unix_timestamp_nanos(i128::from(unix_millis) * 1_000_000)
+        .map_err(|_| SourceExecutionError::InvalidExecutionContext)?
+        .format(&Rfc3339)
+        .map_err(|_| SourceExecutionError::InternalRuntime)
+}
+
+fn parse_timestamp(value: &str) -> Result<i64, SourceExecutionError> {
+    let nanos = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| SourceExecutionError::InvalidProviderRecord)?
+        .unix_timestamp_nanos();
+    i64::try_from(nanos / 1_000_000).map_err(|_| SourceExecutionError::InvalidProviderRecord)
+}
+
+fn map_error(error: AbnormalSecurityError) -> SourceExecutionError {
+    match error {
+        AbnormalSecurityError::InvalidFamily => SourceExecutionError::UnknownAdapter,
+        AbnormalSecurityError::InvalidConfiguration(_) | AbnormalSecurityError::InvalidOrigin => {
+            SourceExecutionError::MissingConfiguration
+        }
+        AbnormalSecurityError::InvalidTenantId => SourceExecutionError::InvalidExecutionContext,
+        AbnormalSecurityError::MissingCredentialReference => {
+            SourceExecutionError::MissingCredentialReference
+        }
+        AbnormalSecurityError::CredentialUnavailable => SourceExecutionError::CredentialUnavailable,
+        AbnormalSecurityError::InvalidCursor => SourceExecutionError::InvalidCursor,
+        AbnormalSecurityError::RequestScopeMismatch => SourceExecutionError::InvalidPlan,
+        AbnormalSecurityError::AuthenticationRejected => {
+            SourceExecutionError::AuthenticationRejected
+        }
+        AbnormalSecurityError::RequiredScopeMissing => {
+            SourceExecutionError::RequiredProviderScopeMissing
+        }
+        AbnormalSecurityError::EgressDenied => SourceExecutionError::EgressDenied,
+        AbnormalSecurityError::DnsFailure | AbnormalSecurityError::ConnectionFailure => {
+            SourceExecutionError::ConnectionFailure
+        }
+        AbnormalSecurityError::ProviderTimeout => SourceExecutionError::ProviderTimeout,
+        AbnormalSecurityError::RateLimited { .. } => SourceExecutionError::ProviderRateLimit,
+        AbnormalSecurityError::ProviderResourceNotFound
+        | AbnormalSecurityError::ProviderUnavailable { .. }
+        | AbnormalSecurityError::UnexpectedStatus { .. }
+        | AbnormalSecurityError::InvalidRetryAfter => {
+            SourceExecutionError::UnexpectedProviderStatus
+        }
+        AbnormalSecurityError::ResponseTooLarge => SourceExecutionError::ResponseTooLarge,
+        AbnormalSecurityError::TooManyRecords => SourceExecutionError::ResultTooLarge,
+        AbnormalSecurityError::MalformedResponse => SourceExecutionError::MalformedResponse,
+        AbnormalSecurityError::InvalidProviderRecord
+        | AbnormalSecurityError::CredentialMaterial => SourceExecutionError::InvalidProviderRecord,
+        AbnormalSecurityError::MissingStableIdentity => SourceExecutionError::MissingStableIdentity,
+        AbnormalSecurityError::TenantMismatch => SourceExecutionError::TenantMismatch,
+        AbnormalSecurityError::ConflictingDuplicate => SourceExecutionError::DuplicateConflict,
+        AbnormalSecurityError::EventContractRejection => {
+            SourceExecutionError::EventContractRejected
+        }
+        AbnormalSecurityError::AppendFailure => SourceExecutionError::AppendFailed,
+        AbnormalSecurityError::ProjectionFailure => SourceExecutionError::ProjectionFailed,
+        AbnormalSecurityError::LeaseLoss => SourceExecutionError::LeaseLost,
+        AbnormalSecurityError::StaleAuthority => SourceExecutionError::StaleAuthority,
+        AbnormalSecurityError::InternalRuntimeFailure => SourceExecutionError::InternalRuntime,
+    }
+}

--- a/crates/source-runtime-next/src/abnormal_security/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/abnormal_security/source_execution_tests.rs
@@ -1,0 +1,425 @@
+use std::{collections::HashMap, fs, path::PathBuf};
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceExecutionLifecycleEnvelopeV2,
+    SourceExecutionLifecycleRequestV1, SourceExecutionPlanV1, SourceWorkerDecodeEnvelopeV2,
+    SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1, SourceWorkerExecutionContextV1,
+    SourceWorkerHttpExecutionV2, SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1,
+    SourceWorkerRuntimeMetadataV2, SourceWorkerSafeReceiptV1, response_digest,
+    seal_page_program_v2,
+};
+
+use super::{
+    AbnormalSecurityFamily,
+    source_execution::{
+        ABNORMAL_SECURITY_SOURCE_EXECUTION_ADAPTERS, AbnormalSecuritySourceExecutionAdapter,
+    },
+};
+
+const OBSERVED_AT_MILLIS: i64 = 1_780_272_000_000;
+
+#[derive(Deserialize)]
+struct GoOracleEvent {
+    payload: Value,
+}
+
+fn root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn adapter(family: AbnormalSecurityFamily) -> &'static AbnormalSecuritySourceExecutionAdapter {
+    ABNORMAL_SECURITY_SOURCE_EXECUTION_ADAPTERS
+        .iter()
+        .find(|adapter| adapter.family_id() == family.as_str())
+        .unwrap()
+}
+
+fn fixture(family: AbnormalSecurityFamily) -> Value {
+    let bytes = fs::read(root().join(format!(
+        "sources/abnormal_security/testdata/read_{}.json",
+        family.as_str()
+    )))
+    .unwrap();
+    serde_json::from_slice::<Vec<GoOracleEvent>>(&bytes)
+        .unwrap()
+        .pop()
+        .unwrap()
+        .payload
+}
+
+fn response(family: AbnormalSecurityFamily, records: Vec<Value>, cursor: Option<u64>) -> Vec<u8> {
+    let mut response = json!({family.response_key(): records});
+    if let Some(cursor) = cursor {
+        if family == AbnormalSecurityFamily::PostureCatalog {
+            response["metadata"] = json!({"next_page": cursor});
+        } else {
+            response["nextPageNumber"] = json!(cursor);
+        }
+    }
+    serde_json::to_vec(&response).unwrap()
+}
+
+fn context(cursor: &str, page: u32) -> SourceWorkerExecutionContextV1 {
+    SourceWorkerExecutionContextV1 {
+        tenant_id: "tenant".to_owned(),
+        runtime_id: "abnormal-security-runtime".to_owned(),
+        logical_page_id: format!("source-page-v2:abnormal-security-{page}"),
+        prior_cursor: cursor.to_owned(),
+        runtime_generation: 7,
+        lease_generation: 11,
+        observed_at_unix_millis: OBSERVED_AT_MILLIS,
+    }
+}
+
+fn metadata(family: AbnormalSecurityFamily) -> SourceWorkerRuntimeMetadataV2 {
+    SourceWorkerRuntimeMetadataV2 {
+        public_config: HashMap::from([("family".to_owned(), family.as_str().to_owned())]),
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    }
+}
+
+fn plan_page(
+    adapter: &AbnormalSecuritySourceExecutionAdapter,
+    plan: &SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    metadata: &SourceWorkerRuntimeMetadataV2,
+) -> SourceWorkerHttpExecutionV2 {
+    adapter
+        .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+        })
+        .unwrap()
+}
+
+fn receipt(
+    plan: &SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    execution: &SourceWorkerHttpExecutionV2,
+    status_code: u32,
+    body: &[u8],
+) -> SourceWorkerSafeReceiptV1 {
+    let request = execution.request.as_ref().unwrap();
+    SourceWorkerSafeReceiptV1 {
+        plan_digest_sha256: plan.plan_digest_sha256.clone(),
+        logical_page_id: context.logical_page_id.clone(),
+        request_intent_digest: request.request_intent_digest.clone(),
+        runtime_generation: context.runtime_generation,
+        lease_generation: context.lease_generation,
+        credential_operation: execution.credential_operation.clone(),
+        status_code,
+        response_bytes: body.len() as u64,
+        response_sha256: response_digest(body),
+        tenant_id: context.tenant_id.clone(),
+        runtime_id: context.runtime_id.clone(),
+        observed_at_unix_millis: context.observed_at_unix_millis,
+    }
+}
+
+fn decode_page(
+    adapter: &AbnormalSecuritySourceExecutionAdapter,
+    plan: &SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    metadata: &SourceWorkerRuntimeMetadataV2,
+    execution: &SourceWorkerHttpExecutionV2,
+    status_code: u32,
+    body: &[u8],
+    response_headers: HashMap<String, String>,
+) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+    let safe_receipt = receipt(plan, context, execution, status_code, body);
+    adapter.decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+        request: Some(SourceWorkerDecodeRequestV1 {
+            plan: Some(plan.clone()),
+            status_code,
+            response_body: body.to_vec(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: execution
+                .request
+                .as_ref()
+                .unwrap()
+                .request_intent_digest
+                .clone(),
+            receipt: Some(safe_receipt),
+            context: Some(context.clone()),
+        }),
+        metadata: Some(metadata.clone()),
+        response_headers,
+        response_headers_sha256: String::new(),
+        execution_intent_digest_sha256: execution.execution_intent_digest_sha256.clone(),
+    })
+}
+
+#[test]
+fn abnormal_security_plans_all_five_families_without_credentials() {
+    for family in AbnormalSecurityFamily::ALL {
+        let adapter = adapter(family);
+        let plan = adapter.compiled_plan();
+        assert_eq!(plan.source_id, "abnormal_security");
+        assert_eq!(plan.family_id, family.as_str());
+        assert_eq!(plan.provider_kernel, family.event_kind());
+        assert_eq!(plan.origin, "https://api.abnormalplatform.com/v1");
+        assert_eq!(plan.path, format!("/v1{}", family.path()));
+        assert_eq!(plan.id_field, family.id_field());
+        assert_eq!(plan.event_kind, family.event_kind());
+        assert_eq!(plan.schema_ref, family.schema_ref());
+
+        let context = context("2", 2);
+        let metadata = metadata(family);
+        let execution = plan_page(adapter, &plan, &context, &metadata);
+        assert_eq!(execution.credential_operation, "source.bearer");
+        assert_eq!(
+            execution.allowed_origin,
+            "https://api.abnormalplatform.com/v1"
+        );
+        assert!(execution.body.is_empty());
+        assert!(execution.declared_headers.is_empty());
+        let request = execution.request.unwrap();
+        assert_eq!(request.method, "GET");
+        assert_eq!(request.accept, "application/json");
+        assert_eq!(
+            request.url,
+            format!(
+                "https://api.abnormalplatform.com/v1{}?pageSize=100&pageNumber=2",
+                family.path()
+            )
+        );
+        for secret_marker in ["authorization", "bearer", "token", "secret"] {
+            assert!(!request.url.to_ascii_lowercase().contains(secret_marker));
+        }
+    }
+}
+
+#[test]
+fn abnormal_security_decodes_every_fixture_with_exact_contract_and_seals() {
+    for family in AbnormalSecurityFamily::ALL {
+        let adapter = adapter(family);
+        let plan = adapter.compiled_plan();
+        let context = context("", 1);
+        let metadata = metadata(family);
+        let execution = plan_page(adapter, &plan, &context, &metadata);
+        let body = response(family, vec![fixture(family)], None);
+        let safe_receipt = receipt(&plan, &context, &execution, 200, &body);
+        let result = decode_page(
+            adapter,
+            &plan,
+            &context,
+            &metadata,
+            &execution,
+            200,
+            &body,
+            HashMap::new(),
+        )
+        .unwrap();
+        assert!(result.next_cursor.is_empty());
+        assert_eq!(result.records.len(), 1);
+        let record = &result.records[0];
+        assert_eq!(record.attributes["tenant_id"], "tenant");
+        assert_eq!(record.attributes["source_event_id"], record.provider_id);
+        assert!(record.event_id.starts_with("abnormal-security-tenant-"));
+        for attribute in &plan.required_attributes {
+            assert!(
+                record
+                    .attributes
+                    .get(attribute)
+                    .is_some_and(|value| !value.is_empty())
+            );
+        }
+        let payload: Value = serde_json::from_slice(&record.payload_json).unwrap();
+        for field in &plan.required_payload_fields {
+            assert!(payload.get(field).is_some_and(|value| !value.is_null()));
+        }
+        adapter
+            .validate_record_identity_v2(&context, record, &metadata)
+            .unwrap();
+
+        let decision = seal_page_program_v2(&SourceExecutionLifecycleEnvelopeV2 {
+            request: Some(SourceExecutionLifecycleRequestV1 {
+                plan: Some(plan),
+                context: Some(context),
+                receipt: Some(safe_receipt),
+                result: Some(result),
+                current_lease_generation: 11,
+            }),
+            metadata: Some(metadata),
+        })
+        .unwrap();
+        assert_eq!(decision.admitted_records.len(), 1);
+        assert!(decision.checkpoint_cursor.is_empty());
+    }
+}
+
+#[test]
+fn abnormal_security_pagination_and_provider_failures_are_typed() {
+    for family in [
+        AbnormalSecurityFamily::Resources,
+        AbnormalSecurityFamily::PostureCatalog,
+    ] {
+        let adapter = adapter(family);
+        let plan = adapter.compiled_plan();
+        let context = context("", 1);
+        let metadata = metadata(family);
+        let execution = plan_page(adapter, &plan, &context, &metadata);
+        let body = response(family, vec![fixture(family)], Some(2));
+        let result = decode_page(
+            adapter,
+            &plan,
+            &context,
+            &metadata,
+            &execution,
+            200,
+            &body,
+            HashMap::new(),
+        )
+        .unwrap();
+        assert_eq!(result.next_cursor, "2");
+    }
+
+    let family = AbnormalSecurityFamily::Threats;
+    let adapter = adapter(family);
+    let plan = adapter.compiled_plan();
+    let context = context("", 1);
+    let metadata = metadata(family);
+    let execution = plan_page(adapter, &plan, &context, &metadata);
+    for (status, expected) in [
+        (401, SourceExecutionError::AuthenticationRejected),
+        (403, SourceExecutionError::RequiredProviderScopeMissing),
+        (404, SourceExecutionError::UnexpectedProviderStatus),
+        (503, SourceExecutionError::UnexpectedProviderStatus),
+    ] {
+        assert_eq!(
+            decode_page(
+                adapter,
+                &plan,
+                &context,
+                &metadata,
+                &execution,
+                status,
+                b"{}",
+                HashMap::new(),
+            ),
+            Err(expected)
+        );
+    }
+    assert_eq!(
+        decode_page(
+            adapter,
+            &plan,
+            &context,
+            &metadata,
+            &execution,
+            429,
+            b"{}",
+            HashMap::from([("retry-after".to_owned(), "60".to_owned())]),
+        ),
+        Err(SourceExecutionError::ProviderRateLimit)
+    );
+}
+
+#[test]
+fn abnormal_security_rejects_bad_scope_cursor_duplicates_and_secret_material() {
+    let family = AbnormalSecurityFamily::Resources;
+    let adapter = adapter(family);
+    let plan = adapter.compiled_plan();
+    let metadata = metadata(family);
+    let bad_context = context("0", 2);
+    assert_eq!(
+        adapter.plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(bad_context),
+            }),
+            metadata: Some(metadata.clone()),
+        }),
+        Err(SourceExecutionError::InvalidCursor)
+    );
+
+    let execution_context = context("", 1);
+    let execution = plan_page(adapter, &plan, &execution_context, &metadata);
+    let original = fixture(family);
+    let duplicate_body = response(family, vec![original.clone(), original.clone()], None);
+    let result = decode_page(
+        adapter,
+        &plan,
+        &execution_context,
+        &metadata,
+        &execution,
+        200,
+        &duplicate_body,
+        HashMap::new(),
+    )
+    .unwrap();
+    assert_eq!(result.records.len(), 1);
+
+    let mut conflicting = original.clone();
+    conflicting["name"] = Value::from("different");
+    let conflicting_body = response(family, vec![original.clone(), conflicting], None);
+    assert_eq!(
+        decode_page(
+            adapter,
+            &plan,
+            &execution_context,
+            &metadata,
+            &execution,
+            200,
+            &conflicting_body,
+            HashMap::new(),
+        ),
+        Err(SourceExecutionError::DuplicateConflict)
+    );
+
+    let mut secret = original;
+    secret["nested"] = json!({"client_secret": "credential-material"});
+    let secret_body = response(family, vec![secret], None);
+    let error = decode_page(
+        adapter,
+        &plan,
+        &execution_context,
+        &metadata,
+        &execution,
+        200,
+        &secret_body,
+        HashMap::new(),
+    )
+    .unwrap_err();
+    assert_eq!(error, SourceExecutionError::InvalidProviderRecord);
+    assert!(!format!("{error:?}").contains("credential-material"));
+
+    let mut untrusted_scope = fixture(family);
+    untrusted_scope["nested"] = json!({"runtime_id": "untrusted-runtime"});
+    let untrusted_scope_body = response(family, vec![untrusted_scope], None);
+    assert_eq!(
+        decode_page(
+            adapter,
+            &plan,
+            &execution_context,
+            &metadata,
+            &execution,
+            200,
+            &untrusted_scope_body,
+            HashMap::new(),
+        ),
+        Err(SourceExecutionError::TenantMismatch)
+    );
+
+    let mut wrong_family = metadata;
+    wrong_family
+        .public_config
+        .insert("family".to_owned(), "threats".to_owned());
+    assert_eq!(
+        adapter.plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan),
+                context: Some(execution_context),
+            }),
+            metadata: Some(wrong_family),
+        }),
+        Err(SourceExecutionError::MissingConfiguration)
+    );
+}


### PR DESCRIPTION
## Summary

- add provider-local credential-free source-execution adapters for all five cataloged Abnormal Security families
- preserve host-owned Bearer authentication, origin-constrained requests, bounded response decoding, and durable checkpoint ownership
- validate exact event contracts, tenant-scoped identity, pagination, duplicate conflicts, and credential-shaped payload rejection

Shared dispatcher registration, authority promotion, deployment, and live-provider qualification are intentionally separate.

## Validation

- `rustfmt --edition 2024 --check` on the affected Rust files
- `git diff --check`
- focused and repository-wide hosted checks pending