### PR TITLE
fix(web): probe configured Rust runtime health

### DIFF
--- a/apps/web/src/components/StatusPanel.test.tsx
+++ b/apps/web/src/components/StatusPanel.test.tsx
@@ -76,6 +76,8 @@ describe("StatusPanel cache behavior", () => {
     const probes = statusProbes({ tenantID: "tenant-a", workspaceID: "workspace-a" });
     expect(probes.find((probe) => probe.key === "healthz")?.path).toBe("/api/cerebro/healthz");
     expect(probes.find((probe) => probe.key === "health")?.path).toBe("/api/cerebro/health");
+    expect(probes.find((probe) => probe.key === "source-runtime")?.path)
+      .toBe("/api/cerebro/v1/source-runtimes/health?limit=1&tenant_id=tenant-a&workspace_id=workspace-a");
     expect(probes.find((probe) => probe.key === "inventory")?.path)
       .toBe("/api/cerebro/grc/inventory/categories?limit=1&tenant_id=tenant-a&workspace_id=workspace-a");
     expect(probes.find((probe) => probe.key === "vendors")?.path)

--- a/apps/web/src/components/StatusPanel.tsx
+++ b/apps/web/src/components/StatusPanel.tsx
@@ -33,7 +33,7 @@ const PRODUCT_READ_TIMEOUT_MS = 5000;
 export const statusProbes = (scope: GRCScope) => [
   { key: "healthz", label: "API liveness", path: "/api/cerebro/healthz", timeoutMs: LIVENESS_TIMEOUT_MS },
   { key: "health", label: "API readiness", path: "/api/cerebro/health", timeoutMs: GRC_QUERY_TIMEOUT_MS },
-  { key: "actions", label: "Action authority", path: withGRCScope("/api/cerebro/v1/actions?limit=1", scope), timeoutMs: PRODUCT_READ_TIMEOUT_MS },
+  { key: "source-runtime", label: "Rust source runtime", path: withGRCScope("/api/cerebro/v1/source-runtimes/health?limit=1", scope), timeoutMs: PRODUCT_READ_TIMEOUT_MS },
   { key: "inventory", label: "Inventory", path: withGRCScope("/api/cerebro/grc/inventory/categories?limit=1", scope), timeoutMs: PRODUCT_READ_TIMEOUT_MS },
   { key: "vendors", label: "Vendor register", path: withGRCScope("/api/cerebro/grc/vendors?limit=1", scope), timeoutMs: PRODUCT_READ_TIMEOUT_MS },
   { key: "policies", label: "Policy lifecycle", path: withGRCScope("/api/cerebro/grc/policy-lifecycle?rule_profile=baseline&limit=1", scope), timeoutMs: PRODUCT_READ_TIMEOUT_MS },

--- a/apps/web/src/lib/ui-contract.test.ts
+++ b/apps/web/src/lib/ui-contract.test.ts
@@ -100,7 +100,8 @@ describe("product UI contract", () => {
     expect(statusSource).toContain("Runtime Health");
     expect(statusSource).toContain("API liveness");
     expect(statusSource).toContain("API readiness");
-    expect(statusSource).toContain("Action authority");
+    expect(statusSource).toContain("Rust source runtime");
+    expect(statusSource).not.toContain('withGRCScope("/api/cerebro/v1/actions?limit=1"');
     expect(statusSource).toContain("Inventory");
     expect(statusSource).toContain("Vendor register");
     expect(statusSource).toContain("Policy lifecycle");


### PR DESCRIPTION
## What changed

- replace the unavailable Action authority status probe with the configured Rust source-runtime health endpoint
- preserve tenant and workspace scope on the runtime probe
- add focused probe and UI contract coverage

## Why

The sec-dev deployment keeps Rust Action authority disabled, so `/v1/actions` is not a valid runtime-health probe there and returns 404. `/v1/source-runtimes/health` is the deployed, explicitly routed Rust health surface.

## Validation

- `npm --workspace apps/web exec -- vitest run src/components/StatusPanel.test.tsx src/lib/ui-contract.test.ts` (20 tests passed)
- `npm --workspace apps/web exec -- eslint src/components/StatusPanel.tsx src/components/StatusPanel.test.tsx src/lib/ui-contract.test.ts`
- `git diff --check`