### PR TITLE
fix(web): scope GRC proxy requests to the graph tenant

### DIFF
--- a/apps/web/src/lib/cerebro-proxy.test.ts
+++ b/apps/web/src/lib/cerebro-proxy.test.ts
@@ -51,14 +51,27 @@ describe("cerebro proxy cache headers", () => {
     expect(getCerebroPublicConfig().apiBase).toBe("/api/cerebro");
   });
 
-  it("adds the server-owned tenant header for local Rust shared-secret auth", () => {
+  it.each([
+    "platform/graph/neighborhood",
+    "grc/inventory/categories",
+    "grc/vendors",
+    "grc/policy-lifecycle",
+  ])("adds the server-owned tenant header to %s", (path) => {
     vi.stubEnv("CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID", " tenant-demo ");
 
     const request = new NextRequest("http://localhost/graph");
-    const headers = new Headers(authHeadersFor(request, "platform/graph/neighborhood"));
+    const headers = new Headers(authHeadersFor(request, path));
 
     expect(headers.get("x-cerebro-tenant")).toBe("tenant-demo");
-    expect(new Headers(authHeadersFor(request, "user/preferences")).get("x-cerebro-tenant")).toBeNull();
+  });
+
+  it("keeps explicit tenant selection and unrelated routes independent of the graph tenant", () => {
+    vi.stubEnv("CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID", "tenant-demo");
+
+    const selectedTenantRequest = new NextRequest("http://localhost/api/cerebro/grc/vendors?tenant_id=tenant-selected");
+
+    expect(new Headers(authHeadersFor(selectedTenantRequest, "grc/vendors")).get("x-cerebro-tenant")).toBeNull();
+    expect(new Headers(authHeadersFor(selectedTenantRequest, "user/preferences")).get("x-cerebro-tenant")).toBeNull();
   });
 
   it("routes only runtime health to the configured Rust platform origin", () => {

--- a/apps/web/src/lib/cerebro-proxy.ts
+++ b/apps/web/src/lib/cerebro-proxy.ts
@@ -103,6 +103,11 @@ export const rustTenantAuthHeaders = (tenantID: string, sharedSecret: string): H
 const isRustRuntimeHealthPath = (path: string) =>
   normalizeProxyPath(path) === RUST_RUNTIME_HEALTH_PATH;
 
+const usesOrganizationalGraphTenant = (path: string) => {
+  const normalizedPath = normalizeProxyPath(path);
+  return normalizedPath === "platform/graph/neighborhood" || normalizedPath.startsWith("grc/");
+};
+
 const forwardRequestAuth =
   parseBooleanEnv(process.env.CEREBRO_FORWARD_AUTH_HEADERS) ??
   !Boolean(SERVER_API_KEY || SERVER_AUTHORIZATION);
@@ -204,7 +209,8 @@ export const authHeadersFor = (request: NextRequest, upstreamPath = ""): Headers
   const organizationalGraphTenant = configuredOrganizationalGraphTenant();
   if (
     organizationalGraphTenant &&
-    normalizeProxyPath(upstreamPath) === "platform/graph/neighborhood"
+    usesOrganizationalGraphTenant(upstreamPath) &&
+    !request.nextUrl.searchParams.get("tenant_id")?.trim()
   ) {
     headers["X-Cerebro-Tenant"] = organizationalGraphTenant;
   }


### PR DESCRIPTION
## Summary
- apply the configured organizational-graph tenant scope to GRC proxy requests when callers omit an explicit tenant
- preserve explicit tenant selection and keep unrelated proxy routes unchanged
- cover inventory, vendor, policy lifecycle, and graph neighborhood request headers

## Validation
- `npm run test -- --run src/lib/cerebro-proxy.test.ts`
- `NODE_OPTIONS=--localstorage-file=<temporary-file> npm run test -- --run`
- `npm run lint`
- `npm run build`
- `make check-structural check-structural-test check-arch`
- `git diff --check`