### PR TITLE
fix(web): keep resource links on authenticated proxy

### DIFF
--- a/apps/web/src/components/ResourceExplorer.test.tsx
+++ b/apps/web/src/components/ResourceExplorer.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenApiOperation } from "@/lib/openapi";
+
+vi.mock("@/components/providers", () => ({
+  useApiKey: () => ({ apiKey: "" }),
+}));
+
+import ResourceExplorer from "./ResourceExplorer";
+
+const operation: OpenApiOperation = {
+  id: "list-assessment-lenses",
+  tag: "GRC",
+  method: "GET",
+  path: "/grc/assessment-lenses",
+  summary: "List assessment lenses",
+  parameters: [],
+  source: "openapi",
+};
+
+describe("ResourceExplorer", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("opens read-only endpoints through the authenticated same-origin proxy", async () => {
+    await act(async () => {
+      root.render(<ResourceExplorer operations={[operation]} schemas={{}} />);
+    });
+
+    const openLink = Array.from(container.querySelectorAll("a")).find(
+      (link) => link.textContent === "Open",
+    );
+
+    expect(openLink?.getAttribute("href")).toBe(
+      "/api/cerebro/grc/assessment-lenses",
+    );
+    expect(openLink?.getAttribute("target")).toBe("_blank");
+  });
+});

--- a/apps/web/src/components/ResourceExplorer.tsx
+++ b/apps/web/src/components/ResourceExplorer.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 
-import { buildApiUrl, normalizePath } from "@/lib/api";
+import { normalizePath } from "@/lib/api";
 import type {
   OpenApiOperation,
   OpenApiParameter,
@@ -212,7 +212,6 @@ function EndpointCard({
   ).toString();
   const fullPath = queryString ? `${normalizedPath}?${queryString}` : normalizedPath;
   const proxyUrl = `/api/cerebro${fullPath}`;
-  const externalUrl = buildApiUrl(fullPath);
 
   const handleFetch = async () => {
     if (missingParams.length > 0) {
@@ -281,7 +280,7 @@ function EndpointCard({
         </div>
         <div className="flex items-center gap-2">
           <a
-            href={missingParams.length === 0 ? externalUrl : undefined}
+            href={missingParams.length === 0 ? proxyUrl : undefined}
             target="_blank"
             rel="noreferrer"
             className={`rounded-md border border-stone-300 px-3 py-2 text-xs font-semibold uppercase tracking-wide transition ${


### PR DESCRIPTION
## Summary
- route resource explorer Open links through the existing same-origin Cerebro proxy
- prevent deployed resource links from resolving to a build-time localhost API origin
- cover the authenticated proxy target with a component regression test

## Validation
- `npm test -- --run src/components/ResourceExplorer.test.tsx` (1/1)
- `npx eslint src/components/ResourceExplorer.tsx src/components/ResourceExplorer.test.tsx`
- bundled Node 24: `npm test -- --run` (109 files, 659 tests)
- bundled Node 24: `npm run build` (49 pages, 77 standalone chunks)

## Live reproduction
`/resources/grc` rendered Open links such as `http://localhost:8080/grc/assessment-lenses`; the link now remains on `/api/cerebro/grc/assessment-lenses` so the environment proxy owns authentication and upstream routing.