### PR TITLE
feat(runtime): serve the source registry from Rust

### DIFF
--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -13,6 +13,7 @@ mod slack_agent_session;
 mod slack_authority;
 mod slack_mrkdwn;
 mod source_page_publisher;
+mod source_runtime_registry;
 mod source_runtime_sync;
 mod threat_insight_projection;
 mod trusted_endpoint_projection;
@@ -625,6 +626,7 @@ fn oidc_scope_for_route(method: &Method, path: &str) -> &'static str {
     match path {
         "/v1/me" => "identity:read",
         "/v1/source-runtimes/health" => "cerebro:read",
+        _ if path.starts_with("/v1/source-runtimes/") && method == Method::PUT => "cerebro:write",
         _ if path.starts_with("/v1/source-runtimes/") && path.ends_with("/sync") => "cerebro:write",
         "/v1/finding-validations" => "cerebro:write",
         _ if path.starts_with("/v1/finding-validations/") => "cerebro:read",
@@ -681,9 +683,14 @@ fn bounded_operation(method: &Method, path: &str) -> &'static str {
         "/v1/graph/expand-batch" => "expand_batch",
         "/v1/graph/paths" => "paths",
         "/v1/security/lifecycle" => "security_lifecycle",
+        "/v1/source-runtimes" => "list_source_runtimes",
+        _ if path.starts_with("/v1/source-runtimes/") && method == Method::PUT => {
+            "put_source_runtime"
+        }
         _ if path.starts_with("/v1/source-runtimes/") && path.ends_with("/sync") => {
             "sync_source_runtime"
         }
+        _ if path.starts_with("/v1/source-runtimes/") => "get_source_runtime",
         "/v1/actions" if method == Method::GET => "list_actions",
         "/v1/actions" => "propose_action",
         "/v1/projections/legacy-deltas" => "record_legacy_projection",
@@ -2234,7 +2241,12 @@ fn router_with_backend(
         .route("/v1/graph/expand-batch", post(expand_batch))
         .route("/v1/graph/paths", post(find_paths))
         .route("/v1/security/lifecycle", get(security_lifecycle))
+        .route("/v1/source-runtimes", get(list_source_runtimes))
         .route("/v1/source-runtimes/health", get(source_runtime_health))
+        .route(
+            "/v1/source-runtimes/{runtime_id}",
+            get(get_source_runtime).put(put_source_runtime),
+        )
         .route(
             "/v1/source-runtimes/{runtime_id}/sync",
             post(sync_source_runtime),
@@ -2646,6 +2658,110 @@ async fn current_user(
     Extension(identity): Extension<AuthenticatedIdentity>,
 ) -> Json<oidc::CurrentUserResponse> {
     Json(identity.current_user_response())
+}
+
+async fn put_source_runtime(
+    State(state): State<AppState>,
+    Extension(authenticated): Extension<AuthenticatedTenant>,
+    Path(runtime_id): Path<String>,
+    Json(request): Json<source_runtime_registry::PutSourceRuntimeRequest>,
+) -> Result<Json<source_runtime_registry::SourceRuntimeResponse>, (StatusCode, Json<ErrorResponse>)>
+{
+    use source_runtime_registry::SourceRuntimeRegistryAuthority;
+
+    let ledger = state
+        .runtime_ledger
+        .ok_or_else(source_runtime_registry_unavailable)?;
+    source_runtime_registry::PostgresSourceRuntimeRegistry::new(ledger)
+        .put(&authenticated.0, &runtime_id, request)
+        .await
+        .map(Json)
+        .map_err(source_runtime_registry_error)
+}
+
+async fn get_source_runtime(
+    State(state): State<AppState>,
+    Extension(authenticated): Extension<AuthenticatedTenant>,
+    Path(runtime_id): Path<String>,
+) -> Result<Json<source_runtime_registry::SourceRuntimeResponse>, (StatusCode, Json<ErrorResponse>)>
+{
+    use source_runtime_registry::SourceRuntimeRegistryAuthority;
+
+    let ledger = state
+        .runtime_ledger
+        .ok_or_else(source_runtime_registry_unavailable)?;
+    source_runtime_registry::PostgresSourceRuntimeRegistry::new(ledger)
+        .get(&authenticated.0, &runtime_id)
+        .await
+        .map(Json)
+        .map_err(source_runtime_registry_error)
+}
+
+async fn list_source_runtimes(
+    State(state): State<AppState>,
+    Extension(authenticated): Extension<AuthenticatedTenant>,
+    Query(query): Query<source_runtime_registry::SourceRuntimeListQuery>,
+) -> Result<
+    Json<source_runtime_registry::SourceRuntimeListResponse>,
+    (StatusCode, Json<ErrorResponse>),
+> {
+    use source_runtime_registry::SourceRuntimeRegistryAuthority;
+
+    let ledger = state
+        .runtime_ledger
+        .ok_or_else(source_runtime_registry_unavailable)?;
+    source_runtime_registry::PostgresSourceRuntimeRegistry::new(ledger)
+        .list(&authenticated.0, query)
+        .await
+        .map(Json)
+        .map_err(source_runtime_registry_error)
+}
+
+fn source_runtime_registry_unavailable() -> (StatusCode, Json<ErrorResponse>) {
+    service_unavailable(
+        "source_runtime_registry_unavailable",
+        "The Rust source-runtime registry is not configured.",
+    )
+}
+
+fn source_runtime_registry_error(
+    error: source_runtime_registry::SourceRuntimeRegistryFailure,
+) -> (StatusCode, Json<ErrorResponse>) {
+    use source_runtime_registry::SourceRuntimeRegistryFailureKind;
+
+    eprintln!("Rust source-runtime registry request failed: {error}");
+    match error.kind() {
+        SourceRuntimeRegistryFailureKind::InvalidRequest => bad_request(
+            "invalid_source_runtime",
+            "The source runtime definition or list filter is invalid.",
+        ),
+        SourceRuntimeRegistryFailureKind::TenantMismatch => (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse {
+                code: "source_runtime_tenant_mismatch",
+                message: "The source runtime tenant does not match the authenticated tenant."
+                    .to_owned(),
+            }),
+        ),
+        SourceRuntimeRegistryFailureKind::NotFound => (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                code: "source_runtime_not_found",
+                message: "The source runtime was not found for this tenant.".to_owned(),
+            }),
+        ),
+        SourceRuntimeRegistryFailureKind::Conflict => (
+            StatusCode::CONFLICT,
+            Json(ErrorResponse {
+                code: "source_runtime_registry_conflict",
+                message: "The source runtime changed or started syncing. Retry the update."
+                    .to_owned(),
+            }),
+        ),
+        SourceRuntimeRegistryFailureKind::RuntimeUnavailable => {
+            source_runtime_registry_unavailable()
+        }
+    }
 }
 
 async fn sync_source_runtime(
@@ -6240,6 +6356,22 @@ mod tests {
 
     #[tokio::test]
     async fn source_runtime_sync_route_is_tenant_bound_and_served_by_rust() {
+        assert_eq!(
+            oidc_scope_for_route(&Method::PUT, "/v1/source-runtimes/runtime-demo"),
+            "cerebro:write"
+        );
+        assert_eq!(
+            oidc_scope_for_route(&Method::GET, "/v1/source-runtimes/runtime-demo"),
+            "cerebro:read"
+        );
+        assert_eq!(
+            bounded_operation(&Method::PUT, "/v1/source-runtimes/runtime-demo"),
+            "put_source_runtime"
+        );
+        assert_eq!(
+            bounded_operation(&Method::GET, "/v1/source-runtimes/runtime-demo"),
+            "get_source_runtime"
+        );
         assert_eq!(
             oidc_scope_for_route(&Method::POST, "/v1/source-runtimes/runtime-demo/sync"),
             "cerebro:write"

--- a/crates/cerebro-platform/src/source_runtime_registry.rs
+++ b/crates/cerebro-platform/src/source_runtime_registry.rs
@@ -1,0 +1,535 @@
+//! Tenant-bound source-runtime registry served by the Rust platform.
+
+use std::{collections::BTreeMap, error::Error, fmt, sync::Arc};
+
+use async_trait::async_trait;
+use cerebro_organizational_model::{SourceRuntimeId, TenantId};
+use cerebro_organizational_store::{PostgresLedger, StoredSourceRuntime};
+use cerebro_source_runtime_next::{parse_aws_secret_reference, parse_credential_reference};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+const REDACTED_VALUE: &str = "[redacted]";
+const RESOURCE_SCOPE_CONFIG_KEY: &str = "cerebro_resource_scope_policy";
+const DEFAULT_LIST_LIMIT: u16 = 100;
+const MAX_LIST_LIMIT: u16 = 500;
+const MAX_RUNTIME_IDS: usize = 500;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SourceRuntimeRegistryFailureKind {
+    InvalidRequest,
+    TenantMismatch,
+    NotFound,
+    Conflict,
+    RuntimeUnavailable,
+}
+
+#[derive(Debug)]
+pub(crate) struct SourceRuntimeRegistryFailure {
+    kind: SourceRuntimeRegistryFailureKind,
+    detail: String,
+}
+
+impl SourceRuntimeRegistryFailure {
+    fn new(kind: SourceRuntimeRegistryFailureKind, detail: impl Into<String>) -> Self {
+        Self {
+            kind,
+            detail: detail.into(),
+        }
+    }
+
+    pub(crate) fn kind(&self) -> SourceRuntimeRegistryFailureKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for SourceRuntimeRegistryFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.detail)
+    }
+}
+
+impl Error for SourceRuntimeRegistryFailure {}
+
+#[derive(Clone, Deserialize)]
+pub(crate) struct PutSourceRuntimeRequest {
+    pub(crate) runtime: Option<SourceRuntimeInput>,
+}
+
+#[derive(Clone, Deserialize)]
+pub(crate) struct SourceRuntimeInput {
+    #[serde(default)]
+    pub(crate) id: String,
+    pub(crate) source_id: String,
+    #[serde(default)]
+    pub(crate) tenant_id: String,
+    #[serde(default)]
+    pub(crate) config: BTreeMap<String, String>,
+    pub(crate) checkpoint: Option<Value>,
+    pub(crate) next_cursor: Option<Value>,
+    pub(crate) last_synced_at: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub(crate) struct SourceRuntimeView {
+    pub(crate) id: String,
+    pub(crate) source_id: String,
+    pub(crate) tenant_id: String,
+    pub(crate) config: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) checkpoint: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) next_cursor: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) last_synced_at: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub(crate) struct SourceRuntimeResponse {
+    pub(crate) runtime: SourceRuntimeView,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub(crate) struct SourceRuntimeListResponse {
+    pub(crate) runtimes: Vec<SourceRuntimeView>,
+}
+
+#[derive(Clone, Default, Deserialize)]
+pub(crate) struct SourceRuntimeListQuery {
+    pub(crate) runtime_id: Option<String>,
+    pub(crate) runtime_ids: Option<String>,
+    pub(crate) source_id: Option<String>,
+    pub(crate) limit: Option<u16>,
+}
+
+#[async_trait]
+pub(crate) trait SourceRuntimeRegistryAuthority: Send + Sync {
+    async fn put(
+        &self,
+        tenant_id: &TenantId,
+        runtime_id: &str,
+        request: PutSourceRuntimeRequest,
+    ) -> Result<SourceRuntimeResponse, SourceRuntimeRegistryFailure>;
+
+    async fn get(
+        &self,
+        tenant_id: &TenantId,
+        runtime_id: &str,
+    ) -> Result<SourceRuntimeResponse, SourceRuntimeRegistryFailure>;
+
+    async fn list(
+        &self,
+        tenant_id: &TenantId,
+        query: SourceRuntimeListQuery,
+    ) -> Result<SourceRuntimeListResponse, SourceRuntimeRegistryFailure>;
+}
+
+pub(crate) struct PostgresSourceRuntimeRegistry {
+    ledger: Arc<PostgresLedger>,
+}
+
+impl PostgresSourceRuntimeRegistry {
+    pub(crate) fn new(ledger: Arc<PostgresLedger>) -> Self {
+        Self { ledger }
+    }
+}
+
+#[async_trait]
+impl SourceRuntimeRegistryAuthority for PostgresSourceRuntimeRegistry {
+    async fn put(
+        &self,
+        tenant_id: &TenantId,
+        runtime_id: &str,
+        request: PutSourceRuntimeRequest,
+    ) -> Result<SourceRuntimeResponse, SourceRuntimeRegistryFailure> {
+        let runtime_id = parse_runtime_id(runtime_id)?;
+        let input = request.runtime.ok_or_else(|| {
+            invalid_request("A source runtime definition is required in the runtime field.")
+        })?;
+        if !input.id.is_empty() && input.id.trim() != runtime_id.as_str() {
+            return Err(invalid_request(
+                "The source runtime body ID must match the path ID.",
+            ));
+        }
+        if !input.tenant_id.is_empty() && input.tenant_id.trim() != tenant_id.as_str() {
+            return Err(SourceRuntimeRegistryFailure::new(
+                SourceRuntimeRegistryFailureKind::TenantMismatch,
+                "source runtime tenant does not match authenticated tenant",
+            ));
+        }
+        let existing = self
+            .ledger
+            .find_source_runtime(&runtime_id)
+            .await
+            .map_err(runtime_unavailable)?;
+        if existing
+            .as_ref()
+            .is_some_and(|runtime| runtime.tenant_id() != tenant_id)
+        {
+            return Err(not_found());
+        }
+        let source_id = input.source_id.trim().to_owned();
+        if existing
+            .as_ref()
+            .is_some_and(|runtime| runtime.source_id() != source_id)
+        {
+            return Err(invalid_request(
+                "An existing source runtime cannot change its source ID.",
+            ));
+        }
+        if input.checkpoint.is_some()
+            || input.next_cursor.is_some()
+            || input.last_synced_at.is_some()
+        {
+            return Err(invalid_request(
+                "Source runtime progress is owned by durable sync and cannot be supplied to the registry.",
+            ));
+        }
+        let config = admit_config(input.config, existing.as_ref())?;
+        let progress_is_current = existing
+            .as_ref()
+            .is_some_and(|runtime| runtime.config() == &config);
+        let checkpoint = progress_is_current
+            .then(|| {
+                existing
+                    .as_ref()
+                    .and_then(|runtime| runtime.checkpoint().cloned())
+            })
+            .flatten();
+        let next_cursor = progress_is_current
+            .then(|| {
+                existing
+                    .as_ref()
+                    .and_then(|runtime| runtime.next_cursor().cloned())
+            })
+            .flatten();
+        let last_synced_at = progress_is_current
+            .then(|| {
+                existing
+                    .as_ref()
+                    .and_then(|runtime| runtime.last_synced_at().map(str::to_owned))
+            })
+            .flatten();
+        let runtime = StoredSourceRuntime::new(
+            runtime_id,
+            tenant_id.clone(),
+            source_id,
+            config,
+            checkpoint,
+            next_cursor,
+            last_synced_at,
+        )
+        .map_err(invalid_request)?;
+        let stored = self
+            .ledger
+            .put_source_runtime(&runtime, existing.as_ref())
+            .await
+            .map_err(runtime_unavailable)?;
+        if !stored {
+            let current = self
+                .ledger
+                .find_source_runtime(runtime.runtime_id())
+                .await
+                .map_err(runtime_unavailable)?;
+            if current
+                .as_ref()
+                .is_some_and(|runtime| runtime.tenant_id() != tenant_id)
+            {
+                return Err(not_found());
+            }
+            return Err(registry_conflict());
+        }
+        Ok(SourceRuntimeResponse {
+            runtime: runtime_view(&runtime),
+        })
+    }
+
+    async fn get(
+        &self,
+        tenant_id: &TenantId,
+        runtime_id: &str,
+    ) -> Result<SourceRuntimeResponse, SourceRuntimeRegistryFailure> {
+        let runtime_id = parse_runtime_id(runtime_id)?;
+        let runtime = self
+            .ledger
+            .find_source_runtime(&runtime_id)
+            .await
+            .map_err(runtime_unavailable)?
+            .filter(|runtime| runtime.tenant_id() == tenant_id)
+            .ok_or_else(not_found)?;
+        Ok(SourceRuntimeResponse {
+            runtime: runtime_view(&runtime),
+        })
+    }
+
+    async fn list(
+        &self,
+        tenant_id: &TenantId,
+        query: SourceRuntimeListQuery,
+    ) -> Result<SourceRuntimeListResponse, SourceRuntimeRegistryFailure> {
+        let limit = query.limit.unwrap_or(DEFAULT_LIST_LIMIT);
+        if limit == 0 || limit > MAX_LIST_LIMIT {
+            return Err(invalid_request(
+                "Source runtime list limit must be between 1 and 500.",
+            ));
+        }
+        let runtime_ids = runtime_ids(&query)?;
+        let source_id = query
+            .source_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let runtimes = self
+            .ledger
+            .list_source_runtimes(tenant_id, source_id, &runtime_ids, limit)
+            .await
+            .map_err(runtime_unavailable)?;
+        Ok(SourceRuntimeListResponse {
+            runtimes: runtimes.iter().map(runtime_view).collect(),
+        })
+    }
+}
+
+fn runtime_ids(
+    query: &SourceRuntimeListQuery,
+) -> Result<Vec<SourceRuntimeId>, SourceRuntimeRegistryFailure> {
+    let mut values = Vec::new();
+    if let Some(runtime_id) = query.runtime_id.as_deref() {
+        values.push(runtime_id);
+    }
+    if let Some(runtime_ids) = query.runtime_ids.as_deref() {
+        values.extend(runtime_ids.split(','));
+    }
+    if values.len() > MAX_RUNTIME_IDS {
+        return Err(invalid_request(
+            "runtime_ids cannot include more than 500 values.",
+        ));
+    }
+    let mut parsed = BTreeMap::new();
+    for value in values {
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        let runtime_id = parse_runtime_id(value)?;
+        parsed.insert(runtime_id.as_str().to_owned(), runtime_id);
+    }
+    Ok(parsed.into_values().collect())
+}
+
+fn admit_config(
+    incoming: BTreeMap<String, String>,
+    existing: Option<&StoredSourceRuntime>,
+) -> Result<BTreeMap<String, String>, SourceRuntimeRegistryFailure> {
+    let mut admitted = BTreeMap::new();
+    for (key, value) in incoming {
+        if key.trim() != key || key.starts_with("__cerebro_") || key == RESOURCE_SCOPE_CONFIG_KEY {
+            return Err(invalid_request(
+                "Source runtime config contains a reserved or malformed key.",
+            ));
+        }
+        if sensitive_config_key(&key) {
+            if value == REDACTED_VALUE {
+                let preserved = existing
+                    .and_then(|runtime| runtime.config().get(&key))
+                    .ok_or_else(|| {
+                        invalid_request(
+                            "A redacted credential can only preserve an existing value.",
+                        )
+                    })?;
+                admitted.insert(key, preserved.clone());
+                continue;
+            }
+            if !supported_secret_reference(&value) {
+                return Err(invalid_request(
+                    "Sensitive source runtime config must use an approved credential reference.",
+                ));
+            }
+        }
+        admitted.insert(key, value);
+    }
+    if let Some(existing) = existing {
+        admitted.extend(
+            existing
+                .config()
+                .iter()
+                .filter(|(key, _)| {
+                    key.starts_with("__cerebro_") || key.as_str() == RESOURCE_SCOPE_CONFIG_KEY
+                })
+                .map(|(key, value)| (key.clone(), value.clone())),
+        );
+    }
+    Ok(admitted)
+}
+
+fn supported_secret_reference(value: &str) -> bool {
+    let value = value.trim();
+    valid_environment_reference(value)
+        || parse_credential_reference(value).is_some()
+        || parse_aws_secret_reference(value).is_ok_and(|reference| reference.is_some())
+}
+
+fn valid_environment_reference(value: &str) -> bool {
+    let Some(name) = value.strip_prefix("env:").map(str::trim) else {
+        return false;
+    };
+    !name.is_empty()
+        && name.len() <= 256
+        && name.chars().all(|character| {
+            character == '_' || character.is_ascii_uppercase() || character.is_ascii_digit()
+        })
+}
+
+fn sensitive_config_key(key: &str) -> bool {
+    let value = key.trim().to_ascii_lowercase();
+    if value.is_empty() {
+        return false;
+    }
+    if value.contains("token") || value.contains("secret") || value.contains("password") {
+        return true;
+    }
+    let compact = value.replace(['_', '-', '.'], "");
+    compact.contains("apikey")
+        || compact.contains("privatekey")
+        || compact.contains("accesskey")
+        || compact.contains("signingkey")
+        || compact == "key"
+}
+
+fn runtime_view(runtime: &StoredSourceRuntime) -> SourceRuntimeView {
+    let config = runtime
+        .config()
+        .iter()
+        .filter_map(|(key, value)| {
+            if key.starts_with("__cerebro_") || key == RESOURCE_SCOPE_CONFIG_KEY {
+                return None;
+            }
+            Some((
+                key.clone(),
+                if sensitive_config_key(key) {
+                    REDACTED_VALUE.to_owned()
+                } else {
+                    value.clone()
+                },
+            ))
+        })
+        .collect();
+    SourceRuntimeView {
+        id: runtime.runtime_id().as_str().to_owned(),
+        source_id: runtime.source_id().to_owned(),
+        tenant_id: runtime.tenant_id().as_str().to_owned(),
+        config,
+        checkpoint: runtime.checkpoint().cloned(),
+        next_cursor: runtime.next_cursor().cloned(),
+        last_synced_at: runtime.last_synced_at().map(str::to_owned),
+    }
+}
+
+fn parse_runtime_id(value: &str) -> Result<SourceRuntimeId, SourceRuntimeRegistryFailure> {
+    SourceRuntimeId::parse(value.trim().to_owned()).map_err(invalid_request)
+}
+
+fn invalid_request(error: impl fmt::Display) -> SourceRuntimeRegistryFailure {
+    SourceRuntimeRegistryFailure::new(
+        SourceRuntimeRegistryFailureKind::InvalidRequest,
+        error.to_string(),
+    )
+}
+
+fn runtime_unavailable(error: impl fmt::Display) -> SourceRuntimeRegistryFailure {
+    SourceRuntimeRegistryFailure::new(
+        SourceRuntimeRegistryFailureKind::RuntimeUnavailable,
+        error.to_string(),
+    )
+}
+
+fn not_found() -> SourceRuntimeRegistryFailure {
+    SourceRuntimeRegistryFailure::new(
+        SourceRuntimeRegistryFailureKind::NotFound,
+        "source runtime was not found for authenticated tenant",
+    )
+}
+
+fn registry_conflict() -> SourceRuntimeRegistryFailure {
+    SourceRuntimeRegistryFailure::new(
+        SourceRuntimeRegistryFailureKind::Conflict,
+        "source runtime changed or acquired a lease during the registry update",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stored(config: BTreeMap<String, String>) -> StoredSourceRuntime {
+        StoredSourceRuntime::new(
+            SourceRuntimeId::parse("runtime-a").unwrap(),
+            TenantId::parse("tenant-a").unwrap(),
+            "github".to_owned(),
+            config,
+            None,
+            None,
+            None,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn runtime_view_redacts_sensitive_config_and_omits_internal_state() {
+        let runtime = stored(BTreeMap::from([
+            ("apiKey".to_owned(), "credential:cred-a:token".to_owned()),
+            ("family".to_owned(), "users".to_owned()),
+            ("__cerebro_runtime_status".to_owned(), "healthy".to_owned()),
+        ]));
+        let view = runtime_view(&runtime);
+        assert_eq!(
+            view.config.get("apiKey").map(String::as_str),
+            Some(REDACTED_VALUE)
+        );
+        assert_eq!(view.config.get("family").map(String::as_str), Some("users"));
+        assert!(!view.config.contains_key("__cerebro_runtime_status"));
+    }
+
+    #[test]
+    fn config_admission_rejects_literals_and_preserves_redacted_updates() {
+        let existing = stored(BTreeMap::from([(
+            "token".to_owned(),
+            "credential:cred-a:token".to_owned(),
+        )]));
+        assert!(
+            admit_config(
+                BTreeMap::from([("token".to_owned(), "literal".to_owned())]),
+                None
+            )
+            .is_err()
+        );
+        let admitted = admit_config(
+            BTreeMap::from([("token".to_owned(), REDACTED_VALUE.to_owned())]),
+            Some(&existing),
+        )
+        .unwrap();
+        assert_eq!(admitted.get("token"), existing.config().get("token"));
+    }
+
+    #[test]
+    fn runtime_id_filters_are_bounded_deduplicated_and_sorted() {
+        let ids = runtime_ids(&SourceRuntimeListQuery {
+            runtime_id: Some("runtime-b".to_owned()),
+            runtime_ids: Some("runtime-a,runtime-b".to_owned()),
+            ..SourceRuntimeListQuery::default()
+        })
+        .unwrap();
+        assert_eq!(
+            ids.iter().map(SourceRuntimeId::as_str).collect::<Vec<_>>(),
+            vec!["runtime-a", "runtime-b"]
+        );
+    }
+
+    #[test]
+    fn concurrent_registry_update_has_a_distinct_retryable_conflict() {
+        assert_eq!(
+            registry_conflict().kind(),
+            SourceRuntimeRegistryFailureKind::Conflict
+        );
+    }
+}

--- a/crates/organizational-store/src/postgres.rs
+++ b/crates/organizational-store/src/postgres.rs
@@ -906,6 +906,9 @@ pub struct StoredSourceRuntime {
     tenant_id: TenantId,
     source_id: String,
     config: BTreeMap<String, String>,
+    checkpoint: Option<Value>,
+    next_cursor: Option<Value>,
+    last_synced_at: Option<String>,
     cursor: Option<String>,
 }
 
@@ -920,6 +923,61 @@ fn sequence_i64(sequence: u64) -> Result<i64, StoreError> {
 }
 
 impl StoredSourceRuntime {
+    pub fn new(
+        runtime_id: SourceRuntimeId,
+        tenant_id: TenantId,
+        source_id: String,
+        config: BTreeMap<String, String>,
+        checkpoint: Option<Value>,
+        next_cursor: Option<Value>,
+        last_synced_at: Option<String>,
+    ) -> Result<Self, StoreError> {
+        validate_source_runtime_source_id(&source_id)?;
+        validate_source_runtime_config(&config)?;
+        validate_source_runtime_json_field("checkpoint", checkpoint.as_ref())?;
+        validate_source_runtime_json_field("next cursor", next_cursor.as_ref())?;
+        if last_synced_at.as_ref().is_some_and(|value| {
+            value.is_empty() || value.len() > 128 || value.chars().any(char::is_control)
+        }) {
+            return Err(StoreError::Conflict(
+                "source runtime last-synced timestamp is invalid".to_owned(),
+            ));
+        }
+        let cursor = next_cursor
+            .as_ref()
+            .and_then(|value| value.get("opaque"))
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+            .or_else(|| {
+                checkpoint
+                    .as_ref()
+                    .and_then(|value| value.get("cursor_opaque"))
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| resumable_checkpoint_cursor(value))
+                    .map(str::to_owned)
+            });
+        if cursor
+            .as_ref()
+            .is_some_and(|cursor| cursor.len() > 64 * 1024)
+        {
+            return Err(StoreError::Conflict(
+                "stored source runtime cursor is too large".to_owned(),
+            ));
+        }
+        Ok(Self {
+            runtime_id,
+            tenant_id,
+            source_id,
+            config,
+            checkpoint,
+            next_cursor,
+            last_synced_at,
+            cursor,
+        })
+    }
+
     pub fn runtime_id(&self) -> &SourceRuntimeId {
         &self.runtime_id
     }
@@ -936,30 +994,33 @@ impl StoredSourceRuntime {
         &self.config
     }
 
+    pub fn checkpoint(&self) -> Option<&Value> {
+        self.checkpoint.as_ref()
+    }
+
+    pub fn next_cursor(&self) -> Option<&Value> {
+        self.next_cursor.as_ref()
+    }
+
+    pub fn last_synced_at(&self) -> Option<&str> {
+        self.last_synced_at.as_deref()
+    }
+
     pub fn cursor(&self) -> Option<&str> {
         self.cursor.as_deref()
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize)]
 struct StoredSourceRuntimeWire {
     id: String,
     source_id: String,
     tenant_id: String,
     #[serde(default)]
     config: BTreeMap<String, String>,
-    next_cursor: Option<StoredSourceCursorWire>,
-    checkpoint: Option<StoredSourceCheckpointWire>,
-}
-
-#[derive(Deserialize)]
-struct StoredSourceCursorWire {
-    opaque: String,
-}
-
-#[derive(Deserialize)]
-struct StoredSourceCheckpointWire {
-    cursor_opaque: String,
+    checkpoint: Option<Value>,
+    next_cursor: Option<Value>,
+    last_synced_at: Option<String>,
 }
 
 pub struct PostgresLedger {
@@ -1331,6 +1392,106 @@ impl PostgresLedger {
             return Ok(None);
         };
         decode_stored_source_runtime(source_runtime_id, row.get(0)).map(Some)
+    }
+
+    /// Upsert one already-admitted, unresolved source-runtime definition.
+    /// Credential resolution remains outside storage, and lease columns are
+    /// deliberately preserved across definition updates.
+    pub async fn put_source_runtime(
+        &self,
+        runtime: &StoredSourceRuntime,
+        expected: Option<&StoredSourceRuntime>,
+    ) -> Result<bool, StoreError> {
+        let runtime_json = stored_source_runtime_json(runtime)?;
+        let client = self.client.lock().await;
+        let changed = if let Some(expected) = expected {
+            let expected_json = stored_source_runtime_json(expected)?;
+            client
+                .execute(
+                    r#"
+UPDATE source_runtimes
+SET runtime_json = $2, updated_at = NOW()
+WHERE id = $1
+  AND runtime_json->>'tenant_id' = $3
+  AND runtime_json = $4
+  AND (lease_expires_at IS NULL OR lease_expires_at <= NOW())
+"#,
+                    &[
+                        &runtime.runtime_id.as_str(),
+                        &runtime_json,
+                        &runtime.tenant_id.as_str(),
+                        &expected_json,
+                    ],
+                )
+                .await?
+        } else {
+            client
+                .execute(
+                    r#"
+INSERT INTO source_runtimes (id, runtime_json)
+VALUES ($1, $2)
+ON CONFLICT (id) DO NOTHING
+"#,
+                    &[&runtime.runtime_id.as_str(), &runtime_json],
+                )
+                .await?
+        };
+        Ok(changed == 1)
+    }
+
+    /// List source-runtime definitions within one authenticated tenant. All
+    /// predicates are applied in PostgreSQL so cross-tenant rows never enter
+    /// the application response path.
+    pub async fn list_source_runtimes(
+        &self,
+        tenant_id: &TenantId,
+        source_id: Option<&str>,
+        runtime_ids: &[SourceRuntimeId],
+        limit: u16,
+    ) -> Result<Vec<StoredSourceRuntime>, StoreError> {
+        if limit == 0 || limit > 500 {
+            return Err(StoreError::Conflict(
+                "source runtime list limit must be between 1 and 500".to_owned(),
+            ));
+        }
+        let source_id = source_id.filter(|value| !value.is_empty());
+        if let Some(source_id) = source_id {
+            validate_source_runtime_source_id(source_id)?;
+        }
+        let runtime_ids = runtime_ids
+            .iter()
+            .map(|runtime_id| runtime_id.as_str().to_owned())
+            .collect::<Vec<_>>();
+        let rows = self
+            .client
+            .lock()
+            .await
+            .query(
+                r#"
+SELECT id, runtime_json
+FROM source_runtimes
+WHERE runtime_json->>'tenant_id' = $1
+  AND ($2::TEXT IS NULL OR runtime_json->>'source_id' = $2)
+  AND (cardinality($3::TEXT[]) = 0 OR id = ANY($3::TEXT[]))
+ORDER BY updated_at ASC, id ASC
+LIMIT $4
+"#,
+                &[
+                    &tenant_id.as_str(),
+                    &source_id,
+                    &runtime_ids,
+                    &i64::from(limit),
+                ],
+            )
+            .await?;
+        rows.into_iter()
+            .map(|row| {
+                let runtime_id = SourceRuntimeId::parse(row.get::<_, String>(0)).map_err(|_| {
+                    StoreError::Conflict("stored source runtime id is invalid".to_owned())
+                })?;
+                decode_stored_source_runtime(&runtime_id, row.get(1))
+            })
+            .collect()
     }
 
     /// Resolve connector-vault references against the exact durable runtime
@@ -2977,7 +3138,30 @@ fn decode_stored_source_runtime(
     }
     let tenant_id = TenantId::parse(wire.tenant_id)
         .map_err(|_| StoreError::Conflict("stored source runtime tenant is invalid".to_owned()))?;
-    let source_id = wire.source_id;
+    StoredSourceRuntime::new(
+        runtime_id,
+        tenant_id,
+        wire.source_id,
+        wire.config,
+        wire.checkpoint,
+        wire.next_cursor,
+        wire.last_synced_at,
+    )
+}
+
+fn stored_source_runtime_json(runtime: &StoredSourceRuntime) -> Result<Value, StoreError> {
+    Ok(serde_json::to_value(StoredSourceRuntimeWire {
+        id: runtime.runtime_id.as_str().to_owned(),
+        source_id: runtime.source_id.clone(),
+        tenant_id: runtime.tenant_id.as_str().to_owned(),
+        config: runtime.config.clone(),
+        checkpoint: runtime.checkpoint.clone(),
+        next_cursor: runtime.next_cursor.clone(),
+        last_synced_at: runtime.last_synced_at.clone(),
+    })?)
+}
+
+fn validate_source_runtime_source_id(source_id: &str) -> Result<(), StoreError> {
     if source_id.is_empty()
         || source_id.trim() != source_id
         || source_id.len() > 128
@@ -2987,31 +3171,45 @@ fn decode_stored_source_runtime(
             "stored source runtime source is invalid".to_owned(),
         ));
     }
-    let cursor = wire
-        .next_cursor
-        .map(|cursor| cursor.opaque)
-        .filter(|cursor| !cursor.is_empty())
-        .or_else(|| {
-            wire.checkpoint
-                .map(|checkpoint| checkpoint.cursor_opaque)
-                .map(|cursor| cursor.trim().to_owned())
-                .filter(|cursor| resumable_checkpoint_cursor(cursor))
-        });
-    if cursor
-        .as_ref()
-        .is_some_and(|cursor| cursor.len() > 64 * 1024)
-    {
+    Ok(())
+}
+
+fn validate_source_runtime_config(config: &BTreeMap<String, String>) -> Result<(), StoreError> {
+    if config.len() > 256 {
         return Err(StoreError::Conflict(
-            "stored source runtime cursor is too large".to_owned(),
+            "source runtime config has too many entries".to_owned(),
         ));
     }
-    Ok(StoredSourceRuntime {
-        runtime_id,
-        tenant_id,
-        source_id,
-        config: wire.config,
-        cursor,
-    })
+    for (key, value) in config {
+        if key.is_empty()
+            || key.trim() != key
+            || key.len() > 256
+            || key.chars().any(char::is_control)
+            || value.len() > 64 * 1024
+            || value.chars().any(|character| character == '\0')
+        {
+            return Err(StoreError::Conflict(
+                "source runtime config is invalid".to_owned(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_source_runtime_json_field(
+    field: &str,
+    value: Option<&Value>,
+) -> Result<(), StoreError> {
+    if value.is_some_and(|value| {
+        serde_json::to_vec(value)
+            .map(|encoded| encoded.len() > 64 * 1024)
+            .unwrap_or(true)
+    }) {
+        return Err(StoreError::Conflict(format!(
+            "source runtime {field} is invalid"
+        )));
+    }
+    Ok(())
 }
 
 async fn track_connector_credential_use(

--- a/docs/domains/source-runtime-guide.md
+++ b/docs/domains/source-runtime-guide.md
@@ -123,6 +123,31 @@ curl -fsS -H "Authorization: Bearer ${CEREBRO_API_KEY}" \
 
 Responses redact sensitive runtime config where the implementation marks config as sensitive.
 
+The Rust platform also serves tenant-bound registry operations from the same
+Postgres table:
+
+```bash
+curl -fsS -X PUT \
+  -H "X-Cerebro-Tenant: <tenant-id>" \
+  -H "Authorization: Bearer ${CEREBRO_RUST_TENANT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  "https://cerebro.example.com/v1/source-runtimes/<runtime-id>" \
+  -d '{"runtime":{"source_id":"<source-id>","config":{"family":"<family>","token":"credential:<credential-id>:token"}}}'
+
+curl -fsS \
+  -H "X-Cerebro-Tenant: <tenant-id>" \
+  -H "Authorization: Bearer ${CEREBRO_RUST_TENANT_TOKEN}" \
+  "https://cerebro.example.com/v1/source-runtimes?source_id=<source-id>&limit=20"
+```
+
+The authenticated identity supplies the tenant; a body tenant must match it.
+Rust filters GET and LIST in Postgres before constructing a response, so a
+missing runtime and a runtime owned by another tenant are indistinguishable.
+Sensitive config accepts only `env:`, `credential:`, or `aws-sm:` references
+and is always returned as `[redacted]`. Registry writes cannot supply a cursor,
+checkpoint, or last-sync time. Unchanged definitions keep durable progress;
+configuration changes clear it so only a fenced sync can advance it again.
+
 ## Sync a runtime
 
 CLI:


### PR DESCRIPTION
## Summary

- serve tenant-bound Rust PUT, GET, and LIST routes for durable source-runtime definitions
- reject literal credential material, redact sensitive config, and keep tenant filtering inside PostgreSQL
- fence registry writes against active leases and concurrent durable-state changes so only sync can advance progress

## Stack

Draft stacked on #2615. Retarget to `main` after #2615 merges normally.

## Validation

Validated at exact head `0bd7468a6b59789777ae20785957ce70b57e0bdf` in an isolated recovery clone because the shared DDESK capacity gate did not admit a workspace:

- `cargo fmt --all -- --check`
- `cargo test -p cerebro-platform source_runtime_registry` (4 passed)
- `cargo test -p cerebro-organizational-store --lib postgres::tests` (7 passed, 1 ignored: disposable PostgreSQL)
- `cargo clippy -p cerebro-platform -p cerebro-organizational-store --all-targets --no-deps -- -D warnings`
- `python3 scripts/docs_drift_check.py`
- `python3 scripts/readme_check.py`
- `make check-structural check-structural-test check-arch`
- `git diff --check`

## Boundaries

- The authenticated identity owns tenant selection.
- Missing and cross-tenant runtimes are indistinguishable.
- Registry writes cannot supply checkpoint, cursor, or last-sync fields.
- No credential values are resolved or returned by the registry.