### PR TITLE
Enforce tenant-qualified application workspace grants

### DIFF
--- a/docs/reference/auth-tenancy.md
+++ b/docs/reference/auth-tenancy.md
@@ -102,6 +102,12 @@ Shape:
     "principal": "<principal>",
     "tenant_id": "<tenant-id>",
     "allowed_tenants": ["<tenant-id>"],
+    "application_workspace_grants": [
+      {
+        "tenant_id": "<tenant-id>",
+        "application_workspace_ids": ["<application-workspace-id>"]
+      }
+    ],
     "scopes": ["<scope>"],
     "roles": ["<role>"]
   }
@@ -153,6 +159,30 @@ Use `CEREBRO_ALLOWED_TENANTS` to restrict unscoped credentials:
 ```bash
 CEREBRO_ALLOWED_TENANTS=<tenant-id>,<another-tenant-id>
 ```
+
+## Application workspace selection
+
+GRC requests can select one Cerebro application workspace with either form:
+
+```text
+?tenant_id=<tenant-id>&workspace_id=<application-workspace-id>
+```
+
+```http
+X-Cerebro-Tenant: <tenant-id>
+X-Cerebro-Workspace: <application-workspace-id>
+```
+
+If both workspace selectors are present, they must match exactly. A workspace
+selector always requires an explicit tenant selector; Cerebro does not infer the
+tenant from the credential for this request. Workspace grants are tenant-qualified,
+so the same workspace identifier in another tenant does not confer access.
+
+When `application_workspace_grants` is omitted from a structured credential or
+capability token, existing tenant-wide behavior is preserved. Once grants are
+configured, the selected `(tenant_id, workspace_id)` pair must appear in the
+principal's grants. Provider record attributes never grant application-workspace
+access.
 
 ## Scopes
 

--- a/docs/reference/config-env-vars.md
+++ b/docs/reference/config-env-vars.md
@@ -8,7 +8,7 @@ Current bootstrap configuration is loaded by `internal/config`.
 | `CEREBRO_SHUTDOWN_TIMEOUT` | `10s` | Graceful shutdown timeout. |
 | `CEREBRO_API_AUTH_ENABLED` | `true` outside acknowledged dev mode | Require bearer/API-key authentication for non-public routes. |
 | `CEREBRO_API_KEYS` | unset | Comma-separated `key[:principal[:tenant_id]]` entries. Required when auth is enabled. |
-| `CEREBRO_API_CREDENTIALS_JSON` | unset | JSON array of structured API credentials with explicit `key` or `key_sha256`, principal metadata, `tenant_id` or `allowed_tenants`, and optional `scopes` and `roles`. Store as a secret. |
+| `CEREBRO_API_CREDENTIALS_JSON` | unset | JSON array of structured API credentials with explicit `key` or `key_sha256`, principal metadata, `tenant_id` or `allowed_tenants`, optional tenant-qualified `application_workspace_grants`, and optional `scopes` and `roles`. Store as a secret. |
 | `CEREBRO_ALLOWED_TENANTS` | unset | Optional comma-separated tenant allowlist for unscoped API keys. |
 | `CEREBRO_PUBLIC_ORIGIN` | request host | Canonical external origin, for example `https://cerebro.example.com`, used for DPoP `htu` and public URL reconstruction. Must not include a path, query, or fragment. |
 | `CEREBRO_TRUSTED_PROXY_CIDRS` | unset | Optional comma-separated CIDRs whose forwarded headers are trusted. Set this explicitly in production to the load-balancer/proxy network. |

--- a/internal/applicationworkspace/scope.go
+++ b/internal/applicationworkspace/scope.go
@@ -36,6 +36,22 @@ func Select(headerValue, queryValue string) (string, error) {
 	return workspaceID, nil
 }
 
