### PR TITLE
fix: include critical product reads in runtime health

### DIFF
--- a/apps/web/src/components/StatusPanel.tsx
+++ b/apps/web/src/components/StatusPanel.tsx
@@ -27,9 +27,12 @@ type ProbeResult = {
 };
 
 const LIVENESS_TIMEOUT_MS = 3000;
+const PRODUCT_READ_TIMEOUT_MS = 5000;
 const STATUS_PROBES = [
   { key: "healthz", label: "API liveness", path: "/api/cerebro/healthz", timeoutMs: LIVENESS_TIMEOUT_MS },
   { key: "health", label: "API readiness", path: "/api/cerebro/health", timeoutMs: GRC_QUERY_TIMEOUT_MS },
+  { key: "vendors", label: "Vendor register", path: "/api/cerebro/grc/vendors?limit=1", timeoutMs: PRODUCT_READ_TIMEOUT_MS },
+  { key: "policies", label: "Policy lifecycle", path: "/api/cerebro/grc/policy-lifecycle?rule_profile=baseline&limit=1", timeoutMs: PRODUCT_READ_TIMEOUT_MS },
 ];
 
 const parseStatus = async (response: Response): Promise<Record<string, unknown>> => {

--- a/apps/web/src/components/StatusPanel.tsx
+++ b/apps/web/src/components/StatusPanel.tsx
@@ -31,6 +31,8 @@ const PRODUCT_READ_TIMEOUT_MS = 5000;
 const STATUS_PROBES = [
   { key: "healthz", label: "API liveness", path: "/api/cerebro/healthz", timeoutMs: LIVENESS_TIMEOUT_MS },
   { key: "health", label: "API readiness", path: "/api/cerebro/health", timeoutMs: GRC_QUERY_TIMEOUT_MS },
+  { key: "actions", label: "Action authority", path: "/api/cerebro/v1/actions?limit=1", timeoutMs: PRODUCT_READ_TIMEOUT_MS },
+  { key: "inventory", label: "Inventory", path: "/api/cerebro/grc/inventory/categories?limit=1", timeoutMs: PRODUCT_READ_TIMEOUT_MS },
   { key: "vendors", label: "Vendor register", path: "/api/cerebro/grc/vendors?limit=1", timeoutMs: PRODUCT_READ_TIMEOUT_MS },
   { key: "policies", label: "Policy lifecycle", path: "/api/cerebro/grc/policy-lifecycle?rule_profile=baseline&limit=1", timeoutMs: PRODUCT_READ_TIMEOUT_MS },
 ];

--- a/apps/web/src/lib/ui-contract.test.ts
+++ b/apps/web/src/lib/ui-contract.test.ts
@@ -100,6 +100,8 @@ describe("product UI contract", () => {
     expect(statusSource).toContain("Runtime Health");
     expect(statusSource).toContain("API liveness");
     expect(statusSource).toContain("API readiness");
+    expect(statusSource).toContain("Action authority");
+    expect(statusSource).toContain("Inventory");
     expect(statusSource).toContain("Vendor register");
     expect(statusSource).toContain("Policy lifecycle");
     expect(statusSource).toContain("LIVENESS_TIMEOUT_MS");

--- a/apps/web/src/lib/ui-contract.test.ts
+++ b/apps/web/src/lib/ui-contract.test.ts
@@ -100,7 +100,10 @@ describe("product UI contract", () => {
     expect(statusSource).toContain("Runtime Health");
     expect(statusSource).toContain("API liveness");
     expect(statusSource).toContain("API readiness");
+    expect(statusSource).toContain("Vendor register");
+    expect(statusSource).toContain("Policy lifecycle");
     expect(statusSource).toContain("LIVENESS_TIMEOUT_MS");
+    expect(statusSource).toContain("PRODUCT_READ_TIMEOUT_MS");
     expect(statusSource).toContain("GRC_QUERY_TIMEOUT_MS");
     expect(statusSource).not.toContain("/api/cerebro/grc/dashboard");
     expect(primitivesSource).toContain("DataStateBanner");


### PR DESCRIPTION
## Summary
- probe Action authority, Inventory, the vendor register, and policy lifecycle in Developer Tools runtime health
- report partial health when product reads fail even if API liveness and readiness pass
- keep each product probe bounded to one record and a five-second timeout

## Validation
- `git diff --check`
- hosted web lint and tests are authoritative because DDESK checkout preparation did not acquire capacity and this isolated Mac checkout has no installed Vitest binary