### PR TITLE
fix: bound runtime health graph probes

### DIFF
--- a/apps/web/src/app/api/cerebro/[...path]/route.test.ts
+++ b/apps/web/src/app/api/cerebro/[...path]/route.test.ts
@@ -24,6 +24,27 @@ afterEach(() => {
 });
 
 describe("Cerebro proxy route", () => {
+  it("does not force ordinary GET reads to bypass the upstream query cache", async () => {
+    delete process.env.CEREBRO_WEB_FIXTURE_MODE;
+    let upstreamInit: RequestInit | undefined;
+    vi.stubGlobal("fetch", vi.fn(async (_url: URL | RequestInfo, init?: RequestInit) => {
+      upstreamInit = init;
+      return new Response(JSON.stringify({ policies: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }));
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/cerebro/grc/policy-lifecycle?cache_regression=ordinary"),
+      { params: Promise.resolve({ path: ["grc", "policy-lifecycle"] }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(upstreamInit?.cache).toBeUndefined();
+    expect(new Headers(upstreamInit?.headers).get("cache-control")).toBeNull();
+  });
+
   it.each([
     ["GET", GET],
     ["POST", POST],

--- a/apps/web/src/app/api/cerebro/[...path]/route.ts
+++ b/apps/web/src/app/api/cerebro/[...path]/route.ts
@@ -142,7 +142,6 @@ export async function GET(request: NextRequest, context: RouteContext) {
       response = await fetchCerebro(target, {
         method: "GET",
         headers: upstreamHeaders,
-        cache: "no-store",
         signal: background ? undefined : request.signal,
       });
     } catch (error) {

--- a/apps/web/src/components/StatusPanel.test.tsx
+++ b/apps/web/src/components/StatusPanel.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/providers", () => ({
+  useApiKey: () => ({ apiKey: "" }),
+  useConsoleConfig: () => ({ config: { apiBase: "/api/cerebro", serverAuthConfigured: true } }),
+  useCurrentUser: () => ({ error: null, loading: false, user: null }),
+}));
+
+vi.mock("@/lib/identity", () => ({
+  identityPosture: () => ({ label: "Trusted proxy", sourceLabel: "Auth proxy headers" }),
+}));
+
+import StatusPanel from "./StatusPanel";
+
+describe("StatusPanel cache behavior", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("uses normal caches automatically and bypasses them only for operator refresh", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ status: "ready" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await act(async () => {
+      root.render(<StatusPanel />);
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(6));
+
+    for (const [, init] of fetchMock.mock.calls) {
+      expect((init as RequestInit | undefined)?.cache).toBeUndefined();
+    }
+
+    const refresh = Array.from(container.querySelectorAll("button")).find((button) => button.textContent === "Refresh");
+    expect(refresh).toBeDefined();
+    await act(async () => {
+      refresh?.click();
+    });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(12));
+
+    for (const [, init] of fetchMock.mock.calls.slice(6)) {
+      expect((init as RequestInit | undefined)?.cache).toBe("no-store");
+    }
+  });
+});

--- a/apps/web/src/components/StatusPanel.tsx
+++ b/apps/web/src/components/StatusPanel.tsx
@@ -73,7 +73,7 @@ export default function StatusPanel() {
   const [loading, setLoading] = useState(true);
   const identity = identityPosture({ error: identityError, loading: identityLoading, user });
 
-  const fetchStatus = useCallback(async (signal?: AbortSignal) => {
+  const fetchStatus = useCallback(async (signal?: AbortSignal, bypassCache = false) => {
     setLoading(true);
     const headers: HeadersInit = apiKey ? { "X-API-Key": apiKey } : {};
 
@@ -84,7 +84,11 @@ export default function StatusPanel() {
       signal?.addEventListener("abort", abort, { once: true });
       const timer = window.setTimeout(() => controller.abort(), probe.timeoutMs);
       try {
-        const response = await fetch(probe.path, { headers, cache: "no-store", signal: controller.signal });
+        const response = await fetch(probe.path, {
+          headers,
+          ...(bypassCache ? { cache: "no-store" as RequestCache } : {}),
+          signal: controller.signal,
+        });
         const data = await parseStatus(response);
         return {
           ...probe,
@@ -144,7 +148,7 @@ export default function StatusPanel() {
         <h3 className="text-[13px] font-semibold text-[var(--text-primary)]">Runtime Health</h3>
         <div className="flex items-center gap-3">
           {state.checkedAt && <span className="text-[11px] text-[var(--text-muted)]">Checked {new Date(state.checkedAt).toLocaleTimeString()}</span>}
-          <button type="button" onClick={() => void fetchStatus()} disabled={loading} className="secondary-button px-2.5 py-1.5 text-[12px]">
+          <button type="button" onClick={() => void fetchStatus(undefined, true)} disabled={loading} className="secondary-button px-2.5 py-1.5 text-[12px]">
             {loading ? "Checking..." : "Refresh"}
           </button>
         </div>

--- a/apps/web/src/lib/cerebro-client.test.ts
+++ b/apps/web/src/lib/cerebro-client.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchCerebro } from "./cerebro-client";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("fetchCerebro", () => {
+  it("does not turn ordinary product reads into cache bypass requests", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    fetchMock.mockResolvedValue(new Response("{}", {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchCerebro("/grc/policy-lifecycle");
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(init?.cache).toBeUndefined();
+    expect(new Headers(init?.headers).get("cache-control")).toBeNull();
+  });
+
+  it("preserves an explicit operator cache bypass", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    fetchMock.mockResolvedValue(new Response("{}", {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchCerebro("/grc/policy-lifecycle", undefined, { cache: "no-store" });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(init?.cache).toBe("no-store");
+  });
+});

--- a/apps/web/src/lib/cerebro-client.ts
+++ b/apps/web/src/lib/cerebro-client.ts
@@ -17,7 +17,6 @@ export const fetchCerebro = async <T = unknown>(
   const response = await fetch(`/api/cerebro${path}`, {
     ...init,
     headers,
-    cache: "no-store",
   });
   const text = await response.text();
   const contentType = response.headers.get("content-type");

--- a/internal/grcpolicylifecycle/lifecycle.go
+++ b/internal/grcpolicylifecycle/lifecycle.go
@@ -13,9 +13,8 @@ import (
 )
 
 const (
-	grcPolicyLifecycleDefaultLimit         = 100
-	grcPolicyLifecycleDefaultRelationLimit = 2000
-	grcPolicyLifecycleExceptionWindow      = 30 * 24 * time.Hour
+	grcPolicyLifecycleDefaultLimit    = 100
+	grcPolicyLifecycleExceptionWindow = 30 * 24 * time.Hour
 )
 
 type Scope struct {
@@ -120,7 +119,18 @@ RETURN e.urn AS urn,
        coalesce(e.attributes_json, '{}') AS attributes_json
 ORDER BY e.entity_type, e.label, e.urn`
 
-const grcPolicyLifecycleRelationsQuery = `MATCH (left:Entity)-[r:RELATION]->(right:Entity)
+const grcPolicyLifecycleRelationsQuery = `UNWIND $entity_urns AS entity_urn
+MATCH (anchor:Entity {urn: entity_urn})
+CALL {
+  WITH anchor
+  MATCH (anchor)-[r:RELATION]->(right:Entity)
+  RETURN anchor AS left, r, right
+  UNION
+  WITH anchor
+  MATCH (left:Entity)-[r:RELATION]->(anchor)
+  RETURN left, r, anchor AS right
+}
+WITH DISTINCT left, r, right
 WHERE ($tenant_id = '' OR left.tenant_id = $tenant_id)
   AND ($tenant_id = '' OR right.tenant_id = $tenant_id)
   AND (
@@ -717,16 +727,18 @@ func Build(ctx context.Context, store ports.RawCypherQueryStore, scope Scope) (R
 	if err != nil {
 		return Response{}, err
 	}
-	relationLimit := limit * 20
-	if relationLimit < grcPolicyLifecycleDefaultRelationLimit {
-		relationLimit = grcPolicyLifecycleDefaultRelationLimit
+	entityURNs := grcPolicyLifecycleEntityURNs(entityRows)
+	if len(entityURNs) == 0 {
+		return grcPolicyLifecycleFromGraphWithScope(entityRows, nil, time.Now().UTC(), scope), nil
 	}
+	relationLimit := len(entityURNs) * 20
 	if relationLimit > ports.MaxCypherQueryRows {
 		relationLimit = ports.MaxCypherQueryRows
 	}
 	relationRows, err := store.ExecuteReadCypher(ctx, ports.CypherQueryRequest{
 		Query: grcPolicyLifecycleRelationsQuery,
 		Params: map[string]any{
+			"entity_urns":                 entityURNs,
 			"tenant_id":                   scope.TenantID,
 			"source_id":                   scope.SourceID,
 			"runtime_id":                  scope.RuntimeID,
@@ -742,6 +754,23 @@ func Build(ctx context.Context, store ports.RawCypherQueryStore, scope Scope) (R
 		return Response{}, err
 	}
 	return grcPolicyLifecycleFromGraphWithScope(entityRows, relationRows, time.Now().UTC(), scope), nil
+}
+
+func grcPolicyLifecycleEntityURNs(rows []ports.CypherRow) []string {
+	seen := make(map[string]struct{}, len(rows))
+	urns := make([]string, 0, len(rows))
+	for _, row := range rows {
+		urn := grcPolicyRowString(row, "urn")
+		if urn == "" {
+			continue
+		}
+		if _, ok := seen[urn]; ok {
+			continue
+		}
+		seen[urn] = struct{}{}
+		urns = append(urns, urn)
+	}
+	return urns
 }
 
 func grcPolicyLifecycleEntityTypeLimit(limit int) int {

--- a/internal/grcpolicylifecycle/lifecycle_test.go
+++ b/internal/grcpolicylifecycle/lifecycle_test.go
@@ -22,7 +22,9 @@ func TestMissingLifecycleStatusDoesNotCreateWork(t *testing.T) {
 }
 
 func TestBuildAppliesEntityLimitPerLifecycleType(t *testing.T) {
-	store := &recordingPolicyLifecycleStore{}
+	store := &recordingPolicyLifecycleStore{responses: [][]ports.CypherRow{{
+		policyLifecycleTestRow("urn:cerebro:writer:policy:access", "policy", "Access policy", nil),
+	}}}
 	_, err := Build(context.Background(), store, Scope{
 		TenantID:  "writer",
 		SourceID:  "grc",
@@ -77,6 +79,18 @@ func TestBuildAppliesEntityLimitPerLifecycleType(t *testing.T) {
 		t.Fatalf("entity query %q does not filter broad claim/document types", entityRequest.Query)
 	}
 	relationRequest := store.requests[1]
+	entityURNs, ok := relationRequest.Params["entity_urns"].([]string)
+	if !ok || len(entityURNs) != 1 || entityURNs[0] != "urn:cerebro:writer:policy:access" {
+		t.Fatalf("relation entity urns = %#v, want selected lifecycle entity", relationRequest.Params["entity_urns"])
+	}
+	if relationRequest.RowLimit != 20 {
+		t.Fatalf("relation row limit = %d, want 20 for one selected entity", relationRequest.RowLimit)
+	}
+	if !strings.Contains(relationRequest.Query, "UNWIND $entity_urns AS entity_urn") ||
+		!strings.Contains(relationRequest.Query, "MATCH (anchor:Entity {urn: entity_urn})") ||
+		strings.HasPrefix(strings.TrimSpace(relationRequest.Query), "MATCH (left:Entity)-[r:RELATION]") {
+		t.Fatalf("relation query %q is not anchored to selected lifecycle entities", relationRequest.Query)
+	}
 	if relationRequest.Params["risk_scenario_attr_fragment"] != grcPolicyLifecycleRiskScenarioAttrFragment {
 		t.Fatalf("relation params = %#v, want risk scenario filter", relationRequest.Params)
 	}
@@ -86,6 +100,21 @@ func TestBuildAppliesEntityLimitPerLifecycleType(t *testing.T) {
 	}
 	if !strings.Contains(relationRequest.Query, "left.entity_type <> 'claim'") || !strings.Contains(relationRequest.Query, "right.entity_type <> 'document'") {
 		t.Fatalf("relation query %q does not filter broad claim/document types", relationRequest.Query)
+	}
+}
+
+func TestBuildSkipsRelationReadWhenNoLifecycleEntitiesMatch(t *testing.T) {
+	store := &recordingPolicyLifecycleStore{}
+
+	response, err := Build(context.Background(), store, Scope{TenantID: "writer", Limit: 1})
+	if err != nil {
+		t.Fatalf("Build error = %v", err)
+	}
+	if len(store.requests) != 1 {
+		t.Fatalf("requests len = %d, want only the entity read", len(store.requests))
+	}
+	if response.Summary.Policies != 0 || len(response.Policies) != 0 {
+		t.Fatalf("response = %#v, want empty policy lifecycle", response)
 	}
 }
 
@@ -1328,7 +1357,8 @@ func TestPolicyDocumentEvidenceFieldsFlowToLifecycleAndExport(t *testing.T) {
 }
 
 type recordingPolicyLifecycleStore struct {
-	requests []ports.CypherQueryRequest
+	requests  []ports.CypherQueryRequest
+	responses [][]ports.CypherRow
 }
 
 func (s *recordingPolicyLifecycleStore) Ping(context.Context) error {
@@ -1340,7 +1370,11 @@ func (s *recordingPolicyLifecycleStore) GetEntityNeighborhood(context.Context, s
 }
 
 func (s *recordingPolicyLifecycleStore) ExecuteReadCypher(_ context.Context, request ports.CypherQueryRequest) ([]ports.CypherRow, error) {
+	call := len(s.requests)
 	s.requests = append(s.requests, request)
+	if call < len(s.responses) {
+		return s.responses[call], nil
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION
## Summary
- preserve normal cache semantics for automatic product reads while keeping operator refresh explicit
- stop the web proxy from forcing backend query-cache bypasses
- anchor policy lifecycle relationship reads to selected entities and scale the row budget to actual matches

## Validation
- `go test ./internal/grcpolicylifecycle ./internal/bootstrap -count=1`
- `make check-structural check-structural-test check-arch`
- `npm test -- --run`
- `npm run lint -- --max-warnings=0`
- `npm run build`