### PR TITLE
fix: use readiness evidence totals on home

### DIFF
--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -142,4 +142,57 @@ describe("Home review links", () => {
     ]);
     expect(container.textContent).toContain("Loading source coverage.");
   });
+
+  it("uses program readiness totals for evidence blockers", async () => {
+    const dashboardPath = grcDashboardPath({ limit: 12, enrichments: "deferred" });
+    const dashboardData = {
+      summary: {
+        open_findings: 0,
+        critical_findings: 0,
+        high_findings: 0,
+        overdue_findings: 0,
+        unassigned: 0,
+        controls_failing: 0,
+        evidence_items: 0,
+        connectors: 0,
+        stale_connectors: 0,
+      },
+      findings: [],
+      controls: [],
+      evidence: [],
+      connectors: [],
+      generated_at: "2026-08-25T00:00:00Z",
+    } as GRCDashboard;
+    const readinessData = {
+      summary: {
+        controls: 36,
+        passing_controls: 0,
+        missing_evidence_items: 32,
+        stale_evidence_items: 2,
+        coverage_blind_spots: 0,
+      },
+      frameworks: [],
+      controls: [],
+      work_items: [],
+      connectors: [],
+    };
+    mocks.useGRCQuery.mockImplementation((path: string | null) => ({
+      data: path === dashboardPath ? dashboardData : path === grcProgramReadinessPath() ? readinessData : null,
+      durationMs: null,
+      error: null,
+      lastSuccessfulAt: null,
+      loading: false,
+      reload: mocks.reload,
+      state: path ? "ready" : "empty",
+    }));
+
+    await act(async () => {
+      root.render(<Home />);
+    });
+
+    const evidenceLink = [...container.querySelectorAll<HTMLAnchorElement>("a")]
+      .find((link) => link.getAttribute("href") === "/evidence");
+    expect(evidenceLink?.textContent).toContain("34");
+    expect(evidenceLink?.textContent).toContain("32 missing, 2 stale");
+  });
 });

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -468,8 +468,10 @@ export default function Home() {
   const coverageBlindSpotCount = readiness?.coverage_blind_spots ?? coverageSummaries.reduce((total, source) => total + source.blind_spots, 0);
   const coverageSourceCount = coverageSummaries.filter((source) => source.blind_spots > 0).length;
   const coveragePending = !readinessQuery.data && !coverageQuery.data && (readinessQuery.loading || coverageQuery.loading);
-  const missingEvidenceItems = (data?.controls ?? []).reduce((total, control) => total + (control.missing_evidence_items ?? 0), 0);
-  const staleEvidenceItems = (data?.controls ?? []).reduce((total, control) => total + (control.stale_evidence_items ?? 0), 0);
+  const missingEvidenceItems = readiness?.missing_evidence_items
+    ?? (data?.controls ?? []).reduce((total, control) => total + (control.missing_evidence_items ?? 0), 0);
+  const staleEvidenceItems = readiness?.stale_evidence_items
+    ?? (data?.controls ?? []).reduce((total, control) => total + (control.stale_evidence_items ?? 0), 0);
   const primaryFrameworkRecord = readinessQuery.data?.frameworks?.[0];
   const primaryFramework = primaryFrameworkRecord?.framework_name || "Program";
   const scopedDashboardControls = (data?.controls ?? []).filter((control) =>


### PR DESCRIPTION
## Summary
- use the authoritative program-readiness evidence totals on Home
- retain the bounded dashboard-control sum only as a fallback while readiness is unavailable
- cover missing and stale evidence totals in the Program health card

## Reproduction
The control register reported required evidence gaps while Home reported zero evidence blockers because Home summed only the dashboard's limited control list.

## Validation
- `vitest run src/app/page.test.tsx` (4 tests passed)
- `npm test` in `apps/web` (107 files, 654 tests passed)
- `eslint src/app/page.tsx src/app/page.test.tsx`
- `npm run build` in `apps/web` (Next.js production build and standalone packaging passed)
- `git diff --check`