### PR TITLE
Restore current-main architecture and Clippy gates

### DIFF
--- a/crates/source-runtime-next/src/abnormal_security/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/abnormal_security/source_execution_tests.rs
@@ -128,12 +128,12 @@ fn decode_page(
     plan: &SourceExecutionPlanV1,
     context: &SourceWorkerExecutionContextV1,
     metadata: &SourceWorkerRuntimeMetadataV2,
-    execution: &SourceWorkerHttpExecutionV2,
     status_code: u32,
     body: &[u8],
     response_headers: HashMap<String, String>,
 ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
-    let safe_receipt = receipt(plan, context, execution, status_code, body);
+    let execution = plan_page(adapter, plan, context, metadata);
+    let safe_receipt = receipt(plan, context, &execution, status_code, body);
     adapter.decode_v2(&SourceWorkerDecodeEnvelopeV2 {
         request: Some(SourceWorkerDecodeRequestV1 {
             plan: Some(plan.clone()),
@@ -211,7 +211,6 @@ fn abnormal_security_decodes_every_fixture_with_exact_contract_and_seals() {
             &plan,
             &context,
             &metadata,
-            &execution,
             200,
             &body,
             HashMap::new(),
@@ -265,14 +264,12 @@ fn abnormal_security_pagination_and_provider_failures_are_typed() {
         let plan = adapter.compiled_plan();
         let context = context("", 1);
         let metadata = metadata(family);
-        let execution = plan_page(adapter, &plan, &context, &metadata);
         let body = response(family, vec![fixture(family)], Some(2));
         let result = decode_page(
             adapter,
             &plan,
             &context,
             &metadata,
-            &execution,
             200,
             &body,
             HashMap::new(),
@@ -286,7 +283,6 @@ fn abnormal_security_pagination_and_provider_failures_are_typed() {
     let plan = adapter.compiled_plan();
     let context = context("", 1);
     let metadata = metadata(family);
-    let execution = plan_page(adapter, &plan, &context, &metadata);
     for (status, expected) in [
         (401, SourceExecutionError::AuthenticationRejected),
         (403, SourceExecutionError::RequiredProviderScopeMissing),
@@ -299,7 +295,6 @@ fn abnormal_security_pagination_and_provider_failures_are_typed() {
                 &plan,
                 &context,
                 &metadata,
-                &execution,
                 status,
                 b"{}",
                 HashMap::new(),
@@ -313,7 +308,6 @@ fn abnormal_security_pagination_and_provider_failures_are_typed() {
             &plan,
             &context,
             &metadata,
-            &execution,
             429,
             b"{}",
             HashMap::from([("retry-after".to_owned(), "60".to_owned())]),
@@ -341,7 +335,6 @@ fn abnormal_security_rejects_bad_scope_cursor_duplicates_and_secret_material() {
     );
 
     let execution_context = context("", 1);
-    let execution = plan_page(adapter, &plan, &execution_context, &metadata);
     let original = fixture(family);
     let duplicate_body = response(family, vec![original.clone(), original.clone()], None);
     let result = decode_page(
@@ -349,7 +342,6 @@ fn abnormal_security_rejects_bad_scope_cursor_duplicates_and_secret_material() {
         &plan,
         &execution_context,
         &metadata,
-        &execution,
         200,
         &duplicate_body,
         HashMap::new(),
@@ -366,7 +358,6 @@ fn abnormal_security_rejects_bad_scope_cursor_duplicates_and_secret_material() {
             &plan,
             &execution_context,
             &metadata,
-            &execution,
             200,
             &conflicting_body,
             HashMap::new(),
@@ -382,7 +373,6 @@ fn abnormal_security_rejects_bad_scope_cursor_duplicates_and_secret_material() {
         &plan,
         &execution_context,
         &metadata,
-        &execution,
         200,
         &secret_body,
         HashMap::new(),
@@ -400,7 +390,6 @@ fn abnormal_security_rejects_bad_scope_cursor_duplicates_and_secret_material() {
             &plan,
             &execution_context,
             &metadata,
-            &execution,
             200,
             &untrusted_scope_body,
             HashMap::new(),

--- a/crates/source-runtime-next/src/portable_ai/adapter.rs
+++ b/crates/source-runtime-next/src/portable_ai/adapter.rs
@@ -369,14 +369,13 @@ impl PortableAiSourceExecutionAdapter {
             in_json_body: true,
             ..
         } = &self.family.pagination
+            && !context.prior_cursor.is_empty()
         {
-            if !context.prior_cursor.is_empty() {
-                validate_cursor(&context.prior_cursor)?;
-                body.insert(
-                    parameter.clone(),
-                    Value::String(context.prior_cursor.clone()),
-                );
-            }
+            validate_cursor(&context.prior_cursor)?;
+            body.insert(
+                parameter.clone(),
+                Value::String(context.prior_cursor.clone()),
+            );
         }
         if body.is_empty() {
             return Ok(Vec::new());

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -15,6 +15,7 @@ import (
 	"github.com/writer/cerebro/internal/graphquery"
 	"github.com/writer/cerebro/internal/grcauditpacket"
 	"github.com/writer/cerebro/internal/grccontrol"
+	"github.com/writer/cerebro/internal/grcdashboard"
 	"github.com/writer/cerebro/internal/grcfindings"
 	"github.com/writer/cerebro/internal/grcpolicylifecycle"
 	"github.com/writer/cerebro/internal/grcproductareas"
@@ -36,7 +37,6 @@ const (
 	grcMaxLimit                       = uint32(500)
 	grcMaxRuntimeScope                = uint32(500)
 	grcRuntimeScopeFetchLimit         = grcMaxRuntimeScope + 1
-	grcDashboardPreviewLimit          = uint32(25)
 	grcRuntimeHealthEnrichmentTimeout = 5 * time.Second
 	grcAuditPacketSchema              = grcauditpacket.SchemaVersion
 )
@@ -49,13 +49,6 @@ type grcScope struct {
 	VendorURN  string
 	Limit      uint32
 }
-
-type grcDashboardEnrichments string
-
-const (
-	grcDashboardEnrichmentsInline   grcDashboardEnrichments = "inline"
-	grcDashboardEnrichmentsDeferred grcDashboardEnrichments = "deferred"
-)
 
 type grcDashboardResponse struct {
 	Summary            grcSummary                   `json:"summary"`
@@ -94,12 +87,12 @@ type grcAuditFindingReference = grcauditpacket.FindingReference
 type grcAuditPacketGap = grcauditpacket.Gap
 
 func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
-	ctx, span := telemetry.Start(r.Context(), "grc.dashboard", grcDashboardTelemetryAttrs())
+	ctx, span := telemetry.Start(r.Context(), "grc.dashboard", grcdashboard.TelemetryAttrs())
 	dashboardCtx := ctx
 	r = r.WithContext(ctx)
 	status := "completed"
 	statusCode := http.StatusOK
-	endAttrs := grcDashboardTelemetryAttrs()
+	endAttrs := grcdashboard.TelemetryAttrs()
 	defer func() {
 		endAttrs = endAttrs.WithField(telemetry.Field{Key: "status_code", Value: statusCode})
 		telemetry.IncrementMain(dashboardCtx, "grc.dashboard.count", 1)
@@ -127,14 +120,14 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, errors.Join(errInvalidHTTPRequest, err))
 		return
 	}
-	enrichments, err := grcDashboardEnrichmentsFromRequest(r)
+	enrichments, err := grcdashboard.ParseEnrichments(r.URL.Query())
 	if err != nil {
 		statusCode = http.StatusBadRequest
 		status, endAttrs = grcTelemetryError(endAttrs, err)
 		writeGRCError(w, errors.Join(errInvalidHTTPRequest, err))
 		return
 	}
-	endAttrs = endAttrs.WithField(telemetry.Field{Key: "enrichments", Value: string(enrichments)})
+	endAttrs = endAttrs.WithField(telemetry.Field{Key: "enrichments", Value: enrichments.String()})
 	scope, err := grcScopeFromRequest(r)
 	if err != nil {
 		statusCode = grcHTTPStatusCode(err)
@@ -143,9 +136,9 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	endAttrs = endAttrs.WithField(telemetry.Field{Key: "limit", Value: scope.Limit})
-	previewLimit := grcDashboardPreviewLimitFor(scope.Limit)
+	previewLimit := grcdashboard.PreviewLimitFor(scope.Limit)
 	endAttrs = endAttrs.WithField(telemetry.Field{Key: "preview_limit", Value: previewLimit})
-	ctx, runtimesSpan := telemetry.Start(r.Context(), "grc.dashboard.runtimes", grcDashboardScopeTelemetryAttrs(scope))
+	ctx, runtimesSpan := telemetry.Start(r.Context(), "grc.dashboard.runtimes", grcdashboard.ScopeTelemetryAttrs(scope.TenantID, scope.RuntimeID, scope.SourceID, scope.Limit))
 	runtimesRequest := r.WithContext(ctx)
 	runtimes, err := a.grcListRuntimes(runtimesRequest, scope)
 	runtimeAttrs := telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: len(runtimes)})
@@ -157,7 +150,7 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	ctx, findingsSpan := telemetry.Start(r.Context(), "grc.dashboard.findings", grcDashboardScopeTelemetryAttrs(scope))
+	ctx, findingsSpan := telemetry.Start(r.Context(), "grc.dashboard.findings", grcdashboard.ScopeTelemetryAttrs(scope.TenantID, scope.RuntimeID, scope.SourceID, scope.Limit))
 	findingsRequest := r.WithContext(ctx)
 	findings, err := a.grcListFindingRecords(findingsRequest, runtimes, grcFindingFilter{Status: "open", Limit: previewLimit})
 	findingAttrs := telemetry.Attrs(telemetry.Field{Key: "finding_count", Value: len(findings)})
@@ -172,13 +165,10 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	findingIDs := grcFindingIDs(findings)
 	generatedAt := time.Now().UTC()
 	var (
-		evidence         []*cerebrov1.FindingEvidence
-		findingSummary   *ports.FindingSummary
-		evidenceCount    *int
-		aggregate        *ports.GRCDashboardAggregate
-		sourceSummaries  []sourceRuntimeHealthSummary
-		coverage         []sourcecoverage.Record
-		runtimeHealthErr error
+		evidence       []*cerebrov1.FindingEvidence
+		findingSummary *ports.FindingSummary
+		evidenceCount  *int
+		aggregate      *ports.GRCDashboardAggregate
 	)
 	group, groupCtx := errgroup.WithContext(r.Context())
 	group.Go(func() error {
@@ -207,41 +197,28 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 			return attrs, err
 		})
 	})
-	if enrichments == grcDashboardEnrichmentsInline {
-		group.Go(func() error {
-			runtimeHealthCtx, cancel := context.WithTimeout(groupCtx, grcRuntimeHealthEnrichmentTimeout)
-			defer cancel()
-			runtimeHealthErr = operationtelemetry.RunMainPhase(runtimeHealthCtx, "grc.dashboard.runtime_health", telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: len(runtimes)}), func(ctx context.Context) (telemetry.Attributes, error) {
-				var err error
-				sourceSummaries, err = a.grcSourceRuntimeHealthSummaries(ctx, runtimes, generatedAt)
-				return telemetry.Attrs(telemetry.Field{Key: "source_summary_count", Value: len(sourceSummaries)}), err
-			})
-			if runtimeHealthErr != nil {
-				sourceSummaries = nil
-			}
-			return nil
-		})
-		group.Go(func() error {
-			var err error
-			return operationtelemetry.RunMainPhase(groupCtx, "grc.dashboard.coverage", telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: len(runtimes)}), func(ctx context.Context) (telemetry.Attributes, error) {
-				coverage, err = a.sourceCoverageRecordsScoped(ctx, runtimes, ports.SourceRuntimeFilter{
-					RuntimeID: scope.RuntimeID, RuntimeIDs: scope.RuntimeIDs, TenantID: scope.TenantID,
-					SourceID: scope.SourceID, Limit: scope.Limit,
-				}, generatedAt, coverageScope)
-				return telemetry.Attrs(telemetry.Field{Key: "coverage_record_count", Value: len(coverage)}), err
-			})
-		})
-	}
+	enrichmentResult := grcdashboard.ScheduleEnrichments(group, groupCtx, enrichments, grcdashboard.EnrichmentWork[sourceRuntimeHealthSummary, sourcecoverage.Record]{
+		RuntimeCount:         len(runtimes),
+		RuntimeHealthTimeout: grcRuntimeHealthEnrichmentTimeout,
+		RuntimeHealth: func(ctx context.Context) ([]sourceRuntimeHealthSummary, error) {
+			return a.grcSourceRuntimeHealthSummaries(ctx, runtimes, generatedAt)
+		},
+		Coverage: func(ctx context.Context) ([]sourcecoverage.Record, error) {
+			return a.sourceCoverageRecordsScoped(ctx, runtimes, ports.SourceRuntimeFilter{
+				RuntimeID: scope.RuntimeID, RuntimeIDs: scope.RuntimeIDs, TenantID: scope.TenantID,
+				SourceID: scope.SourceID, Limit: scope.Limit,
+			}, generatedAt, coverageScope)
+		},
+	})
 	if err := group.Wait(); err != nil {
 		statusCode = grcHTTPStatusCode(err)
 		status, endAttrs = grcTelemetryError(endAttrs, err)
 		writeGRCError(w, err)
 		return
 	}
-	sourceSummariesStatus := grcTelemetryStatus(runtimeHealthErr)
-	if enrichments == grcDashboardEnrichmentsDeferred {
-		sourceSummariesStatus = string(grcDashboardEnrichmentsDeferred)
-	}
+	sourceSummaries := enrichmentResult.SourceSummaries
+	coverage := enrichmentResult.Coverage
+	sourceSummariesStatus := enrichments.SourceSummariesStatus(grcTelemetryStatus(enrichmentResult.RuntimeHealthErr))
 	endAttrs = endAttrs.With(
 		telemetry.Attrs(
 			telemetry.Field{Key: "source_summaries_status", Value: sourceSummariesStatus},
@@ -262,10 +239,7 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	controls := grcControlItems(findingItems, evidenceItems)
 	coverageBlindSpots := sourcecoverage.BlindSpots(coverage)
 	serializedCoverageBlindSpots := coverageBlindSpots
-	var productAreas []grcproductareas.View
-	if enrichments == grcDashboardEnrichmentsInline {
-		productAreas = grcproductareas.BuildCoverageViews(coverage)
-	}
+	productAreas := grcdashboard.ProductAreas(enrichments, coverage)
 	if view == responseview.Summary {
 		serializedCoverageBlindSpots = nil
 		productAreas = responseview.CompactProductAreas(productAreas)
@@ -287,33 +261,12 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func grcDashboardEnrichmentsFromRequest(r *http.Request) (grcDashboardEnrichments, error) {
-	if r == nil || r.URL == nil {
-		return grcDashboardEnrichmentsInline, nil
-	}
-	switch strings.ToLower(strings.TrimSpace(r.URL.Query().Get("enrichments"))) {
-	case "", string(grcDashboardEnrichmentsInline):
-		return grcDashboardEnrichmentsInline, nil
-	case string(grcDashboardEnrichmentsDeferred):
-		return grcDashboardEnrichmentsDeferred, nil
-	default:
-		return grcDashboardEnrichmentsInline, errors.New("enrichments must be inline or deferred when provided")
-	}
-}
-
 func (a *App) grcSourceRuntimeHealthSummaries(ctx context.Context, runtimes []*cerebrov1.SourceRuntime, generatedAt time.Time) ([]sourceRuntimeHealthSummary, error) {
 	records, err := a.sourceRuntimeHealthRecords(ctx, runtimes, generatedAt)
 	if err != nil {
 		return nil, err
 	}
 	return sourceRuntimeHealthSummaries(records), nil
-}
-
-func grcDashboardPreviewLimitFor(limit uint32) uint32 {
-	if limit == 0 || limit > grcDashboardPreviewLimit {
-		return grcDashboardPreviewLimit
-	}
-	return limit
 }
 
 const (
@@ -798,21 +751,6 @@ type grcFindingHeaderLister interface {
 
 type grcFindingTrendsProvider interface {
 	SummarizeGRCFindingTrends(context.Context, ports.GRCFindingTrendsRequest) (ports.GRCFindingTrends, error)
-}
-
-func grcDashboardTelemetryAttrs() telemetry.Attributes {
-	return telemetry.Attrs(
-		telemetry.Field{Key: "route", Value: "/grc/dashboard"},
-		telemetry.Field{Key: "dashboard", Value: "grc"},
-	)
-}
-
-func grcDashboardScopeTelemetryAttrs(scope grcScope) telemetry.Attributes {
-	return grcDashboardTelemetryAttrs().
-		WithField(telemetry.Field{Key: "tenant_id", Value: scope.TenantID}).
-		WithField(telemetry.Field{Key: "runtime_id", Value: scope.RuntimeID}).
-		WithField(telemetry.Field{Key: "source_id", Value: scope.SourceID}).
-		WithField(telemetry.Field{Key: "limit", Value: scope.Limit})
 }
 
 func grcTelemetryStatus(err error) string {

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/grcaudit"
 	"github.com/writer/cerebro/internal/grcauditpacket"
+	"github.com/writer/cerebro/internal/grcdashboard"
 	"github.com/writer/cerebro/internal/grcfindings"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
@@ -746,20 +747,20 @@ func TestGRCDashboardCapsPreviewWorkToRenderedLimit(t *testing.T) {
 	if len(payload.Evidence) != 25 {
 		t.Fatalf("evidence len = %d, want capped preview 25", len(payload.Evidence))
 	}
-	if store.findingListRequest.Limit != grcDashboardPreviewLimit {
-		t.Fatalf("finding list limit = %d, want dashboard preview limit %d", store.findingListRequest.Limit, grcDashboardPreviewLimit)
+	if store.findingListRequest.Limit != grcdashboard.PreviewLimit {
+		t.Fatalf("finding list limit = %d, want dashboard preview limit %d", store.findingListRequest.Limit, grcdashboard.PreviewLimit)
 	}
-	if store.findingEvidenceListRequest.Limit != grcDashboardPreviewLimit {
-		t.Fatalf("evidence list limit = %d, want dashboard preview limit %d", store.findingEvidenceListRequest.Limit, grcDashboardPreviewLimit)
+	if store.findingEvidenceListRequest.Limit != grcdashboard.PreviewLimit {
+		t.Fatalf("evidence list limit = %d, want dashboard preview limit %d", store.findingEvidenceListRequest.Limit, grcdashboard.PreviewLimit)
 	}
-	if got := len(store.findingEvidenceListRequest.FindingIDs); got != int(grcDashboardPreviewLimit) {
-		t.Fatalf("evidence finding id count = %d, want dashboard preview limit %d", got, grcDashboardPreviewLimit)
+	if got := len(store.findingEvidenceListRequest.FindingIDs); got != int(grcdashboard.PreviewLimit) {
+		t.Fatalf("evidence finding id count = %d, want dashboard preview limit %d", got, grcdashboard.PreviewLimit)
 	}
 	if payload.Summary.OpenFindings != 40 {
 		t.Fatalf("summary open findings = %d, want unpaginated total 40", payload.Summary.OpenFindings)
 	}
 	if payload.Summary.EvidenceItems != 40 {
-		t.Fatalf("summary evidence items = %d, want unpaginated total 40 (not the %d-row preview)", payload.Summary.EvidenceItems, grcDashboardPreviewLimit)
+		t.Fatalf("summary evidence items = %d, want unpaginated total 40 (not the %d-row preview)", payload.Summary.EvidenceItems, grcdashboard.PreviewLimit)
 	}
 	if store.aggregateCalls != 1 {
 		t.Fatalf("aggregate calls = %d, want 1", store.aggregateCalls)

--- a/internal/grcdashboard/enrichments.go
+++ b/internal/grcdashboard/enrichments.go
@@ -1,0 +1,121 @@
+package grcdashboard
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/grcproductareas"
+	"github.com/writer/cerebro/internal/operationtelemetry"
+	"github.com/writer/cerebro/internal/sourcecoverage"
+	"github.com/writer/cerebro/internal/telemetry"
+	"golang.org/x/sync/errgroup"
+)
+
+const PreviewLimit = uint32(25)
+
+type Enrichments string
+
+const (
+	EnrichmentsInline   Enrichments = "inline"
+	EnrichmentsDeferred Enrichments = "deferred"
+)
+
+func TelemetryAttrs() telemetry.Attributes {
+	return telemetry.Attrs(
+		telemetry.Field{Key: "route", Value: "/grc/dashboard"},
+		telemetry.Field{Key: "dashboard", Value: "grc"},
+	)
+}
+
+func ScopeTelemetryAttrs(tenantID, runtimeID, sourceID string, limit uint32) telemetry.Attributes {
+	return TelemetryAttrs().
+		WithField(telemetry.Field{Key: "tenant_id", Value: tenantID}).
+		WithField(telemetry.Field{Key: "runtime_id", Value: runtimeID}).
+		WithField(telemetry.Field{Key: "source_id", Value: sourceID}).
+		WithField(telemetry.Field{Key: "limit", Value: limit})
+}
+
+func ParseEnrichments(values url.Values) (Enrichments, error) {
+	switch strings.ToLower(strings.TrimSpace(values.Get("enrichments"))) {
+	case "", string(EnrichmentsInline):
+		return EnrichmentsInline, nil
+	case string(EnrichmentsDeferred):
+		return EnrichmentsDeferred, nil
+	default:
+		return EnrichmentsInline, errors.New("enrichments must be inline or deferred when provided")
+	}
+}
+
+func (e Enrichments) String() string {
+	return string(e)
+}
+
+func (e Enrichments) SourceSummariesStatus(inlineStatus string) string {
+	if e == EnrichmentsDeferred {
+		return string(EnrichmentsDeferred)
+	}
+	return inlineStatus
+}
+
+func PreviewLimitFor(limit uint32) uint32 {
+	if limit == 0 || limit > PreviewLimit {
+		return PreviewLimit
+	}
+	return limit
+}
+
+func ProductAreas(enrichments Enrichments, coverage []sourcecoverage.Record) []grcproductareas.View {
+	if enrichments == EnrichmentsDeferred {
+		return nil
+	}
+	return grcproductareas.BuildCoverageViews(coverage)
+}
+
+type EnrichmentWork[Summary, Coverage any] struct {
+	RuntimeCount         int
+	RuntimeHealthTimeout time.Duration
+	RuntimeHealth        func(context.Context) ([]Summary, error)
+	Coverage             func(context.Context) ([]Coverage, error)
+}
+
+type EnrichmentResult[Summary, Coverage any] struct {
+	SourceSummaries  []Summary
+	Coverage         []Coverage
+	RuntimeHealthErr error
+}
+
+func ScheduleEnrichments[Summary, Coverage any](
+	group *errgroup.Group,
+	groupCtx context.Context,
+	enrichments Enrichments,
+	work EnrichmentWork[Summary, Coverage],
+) *EnrichmentResult[Summary, Coverage] {
+	result := &EnrichmentResult[Summary, Coverage]{}
+	if enrichments == EnrichmentsDeferred {
+		return result
+	}
+	group.Go(func() error {
+		runtimeHealthCtx, cancel := context.WithTimeout(groupCtx, work.RuntimeHealthTimeout)
+		defer cancel()
+		result.RuntimeHealthErr = operationtelemetry.RunMainPhase(runtimeHealthCtx, "grc.dashboard.runtime_health", telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: work.RuntimeCount}), func(ctx context.Context) (telemetry.Attributes, error) {
+			var err error
+			result.SourceSummaries, err = work.RuntimeHealth(ctx)
+			return telemetry.Attrs(telemetry.Field{Key: "source_summary_count", Value: len(result.SourceSummaries)}), err
+		})
+		if result.RuntimeHealthErr != nil {
+			result.SourceSummaries = nil
+		}
+		return nil
+	})
+	group.Go(func() error {
+		var err error
+		return operationtelemetry.RunMainPhase(groupCtx, "grc.dashboard.coverage", telemetry.Attrs(telemetry.Field{Key: "runtime_count", Value: work.RuntimeCount}), func(ctx context.Context) (telemetry.Attributes, error) {
+			result.Coverage, err = work.Coverage(ctx)
+			return telemetry.Attrs(telemetry.Field{Key: "coverage_record_count", Value: len(result.Coverage)}), err
+		})
+	})
+	return result
+}

--- a/internal/grcdashboard/enrichments_test.go
+++ b/internal/grcdashboard/enrichments_test.go
@@ -1,0 +1,108 @@
+package grcdashboard
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+func TestParseEnrichments(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		value   string
+		want    Enrichments
+		wantErr bool
+	}{
+		{name: "default", want: EnrichmentsInline},
+		{name: "inline", value: " INLINE ", want: EnrichmentsInline},
+		{name: "deferred", value: "deferred", want: EnrichmentsDeferred},
+		{name: "invalid", value: "eventually", want: EnrichmentsInline, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseEnrichments(url.Values{"enrichments": []string{tc.value}})
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ParseEnrichments() error = %v, wantErr %t", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Fatalf("ParseEnrichments() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestScheduleEnrichmentsDeferredSkipsWork(t *testing.T) {
+	t.Parallel()
+	group, ctx := errgroup.WithContext(context.Background())
+	result := ScheduleEnrichments(group, ctx, EnrichmentsDeferred, EnrichmentWork[string, string]{
+		RuntimeHealth: func(context.Context) ([]string, error) {
+			t.Fatal("deferred runtime health ran")
+			return nil, nil
+		},
+		Coverage: func(context.Context) ([]string, error) {
+			t.Fatal("deferred coverage ran")
+			return nil, nil
+		},
+	})
+	if err := group.Wait(); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if len(result.SourceSummaries) != 0 || len(result.Coverage) != 0 || result.RuntimeHealthErr != nil {
+		t.Fatalf("deferred result = %+v, want empty", result)
+	}
+}
+
+func TestScheduleEnrichmentsKeepsRuntimeHealthFailureNonFatal(t *testing.T) {
+	t.Parallel()
+	runtimeErr := errors.New("runtime health unavailable")
+	group, ctx := errgroup.WithContext(context.Background())
+	result := ScheduleEnrichments(group, ctx, EnrichmentsInline, EnrichmentWork[string, string]{
+		RuntimeHealthTimeout: time.Second,
+		RuntimeHealth: func(context.Context) ([]string, error) {
+			return []string{"partial"}, runtimeErr
+		},
+		Coverage: func(context.Context) ([]string, error) {
+			return []string{"coverage"}, nil
+		},
+	})
+	if err := group.Wait(); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if !errors.Is(result.RuntimeHealthErr, runtimeErr) {
+		t.Fatalf("runtime health error = %v, want %v", result.RuntimeHealthErr, runtimeErr)
+	}
+	if len(result.SourceSummaries) != 0 {
+		t.Fatalf("source summaries = %v, want cleared after error", result.SourceSummaries)
+	}
+	if len(result.Coverage) != 1 || result.Coverage[0] != "coverage" {
+		t.Fatalf("coverage = %v, want successful result", result.Coverage)
+	}
+}
+
+func TestScheduleEnrichmentsReturnsCoverageFailure(t *testing.T) {
+	t.Parallel()
+	coverageErr := errors.New("coverage unavailable")
+	group, ctx := errgroup.WithContext(context.Background())
+	ScheduleEnrichments(group, ctx, EnrichmentsInline, EnrichmentWork[string, string]{
+		RuntimeHealthTimeout: time.Second,
+		RuntimeHealth:        func(context.Context) ([]string, error) { return nil, nil },
+		Coverage:             func(context.Context) ([]string, error) { return nil, coverageErr },
+	})
+	if err := group.Wait(); !errors.Is(err, coverageErr) {
+		t.Fatalf("Wait() error = %v, want %v", err, coverageErr)
+	}
+}
+
+func TestPreviewLimitFor(t *testing.T) {
+	t.Parallel()
+	for input, want := range map[uint32]uint32{0: PreviewLimit, 1: 1, PreviewLimit: PreviewLimit, PreviewLimit + 1: PreviewLimit} {
+		if got := PreviewLimitFor(input); got != want {
+			t.Fatalf("PreviewLimitFor(%d) = %d, want %d", input, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- move dashboard enrichment parsing, scheduling, preview limits, and telemetry attributes into internal/grcdashboard
- keep bootstrap focused on HTTP mapping and dependency callbacks without increasing the architecture budget
- include the exact portable AI cursor-guard and Abnormal decode-helper cleanups required by the current protection cycle
- leave all other provider behavior unchanged

## Validation

- cargo clippy -p cerebro-source-runtime-next --lib --all-features --locked -- -D warnings
- cargo test -p cerebro-source-runtime-next portable_ai --lib --locked
- cargo test -p cerebro-source-runtime-next abnormal_security --lib --locked
- rustfmt --edition 2024 --check on both changed Rust files
- go test ./internal/grcdashboard -count=1
- go test ./internal/bootstrap -run TestGRCDashboard -count=1
- go test -race ./internal/grcdashboard -count=1
- go test -race ./internal/bootstrap -run TestGRCDashboard -count=1
- go test ./tools/archtests -count=1
- make check-structural check-structural-test check-arch
- make lint-internal
- git diff --check