### PR TITLE
feat(runtime): serve invalid event diagnostics from Rust

### DIFF
--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -13,6 +13,7 @@ mod slack_agent_session;
 mod slack_authority;
 mod slack_mrkdwn;
 mod source_page_publisher;
+mod source_runtime_invalid_events;
 mod source_runtime_registry;
 mod source_runtime_sync;
 mod threat_insight_projection;
@@ -684,6 +685,9 @@ fn bounded_operation(method: &Method, path: &str) -> &'static str {
         "/v1/graph/paths" => "paths",
         "/v1/security/lifecycle" => "security_lifecycle",
         "/v1/source-runtimes" => "list_source_runtimes",
+        _ if path.starts_with("/v1/source-runtimes/") && path.ends_with("/invalid-events") => {
+            "list_source_runtime_invalid_events"
+        }
         _ if path.starts_with("/v1/source-runtimes/") && method == Method::PUT => {
             "put_source_runtime"
         }
@@ -2252,6 +2256,10 @@ fn router_with_backend(
             post(sync_source_runtime),
         )
         .route(
+            "/v1/source-runtimes/{runtime_id}/invalid-events",
+            get(list_source_runtime_invalid_events),
+        )
+        .route(
             "/v1/projections/legacy-deltas",
             post(record_legacy_projection),
         )
@@ -2761,6 +2769,48 @@ fn source_runtime_registry_error(
         SourceRuntimeRegistryFailureKind::RuntimeUnavailable => {
             source_runtime_registry_unavailable()
         }
+    }
+}
+
+async fn list_source_runtime_invalid_events(
+    State(state): State<AppState>,
+    Extension(authenticated): Extension<AuthenticatedTenant>,
+    Path(runtime_id): Path<String>,
+) -> Result<
+    Json<source_runtime_invalid_events::SourceRuntimeInvalidEventsResponse>,
+    (StatusCode, Json<ErrorResponse>),
+> {
+    let ledger = state.runtime_ledger.ok_or_else(|| {
+        service_unavailable(
+            "source_runtime_invalid_events_unavailable",
+            "The Rust source-runtime ledger is not configured.",
+        )
+    })?;
+    source_runtime_invalid_events::list_source_runtime_invalid_events(
+        ledger,
+        &authenticated.0,
+        &runtime_id,
+    )
+    .await
+    .map(Json)
+    .map_err(source_runtime_invalid_events_error)
+}
+
+fn source_runtime_invalid_events_error(
+    error: source_runtime_invalid_events::SourceRuntimeInvalidEventsFailure,
+) -> (StatusCode, Json<ErrorResponse>) {
+    use source_runtime_invalid_events::SourceRuntimeInvalidEventsFailureKind;
+
+    eprintln!("Rust source-runtime invalid-event request failed: {error}");
+    match error.kind() {
+        SourceRuntimeInvalidEventsFailureKind::InvalidRequest => bad_request(
+            "invalid_source_runtime",
+            "The source runtime identifier is invalid.",
+        ),
+        SourceRuntimeInvalidEventsFailureKind::RuntimeUnavailable => service_unavailable(
+            "source_runtime_invalid_events_unavailable",
+            "Source-runtime invalid-event evidence is temporarily unavailable.",
+        ),
     }
 }
 
