### PR TITLE
fix(sources): collapse portable AI cursor guard

### DIFF
--- a/crates/source-runtime-next/src/portable_ai/adapter.rs
+++ b/crates/source-runtime-next/src/portable_ai/adapter.rs
@@ -369,14 +369,13 @@ impl PortableAiSourceExecutionAdapter {
             in_json_body: true,
             ..
         } = &self.family.pagination
+            && !context.prior_cursor.is_empty()
         {
-            if !context.prior_cursor.is_empty() {
-                validate_cursor(&context.prior_cursor)?;
-                body.insert(
-                    parameter.clone(),
-                    Value::String(context.prior_cursor.clone()),
-                );
-            }
+            validate_cursor(&context.prior_cursor)?;
+            body.insert(
+                parameter.clone(),
+                Value::String(context.prior_cursor.clone()),
+            );
         }
         if body.is_empty() {
             return Ok(Vec::new());


### PR DESCRIPTION
## Summary

- collapse the nested portable AI JSON-body cursor guard
- preserve cursor validation and request-body behavior

## Validation

- `rustfmt --edition 2024 --check crates/source-runtime-next/src/portable_ai/adapter.rs`
- `cargo clippy -p cerebro-source-runtime-next --lib --all-features --locked -- -D warnings`
- `cargo test -p cerebro-source-runtime-next portable_ai --lib --locked`
- `git diff --check`