### PR TITLE
Scope GRC views to application workspaces

### DIFF
--- a/apps/web/src/app/inventory/[urn]/page.tsx
+++ b/apps/web/src/app/inventory/[urn]/page.tsx
@@ -21,6 +21,7 @@ import {
   shortEntity,
 } from "@/lib/grc";
 import { grcPath, useGRCQuery } from "@/lib/grc-client";
+import { grcScopeQuery } from "@/lib/grc-scope";
 import { controlMatchesFrameworkSegment, frameworkOptionLabel, supportedGRCFrameworkNames } from "@/lib/grc-frameworks";
 import { inventoryAccountability, inventoryReviewDetail, inventoryReviewLabel, inventoryReviewState } from "@/lib/inventory-review";
 import { inventoryAssetSurface } from "@/lib/inventory-surface";
@@ -373,6 +374,10 @@ export default function InventoryAssetPage() {
   const { apiKey } = useApiKey();
   const { actor } = useCurrentUser();
   const urn = useMemo(() => decodeURIComponent(params.urn ?? ""), [params.urn]);
+  const scope = {
+    tenantID: searchParams.get("tenant_id") ?? "",
+    workspaceID: searchParams.get("workspace_id") ?? "",
+  };
   const initialTab = (searchParams.get("tab") as Tab | null) ?? "overview";
   const [tab, setTab] = useState<Tab>(["overview", "vulnerabilities", "tests", "framework", "reports", "timeline"].includes(initialTab) ? initialTab : "overview");
   const [scopeSaving, setScopeSaving] = useState(false);
@@ -383,7 +388,7 @@ export default function InventoryAssetPage() {
   const [triageSavingID, setTriageSavingID] = useState<string | null>(null);
   const [triageError, setTriageError] = useState<string | null>(null);
   const { data, error, loading, reload } = useGRCQuery<GRCInventoryAssetDetail>(
-    urn ? grcPath("/grc/inventory/assets/detail", { urn, limit: 100 }) : null,
+    urn ? grcPath("/grc/inventory/assets/detail", { ...grcScopeQuery(scope), urn, limit: 100 }) : null,
   );
   const asset = data?.asset;
   const externalURL = attr(asset, "html_url", "url", "web_url", "console_url");
@@ -397,6 +402,7 @@ export default function InventoryAssetPage() {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
+        ...grcScopeQuery(scope),
         asset_urn: asset.urn,
         source_id: asset.source_id,
         runtime_id: asset.runtime_id,
@@ -419,6 +425,7 @@ export default function InventoryAssetPage() {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
+        ...grcScopeQuery(scope),
         asset_urn: asset.urn,
         source_id: asset.source_id,
         reason,
@@ -445,6 +452,7 @@ export default function InventoryAssetPage() {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
+        ...grcScopeQuery(scope),
         triage_status: status,
         triage_reason: `Marked ${humanize(status)} from inventory detail`,
         triaged_by: actor || undefined,

--- a/apps/web/src/app/inventory/page.tsx
+++ b/apps/web/src/app/inventory/page.tsx
@@ -20,6 +20,7 @@ import {
   shortEntity,
 } from "@/lib/grc";
 import { grcPath, useDebouncedValue, useGRCQuery } from "@/lib/grc-client";
+import { grcScopeQuery, useDebouncedGRCScope, useGRCScopeQueryState, withGRCScope } from "@/lib/grc-scope";
 import { frameworkOptionLabel, inventoryAssetMatchesFrameworkSegment, supportedGRCFrameworkNames } from "@/lib/grc-frameworks";
 import { GRC_WORKLIST_LIMIT, grcBoundedRows } from "@/lib/grc-list";
 import {
@@ -453,7 +454,7 @@ function AccountabilityModal({
 export default function InventoryPage() {
   const { apiKey } = useApiKey();
   const { actor } = useCurrentUser();
-  const [tenantID, setTenantID] = useQueryParamState("tenant_id");
+  const { tenantID, workspaceID, setTenantID, setWorkspaceID } = useGRCScopeQueryState();
   const [categoryID, setCategoryID] = useQueryParamState("category_id");
   const [query, setQuery] = useQueryParamState("q");
   const [sourceID, setSourceID] = useQueryParamState("source_id");
@@ -476,7 +477,7 @@ export default function InventoryPage() {
   const [accountabilityDefaultState, setAccountabilityDefaultState] = useState<AccountabilityUpdateState>("known");
   const [accountabilitySaving, setAccountabilitySaving] = useState(false);
   const [accountabilityError, setAccountabilityError] = useState<string | null>(null);
-  const debouncedTenantID = useDebouncedValue(tenantID.trim());
+  const debouncedScope = useDebouncedGRCScope({ tenantID, workspaceID });
   const debouncedCategoryID = useDebouncedValue(categoryID.trim());
   const debouncedQuery = useDebouncedValue(query.trim());
   const debouncedSourceID = useDebouncedValue(sourceID.trim());
@@ -489,11 +490,11 @@ export default function InventoryPage() {
   const selectedSurface = inventoryRequestSurface(debouncedSurfaceFilter);
 
   const categoriesQuery = useGRCQuery<GRCInventoryCategoriesResponse>(
-    grcPath("/grc/inventory/categories", { tenant_id: debouncedTenantID, source_id: debouncedSourceID, surface: selectedSurface, limit: GRC_WORKLIST_LIMIT }),
+    grcPath("/grc/inventory/categories", { ...grcScopeQuery(debouncedScope), source_id: debouncedSourceID, surface: selectedSurface, limit: GRC_WORKLIST_LIMIT }),
   );
   const assetsQuery = useGRCQuery<GRCInventoryAssetsResponse>(
     grcPath("/grc/inventory/assets", {
-      tenant_id: debouncedTenantID,
+      ...grcScopeQuery(debouncedScope),
       source_id: debouncedSourceID,
       surface: selectedSurface,
       category_id: debouncedCategoryID,
@@ -505,7 +506,7 @@ export default function InventoryPage() {
     }),
   );
   const scopeQuery = useGRCQuery<GRCResourceScopeResponse>(
-    scopeOpen ? grcPath("/grc/inventory/resource-scope", { tenant_id: debouncedTenantID, source_id: debouncedSourceID || "github", surface: selectedSurface, category_id: debouncedCategoryID, q: debouncedQuery, limit: GRC_WORKLIST_LIMIT }) : null,
+    scopeOpen ? grcPath("/grc/inventory/resource-scope", { ...grcScopeQuery(debouncedScope), source_id: debouncedSourceID || "github", surface: selectedSurface, category_id: debouncedCategoryID, q: debouncedQuery, limit: GRC_WORKLIST_LIMIT }) : null,
   );
 
   const surfaceIsAssets = selectedSurface === "asset";
@@ -585,6 +586,7 @@ export default function InventoryPage() {
     { label: "Source", value: sourceID, onClear: () => setSourceID("") },
     { label: "Scope", value: scopeFilter ? inventoryScopeCopy(scopeFilter) : "", onClear: () => setScopeFilter("") },
     { label: "Tenant", value: tenantID, onClear: () => setTenantID("") },
+    { label: "Workspace", value: workspaceID, onClear: () => setWorkspaceID("") },
   ];
   const activeFilterCount = inventoryNarrowingFilterCount({
     surface: surfaceFilter,
@@ -597,7 +599,7 @@ export default function InventoryPage() {
     accountability: accountabilityFilter,
     source: sourceID,
     scope: scopeFilter,
-  });
+  }) + Number(Boolean(workspaceID.trim()));
   const clearFilters = () => {
     setCategoryID("");
     setQuery("");
@@ -609,6 +611,7 @@ export default function InventoryPage() {
     setSourceID("");
     setScopeFilter("");
     setTenantID("");
+    setWorkspaceID("");
     setSelectedAssetURNs([]);
   };
   const toggleAssetSelection = useCallback((asset: GRCInventoryAsset) => {
@@ -636,7 +639,7 @@ export default function InventoryPage() {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        tenant_id: debouncedTenantID || undefined,
+        ...grcScopeQuery(debouncedScope),
         asset_urn: asset.urn,
         source_id: asset.source_id || debouncedSourceID || undefined,
         runtime_id: asset.runtime_id || undefined,
@@ -654,7 +657,7 @@ export default function InventoryPage() {
       void scopeQuery.reload();
     }
     return true;
-  }, [apiKey, assetsQuery, debouncedSourceID, debouncedTenantID, scopeQuery]);
+  }, [apiKey, assetsQuery, debouncedScope, debouncedSourceID, scopeQuery]);
   const updateScopeForAssets = useCallback(async (targetAssets: GRCInventoryAsset[], state: "in_scope" | "out_of_scope") => {
     if (targetAssets.length === 0) return;
     for (const asset of targetAssets) {
@@ -674,7 +677,7 @@ export default function InventoryPage() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          tenant_id: debouncedTenantID || undefined,
+          ...grcScopeQuery(debouncedScope),
           asset_urn: asset.urn,
           source_id: asset.source_id || debouncedSourceID || undefined,
           runtime_id: asset.runtime_id || undefined,
@@ -694,7 +697,7 @@ export default function InventoryPage() {
     setSelectedAssetURNs([]);
     void assetsQuery.reload();
     void scopeQuery.reload();
-  }, [apiKey, assetsQuery, debouncedSourceID, debouncedTenantID, scopeQuery]);
+  }, [apiKey, assetsQuery, debouncedScope, debouncedSourceID, scopeQuery]);
   const submitAssetReport = useCallback(async (asset: GRCInventoryAsset, reason: string) => {
     setReportSavingURN(asset.urn);
     setReportError(null);
@@ -702,7 +705,7 @@ export default function InventoryPage() {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        tenant_id: debouncedTenantID || undefined,
+        ...grcScopeQuery(debouncedScope),
         asset_urn: asset.urn,
         source_id: asset.source_id || debouncedSourceID || undefined,
         reason,
@@ -721,7 +724,7 @@ export default function InventoryPage() {
     }
     setReportAsset(null);
     void assetsQuery.reload();
-  }, [actor, apiKey, assetsQuery, debouncedSourceID, debouncedTenantID]);
+  }, [actor, apiKey, assetsQuery, debouncedScope, debouncedSourceID]);
   const exportAssets = useCallback(() => {
     const headers = ["Record", "Surface", "Class", "Review state", "Accountability", "Risk score", "Owner", "Scope", "Source", "Account / region", "URN"];
     const rows = assets.map((asset) => [
@@ -868,8 +871,11 @@ export default function InventoryPage() {
                 </select>
               </label>
             </div>
-            <div className={`${filtersOpen ? "block" : "hidden"} mt-3 max-w-xs md:block`}>
-              <label className={labelClass}>Tenant<input value={tenantID} onChange={(event) => { setTenantID(event.target.value); setSelectedAssetURNs([]); }} placeholder="All" className={inputClass} /></label>
+            <div className={`${filtersOpen ? "block" : "hidden"} mt-3 max-w-2xl md:block`}>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <label className={labelClass}>Tenant ID<input value={tenantID} onChange={(event) => { setTenantID(event.target.value); setSelectedAssetURNs([]); }} placeholder="All authorized tenants" className={inputClass} /></label>
+                <label className={labelClass}>Workspace ID<input value={workspaceID} onChange={(event) => { setWorkspaceID(event.target.value); setSelectedAssetURNs([]); }} placeholder="All authorized workspaces" className={inputClass} /></label>
+              </div>
             </div>
             <AppliedFilterChips filters={filterChips} onClearAll={clearFilters} />
             <div className={`${filtersOpen ? "flex" : "hidden"} mt-4 flex-wrap items-center gap-2 border-t border-[color:var(--border)] pt-3 md:flex`}>
@@ -967,7 +973,7 @@ export default function InventoryPage() {
                               <div className="flex items-center gap-3">
                                 <SourceMark asset={asset} />
                                 <div className="min-w-0">
-                                  <Link href={`/inventory/${encodeURIComponent(asset.urn)}`} className="block max-w-[26rem] truncate font-medium text-[var(--text-primary)] hover:text-[var(--primary)]">{asset.label || shortEntity(asset.urn)}</Link>
+                                  <Link href={withGRCScope(`/inventory/${encodeURIComponent(asset.urn)}`, { tenantID, workspaceID })} className="block max-w-[26rem] truncate font-medium text-[var(--text-primary)] hover:text-[var(--primary)]">{asset.label || shortEntity(asset.urn)}</Link>
                                   {secondaryAssetID(asset) && <div className="truncate font-mono text-[11px] text-[var(--text-muted)]">{secondaryAssetID(asset)}</div>}
                                   <div className="mt-1 text-[11px] text-[var(--text-muted)]">{surfaceFilterLabel(inventoryAssetSurface(asset))} / {descriptionLabel(asset)}</div>
                                 </div>

--- a/apps/web/src/app/policies/page.tsx
+++ b/apps/web/src/app/policies/page.tsx
@@ -43,6 +43,7 @@ import type {
 import { displayDate, humanize, shortEntity } from "@/lib/grc";
 import { downloadGRCExport, grcExportFilename, grcPath, useDebouncedValue, useGRCFormMutation, useGRCMutation, useGRCQuery } from "@/lib/grc-client";
 import { useGRCFilterState } from "@/lib/grc-filters";
+import { grcScopeQuery, useDebouncedGRCScope, useGRCScopeQueryState, withGRCScope } from "@/lib/grc-scope";
 import { grcUploadFileError } from "@/lib/grc-upload-limits";
 import { grcUploadHistoryKey, grcUploadHistoryWith, readGRCUploadHistory, writeGRCUploadHistory } from "@/lib/grc-upload-history";
 import { useQueryParamState } from "@/lib/query-params";
@@ -441,7 +442,7 @@ const selectedPolicyFallback = (
 
 export default function PoliciesPage() {
   const { apiKey } = useApiKey();
-  const [tenantID, setTenantID] = useQueryParamState("tenant_id");
+  const { tenantID, workspaceID, setTenantID, setWorkspaceID } = useGRCScopeQueryState();
   const [owner, setOwner] = useQueryParamState("owner");
   const [state, setState] = useQueryParamState("state");
   const [ruleProfile, setRuleProfile] = useQueryParamState("rule_profile");
@@ -449,7 +450,7 @@ export default function PoliciesPage() {
   const [selectedPolicyID, setSelectedPolicyID] = useState<string | null>(null);
   const [policySection, setPolicySection] = useState<PolicySection>("queues");
   const [showUpload, setShowUpload] = useState(false);
-  const [showAdvancedFilters, setShowAdvancedFilters] = useState(Boolean(tenantID || ruleProfile));
+  const [showAdvancedFilters, setShowAdvancedFilters] = useState(Boolean(tenantID || workspaceID || ruleProfile));
   const [selectedAction, setSelectedAction] = useState<GRCPolicyLifecycleAction | null>(null);
   const [actionReason, setActionReason] = useState("");
   const [actionDate, setActionDate] = useState("");
@@ -469,7 +470,7 @@ export default function PoliciesPage() {
   const actionIdempotencyCounterRef = useRef(0);
   const policyUploadFormRef = useRef<HTMLFormElement>(null);
   const policyUploadInputRef = useRef<HTMLInputElement>(null);
-  const debouncedTenantID = useDebouncedValue(tenantID.trim());
+  const debouncedScope = useDebouncedGRCScope({ tenantID, workspaceID });
   const debouncedOwner = useDebouncedValue(owner.trim());
   const debouncedQuery = useDebouncedValue(query.trim());
   const activeRuleProfile = normalized(ruleProfile) === "strict" ? "strict" : "baseline";
@@ -480,7 +481,7 @@ export default function PoliciesPage() {
   const { mutate: replayPolicyUploadEvents, saving: policyReplaySaving, error: policyReplayError, setError: setPolicyReplayError } =
     useGRCMutation<GRCUploadReplayResponse>();
   const { data, error, loading, reload } = useGRCQuery<GRCPolicyLifecycleResponse>(
-    grcPath("/grc/policy-lifecycle", { tenant_id: debouncedTenantID, rule_profile: activeRuleProfile, limit: POLICY_LIFECYCLE_LIMIT }),
+    grcPath("/grc/policy-lifecycle", { ...grcScopeQuery(debouncedScope), rule_profile: activeRuleProfile, limit: POLICY_LIFECYCLE_LIMIT }),
   );
   const isInitialLoading = loading && !data;
   const isRefreshing = loading && Boolean(data);
@@ -558,6 +559,7 @@ export default function PoliciesPage() {
   );
   const filterState = useGRCFilterState([
     { key: "tenant_id", label: "Tenant", value: tenantID, setValue: setTenantID },
+    { key: "workspace_id", label: "Workspace", value: workspaceID, setValue: setWorkspaceID },
     { key: "owner", label: "Owner", value: owner, setValue: setOwner },
     { key: "state", label: "State", value: state, setValue: setState },
     { key: "rule_profile", label: "Rules", value: ruleProfile, setValue: setRuleProfile },
@@ -574,7 +576,7 @@ export default function PoliciesPage() {
     { label: "High risks", value: summary?.high_risks ?? 0, detail: `${summary?.risk_register_items ?? 0} risks tracked` },
     { label: "Active gaps", value: activeGapCount, detail: `${summary?.resolved_governance_gaps ?? 0} resolved` },
   ];
-  const policyUploadStorageKey = useMemo(() => grcUploadHistoryKey("policy", tenantID), [tenantID]);
+  const policyUploadStorageKey = useMemo(() => grcUploadHistoryKey("policy", tenantID, workspaceID), [tenantID, workspaceID]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -596,7 +598,7 @@ export default function PoliciesPage() {
     setPolicyReplayError(null);
     try {
       const response = await replayPolicyUploadEvents(
-        grcPath(`/grc/policy-lifecycle/uploads/${encodeURIComponent(upload.upload_id)}/replay`, { tenant_id: tenantID.trim() }),
+        grcPath(`/grc/policy-lifecycle/uploads/${encodeURIComponent(upload.upload_id)}/replay`, grcScopeQuery({ tenantID, workspaceID })),
         {},
       );
       setPolicyReplayMessage(`${countLabel(response.events_projected ?? 0, "event")} replayed. ${countLabel((response.entities_projected ?? 0) + (response.links_projected ?? 0), "graph update")} projected.`);
@@ -630,7 +632,7 @@ export default function PoliciesPage() {
     const value = actionValue.trim();
     const body: GRCPolicyLifecycleActionRequest = {
       action: selectedAction.action,
-      tenant_id: tenantID.trim() || undefined,
+      ...grcScopeQuery({ tenantID, workspaceID }),
       policy_id: selectedAction.policy_id,
       policy_version_id: selectedAction.policy_version_id,
       gap_id: selectedAction.gap_id,
@@ -657,7 +659,7 @@ export default function PoliciesPage() {
       else if (valueField) body.attributes = { ...(body.attributes ?? {}), [valueField]: value };
     }
     try {
-      const response = await recordAction(grcPath("/grc/policy-lifecycle/actions", { tenant_id: tenantID.trim() }), body);
+      const response = await recordAction(grcPath("/grc/policy-lifecycle/actions", grcScopeQuery({ tenantID, workspaceID })), body);
       setLastActionStatus(`${humanize(response.action)} ${humanize(response.status)}`);
       setSelectedAction(null);
       setActionValue("");
@@ -692,12 +694,13 @@ export default function PoliciesPage() {
     body.set("document_class", "policy");
     body.set("status", "uploaded");
     if (tenantID.trim()) body.set("tenant_id", tenantID.trim());
+    if (workspaceID.trim()) body.set("workspace_id", workspaceID.trim());
     if (policyUploadID.trim()) body.set("policy_id", policyUploadID.trim());
     if (policyUploadOwner.trim()) body.set("owner_id", policyUploadOwner.trim());
     if (policyUploadReviewDue.trim()) body.set("next_review_due_at", policyUploadReviewDue.trim());
     try {
       const response = await uploadPolicyDocument(
-        grcPath("/grc/policy-lifecycle/uploads", { tenant_id: tenantID.trim() }),
+        grcPath("/grc/policy-lifecycle/uploads", grcScopeQuery({ tenantID, workspaceID })),
         body,
       );
       setLastPolicyUpload(response);
@@ -721,7 +724,7 @@ export default function PoliciesPage() {
     setExportError(null);
     try {
       const result = await downloadGRCExport(
-        grcPath("/grc/policy-lifecycle/export", { tenant_id: debouncedTenantID, rule_profile: activeRuleProfile }),
+        grcPath("/grc/policy-lifecycle/export", { ...grcScopeQuery(debouncedScope), rule_profile: activeRuleProfile }),
         apiKey,
         grcExportFilename("policy-lifecycle"),
       );
@@ -1023,8 +1026,9 @@ export default function PoliciesPage() {
           </button>
         </div>
         {showAdvancedFilters && (
-          <div id="policy-advanced-filters" className="mt-4 grid gap-3 border-t border-slate-200 pt-4 sm:grid-cols-2 lg:max-w-2xl">
-            <label className={labelClass}>Tenant<input value={tenantID} onChange={(event) => setTenantID(event.target.value)} placeholder="All tenants" className={inputClass} /></label>
+          <div id="policy-advanced-filters" className="mt-4 grid gap-3 border-t border-slate-200 pt-4 sm:grid-cols-3 lg:max-w-4xl">
+            <label className={labelClass}>Tenant ID<input value={tenantID} onChange={(event) => setTenantID(event.target.value)} placeholder="All authorized tenants" className={inputClass} /></label>
+            <label className={labelClass}>Workspace ID<input value={workspaceID} onChange={(event) => setWorkspaceID(event.target.value)} placeholder="All authorized workspaces" className={inputClass} /></label>
             <label className={labelClass}>
               Rules
               <select
@@ -1361,6 +1365,8 @@ export default function PoliciesPage() {
               generatedAt={generatedAt}
               onAction={openAction}
               savingActionID={actionSaving ? selectedAction?.id : undefined}
+              tenantID={tenantID}
+              workspaceID={workspaceID}
             />
             </div>
           )}
@@ -1583,11 +1589,15 @@ function PolicyDetail({
   generatedAt,
   onAction,
   savingActionID,
+  tenantID,
+  workspaceID,
 }: {
   policy: GRCPolicyLifecyclePolicy | null;
   generatedAt?: string;
   onAction: (action: GRCPolicyLifecycleAction) => void;
   savingActionID?: string;
+  tenantID: string;
+  workspaceID: string;
 }) {
   if (!policy) {
     return (
@@ -1628,7 +1638,7 @@ function PolicyDetail({
                 <Badge value={policy.review_cadence || "no cadence"} />
               </div>
             </div>
-            <Link href={`/reports?policy=${encodeURIComponent(policy.id)}`} className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 px-2.5 py-1.5 text-[12px] font-medium text-indigo-600 transition hover:border-indigo-200 hover:bg-indigo-50">
+            <Link href={withGRCScope(`/reports?policy=${encodeURIComponent(policy.id)}`, { tenantID, workspaceID })} className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 px-2.5 py-1.5 text-[12px] font-medium text-indigo-600 transition hover:border-indigo-200 hover:bg-indigo-50">
               Report
               <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
             </Link>

--- a/apps/web/src/app/vendors/[urn]/page.tsx
+++ b/apps/web/src/app/vendors/[urn]/page.tsx
@@ -48,6 +48,7 @@ import {
   shortEntity,
 } from "@/lib/grc";
 import { grcPath, useGRCMutation, useGRCQuery } from "@/lib/grc-client";
+import { grcScopeQuery, withGRCScope } from "@/lib/grc-scope";
 import { GRC_DETAIL_LIMIT, grcBoundedRows } from "@/lib/grc-list";
 import { primaryAnswerForRun, questionnaireDirectionLabel, questionnaireQueueRows, questionnaireRollups, questionnaireStateIntent, type QuestionnaireQueueRow } from "@/lib/questionnaires";
 
@@ -69,7 +70,7 @@ const ownerLabel = (vendor?: GRCVendor) => {
   return vendor.owner || vendor.security_owner_user_id || vendor.business_owner_user_id || "Owner missing";
 };
 
-function RelationshipList({ items }: { items: GRCVendorRelatedRecord[] }) {
+function RelationshipList({ items, tenantID, workspaceID }: { items: GRCVendorRelatedRecord[]; tenantID: string; workspaceID: string }) {
   if (items.length === 0) {
     return <div className="rounded-md border border-dashed border-[color:var(--border-strong)] p-4 text-[13px] text-[var(--text-muted)]">No linked records.</div>;
   }
@@ -89,7 +90,7 @@ function RelationshipList({ items }: { items: GRCVendorRelatedRecord[] }) {
                   {item.source_id && <span>{item.source_id}</span>}
                 </div>
               </div>
-              <Link href={`/inventory/${encodeURIComponent(item.urn)}`} className="text-[12px] font-semibold text-[var(--primary)] hover:text-[var(--primary-hover)]">
+              <Link href={withGRCScope(`/inventory/${encodeURIComponent(item.urn)}`, { tenantID, workspaceID })} className="text-[12px] font-semibold text-[var(--primary)] hover:text-[var(--primary-hover)]">
                 Open
               </Link>
             </div>
@@ -253,7 +254,7 @@ function BadgeList({ items, emptyLabel }: { items: string[]; emptyLabel: string 
   );
 }
 
-function QuestionnaireReviewsPanel({ tenantID, vendorURN }: { tenantID: string; vendorURN: string }) {
+function QuestionnaireReviewsPanel({ tenantID, vendorURN, workspaceID }: { tenantID: string; vendorURN: string; workspaceID: string }) {
   const [selectedRowID, setSelectedRowID] = useState<string | null>(null);
   const [assignmentOwner, setAssignmentOwner] = useState("");
   const [assignmentTeam, setAssignmentTeam] = useState("");
@@ -263,7 +264,7 @@ function QuestionnaireReviewsPanel({ tenantID, vendorURN }: { tenantID: string; 
   const [decisionReason, setDecisionReason] = useState("");
   const runsQuery = useGRCQuery<GRCQuestionnaireRunsResponse>(
     grcPath("/grc/questionnaire-runs", {
-      tenant_id: tenantID,
+      ...grcScopeQuery({ tenantID, workspaceID }),
       direction: "vendor_review",
       vendor_urn: vendorURN,
       limit: 50,
@@ -282,8 +283,9 @@ function QuestionnaireReviewsPanel({ tenantID, vendorURN }: { tenantID: string; 
   const queueHref = useMemo(() => {
     const params = new URLSearchParams({ direction: "vendor_review", vendor_urn: vendorURN });
     if (tenantID) params.set("tenant_id", tenantID);
+    if (workspaceID) params.set("workspace_id", workspaceID);
     return `/questionnaires?${params.toString()}`;
-  }, [tenantID, vendorURN]);
+  }, [tenantID, vendorURN, workspaceID]);
 
   const resetRowActionForms = () => {
     setAssignmentOwner("");
@@ -304,7 +306,7 @@ function QuestionnaireReviewsPanel({ tenantID, vendorURN }: { tenantID: string; 
   const processRun = async () => {
     if (!selectedRun) return;
     try {
-      await mutation.mutate(`/grc/questionnaire-runs/${encodeURIComponent(selectedRun.run_id)}/process`, { tenant_id: tenantID || undefined });
+      await mutation.mutate(grcPath(`/grc/questionnaire-runs/${encodeURIComponent(selectedRun.run_id)}/process`, grcScopeQuery({ tenantID, workspaceID })), grcScopeQuery({ tenantID, workspaceID }));
     } catch {
       return;
     }
@@ -315,8 +317,8 @@ function QuestionnaireReviewsPanel({ tenantID, vendorURN }: { tenantID: string; 
     event.preventDefault();
     if (!selectedRun) return;
     try {
-      await mutation.mutate(`/grc/questionnaire-runs/${encodeURIComponent(selectedRun.run_id)}/assignments`, {
-        tenant_id: tenantID || undefined,
+      await mutation.mutate(grcPath(`/grc/questionnaire-runs/${encodeURIComponent(selectedRun.run_id)}/assignments`, grcScopeQuery({ tenantID, workspaceID })), {
+        ...grcScopeQuery({ tenantID, workspaceID }),
         question_id: selectedQuestionID || undefined,
         gap_id: selectedGap?.id || undefined,
         slot_id: selectedSlotID || undefined,
@@ -334,8 +336,8 @@ function QuestionnaireReviewsPanel({ tenantID, vendorURN }: { tenantID: string; 
     event.preventDefault();
     if (!selectedRun) return;
     try {
-      await mutation.mutate(`/grc/questionnaire-runs/${encodeURIComponent(selectedRun.run_id)}/decisions`, {
-        tenant_id: tenantID || undefined,
+      await mutation.mutate(grcPath(`/grc/questionnaire-runs/${encodeURIComponent(selectedRun.run_id)}/decisions`, grcScopeQuery({ tenantID, workspaceID })), {
+        ...grcScopeQuery({ tenantID, workspaceID }),
         question_id: selectedQuestionID || undefined,
         state: decisionState,
         reason: decisionReason,
@@ -350,8 +352,8 @@ function QuestionnaireReviewsPanel({ tenantID, vendorURN }: { tenantID: string; 
     event.preventDefault();
     if (!selectedRun || !commentBody.trim()) return;
     try {
-      await mutation.mutate(`/grc/questionnaire-runs/${encodeURIComponent(selectedRun.run_id)}/comments`, {
-        tenant_id: tenantID || undefined,
+      await mutation.mutate(grcPath(`/grc/questionnaire-runs/${encodeURIComponent(selectedRun.run_id)}/comments`, grcScopeQuery({ tenantID, workspaceID })), {
+        ...grcScopeQuery({ tenantID, workspaceID }),
         question_id: selectedQuestionID || undefined,
         body: commentBody,
       });
@@ -1228,8 +1230,9 @@ export default function VendorDetailPage() {
   const [activeTab, setActiveTab] = useState<VendorTab>("overview");
   const vendorID = decodeURIComponent(String(params.urn ?? ""));
   const tenantID = searchParams.get("tenant_id") ?? "";
+  const workspaceID = searchParams.get("workspace_id") ?? "";
   const detailQuery = useGRCQuery<GRCVendorDetailResponse>(
-    vendorID ? grcPath(`/grc/vendors/${encodeURIComponent(vendorID)}`, { tenant_id: tenantID, limit: 100 }) : null,
+    vendorID ? grcPath(`/grc/vendors/${encodeURIComponent(vendorID)}`, { ...grcScopeQuery({ tenantID, workspaceID }), limit: 100 }) : null,
   );
   const data = detailQuery.data;
   const vendor = data?.vendor;
@@ -1346,7 +1349,7 @@ export default function VendorDetailPage() {
           )}
 
           {activeTab === "questionnaire" && (
-            <QuestionnaireReviewsPanel tenantID={tenantID} vendorURN={vendor.urn} />
+            <QuestionnaireReviewsPanel tenantID={tenantID} vendorURN={vendor.urn} workspaceID={workspaceID} />
           )}
 
           {activeTab === "evidence" && (
@@ -1432,11 +1435,11 @@ export default function VendorDetailPage() {
                   <div className="grid gap-6 lg:grid-cols-2">
                     <div>
                       <h3 className="mb-3 text-[13px] font-semibold text-[var(--text-primary)]">Contracts</h3>
-                      <RelationshipList items={relationships.contracts ?? []} />
+                      <RelationshipList items={relationships.contracts ?? []} tenantID={tenantID} workspaceID={workspaceID} />
                     </div>
                     <div>
                       <h3 className="mb-3 text-[13px] font-semibold text-[var(--text-primary)]">Reviews and assurance</h3>
-                      <RelationshipList items={reviews} />
+                      <RelationshipList items={reviews} tenantID={tenantID} workspaceID={workspaceID} />
                     </div>
                   </div>
                 </Panel>
@@ -1486,23 +1489,23 @@ export default function VendorDetailPage() {
                   <div className="space-y-4">
                     <div>
                       <div className="mb-2 text-[12px] font-semibold text-[var(--text-muted)]">Owners</div>
-                      <RelationshipList items={relationships.owners ?? []} />
+                      <RelationshipList items={relationships.owners ?? []} tenantID={tenantID} workspaceID={workspaceID} />
                     </div>
                     <div>
                       <div className="mb-2 text-[12px] font-semibold text-[var(--text-muted)]">Hosts</div>
-                      <RelationshipList items={relationships.hosts ?? []} />
+                      <RelationshipList items={relationships.hosts ?? []} tenantID={tenantID} workspaceID={workspaceID} />
                     </div>
                     <div>
                       <div className="mb-2 text-[12px] font-semibold text-[var(--text-muted)]">Aliases</div>
-                      <RelationshipList items={relationships.aliases ?? []} />
+                      <RelationshipList items={relationships.aliases ?? []} tenantID={tenantID} workspaceID={workspaceID} />
                     </div>
                     <div>
                       <div className="mb-2 text-[12px] font-semibold text-[var(--text-muted)]">Contacts</div>
-                      <RelationshipList items={relationships.contacts ?? []} />
+                      <RelationshipList items={relationships.contacts ?? []} tenantID={tenantID} workspaceID={workspaceID} />
                     </div>
                     <div>
                       <div className="mb-2 text-[12px] font-semibold text-[var(--text-muted)]">Fourth parties</div>
-                      <RelationshipList items={relationships.fourth_parties ?? []} />
+                      <RelationshipList items={relationships.fourth_parties ?? []} tenantID={tenantID} workspaceID={workspaceID} />
                     </div>
                   </div>
                 </Panel>

--- a/apps/web/src/app/vendors/page.tsx
+++ b/apps/web/src/app/vendors/page.tsx
@@ -44,6 +44,7 @@ import {
   shortEntity,
 } from "@/lib/grc";
 import { grcPath, useDebouncedValue, useGRCFormMutation, useGRCMutation, useGRCQuery } from "@/lib/grc-client";
+import { type GRCScope, grcScopeQuery, useDebouncedGRCScope, useGRCScopeQueryState, withGRCScope } from "@/lib/grc-scope";
 import { GRC_DETAIL_LIMIT, GRC_WORKLIST_LIMIT } from "@/lib/grc-list";
 import { riskBadgeClassFor } from "@/lib/grc-status";
 import { grcUploadHistoryKey, grcUploadHistoryWith, readGRCUploadHistory, writeGRCUploadHistory } from "@/lib/grc-upload-history";
@@ -198,8 +199,8 @@ const quickReviewOptions = [
 const compactAttributes = (attributes: Record<string, string | undefined>) =>
   Object.fromEntries(Object.entries(attributes).filter(([, value]) => Boolean(value))) as Record<string, string>;
 
-const vendorCreateRequest = (draft: VendorCreateDraft, tenantID: string): GRCVendorCreateRequest => ({
-  tenant_id: tenantID.trim() || undefined,
+const vendorCreateRequest = (draft: VendorCreateDraft, scope: GRCScope): GRCVendorCreateRequest => ({
+  ...grcScopeQuery(scope),
   name: draft.name.trim(),
   source_id: "grc",
   owner: draft.owner.trim() || undefined,
@@ -418,8 +419,8 @@ function DuplicateMatchList({
   );
 }
 
-const vendorDetailHref = (vendor: GRCVendor) =>
-  `/vendors/${encodeURIComponent(vendor.urn)}`;
+const vendorDetailHref = (vendor: GRCVendor, scope: GRCScope) =>
+  withGRCScope(`/vendors/${encodeURIComponent(vendor.urn)}`, scope);
 
 function DiscoveryStateBadge({ state }: { state?: string }) {
   const normalized = state?.trim().toLowerCase() || "discovered";
@@ -1200,6 +1201,7 @@ function VendorRegisterSection({
   graphRevision,
   meta,
   onOpenVendor,
+  scope,
   vendors,
 }: {
   assuranceItems: number;
@@ -1207,6 +1209,7 @@ function VendorRegisterSection({
   graphRevision?: number;
   meta?: GRCVendorsResponse["meta"];
   onOpenVendor: (vendorURN: string) => void;
+  scope: GRCScope;
   vendors: GRCVendor[];
 }) {
   const vendorColumns = useMemo<TableColumn<GRCVendor>[]>(() => [
@@ -1311,7 +1314,7 @@ function VendorRegisterSection({
       onRowClick={(vendor) => onOpenVendor(vendor.urn)}
       tableContainerClassName="max-h-[36rem] overflow-auto"
       action={(
-        <Link href="/inventory?entity_type=vendor" className="text-[12px] font-semibold text-[var(--primary)] hover:text-[var(--primary-hover)]">
+        <Link href={withGRCScope("/inventory?entity_type=vendor", scope)} className="text-[12px] font-semibold text-[var(--primary)] hover:text-[var(--primary-hover)]">
           Inventory
         </Link>
       )}
@@ -1329,7 +1332,7 @@ function VendorRegisterSection({
             Open
           </button>
           <Link
-            href={vendorDetailHref(vendor)}
+            href={vendorDetailHref(vendor, scope)}
             onClick={(event) => event.stopPropagation()}
             className="text-[12px] font-semibold text-[var(--primary)] hover:text-[var(--primary-hover)]"
           >
@@ -1417,6 +1420,7 @@ function VendorDetailDrawer({
   onQuickAction,
   onReload,
   onUpdateActionDraft,
+  scope,
   vendor,
 }: {
   actionDraft: VendorQuickActionDraft;
@@ -1432,6 +1436,7 @@ function VendorDetailDrawer({
   onQuickAction: (action: "assign_owner" | "change_lifecycle" | "start_review") => Promise<void> | void;
   onReload: () => void;
   onUpdateActionDraft: (patch: Partial<VendorQuickActionDraft>) => void;
+  scope: GRCScope;
   vendor?: GRCVendor | null;
 }) {
   const activeVendor = detail?.vendor ?? vendor;
@@ -1623,7 +1628,7 @@ function VendorDetailDrawer({
                 <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
                 Refresh
               </button>
-              <Link href={vendorDetailHref(activeVendor)} className="primary-button px-3 py-1.5 text-[13px]">
+              <Link href={vendorDetailHref(activeVendor, scope)} className="primary-button px-3 py-1.5 text-[13px]">
                 Open full detail
               </Link>
             </div>
@@ -1635,7 +1640,7 @@ function VendorDetailDrawer({
 }
 
 export default function VendorsPage() {
-  const [tenantID, setTenantID] = useQueryParamState("tenant_id");
+  const { tenantID, workspaceID, setTenantID, setWorkspaceID } = useGRCScopeQueryState();
   const [query, setQuery] = useQueryParamState("q");
   const [sourceID, setSourceID] = useQueryParamState("source_id");
   const [riskLevel, setRiskLevel] = useQueryParamState("risk_level");
@@ -1668,7 +1673,7 @@ export default function VendorsPage() {
   const [quickActionMessage, setQuickActionMessage] = useState("");
   const [quickActionDraft, setQuickActionDraft] = useState<VendorQuickActionDraft>(() => defaultVendorQuickActionDraft());
   const uploadPanelRef = useRef<HTMLDivElement>(null);
-  const debouncedTenantID = useDebouncedValue(tenantID.trim());
+  const debouncedScope = useDebouncedGRCScope({ tenantID, workspaceID });
   const debouncedQuery = useDebouncedValue(query.trim());
   const debouncedSourceID = useDebouncedValue(sourceID.trim());
   const debouncedRiskLevel = useDebouncedValue(riskLevel.trim());
@@ -1687,7 +1692,7 @@ export default function VendorsPage() {
 
   const vendorsQuery = useGRCQuery<GRCVendorsResponse>(
     grcPath("/grc/vendors", {
-      tenant_id: debouncedTenantID,
+      ...grcScopeQuery(debouncedScope),
       source_id: debouncedSourceID,
       q: debouncedQuery,
       risk_level: debouncedRiskLevel,
@@ -1700,7 +1705,7 @@ export default function VendorsPage() {
   );
   const discoveriesQuery = useGRCQuery<GRCVendorDiscoveriesResponse>(
     shouldLoadDiscoveries ? grcPath("/grc/vendor-discoveries", {
-      tenant_id: debouncedTenantID,
+      ...grcScopeQuery(debouncedScope),
       source_id: debouncedSourceID,
       q: debouncedQuery,
       limit: GRC_DETAIL_LIMIT,
@@ -1708,7 +1713,7 @@ export default function VendorsPage() {
   );
   const vendorDetailQuery = useGRCQuery<GRCVendorDetailResponse>(
     selectedVendorURN
-      ? grcPath(`/grc/vendors/${encodeURIComponent(selectedVendorURN)}`, { tenant_id: debouncedTenantID, limit: GRC_DETAIL_LIMIT })
+      ? grcPath(`/grc/vendors/${encodeURIComponent(selectedVendorURN)}`, { ...grcScopeQuery(debouncedScope), limit: GRC_DETAIL_LIMIT })
       : null,
   );
   const { mutate: mutateDiscoveryDecision, saving: decisionSaving, error: decisionError } = useGRCMutation();
@@ -1778,7 +1783,7 @@ export default function VendorsPage() {
       return Boolean((selectedHost && discoveryHost === selectedHost) || (selectedNameKey && discoveryNameKey === selectedNameKey));
     });
   }, [discoveries, selectedVendor?.name, selectedVendor?.website_url, selectedVendorURN]);
-  const vendorUploadStorageKey = useMemo(() => grcUploadHistoryKey("vendor", tenantID), [tenantID]);
+  const vendorUploadStorageKey = useMemo(() => grcUploadHistoryKey("vendor", tenantID, workspaceID), [tenantID, workspaceID]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -1800,7 +1805,7 @@ export default function VendorsPage() {
     setVendorReplayError(null);
     try {
       const response = await replayVendorUploadEvents(
-        grcPath(`/grc/vendors/uploads/${encodeURIComponent(upload.upload_id)}/replay`, { tenant_id: tenantID.trim() }),
+        grcPath(`/grc/vendors/uploads/${encodeURIComponent(upload.upload_id)}/replay`, grcScopeQuery({ tenantID, workspaceID })),
         {},
       );
       setVendorReplayMessage(`${countLabel(response.events_projected ?? 0, "event")} replayed. ${countLabel((response.entities_projected ?? 0) + (response.links_projected ?? 0), "graph update")} projected.`);
@@ -1880,7 +1885,7 @@ export default function VendorsPage() {
     setCreateError(null);
   }, [setCreateError]);
   const submitVendorCreate = useCallback(async (draft: VendorCreateDraft) => {
-    const response = await mutateCreateVendor("/grc/vendors", vendorCreateRequest(draft, tenantID));
+    const response = await mutateCreateVendor(grcPath("/grc/vendors", grcScopeQuery({ tenantID, workspaceID })), vendorCreateRequest(draft, { tenantID, workspaceID }));
     setCreateOpen(false);
     setCreateDraft(defaultVendorCreateDraft());
     setCreateMessage(`${response.vendor.name} saved.`);
@@ -1888,7 +1893,7 @@ export default function VendorsPage() {
     const reloads = [vendorsQuery.reload()];
     if (shouldLoadDiscoveries) reloads.push(discoveriesQuery.reload());
     await Promise.all(reloads);
-  }, [discoveriesQuery, mutateCreateVendor, shouldLoadDiscoveries, tenantID, vendorsQuery]);
+  }, [discoveriesQuery, mutateCreateVendor, shouldLoadDiscoveries, tenantID, vendorsQuery, workspaceID]);
   const updateDecisionDraft = useCallback((urn: string, patch: Partial<DiscoveryDecisionDraft>) => {
     setDecisionDrafts((current) => ({
       ...current,
@@ -1901,8 +1906,8 @@ export default function VendorsPage() {
   }, []);
   const setDiscoveryDecision = useCallback(async (discovery: GRCVendorDiscovery, decision: DiscoveryDecision, overrideDraft?: DiscoveryDecisionDraft) => {
     const draft = overrideDraft ?? decisionDrafts[discovery.urn] ?? { reason: "", linkedVendorURN: "" };
-    await mutateDiscoveryDecision(`/grc/vendor-discoveries/${encodeURIComponent(discovery.urn)}/decision`, {
-      tenant_id: tenantID.trim(),
+    await mutateDiscoveryDecision(grcPath(`/grc/vendor-discoveries/${encodeURIComponent(discovery.urn)}/decision`, grcScopeQuery({ tenantID, workspaceID })), {
+      ...grcScopeQuery({ tenantID, workspaceID }),
       discovery_urn: discovery.urn,
       source_id: discovery.source_id,
       decision,
@@ -1916,11 +1921,11 @@ export default function VendorsPage() {
     });
     await discoveriesQuery.reload();
     await vendorsQuery.reload();
-  }, [decisionDrafts, discoveriesQuery, mutateDiscoveryDecision, tenantID, vendorsQuery]);
+  }, [decisionDrafts, discoveriesQuery, mutateDiscoveryDecision, tenantID, vendorsQuery, workspaceID]);
   const createVendorFromDiscovery = useCallback(async (discovery: GRCVendorDiscovery, overrides?: Partial<Pick<VendorCreateDraft, "owner" | "riskLevel">>) => {
     setCreateMessage("");
-    const response = await mutateCreateVendor("/grc/vendors", {
-      tenant_id: tenantID.trim() || undefined,
+    const response = await mutateCreateVendor(grcPath("/grc/vendors", grcScopeQuery({ tenantID, workspaceID })), {
+      ...grcScopeQuery({ tenantID, workspaceID }),
       name: discovery.name || shortEntity(discovery.urn),
       source_id: discovery.source_id || "grc",
       runtime_id: discovery.runtime_id,
@@ -1938,8 +1943,8 @@ export default function VendorsPage() {
         source_status: discovery.source_status,
       }),
     } satisfies GRCVendorCreateRequest);
-    await mutateDiscoveryDecision(`/grc/vendor-discoveries/${encodeURIComponent(discovery.urn)}/decision`, {
-      tenant_id: tenantID.trim(),
+    await mutateDiscoveryDecision(grcPath(`/grc/vendor-discoveries/${encodeURIComponent(discovery.urn)}/decision`, grcScopeQuery({ tenantID, workspaceID })), {
+      ...grcScopeQuery({ tenantID, workspaceID }),
       discovery_urn: discovery.urn,
       source_id: discovery.source_id,
       decision: "approved",
@@ -1954,7 +1959,7 @@ export default function VendorsPage() {
     setCreateMessage(`${response.vendor.name} saved.`);
     setCreatedVendor(response.vendor);
     await Promise.all([discoveriesQuery.reload(), vendorsQuery.reload()]);
-  }, [discoveriesQuery, mutateCreateVendor, mutateDiscoveryDecision, tenantID, vendorsQuery]);
+  }, [discoveriesQuery, mutateCreateVendor, mutateDiscoveryDecision, tenantID, vendorsQuery, workspaceID]);
 
   const runBulkDiscoveryAction = useCallback(async (action: "create" | "dismiss" | "link") => {
     const selectedDiscoveries = discoveries.filter((discovery) => selectedDiscoveryURNs.has(discovery.urn) && discoveryNeedsReview(discovery));
@@ -1997,8 +2002,8 @@ export default function VendorsPage() {
   }, [bulkDraft.linkedVendorURN, bulkDraft.owner, bulkDraft.reason, bulkDraft.riskLevel, createVendorFromDiscovery, discoveries, selectedDiscoveryURNs, setDiscoveryDecision]);
 
   const runDiscoverySync = useCallback(async (runSourceID?: string) => {
-    const response = await mutateDiscoverySync("/grc/vendor-discoveries/sync", {
-      tenant_id: tenantID.trim() || undefined,
+    const response = await mutateDiscoverySync(grcPath("/grc/vendor-discoveries/sync", grcScopeQuery({ tenantID, workspaceID })), {
+      ...grcScopeQuery({ tenantID, workspaceID }),
       source_id: runSourceID,
     });
     const sourceName = runSourceID
@@ -2006,12 +2011,12 @@ export default function VendorsPage() {
       : "All sources";
     setSyncMessage(`${sourceName} discovery ${response.status}.`);
     await discoveriesQuery.reload();
-  }, [discoveriesQuery, discoverySources, mutateDiscoverySync, tenantID]);
+  }, [discoveriesQuery, discoverySources, mutateDiscoverySync, tenantID, workspaceID]);
 
   const runVendorQuickAction = useCallback(async (action: "assign_owner" | "change_lifecycle" | "start_review") => {
     if (!selectedVendorURN) return;
-    const response = await mutateVendorAction(`/grc/vendors/${encodeURIComponent(selectedVendorURN)}/actions`, {
-      tenant_id: tenantID.trim() || undefined,
+    const response = await mutateVendorAction(grcPath(`/grc/vendors/${encodeURIComponent(selectedVendorURN)}/actions`, grcScopeQuery({ tenantID, workspaceID })), {
+      ...grcScopeQuery({ tenantID, workspaceID }),
       action,
       owner: action === "assign_owner" ? quickActionDraft.owner.trim() : undefined,
       lifecycle_state: action === "change_lifecycle" ? quickActionDraft.lifecycleState : undefined,
@@ -2020,7 +2025,7 @@ export default function VendorsPage() {
     });
     setQuickActionMessage(`${response.vendor.name} updated.`);
     await Promise.all([vendorsQuery.reload(), vendorDetailQuery.reload()]);
-  }, [mutateVendorAction, quickActionDraft.lifecycleState, quickActionDraft.owner, quickActionDraft.reviewState, selectedVendorURN, tenantID, vendorDetailQuery, vendorsQuery]);
+  }, [mutateVendorAction, quickActionDraft.lifecycleState, quickActionDraft.owner, quickActionDraft.reviewState, selectedVendorURN, tenantID, vendorDetailQuery, vendorsQuery, workspaceID]);
 
   const submitVendorUpload = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -2045,13 +2050,14 @@ export default function VendorsPage() {
     body.set("document_type", vendorUploadDocumentType.trim() || "assurance_document");
     body.set("status", "active");
     if (tenantID.trim()) body.set("tenant_id", tenantID.trim());
+    if (workspaceID.trim()) body.set("workspace_id", workspaceID.trim());
     if (sourceID.trim()) body.set("source_id", sourceID.trim());
     if (vendorUploadID.trim()) body.set("vendor_id", vendorUploadID.trim());
     if (vendorUploadRiskLevel.trim()) body.set("risk_level", vendorUploadRiskLevel.trim());
     if (vendorUploadWebsite.trim()) body.set("website_url", vendorUploadWebsite.trim());
     try {
       const response = await uploadVendorDocument(
-        grcPath("/grc/vendors/uploads", { tenant_id: tenantID.trim(), source_id: sourceID.trim() }),
+        grcPath("/grc/vendors/uploads", { ...grcScopeQuery({ tenantID, workspaceID }), source_id: sourceID.trim() }),
         body,
       );
       setLastVendorUpload(response);
@@ -2080,6 +2086,7 @@ export default function VendorsPage() {
     { label: "Queue", value: queueState ? selectLabel(queueFilters, queueState) : "", onClear: () => setQueueState("") },
     { label: "Source", value: sourceID ? sourceFilterOptions.find((item) => item.value === sourceID)?.label ?? sourceID : "", onClear: () => setSourceID("") },
     { label: "Tenant", value: tenantID, onClear: () => setTenantID("") },
+    { label: "Workspace", value: workspaceID, onClear: () => setWorkspaceID("") },
   ];
   const clearFilters = () => {
     setQuery("");
@@ -2090,6 +2097,7 @@ export default function VendorsPage() {
     setQueueState("");
     setSourceID("");
     setTenantID("");
+    setWorkspaceID("");
   };
 
   return (
@@ -2143,6 +2151,7 @@ export default function VendorsPage() {
         onQuickAction={runVendorQuickAction}
         onReload={() => { void vendorDetailQuery.reload(); }}
         onUpdateActionDraft={updateQuickActionDraft}
+        scope={{ tenantID, workspaceID }}
         vendor={selectedVendor}
       />
 
@@ -2319,7 +2328,7 @@ export default function VendorsPage() {
                       <button type="button" onClick={() => setSelectedVendorURN(vendorURN)} className="inline-flex items-center rounded-md border border-emerald-300 bg-white/80 px-3 py-1.5 text-[12px] font-semibold text-emerald-800 transition hover:border-emerald-400 hover:text-emerald-950">
                         Open vendor
                       </button>
-                      <Link href={`/vendors/${encodeURIComponent(vendorURN)}`} className="inline-flex items-center rounded-md border border-emerald-300 bg-white/80 px-3 py-1.5 text-[12px] font-semibold text-emerald-800 transition hover:border-emerald-400 hover:text-emerald-950">
+                      <Link href={withGRCScope(`/vendors/${encodeURIComponent(vendorURN)}`, { tenantID, workspaceID })} className="inline-flex items-center rounded-md border border-emerald-300 bg-white/80 px-3 py-1.5 text-[12px] font-semibold text-emerald-800 transition hover:border-emerald-400 hover:text-emerald-950">
                         Open full detail
                       </Link>
                     </>
@@ -2408,8 +2417,12 @@ export default function VendorsPage() {
               </select>
             </label>
             <label className={labelClass}>
-              Tenant
-              <input value={tenantID} onChange={(event) => setTenantID(event.target.value)} placeholder="Current" className={inputClass} />
+              Tenant ID
+              <input value={tenantID} onChange={(event) => setTenantID(event.target.value)} placeholder="All authorized tenants" className={inputClass} />
+            </label>
+            <label className={labelClass}>
+              Workspace ID
+              <input value={workspaceID} onChange={(event) => setWorkspaceID(event.target.value)} placeholder="All authorized workspaces" className={inputClass} />
             </label>
           </div>
         </details>
@@ -2479,6 +2492,7 @@ export default function VendorsPage() {
           graphRevision={vendorsQuery.data?.graph_revision}
           meta={vendorMeta}
           onOpenVendor={openVendorDrawer}
+          scope={{ tenantID, workspaceID }}
           vendors={vendors}
         />
       ))}

--- a/apps/web/src/components/StatusPanel.test.tsx
+++ b/apps/web/src/components/StatusPanel.test.tsx
@@ -5,6 +5,10 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
 vi.mock("@/components/providers", () => ({
   useApiKey: () => ({ apiKey: "" }),
   useConsoleConfig: () => ({ config: { apiBase: "/api/cerebro", serverAuthConfigured: true } }),
@@ -15,7 +19,7 @@ vi.mock("@/lib/identity", () => ({
   identityPosture: () => ({ label: "Trusted proxy", sourceLabel: "Auth proxy headers" }),
 }));
 
-import StatusPanel from "./StatusPanel";
+import StatusPanel, { statusProbes } from "./StatusPanel";
 
 const reactActEnvironment = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
@@ -66,6 +70,18 @@ describe("StatusPanel cache behavior", () => {
     for (const [, init] of fetchMock.mock.calls.slice(6)) {
       expect((init as RequestInit | undefined)?.cache).toBe("no-store");
     }
+  });
+
+  it("scopes product probes without changing liveness and readiness paths", () => {
+    const probes = statusProbes({ tenantID: "tenant-a", workspaceID: "workspace-a" });
+    expect(probes.find((probe) => probe.key === "healthz")?.path).toBe("/api/cerebro/healthz");
+    expect(probes.find((probe) => probe.key === "health")?.path).toBe("/api/cerebro/health");
+    expect(probes.find((probe) => probe.key === "inventory")?.path)
+      .toBe("/api/cerebro/grc/inventory/categories?limit=1&tenant_id=tenant-a&workspace_id=workspace-a");
+    expect(probes.find((probe) => probe.key === "vendors")?.path)
+      .toContain("workspace_id=workspace-a");
+    expect(probes.find((probe) => probe.key === "policies")?.path)
+      .toContain("tenant_id=tenant-a");
   });
 
   it("publishes probe results without waiting for the slowest request", async () => {

--- a/apps/web/src/components/StatusPanel.tsx
+++ b/apps/web/src/components/StatusPanel.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useApiKey, useConsoleConfig, useCurrentUser } from "@/components/providers";
 import { identityPosture } from "@/lib/identity";
 import { GRC_QUERY_TIMEOUT_MS } from "@/lib/grc-client";
+import { type GRCScope, useDebouncedGRCScope, withGRCScope } from "@/lib/grc-scope";
 import { RuntimeState, runtimeStateCopy, runtimeStateForError, runtimeStateLabel } from "@/lib/runtime-state";
 
 type StatusState = {
@@ -28,16 +30,16 @@ type ProbeResult = {
 
 const LIVENESS_TIMEOUT_MS = 3000;
 const PRODUCT_READ_TIMEOUT_MS = 5000;
-const STATUS_PROBES = [
+export const statusProbes = (scope: GRCScope) => [
   { key: "healthz", label: "API liveness", path: "/api/cerebro/healthz", timeoutMs: LIVENESS_TIMEOUT_MS },
   { key: "health", label: "API readiness", path: "/api/cerebro/health", timeoutMs: GRC_QUERY_TIMEOUT_MS },
-  { key: "actions", label: "Action authority", path: "/api/cerebro/v1/actions?limit=1", timeoutMs: PRODUCT_READ_TIMEOUT_MS },
-  { key: "inventory", label: "Inventory", path: "/api/cerebro/grc/inventory/categories?limit=1", timeoutMs: PRODUCT_READ_TIMEOUT_MS },
-  { key: "vendors", label: "Vendor register", path: "/api/cerebro/grc/vendors?limit=1", timeoutMs: PRODUCT_READ_TIMEOUT_MS },
-  { key: "policies", label: "Policy lifecycle", path: "/api/cerebro/grc/policy-lifecycle?rule_profile=baseline&limit=1", timeoutMs: PRODUCT_READ_TIMEOUT_MS },
+  { key: "actions", label: "Action authority", path: withGRCScope("/api/cerebro/v1/actions?limit=1", scope), timeoutMs: PRODUCT_READ_TIMEOUT_MS },
+  { key: "inventory", label: "Inventory", path: withGRCScope("/api/cerebro/grc/inventory/categories?limit=1", scope), timeoutMs: PRODUCT_READ_TIMEOUT_MS },
+  { key: "vendors", label: "Vendor register", path: withGRCScope("/api/cerebro/grc/vendors?limit=1", scope), timeoutMs: PRODUCT_READ_TIMEOUT_MS },
+  { key: "policies", label: "Policy lifecycle", path: withGRCScope("/api/cerebro/grc/policy-lifecycle?rule_profile=baseline&limit=1", scope), timeoutMs: PRODUCT_READ_TIMEOUT_MS },
 ];
 
-const pendingProbe = (probe: typeof STATUS_PROBES[number]): ProbeResult => ({
+const pendingProbe = (probe: ReturnType<typeof statusProbes>[number]): ProbeResult => ({
   ...probe,
   durationMs: 0,
   ok: false,
@@ -74,19 +76,28 @@ const stateClass = (state: RuntimeState) => {
 };
 
 export default function StatusPanel() {
+  const searchParams = useSearchParams();
   const { apiKey } = useApiKey();
   const { config } = useConsoleConfig();
   const { error: identityError, loading: identityLoading, user } = useCurrentUser();
   const [state, setState] = useState<StatusState>({});
   const [loading, setLoading] = useState(true);
   const identity = identityPosture({ error: identityError, loading: identityLoading, user });
+  const debouncedScope = useDebouncedGRCScope({
+    tenantID: searchParams.get("tenant_id") ?? "",
+    workspaceID: searchParams.get("workspace_id") ?? "",
+  });
+  const probesToRun = useMemo(
+    () => statusProbes(debouncedScope),
+    [debouncedScope],
+  );
 
   const fetchStatus = useCallback(async (signal?: AbortSignal, bypassCache = false) => {
     setLoading(true);
-    setState({ probes: STATUS_PROBES.map(pendingProbe) });
+    setState({ probes: probesToRun.map(pendingProbe) });
     const headers: HeadersInit = apiKey ? { "X-API-Key": apiKey } : {};
 
-    const runProbe = async (probe: typeof STATUS_PROBES[number]): Promise<ProbeResult> => {
+    const runProbe = async (probe: ReturnType<typeof statusProbes>[number]): Promise<ProbeResult> => {
       const started = performance.now();
       const controller = new AbortController();
       const abort = () => controller.abort();
@@ -126,11 +137,11 @@ export default function StatusPanel() {
     };
 
     try {
-      const probes = await Promise.all(STATUS_PROBES.map(async (probe) => {
+      const probes = await Promise.all(probesToRun.map(async (probe) => {
         const result = await runProbe(probe);
         if (!signal?.aborted) {
           setState((current) => {
-            const nextProbes = (current.probes ?? STATUS_PROBES.map(pendingProbe)).map((currentProbe) => (
+            const nextProbes = (current.probes ?? probesToRun.map(pendingProbe)).map((currentProbe) => (
               currentProbe.key === result.key ? result : currentProbe
             ));
             return {
@@ -152,7 +163,7 @@ export default function StatusPanel() {
     } finally {
       if (!signal?.aborted) setLoading(false);
     }
-  }, [apiKey]);
+  }, [apiKey, probesToRun]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -212,7 +223,7 @@ export default function StatusPanel() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-[color:var(--border)]">
-                {(probes.length > 0 ? probes : STATUS_PROBES.map((probe) => ({
+                {(probes.length > 0 ? probes : probesToRun.map((probe) => ({
                   ...probe,
                   durationMs: 0,
                   ok: false,

--- a/apps/web/src/lib/grc-scope.test.tsx
+++ b/apps/web/src/lib/grc-scope.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { NuqsTestingAdapter, type UrlUpdateEvent } from "nuqs/adapters/testing";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { grcScopeQuery, useGRCScopeQueryState, withGRCScope } from "./grc-scope";
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+const flushNuqsUpdates = () => new Promise((resolve) => setTimeout(resolve, 80));
+
+function ScopeHarness() {
+  const { tenantID, workspaceID, setTenantID, setWorkspaceID } = useGRCScopeQueryState();
+  return (
+    <div>
+      <span id="tenant">{tenantID}</span>
+      <span id="workspace">{workspaceID}</span>
+      <button id="change-tenant" type="button" onClick={() => setTenantID(" tenant-b ")}>Change tenant</button>
+      <button id="change-workspace" type="button" onClick={() => setWorkspaceID(" workspace-b ")}>Change workspace</button>
+    </div>
+  );
+}
+
+describe("GRC scope", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("uses only the public tenant and workspace selectors", () => {
+    expect(grcScopeQuery({ tenantID: " tenant-a ", workspaceID: " workspace-a " })).toEqual({
+      tenant_id: "tenant-a",
+      workspace_id: "workspace-a",
+    });
+    expect(grcScopeQuery({ tenantID: "tenant-a", workspaceID: " " })).toEqual({
+      tenant_id: "tenant-a",
+      workspace_id: undefined,
+    });
+  });
+
+  it("preserves existing link queries and fragments", () => {
+    expect(withGRCScope("/inventory/asset?tab=reports#events", { tenantID: "tenant-a", workspaceID: "workspace-a" }))
+      .toBe("/inventory/asset?tab=reports&tenant_id=tenant-a&workspace_id=workspace-a#events");
+  });
+
+  it("clears workspace when tenant changes and keeps it for workspace-only changes", async () => {
+    const updates: UrlUpdateEvent[] = [];
+    await act(async () => {
+      root.render(
+        <NuqsTestingAdapter
+          hasMemory
+          onUrlUpdate={(event) => updates.push(event)}
+          searchParams="?tenant_id=tenant-a&workspace_id=workspace-a"
+        >
+          <ScopeHarness />
+        </NuqsTestingAdapter>,
+      );
+    });
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("#change-workspace")?.click();
+      await flushNuqsUpdates();
+    });
+    expect(updates.at(-1)?.searchParams.get("workspace_id")).toBe("workspace-b");
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>("#change-tenant")?.click();
+      await flushNuqsUpdates();
+    });
+    expect(updates.at(-1)?.searchParams.get("tenant_id")).toBe("tenant-b");
+    expect(updates.at(-1)?.searchParams.has("workspace_id")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/grc-scope.ts
+++ b/apps/web/src/lib/grc-scope.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { parseAsString, useQueryStates } from "nuqs";
+import { useCallback, useMemo } from "react";
+
+import { useDebouncedValue } from "@/lib/grc-client";
+
+export type GRCScope = {
+  tenantID: string;
+  workspaceID: string;
+};
+
+export type GRCScopeQuery = {
+  tenant_id?: string;
+  workspace_id?: string;
+};
+
+const cleanScopeValue = (value: string | null | undefined) => value?.trim() ?? "";
+
+export const grcScopeQuery = ({ tenantID, workspaceID }: GRCScope): GRCScopeQuery => ({
+  tenant_id: cleanScopeValue(tenantID) || undefined,
+  workspace_id: cleanScopeValue(workspaceID) || undefined,
+});
+
+export const withGRCScope = (path: string, scope: GRCScope) => {
+  const params = new URLSearchParams();
+  const query = grcScopeQuery(scope);
+  if (query.tenant_id) params.set("tenant_id", query.tenant_id);
+  if (query.workspace_id) params.set("workspace_id", query.workspace_id);
+  const suffix = params.toString();
+  if (!suffix) return path;
+  const hashIndex = path.indexOf("#");
+  const base = hashIndex >= 0 ? path.slice(0, hashIndex) : path;
+  const hash = hashIndex >= 0 ? path.slice(hashIndex) : "";
+  return `${base}${base.includes("?") ? "&" : "?"}${suffix}${hash}`;
+};
+
+const scopeParsers = {
+  tenant_id: parseAsString.withDefault("").withOptions({ clearOnDefault: true }),
+  workspace_id: parseAsString.withDefault("").withOptions({ clearOnDefault: true }),
+};
+
+export const useGRCScopeQueryState = () => {
+  const [queryScope, setQueryScope] = useQueryStates(scopeParsers, {
+    history: "replace",
+    scroll: false,
+    shallow: true,
+  });
+  const tenantID = queryScope.tenant_id;
+  const workspaceID = queryScope.workspace_id;
+  const setTenantID = useCallback((nextValue: string) => {
+    const normalized = cleanScopeValue(nextValue);
+    void setQueryScope({
+      tenant_id: normalized || null,
+      workspace_id: normalized === tenantID.trim() ? workspaceID.trim() || null : null,
+    });
+  }, [setQueryScope, tenantID, workspaceID]);
+  const setWorkspaceID = useCallback((nextValue: string) => {
+    const normalized = cleanScopeValue(nextValue);
+    void setQueryScope({ workspace_id: normalized || null });
+  }, [setQueryScope]);
+
+  return { tenantID, workspaceID, setTenantID, setWorkspaceID };
+};
+
+export const useDebouncedGRCScope = (scope: GRCScope, delayMs = 300) => {
+  const tenantID = useDebouncedValue(scope.tenantID.trim(), delayMs);
+  const workspaceID = useDebouncedValue(scope.workspaceID.trim(), delayMs);
+  return useMemo(() => ({ tenantID, workspaceID }), [tenantID, workspaceID]);
+};

--- a/apps/web/src/lib/grc-upload-history.test.ts
+++ b/apps/web/src/lib/grc-upload-history.test.ts
@@ -13,8 +13,9 @@ const upload = (uploadID: string, fileName = `${uploadID}.pdf`): GRCUploadRespon
 
 describe("GRC upload history", () => {
   it("uses tenant-scoped storage keys", () => {
-    expect(grcUploadHistoryKey("policy", "tenant-1")).toBe("cerebro.grc.uploads.policy.tenant-1");
-    expect(grcUploadHistoryKey("policy", "")).toBe("cerebro.grc.uploads.policy.default");
+    expect(grcUploadHistoryKey("policy", "tenant-1", "workspace-1")).toBe("cerebro.grc.uploads.policy.tenant-1.workspace-1");
+    expect(grcUploadHistoryKey("policy", "tenant-1")).toBe("cerebro.grc.uploads.policy.tenant-1.all-workspaces");
+    expect(grcUploadHistoryKey("policy", "")).toBe("cerebro.grc.uploads.policy.default.all-workspaces");
   });
 
   it("deduplicates uploads by ID and keeps newest first", () => {

--- a/apps/web/src/lib/grc-upload-history.ts
+++ b/apps/web/src/lib/grc-upload-history.ts
@@ -2,8 +2,8 @@ import type { GRCUploadResponse } from "@/lib/grc";
 
 export const GRC_UPLOAD_HISTORY_LIMIT = 5;
 
-export const grcUploadHistoryKey = (target: string, tenantID: string) =>
-  `cerebro.grc.uploads.${target}.${tenantID.trim() || "default"}`;
+export const grcUploadHistoryKey = (target: string, tenantID: string, workspaceID = "") =>
+  `cerebro.grc.uploads.${target}.${tenantID.trim() || "default"}.${workspaceID.trim() || "all-workspaces"}`;
 
 export const grcUploadHistoryWith = (
   current: GRCUploadResponse[],

--- a/apps/web/src/lib/grc.ts
+++ b/apps/web/src/lib/grc.ts
@@ -1432,6 +1432,7 @@ export type GRCVendorsResponse = {
 
 export type GRCVendorCreateRequest = {
   tenant_id?: string;
+  workspace_id?: string;
   name: string;
   vendor_id?: string;
   source_id?: string;
@@ -2219,6 +2220,7 @@ export type GRCPolicyLifecycleActionDefinition = {
 export type GRCPolicyLifecycleActionRequest = {
   action: string;
   tenant_id?: string;
+  workspace_id?: string;
   source_id?: string;
   runtime_id?: string;
   policy_id?: string;


### PR DESCRIPTION
## Summary
- add shared tenant and application-workspace query state for GRC views
- propagate the public `workspace_id` selector through inventory, vendor, and policy reads and operator actions
- scope runtime product probes and preserve scope in detail links

## Validation
- `npm run lint --workspace apps/web -- --max-warnings=0`
- focused Vitest coverage for GRC scope state, runtime probes, and upload history