### PR TITLE
Scope GRC reads to application workspaces

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -1799,6 +1799,13 @@ func (s *stubGraphStore) ListEntities(_ context.Context, request ports.EntityCat
 	for _, row := range rows {
 		attrs := map[string]string{}
 		_ = json.Unmarshal([]byte(fmt.Sprint(row.Values["attributes_json"])), &attrs)
+		workspaceID := fmt.Sprint(row.Values["application_workspace_id"])
+		if workspaceID == "<nil>" {
+			workspaceID = ""
+		}
+		if request.Filter.ApplicationWorkspaceID != "" && workspaceID != request.Filter.ApplicationWorkspaceID {
+			continue
+		}
 		tenant := fmt.Sprint(row.Values["tenant_id"])
 		if tenant == "<nil>" || tenant == "" {
 			tenant = request.Filter.TenantID
@@ -1812,7 +1819,7 @@ func (s *stubGraphStore) ListEntities(_ context.Context, request ports.EntityCat
 }
 
 func (s *stubGraphStore) ListVendorRegister(ctx context.Context, filter ports.VendorRegisterFilter) (*ports.VendorRegisterPage, error) {
-	page, err := s.ListEntities(ctx, ports.EntityCatalogPageRequest{Filter: ports.EntityCatalogFilter{TenantID: filter.TenantID, SourceID: filter.SourceID, RuntimeIDs: filter.RuntimeIDs, IncludeKinds: []string{"vendor"}, Query: filter.Query, QueryAttributes: true}, Limit: filter.Limit})
+	page, err := s.ListEntities(ctx, ports.EntityCatalogPageRequest{Filter: ports.EntityCatalogFilter{TenantID: filter.TenantID, ApplicationWorkspaceID: filter.ApplicationWorkspaceID, SourceID: filter.SourceID, RuntimeIDs: filter.RuntimeIDs, IncludeKinds: []string{"vendor"}, Query: filter.Query, QueryAttributes: true}, Limit: filter.Limit})
 	if err != nil {
 		return nil, err
 	}
@@ -4223,7 +4230,7 @@ func TestGRCVendorDetailSelectsExactRustRegisterRow(t *testing.T) {
 	const vendorURN = "urn:cerebro:writer:vendor:one"
 	graph := &stubGraphStore{cypherRows: [][]ports.CypherRow{{{
 		Values: map[string]any{
-			"urn": vendorURN, "tenant_id": "writer", "runtime_id": "vendor-runtime",
+			"urn": vendorURN, "tenant_id": "writer", "application_workspace_id": "workspace-a", "runtime_id": "vendor-runtime",
 			"source_id": "vendor-source", "entity_type": "vendor", "label": "Vendor One",
 			"attributes_json": `{"risk_level":"high","security_owner_user_id":"alice"}`,
 		},
@@ -4231,7 +4238,7 @@ func TestGRCVendorDetailSelectsExactRustRegisterRow(t *testing.T) {
 	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph)}, nil)
 	request := httptest.NewRequest(http.MethodGet, "/grc/vendors/"+url.PathEscape(vendorURN), nil)
 
-	row, page, err := app.grcVendorRegisterDetail(request, grcScope{TenantID: "writer", Limit: 10}, vendorURN, "")
+	row, page, err := app.grcVendorRegisterDetail(request, grcScope{TenantID: "writer", ApplicationWorkspaceID: "workspace-a", Limit: 10}, vendorURN, "")
 	if err != nil {
 		t.Fatalf("grcVendorRegisterDetail() error = %v", err)
 	}
@@ -4240,6 +4247,9 @@ func TestGRCVendorDetailSelectsExactRustRegisterRow(t *testing.T) {
 	}
 	if page.GraphRevision != 1 || page.DataAuthority != "rust_graph" {
 		t.Fatalf("page = %#v, want Rust graph revision 1", page)
+	}
+	if len(graph.entityRequests) != 1 || graph.entityRequests[0].Filter.ApplicationWorkspaceID != "workspace-a" {
+		t.Fatalf("entity requests = %#v, want workspace-a vendor filter", graph.entityRequests)
 	}
 }
 

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -631,7 +631,7 @@ func (a *App) buildGRCAuditPreview(r *http.Request, findingID string) (grcAuditP
 	if findingID == "" {
 		return grcAuditPacketResponse{}, fmt.Errorf("%w: finding id is required", errInvalidHTTPRequest)
 	}
-	limit, err := grcLimitFromRequest(r)
+	scope, err := grcScopeFromRequest(r)
 	if err != nil {
 		return grcAuditPacketResponse{}, err
 	}
@@ -646,13 +646,22 @@ func (a *App) buildGRCAuditPreview(r *http.Request, findingID string) (grcAuditP
 	if err != nil {
 		return grcAuditPacketResponse{}, err
 	}
-	scope := grcScope{TenantID: finding.TenantID, RuntimeID: finding.RuntimeID, Limit: limit}
+	workspaceGraph, err := a.graphQueryService().QualifyWorkspaceResources(r.Context(), graphquery.WorkspaceResourceRequest{
+		TenantID: scope.TenantID, ResourceTenantID: finding.TenantID, ApplicationWorkspaceID: scope.ApplicationWorkspaceID, URNs: finding.ResourceURNs,
+	})
+	if errors.Is(err, ports.ErrGraphEntityNotFound) || errors.Is(err, graphquery.ErrInvalidRequest) {
+		return grcAuditPacketResponse{}, ports.ErrFindingNotFound
+	}
+	if err != nil {
+		return grcAuditPacketResponse{}, err
+	}
+	scope.TenantID, scope.RuntimeID, scope.RuntimeIDs = finding.TenantID, finding.RuntimeID, nil
 	runtimes, err := a.grcListRuntimes(r, scope)
 	if err != nil {
 		return grcAuditPacketResponse{}, err
 	}
 	reportScopeRuntimes := a.grcReportScopeRuntimes(r, scope, runtimes)
-	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingID: finding.ID, Limit: limit})
+	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingID: finding.ID, Limit: scope.Limit})
 	if err != nil {
 		return grcAuditPacketResponse{}, err
 	}
@@ -669,14 +678,14 @@ func (a *App) buildGRCAuditPreview(r *http.Request, findingID string) (grcAuditP
 	case *evidenceTotal > len(evidence):
 		packetGaps = append(packetGaps, grcAuditPacketGap{
 			Code:    "evidence_snapshot_truncated",
-			Message: fmt.Sprintf("The snapshot includes %d of %d matching evidence records because the request limit is %d.", len(evidence), *evidenceTotal, limit),
+			Message: fmt.Sprintf("The snapshot includes %d of %d matching evidence records because the request limit is %d.", len(evidence), *evidenceTotal, scope.Limit),
 		})
 	}
-	var graph *ports.EntityNeighborhood
-	if len(finding.ResourceURNs) > 0 {
+	graph := workspaceGraph
+	if graph == nil && len(finding.ResourceURNs) > 0 {
 		if graphStore := a.deps.GraphReads.Neighborhoods; graphStore != nil {
 			var graphErr error
-			graph, graphErr = graphStore.GetEntityNeighborhood(r.Context(), finding.ResourceURNs[0], int(limit))
+			graph, graphErr = graphStore.GetEntityNeighborhood(r.Context(), finding.ResourceURNs[0], int(scope.Limit))
 			if graphErr != nil {
 				graph = nil
 			}

--- a/internal/bootstrap/grc_inventory.go
+++ b/internal/bootstrap/grc_inventory.go
@@ -160,7 +160,7 @@ func (a *App) handleGRCInventoryCategories(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	categories, err := a.graphQueryService().ListInventoryCategories(r.Context(), graphquery.InventoryCategoryRequest{
-		TenantID: scope.TenantID, SourceID: scope.SourceID,
+		TenantID: scope.TenantID, ApplicationWorkspaceID: scope.ApplicationWorkspaceID, SourceID: scope.SourceID,
 		Surface: strings.TrimSpace(r.URL.Query().Get("surface")),
 		Limit:   scope.Limit,
 	})
@@ -178,7 +178,7 @@ func (a *App) handleGRCInventoryAssets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	assets, err := a.graphQueryService().ListInventoryAssets(r.Context(), graphquery.InventoryAssetRequest{
-		TenantID: scope.TenantID, SourceID: scope.SourceID,
+		TenantID: scope.TenantID, ApplicationWorkspaceID: scope.ApplicationWorkspaceID, SourceID: scope.SourceID,
 		Surface:    strings.TrimSpace(r.URL.Query().Get("surface")),
 		CategoryID: strings.TrimSpace(r.URL.Query().Get("category_id")),
 		EntityType: strings.TrimSpace(r.URL.Query().Get("entity_type")),
@@ -213,8 +213,9 @@ func (a *App) handleGRCInventoryAssetDetail(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	detail, err := a.graphQueryService().GetInventoryAsset(r.Context(), graphquery.InventoryAssetDetailRequest{
-		URN:   urn,
-		Limit: scope.Limit,
+		URN:                    urn,
+		ApplicationWorkspaceID: scope.ApplicationWorkspaceID,
+		Limit:                  scope.Limit,
 	})
 	if err != nil {
 		writeGRCError(w, err)
@@ -294,7 +295,7 @@ func (a *App) handleGRCResourceScope(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resources, err := a.graphQueryService().ListInventoryAssets(r.Context(), graphquery.InventoryAssetRequest{
-		TenantID: scope.TenantID, SourceID: sourceID,
+		TenantID: scope.TenantID, ApplicationWorkspaceID: scope.ApplicationWorkspaceID, SourceID: sourceID,
 		Surface:    strings.TrimSpace(r.URL.Query().Get("surface")),
 		CategoryID: strings.TrimSpace(r.URL.Query().Get("category_id")),
 		EntityType: strings.TrimSpace(r.URL.Query().Get("entity_type")),

--- a/internal/bootstrap/grc_policy_lifecycle.go
+++ b/internal/bootstrap/grc_policy_lifecycle.go
@@ -23,13 +23,7 @@ func (a *App) handleGRCPolicyLifecycle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ruleProfile := strings.TrimSpace(r.URL.Query().Get("rule_profile"))
-	response, err := grcpolicylifecycle.Build(r.Context(), store, grcpolicylifecycle.Scope{
-		TenantID:    scope.TenantID,
-		SourceID:    scope.SourceID,
-		RuntimeID:   scope.RuntimeID,
-		Limit:       scope.Limit,
-		RuleProfile: ruleProfile,
-	})
+	response, err := grcpolicylifecycle.Build(r.Context(), store, grcpolicylifecycle.Scope{TenantID: scope.TenantID, ApplicationWorkspaceID: scope.ApplicationWorkspaceID, SourceID: scope.SourceID, RuntimeID: scope.RuntimeID, Limit: scope.Limit, RuleProfile: ruleProfile})
 	if err != nil {
 		writeGRCError(w, err)
 		return
@@ -105,13 +99,7 @@ func (a *App) handleGRCPolicyLifecycleExport(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	ruleProfile := strings.TrimSpace(r.URL.Query().Get("rule_profile"))
-	response, err := grcpolicylifecycle.Build(r.Context(), store, grcpolicylifecycle.Scope{
-		TenantID:    scope.TenantID,
-		SourceID:    scope.SourceID,
-		RuntimeID:   scope.RuntimeID,
-		Limit:       grcExportLimit,
-		RuleProfile: ruleProfile,
-	})
+	response, err := grcpolicylifecycle.Build(r.Context(), store, grcpolicylifecycle.Scope{TenantID: scope.TenantID, ApplicationWorkspaceID: scope.ApplicationWorkspaceID, SourceID: scope.SourceID, RuntimeID: scope.RuntimeID, Limit: grcExportLimit, RuleProfile: ruleProfile})
 	if err != nil {
 		writeGRCError(w, err)
 		return

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -1782,6 +1782,58 @@ func TestGRCAuditPacketNormalizesForeignFindingLookup(t *testing.T) {
 	}
 }
 
+func TestGRCAuditPreviewApplicationWorkspaceIsolation(t *testing.T) {
+	const (
+		tenantID   = "tenant-a"
+		runtimeID  = "runtime-a"
+		workspaceA = "workspace-a"
+		resourceA  = "urn:cerebro:tenant-a:asset:a"
+		resourceB  = "urn:cerebro:tenant-a:asset:b"
+	)
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			runtimeID: {Id: runtimeID, TenantId: tenantID, SourceId: "source-a"},
+		},
+		findings: map[string]*ports.FindingRecord{
+			"finding-a": {ID: "finding-a", TenantID: tenantID, RuntimeID: runtimeID, Title: "Finding A", Status: "open", ResourceURNs: []string{resourceA}},
+			"finding-b": {ID: "finding-b", TenantID: tenantID, RuntimeID: runtimeID, Title: "Finding B", Status: "open", ResourceURNs: []string{resourceB}},
+		},
+	}
+	graph := &stubGraphStore{cypherRows: [][]ports.CypherRow{
+		{{Values: map[string]any{"urn": resourceA, "tenant_id": tenantID, "application_workspace_id": workspaceA, "runtime_id": runtimeID, "source_id": "source-a", "entity_type": "asset", "label": "Asset A", "attributes_json": `{}`}}},
+		{{Values: map[string]any{"urn": resourceB, "tenant_id": tenantID, "application_workspace_id": "workspace-b", "runtime_id": runtimeID, "source_id": "source-a", "entity_type": "asset", "label": "Asset B", "attributes_json": `{}`}}},
+	}}
+	app := New(config.Config{}, Dependencies{StateStore: store, GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph)}, nil)
+	request := func(findingID string) *http.Request {
+		r := httptest.NewRequest(http.MethodGet, "/grc/findings/"+findingID+"/audit-preview?tenant_id="+tenantID+"&workspace_id="+workspaceA, nil)
+		return r.WithContext(context.WithValue(r.Context(), authContextKey{}, authContext{principal: authPrincipal{
+			TenantID: tenantID,
+			ApplicationWorkspaceGrants: []config.ApplicationWorkspaceGrant{{
+				TenantID: tenantID, ApplicationWorkspaceIDs: []string{workspaceA},
+			}},
+		}}))
+	}
+
+	preview, err := app.buildGRCAuditPreview(request("finding-a"), "finding-a")
+	if err != nil {
+		t.Fatalf("buildGRCAuditPreview(workspace-a) error = %v", err)
+	}
+	if preview.Graph == nil || preview.Graph.Root == nil || preview.Graph.Root.URN != resourceA || len(preview.Graph.Neighbors) != 0 {
+		t.Fatalf("workspace preview graph = %#v, want an isolated root-only graph", preview.Graph)
+	}
+	if graph.neighborhoodRootURN != "" {
+		t.Fatalf("workspace preview traversed unscoped neighborhood root %q", graph.neighborhoodRootURN)
+	}
+	if len(graph.entityRequests) != 1 || graph.entityRequests[0].Filter.ApplicationWorkspaceID != workspaceA {
+		t.Fatalf("workspace catalog requests = %#v, want workspace-a", graph.entityRequests)
+	}
+
+	_, err = app.buildGRCAuditPreview(request("finding-b"), "finding-b")
+	if !errors.Is(err, ports.ErrFindingNotFound) {
+		t.Fatalf("buildGRCAuditPreview(workspace-a, finding-b) error = %v, want finding not found", err)
+	}
+}
+
 func TestGRCAuditPacketNormalizesForeignReceiptLookup(t *testing.T) {
 	store := &stubRuntimeStore{grcAuditPackets: map[string]*ports.GRCAuditPacketReceipt{
 		"packet-other": {ID: "packet-other", TenantID: "other", FindingID: "finding-other", Digest: "sha256:unused", Payload: []byte(`{}`), CreatedAt: time.Now()},

--- a/internal/bootstrap/grc_vendor.go
+++ b/internal/bootstrap/grc_vendor.go
@@ -57,7 +57,7 @@ func (a *App) handleGRCVendors(w http.ResponseWriter, r *http.Request) {
 	}
 	runtimeIDs := grcvendor.ResolvedRuntimeIDs(scope.RuntimeID, scope.RuntimeIDs)
 	page, err := a.deps.GraphReads.VendorRegister.ListVendorRegister(r.Context(), ports.VendorRegisterFilter{
-		TenantID: scope.TenantID, SourceID: scope.SourceID, RuntimeIDs: runtimeIDs,
+		TenantID: scope.TenantID, ApplicationWorkspaceID: scope.ApplicationWorkspaceID, SourceID: scope.SourceID, RuntimeIDs: runtimeIDs,
 		Query: strings.TrimSpace(r.URL.Query().Get("q")), RiskLevel: strings.TrimSpace(r.URL.Query().Get("risk_level")), ReviewState: strings.TrimSpace(r.URL.Query().Get("review_state")), OwnerState: strings.TrimSpace(r.URL.Query().Get("owner_state")), LifecycleState: strings.TrimSpace(r.URL.Query().Get("lifecycle_state")), QueueOnly: queueOnly, Limit: int(scope.Limit),
 	})
 	if err != nil {
@@ -115,12 +115,13 @@ func (a *App) grcVendorDetailResponse(r *http.Request) (grcVendorDetailResponse,
 		return grcVendorDetailResponse{}, err
 	}
 	detail, err := grcvendor.NewWithCapabilities(a.deps.GraphReads.Catalog, a.deps.GraphReads.Neighborhoods).GetVendor(r.Context(), grcvendor.VendorDetailRequest{
-		URN:        registerRow.URN,
-		TenantID:   scope.TenantID,
-		RuntimeID:  scope.RuntimeID,
-		RuntimeIDs: scope.RuntimeIDs,
-		SourceID:   scope.SourceID,
-		Limit:      scope.Limit,
+		URN:                    registerRow.URN,
+		TenantID:               scope.TenantID,
+		ApplicationWorkspaceID: scope.ApplicationWorkspaceID,
+		RuntimeID:              scope.RuntimeID,
+		RuntimeIDs:             scope.RuntimeIDs,
+		SourceID:               scope.SourceID,
+		Limit:                  scope.Limit,
 	})
 	if err != nil {
 		return grcVendorDetailResponse{}, err
@@ -183,7 +184,7 @@ func (a *App) grcVendorRegisterDetail(r *http.Request, scope grcScope, urn strin
 		query = strings.TrimSpace(vendorID)
 	}
 	page, err := a.deps.GraphReads.VendorRegister.ListVendorRegister(r.Context(), ports.VendorRegisterFilter{
-		TenantID: scope.TenantID, SourceID: scope.SourceID, RuntimeIDs: runtimeIDs, Query: query, Limit: int(scope.Limit),
+		TenantID: scope.TenantID, ApplicationWorkspaceID: scope.ApplicationWorkspaceID, SourceID: scope.SourceID, RuntimeIDs: runtimeIDs, Query: query, Limit: int(scope.Limit),
 	})
 	if err != nil {
 		return ports.VendorRegisterRow{}, nil, err

--- a/internal/graphquery/inventory.go
+++ b/internal/graphquery/inventory.go
@@ -16,25 +16,28 @@ const (
 )
 
 type InventoryCategoryRequest struct {
-	TenantID string
-	SourceID string
-	Surface  string
-	Limit    uint32
+	TenantID               string
+	ApplicationWorkspaceID string
+	SourceID               string
+	Surface                string
+	Limit                  uint32
 }
 
 type InventoryAssetRequest struct {
-	TenantID   string
-	SourceID   string
-	Surface    string
-	CategoryID string
-	EntityType string
-	Query      string
-	Limit      uint32
+	TenantID               string
+	ApplicationWorkspaceID string
+	SourceID               string
+	Surface                string
+	CategoryID             string
+	EntityType             string
+	Query                  string
+	Limit                  uint32
 }
 
 type InventoryAssetDetailRequest struct {
-	URN   string
-	Limit uint32
+	URN                    string
+	ApplicationWorkspaceID string
+	Limit                  uint32
 }
 
 type InventoryCategory struct {
@@ -112,7 +115,7 @@ func (s *Service) ListInventoryCategories(ctx context.Context, request Inventory
 	if tenantID == "" {
 		return nil, fmt.Errorf("%w: tenant_id is required", ErrInvalidRequest)
 	}
-	filter := inventoryCatalogFilter(tenantID, request.SourceID, request.Surface)
+	filter := inventoryCatalogFilter(tenantID, request.ApplicationWorkspaceID, request.SourceID, request.Surface)
 	page, err := s.catalog.CountEntityKinds(ctx, ports.EntityKindCountRequest{Filter: filter, Limit: maxInventoryLimit})
 	if err != nil {
 		return nil, err
@@ -169,7 +172,7 @@ func (s *Service) ListInventoryAssets(ctx context.Context, request InventoryAsse
 	if tenantID == "" {
 		return nil, fmt.Errorf("%w: tenant_id is required", ErrInvalidRequest)
 	}
-	filter := inventoryCatalogFilter(tenantID, request.SourceID, request.Surface)
+	filter := inventoryCatalogFilter(tenantID, request.ApplicationWorkspaceID, request.SourceID, request.Surface)
 	filter.Query = strings.TrimSpace(request.Query)
 	if len(entityTypes) > 0 {
 		filter.IncludeKinds = entityTypes
@@ -204,7 +207,7 @@ func (s *Service) GetInventoryAsset(ctx context.Context, request InventoryAssetD
 		return nil, err
 	}
 	tenantID := cerebrourn.TenantID(urn)
-	page, err := s.catalog.ListEntities(ctx, ports.EntityCatalogPageRequest{Filter: ports.EntityCatalogFilter{TenantID: tenantID, ExactAgentKey: urn}, Limit: 1})
+	page, err := s.catalog.ListEntities(ctx, ports.EntityCatalogPageRequest{Filter: ports.EntityCatalogFilter{TenantID: tenantID, ApplicationWorkspaceID: strings.TrimSpace(request.ApplicationWorkspaceID), ExactAgentKey: urn}, Limit: 1})
 	if err != nil {
 		return nil, err
 	}
@@ -213,6 +216,20 @@ func (s *Service) GetInventoryAsset(ctx context.Context, request InventoryAssetD
 	}
 	if len(page.Entities) == 0 {
 		return nil, ports.ErrGraphEntityNotFound
+	}
+	if strings.TrimSpace(request.ApplicationWorkspaceID) != "" {
+		entity := page.Entities[0]
+		return &InventoryAssetDetail{
+			Asset: inventoryAssetFromCatalog(entity),
+			Graph: &ports.EntityNeighborhood{
+				Root:      &ports.NeighborhoodNode{URN: entity.URN, EntityType: entity.EntityType, Label: entity.Label},
+				Neighbors: []*ports.NeighborhoodNode{},
+				Relations: []*ports.NeighborhoodRelation{},
+			},
+			Generated: map[string]InventorySignal{
+				"neighborhood": {Count: 0, State: "workspace_root_only"},
+			},
+		}, nil
 	}
 	limit := normalizeInventoryLimit(request.Limit)
 	if limit > maxNeighborhoodLimit {
@@ -248,8 +265,8 @@ func inventoryAssetFromCatalog(entity ports.CatalogEntity) InventoryAsset {
 	return InventoryAsset{URN: entity.URN, EntityType: entity.EntityType, Surface: InventorySurfaceForEntityType(entity.EntityType), Label: firstInventoryString(entity.Label, entity.URN), SourceID: entity.SourceID, RuntimeID: entity.RuntimeID, RiskScore: score, RiskLevel: inventoryRiskLevel(score), RiskReasons: reasons, ScopeState: "in_scope", Attributes: attrs}
 }
 
-func inventoryCatalogFilter(tenantID, sourceID, surface string) ports.EntityCatalogFilter {
-	filter := ports.EntityCatalogFilter{TenantID: tenantID, SourceID: strings.TrimSpace(sourceID), ExcludeKinds: excludedInventoryEntityTypes(), QueryAttributes: true}
+func inventoryCatalogFilter(tenantID, applicationWorkspaceID, sourceID, surface string) ports.EntityCatalogFilter {
+	filter := ports.EntityCatalogFilter{TenantID: tenantID, ApplicationWorkspaceID: strings.TrimSpace(applicationWorkspaceID), SourceID: strings.TrimSpace(sourceID), ExcludeKinds: excludedInventoryEntityTypes(), QueryAttributes: true}
 	normalized := NormalizeInventorySurface(surface)
 	if normalized == InventorySurfaceAll {
 		return filter

--- a/internal/graphquery/inventory_test.go
+++ b/internal/graphquery/inventory_test.go
@@ -1,9 +1,88 @@
 package graphquery
 
 import (
+	"context"
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
 )
+
+type recordingInventoryCatalog struct {
+	entities []struct {
+		workspaceID string
+		entity      ports.CatalogEntity
+	}
+	entityRequests []ports.EntityCatalogPageRequest
+}
+
+func (s *recordingInventoryCatalog) ListEntities(_ context.Context, request ports.EntityCatalogPageRequest) (*ports.EntityCatalogPage, error) {
+	s.entityRequests = append(s.entityRequests, request)
+	page := &ports.EntityCatalogPage{TenantID: request.Filter.TenantID}
+	for _, candidate := range s.entities {
+		if request.Filter.ApplicationWorkspaceID != "" && candidate.workspaceID != request.Filter.ApplicationWorkspaceID {
+			continue
+		}
+		if request.Filter.ExactAgentKey != "" && candidate.entity.URN != request.Filter.ExactAgentKey {
+			continue
+		}
+		page.Entities = append(page.Entities, candidate.entity)
+	}
+	return page, nil
+}
+
+func (s *recordingInventoryCatalog) CountEntityKinds(_ context.Context, request ports.EntityKindCountRequest) (*ports.EntityKindCountPage, error) {
+	counts := map[string]uint64{}
+	for _, candidate := range s.entities {
+		if request.Filter.ApplicationWorkspaceID == "" || candidate.workspaceID == request.Filter.ApplicationWorkspaceID {
+			counts[candidate.entity.EntityType]++
+		}
+	}
+	page := &ports.EntityKindCountPage{TenantID: request.Filter.TenantID}
+	for kind, count := range counts {
+		page.Counts = append(page.Counts, ports.EntityKindCount{EntityKind: kind, Count: count})
+	}
+	return page, nil
+}
+
+func (s *recordingInventoryCatalog) ListEntityRelations(context.Context, ports.EntityRelationPageRequest) (*ports.EntityRelationPage, error) {
+	return &ports.EntityRelationPage{TenantID: "tenant-a"}, nil
+}
+
+func TestInventoryReadsIsolateApplicationWorkspacesAndPreserveTenantWideDefault(t *testing.T) {
+	store := &recordingInventoryCatalog{entities: []struct {
+		workspaceID string
+		entity      ports.CatalogEntity
+	}{
+		{workspaceID: "workspace-a", entity: ports.CatalogEntity{URN: "urn:cerebro:tenant-a:asset:a", TenantID: "tenant-a", EntityType: "asset", Label: "Asset A"}},
+		{workspaceID: "workspace-b", entity: ports.CatalogEntity{URN: "urn:cerebro:tenant-a:asset:b", TenantID: "tenant-a", EntityType: "asset", Label: "Asset B"}},
+	}}
+	service := NewWithCapabilities(nil, nil, store, nil)
+
+	assetsA, err := service.ListInventoryAssets(context.Background(), InventoryAssetRequest{TenantID: "tenant-a", ApplicationWorkspaceID: " workspace-a ", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListInventoryAssets(workspace-a) error = %v", err)
+	}
+	assetsB, err := service.ListInventoryAssets(context.Background(), InventoryAssetRequest{TenantID: "tenant-a", ApplicationWorkspaceID: "workspace-b", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListInventoryAssets(workspace-b) error = %v", err)
+	}
+	allAssets, err := service.ListInventoryAssets(context.Background(), InventoryAssetRequest{TenantID: "tenant-a", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListInventoryAssets(tenant-wide) error = %v", err)
+	}
+	if len(assetsA) != 1 || !strings.HasSuffix(assetsA[0].URN, ":a") || len(assetsB) != 1 || !strings.HasSuffix(assetsB[0].URN, ":b") || len(allAssets) != 2 {
+		t.Fatalf("workspace assets = A:%#v B:%#v all:%#v", assetsA, assetsB, allAssets)
+	}
+	if _, err := service.GetInventoryAsset(context.Background(), InventoryAssetDetailRequest{URN: "urn:cerebro:tenant-a:asset:b", ApplicationWorkspaceID: "workspace-a", Limit: 10}); !errors.Is(err, ports.ErrGraphEntityNotFound) {
+		t.Fatalf("GetInventoryAsset(workspace-a, asset-b) error = %v, want graph entity not found", err)
+	}
+	if got := store.entityRequests[0].Filter.ApplicationWorkspaceID; got != "workspace-a" {
+		t.Fatalf("first recorded filter workspace = %q, want workspace-a", got)
+	}
+}
 
 func TestInventoryEntityTypesForFilterUsesSynthesizedCategoryID(t *testing.T) {
 	got := inventoryEntityTypesForFilter("aws-lambda-function", "")

--- a/internal/graphquery/workspace.go
+++ b/internal/graphquery/workspace.go
@@ -1,0 +1,78 @@
+package graphquery
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type WorkspaceResourceRequest struct {
+	TenantID               string
+	ResourceTenantID       string
+	ApplicationWorkspaceID string
+	URNs                   []string
+}
+
+func (s *Service) QualifyWorkspaceResources(ctx context.Context, request WorkspaceResourceRequest) (*ports.EntityNeighborhood, error) {
+	if s == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	tenantID := strings.TrimSpace(request.TenantID)
+	resourceTenantID := strings.TrimSpace(request.ResourceTenantID)
+	if tenantID != "" && resourceTenantID != "" && tenantID != resourceTenantID {
+		return nil, ports.ErrGraphEntityNotFound
+	}
+	if resourceTenantID != "" {
+		tenantID = resourceTenantID
+	}
+	workspaceID := strings.TrimSpace(request.ApplicationWorkspaceID)
+	if tenantID != "" && workspaceID == "" {
+		return nil, nil
+	}
+	if s.catalog == nil {
+		return nil, ErrRuntimeUnavailable
+	}
+	urns := uniqueWorkspaceURNs(request.URNs)
+	if tenantID == "" || workspaceID == "" || len(urns) == 0 {
+		return nil, fmt.Errorf("%w: tenant_id, workspace_id, and resource urns are required", ErrInvalidRequest)
+	}
+	var root *ports.NeighborhoodNode
+	for _, urn := range urns {
+		page, err := s.catalog.ListEntities(ctx, ports.EntityCatalogPageRequest{Filter: ports.EntityCatalogFilter{
+			TenantID: tenantID, ApplicationWorkspaceID: workspaceID, ExactAgentKey: urn,
+		}, Limit: 1})
+		if err != nil {
+			return nil, err
+		}
+		if page == nil || page.TenantID != tenantID || page.Truncated {
+			return nil, ErrRuntimeUnavailable
+		}
+		if len(page.Entities) != 1 || page.Entities[0].URN != urn || page.Entities[0].TenantID != tenantID {
+			return nil, ports.ErrGraphEntityNotFound
+		}
+		if root == nil {
+			entity := page.Entities[0]
+			root = &ports.NeighborhoodNode{URN: entity.URN, EntityType: entity.EntityType, Label: entity.Label}
+		}
+	}
+	return &ports.EntityNeighborhood{Root: root, Neighbors: []*ports.NeighborhoodNode{}, Relations: []*ports.NeighborhoodRelation{}}, nil
+}
+
+func uniqueWorkspaceURNs(values []string) []string {
+	unique := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
+	}
+	return unique
+}

--- a/internal/grcpolicylifecycle/lifecycle.go
+++ b/internal/grcpolicylifecycle/lifecycle.go
@@ -18,11 +18,12 @@ const (
 )
 
 type Scope struct {
-	TenantID    string
-	SourceID    string
-	RuntimeID   string
-	Limit       uint32
-	RuleProfile string
+	TenantID               string
+	ApplicationWorkspaceID string
+	SourceID               string
+	RuntimeID              string
+	Limit                  uint32
+	RuleProfile            string
 }
 
 var grcPolicyLifecycleEntityTypes = []string{
@@ -100,6 +101,7 @@ CALL {
   WITH entity_type
   MATCH (e:Entity)
   WHERE ($tenant_id = '' OR e.tenant_id = $tenant_id)
+    AND ($application_workspace_id = '' OR coalesce(e.application_workspace_id, '') = $application_workspace_id)
     AND ($source_id = '' OR e.source_id = $source_id)
     AND ($runtime_id = '' OR coalesce(e.runtime_id, '') = $runtime_id)
     AND e.entity_type = entity_type
@@ -133,6 +135,8 @@ CALL {
 WITH DISTINCT left, r, right
 WHERE ($tenant_id = '' OR left.tenant_id = $tenant_id)
   AND ($tenant_id = '' OR right.tenant_id = $tenant_id)
+  AND ($application_workspace_id = '' OR coalesce(left.application_workspace_id, '') = $application_workspace_id)
+  AND ($application_workspace_id = '' OR coalesce(right.application_workspace_id, '') = $application_workspace_id)
   AND (
     $source_id = '' OR
     (left.entity_type IN $entity_types AND left.source_id = $source_id) OR
@@ -715,6 +719,7 @@ func Build(ctx context.Context, store ports.RawCypherQueryStore, scope Scope) (R
 		Query: grcPolicyLifecycleEntitiesQuery,
 		Params: map[string]any{
 			"tenant_id":                   scope.TenantID,
+			"application_workspace_id":    scope.ApplicationWorkspaceID,
 			"source_id":                   scope.SourceID,
 			"runtime_id":                  scope.RuntimeID,
 			"entity_types":                grcPolicyLifecycleEntityTypes,
@@ -740,6 +745,7 @@ func Build(ctx context.Context, store ports.RawCypherQueryStore, scope Scope) (R
 		Params: map[string]any{
 			"entity_urns":                 entityURNs,
 			"tenant_id":                   scope.TenantID,
+			"application_workspace_id":    scope.ApplicationWorkspaceID,
 			"source_id":                   scope.SourceID,
 			"runtime_id":                  scope.RuntimeID,
 			"entity_types":                grcPolicyLifecycleEntityTypes,

--- a/internal/grcpolicylifecycle/lifecycle_test.go
+++ b/internal/grcpolicylifecycle/lifecycle_test.go
@@ -26,10 +26,11 @@ func TestBuildAppliesEntityLimitPerLifecycleType(t *testing.T) {
 		policyLifecycleTestRow("urn:cerebro:writer:policy:access", "policy", "Access policy", nil),
 	}}}
 	_, err := Build(context.Background(), store, Scope{
-		TenantID:  "writer",
-		SourceID:  "grc",
-		RuntimeID: "rt-1",
-		Limit:     25,
+		TenantID:               "writer",
+		ApplicationWorkspaceID: "workspace-a",
+		SourceID:               "grc",
+		RuntimeID:              "rt-1",
+		Limit:                  25,
 	})
 	if err != nil {
 		t.Fatalf("Build error = %v", err)
@@ -40,6 +41,9 @@ func TestBuildAppliesEntityLimitPerLifecycleType(t *testing.T) {
 	entityRequest := store.requests[0]
 	if entityRequest.Params["type_limit"] != 25 {
 		t.Fatalf("entity params = %#v, want per-type limit", entityRequest.Params)
+	}
+	if entityRequest.Params["application_workspace_id"] != "workspace-a" || !strings.Contains(entityRequest.Query, "e.application_workspace_id") {
+		t.Fatalf("entity request = %#v, want workspace-a closed filter", entityRequest)
 	}
 	wantRowLimit := 25 * len(grcPolicyLifecycleEntityTypes)
 	if entityRequest.RowLimit != wantRowLimit {
@@ -93,6 +97,11 @@ func TestBuildAppliesEntityLimitPerLifecycleType(t *testing.T) {
 	}
 	if relationRequest.Params["risk_scenario_attr_fragment"] != grcPolicyLifecycleRiskScenarioAttrFragment {
 		t.Fatalf("relation params = %#v, want risk scenario filter", relationRequest.Params)
+	}
+	if relationRequest.Params["application_workspace_id"] != "workspace-a" ||
+		!strings.Contains(relationRequest.Query, "left.application_workspace_id") ||
+		!strings.Contains(relationRequest.Query, "right.application_workspace_id") {
+		t.Fatalf("relation request = %#v, want both endpoints closed to workspace-a", relationRequest)
 	}
 	anchorTypes, ok := relationRequest.Params["policy_anchor_entity_types"].([]string)
 	if !ok || !stringSliceContains(anchorTypes, "policy.version") {

--- a/internal/grcvendor/service.go
+++ b/internal/grcvendor/service.go
@@ -88,13 +88,14 @@ type ListVendorsRequest struct {
 }
 
 type VendorDetailRequest struct {
-	URN        string
-	VendorID   string
-	TenantID   string
-	RuntimeID  string
-	RuntimeIDs []string
-	SourceID   string
-	Limit      uint32
+	URN                    string
+	VendorID               string
+	TenantID               string
+	ApplicationWorkspaceID string
+	RuntimeID              string
+	RuntimeIDs             []string
+	SourceID               string
+	Limit                  uint32
 }
 
 type ListDiscoveriesRequest struct {
@@ -666,6 +667,7 @@ func (s *Service) GetVendor(ctx context.Context, request VendorDetailRequest) (*
 	} else {
 		filter.Query = vendorID
 	}
+	filter.ApplicationWorkspaceID = strings.TrimSpace(request.ApplicationWorkspaceID)
 	filter.RelationCounts = &ports.EntityRelationCountFilter{Directions: []ports.EntityRelationDirection{ports.EntityRelationIncoming}, Relations: []string{"associated_with"}, NeighborKinds: []string{"contract", "security.review", "security.questionnaire", "assurance.document"}}
 	entityLimit := 2
 	if vendorID != "" {
@@ -699,6 +701,19 @@ func (s *Service) GetVendor(ctx context.Context, request VendorDetailRequest) (*
 		return nil, ports.ErrGraphEntityNotFound
 	}
 	urn = vendor.URN
+	if filter.ApplicationWorkspaceID != "" {
+		relationships := VendorRelationships{}
+		return &VendorDetail{
+			Vendor:        vendor,
+			Relationships: relationships,
+			Packet:        BuildVendorPacket(vendor, relationships),
+			Graph: &ports.EntityNeighborhood{
+				Root:      &ports.NeighborhoodNode{URN: vendor.URN, EntityType: "vendor", Label: vendor.Name},
+				Neighbors: []*ports.NeighborhoodNode{},
+				Relations: []*ports.NeighborhoodRelation{},
+			},
+		}, nil
+	}
 	limit := normalizeRelatedLimit(request.Limit)
 	relationPage, err := store.ListEntityRelations(ctx, ports.EntityRelationPageRequest{TenantID: tenantID, AgentKey: urn, Directions: []ports.EntityRelationDirection{ports.EntityRelationIncoming, ports.EntityRelationOutgoing}, Relations: []string{"associated_with", "owned_by", "has_identifier", "has_contact", "uses_subprocessor", "depends_on"}, NeighborKinds: vendorRelatedKinds(), Limit: limit})
 	if err != nil {

--- a/internal/grcvendor/service_test.go
+++ b/internal/grcvendor/service_test.go
@@ -40,7 +40,7 @@ func (s *stubGraphStore) ListEntities(_ context.Context, request ports.EntityCat
 	if s.err != nil {
 		return nil, s.err
 	}
-	s.requests = append(s.requests, ports.CypherQueryRequest{Params: map[string]any{"tenant_id": request.Filter.TenantID, "limit": request.Limit}})
+	s.requests = append(s.requests, ports.CypherQueryRequest{Params: map[string]any{"tenant_id": request.Filter.TenantID, "application_workspace_id": request.Filter.ApplicationWorkspaceID, "limit": request.Limit}})
 	page := &ports.EntityCatalogPage{TenantID: request.Filter.TenantID, GraphRevision: s.graphRevision}
 	if len(s.rows) == 0 {
 		return page, nil
@@ -479,6 +479,23 @@ func TestGetVendorReturnsRelationshipsAndGraph(t *testing.T) {
 	}
 	if store.rootURN != urn || store.limit != relatedLimit {
 		t.Fatalf("neighborhood request = %q/%d, want %q/%d", store.rootURN, store.limit, urn, relatedLimit)
+	}
+}
+
+func TestGetVendorWorkspaceScopeDoesNotTraverseUnscopedRelationships(t *testing.T) {
+	urn := "urn:cerebro:writer:vendor:vrm:acme"
+	store := &stubGraphStore{rows: [][]ports.CypherRow{{vendorRow(urn, "Acme", `{"vendor_id":"acme"}`, 0, 0, 0, 0)}}}
+	detail, err := New(store).GetVendor(context.Background(), VendorDetailRequest{
+		URN: urn, TenantID: "writer", ApplicationWorkspaceID: "workspace-a", Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("GetVendor(workspace-a) error = %v", err)
+	}
+	if store.requests[0].Params["application_workspace_id"] != "workspace-a" {
+		t.Fatalf("catalog request params = %#v, want workspace-a", store.requests[0].Params)
+	}
+	if store.rootURN != "" || detail.Graph == nil || detail.Graph.Root == nil || len(detail.Graph.Neighbors) != 0 || len(detail.Graph.Relations) != 0 {
+		t.Fatalf("workspace detail graph = %#v root traversal = %q, want root-only graph", detail.Graph, store.rootURN)
 	}
 }
 


### PR DESCRIPTION
## Summary

- forward tenant-qualified application workspace selectors through inventory, vendor, and policy lifecycle reads
- qualify audit-preview resources through the workspace-scoped catalog before returning finding evidence
- keep workspace-scoped detail graphs root-only until relationship reads have an equivalent workspace filter

## Validation

- `go test ./internal/graphquery ./internal/grcvendor ./internal/grcpolicylifecycle ./internal/bootstrap -count=1`
- `make lint-bootstrap`
- `make check-structural check-structural-test check-arch`
