### PR TITLE
perf: stream runtime probe results

### DIFF
--- a/apps/web/src/components/StatusPanel.test.tsx
+++ b/apps/web/src/components/StatusPanel.test.tsx
@@ -17,11 +17,16 @@ vi.mock("@/lib/identity", () => ({
 
 import StatusPanel from "./StatusPanel";
 
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
 describe("StatusPanel cache behavior", () => {
   let container: HTMLDivElement;
   let root: Root;
 
   beforeEach(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -61,5 +66,44 @@ describe("StatusPanel cache behavior", () => {
     for (const [, init] of fetchMock.mock.calls.slice(6)) {
       expect((init as RequestInit | undefined)?.cache).toBe("no-store");
     }
+  });
+
+  it("publishes probe results without waiting for the slowest request", async () => {
+    const pending = new Map<string, (response: Response) => void>();
+    const fetchMock = vi.fn<typeof fetch>((input) => new Promise<Response>((resolve) => {
+      pending.set(String(input), resolve);
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await act(async () => {
+      root.render(<StatusPanel />);
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(6));
+
+    await act(async () => {
+      pending.get("/api/cerebro/healthz")?.(new Response(JSON.stringify({ status: "ready" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }));
+    });
+    await vi.waitFor(() => {
+      const rows = Array.from(container.querySelectorAll("tbody tr"));
+      expect(rows[0]?.textContent).toContain("Ready");
+      expect(rows[1]?.textContent).toContain("Loading");
+      expect(container.textContent).toContain("Healthz");
+      expect(container.textContent).toContain("Checking...");
+    });
+
+    await act(async () => {
+      for (const [path, resolve] of pending) {
+        if (path === "/api/cerebro/healthz") continue;
+        resolve(new Response(JSON.stringify({ status: "ready" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }));
+      }
+    });
+    await vi.waitFor(() => expect(container.textContent).toContain("Refresh"));
   });
 });

--- a/apps/web/src/components/StatusPanel.tsx
+++ b/apps/web/src/components/StatusPanel.tsx
@@ -37,6 +37,14 @@ const STATUS_PROBES = [
   { key: "policies", label: "Policy lifecycle", path: "/api/cerebro/grc/policy-lifecycle?rule_profile=baseline&limit=1", timeoutMs: PRODUCT_READ_TIMEOUT_MS },
 ];
 
+const pendingProbe = (probe: typeof STATUS_PROBES[number]): ProbeResult => ({
+  ...probe,
+  durationMs: 0,
+  ok: false,
+  state: "loading",
+  status: 0,
+});
+
 const parseStatus = async (response: Response): Promise<Record<string, unknown>> => {
   const text = await response.text();
   let body: unknown = text;
@@ -75,6 +83,7 @@ export default function StatusPanel() {
 
   const fetchStatus = useCallback(async (signal?: AbortSignal, bypassCache = false) => {
     setLoading(true);
+    setState({ probes: STATUS_PROBES.map(pendingProbe) });
     const headers: HeadersInit = apiKey ? { "X-API-Key": apiKey } : {};
 
     const runProbe = async (probe: typeof STATUS_PROBES[number]): Promise<ProbeResult> => {
@@ -117,7 +126,23 @@ export default function StatusPanel() {
     };
 
     try {
-      const probes = await Promise.all(STATUS_PROBES.map(runProbe));
+      const probes = await Promise.all(STATUS_PROBES.map(async (probe) => {
+        const result = await runProbe(probe);
+        if (!signal?.aborted) {
+          setState((current) => {
+            const nextProbes = (current.probes ?? STATUS_PROBES.map(pendingProbe)).map((currentProbe) => (
+              currentProbe.key === result.key ? result : currentProbe
+            ));
+            return {
+              ...current,
+              health: result.key === "health" ? result.data : current.health,
+              healthz: result.key === "healthz" ? result.data : current.healthz,
+              probes: nextProbes,
+            };
+          });
+        }
+        return result;
+      }));
       if (signal?.aborted) return;
       const health = probes.find((probe) => probe.key === "health")?.data;
       const healthz = probes.find((probe) => probe.key === "healthz")?.data;
@@ -210,7 +235,7 @@ export default function StatusPanel() {
             </table>
           </div>
 
-          {!loading && !state.error && (
+          {!state.error && (state.health || state.healthz) && (
             <div className="grid gap-4 md:grid-cols-2">
               {[
                 { title: "Health", data: state.health },


### PR DESCRIPTION
## Summary
- initialize every runtime probe in an explicit loading state
- publish each completed probe immediately instead of waiting for the slowest request
- show health and liveness payloads as soon as either response arrives

## Validation
- `npm test` (111 files, 664 tests passed)
- `npm run lint -- --max-warnings=0`
- `npm run build` (49 pages, 77 standalone chunks)
- `git diff --check`