### PR TITLE
source-runtime: add generic x-api-key host operation

### DIFF
--- a/crates/source-runtime-next/src/source_execution/contract.rs
+++ b/crates/source-runtime-next/src/source_execution/contract.rs
@@ -157,6 +157,7 @@ pub fn validate_http_execution(
         || !matches!(
             execution.credential_operation.as_str(),
             "source.bearer"
+                | "source.x_api_key"
                 | "google.api_key_header"
                 | "langfuse.basic"
                 | "aws.sigv4"

--- a/crates/source-runtime-next/src/source_execution/tests.rs
+++ b/crates/source-runtime-next/src/source_execution/tests.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use prost::Message;
 
 use super::{
-    canonical_plan_digest, canonical_response_headers_digest,
+    canonical_http_execution_digest, canonical_plan_digest, canonical_response_headers_digest,
     contract::{
         AUTHORIZATION_POLICY_FALLBACK_ID, AUTHORIZATION_POLICY_FAMILY, AUTHORIZATION_POLICY_KERNEL,
         AUTHORIZATION_POLICY_KIND, AUTHORIZATION_POLICY_PATH, AUTHORIZATION_POLICY_SCHEMA,
@@ -13,8 +13,8 @@ use super::{
     decode, decode_v2,
     error::SourceExecutionError,
     plan, plan_v2, response_digest, tenant_scoped_event_id, validate_and_deduplicate_records,
-    validate_cursor, validate_declared_headers, validate_http_request, validate_public_config,
-    validate_response_headers, validate_runtime_metadata,
+    validate_cursor, validate_declared_headers, validate_http_execution, validate_http_request,
+    validate_public_config, validate_response_headers, validate_runtime_metadata,
     wire::{
         SourceExecutionPlanV1, SourceExecutionSelectionRequestV1, SourceWorkerDecodeEnvelopeV2,
         SourceWorkerDecodeOutputV2, SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1,
@@ -296,6 +296,32 @@ fn v2_header_contract_rejects_credentials_and_bounds_metadata() {
     assert_eq!(
         canonical_response_headers_digest(&first).unwrap(),
         canonical_response_headers_digest(&second).unwrap()
+    );
+}
+
+#[test]
+fn generic_x_api_key_operation_is_closed_and_digest_bound() {
+    let plan = exact_plan();
+    let context = exact_context("tenant-a");
+    let metadata = SourceWorkerRuntimeMetadataV2::default();
+    let mut execution = SourceWorkerHttpExecutionV2 {
+        request: Some(planned_request(&context)),
+        body: Vec::new(),
+        declared_headers: HashMap::new(),
+        execution_intent_digest_sha256: String::new(),
+        credential_operation: "source.x_api_key".to_owned(),
+        allowed_origin: plan.origin.clone(),
+    };
+    execution.execution_intent_digest_sha256 =
+        canonical_http_execution_digest(&plan, &context, &metadata, &execution);
+    assert!(validate_http_execution(&plan, &context, &execution, &metadata).is_ok());
+
+    execution.credential_operation = "source.api_key".to_owned();
+    execution.execution_intent_digest_sha256 =
+        canonical_http_execution_digest(&plan, &context, &metadata, &execution);
+    assert_eq!(
+        validate_http_execution(&plan, &context, &execution, &metadata),
+        Err(SourceExecutionError::InvalidPlan)
     );
 }
 

--- a/internal/sourceruntime/sourceworker/host.go
+++ b/internal/sourceruntime/sourceworker/host.go
@@ -205,6 +205,8 @@ func credentialHeader(operation string, credential []byte) (string, []byte, erro
 	switch operation {
 	case "source.bearer":
 		return "Authorization", append([]byte("Bearer "), credential...), nil
+	case "source.x_api_key":
+		return "X-Api-Key", append([]byte(nil), credential...), nil
 	case "anthropic.admin_x_api_key", "anthropic.compliance_x_api_key":
 		return "X-Api-Key", append([]byte(nil), credential...), nil
 	case "anthropic.org_admin_bearer":

--- a/internal/sourceruntime/sourceworker/host_test.go
+++ b/internal/sourceruntime/sourceworker/host_test.go
@@ -219,6 +219,17 @@ func TestCredentialHeaderAppliesOnlyTheClosedSentinelOneScheme(t *testing.T) {
 	}
 }
 
+func TestCredentialHeaderAppliesGenericXAPIKeyOnlyInsideTheTrustedHost(t *testing.T) {
+	header, value, err := credentialHeader("source.x_api_key", []byte("synthetic-secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clear(value)
+	if header != "X-Api-Key" || string(value) != "synthetic-secret" {
+		t.Fatal("generic x-api-key operation did not produce the exact host-owned header")
+	}
+}
+
 func TestCredentialHeaderAppliesOnlyClosedAnthropicSchemes(t *testing.T) {
 	for _, operation := range []string{"anthropic.admin_x_api_key", "anthropic.compliance_x_api_key"} {
 		header, value, err := credentialHeader(operation, []byte("synthetic-secret"))


### PR DESCRIPTION
Adds the closed `source.x_api_key` credential operation for provider-neutral source adapters that require a raw `X-Api-Key` header.

The portable Rust contract admits the operation; the trusted Go host alone converts the redeemed credential lease into the header. Provider kernels still receive no secret bytes, and declared public headers still reject `x-api-key`.

Validation on exact head `49b11e268dac17531164bb4a94661a4c0eac7589`:
- `go test ./internal/sourceruntime/sourceworker -count=1`
- `go test -race ./internal/sourceruntime/sourceworker -count=1`
- `rustfmt --edition 2024 --check crates/source-runtime-next/src/source_execution/contract.rs crates/source-runtime-next/src/source_execution/tests.rs`
- `git diff --check`

Managed Cargo stopped before compilation because the shared DDESK cache is 3,606,448,742 bytes short of safe capacity. Hosted Rust checks are the compile receipt.

This is reusable host plumbing for credential-free provider kernels; provider registration and authority changes are outside this PR.