### PR TITLE
Add Aha Rust source execution

### DIFF
--- a/crates/source-runtime-next/src/aha.rs
+++ b/crates/source-runtime-next/src/aha.rs
@@ -13,6 +13,10 @@ mod origin;
 mod projection;
 mod request;
 mod response;
+#[allow(dead_code)]
+mod source_execution;
+#[cfg(test)]
+mod source_execution_tests;
 mod types;
 
 pub use catalog::{AhaEventContract, AhaRuntimeDefinition};
@@ -20,6 +24,9 @@ pub use error::AhaError;
 pub use family::AhaFamily;
 pub use projection::{AhaEntityFact, AhaProjectionFacts, project_aha_records};
 pub use types::{AhaCheckpointCandidate, AhaKernel, AhaPage, AhaRecord, AhaRequest};
+
+#[allow(unused_imports)]
+pub(crate) use source_execution::AHA_SOURCE_EXECUTION_ADAPTERS;
 
 #[cfg(test)]
 mod tests;

--- a/crates/source-runtime-next/src/aha/normalize.rs
+++ b/crates/source-runtime-next/src/aha/normalize.rs
@@ -237,7 +237,7 @@ fn admit(record: &AhaRecord) -> Result<(), AhaError> {
     Ok(())
 }
 
-fn event_id(kernel: &AhaKernel, provider_id: &str) -> String {
+pub(super) fn event_id(kernel: &AhaKernel, provider_id: &str) -> String {
     let scope = Sha256::digest(format!(
         "{}\0{}\0{}",
         kernel.base_url.as_str(),
@@ -320,9 +320,12 @@ fn normalize_id(value: &str) -> String {
     }
     value
         .chars()
-        .map(|character| match character {
-            ' ' | '/' | ':' | '\t' | '\n' => '-',
-            other => other,
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.') {
+                character
+            } else {
+                '-'
+            }
         })
         .collect()
 }
@@ -338,7 +341,10 @@ fn reject_protected(value: &Value, depth: usize) -> Result<(), AhaError> {
             }
             for (key, value) in values {
                 let key = key.trim().to_ascii_lowercase().replace('-', "_");
-                if key == "tenant_id" {
+                if matches!(
+                    key.as_str(),
+                    "tenant_id" | "runtime_id" | "source_runtime_id"
+                ) {
                     return Err(AhaError::TenantMismatch);
                 }
                 if matches!(
@@ -346,9 +352,14 @@ fn reject_protected(value: &Value, depth: usize) -> Result<(), AhaError> {
                     "token"
                         | "access_token"
                         | "refresh_token"
+                        | "session_token"
                         | "api_key"
                         | "api_token"
+                        | "x_api_key"
+                        | "set_cookie"
                         | "password"
+                        | "passcode"
+                        | "secret"
                         | "private_key"
                         | "authorization"
                         | "client_secret"

--- a/crates/source-runtime-next/src/aha/source_execution.rs
+++ b/crates/source-runtime-next/src/aha/source_execution.rs
@@ -1,0 +1,455 @@
+//! Aha bridge for the closed source-execution protocol.
+//!
+//! These adapters receive authenticated tenant context, public provider
+//! configuration, and bounded provider response bytes. The trusted host owns
+//! credential redemption, `x-api-key` authentication, origin-constrained network
+//! I/O, durable append, projection, and checkpoint persistence.
+
+use std::collections::HashMap;
+
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceExecutionPlanV1,
+    SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1,
+    SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2, SourceWorkerHttpRequestV1,
+    SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1, SourceWorkerRecordV1,
+    SourceWorkerRuntimeMetadataV2, canonical_http_execution_digest, canonical_plan_digest,
+    canonical_request_intent_digest, canonical_result_digest, validate_and_deduplicate_records,
+    validate_execution_context, validate_runtime_metadata,
+};
+
+use super::{AhaError, AhaFamily, AhaKernel, AhaRuntimeDefinition, normalize::event_id};
+
+const SOURCE_ID: &str = "aha";
+const PLAN_ORIGIN: &str = "https://{account}.aha.io";
+const METHOD: &str = "GET";
+const ACCEPT: &str = "application/json";
+const MAX_RESPONSE_BYTES: u64 = 8 << 20;
+
+/// Credential-free adapter for one cataloged Aha family.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AhaSourceExecutionAdapter {
+    family: AhaFamily,
+}
+
+/// Provider-local adapter set. Shared dispatcher registration and authority
+/// promotion remain separate delivery steps.
+pub(crate) static AHA_SOURCE_EXECUTION_ADAPTERS: [AhaSourceExecutionAdapter; 5] = [
+    AhaSourceExecutionAdapter::new(AhaFamily::AuditEvents),
+    AhaSourceExecutionAdapter::new(AhaFamily::Features),
+    AhaSourceExecutionAdapter::new(AhaFamily::Products),
+    AhaSourceExecutionAdapter::new(AhaFamily::Releases),
+    AhaSourceExecutionAdapter::new(AhaFamily::Users),
+];
+
+impl AhaSourceExecutionAdapter {
+    const fn new(family: AhaFamily) -> Self {
+        Self { family }
+    }
+
+    pub(crate) fn compiled_plan(&self) -> SourceExecutionPlanV1 {
+        let family_id = self.family.as_str();
+        let definition =
+            AhaRuntimeDefinition::compile(self.family).expect("closed Aha family must compile");
+        let mut plan = SourceExecutionPlanV1 {
+            plan_id: format!("source-plan-v1:{SOURCE_ID}:{family_id}"),
+            source_id: SOURCE_ID.to_owned(),
+            family_id: family_id.to_owned(),
+            provider_kernel: self.family.event_kind().to_owned(),
+            method: METHOD.to_owned(),
+            origin: PLAN_ORIGIN.to_owned(),
+            path: family_path(self.family, "{product_id}"),
+            record_selector: record_selector(self.family).to_owned(),
+            id_field: self.family.id_field().to_owned(),
+            singleton_fallback_id: String::new(),
+            max_response_bytes: MAX_RESPONSE_BYTES,
+            event_kind: definition.event_contract.kind.to_owned(),
+            schema_ref: definition.event_contract.schema_ref.to_owned(),
+            required_attributes: definition
+                .event_contract
+                .required_attributes
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
+            required_payload_fields: definition
+                .event_contract
+                .required_payload_fields
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
+            plan_digest_sha256: String::new(),
+        };
+        plan.plan_digest_sha256 = canonical_plan_digest(&plan);
+        plan
+    }
+
+    fn validate_plan(&self, plan: &SourceExecutionPlanV1) -> Result<(), SourceExecutionError> {
+        if plan != &self.compiled_plan() {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        Ok(())
+    }
+
+    fn kernel(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(AhaKernel, String), SourceExecutionError> {
+        validate_execution_context(context)?;
+        validate_runtime_metadata(metadata)?;
+        if public_value(&metadata.public_config, "family")
+            .is_some_and(|value| value != self.family.as_str())
+        {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        let base_url = public_value(&metadata.public_config, "base_url")
+            .ok_or(SourceExecutionError::MissingConfiguration)?;
+        let product_id = public_value(&metadata.public_config, "product_id");
+        if self.family == AhaFamily::Releases && product_id.is_none() {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        let observed_at = timestamp(context.observed_at_unix_millis)?;
+        let kernel = AhaKernel::new(
+            base_url,
+            &context.tenant_id,
+            self.family,
+            product_id,
+            &observed_at,
+        )
+        .map_err(map_error)?;
+        let mut allowed_origin = kernel.plan(None).map_err(map_error)?.url().clone();
+        allowed_origin.set_path("/");
+        allowed_origin.set_query(None);
+        Ok((
+            kernel,
+            allowed_origin.to_string().trim_end_matches('/').to_owned(),
+        ))
+    }
+
+    fn validate_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+        metadata: Option<&SourceWorkerRuntimeMetadataV2>,
+    ) -> Result<(), SourceExecutionError> {
+        let metadata = metadata.ok_or(SourceExecutionError::MissingConfiguration)?;
+        let (kernel, _) = self.kernel(context, metadata)?;
+        if record.event_id != event_id(&kernel, &record.provider_id)
+            || record.attributes.get("tenant_id") != Some(&context.tenant_id)
+            || record.attributes.get("source_event_id") != Some(&record.provider_id)
+        {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        Ok(())
+    }
+}
+
+impl SourceExecutionAdapter for AhaSourceExecutionAdapter {
+    fn source_id(&self) -> &'static str {
+        SOURCE_ID
+    }
+
+    fn family_id(&self) -> &'static str {
+        self.family.as_str()
+    }
+
+    fn provider_kernel(&self) -> &'static str {
+        self.family.event_kind()
+    }
+
+    fn validate_record_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+    ) -> Result<(), SourceExecutionError> {
+        self.validate_identity(context, record, None)
+    }
+
+    fn validate_record_identity_v2(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(), SourceExecutionError> {
+        self.validate_identity(context, record, Some(metadata))
+    }
+
+    fn plan(
+        &self,
+        _request: &SourceWorkerPlanRequestV1,
+    ) -> Result<SourceWorkerHttpRequestV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn plan_v2(
+        &self,
+        envelope: &SourceWorkerPlanEnvelopeV2,
+    ) -> Result<SourceWorkerHttpExecutionV2, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, allowed_origin) = self.kernel(context, metadata)?;
+        let provider_request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        if provider_request.method() != plan.method
+            || provider_request.url().path()
+                != family_path(
+                    self.family,
+                    public_value(&metadata.public_config, "product_id").unwrap_or_default(),
+                )
+            || provider_request.authentication_header() != "Authorization"
+            || provider_request.authentication_scheme() != "Bearer"
+            || provider_request.contains_credentials()
+            || provider_request.allows_redirects()
+        {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        let mut planned = SourceWorkerHttpRequestV1 {
+            plan_id: plan.plan_id.clone(),
+            method: provider_request.method().to_owned(),
+            url: provider_request.url().to_string(),
+            accept: ACCEPT.to_owned(),
+            max_response_bytes: u64::try_from(provider_request.max_response_bytes())
+                .map_err(|_| SourceExecutionError::InvalidPlan)?,
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            request_intent_digest: String::new(),
+        };
+        planned.request_intent_digest = canonical_request_intent_digest(plan, context, &planned);
+        let mut execution = SourceWorkerHttpExecutionV2 {
+            request: Some(planned),
+            body: Vec::new(),
+            declared_headers: HashMap::new(),
+            execution_intent_digest_sha256: String::new(),
+            credential_operation: "source.bearer".to_owned(),
+            allowed_origin,
+        };
+        execution.execution_intent_digest_sha256 =
+            canonical_http_execution_digest(plan, context, metadata, &execution);
+        Ok(execution)
+    }
+
+    fn decode(
+        &self,
+        _request: &SourceWorkerDecodeRequestV1,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn decode_v2(
+        &self,
+        envelope: &SourceWorkerDecodeEnvelopeV2,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let receipt = request
+            .receipt
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, _) = self.kernel(context, metadata)?;
+        let provider_request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        let retry_after_seconds = response_header(&envelope.response_headers, "retry-after")
+            .map(|value| {
+                value
+                    .parse::<u64>()
+                    .map_err(|_| SourceExecutionError::UnexpectedProviderStatus)
+            })
+            .transpose()?;
+        let status = u16::try_from(request.status_code)
+            .map_err(|_| SourceExecutionError::UnexpectedProviderStatus)?;
+        let page = kernel
+            .decode(
+                &provider_request,
+                status,
+                retry_after_seconds,
+                &request.response_body,
+            )
+            .map_err(map_error)?;
+        let checkpoint = kernel
+            .checkpoint_candidate(
+                &provider_request,
+                &page,
+                optional_watermark(metadata)?.as_deref(),
+            )
+            .map_err(map_error)?;
+        let next_cursor = checkpoint.cursor.unwrap_or_default();
+        let records = page
+            .records
+            .into_iter()
+            .map(|record| {
+                if record.tenant_id != context.tenant_id
+                    || record.family != self.family
+                    || record.kind != plan.event_kind
+                    || record.schema_ref != plan.schema_ref
+                {
+                    return Err(SourceExecutionError::TenantMismatch);
+                }
+                Ok(SourceWorkerRecordV1 {
+                    provider_id: record.provider_id,
+                    event_id: record.event_id,
+                    occurred_at_unix_millis: parse_timestamp(&record.occurred_at)?,
+                    attributes: record.attributes.into_iter().collect(),
+                    payload_json: serde_json::to_vec(&record.payload)
+                        .map_err(|_| SourceExecutionError::InternalRuntime)?,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let records = validate_and_deduplicate_records(records)?;
+        for record in &records {
+            self.validate_record_identity_v2(context, record, metadata)?;
+        }
+        let result_digest_sha256 = canonical_result_digest(receipt, &next_cursor, &records)?;
+        Ok(SourceWorkerDecodeResultV1 {
+            plan_id: plan.plan_id.clone(),
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: request.request_intent_digest.clone(),
+            records,
+            next_cursor,
+            result_digest_sha256,
+            tenant_id: context.tenant_id.clone(),
+            runtime_id: context.runtime_id.clone(),
+            runtime_generation: context.runtime_generation,
+            lease_generation: context.lease_generation,
+            observed_at_unix_millis: context.observed_at_unix_millis,
+        })
+    }
+}
+
+const fn record_selector(family: AhaFamily) -> &'static str {
+    match family {
+        AhaFamily::AuditEvents => "$.audits[*]",
+        AhaFamily::Features => "$.features[*]",
+        AhaFamily::Products => "$.products[*]",
+        AhaFamily::Releases => "$.releases[*]",
+        AhaFamily::Users => "$.users[*]",
+    }
+}
+
+fn family_path(family: AhaFamily, product_id: &str) -> String {
+    let suffix = match family {
+        AhaFamily::AuditEvents => "/audits".to_owned(),
+        AhaFamily::Features => "/features".to_owned(),
+        AhaFamily::Products => "/products".to_owned(),
+        AhaFamily::Releases => format!("/products/{product_id}/releases"),
+        AhaFamily::Users => "/users".to_owned(),
+    };
+    format!("/api/v1{suffix}")
+}
+
+fn public_value<'a>(config: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    config
+        .get(key)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn response_header<'a>(headers: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    headers
+        .get(key)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn optional(value: &str) -> Option<&str> {
+    (!value.is_empty()).then_some(value)
+}
+
+fn optional_watermark(
+    metadata: &SourceWorkerRuntimeMetadataV2,
+) -> Result<Option<String>, SourceExecutionError> {
+    (metadata.prior_terminal_watermark_unix_millis > 0)
+        .then(|| timestamp(metadata.prior_terminal_watermark_unix_millis))
+        .transpose()
+}
+
+fn timestamp(unix_millis: i64) -> Result<String, SourceExecutionError> {
+    OffsetDateTime::from_unix_timestamp_nanos(i128::from(unix_millis) * 1_000_000)
+        .map_err(|_| SourceExecutionError::InvalidExecutionContext)?
+        .format(&Rfc3339)
+        .map_err(|_| SourceExecutionError::InternalRuntime)
+}
+
+fn parse_timestamp(value: &str) -> Result<i64, SourceExecutionError> {
+    let nanos = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| SourceExecutionError::InvalidProviderRecord)?
+        .unix_timestamp_nanos();
+    i64::try_from(nanos / 1_000_000).map_err(|_| SourceExecutionError::InvalidProviderRecord)
+}
+
+fn map_error(error: AhaError) -> SourceExecutionError {
+    match error {
+        AhaError::InvalidFamily => SourceExecutionError::UnknownAdapter,
+        AhaError::InvalidConfiguration(_)
+        | AhaError::InvalidOrigin
+        | AhaError::MissingProductId => SourceExecutionError::MissingConfiguration,
+        AhaError::InvalidTenantId => SourceExecutionError::InvalidExecutionContext,
+        AhaError::MissingCredentialReference => SourceExecutionError::MissingCredentialReference,
+        AhaError::CredentialUnavailable => SourceExecutionError::CredentialUnavailable,
+        AhaError::InvalidCursor => SourceExecutionError::InvalidCursor,
+        AhaError::RequestScopeMismatch => SourceExecutionError::InvalidPlan,
+        AhaError::AuthenticationRejected => SourceExecutionError::AuthenticationRejected,
+        AhaError::RequiredScopeMissing => SourceExecutionError::RequiredProviderScopeMissing,
+        AhaError::EgressDenied => SourceExecutionError::EgressDenied,
+        AhaError::DnsFailure | AhaError::ConnectionFailure => {
+            SourceExecutionError::ConnectionFailure
+        }
+        AhaError::ProviderTimeout => SourceExecutionError::ProviderTimeout,
+        AhaError::RateLimited { .. } => SourceExecutionError::ProviderRateLimit,
+        AhaError::ProviderResourceNotFound
+        | AhaError::ProviderUnavailable { .. }
+        | AhaError::UnexpectedStatus { .. }
+        | AhaError::InvalidRetryAfter => SourceExecutionError::UnexpectedProviderStatus,
+        AhaError::ResponseTooLarge => SourceExecutionError::ResponseTooLarge,
+        AhaError::TooManyRecords => SourceExecutionError::ResultTooLarge,
+        AhaError::MalformedResponse => SourceExecutionError::MalformedResponse,
+        AhaError::InvalidProviderRecord | AhaError::CredentialMaterial => {
+            SourceExecutionError::InvalidProviderRecord
+        }
+        AhaError::MissingStableIdentity => SourceExecutionError::MissingStableIdentity,
+        AhaError::ProductMismatch | AhaError::TenantMismatch => {
+            SourceExecutionError::TenantMismatch
+        }
+        AhaError::ConflictingDuplicate => SourceExecutionError::DuplicateConflict,
+        AhaError::EventContractRejection => SourceExecutionError::EventContractRejected,
+        AhaError::AppendFailure => SourceExecutionError::AppendFailed,
+        AhaError::ProjectionFailure => SourceExecutionError::ProjectionFailed,
+        AhaError::LeaseLoss => SourceExecutionError::LeaseLost,
+        AhaError::StaleAuthority => SourceExecutionError::StaleAuthority,
+        AhaError::InternalRuntimeFailure => SourceExecutionError::InternalRuntime,
+    }
+}

--- a/crates/source-runtime-next/src/aha/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/aha/source_execution_tests.rs
@@ -1,0 +1,432 @@
+use std::{collections::HashMap, fs, path::PathBuf};
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceExecutionLifecycleEnvelopeV2,
+    SourceExecutionLifecycleRequestV1, SourceExecutionPlanV1, SourceWorkerDecodeEnvelopeV2,
+    SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1, SourceWorkerExecutionContextV1,
+    SourceWorkerHttpExecutionV2, SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1,
+    SourceWorkerRuntimeMetadataV2, SourceWorkerSafeReceiptV1, response_digest,
+    seal_page_program_v2,
+};
+
+use super::{
+    AhaFamily,
+    source_execution::{AHA_SOURCE_EXECUTION_ADAPTERS, AhaSourceExecutionAdapter},
+};
+
+const OBSERVED_AT_MILLIS: i64 = 1_780_272_000_000;
+
+#[derive(Deserialize)]
+struct GoOracleEvent {
+    payload: Value,
+}
+
+fn root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn adapter(family: AhaFamily) -> &'static AhaSourceExecutionAdapter {
+    AHA_SOURCE_EXECUTION_ADAPTERS
+        .iter()
+        .find(|adapter| adapter.family_id() == family.as_str())
+        .unwrap()
+}
+
+fn fixture(family: AhaFamily) -> Value {
+    let bytes = fs::read(root().join(format!(
+        "sources/aha/testdata/read_{}.json",
+        family.as_str()
+    )))
+    .unwrap();
+    serde_json::from_slice::<Vec<GoOracleEvent>>(&bytes)
+        .unwrap()
+        .pop()
+        .unwrap()
+        .payload
+}
+
+fn response(family: AhaFamily, records: Vec<Value>) -> Vec<u8> {
+    serde_json::to_vec(&json!({family.response_key(): records})).unwrap()
+}
+
+fn context(cursor: &str, page: u32) -> SourceWorkerExecutionContextV1 {
+    SourceWorkerExecutionContextV1 {
+        tenant_id: "tenant".to_owned(),
+        runtime_id: "aha-runtime".to_owned(),
+        logical_page_id: format!("source-page-v2:aha-{page}"),
+        prior_cursor: cursor.to_owned(),
+        runtime_generation: 7,
+        lease_generation: 11,
+        observed_at_unix_millis: OBSERVED_AT_MILLIS,
+    }
+}
+
+fn metadata(family: AhaFamily) -> SourceWorkerRuntimeMetadataV2 {
+    SourceWorkerRuntimeMetadataV2 {
+        public_config: HashMap::from([
+            ("family".to_owned(), family.as_str().to_owned()),
+            ("base_url".to_owned(), "https://example.aha.io".to_owned()),
+            ("product_id".to_owned(), "product-1".to_owned()),
+        ]),
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    }
+}
+
+fn plan_page(
+    adapter: &AhaSourceExecutionAdapter,
+    plan: &SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    metadata: &SourceWorkerRuntimeMetadataV2,
+) -> SourceWorkerHttpExecutionV2 {
+    adapter
+        .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+        })
+        .unwrap()
+}
+
+fn receipt(
+    plan: &SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    execution: &SourceWorkerHttpExecutionV2,
+    status_code: u32,
+    body: &[u8],
+) -> SourceWorkerSafeReceiptV1 {
+    let request = execution.request.as_ref().unwrap();
+    SourceWorkerSafeReceiptV1 {
+        plan_digest_sha256: plan.plan_digest_sha256.clone(),
+        logical_page_id: context.logical_page_id.clone(),
+        request_intent_digest: request.request_intent_digest.clone(),
+        runtime_generation: context.runtime_generation,
+        lease_generation: context.lease_generation,
+        credential_operation: execution.credential_operation.clone(),
+        status_code,
+        response_bytes: body.len() as u64,
+        response_sha256: response_digest(body),
+        tenant_id: context.tenant_id.clone(),
+        runtime_id: context.runtime_id.clone(),
+        observed_at_unix_millis: context.observed_at_unix_millis,
+    }
+}
+
+fn decode_page(
+    adapter: &AhaSourceExecutionAdapter,
+    plan: &SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    metadata: &SourceWorkerRuntimeMetadataV2,
+    status_code: u32,
+    body: &[u8],
+    response_headers: HashMap<String, String>,
+) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+    let execution = plan_page(adapter, plan, context, metadata);
+    let safe_receipt = receipt(plan, context, &execution, status_code, body);
+    adapter.decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+        request: Some(SourceWorkerDecodeRequestV1 {
+            plan: Some(plan.clone()),
+            status_code,
+            response_body: body.to_vec(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: execution
+                .request
+                .as_ref()
+                .unwrap()
+                .request_intent_digest
+                .clone(),
+            receipt: Some(safe_receipt),
+            context: Some(context.clone()),
+        }),
+        metadata: Some(metadata.clone()),
+        response_headers,
+        response_headers_sha256: String::new(),
+        execution_intent_digest_sha256: execution.execution_intent_digest_sha256.clone(),
+    })
+}
+
+#[test]
+fn aha_plans_all_five_families_without_credentials() {
+    for family in AhaFamily::ALL {
+        let adapter = adapter(family);
+        let plan = adapter.compiled_plan();
+        assert_eq!(plan.source_id, "aha");
+        assert_eq!(plan.family_id, family.as_str());
+        assert_eq!(plan.provider_kernel, family.event_kind());
+        assert_eq!(plan.origin, "https://{account}.aha.io");
+        assert_eq!(
+            plan.path,
+            format!("/api/v1{}", family.path(Some("{product_id}")).unwrap())
+        );
+        assert_eq!(plan.id_field, family.id_field());
+        assert_eq!(plan.event_kind, family.event_kind());
+        assert_eq!(plan.schema_ref, family.schema_ref());
+
+        let context = context("", 1);
+        let metadata = metadata(family);
+        let execution = plan_page(adapter, &plan, &context, &metadata);
+        assert_eq!(execution.credential_operation, "source.bearer");
+        assert_eq!(execution.allowed_origin, "https://example.aha.io");
+        assert!(execution.body.is_empty());
+        assert!(execution.declared_headers.is_empty());
+        let request = execution.request.unwrap();
+        assert_eq!(request.method, "GET");
+        assert_eq!(request.accept, "application/json");
+        let suffix = family.path(Some("product-1")).unwrap();
+        let expected_url = format!("https://example.aha.io/api/v1{suffix}?per_page=100&page=1");
+        assert_eq!(request.url, expected_url);
+        for secret_marker in ["authorization", "bearer", "token", "secret"] {
+            assert!(!request.url.to_ascii_lowercase().contains(secret_marker));
+        }
+    }
+}
+
+#[test]
+fn aha_decodes_every_fixture_with_exact_contract_and_seals() {
+    for family in AhaFamily::ALL {
+        let adapter = adapter(family);
+        let plan = adapter.compiled_plan();
+        let context = context("", 1);
+        let metadata = metadata(family);
+        let execution = plan_page(adapter, &plan, &context, &metadata);
+        let body = response(family, vec![fixture(family)]);
+        let safe_receipt = receipt(&plan, &context, &execution, 200, &body);
+        let result = decode_page(
+            adapter,
+            &plan,
+            &context,
+            &metadata,
+            200,
+            &body,
+            HashMap::new(),
+        )
+        .unwrap_or_else(|error| panic!("{family:?}: {error:?}"));
+        assert!(result.next_cursor.is_empty());
+        assert_eq!(result.records.len(), 1);
+        let record = &result.records[0];
+        assert_eq!(record.attributes["tenant_id"], "tenant");
+        assert_eq!(record.attributes["source_event_id"], record.provider_id);
+        assert!(record.event_id.starts_with("aha-tenant-"));
+        for attribute in &plan.required_attributes {
+            assert!(
+                record
+                    .attributes
+                    .get(attribute)
+                    .is_some_and(|value| !value.is_empty())
+            );
+        }
+        let payload: Value = serde_json::from_slice(&record.payload_json).unwrap();
+        for field in &plan.required_payload_fields {
+            assert!(payload.get(field).is_some_and(|value| !value.is_null()));
+        }
+        adapter
+            .validate_record_identity_v2(&context, record, &metadata)
+            .unwrap();
+
+        let decision = seal_page_program_v2(&SourceExecutionLifecycleEnvelopeV2 {
+            request: Some(SourceExecutionLifecycleRequestV1 {
+                plan: Some(plan),
+                context: Some(context),
+                receipt: Some(safe_receipt),
+                result: Some(result),
+                current_lease_generation: 11,
+            }),
+            metadata: Some(metadata),
+        })
+        .unwrap();
+        assert_eq!(decision.admitted_records.len(), 1);
+        assert!(decision.checkpoint_cursor.is_empty());
+    }
+}
+
+#[test]
+fn aha_pagination_and_provider_failures_are_typed() {
+    let paged_family = AhaFamily::Features;
+    let paged_adapter = adapter(paged_family);
+    let paged_plan = paged_adapter.compiled_plan();
+    let paged_context = context("", 1);
+    let paged_metadata = metadata(paged_family);
+    let template = fixture(paged_family);
+    let body = response(
+        paged_family,
+        (1..=100)
+            .map(|number| {
+                let mut record = template.clone();
+                record["id"] = Value::String(format!("feature-{number}"));
+                record["name"] = Value::String(format!("Feature {number}"));
+                record
+            })
+            .collect(),
+    );
+    let result = decode_page(
+        paged_adapter,
+        &paged_plan,
+        &paged_context,
+        &paged_metadata,
+        200,
+        &body,
+        HashMap::new(),
+    )
+    .unwrap();
+    assert_eq!(result.next_cursor, "2");
+
+    let family = AhaFamily::Users;
+    let adapter = adapter(family);
+    let plan = adapter.compiled_plan();
+    let context = context("", 1);
+    let metadata = metadata(family);
+    for (status, expected) in [
+        (401, SourceExecutionError::AuthenticationRejected),
+        (403, SourceExecutionError::RequiredProviderScopeMissing),
+        (404, SourceExecutionError::UnexpectedProviderStatus),
+        (503, SourceExecutionError::UnexpectedProviderStatus),
+    ] {
+        assert_eq!(
+            decode_page(
+                adapter,
+                &plan,
+                &context,
+                &metadata,
+                status,
+                b"{}",
+                HashMap::new(),
+            ),
+            Err(expected)
+        );
+    }
+    assert_eq!(
+        decode_page(
+            adapter,
+            &plan,
+            &context,
+            &metadata,
+            429,
+            b"{}",
+            HashMap::from([("retry-after".to_owned(), "60".to_owned())]),
+        ),
+        Err(SourceExecutionError::ProviderRateLimit)
+    );
+}
+
+#[test]
+fn aha_rejects_bad_scope_cursor_duplicates_and_secret_material() {
+    let family = AhaFamily::Products;
+    let adapter = adapter(family);
+    let plan = adapter.compiled_plan();
+    let metadata = metadata(family);
+    let bad_context = context("0", 2);
+    assert_eq!(
+        adapter.plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(bad_context),
+            }),
+            metadata: Some(metadata.clone()),
+        }),
+        Err(SourceExecutionError::InvalidCursor)
+    );
+
+    let release_adapter = AHA_SOURCE_EXECUTION_ADAPTERS
+        .iter()
+        .find(|candidate| candidate.family_id() == AhaFamily::Releases.as_str())
+        .unwrap();
+    let release_plan = release_adapter.compiled_plan();
+    let mut missing_product = metadata.clone();
+    missing_product
+        .public_config
+        .insert("family".to_owned(), "releases".to_owned());
+    missing_product.public_config.remove("product_id");
+    assert_eq!(
+        release_adapter.plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(release_plan),
+                context: Some(context("", 1)),
+            }),
+            metadata: Some(missing_product),
+        }),
+        Err(SourceExecutionError::MissingConfiguration)
+    );
+
+    let execution_context = context("", 1);
+    let original = fixture(family);
+    let duplicate_body = response(family, vec![original.clone(), original.clone()]);
+    let result = decode_page(
+        adapter,
+        &plan,
+        &execution_context,
+        &metadata,
+        200,
+        &duplicate_body,
+        HashMap::new(),
+    )
+    .unwrap();
+    assert_eq!(result.records.len(), 1);
+
+    let mut conflicting = original.clone();
+    conflicting["updated_at"] = Value::from("2026-06-03T00:00:00Z");
+    let conflicting_body = response(family, vec![original.clone(), conflicting]);
+    assert_eq!(
+        decode_page(
+            adapter,
+            &plan,
+            &execution_context,
+            &metadata,
+            200,
+            &conflicting_body,
+            HashMap::new(),
+        ),
+        Err(SourceExecutionError::DuplicateConflict)
+    );
+
+    let mut secret = original;
+    secret["nested"] = json!({"client_secret": "credential-material"});
+    let secret_body = response(family, vec![secret]);
+    let error = decode_page(
+        adapter,
+        &plan,
+        &execution_context,
+        &metadata,
+        200,
+        &secret_body,
+        HashMap::new(),
+    )
+    .unwrap_err();
+    assert_eq!(error, SourceExecutionError::InvalidProviderRecord);
+    assert!(!format!("{error:?}").contains("credential-material"));
+
+    let mut untrusted_scope = fixture(family);
+    untrusted_scope["nested"] = json!({"runtime_id": "untrusted-runtime"});
+    let untrusted_scope_body = response(family, vec![untrusted_scope]);
+    assert_eq!(
+        decode_page(
+            adapter,
+            &plan,
+            &execution_context,
+            &metadata,
+            200,
+            &untrusted_scope_body,
+            HashMap::new(),
+        ),
+        Err(SourceExecutionError::TenantMismatch)
+    );
+
+    let mut wrong_family = metadata;
+    wrong_family
+        .public_config
+        .insert("family".to_owned(), "users".to_owned());
+    assert_eq!(
+        adapter.plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan),
+                context: Some(execution_context),
+            }),
+            metadata: Some(wrong_family),
+        }),
+        Err(SourceExecutionError::MissingConfiguration)
+    );
+}


