### PR TITLE
fix: filter credential store runtime bindings

### DIFF
--- a/apps/web/src/app/credential-stores/page.tsx
+++ b/apps/web/src/app/credential-stores/page.tsx
@@ -8,6 +8,7 @@ import { AppliedFilterChips, Badge, EmptyBlock, ErrorBlock, LoadingBlock, Metric
 import { withQuery } from "@/lib/cerebro-data";
 import {
   credentialStoreActionLabel,
+  credentialStoreBindingsMatchingQuery,
   credentialStoreIssueMatchesQuery,
   credentialStoreMatchesQuery,
   credentialStoreModeLabel,
@@ -48,13 +49,6 @@ function compactList(values?: string[], fallback = "No values") {
 function storePrimaryAction(store: CredentialStoreOperational) {
   const issueAction = store.issues?.find((issue) => issue.next_action)?.next_action;
   return credentialStoreActionLabel(issueAction || store.health.next_action);
-}
-
-function flattenBindings(stores: CredentialStoreOperational[]) {
-  return stores.flatMap((store) => (store.bindings ?? []).map((binding) => ({
-    ...binding,
-    credential_store_label: store.store.label,
-  })));
 }
 
 function StoreTable({ stores }: { stores: CredentialStoreOperational[] }) {
@@ -241,7 +235,10 @@ export default function CredentialStoresPage() {
     }),
     [allIssues, debouncedStoreQuery, visibleStoreIDs],
   );
-  const allBindings = useMemo(() => flattenBindings(visibleStores), [visibleStores]);
+  const allBindings = useMemo(
+    () => credentialStoreBindingsMatchingQuery(visibleStores, debouncedStoreQuery),
+    [debouncedStoreQuery, visibleStores],
+  );
   const boundedBindings = useMemo(() => grcBoundedRows({ rows: allBindings, limit: GRC_DETAIL_LIMIT }), [allBindings]);
   const bindings = boundedBindings.rows;
   const totals = useMemo(() => credentialStoreUsageTotals(stores), [stores]);

--- a/apps/web/src/lib/credential-stores.test.ts
+++ b/apps/web/src/lib/credential-stores.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  credentialStoreBindingsMatchingQuery,
+  credentialStoreMatchesQuery,
+  type CredentialStoreOperational,
+} from "@/lib/credential-stores";
+
+const environmentStore: CredentialStoreOperational = {
+  store: {
+    id: "environment_managed",
+    label: "Environment managed",
+    provider: "Deployment",
+    available: true,
+    mode: "environment_managed",
+    status: "available",
+    description: "Secrets are resolved inside the backend process.",
+  },
+  health: { status: "in_use" },
+  usage: {
+    connections: 2,
+    credentials: 0,
+    bindings: 2,
+    field_references: 4,
+    issues: 0,
+  },
+  bindings: [
+    {
+      id: "sentinelone-agent",
+      credential_store_id: "environment_managed",
+      source_id: "sentinelone",
+      source_name: "SentinelOne",
+      runtime_id: "writer-sentinelone-agent",
+      fields: ["base_url", "token"],
+    },
+    {
+      id: "okta-user",
+      credential_store_id: "environment_managed",
+      source_id: "okta",
+      source_name: "Okta",
+      runtime_id: "writer-okta-user",
+      fields: ["domain", "token"],
+    },
+  ],
+};
+
+describe("credential store search", () => {
+  it("keeps a store visible when one nested runtime matches", () => {
+    expect(credentialStoreMatchesQuery(environmentStore, "SentinelOne")).toBe(true);
+  });
+
+  it("returns only runtime bindings that match a nested runtime query", () => {
+    expect(credentialStoreBindingsMatchingQuery([environmentStore], "SentinelOne")).toEqual([
+      expect.objectContaining({ id: "sentinelone-agent", credential_store_label: "Environment managed" }),
+    ]);
+  });
+
+  it("returns every runtime binding when store metadata matches", () => {
+    expect(credentialStoreBindingsMatchingQuery([environmentStore], "Environment managed")).toHaveLength(2);
+  });
+
+  it("matches runtime fields without retaining unrelated bindings", () => {
+    expect(credentialStoreBindingsMatchingQuery([environmentStore], "domain")).toEqual([
+      expect.objectContaining({ id: "okta-user" }),
+    ]);
+  });
+});

--- a/apps/web/src/lib/credential-stores.ts
+++ b/apps/web/src/lib/credential-stores.ts
@@ -177,6 +177,12 @@ export function credentialStoreResolverLabel(resolver?: string) {
 }
 
 export function credentialStoreMatchesQuery(item: CredentialStoreOperational, query: string) {
+  return credentialStoreMetadataMatchesQuery(item, query)
+    || (item.bindings ?? []).some((binding) => credentialStoreBindingMatchesQuery(binding, query))
+    || (item.issues ?? []).some((issue) => credentialStoreIssueMatchesQuery(issue, query));
+}
+
+export function credentialStoreMetadataMatchesQuery(item: CredentialStoreOperational, query: string) {
   const normalized = query.trim().toLowerCase();
   if (!normalized) return true;
   const values = [
@@ -190,28 +196,38 @@ export function credentialStoreMatchesQuery(item: CredentialStoreOperational, qu
     item.health.detail,
     item.health.next_action,
     ...(item.store.reference_prefixes ?? []),
-    ...(item.bindings ?? []).flatMap((binding) => [
-      binding.source_id,
-      binding.source_name,
-      binding.runtime_id,
-      binding.tenant_id,
-      binding.auth_method,
-      binding.resolver,
-      binding.credential_id,
-      binding.credential_status,
-      ...(binding.fields ?? []),
-      ...(binding.reference_prefixes ?? []),
-    ]),
-    ...(item.issues ?? []).flatMap((issue) => [
-      issue.source_id,
-      issue.runtime_id,
-      issue.credential_id,
-      issue.field,
-      issue.detail,
-      issue.next_action,
-    ]),
   ];
   return values.filter(Boolean).some((value) => String(value).toLowerCase().includes(normalized));
+}
+
+export function credentialStoreBindingMatchesQuery(binding: CredentialStoreBinding, query: string) {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return true;
+  return [
+    binding.credential_store_id,
+    binding.source_id,
+    binding.source_name,
+    binding.runtime_id,
+    binding.tenant_id,
+    binding.auth_method,
+    binding.resolver,
+    binding.credential_id,
+    binding.credential_status,
+    ...(binding.fields ?? []),
+    ...(binding.reference_prefixes ?? []),
+  ].filter(Boolean).some((value) => String(value).toLowerCase().includes(normalized));
+}
+
+export function credentialStoreBindingsMatchingQuery(stores: CredentialStoreOperational[], query: string) {
+  return stores.flatMap((item) => {
+    const includeAllBindings = credentialStoreMetadataMatchesQuery(item, query);
+    return (item.bindings ?? [])
+      .filter((binding) => includeAllBindings || credentialStoreBindingMatchesQuery(binding, query))
+      .map((binding) => ({
+        ...binding,
+        credential_store_label: item.store.label,
+      }));
+  });
 }
 
 export function credentialStoreIssueMatchesQuery(issue: CredentialStoreIssue, query: string) {


### PR DESCRIPTION
## Summary
- keep a credential store visible when its metadata, runtime binding, or issue matches the search
- filter nested runtime bindings independently so unrelated siblings in the same store do not remain visible
- preserve all bindings when the store metadata itself matches

## Reproduction
Searching for a source name narrowed Store Health to its shared credential store, but Runtime Bindings still showed every binding attached to that store.

## Validation
- `vitest run src/lib/credential-stores.test.ts` (4 tests passed)
- `npm test` in `apps/web` (108 files, 657 tests passed)
- `eslint src/app/credential-stores/page.tsx src/lib/credential-stores.ts src/lib/credential-stores.test.ts`
- `npm run build` in `apps/web` (Next.js production build and standalone packaging passed)
- `git diff --check`