+// SelectValues rejects ambiguous repeated selectors before reconciling header
+// and query values.
+func SelectValues(headerValues, queryValues []string) (string, error) {
+	if len(headerValues) > 1 || len(queryValues) > 1 {
+		return "", ErrInvalidSelector
+	}
+	var headerValue, queryValue string
+	if len(headerValues) == 1 {
+		headerValue = headerValues[0]
+	}
+	if len(queryValues) == 1 {
+		queryValue = queryValues[0]
+	}
+	return Select(headerValue, queryValue)
+}
+
 // ValidID reports whether value is a single bounded opaque workspace ID.
 func ValidID(value string) bool {
 	if value == "" || len(value) > maxSelectorIDBytes || !utf8.ValidString(value) || value == "*" || strings.Contains(value, ",") {

--- a/internal/applicationworkspace/scope.go
+++ b/internal/applicationworkspace/scope.go
@@ -1,0 +1,142 @@
+// Package applicationworkspace owns application-workspace selector validation
+// and tenant-qualified grant evaluation.
+package applicationworkspace
+
+import (
+	"errors"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/writer/cerebro/internal/config"
+)
+
+const (
+	Header             = "X-Cerebro-Workspace"
+	maxSelectorIDBytes = 256
+)
+
+var ErrInvalidSelector = errors.New("invalid application workspace selector")
+
+// Select reconciles the header and query selectors and validates the result.
+func Select(headerValue, queryValue string) (string, error) {
+	headerValue = strings.TrimSpace(headerValue)
+	queryValue = strings.TrimSpace(queryValue)
+	if headerValue != "" && queryValue != "" && headerValue != queryValue {
+		return "", ErrInvalidSelector
+	}
+	workspaceID := queryValue
+	if workspaceID == "" {
+		workspaceID = headerValue
+	}
+	if workspaceID != "" && !ValidID(workspaceID) {
+		return "", ErrInvalidSelector
+	}
+	return workspaceID, nil
+}
+
+// ValidID reports whether value is a single bounded opaque workspace ID.
+func ValidID(value string) bool {
+	if value == "" || len(value) > maxSelectorIDBytes || !utf8.ValidString(value) || value == "*" || strings.Contains(value, ",") {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+// Allowed preserves tenant-wide legacy access when no grants are configured.
+func Allowed(grants []config.ApplicationWorkspaceGrant, tenantID, workspaceID string) bool {
+	if workspaceID == "" || len(grants) == 0 {
+		return true
+	}
+	for _, grant := range grants {
+		if strings.TrimSpace(grant.TenantID) != tenantID {
+			continue
+		}
+		for _, grantedID := range grant.ApplicationWorkspaceIDs {
+			if grantedID == workspaceID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// NormalizeGrants validates, deduplicates, and sorts tenant-qualified grants.
+func NormalizeGrants(grants []config.ApplicationWorkspaceGrant) ([]config.ApplicationWorkspaceGrant, bool) {
+	if len(grants) == 0 {
+		return nil, true
+	}
+	byTenant := make(map[string]map[string]struct{}, len(grants))
+	for _, grant := range grants {
+		tenantID := strings.TrimSpace(grant.TenantID)
+		if tenantID == "" || len(grant.ApplicationWorkspaceIDs) == 0 {
+			return nil, false
+		}
+		workspaceIDs := byTenant[tenantID]
+		if workspaceIDs == nil {
+			workspaceIDs = make(map[string]struct{}, len(grant.ApplicationWorkspaceIDs))
+			byTenant[tenantID] = workspaceIDs
+		}
+		for _, candidate := range grant.ApplicationWorkspaceIDs {
+			workspaceID := strings.TrimSpace(candidate)
+			if !ValidID(workspaceID) {
+				return nil, false
+			}
+			workspaceIDs[workspaceID] = struct{}{}
+		}
+	}
+	tenantIDs := make([]string, 0, len(byTenant))
+	for tenantID := range byTenant {
+		tenantIDs = append(tenantIDs, tenantID)
+	}
+	sort.Strings(tenantIDs)
+	normalized := make([]config.ApplicationWorkspaceGrant, 0, len(tenantIDs))
+	for _, tenantID := range tenantIDs {
+		workspaceIDs := make([]string, 0, len(byTenant[tenantID]))
+		for workspaceID := range byTenant[tenantID] {
+			workspaceIDs = append(workspaceIDs, workspaceID)
+		}
+		sort.Strings(workspaceIDs)
+		normalized = append(normalized, config.ApplicationWorkspaceGrant{
+			TenantID:                tenantID,
+			ApplicationWorkspaceIDs: workspaceIDs,
+		})
+	}
+	return normalized, true
+}
+
+// GrantTenantsAllowed verifies every grant is within the principal tenant set.
+func GrantTenantsAllowed(tenantID string, allowedTenants []string, grants []config.ApplicationWorkspaceGrant) bool {
+	allowed := make(map[string]struct{}, len(allowedTenants))
+	for _, candidate := range allowedTenants {
+		allowed[strings.TrimSpace(candidate)] = struct{}{}
+	}
+	for _, grant := range grants {
+		if tenantID != "" && grant.TenantID == tenantID {
+			continue
+		}
+		if _, ok := allowed[grant.TenantID]; ok {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// CloneGrants returns a deep copy suitable for an authenticated principal.
+func CloneGrants(grants []config.ApplicationWorkspaceGrant) []config.ApplicationWorkspaceGrant {
+	cloned := make([]config.ApplicationWorkspaceGrant, 0, len(grants))
+	for _, grant := range grants {
+		cloned = append(cloned, config.ApplicationWorkspaceGrant{
+			TenantID:                grant.TenantID,
+			ApplicationWorkspaceIDs: append([]string(nil), grant.ApplicationWorkspaceIDs...),
+		})
+	}
+	return cloned
+}

--- a/internal/applicationworkspace/scope_test.go
+++ b/internal/applicationworkspace/scope_test.go
@@ -16,6 +16,23 @@ func TestSelectRequiresHeaderAndQueryAgreement(t *testing.T) {
 	}
 }
 
+func TestSelectValuesRejectsRepeatedSelectors(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		headers []string
+		query   []string
+	}{
+		{name: "headers", headers: []string{"workspace-a", "workspace-b"}},
+		{name: "query", query: []string{"workspace-a", "workspace-b"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := SelectValues(test.headers, test.query); err == nil {
+				t.Fatal("SelectValues() error = nil, want repeated-selector rejection")
+			}
+		})
+	}
+}
+
 func TestNormalizeGrantsDeduplicatesAndSorts(t *testing.T) {
 	got, ok := NormalizeGrants([]config.ApplicationWorkspaceGrant{
 		{TenantID: "writer", ApplicationWorkspaceIDs: []string{"workspace-b", "workspace-a"}},

--- a/internal/applicationworkspace/scope_test.go
+++ b/internal/applicationworkspace/scope_test.go
@@ -1,0 +1,41 @@
+package applicationworkspace
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/writer/cerebro/internal/config"
+)
+
+func TestSelectRequiresHeaderAndQueryAgreement(t *testing.T) {
+	if _, err := Select("workspace-a", "workspace-b"); err == nil {
+		t.Fatal("Select() error = nil, want selector disagreement")
+	}
+	if got, err := Select("workspace-a", "workspace-a"); err != nil || got != "workspace-a" {
+		t.Fatalf("Select() = %q, %v, want workspace-a, nil", got, err)
+	}
+}
+
+func TestNormalizeGrantsDeduplicatesAndSorts(t *testing.T) {
+	got, ok := NormalizeGrants([]config.ApplicationWorkspaceGrant{
+		{TenantID: "writer", ApplicationWorkspaceIDs: []string{"workspace-b", "workspace-a"}},
+		{TenantID: "writer", ApplicationWorkspaceIDs: []string{"workspace-a"}},
+	})
+	want := []config.ApplicationWorkspaceGrant{{TenantID: "writer", ApplicationWorkspaceIDs: []string{"workspace-a", "workspace-b"}}}
+	if !ok || !reflect.DeepEqual(got, want) {
+		t.Fatalf("NormalizeGrants() = %#v, %v, want %#v, true", got, ok, want)
+	}
+}
+
+func TestAllowedRequiresTenantQualifiedGrant(t *testing.T) {
+	grants := []config.ApplicationWorkspaceGrant{{TenantID: "writer", ApplicationWorkspaceIDs: []string{"workspace-a"}}}
+	if !Allowed(grants, "writer", "workspace-a") {
+		t.Fatal("Allowed() = false for granted tenant workspace")
+	}
+	if Allowed(grants, "other", "workspace-a") || Allowed(grants, "writer", "workspace-b") {
+		t.Fatal("Allowed() = true outside tenant-qualified grant")
+	}
+	if !Allowed(nil, "writer", "workspace-a") {
+		t.Fatal("Allowed() = false for legacy tenant-wide access")
+	}
+}

--- a/internal/bootstrap/api_client_credentials_test.go
+++ b/internal/bootstrap/api_client_credentials_test.go
@@ -37,6 +37,13 @@ func TestAPIClientCredentialsIssuesAPIResourceBoundCapabilityToken(t *testing.T)
 	if tokenResp.AccessToken == "" || tokenResp.RefreshToken != "" || tokenResp.TokenType != "Bearer" {
 		t.Fatalf("token response = %#v", tokenResp)
 	}
+	principal, ok := authenticateCapabilityToken(cfg.Auth, tokenResp.AccessToken, time.Now())
+	if !ok {
+		t.Fatal("issued token did not authenticate")
+	}
+	if !applicationWorkspaceAllowed(principal, "writer", "workspace-a") || applicationWorkspaceAllowed(principal, "writer", "workspace-b") {
+		t.Fatalf("issued token application workspace grants = %#v, want writer/workspace-a only", principal.ApplicationWorkspaceGrants)
+	}
 
 	staticSecretReq, err := http.NewRequest(http.MethodGet, server.URL+"/sources?tenant_id=writer", nil)
 	if err != nil {
@@ -236,6 +243,9 @@ func apiClientCredentialsTestConfig() config.Config {
 				Principal: "ci",
 				TenantID:  "writer",
 				Scopes:    []string{scopeCosmoSecurityRead},
+				ApplicationWorkspaceGrants: []config.ApplicationWorkspaceGrant{
+					{TenantID: "writer", ApplicationWorkspaceIDs: []string{"workspace-a"}},
+				},
 			}},
 			RequestOrigin: config.RequestOriginConfig{PublicOrigin: "https://cerebro.example"},
 		},

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -13,8 +13,11 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/proto"
@@ -32,8 +35,10 @@ import (
 )
 
 const (
-	authMessageTenantForbidden = "tenant forbidden"
-	authMessageScopeForbidden  = "scope forbidden"
+	authMessageTenantForbidden           = "tenant forbidden"
+	authMessageScopeForbidden            = "scope forbidden"
+	applicationWorkspaceHeader           = "X-Cerebro-Workspace"
+	maxApplicationWorkspaceSelectorBytes = 256
 )
 
 var errTenantForbidden = errors.New(authMessageTenantForbidden)
@@ -48,19 +53,20 @@ type accessAuditResult struct {
 }
 
 type authPrincipal struct {
-	Name           string
-	TenantID       string
-	CredentialID   string
-	ClientID       string
-	AuthMode       string
-	TokenResource  string
-	AllowedTenants []string
-	Scopes         []string
-	Roles          []string
-	Groups         []string
-	Capability     bool
-	DeviceID       string
-	HardwareUUID   string
+	Name                       string
+	TenantID                   string
+	CredentialID               string
+	ClientID                   string
+	AuthMode                   string
+	TokenResource              string
+	AllowedTenants             []string
+	ApplicationWorkspaceGrants []config.ApplicationWorkspaceGrant
+	Scopes                     []string
+	Roles                      []string
+	Groups                     []string
+	Capability                 bool
+	DeviceID                   string
+	HardwareUUID               string
 	// AssuranceLevel is "hardware" or "software" for device principals.
 	AssuranceLevel string
 	// RiskScore / RiskLevel are populated by the risk pipeline during
@@ -275,8 +281,11 @@ func authenticateRequest(cfg config.AuthConfig, deviceVerifier *deviceauth.JWTVe
 				ClientID:       credential.ClientID,
 				AuthMode:       "api_credential",
 				AllowedTenants: credential.AllowedTenants,
-				Scopes:         credential.Scopes,
-				Roles:          credential.Roles,
+				ApplicationWorkspaceGrants: cloneApplicationWorkspaceGrants(
+					credential.ApplicationWorkspaceGrants,
+				),
+				Scopes: credential.Scopes,
+				Roles:  credential.Roles,
 			}, "", token, true
 		}
 	}
@@ -398,6 +407,10 @@ func authenticateCapabilityToken(cfg config.AuthConfig, token string, now time.T
 	roles := normalizeAuthList(claims.Roles)
 	allowedTenants := normalizeAuthList(claims.AllowedTenants)
 	tenantID := strings.TrimSpace(claims.TenantID)
+	applicationWorkspaceGrants, ok := normalizeApplicationWorkspaceGrants(claims.ApplicationWorkspaceGrants)
+	if !ok || !applicationWorkspaceGrantTenantsAllowed(tenantID, allowedTenants, applicationWorkspaceGrants) {
+		return authPrincipal{}, false
+	}
 	if len(scopes) == 0 && len(roles) == 0 {
 		return authPrincipal{}, false
 	}
@@ -405,34 +418,36 @@ func authenticateCapabilityToken(cfg config.AuthConfig, token string, now time.T
 		return authPrincipal{}, false
 	}
 	return authPrincipal{
-		Name:           strings.TrimSpace(claims.Subject),
-		TenantID:       tenantID,
-		CredentialID:   strings.TrimSpace(claims.CredentialID),
-		ClientID:       strings.TrimSpace(claims.ClientID),
-		AuthMode:       "capability_token",
-		TokenResource:  strings.TrimSpace(claims.Resource),
-		AllowedTenants: allowedTenants,
-		Scopes:         scopes,
-		Roles:          roles,
-		Groups:         normalizeAuthList(claims.Groups),
-		Capability:     true,
+		Name:                       strings.TrimSpace(claims.Subject),
+		TenantID:                   tenantID,
+		CredentialID:               strings.TrimSpace(claims.CredentialID),
+		ClientID:                   strings.TrimSpace(claims.ClientID),
+		AuthMode:                   "capability_token",
+		TokenResource:              strings.TrimSpace(claims.Resource),
+		AllowedTenants:             allowedTenants,
+		ApplicationWorkspaceGrants: applicationWorkspaceGrants,
+		Scopes:                     scopes,
+		Roles:                      roles,
+		Groups:                     normalizeAuthList(claims.Groups),
+		Capability:                 true,
 	}, true
 }
 
 type capabilityClaims struct {
-	Audience       string   `json:"aud"`
-	Subject        string   `json:"sub"`
-	ExpiresAt      int64    `json:"exp"`
-	IssuedAt       int64    `json:"iat,omitempty"`
-	CredentialID   string   `json:"credential_id,omitempty"`
-	ClientID       string   `json:"client_id,omitempty"`
-	Resource       string   `json:"resource,omitempty"`
-	TenantID       string   `json:"tenant_id,omitempty"`
-	AllowedTenants []string `json:"allowed_tenants,omitempty"`
-	Scopes         []string `json:"scopes,omitempty"`
-	Roles          []string `json:"roles,omitempty"`
-	Groups         []string `json:"groups,omitempty"`
-	JWTID          string   `json:"jti,omitempty"`
+	Audience                   string                             `json:"aud"`
+	Subject                    string                             `json:"sub"`
+	ExpiresAt                  int64                              `json:"exp"`
+	IssuedAt                   int64                              `json:"iat,omitempty"`
+	CredentialID               string                             `json:"credential_id,omitempty"`
+	ClientID                   string                             `json:"client_id,omitempty"`
+	Resource                   string                             `json:"resource,omitempty"`
+	TenantID                   string                             `json:"tenant_id,omitempty"`
+	AllowedTenants             []string                           `json:"allowed_tenants,omitempty"`
+	ApplicationWorkspaceGrants []config.ApplicationWorkspaceGrant `json:"application_workspace_grants,omitempty"`
+	Scopes                     []string                           `json:"scopes,omitempty"`
+	Roles                      []string                           `json:"roles,omitempty"`
+	Groups                     []string                           `json:"groups,omitempty"`
+	JWTID                      string                             `json:"jti,omitempty"`
 }
 
 func validCapabilitySignature(signingInput []byte, signature []byte, secrets []string) bool {
@@ -476,6 +491,11 @@ func issueCapabilityToken(cfg config.AuthConfig, claims capabilityClaims, ttl ti
 		}
 		claims.JWTID = jti
 	}
+	applicationWorkspaceGrants, ok := normalizeApplicationWorkspaceGrants(claims.ApplicationWorkspaceGrants)
+	if !ok || !applicationWorkspaceGrantTenantsAllowed(strings.TrimSpace(claims.TenantID), normalizeAuthList(claims.AllowedTenants), applicationWorkspaceGrants) {
+		return "", fmt.Errorf("capability token application workspace grants are invalid")
+	}
+	claims.ApplicationWorkspaceGrants = applicationWorkspaceGrants
 	headerBytes, err := json.Marshal(map[string]string{"alg": "HS256", "typ": "JWT", "kid": "0"})
 	if err != nil {
 		return "", fmt.Errorf("marshal capability token header: %w", err)
@@ -509,6 +529,130 @@ func requestTenantHint(r *http.Request) string {
 		return tenantID
 	}
 	return ""
+}
+
+func requestApplicationWorkspaceSelector(r *http.Request) (string, error) {
+	if r == nil || r.URL == nil {
+		return "", nil
+	}
+	headerValue := strings.TrimSpace(r.Header.Get(applicationWorkspaceHeader))
+	queryValue := strings.TrimSpace(r.URL.Query().Get("workspace_id"))
+	if headerValue != "" && queryValue != "" && headerValue != queryValue {
+		return "", fmt.Errorf("%w: workspace_id and %s disagree", errInvalidHTTPRequest, applicationWorkspaceHeader)
+	}
+	workspaceID := firstNonEmpty(queryValue, headerValue)
+	if workspaceID != "" && !validApplicationWorkspaceSelector(workspaceID) {
+		return "", fmt.Errorf("%w: workspace_id is invalid", errInvalidHTTPRequest)
+	}
+	return workspaceID, nil
+}
+
+func validApplicationWorkspaceSelector(value string) bool {
+	if value == "" || len(value) > maxApplicationWorkspaceSelectorBytes || !utf8.ValidString(value) || value == "*" || strings.Contains(value, ",") {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func authorizeApplicationWorkspaceID(ctx context.Context, tenantID string, applicationWorkspaceID string) error {
+	applicationWorkspaceID = strings.TrimSpace(applicationWorkspaceID)
+	if applicationWorkspaceID == "" {
+		return nil
+	}
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" {
+		return fmt.Errorf("%w: tenant_id is required with workspace_id", errInvalidHTTPRequest)
+	}
+	auth, ok := ctx.Value(authContextKey{}).(authContext)
+	if !ok || applicationWorkspaceAllowed(auth.principal, tenantID, applicationWorkspaceID) {
+		return nil
+	}
+	return errTenantForbidden
+}
+
+func applicationWorkspaceAllowed(principal authPrincipal, tenantID string, applicationWorkspaceID string) bool {
+	if applicationWorkspaceID == "" || len(principal.ApplicationWorkspaceGrants) == 0 {
+		return true
+	}
+	for _, grant := range principal.ApplicationWorkspaceGrants {
+		if strings.TrimSpace(grant.TenantID) != tenantID {
+			continue
+		}
+		if containsAuthValue(grant.ApplicationWorkspaceIDs, applicationWorkspaceID) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeApplicationWorkspaceGrants(grants []config.ApplicationWorkspaceGrant) ([]config.ApplicationWorkspaceGrant, bool) {
+	if len(grants) == 0 {
+		return nil, true
+	}
+	byTenant := make(map[string][]string, len(grants))
+	for _, grant := range grants {
+		tenantID := strings.TrimSpace(grant.TenantID)
+		if tenantID == "" {
+			return nil, false
+		}
+		for _, candidate := range grant.ApplicationWorkspaceIDs {
+			workspaceID := strings.TrimSpace(candidate)
+			if !validApplicationWorkspaceSelector(workspaceID) {
+				return nil, false
+			}
+			byTenant[tenantID] = append(byTenant[tenantID], workspaceID)
+		}
+		if len(grant.ApplicationWorkspaceIDs) == 0 {
+			return nil, false
+		}
+	}
+	tenants := make([]string, 0, len(byTenant))
+	for tenantID := range byTenant {
+		tenants = append(tenants, tenantID)
+	}
+	sort.Strings(tenants)
+	normalized := make([]config.ApplicationWorkspaceGrant, 0, len(tenants))
+	for _, tenantID := range tenants {
+		workspaceIDs := normalizeAuthList(byTenant[tenantID])
+		if len(workspaceIDs) == 0 {
+			return nil, false
+		}
+		sort.Strings(workspaceIDs)
+		normalized = append(normalized, config.ApplicationWorkspaceGrant{
+			TenantID:                tenantID,
+			ApplicationWorkspaceIDs: workspaceIDs,
+		})
+	}
+	return normalized, true
+}
+
+func applicationWorkspaceGrantTenantsAllowed(tenantID string, allowedTenants []string, grants []config.ApplicationWorkspaceGrant) bool {
+	for _, grant := range grants {
+		if tenantID != "" && grant.TenantID == tenantID {
+			continue
+		}
+		if containsAuthValue(allowedTenants, grant.TenantID) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func cloneApplicationWorkspaceGrants(grants []config.ApplicationWorkspaceGrant) []config.ApplicationWorkspaceGrant {
+	cloned := make([]config.ApplicationWorkspaceGrant, 0, len(grants))
+	for _, grant := range grants {
+		cloned = append(cloned, config.ApplicationWorkspaceGrant{
+			TenantID:                grant.TenantID,
+			ApplicationWorkspaceIDs: append([]string(nil), grant.ApplicationWorkspaceIDs...),
+		})
+	}
+	return cloned
 }
 
 func authorizeProtoTenant(ctx context.Context, cfg config.AuthConfig, message any) error {

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -532,7 +532,10 @@ func requestApplicationWorkspaceSelector(r *http.Request) (string, error) {
 	if r == nil || r.URL == nil {
 		return "", nil
 	}
-	workspaceID, err := applicationworkspace.Select(r.Header.Get(applicationworkspace.Header), r.URL.Query().Get("workspace_id"))
+	workspaceID, err := applicationworkspace.SelectValues(
+		r.Header.Values(applicationworkspace.Header),
+		r.URL.Query()["workspace_id"],
+	)
 	if err != nil {
 		return "", fmt.Errorf("%w: workspace_id is invalid", errInvalidHTTPRequest)
 	}

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -13,11 +13,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"sort"
 	"strings"
 	"time"
-	"unicode"
-	"unicode/utf8"
 
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/proto"
@@ -25,6 +22,7 @@ import (
 
 	"github.com/writer/cerebro/gen/cerebro/v1/cerebrov1connect"
 	"github.com/writer/cerebro/internal/agentplatform"
+	"github.com/writer/cerebro/internal/applicationworkspace"
 	"github.com/writer/cerebro/internal/authz"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/deviceauth"
@@ -35,10 +33,9 @@ import (
 )
 
 const (
-	authMessageTenantForbidden           = "tenant forbidden"
-	authMessageScopeForbidden            = "scope forbidden"
-	applicationWorkspaceHeader           = "X-Cerebro-Workspace"
-	maxApplicationWorkspaceSelectorBytes = 256
+	authMessageTenantForbidden = "tenant forbidden"
+	authMessageScopeForbidden  = "scope forbidden"
+	applicationWorkspaceHeader = applicationworkspace.Header
 )
 
 var errTenantForbidden = errors.New(authMessageTenantForbidden)
@@ -281,7 +278,7 @@ func authenticateRequest(cfg config.AuthConfig, deviceVerifier *deviceauth.JWTVe
 				ClientID:       credential.ClientID,
 				AuthMode:       "api_credential",
 				AllowedTenants: credential.AllowedTenants,
-				ApplicationWorkspaceGrants: cloneApplicationWorkspaceGrants(
+				ApplicationWorkspaceGrants: applicationworkspace.CloneGrants(
 					credential.ApplicationWorkspaceGrants,
 				),
 				Scopes: credential.Scopes,
@@ -407,8 +404,8 @@ func authenticateCapabilityToken(cfg config.AuthConfig, token string, now time.T
 	roles := normalizeAuthList(claims.Roles)
 	allowedTenants := normalizeAuthList(claims.AllowedTenants)
 	tenantID := strings.TrimSpace(claims.TenantID)
-	applicationWorkspaceGrants, ok := normalizeApplicationWorkspaceGrants(claims.ApplicationWorkspaceGrants)
-	if !ok || !applicationWorkspaceGrantTenantsAllowed(tenantID, allowedTenants, applicationWorkspaceGrants) {
+	applicationWorkspaceGrants, ok := applicationworkspace.NormalizeGrants(claims.ApplicationWorkspaceGrants)
+	if !ok || !applicationworkspace.GrantTenantsAllowed(tenantID, allowedTenants, applicationWorkspaceGrants) {
 		return authPrincipal{}, false
 	}
 	if len(scopes) == 0 && len(roles) == 0 {
@@ -491,8 +488,8 @@ func issueCapabilityToken(cfg config.AuthConfig, claims capabilityClaims, ttl ti
 		}
 		claims.JWTID = jti
 	}
-	applicationWorkspaceGrants, ok := normalizeApplicationWorkspaceGrants(claims.ApplicationWorkspaceGrants)
-	if !ok || !applicationWorkspaceGrantTenantsAllowed(strings.TrimSpace(claims.TenantID), normalizeAuthList(claims.AllowedTenants), applicationWorkspaceGrants) {
+	applicationWorkspaceGrants, ok := applicationworkspace.NormalizeGrants(claims.ApplicationWorkspaceGrants)
+	if !ok || !applicationworkspace.GrantTenantsAllowed(strings.TrimSpace(claims.TenantID), normalizeAuthList(claims.AllowedTenants), applicationWorkspaceGrants) {
 		return "", fmt.Errorf("capability token application workspace grants are invalid")
 	}
 	claims.ApplicationWorkspaceGrants = applicationWorkspaceGrants
@@ -535,28 +532,11 @@ func requestApplicationWorkspaceSelector(r *http.Request) (string, error) {
 	if r == nil || r.URL == nil {
 		return "", nil
 	}
-	headerValue := strings.TrimSpace(r.Header.Get(applicationWorkspaceHeader))
-	queryValue := strings.TrimSpace(r.URL.Query().Get("workspace_id"))
-	if headerValue != "" && queryValue != "" && headerValue != queryValue {
-		return "", fmt.Errorf("%w: workspace_id and %s disagree", errInvalidHTTPRequest, applicationWorkspaceHeader)
-	}
-	workspaceID := firstNonEmpty(queryValue, headerValue)
-	if workspaceID != "" && !validApplicationWorkspaceSelector(workspaceID) {
+	workspaceID, err := applicationworkspace.Select(r.Header.Get(applicationworkspace.Header), r.URL.Query().Get("workspace_id"))
+	if err != nil {
 		return "", fmt.Errorf("%w: workspace_id is invalid", errInvalidHTTPRequest)
 	}
 	return workspaceID, nil
-}
-
-func validApplicationWorkspaceSelector(value string) bool {
-	if value == "" || len(value) > maxApplicationWorkspaceSelectorBytes || !utf8.ValidString(value) || value == "*" || strings.Contains(value, ",") {
-		return false
-	}
-	for _, character := range value {
-		if unicode.IsControl(character) {
-			return false
-		}
-	}
-	return true
 }
 
 func authorizeApplicationWorkspaceID(ctx context.Context, tenantID string, applicationWorkspaceID string) error {
@@ -569,90 +549,15 @@ func authorizeApplicationWorkspaceID(ctx context.Context, tenantID string, appli
 		return fmt.Errorf("%w: tenant_id is required with workspace_id", errInvalidHTTPRequest)
 	}
 	auth, ok := ctx.Value(authContextKey{}).(authContext)
-	if !ok || applicationWorkspaceAllowed(auth.principal, tenantID, applicationWorkspaceID) {
+	if !ok || applicationworkspace.Allowed(auth.principal.ApplicationWorkspaceGrants, tenantID, applicationWorkspaceID) {
 		return nil
 	}
 	return errTenantForbidden
 }
 
-func applicationWorkspaceAllowed(principal authPrincipal, tenantID string, applicationWorkspaceID string) bool {
-	if applicationWorkspaceID == "" || len(principal.ApplicationWorkspaceGrants) == 0 {
-		return true
-	}
-	for _, grant := range principal.ApplicationWorkspaceGrants {
-		if strings.TrimSpace(grant.TenantID) != tenantID {
-			continue
-		}
-		if containsAuthValue(grant.ApplicationWorkspaceIDs, applicationWorkspaceID) {
-			return true
-		}
-	}
-	return false
-}
-
-func normalizeApplicationWorkspaceGrants(grants []config.ApplicationWorkspaceGrant) ([]config.ApplicationWorkspaceGrant, bool) {
-	if len(grants) == 0 {
-		return nil, true
-	}
-	byTenant := make(map[string][]string, len(grants))
-	for _, grant := range grants {
-		tenantID := strings.TrimSpace(grant.TenantID)
-		if tenantID == "" {
-			return nil, false
-		}
-		for _, candidate := range grant.ApplicationWorkspaceIDs {
-			workspaceID := strings.TrimSpace(candidate)
-			if !validApplicationWorkspaceSelector(workspaceID) {
-				return nil, false
-			}
-			byTenant[tenantID] = append(byTenant[tenantID], workspaceID)
-		}
-		if len(grant.ApplicationWorkspaceIDs) == 0 {
-			return nil, false
-		}
-	}
-	tenants := make([]string, 0, len(byTenant))
-	for tenantID := range byTenant {
-		tenants = append(tenants, tenantID)
-	}
-	sort.Strings(tenants)
-	normalized := make([]config.ApplicationWorkspaceGrant, 0, len(tenants))
-	for _, tenantID := range tenants {
-		workspaceIDs := normalizeAuthList(byTenant[tenantID])
-		if len(workspaceIDs) == 0 {
-			return nil, false
-		}
-		sort.Strings(workspaceIDs)
-		normalized = append(normalized, config.ApplicationWorkspaceGrant{
-			TenantID:                tenantID,
-			ApplicationWorkspaceIDs: workspaceIDs,
-		})
-	}
-	return normalized, true
-}
-
-func applicationWorkspaceGrantTenantsAllowed(tenantID string, allowedTenants []string, grants []config.ApplicationWorkspaceGrant) bool {
-	for _, grant := range grants {
-		if tenantID != "" && grant.TenantID == tenantID {
-			continue
-		}
-		if containsAuthValue(allowedTenants, grant.TenantID) {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
-func cloneApplicationWorkspaceGrants(grants []config.ApplicationWorkspaceGrant) []config.ApplicationWorkspaceGrant {
-	cloned := make([]config.ApplicationWorkspaceGrant, 0, len(grants))
-	for _, grant := range grants {
-		cloned = append(cloned, config.ApplicationWorkspaceGrant{
-			TenantID:                grant.TenantID,
-			ApplicationWorkspaceIDs: append([]string(nil), grant.ApplicationWorkspaceIDs...),
-		})
-	}
-	return cloned
+// applicationWorkspaceAllowed is retained as a narrow bootstrap test seam.
+func applicationWorkspaceAllowed(principal authPrincipal, tenantID, applicationWorkspaceID string) bool {
+	return applicationworkspace.Allowed(principal.ApplicationWorkspaceGrants, tenantID, applicationWorkspaceID)
 }
 
 func authorizeProtoTenant(ctx context.Context, cfg config.AuthConfig, message any) error {

--- a/internal/bootstrap/auth_api_client_credentials.go
+++ b/internal/bootstrap/auth_api_client_credentials.go
@@ -60,17 +60,18 @@ func (app *App) exchangeAPIClientCredentialsToken(_ context.Context, r *http.Req
 		ttl = app.cfg.Auth.MCPOAuth.AccessTTL
 	}
 	access, err := issueCapabilityToken(app.cfg.Auth, capabilityClaims{
-		Audience:       app.cfg.Auth.CapabilityTokenAudience,
-		Subject:        "service:" + clientID,
-		IssuedAt:       now.Unix(),
-		CredentialID:   apiCredentialIdentifier(credential),
-		ClientID:       clientID,
-		Resource:       resource,
-		TenantID:       credential.TenantID,
-		AllowedTenants: cloneAuthValues(credential.AllowedTenants),
-		Scopes:         scopes,
-		Roles:          roles,
-		Groups:         []string{"security"},
+		Audience:                   app.cfg.Auth.CapabilityTokenAudience,
+		Subject:                    "service:" + clientID,
+		IssuedAt:                   now.Unix(),
+		CredentialID:               apiCredentialIdentifier(credential),
+		ClientID:                   clientID,
+		Resource:                   resource,
+		TenantID:                   credential.TenantID,
+		AllowedTenants:             cloneAuthValues(credential.AllowedTenants),
+		ApplicationWorkspaceGrants: cloneApplicationWorkspaceGrants(credential.ApplicationWorkspaceGrants),
+		Scopes:                     scopes,
+		Roles:                      roles,
+		Groups:                     []string{"security"},
 	}, ttl, now)
 	if err != nil {
 		return mcpoauth.TokenResponse{}, err

--- a/internal/bootstrap/auth_api_client_credentials.go
+++ b/internal/bootstrap/auth_api_client_credentials.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/writer/cerebro/internal/applicationworkspace"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/mcpoauth"
 )
@@ -68,7 +69,7 @@ func (app *App) exchangeAPIClientCredentialsToken(_ context.Context, r *http.Req
 		Resource:                   resource,
 		TenantID:                   credential.TenantID,
 		AllowedTenants:             cloneAuthValues(credential.AllowedTenants),
-		ApplicationWorkspaceGrants: cloneApplicationWorkspaceGrants(credential.ApplicationWorkspaceGrants),
+		ApplicationWorkspaceGrants: applicationworkspace.CloneGrants(credential.ApplicationWorkspaceGrants),
 		Scopes:                     scopes,
 		Roles:                      roles,
 		Groups:                     []string{"security"},

--- a/internal/bootstrap/auth_test.go
+++ b/internal/bootstrap/auth_test.go
@@ -97,3 +97,73 @@ func TestCapabilityTokenCanAuthorizeWithRoleOnlyGrant(t *testing.T) {
 		t.Fatalf("role-only capability token rejected for read route: %v", err)
 	}
 }
+
+func TestApplicationWorkspaceAuthorizationIsTenantQualifiedAndBackwardCompatible(t *testing.T) {
+	legacy := authPrincipal{TenantID: "tenant-a"}
+	if !applicationWorkspaceAllowed(legacy, "tenant-a", "workspace-any") {
+		t.Fatal("principal with omitted application workspace grants lost legacy access")
+	}
+
+	restricted := authPrincipal{
+		AllowedTenants: []string{"tenant-a", "tenant-b"},
+		ApplicationWorkspaceGrants: []config.ApplicationWorkspaceGrant{
+			{TenantID: "tenant-a", ApplicationWorkspaceIDs: []string{"workspace-shared"}},
+			{TenantID: "tenant-b", ApplicationWorkspaceIDs: []string{"workspace-b"}},
+		},
+	}
+	if !applicationWorkspaceAllowed(restricted, "tenant-a", "workspace-shared") {
+		t.Fatal("tenant-a workspace grant was rejected")
+	}
+	if applicationWorkspaceAllowed(restricted, "tenant-b", "workspace-shared") {
+		t.Fatal("workspace authority crossed tenants")
+	}
+	if applicationWorkspaceAllowed(restricted, "tenant-a", "workspace-other") {
+		t.Fatal("ungranted application workspace was authorized")
+	}
+}
+
+func TestCapabilityTokenPreservesApplicationWorkspaceGrants(t *testing.T) {
+	cfg := config.AuthConfig{
+		CapabilityTokenSecrets:  []string{"capability-secret"},
+		CapabilityTokenAudience: "cerebro-api",
+	}
+	token, err := issueCapabilityToken(cfg, capabilityClaims{
+		Audience: cfg.CapabilityTokenAudience,
+		Subject:  "service:workspace-reader",
+		TenantID: "tenant-a",
+		Scopes:   []string{scopeCosmoSecurityRead},
+		ApplicationWorkspaceGrants: []config.ApplicationWorkspaceGrant{
+			{TenantID: "tenant-a", ApplicationWorkspaceIDs: []string{"workspace-b", "workspace-a", "workspace-a"}},
+		},
+	}, time.Minute, time.Now())
+	if err != nil {
+		t.Fatalf("issueCapabilityToken() error = %v", err)
+	}
+	principal, ok := authenticateCapabilityToken(cfg, token, time.Now())
+	if !ok {
+		t.Fatal("authenticateCapabilityToken() rejected application workspace grant")
+	}
+	grants := principal.ApplicationWorkspaceGrants
+	if len(grants) != 1 || grants[0].TenantID != "tenant-a" || len(grants[0].ApplicationWorkspaceIDs) != 2 || grants[0].ApplicationWorkspaceIDs[0] != "workspace-a" || grants[0].ApplicationWorkspaceIDs[1] != "workspace-b" {
+		t.Fatalf("application workspace grants = %#v, want normalized tenant-a grant", grants)
+	}
+}
+
+func TestCapabilityTokenRejectsApplicationWorkspaceGrantOutsideTenantAuthority(t *testing.T) {
+	cfg := config.AuthConfig{
+		CapabilityTokenSecrets:  []string{"capability-secret"},
+		CapabilityTokenAudience: "cerebro-api",
+	}
+	_, err := issueCapabilityToken(cfg, capabilityClaims{
+		Audience: cfg.CapabilityTokenAudience,
+		Subject:  "service:workspace-reader",
+		TenantID: "tenant-a",
+		Scopes:   []string{scopeCosmoSecurityRead},
+		ApplicationWorkspaceGrants: []config.ApplicationWorkspaceGrant{
+			{TenantID: "tenant-b", ApplicationWorkspaceIDs: []string{"workspace-b"}},
+		},
+	}, time.Minute, time.Now())
+	if err == nil {
+		t.Fatal("issueCapabilityToken() error = nil, want cross-tenant workspace grant rejection")
+	}
+}

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -42,12 +42,13 @@ const (
 )
 
 type grcScope struct {
-	TenantID   string
-	RuntimeID  string
-	RuntimeIDs []string
-	SourceID   string
-	VendorURN  string
-	Limit      uint32
+	TenantID               string
+	ApplicationWorkspaceID string
+	RuntimeID              string
+	RuntimeIDs             []string
+	SourceID               string
+	VendorURN              string
+	Limit                  uint32
 }
 
 type grcDashboardResponse struct {
@@ -811,14 +812,21 @@ func grcScopeFromRequest(r *http.Request) (grcScope, error) {
 	if err != nil {
 		return grcScope{}, err
 	}
+	applicationWorkspaceID, err := requestApplicationWorkspaceSelector(r)
+	if err != nil {
+		return grcScope{}, err
+	}
 	tenantID := strings.TrimSpace(r.URL.Query().Get("tenant_id"))
+	if tenantID == "" {
+		tenantID = strings.TrimSpace(r.Header.Get("X-Cerebro-Tenant"))
+	}
+	if applicationWorkspaceID != "" && tenantID == "" {
+		return grcScope{}, fmt.Errorf("%w: tenant_id is required with workspace_id", errInvalidHTTPRequest)
+	}
 	if tenantID == "" {
 		if auth, ok := r.Context().Value(authContextKey{}).(authContext); ok {
 			tenantID = strings.TrimSpace(auth.principal.TenantID)
 		}
-	}
-	if tenantID == "" {
-		tenantID = strings.TrimSpace(r.Header.Get("X-Cerebro-Tenant"))
 	}
 	if tenantID == "" && requiresTenantFilter(r.Context()) {
 		return grcScope{}, errTenantForbidden
@@ -826,12 +834,16 @@ func grcScopeFromRequest(r *http.Request) (grcScope, error) {
 	if err := authorizeTenantID(r.Context(), tenantID); err != nil {
 		return grcScope{}, err
 	}
+	if err := authorizeApplicationWorkspaceID(r.Context(), tenantID, applicationWorkspaceID); err != nil {
+		return grcScope{}, err
+	}
 	return grcScope{
-		TenantID:   tenantID,
-		RuntimeID:  strings.TrimSpace(r.URL.Query().Get("runtime_id")),
-		RuntimeIDs: csvQueryValues(r.URL.Query().Get("runtime_ids")),
-		SourceID:   strings.TrimSpace(r.URL.Query().Get("source_id")),
-		Limit:      limit,
+		TenantID:               tenantID,
+		ApplicationWorkspaceID: applicationWorkspaceID,
+		RuntimeID:              strings.TrimSpace(r.URL.Query().Get("runtime_id")),
+		RuntimeIDs:             csvQueryValues(r.URL.Query().Get("runtime_ids")),
+		SourceID:               strings.TrimSpace(r.URL.Query().Get("source_id")),
+		Limit:                  limit,
 	}, nil
 }
 

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -66,6 +66,85 @@ func TestGRCScopeDoesNotReadQuestionnaireVendorURN(t *testing.T) {
 	}
 }
 
+func TestGRCScopeAuthorizesTenantQualifiedApplicationWorkspace(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/grc/dashboard?tenant_id=tenant-a&workspace_id=workspace-a", nil)
+	req.Header.Set(applicationWorkspaceHeader, "workspace-a")
+	req = req.WithContext(context.WithValue(req.Context(), authContextKey{}, authContext{
+		principal: authPrincipal{
+			AllowedTenants: []string{"tenant-a", "tenant-b"},
+			ApplicationWorkspaceGrants: []config.ApplicationWorkspaceGrant{
+				{TenantID: "tenant-a", ApplicationWorkspaceIDs: []string{"workspace-a"}},
+				{TenantID: "tenant-b", ApplicationWorkspaceIDs: []string{"workspace-b"}},
+			},
+		},
+	}))
+
+	scope, err := grcScopeFromRequest(req)
+	if err != nil {
+		t.Fatalf("grcScopeFromRequest() error = %v", err)
+	}
+	if scope.TenantID != "tenant-a" || scope.ApplicationWorkspaceID != "workspace-a" {
+		t.Fatalf("scope = %#v, want tenant-a/workspace-a", scope)
+	}
+}
+
+func TestGRCScopeRejectsApplicationWorkspaceWithoutExplicitTenant(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/grc/dashboard?workspace_id=workspace-a", nil)
+	req = req.WithContext(context.WithValue(req.Context(), authContextKey{}, authContext{
+		principal: authPrincipal{
+			TenantID: "tenant-a",
+			ApplicationWorkspaceGrants: []config.ApplicationWorkspaceGrant{
+				{TenantID: "tenant-a", ApplicationWorkspaceIDs: []string{"workspace-a"}},
+			},
+		},
+	}))
+
+	_, err := grcScopeFromRequest(req)
+	if !errors.Is(err, errInvalidHTTPRequest) {
+		t.Fatalf("grcScopeFromRequest() error = %v, want invalid request", err)
+	}
+}
+
+func TestGRCScopeRejectsApplicationWorkspaceOutsidePrincipalGrant(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/grc/dashboard?tenant_id=tenant-a&workspace_id=workspace-b", nil)
+	req = req.WithContext(context.WithValue(req.Context(), authContextKey{}, authContext{
+		principal: authPrincipal{
+			TenantID: "tenant-a",
+			ApplicationWorkspaceGrants: []config.ApplicationWorkspaceGrant{
+				{TenantID: "tenant-a", ApplicationWorkspaceIDs: []string{"workspace-a"}},
+			},
+		},
+	}))
+
+	_, err := grcScopeFromRequest(req)
+	if !errors.Is(err, errTenantForbidden) {
+		t.Fatalf("grcScopeFromRequest() error = %v, want tenant forbidden", err)
+	}
+}
+
+func TestGRCScopeRejectsConflictingOrInvalidApplicationWorkspaceSelectors(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		queryValue  string
+		headerValue string
+	}{
+		{name: "query header mismatch", queryValue: "workspace-a", headerValue: "workspace-b"},
+		{name: "wildcard", queryValue: "*"},
+		{name: "ambiguous list", queryValue: "workspace-a,workspace-b"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/grc/dashboard?tenant_id=tenant-a&workspace_id="+url.QueryEscape(test.queryValue), nil)
+			if test.headerValue != "" {
+				req.Header.Set(applicationWorkspaceHeader, test.headerValue)
+			}
+			_, err := grcScopeFromRequest(req)
+			if !errors.Is(err, errInvalidHTTPRequest) {
+				t.Fatalf("grcScopeFromRequest() error = %v, want invalid request", err)
+			}
+		})
+	}
+}
+
 func TestGRCDashboardAggregatesOperatorView(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	store := &stubRuntimeStore{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,12 +13,14 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf8"
 )
 
 const defaultHTTPAddr = ":8080"
 const defaultShutdownTimeout = 10 * time.Second
 const defaultJetStreamSubjectPrefix = "events"
 const defaultSourceEventAdmissionWorkers = 4
+const maxApplicationWorkspaceIDBytes = 256
 
 const (
 	defaultPostgresMaxOpenConns        = 25
@@ -262,19 +264,28 @@ type APIKey struct {
 	TenantID  string
 }
 
+// ApplicationWorkspaceGrant restricts application-workspace selection within
+// one tenant. Workspace identifiers are opaque deployment-owned values; they
+// are never derived from provider records.
+type ApplicationWorkspaceGrant struct {
+	TenantID                string   `json:"tenant_id"`
+	ApplicationWorkspaceIDs []string `json:"application_workspace_ids"`
+}
+
 // APICredential grants scoped bearer access with stable attribution metadata.
 type APICredential struct {
-	ID             string
-	ClientID       string
-	Name           string
-	Kind           string
-	Key            string
-	KeySHA256      string
-	Principal      string
-	TenantID       string
-	AllowedTenants []string
-	Scopes         []string
-	Roles          []string
+	ID                         string
+	ClientID                   string
+	Name                       string
+	Kind                       string
+	Key                        string
+	KeySHA256                  string
+	Principal                  string
+	TenantID                   string
+	AllowedTenants             []string
+	ApplicationWorkspaceGrants []ApplicationWorkspaceGrant
+	Scopes                     []string
+	Roles                      []string
 }
 
 // AuthConfig controls optional API authentication and tenant scoping.
@@ -1370,18 +1381,19 @@ func parseAPICredentials(raw string) ([]APICredential, error) {
 		return nil, nil
 	}
 	type credentialJSON struct {
-		ID             string   `json:"id"`
-		CredentialID   string   `json:"credential_id"`
-		ClientID       string   `json:"client_id"`
-		Name           string   `json:"name"`
-		Kind           string   `json:"kind"`
-		Key            string   `json:"key"`
-		KeySHA256      string   `json:"key_sha256"`
-		Principal      string   `json:"principal"`
-		TenantID       string   `json:"tenant_id"`
-		AllowedTenants []string `json:"allowed_tenants"`
-		Scopes         []string `json:"scopes"`
-		Roles          []string `json:"roles"`
+		ID                         string                      `json:"id"`
+		CredentialID               string                      `json:"credential_id"`
+		ClientID                   string                      `json:"client_id"`
+		Name                       string                      `json:"name"`
+		Kind                       string                      `json:"kind"`
+		Key                        string                      `json:"key"`
+		KeySHA256                  string                      `json:"key_sha256"`
+		Principal                  string                      `json:"principal"`
+		TenantID                   string                      `json:"tenant_id"`
+		AllowedTenants             []string                    `json:"allowed_tenants"`
+		ApplicationWorkspaceGrants []ApplicationWorkspaceGrant `json:"application_workspace_grants"`
+		Scopes                     []string                    `json:"scopes"`
+		Roles                      []string                    `json:"roles"`
 	}
 	var entries []credentialJSON
 	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
@@ -1389,24 +1401,32 @@ func parseAPICredentials(raw string) ([]APICredential, error) {
 	}
 	credentials := make([]APICredential, 0, len(entries))
 	for index, entry := range entries {
+		applicationWorkspaceGrants, err := normalizeApplicationWorkspaceGrants(entry.ApplicationWorkspaceGrants)
+		if err != nil {
+			return nil, fmt.Errorf("CEREBRO_API_CREDENTIALS_JSON[%d].application_workspace_grants: %w", index, err)
+		}
 		credential := APICredential{
-			ID:             strings.TrimSpace(firstNonEmpty(entry.CredentialID, entry.ID)),
-			ClientID:       strings.TrimSpace(entry.ClientID),
-			Name:           strings.TrimSpace(entry.Name),
-			Kind:           strings.TrimSpace(entry.Kind),
-			Key:            strings.TrimSpace(entry.Key),
-			KeySHA256:      strings.ToLower(strings.TrimSpace(entry.KeySHA256)),
-			Principal:      strings.TrimSpace(entry.Principal),
-			TenantID:       strings.TrimSpace(entry.TenantID),
-			AllowedTenants: normalizeStringSlice(entry.AllowedTenants),
-			Scopes:         normalizeStringSlice(entry.Scopes),
-			Roles:          normalizeStringSlice(entry.Roles),
+			ID:                         strings.TrimSpace(firstNonEmpty(entry.CredentialID, entry.ID)),
+			ClientID:                   strings.TrimSpace(entry.ClientID),
+			Name:                       strings.TrimSpace(entry.Name),
+			Kind:                       strings.TrimSpace(entry.Kind),
+			Key:                        strings.TrimSpace(entry.Key),
+			KeySHA256:                  strings.ToLower(strings.TrimSpace(entry.KeySHA256)),
+			Principal:                  strings.TrimSpace(entry.Principal),
+			TenantID:                   strings.TrimSpace(entry.TenantID),
+			AllowedTenants:             normalizeStringSlice(entry.AllowedTenants),
+			ApplicationWorkspaceGrants: applicationWorkspaceGrants,
+			Scopes:                     normalizeStringSlice(entry.Scopes),
+			Roles:                      normalizeStringSlice(entry.Roles),
 		}
 		if credential.Key == "" && credential.KeySHA256 == "" {
 			return nil, fmt.Errorf("CEREBRO_API_CREDENTIALS_JSON[%d] must set key or key_sha256", index)
 		}
 		if (len(credential.Scopes) > 0 || len(credential.Roles) > 0) && credential.TenantID == "" && len(credential.AllowedTenants) == 0 {
 			return nil, fmt.Errorf("CEREBRO_API_CREDENTIALS_JSON[%d] scoped credentials must set tenant_id or allowed_tenants", index)
+		}
+		if err := validateApplicationWorkspaceGrantTenants(credential); err != nil {
+			return nil, fmt.Errorf("CEREBRO_API_CREDENTIALS_JSON[%d]: %w", index, err)
 		}
 		if err := validateKnownRBACRoles(fmt.Sprintf("CEREBRO_API_CREDENTIALS_JSON[%d].roles", index), credential.Roles); err != nil {
 			return nil, err
@@ -1417,6 +1437,90 @@ func parseAPICredentials(raw string) ([]APICredential, error) {
 		credentials = append(credentials, credential)
 	}
 	return credentials, nil
+}
+
+func normalizeApplicationWorkspaceGrants(grants []ApplicationWorkspaceGrant) ([]ApplicationWorkspaceGrant, error) {
+	if len(grants) == 0 {
+		return nil, nil
+	}
+	byTenant := make(map[string][]string, len(grants))
+	for index, grant := range grants {
+		tenantID := strings.TrimSpace(grant.TenantID)
+		workspaceIDs, err := normalizeApplicationWorkspaceIDs(grant.ApplicationWorkspaceIDs)
+		if err != nil {
+			return nil, fmt.Errorf("entry %d: %w", index, err)
+		}
+		if tenantID == "" {
+			return nil, fmt.Errorf("entry %d requires tenant_id", index)
+		}
+		if len(workspaceIDs) == 0 {
+			return nil, fmt.Errorf("entry %d requires application_workspace_ids", index)
+		}
+		byTenant[tenantID] = append(byTenant[tenantID], workspaceIDs...)
+	}
+	tenants := make([]string, 0, len(byTenant))
+	for tenantID := range byTenant {
+		tenants = append(tenants, tenantID)
+	}
+	sort.Strings(tenants)
+	normalized := make([]ApplicationWorkspaceGrant, 0, len(tenants))
+	for _, tenantID := range tenants {
+		workspaceIDs, err := normalizeApplicationWorkspaceIDs(byTenant[tenantID])
+		if err != nil {
+			return nil, err
+		}
+		normalized = append(normalized, ApplicationWorkspaceGrant{
+			TenantID:                tenantID,
+			ApplicationWorkspaceIDs: workspaceIDs,
+		})
+	}
+	return normalized, nil
+}
+
+func normalizeApplicationWorkspaceIDs(values []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(values))
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		workspaceID := strings.TrimSpace(value)
+		if workspaceID == "" {
+			continue
+		}
+		if !validApplicationWorkspaceID(workspaceID) {
+			return nil, fmt.Errorf("application workspace id %q is invalid", workspaceID)
+		}
+		if _, exists := seen[workspaceID]; exists {
+			continue
+		}
+		seen[workspaceID] = struct{}{}
+		normalized = append(normalized, workspaceID)
+	}
+	sort.Strings(normalized)
+	return normalized, nil
+}
+
+func validApplicationWorkspaceID(value string) bool {
+	if value == "" || len(value) > maxApplicationWorkspaceIDBytes || !utf8.ValidString(value) || value == "*" || strings.Contains(value, ",") {
+		return false
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func validateApplicationWorkspaceGrantTenants(credential APICredential) error {
+	for _, grant := range credential.ApplicationWorkspaceGrants {
+		allowed := credential.TenantID != "" && grant.TenantID == credential.TenantID
+		if !allowed {
+			allowed = containsString(credential.AllowedTenants, grant.TenantID)
+		}
+		if !allowed {
+			return fmt.Errorf("application workspace grant tenant %q is not allowed by the credential", grant.TenantID)
+		}
+	}
+	return nil
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -1045,6 +1046,10 @@ func TestLoadParsesStructuredAPICredentials(t *testing.T) {
 			"key_sha256": "`+hex.EncodeToString(sum[:])+`",
 			"principal": "cosmo-security",
 			"allowed_tenants": ["writer", "writer"],
+			"application_workspace_grants": [
+				{"tenant_id":"writer","application_workspace_ids":["workspace-b","workspace-a","workspace-a"]},
+				{"tenant_id":"writer","application_workspace_ids":["workspace-c"]}
+			],
 			"scopes": ["cerebro.cosmo.security.read", "cerebro.cosmo.security.read"],
 			"roles": ["cerebro.viewer", "cerebro.viewer"]
 		}
@@ -1064,11 +1069,50 @@ func TestLoadParsesStructuredAPICredentials(t *testing.T) {
 	if got := credential.AllowedTenants; len(got) != 1 || got[0] != "writer" {
 		t.Fatalf("AllowedTenants = %#v, want [writer]", got)
 	}
+	if got := credential.ApplicationWorkspaceGrants; len(got) != 1 || got[0].TenantID != "writer" || strings.Join(got[0].ApplicationWorkspaceIDs, ",") != "workspace-a,workspace-b,workspace-c" {
+		t.Fatalf("ApplicationWorkspaceGrants = %#v, want one normalized writer grant", got)
+	}
 	if got := credential.Scopes; len(got) != 1 || got[0] != "cerebro.cosmo.security.read" {
 		t.Fatalf("Scopes = %#v, want [cerebro.cosmo.security.read]", got)
 	}
 	if got := credential.Roles; len(got) != 1 || got[0] != "cerebro.viewer" {
 		t.Fatalf("Roles = %#v, want [cerebro.viewer]", got)
+	}
+}
+
+func TestLoadStructuredAPICredentialsKeepOmittedApplicationWorkspaceGrantsBackwardCompatible(t *testing.T) {
+	clearDependencyEnv(t)
+	t.Setenv("CEREBRO_API_AUTH_ENABLED", "true")
+	t.Setenv("CEREBRO_API_CREDENTIALS_JSON", `[{"key":"test-key","tenant_id":"writer","scopes":["cerebro.cosmo.security.read"]}]`)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got := cfg.Auth.APICredentials[0].ApplicationWorkspaceGrants; got != nil {
+		t.Fatalf("ApplicationWorkspaceGrants = %#v, want nil for omitted grant", got)
+	}
+}
+
+func TestLoadRejectsInvalidApplicationWorkspaceGrants(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		grants string
+	}{
+		{name: "missing tenant", grants: `[{"application_workspace_ids":["workspace-a"]}]`},
+		{name: "missing workspaces", grants: `[{"tenant_id":"writer","application_workspace_ids":[]}]`},
+		{name: "foreign tenant", grants: `[{"tenant_id":"other","application_workspace_ids":["workspace-a"]}]`},
+		{name: "wildcard workspace", grants: `[{"tenant_id":"writer","application_workspace_ids":["*"]}]`},
+		{name: "ambiguous workspace list", grants: `[{"tenant_id":"writer","application_workspace_ids":["workspace-a,workspace-b"]}]`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			clearDependencyEnv(t)
+			t.Setenv("CEREBRO_API_AUTH_ENABLED", "true")
+			t.Setenv("CEREBRO_API_CREDENTIALS_JSON", `[{"key":"test-key","tenant_id":"writer","application_workspace_grants":`+test.grants+`}]`)
+			if _, err := Load(); err == nil {
+				t.Fatal("Load() error = nil, want invalid application workspace grant")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- add optional tenant-qualified application workspace grants to structured API credentials and capability tokens
- validate `workspace_id` and `X-Cerebro-Workspace` agreement for GRC scope and require an explicit tenant selector
- preserve tenant-wide behavior when workspace grants are omitted
- document the credential and request contract

## Validation
- `CEREBRO_TELEMETRY_STDOUT_ENABLED=false go test ./internal/config ./internal/bootstrap -count=1`
- `go vet ./internal/config ./internal/bootstrap`
- `git diff --check`

## Execution note
DDESK project bootstrap remained blocked by `ATTACHMENT_SLOTS_FULL`; focused validation ran in the disclosed local recovery environment.