### PR DESCRIPTION
## Scope

- add provider-local source-execution adapters for Aha audit events, features, products, releases, and users
- compile account-origin templates while requiring the exact public account base URL at execution time
- preserve explicit release `product_id` scope, bounded page pagination, typed provider failures, tenant-scoped identity, duplicate handling, and lifecycle sealing
- keep dispatcher registration and collection-authority promotion out of this independently reviewable slice

## Invariants

- the Rust kernel receives no credential bytes or secret references
- the trusted host alone resolves the credential lease, applies Bearer authentication, constrains origin and redirects, bounds network execution, and owns durable append/projection/checkpoint ordering
- account origins must be one HTTPS `<account>.aha.io` host; nested hosts, credentials, ports, paths, queries, and origin escape fail closed
- release execution requires a public non-secret `product_id`, and returned release product scope must match it
- tenant and runtime identity come from the authenticated execution context; provider `tenant_id` and runtime-shaped fields are rejected

## Local validation

Exact head before publication: `20ff4e4e2`

- `cargo fmt --all -- --check`
- `cargo test -p cerebro-source-runtime-next aha::source_execution_tests -- --nocapture` — 4 passed
- `cargo test -p cerebro-source-runtime-next` — 728 unit tests and 7 integration tests passed
- `git diff --check`
- `cargo clippy -p cerebro-source-runtime-next --all-targets -- -D warnings` reached the affected crate and failed only on inherited current-main diagnostics in `portable_ai/adapter.rs` and `abnormal_security/source_execution_tests.rs`; both are repaired by canonical shared PR #2613. No Aha diagnostic was emitted.

DDESK runtime readiness is healthy, but this isolated checkout cannot attach because desk capacity is `waiting-for-disk` / critical. No project disk was provisioned. The commands above ran in the explicitly authorized local recovery environment through the managed Cargo wrapper.

Keep this PR draft until canonical shared repair #2613 lands and fresh exact-head hosted checks are classified.