### PR TITLE
feat(sources): add Akeneo Rust source execution

### DIFF
--- a/crates/source-runtime-next/src/akeneo.rs
+++ b/crates/source-runtime-next/src/akeneo.rs
@@ -12,6 +12,10 @@ mod origin;
 mod projection;
 mod request;
 mod response;
+#[allow(dead_code)]
+mod source_execution;
+#[cfg(test)]
+mod source_execution_tests;
 mod types;
 
 pub use catalog::{AkeneoEventContract, AkeneoRuntimeDefinition};
@@ -21,6 +25,9 @@ pub use projection::{AkeneoEntityFact, AkeneoProjectionFacts, project_akeneo_rec
 pub use types::{
     AkeneoCheckpointCandidate, AkeneoKernel, AkeneoPage, AkeneoRecord, AkeneoRequest, AkeneoScope,
 };
+
+#[allow(unused_imports)]
+pub(crate) use source_execution::AKENEO_SOURCE_EXECUTION_ADAPTERS;
 
 #[cfg(test)]
 mod tests;

--- a/crates/source-runtime-next/src/akeneo/normalize.rs
+++ b/crates/source-runtime-next/src/akeneo/normalize.rs
@@ -197,7 +197,7 @@ fn stable_identity(values: &Map<String, Value>) -> Option<String> {
     .filter(|value| !value.is_empty() && value.len() <= 512)
 }
 
-fn event_id(kernel: &AkeneoKernel, provider_id: &str) -> String {
+pub(super) fn event_id(kernel: &AkeneoKernel, provider_id: &str) -> String {
     let scope = Sha256::digest(format!(
         "{}\0{}\0{}",
         kernel.base_url.as_str(),
@@ -210,9 +210,9 @@ fn event_id(kernel: &AkeneoKernel, provider_id: &str) -> String {
         .collect::<String>();
     format!(
         "akeneo-{}-{scope}-{}-{}",
-        normalize_id(&kernel.tenant_id),
-        normalize_id(kernel.family.as_str()),
-        normalize_id(provider_id)
+        event_segment(&kernel.tenant_id),
+        event_segment(kernel.family.as_str()),
+        event_segment(provider_id)
     )
 }
 
@@ -237,18 +237,23 @@ fn encode_segment(value: &str) -> String {
     encoded
 }
 
-fn normalize_id(value: &str) -> String {
+fn event_segment(value: &str) -> String {
     let value = value.trim();
-    if value.is_empty() {
-        return "unknown".to_owned();
+    if !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    {
+        return value.to_owned();
     }
-    value
-        .chars()
-        .map(|character| match character {
-            ' ' | '/' | ':' | '\t' | '\n' => '-',
-            other => other,
-        })
-        .collect()
+    let digest = Sha256::digest(value.as_bytes());
+    format!(
+        "sha256-{}",
+        digest
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>()
+    )
 }
 
 fn reject_protected(value: &Value, depth: usize) -> Result<(), AkeneoError> {
@@ -262,7 +267,10 @@ fn reject_protected(value: &Value, depth: usize) -> Result<(), AkeneoError> {
             }
             for (key, value) in values {
                 let key = key.trim().to_ascii_lowercase().replace('-', "_");
-                if key == "tenant_id" {
+                if matches!(
+                    key.as_str(),
+                    "tenant_id" | "runtime_id" | "source_runtime_id"
+                ) {
                     return Err(AkeneoError::TenantMismatch);
                 }
                 if matches!(key.as_str(), "source_id" | "schema_ref") {
@@ -273,9 +281,14 @@ fn reject_protected(value: &Value, depth: usize) -> Result<(), AkeneoError> {
                     "token"
                         | "access_token"
                         | "refresh_token"
+                        | "session_token"
                         | "api_key"
                         | "api_token"
+                        | "x_api_key"
+                        | "set_cookie"
                         | "password"
+                        | "passcode"
+                        | "secret"
                         | "private_key"
                         | "authorization"
                         | "client_secret"

--- a/crates/source-runtime-next/src/akeneo/source_execution.rs
+++ b/crates/source-runtime-next/src/akeneo/source_execution.rs
@@ -1,0 +1,443 @@
+//! Akeneo bridge for the closed source-execution protocol.
+//!
+//! The adapter receives authenticated tenant context, public provider scope,
+//! and bounded provider response bytes. The trusted host owns credential
+//! redemption, bearer authentication, origin-constrained network I/O, durable
+//! append, projection, and checkpoint persistence.
+
+use std::collections::HashMap;
+
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceExecutionPlanV1,
+    SourceWorkerDecodeEnvelopeV2, SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1,
+    SourceWorkerExecutionContextV1, SourceWorkerHttpExecutionV2, SourceWorkerHttpRequestV1,
+    SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1, SourceWorkerRecordV1,
+    SourceWorkerRuntimeMetadataV2, canonical_http_execution_digest, canonical_plan_digest,
+    canonical_request_intent_digest, canonical_result_digest, validate_and_deduplicate_records,
+    validate_execution_context, validate_runtime_metadata,
+};
+
+use super::{
+    AkeneoError, AkeneoFamily, AkeneoKernel, AkeneoRuntimeDefinition, AkeneoScope,
+    normalize::event_id,
+};
+
+const SOURCE_ID: &str = "akeneo";
+const PLAN_ORIGIN: &str = "https://{tenant}.akeneo.com";
+const METHOD: &str = "GET";
+const ACCEPT: &str = "application/json";
+const MAX_RESPONSE_BYTES: u64 = 8 << 20;
+
+/// Credential-free adapter for one cataloged Akeneo family.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct AkeneoSourceExecutionAdapter {
+    family: AkeneoFamily,
+}
+
+/// Provider-local adapter set. Shared dispatcher registration and authority
+/// promotion remain separate delivery steps.
+pub(crate) static AKENEO_SOURCE_EXECUTION_ADAPTERS: [AkeneoSourceExecutionAdapter; 12] = [
+    AkeneoSourceExecutionAdapter::new(AkeneoFamily::Asset),
+    AkeneoSourceExecutionAdapter::new(AkeneoFamily::AssetFamiliesAttribute),
+    AkeneoSourceExecutionAdapter::new(AkeneoFamily::AssetFamily),
+    AkeneoSourceExecutionAdapter::new(AkeneoFamily::Attribute),
+    AkeneoSourceExecutionAdapter::new(AkeneoFamily::AttributeGroup),
+    AkeneoSourceExecutionAdapter::new(AkeneoFamily::AttributesOption),
+    AkeneoSourceExecutionAdapter::new(AkeneoFamily::Draft),
+    AkeneoSourceExecutionAdapter::new(AkeneoFamily::Option),
+    AkeneoSourceExecutionAdapter::new(AkeneoFamily::ProductsDraft),
+    AkeneoSourceExecutionAdapter::new(AkeneoFamily::ProductsUuidDraft),
+    AkeneoSourceExecutionAdapter::new(AkeneoFamily::ReferenceEntitiesAttribute),
+    AkeneoSourceExecutionAdapter::new(AkeneoFamily::V1Attribute),
+];
+
+impl AkeneoSourceExecutionAdapter {
+    const fn new(family: AkeneoFamily) -> Self {
+        Self { family }
+    }
+
+    pub(crate) fn compiled_plan(&self) -> SourceExecutionPlanV1 {
+        let definition = AkeneoRuntimeDefinition::compile(self.family)
+            .expect("closed Akeneo family must compile");
+        let mut plan = SourceExecutionPlanV1 {
+            plan_id: format!("source-plan-v1:{SOURCE_ID}:{}", self.family.as_str()),
+            source_id: SOURCE_ID.to_owned(),
+            family_id: self.family.as_str().to_owned(),
+            provider_kernel: self.family.event_kind().to_owned(),
+            method: METHOD.to_owned(),
+            origin: PLAN_ORIGIN.to_owned(),
+            path: self.family.path_template().to_owned(),
+            record_selector: self.family.record_selector().to_owned(),
+            id_field: "id".to_owned(),
+            singleton_fallback_id: String::new(),
+            max_response_bytes: MAX_RESPONSE_BYTES,
+            event_kind: definition.event_contract.kind.to_owned(),
+            schema_ref: definition.event_contract.schema_ref.to_owned(),
+            required_attributes: definition
+                .event_contract
+                .required_attributes
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
+            required_payload_fields: definition
+                .event_contract
+                .required_payload_fields
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
+            plan_digest_sha256: String::new(),
+        };
+        plan.plan_digest_sha256 = canonical_plan_digest(&plan);
+        plan
+    }
+
+    fn validate_plan(&self, plan: &SourceExecutionPlanV1) -> Result<(), SourceExecutionError> {
+        if plan != &self.compiled_plan() {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        Ok(())
+    }
+
+    fn kernel(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(AkeneoKernel, String, String), SourceExecutionError> {
+        validate_execution_context(context)?;
+        validate_runtime_metadata(metadata)?;
+        if public_value(&metadata.public_config, "family")
+            .is_some_and(|value| value != self.family.as_str())
+        {
+            return Err(SourceExecutionError::MissingConfiguration);
+        }
+        let base_url = public_value(&metadata.public_config, "base_url")
+            .ok_or(SourceExecutionError::MissingConfiguration)?;
+        let scope = AkeneoScope::new(
+            public_value(&metadata.public_config, "asset_family_code"),
+            public_value(&metadata.public_config, "code"),
+            public_value(&metadata.public_config, "attribute_code"),
+            public_value(&metadata.public_config, "reference_entity_code"),
+            public_value(&metadata.public_config, "uuid"),
+        );
+        let expected_path = self.family.path(&scope).map_err(map_error)?;
+        let observed_at = timestamp(context.observed_at_unix_millis)?;
+        let kernel = AkeneoKernel::new(
+            base_url,
+            &context.tenant_id,
+            self.family,
+            scope,
+            &observed_at,
+        )
+        .map_err(map_error)?;
+        let mut allowed_origin = kernel.plan(None).map_err(map_error)?.url().clone();
+        allowed_origin.set_path("/");
+        allowed_origin.set_query(None);
+        Ok((
+            kernel,
+            allowed_origin.to_string().trim_end_matches('/').to_owned(),
+            expected_path,
+        ))
+    }
+
+    fn validate_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+        metadata: Option<&SourceWorkerRuntimeMetadataV2>,
+    ) -> Result<(), SourceExecutionError> {
+        let metadata = metadata.ok_or(SourceExecutionError::MissingConfiguration)?;
+        let (kernel, _, _) = self.kernel(context, metadata)?;
+        if record.event_id != event_id(&kernel, &record.provider_id)
+            || record.attributes.get("tenant_id") != Some(&context.tenant_id)
+            || record.attributes.get("source_event_id") != Some(&record.provider_id)
+        {
+            return Err(SourceExecutionError::TenantMismatch);
+        }
+        Ok(())
+    }
+}
+
+impl SourceExecutionAdapter for AkeneoSourceExecutionAdapter {
+    fn source_id(&self) -> &'static str {
+        SOURCE_ID
+    }
+
+    fn family_id(&self) -> &'static str {
+        self.family.as_str()
+    }
+
+    fn provider_kernel(&self) -> &'static str {
+        self.family.event_kind()
+    }
+
+    fn validate_record_identity(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+    ) -> Result<(), SourceExecutionError> {
+        self.validate_identity(context, record, None)
+    }
+
+    fn validate_record_identity_v2(
+        &self,
+        context: &SourceWorkerExecutionContextV1,
+        record: &SourceWorkerRecordV1,
+        metadata: &SourceWorkerRuntimeMetadataV2,
+    ) -> Result<(), SourceExecutionError> {
+        self.validate_identity(context, record, Some(metadata))
+    }
+
+    fn plan(
+        &self,
+        _request: &SourceWorkerPlanRequestV1,
+    ) -> Result<SourceWorkerHttpRequestV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn plan_v2(
+        &self,
+        envelope: &SourceWorkerPlanEnvelopeV2,
+    ) -> Result<SourceWorkerHttpExecutionV2, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, allowed_origin, expected_path) = self.kernel(context, metadata)?;
+        let provider_request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        if provider_request.method() != plan.method
+            || provider_request.url().path() != expected_path
+            || provider_request.authentication_header() != "Authorization"
+            || provider_request.authentication_scheme() != "Bearer"
+            || provider_request.contains_credentials()
+            || provider_request.allows_redirects()
+        {
+            return Err(SourceExecutionError::InvalidPlan);
+        }
+        let mut planned = SourceWorkerHttpRequestV1 {
+            plan_id: plan.plan_id.clone(),
+            method: provider_request.method().to_owned(),
+            url: provider_request.url().to_string(),
+            accept: ACCEPT.to_owned(),
+            max_response_bytes: u64::try_from(provider_request.max_response_bytes())
+                .map_err(|_| SourceExecutionError::InvalidPlan)?,
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            request_intent_digest: String::new(),
+        };
+        planned.request_intent_digest = canonical_request_intent_digest(plan, context, &planned);
+        let mut execution = SourceWorkerHttpExecutionV2 {
+            request: Some(planned),
+            body: Vec::new(),
+            declared_headers: HashMap::new(),
+            execution_intent_digest_sha256: String::new(),
+            credential_operation: "source.bearer".to_owned(),
+            allowed_origin,
+        };
+        execution.execution_intent_digest_sha256 =
+            canonical_http_execution_digest(plan, context, metadata, &execution);
+        Ok(execution)
+    }
+
+    fn decode(
+        &self,
+        _request: &SourceWorkerDecodeRequestV1,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        Err(SourceExecutionError::InvalidPlan)
+    }
+
+    fn decode_v2(
+        &self,
+        envelope: &SourceWorkerDecodeEnvelopeV2,
+    ) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+        let request = envelope
+            .request
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let plan = request
+            .plan
+            .as_ref()
+            .ok_or(SourceExecutionError::InvalidPlan)?;
+        let context = request
+            .context
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let receipt = request
+            .receipt
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        let metadata = envelope
+            .metadata
+            .as_ref()
+            .ok_or(SourceExecutionError::MissingExecutionIdentity)?;
+        self.validate_plan(plan)?;
+        let (kernel, _, _) = self.kernel(context, metadata)?;
+        let provider_request = kernel
+            .plan(optional(&context.prior_cursor))
+            .map_err(map_error)?;
+        let retry_after_seconds = response_header(&envelope.response_headers, "retry-after")
+            .map(|value| {
+                value
+                    .parse::<u64>()
+                    .map_err(|_| SourceExecutionError::UnexpectedProviderStatus)
+            })
+            .transpose()?;
+        let status = u16::try_from(request.status_code)
+            .map_err(|_| SourceExecutionError::UnexpectedProviderStatus)?;
+        let page = kernel
+            .decode(
+                &provider_request,
+                status,
+                retry_after_seconds,
+                &request.response_body,
+            )
+            .map_err(map_error)?;
+        let checkpoint = kernel
+            .checkpoint_candidate(
+                &provider_request,
+                &page,
+                optional_watermark(metadata)?.as_deref(),
+            )
+            .map_err(map_error)?;
+        let next_cursor = checkpoint.cursor.unwrap_or_default();
+        let records = page
+            .records
+            .into_iter()
+            .map(|record| {
+                if record.tenant_id != context.tenant_id
+                    || record.family != self.family
+                    || record.kind != plan.event_kind
+                    || record.schema_ref != plan.schema_ref
+                {
+                    return Err(SourceExecutionError::TenantMismatch);
+                }
+                Ok(SourceWorkerRecordV1 {
+                    provider_id: record.provider_id,
+                    event_id: record.event_id,
+                    occurred_at_unix_millis: parse_timestamp(&record.occurred_at)?,
+                    attributes: record.attributes.into_iter().collect(),
+                    payload_json: serde_json::to_vec(&record.payload)
+                        .map_err(|_| SourceExecutionError::InternalRuntime)?,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let records = validate_and_deduplicate_records(records)?;
+        for record in &records {
+            self.validate_record_identity_v2(context, record, metadata)?;
+        }
+        let result_digest_sha256 = canonical_result_digest(receipt, &next_cursor, &records)?;
+        Ok(SourceWorkerDecodeResultV1 {
+            plan_id: plan.plan_id.clone(),
+            plan_digest_sha256: plan.plan_digest_sha256.clone(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: request.request_intent_digest.clone(),
+            records,
+            next_cursor,
+            result_digest_sha256,
+            tenant_id: context.tenant_id.clone(),
+            runtime_id: context.runtime_id.clone(),
+            runtime_generation: context.runtime_generation,
+            lease_generation: context.lease_generation,
+            observed_at_unix_millis: context.observed_at_unix_millis,
+        })
+    }
+}
+
+fn public_value<'a>(config: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    config
+        .get(key)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn response_header<'a>(headers: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    headers
+        .get(key)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn optional(value: &str) -> Option<&str> {
+    (!value.is_empty()).then_some(value)
+}
+
+fn optional_watermark(
+    metadata: &SourceWorkerRuntimeMetadataV2,
+) -> Result<Option<String>, SourceExecutionError> {
+    (metadata.prior_terminal_watermark_unix_millis > 0)
+        .then(|| timestamp(metadata.prior_terminal_watermark_unix_millis))
+        .transpose()
+}
+
+fn timestamp(unix_millis: i64) -> Result<String, SourceExecutionError> {
+    OffsetDateTime::from_unix_timestamp_nanos(i128::from(unix_millis) * 1_000_000)
+        .map_err(|_| SourceExecutionError::InvalidExecutionContext)?
+        .format(&Rfc3339)
+        .map_err(|_| SourceExecutionError::InternalRuntime)
+}
+
+fn parse_timestamp(value: &str) -> Result<i64, SourceExecutionError> {
+    let nanos = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| SourceExecutionError::InvalidProviderRecord)?
+        .unix_timestamp_nanos();
+    i64::try_from(nanos / 1_000_000).map_err(|_| SourceExecutionError::InvalidProviderRecord)
+}
+
+fn map_error(error: AkeneoError) -> SourceExecutionError {
+    match error {
+        AkeneoError::InvalidFamily => SourceExecutionError::UnknownAdapter,
+        AkeneoError::InvalidConfiguration(_)
+        | AkeneoError::InvalidOrigin
+        | AkeneoError::MissingPathParameter(_)
+        | AkeneoError::InvalidPathParameter(_) => SourceExecutionError::MissingConfiguration,
+        AkeneoError::InvalidTenantId => SourceExecutionError::InvalidExecutionContext,
+        AkeneoError::MissingCredentialReference => SourceExecutionError::MissingCredentialReference,
+        AkeneoError::CredentialUnavailable => SourceExecutionError::CredentialUnavailable,
+        AkeneoError::InvalidCursor => SourceExecutionError::InvalidCursor,
+        AkeneoError::RequestScopeMismatch => SourceExecutionError::InvalidPlan,
+        AkeneoError::AuthenticationRejected => SourceExecutionError::AuthenticationRejected,
+        AkeneoError::RequiredScopeMissing => SourceExecutionError::RequiredProviderScopeMissing,
+        AkeneoError::EgressDenied => SourceExecutionError::EgressDenied,
+        AkeneoError::DnsFailure | AkeneoError::ConnectionFailure => {
+            SourceExecutionError::ConnectionFailure
+        }
+        AkeneoError::ProviderTimeout => SourceExecutionError::ProviderTimeout,
+        AkeneoError::RateLimited { .. } => SourceExecutionError::ProviderRateLimit,
+        AkeneoError::ProviderResourceNotFound
+        | AkeneoError::ProviderUnavailable { .. }
+        | AkeneoError::UnexpectedStatus { .. }
+        | AkeneoError::InvalidRetryAfter => SourceExecutionError::UnexpectedProviderStatus,
+        AkeneoError::ResponseTooLarge => SourceExecutionError::ResponseTooLarge,
+        AkeneoError::TooManyRecords => SourceExecutionError::ResultTooLarge,
+        AkeneoError::MalformedResponse => SourceExecutionError::MalformedResponse,
+        AkeneoError::InvalidProviderRecord
+        | AkeneoError::ProtectedContractField
+        | AkeneoError::CredentialMaterial => SourceExecutionError::InvalidProviderRecord,
+        AkeneoError::MissingStableIdentity => SourceExecutionError::MissingStableIdentity,
+        AkeneoError::TenantMismatch => SourceExecutionError::TenantMismatch,
+        AkeneoError::ConflictingDuplicate => SourceExecutionError::DuplicateConflict,
+        AkeneoError::EventContractRejection => SourceExecutionError::EventContractRejected,
+        AkeneoError::AppendFailure => SourceExecutionError::AppendFailed,
+        AkeneoError::ProjectionFailure => SourceExecutionError::ProjectionFailed,
+        AkeneoError::LeaseLoss => SourceExecutionError::LeaseLost,
+        AkeneoError::StaleAuthority => SourceExecutionError::StaleAuthority,
+        AkeneoError::InternalRuntimeFailure => SourceExecutionError::InternalRuntime,
+    }
+}

--- a/crates/source-runtime-next/src/akeneo/source_execution_tests.rs
+++ b/crates/source-runtime-next/src/akeneo/source_execution_tests.rs
@@ -1,0 +1,442 @@
+use std::{collections::HashMap, fs, path::PathBuf};
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::source_execution::{
+    SourceExecutionAdapter, SourceExecutionError, SourceExecutionLifecycleEnvelopeV2,
+    SourceExecutionLifecycleRequestV1, SourceExecutionPlanV1, SourceWorkerDecodeEnvelopeV2,
+    SourceWorkerDecodeRequestV1, SourceWorkerDecodeResultV1, SourceWorkerExecutionContextV1,
+    SourceWorkerHttpExecutionV2, SourceWorkerPlanEnvelopeV2, SourceWorkerPlanRequestV1,
+    SourceWorkerRuntimeMetadataV2, SourceWorkerSafeReceiptV1, response_digest,
+    seal_page_program_v2,
+};
+
+use super::{
+    AkeneoFamily, AkeneoScope,
+    source_execution::{AKENEO_SOURCE_EXECUTION_ADAPTERS, AkeneoSourceExecutionAdapter},
+};
+
+const OBSERVED_AT_MILLIS: i64 = 1_780_272_000_000;
+
+#[derive(Deserialize)]
+struct GoOracleEvent {
+    payload: Value,
+}
+
+fn root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn adapter(family: AkeneoFamily) -> &'static AkeneoSourceExecutionAdapter {
+    AKENEO_SOURCE_EXECUTION_ADAPTERS
+        .iter()
+        .find(|adapter| adapter.family_id() == family.as_str())
+        .unwrap()
+}
+
+fn scope() -> AkeneoScope {
+    AkeneoScope::new(
+        Some("asset-family-1"),
+        Some("code-1"),
+        Some("attribute-1"),
+        Some("reference-1"),
+        Some("123e4567-e89b-12d3-a456-426614174000"),
+    )
+}
+
+fn fixture(family: AkeneoFamily) -> Value {
+    let bytes = fs::read(root().join(format!(
+        "sources/akeneo/testdata/read_{}.json",
+        family.as_str()
+    )))
+    .unwrap();
+    let mut payload = serde_json::from_slice::<Vec<GoOracleEvent>>(&bytes)
+        .unwrap()
+        .pop()
+        .unwrap()
+        .payload;
+    let values = payload.as_object_mut().unwrap();
+    values.remove("tenant_id");
+    values.remove("source_id");
+    values.remove("schema_ref");
+    payload
+}
+
+fn response(family: AkeneoFamily, records: Vec<Value>) -> Vec<u8> {
+    let value = if family.collection() {
+        Value::Array(records)
+    } else {
+        records.into_iter().next().unwrap_or_else(|| json!({}))
+    };
+    serde_json::to_vec(&value).unwrap()
+}
+
+fn context(cursor: &str, page: u32) -> SourceWorkerExecutionContextV1 {
+    SourceWorkerExecutionContextV1 {
+        tenant_id: "tenant".to_owned(),
+        runtime_id: "akeneo-runtime".to_owned(),
+        logical_page_id: format!("source-page-v2:akeneo-{page}"),
+        prior_cursor: cursor.to_owned(),
+        runtime_generation: 7,
+        lease_generation: 11,
+        observed_at_unix_millis: OBSERVED_AT_MILLIS,
+    }
+}
+
+fn metadata(family: AkeneoFamily) -> SourceWorkerRuntimeMetadataV2 {
+    SourceWorkerRuntimeMetadataV2 {
+        public_config: HashMap::from([
+            ("family".to_owned(), family.as_str().to_owned()),
+            (
+                "base_url".to_owned(),
+                "https://tenant.akeneo.com".to_owned(),
+            ),
+            ("asset_family_code".to_owned(), "asset-family-1".to_owned()),
+            ("code".to_owned(), "code-1".to_owned()),
+            ("attribute_code".to_owned(), "attribute-1".to_owned()),
+            ("reference_entity_code".to_owned(), "reference-1".to_owned()),
+            (
+                "uuid".to_owned(),
+                "123e4567-e89b-12d3-a456-426614174000".to_owned(),
+            ),
+        ]),
+        prior_terminal_watermark_unix_millis: 0,
+        prior_checkpoint: String::new(),
+    }
+}
+
+fn plan_page(
+    adapter: &AkeneoSourceExecutionAdapter,
+    plan: &SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    metadata: &SourceWorkerRuntimeMetadataV2,
+) -> SourceWorkerHttpExecutionV2 {
+    adapter
+        .plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(context.clone()),
+            }),
+            metadata: Some(metadata.clone()),
+        })
+        .unwrap()
+}
+
+fn receipt(
+    plan: &SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    execution: &SourceWorkerHttpExecutionV2,
+    status_code: u32,
+    body: &[u8],
+) -> SourceWorkerSafeReceiptV1 {
+    let request = execution.request.as_ref().unwrap();
+    SourceWorkerSafeReceiptV1 {
+        plan_digest_sha256: plan.plan_digest_sha256.clone(),
+        logical_page_id: context.logical_page_id.clone(),
+        request_intent_digest: request.request_intent_digest.clone(),
+        runtime_generation: context.runtime_generation,
+        lease_generation: context.lease_generation,
+        credential_operation: execution.credential_operation.clone(),
+        status_code,
+        response_bytes: body.len() as u64,
+        response_sha256: response_digest(body),
+        tenant_id: context.tenant_id.clone(),
+        runtime_id: context.runtime_id.clone(),
+        observed_at_unix_millis: context.observed_at_unix_millis,
+    }
+}
+
+fn decode_page(
+    adapter: &AkeneoSourceExecutionAdapter,
+    plan: &SourceExecutionPlanV1,
+    context: &SourceWorkerExecutionContextV1,
+    metadata: &SourceWorkerRuntimeMetadataV2,
+    status_code: u32,
+    body: &[u8],
+    response_headers: HashMap<String, String>,
+) -> Result<SourceWorkerDecodeResultV1, SourceExecutionError> {
+    let execution = plan_page(adapter, plan, context, metadata);
+    let safe_receipt = receipt(plan, context, &execution, status_code, body);
+    adapter.decode_v2(&SourceWorkerDecodeEnvelopeV2 {
+        request: Some(SourceWorkerDecodeRequestV1 {
+            plan: Some(plan.clone()),
+            status_code,
+            response_body: body.to_vec(),
+            logical_page_id: context.logical_page_id.clone(),
+            request_intent_digest: execution
+                .request
+                .as_ref()
+                .unwrap()
+                .request_intent_digest
+                .clone(),
+            receipt: Some(safe_receipt),
+            context: Some(context.clone()),
+        }),
+        metadata: Some(metadata.clone()),
+        response_headers,
+        response_headers_sha256: String::new(),
+        execution_intent_digest_sha256: execution.execution_intent_digest_sha256.clone(),
+    })
+}
+
+#[test]
+fn akeneo_plans_all_twelve_families_without_credentials() {
+    for family in AkeneoFamily::ALL {
+        let adapter = adapter(family);
+        let plan = adapter.compiled_plan();
+        assert_eq!(plan.source_id, "akeneo");
+        assert_eq!(plan.family_id, family.as_str());
+        assert_eq!(plan.provider_kernel, family.event_kind());
+        assert_eq!(plan.origin, "https://{tenant}.akeneo.com");
+        assert_eq!(plan.path, family.path_template());
+        assert_eq!(plan.record_selector, family.record_selector());
+        assert_eq!(plan.event_kind, family.event_kind());
+        assert_eq!(plan.schema_ref, family.schema_ref());
+
+        let context = context("", 1);
+        let metadata = metadata(family);
+        let execution = plan_page(adapter, &plan, &context, &metadata);
+        assert_eq!(execution.credential_operation, "source.bearer");
+        assert_eq!(execution.allowed_origin, "https://tenant.akeneo.com");
+        assert!(execution.body.is_empty());
+        assert!(execution.declared_headers.is_empty());
+        let request = execution.request.unwrap();
+        assert_eq!(request.method, "GET");
+        assert_eq!(request.accept, "application/json");
+        assert_eq!(
+            request.url,
+            format!(
+                "https://tenant.akeneo.com{}",
+                family.path(&scope()).unwrap()
+            )
+        );
+        for secret_marker in ["authorization", "bearer", "token", "secret"] {
+            assert!(!request.url.to_ascii_lowercase().contains(secret_marker));
+        }
+    }
+}
+
+#[test]
+fn akeneo_decodes_every_fixture_with_exact_contract_and_seals() {
+    for family in AkeneoFamily::ALL {
+        let adapter = adapter(family);
+        let plan = adapter.compiled_plan();
+        let context = context("", 1);
+        let metadata = metadata(family);
+        let execution = plan_page(adapter, &plan, &context, &metadata);
+        let body = response(family, vec![fixture(family)]);
+        let safe_receipt = receipt(&plan, &context, &execution, 200, &body);
+        let result = decode_page(
+            adapter,
+            &plan,
+            &context,
+            &metadata,
+            200,
+            &body,
+            HashMap::new(),
+        )
+        .unwrap_or_else(|error| panic!("{family:?}: {error:?}"));
+        assert!(result.next_cursor.is_empty());
+        assert_eq!(result.records.len(), 1);
+        let record = &result.records[0];
+        assert_eq!(record.attributes["tenant_id"], "tenant");
+        assert_eq!(record.attributes["source_event_id"], record.provider_id);
+        assert!(record.event_id.starts_with("akeneo-tenant-"));
+        for attribute in &plan.required_attributes {
+            assert!(
+                record
+                    .attributes
+                    .get(attribute)
+                    .is_some_and(|value| !value.is_empty())
+            );
+        }
+        let payload: Value = serde_json::from_slice(&record.payload_json).unwrap();
+        for field in &plan.required_payload_fields {
+            assert!(payload.get(field).is_some_and(|value| !value.is_null()));
+        }
+        adapter
+            .validate_record_identity_v2(&context, record, &metadata)
+            .unwrap();
+
+        let decision = seal_page_program_v2(&SourceExecutionLifecycleEnvelopeV2 {
+            request: Some(SourceExecutionLifecycleRequestV1 {
+                plan: Some(plan),
+                context: Some(context),
+                receipt: Some(safe_receipt),
+                result: Some(result),
+                current_lease_generation: 11,
+            }),
+            metadata: Some(metadata),
+        })
+        .unwrap();
+        assert_eq!(decision.admitted_records.len(), 1);
+        assert!(decision.checkpoint_cursor.is_empty());
+    }
+}
+
+#[test]
+fn akeneo_terminal_checkpoint_and_provider_failures_are_typed() {
+    let family = AkeneoFamily::Attribute;
+    let adapter = adapter(family);
+    let plan = adapter.compiled_plan();
+    let context = context("", 1);
+    let metadata = metadata(family);
+    let result = decode_page(
+        adapter,
+        &plan,
+        &context,
+        &metadata,
+        200,
+        &response(family, vec![fixture(family)]),
+        HashMap::new(),
+    )
+    .unwrap();
+    assert!(result.next_cursor.is_empty());
+
+    for (status, expected) in [
+        (401, SourceExecutionError::AuthenticationRejected),
+        (403, SourceExecutionError::RequiredProviderScopeMissing),
+        (404, SourceExecutionError::UnexpectedProviderStatus),
+        (503, SourceExecutionError::UnexpectedProviderStatus),
+    ] {
+        assert_eq!(
+            decode_page(
+                adapter,
+                &plan,
+                &context,
+                &metadata,
+                status,
+                b"{}",
+                HashMap::new(),
+            ),
+            Err(expected)
+        );
+    }
+    assert_eq!(
+        decode_page(
+            adapter,
+            &plan,
+            &context,
+            &metadata,
+            429,
+            b"{}",
+            HashMap::from([("retry-after".to_owned(), "60".to_owned())]),
+        ),
+        Err(SourceExecutionError::ProviderRateLimit)
+    );
+}
+
+#[test]
+fn akeneo_rejects_bad_scope_cursor_collisions_and_secret_material() {
+    let family = AkeneoFamily::Attribute;
+    let adapter = adapter(family);
+    let plan = adapter.compiled_plan();
+    let metadata = metadata(family);
+    assert_eq!(
+        adapter.plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(context("unexpected-cursor", 2)),
+            }),
+            metadata: Some(metadata.clone()),
+        }),
+        Err(SourceExecutionError::InvalidCursor)
+    );
+
+    let mut missing_scope = metadata.clone();
+    missing_scope.public_config.remove("asset_family_code");
+    assert_eq!(
+        adapter.plan_v2(&SourceWorkerPlanEnvelopeV2 {
+            request: Some(SourceWorkerPlanRequestV1 {
+                plan: Some(plan.clone()),
+                context: Some(context("", 1)),
+            }),
+            metadata: Some(missing_scope),
+        }),
+        Err(SourceExecutionError::MissingConfiguration)
+    );
+
+    let execution_context = context("", 1);
+    let original = fixture(family);
+    let duplicate = response(family, vec![original.clone(), original.clone()]);
+    assert_eq!(
+        decode_page(
+            adapter,
+            &plan,
+            &execution_context,
+            &metadata,
+            200,
+            &duplicate,
+            HashMap::new(),
+        )
+        .unwrap()
+        .records
+        .len(),
+        1
+    );
+
+    let mut slash_identity = original.clone();
+    slash_identity["id"] = Value::String("object/a".to_owned());
+    slash_identity["allowed_extensions"] = Value::String("object/a".to_owned());
+    let mut colon_identity = original.clone();
+    colon_identity["id"] = Value::String("object:a".to_owned());
+    colon_identity["allowed_extensions"] = Value::String("object:a".to_owned());
+    let distinct = decode_page(
+        adapter,
+        &plan,
+        &execution_context,
+        &metadata,
+        200,
+        &response(family, vec![slash_identity, colon_identity]),
+        HashMap::new(),
+    )
+    .unwrap();
+    assert_eq!(distinct.records.len(), 2);
+    assert_ne!(distinct.records[0].event_id, distinct.records[1].event_id);
+
+    let mut conflicting = original.clone();
+    conflicting["name"] = Value::String("Different".to_owned());
+    assert_eq!(
+        decode_page(
+            adapter,
+            &plan,
+            &execution_context,
+            &metadata,
+            200,
+            &response(family, vec![original.clone(), conflicting]),
+            HashMap::new(),
+        ),
+        Err(SourceExecutionError::DuplicateConflict)
+    );
+
+    let mut secret = original.clone();
+    secret["nested"] = json!({"client_secret": "credential-material"});
+    let error = decode_page(
+        adapter,
+        &plan,
+        &execution_context,
+        &metadata,
+        200,
+        &response(family, vec![secret]),
+        HashMap::new(),
+    )
+    .unwrap_err();
+    assert_eq!(error, SourceExecutionError::InvalidProviderRecord);
+    assert!(!format!("{error:?}").contains("credential-material"));
+
+    let mut untrusted_scope = original;
+    untrusted_scope["nested"] = json!({"runtime_id": "untrusted-runtime"});
+    assert_eq!(
+        decode_page(
+            adapter,
+            &plan,
+            &execution_context,
+            &metadata,
+            200,
+            &response(family, vec![untrusted_scope]),
+            HashMap::new(),
+        ),
+        Err(SourceExecutionError::TenantMismatch)
+    );
+}


### PR DESCRIPTION
Adds credential-free Rust request planning and bounded response normalization for all 12 cataloged Akeneo families.

The adapter validates the public Akeneo tenant origin and family-specific path scope, keeps OAuth bearer credential application in the trusted host, rejects cursors for the currently non-paginated contract, scopes stable identities by tenant, account, family, and public request scope, preserves fixture parity, and rejects credential-shaped or runtime-owned provider fields. Event identity encoding is collision-resistant for provider IDs containing reserved characters.

Local validation on the exact head:
- cargo fmt --all -- --check
- cargo test -p cerebro-source-runtime-next akeneo::source_execution_tests (4 passed)
- cargo test -p cerebro-source-runtime-next (728 unit and 7 integration tests passed)
- cargo clippy -p cerebro-source-runtime-next --all-targets --all-features --locked -- -D warnings

This is provider-local adapter work. Shared dispatcher registration, authority promotion, and live-provider qualification remain separate protected steps.