@@ -6371,6 +6421,20 @@ mod tests {
         assert_eq!(
             bounded_operation(&Method::GET, "/v1/source-runtimes/runtime-demo"),
             "get_source_runtime"
+        );
+        assert_eq!(
+            oidc_scope_for_route(
+                &Method::GET,
+                "/v1/source-runtimes/runtime-demo/invalid-events"
+            ),
+            "cerebro:read"
+        );
+        assert_eq!(
+            bounded_operation(
+                &Method::GET,
+                "/v1/source-runtimes/runtime-demo/invalid-events"
+            ),
+            "list_source_runtime_invalid_events"
         );
         assert_eq!(
             oidc_scope_for_route(&Method::POST, "/v1/source-runtimes/runtime-demo/sync"),

--- a/crates/cerebro-platform/src/source_runtime_invalid_events.rs
+++ b/crates/cerebro-platform/src/source_runtime_invalid_events.rs
@@ -1,0 +1,217 @@
+//! Tenant-bound invalid-event inspection for durable source runtimes.
+
+use std::{error::Error, fmt, sync::Arc};
+
+use cerebro_organizational_model::{SourceRuntimeId, TenantId};
+use cerebro_organizational_store::{PostgresLedger, StoredSourceRuntime};
+use serde::Serialize;
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+
+const LAST_FAILURE_CATEGORY: &str = "__cerebro_runtime_last_failure_category";
+const LAST_INVALID_EVENT_ID: &str = "__cerebro_runtime_last_invalid_event_id";
+const LAST_INVALID_FIELD: &str = "__cerebro_runtime_last_invalid_field";
+const LAST_INVALID_STATUS: &str = "__cerebro_runtime_last_invalid_status";
+const LAST_INVALID_OBSERVED_AT: &str = "__cerebro_runtime_last_invalid_observed_at";
+const LAST_INVALID_OCCURRED_AT: &str = "__cerebro_runtime_last_invalid_occurred_at";
+const LAST_INVALID_DIAGNOSTIC: &str = "__cerebro_runtime_last_invalid_diagnostic";
+const LAST_INVALID_RETRYABLE: &str = "__cerebro_runtime_last_invalid_retryable";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SourceRuntimeInvalidEventsFailureKind {
+    InvalidRequest,
+    RuntimeUnavailable,
+}
+
+#[derive(Debug)]
+pub(crate) struct SourceRuntimeInvalidEventsFailure {
+    kind: SourceRuntimeInvalidEventsFailureKind,
+    detail: String,
+}
+
+impl SourceRuntimeInvalidEventsFailure {
+    fn new(kind: SourceRuntimeInvalidEventsFailureKind, detail: impl Into<String>) -> Self {
+        Self {
+            kind,
+            detail: detail.into(),
+        }
+    }
+
+    pub(crate) fn kind(&self) -> SourceRuntimeInvalidEventsFailureKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for SourceRuntimeInvalidEventsFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.detail)
+    }
+}
+
+impl Error for SourceRuntimeInvalidEventsFailure {}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct SourceRuntimeInvalidEventsResponse {
+    generated_at: String,
+    events: Vec<SourceRuntimeInvalidEventRecord>,
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+struct SourceRuntimeInvalidEventRecord {
+    runtime_id: String,
+    source_id: String,
+    tenant_id: String,
+    failure_category: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    fields: Vec<String>,
+    status: String,
+    retryable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    observed_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    occurred_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_event_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    diagnostic: Option<String>,
+}
+
+pub(crate) async fn list_source_runtime_invalid_events(
+    ledger: Arc<PostgresLedger>,
+    tenant_id: &TenantId,
+    runtime_id: &str,
+) -> Result<SourceRuntimeInvalidEventsResponse, SourceRuntimeInvalidEventsFailure> {
+    let runtime_id = SourceRuntimeId::parse(runtime_id.trim().to_owned()).map_err(|error| {
+        SourceRuntimeInvalidEventsFailure::new(
+            SourceRuntimeInvalidEventsFailureKind::InvalidRequest,
+            error.to_string(),
+        )
+    })?;
+    let runtime = ledger
+        .find_source_runtime(&runtime_id)
+        .await
+        .map_err(runtime_unavailable)?;
+    let generated_at = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .map_err(runtime_unavailable)?;
+    Ok(response_for_runtime(
+        tenant_id,
+        runtime.as_ref(),
+        generated_at,
+    ))
+}
+
+fn response_for_runtime(
+    tenant_id: &TenantId,
+    runtime: Option<&StoredSourceRuntime>,
+    generated_at: String,
+) -> SourceRuntimeInvalidEventsResponse {
+    let events = runtime
+        .filter(|runtime| runtime.tenant_id() == tenant_id)
+        .and_then(invalid_event_record)
+        .into_iter()
+        .collect();
+    SourceRuntimeInvalidEventsResponse {
+        generated_at,
+        events,
+    }
+}
+
+fn invalid_event_record(runtime: &StoredSourceRuntime) -> Option<SourceRuntimeInvalidEventRecord> {
+    let config = runtime.config();
+    let failure_category = trimmed(config.get(LAST_FAILURE_CATEGORY)).unwrap_or_default();
+    let invalid_field = trimmed(config.get(LAST_INVALID_FIELD));
+    if failure_category.is_empty() && invalid_field.is_none() {
+        return None;
+    }
+    let status = trimmed(config.get(LAST_INVALID_STATUS)).unwrap_or_else(|| "terminal".to_owned());
+    let retryable = trimmed(config.get(LAST_INVALID_RETRYABLE))
+        .is_some_and(|value| value.eq_ignore_ascii_case("true"));
+    Some(SourceRuntimeInvalidEventRecord {
+        runtime_id: runtime.runtime_id().as_str().trim().to_owned(),
+        source_id: runtime.source_id().trim().to_owned(),
+        tenant_id: runtime.tenant_id().as_str().trim().to_owned(),
+        failure_category,
+        fields: invalid_field.into_iter().collect(),
+        status,
+        retryable,
+        observed_at: trimmed(config.get(LAST_INVALID_OBSERVED_AT)),
+        occurred_at: trimmed(config.get(LAST_INVALID_OCCURRED_AT)),
+        source_event_id: trimmed(config.get(LAST_INVALID_EVENT_ID)),
+        diagnostic: trimmed(config.get(LAST_INVALID_DIAGNOSTIC)),
+    })
+}
+
+fn trimmed(value: Option<&String>) -> Option<String> {
+    value
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn runtime_unavailable(error: impl fmt::Display) -> SourceRuntimeInvalidEventsFailure {
+    SourceRuntimeInvalidEventsFailure::new(
+        SourceRuntimeInvalidEventsFailureKind::RuntimeUnavailable,
+        error.to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    fn stored(tenant_id: &str, config: BTreeMap<String, String>) -> StoredSourceRuntime {
+        StoredSourceRuntime::new(
+            SourceRuntimeId::parse("runtime-a").unwrap(),
+            TenantId::parse(tenant_id).unwrap(),
+            "github".to_owned(),
+            config,
+            None,
+            None,
+            None,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn invalid_event_record_is_bounded_to_safe_diagnostic_fields() {
+        let runtime = stored(
+            "tenant-a",
+            BTreeMap::from([
+                (LAST_FAILURE_CATEGORY.to_owned(), " malformed ".to_owned()),
+                (LAST_INVALID_FIELD.to_owned(), " resource_urn ".to_owned()),
+                (LAST_INVALID_EVENT_ID.to_owned(), " event-a ".to_owned()),
+                (
+                    LAST_INVALID_DIAGNOSTIC.to_owned(),
+                    " invalid source event ".to_owned(),
+                ),
+                (LAST_INVALID_RETRYABLE.to_owned(), "TRUE".to_owned()),
+                ("token".to_owned(), "credential:cred-a:token".to_owned()),
+            ]),
+        );
+        let record = invalid_event_record(&runtime).unwrap();
+        assert_eq!(record.failure_category, "malformed");
+        assert_eq!(record.fields, vec!["resource_urn"]);
+        assert_eq!(record.source_event_id.as_deref(), Some("event-a"));
+        assert_eq!(record.status, "terminal");
+        assert!(record.retryable);
+        let json = serde_json::to_value(record).unwrap();
+        assert!(!json.to_string().contains("credential:cred-a:token"));
+        assert!(json.get("payload").is_none());
+    }
+
+    #[test]
+    fn missing_foreign_and_clean_runtimes_return_no_events() {
+        let tenant_a = TenantId::parse("tenant-a").unwrap();
+        let foreign = stored(
+            "tenant-b",
+            BTreeMap::from([(LAST_FAILURE_CATEGORY.to_owned(), "malformed".to_owned())]),
+        );
+        let clean = stored("tenant-a", BTreeMap::new());
+        for runtime in [None, Some(&foreign), Some(&clean)] {
+            let response = response_for_runtime(&tenant_a, runtime, "2026-08-25T00:00:00Z".into());
+            assert!(response.events.is_empty());
+        }
+    }
+}

--- a/crates/cerebro-platform/src/source_runtime_invalid_events.rs
+++ b/crates/cerebro-platform/src/source_runtime_invalid_events.rs
@@ -80,12 +80,7 @@ pub(crate) async fn list_source_runtime_invalid_events(
     tenant_id: &TenantId,
     runtime_id: &str,
 ) -> Result<SourceRuntimeInvalidEventsResponse, SourceRuntimeInvalidEventsFailure> {
-    let runtime_id = SourceRuntimeId::parse(runtime_id.trim().to_owned()).map_err(|error| {
-        SourceRuntimeInvalidEventsFailure::new(
-            SourceRuntimeInvalidEventsFailureKind::InvalidRequest,
-            error.to_string(),
-        )
-    })?;
+    let runtime_id = parse_runtime_id(runtime_id)?;
     let runtime = ledger
         .find_source_runtime(&runtime_id)
         .await
@@ -98,6 +93,17 @@ pub(crate) async fn list_source_runtime_invalid_events(
         runtime.as_ref(),
         generated_at,
     ))
+}
+
+fn parse_runtime_id(
+    runtime_id: &str,
+) -> Result<SourceRuntimeId, SourceRuntimeInvalidEventsFailure> {
+    SourceRuntimeId::parse(runtime_id.trim().to_owned()).map_err(|error| {
+        SourceRuntimeInvalidEventsFailure::new(
+            SourceRuntimeInvalidEventsFailureKind::InvalidRequest,
+            error.to_string(),
+        )
+    })
 }
 
 fn response_for_runtime(
@@ -213,5 +219,74 @@ mod tests {
             let response = response_for_runtime(&tenant_a, runtime, "2026-08-25T00:00:00Z".into());
             assert!(response.events.is_empty());
         }
+    }
+
+    #[test]
+    fn invalid_event_record_preserves_bounded_timestamps_and_explicit_status() {
+        let runtime = stored(
+            "tenant-a",
+            BTreeMap::from([
+                (LAST_INVALID_FIELD.to_owned(), " object_id ".to_owned()),
+                (LAST_INVALID_STATUS.to_owned(), " quarantined ".to_owned()),
+                (
+                    LAST_INVALID_OBSERVED_AT.to_owned(),
+                    " 2026-08-25T00:00:00Z ".to_owned(),
+                ),
+                (
+                    LAST_INVALID_OCCURRED_AT.to_owned(),
+                    " 2026-08-24T23:59:00Z ".to_owned(),
+                ),
+                (LAST_INVALID_EVENT_ID.to_owned(), "  ".to_owned()),
+                (LAST_INVALID_DIAGNOSTIC.to_owned(), "  ".to_owned()),
+                (LAST_INVALID_RETRYABLE.to_owned(), "false".to_owned()),
+            ]),
+        );
+        let record = invalid_event_record(&runtime).unwrap();
+        assert_eq!(record.runtime_id, "runtime-a");
+        assert_eq!(record.source_id, "github");
+        assert_eq!(record.tenant_id, "tenant-a");
+        assert_eq!(record.failure_category, "");
+        assert_eq!(record.fields, vec!["object_id"]);
+        assert_eq!(record.status, "quarantined");
+        assert!(!record.retryable);
+        assert_eq!(record.observed_at.as_deref(), Some("2026-08-25T00:00:00Z"));
+        assert_eq!(record.occurred_at.as_deref(), Some("2026-08-24T23:59:00Z"));
+        assert_eq!(record.source_event_id, None);
+        assert_eq!(record.diagnostic, None);
+    }
+
+    #[test]
+    fn same_tenant_response_includes_one_invalid_event_and_generation_time() {
+        let tenant = TenantId::parse("tenant-a").unwrap();
+        let runtime = stored(
+            "tenant-a",
+            BTreeMap::from([(LAST_FAILURE_CATEGORY.to_owned(), "malformed".to_owned())]),
+        );
+        let response =
+            response_for_runtime(&tenant, Some(&runtime), "2026-08-25T01:00:00Z".to_owned());
+        assert_eq!(response.generated_at, "2026-08-25T01:00:00Z");
+        assert_eq!(response.events.len(), 1);
+        assert_eq!(response.events[0].failure_category, "malformed");
+    }
+
+    #[test]
+    fn runtime_selector_and_backend_failures_keep_operator_actions_distinct() {
+        assert_eq!(
+            parse_runtime_id(" runtime-a ").unwrap().as_str(),
+            "runtime-a"
+        );
+        let invalid = parse_runtime_id("invalid runtime").unwrap_err();
+        assert_eq!(
+            invalid.kind(),
+            SourceRuntimeInvalidEventsFailureKind::InvalidRequest
+        );
+        assert!(!invalid.to_string().is_empty());
+
+        let unavailable = runtime_unavailable("postgres unavailable");
+        assert_eq!(
+            unavailable.kind(),
+            SourceRuntimeInvalidEventsFailureKind::RuntimeUnavailable
+        );
+        assert_eq!(unavailable.to_string(), "postgres unavailable");
     }
 }

--- a/docs/domains/source-runtime-guide.md
+++ b/docs/domains/source-runtime-guide.md
@@ -289,6 +289,17 @@ curl -fsS -H "Authorization: Bearer ${CEREBRO_API_KEY}" \
   "https://cerebro.example.com/source-runtimes/<runtime-id>/invalid-events?limit=20"
 ```
 
+The Rust platform serves the tenant-bound runtime view at:
+
+```bash
+curl -fsS -H "Authorization: Bearer ${CEREBRO_OIDC_TOKEN}" \
+  "https://cerebro.example.com/v1/source-runtimes/<runtime-id>/invalid-events"
+```
+
+Missing and cross-tenant runtime IDs return the same empty event list. The
+response includes only bounded validation diagnostics; it never includes the
+rejected provider payload or source-runtime credential references.
+
 Use these during onboarding and after source code changes. Invalid events usually mean a source emitted data that failed validation or projection constraints.
 
 ## Claims and findings


### PR DESCRIPTION
## Summary

- serve tenant-bound invalid-event diagnostics from the Rust source-runtime platform
- keep missing and cross-tenant runtime IDs indistinguishable with an empty event list
- expose only bounded reserved diagnostic fields, never provider payloads or credential-bearing runtime config

## Runtime boundary

This adds `GET /v1/source-runtimes/{runtime_id}/invalid-events` beside the Rust registry, sync, and health routes. The legacy Go compatibility route remains unchanged while consumers move to the Rust platform path.

## Validation

Validated at exact head `591b08a07a54c75ad33d7a9d5b1824f3e2fdd57a` through the managed Mac recovery cache because DDESK was healthy but its shared workspace-capacity gate did not admit this isolated checkout:

- `cargo fmt --all -- --check`
- `cargo test -p cerebro-platform` (295 passed, 7 ignored)
- `cargo test -p cerebro-platform source_runtime_invalid_events` (2 passed)
- `cargo clippy -p cerebro-platform --all-targets --no-deps -- -D warnings`
- `python3 scripts/docs_drift_check.py`
- `python3 scripts/readme_check.py`
- `make check-structural check-structural-test check-arch`
- `git diff --check`

Hosted exact-head checks remain the execution authority until DDESK admits the checkout.