### PR TITLE
Materialize trusted application workspace scope

### DIFF
--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -1458,6 +1458,8 @@ struct ProjectEventResponse {
 struct LegacyEntityDeltaRecord {
     urn: String,
     tenant_id: String,
+    #[serde(default)]
+    application_workspace_id: String,
     source_id: String,
     runtime_id: String,
     entity_type: String,
@@ -1470,6 +1472,8 @@ struct LegacyEntityDeltaRecord {
 #[serde(deny_unknown_fields)]
 struct LegacyLinkDeltaRecord {
     tenant_id: String,
+    #[serde(default)]
+    application_workspace_id: String,
     source_id: String,
     runtime_id: String,
     from_urn: String,
@@ -2553,6 +2557,7 @@ fn validate_legacy_projection(
     let expected_runtime = request.source_runtime_id.trim();
     for entity in &request.delta.entities {
         if entity.tenant_id.trim() != expected_tenant
+            || !valid_legacy_application_workspace_id(&entity.application_workspace_id)
             || entity.source_id.trim() != source_id
             || entity.runtime_id.trim() != expected_runtime
             || entity.urn.trim().is_empty()
@@ -2572,6 +2577,7 @@ fn validate_legacy_projection(
         .chain(request.delta.link_retractions.iter())
     {
         if link.tenant_id.trim() != expected_tenant
+            || !valid_legacy_application_workspace_id(&link.application_workspace_id)
             || link.source_id.trim() != source_id
             || link.runtime_id.trim() != expected_runtime
             || link.relation.trim().is_empty()
@@ -2611,6 +2617,15 @@ fn validate_legacy_projection(
         }
     }
     Ok(())
+}
+
+fn valid_legacy_application_workspace_id(value: &str) -> bool {
+    value.is_empty()
+        || (value.trim() == value
+            && value.len() <= 256
+            && value != "*"
+            && !value.contains(',')
+            && !value.chars().any(char::is_control))
 }
 
 fn legacy_urn_matches_tenant(tenant_id: &str, value: &str) -> bool {
@@ -5913,6 +5928,7 @@ mod tests {
                 entities: vec![LegacyEntityDeltaRecord {
                     urn: "urn:cerebro:tenant-demo:asset:one".to_owned(),
                     tenant_id: tenant_id.as_str().to_owned(),
+                    application_workspace_id: "workspace-a".to_owned(),
                     source_id: "box".to_owned(),
                     runtime_id: "box-runtime".to_owned(),
                     entity_type: "box.asset".to_owned(),

--- a/internal/graphstore/neo4j/store.go
+++ b/internal/graphstore/neo4j/store.go
@@ -40,12 +40,19 @@ const (
 )
 const mergeEntityAndLoadAttributesQuery = `MERGE (e:Entity {urn: $urn})
 ON CREATE SET e.attributes_json = '{}', e.attributes_version = 0
-SET e.tenant_id = $tenant_id,
+WITH e, coalesce(e.tenant_id, '') AS existing_tenant_id, coalesce(e.application_workspace_id, '') AS existing_workspace_id
+WITH e, existing_workspace_id,
+     (existing_tenant_id <> '' AND existing_tenant_id <> $tenant_id)
+       OR (existing_workspace_id <> '' AND existing_workspace_id <> $application_workspace_id) AS workspace_conflict
+FOREACH (_ IN CASE WHEN workspace_conflict THEN [] ELSE [1] END |
+  SET e.tenant_id = $tenant_id,
+    e.application_workspace_id = CASE WHEN $application_workspace_id <> '' THEN $application_workspace_id ELSE existing_workspace_id END,
     e.source_id = $source_id,
     e.runtime_id = CASE WHEN $runtime_id <> '' THEN $runtime_id ELSE coalesce(e.runtime_id, '') END,
     e.entity_type = $entity_type,
     e.label = CASE WHEN $label <> $urn THEN $label ELSE coalesce(e.label, $label) END
-RETURN coalesce(e.attributes_json, '{}'), coalesce(e.attributes_version, 0)`
+)
+RETURN coalesce(e.attributes_json, '{}'), coalesce(e.attributes_version, 0), workspace_conflict`
 
 var errConcurrentAttributeMerge = errors.New("concurrent attribute merge")
 var errProjectionAssertionMigrationScopeRequired = errors.New("tenant_id and relations are required for projected link assertion migration")
@@ -578,19 +585,23 @@ func (s *Store) UpsertProjectedEntity(ctx context.Context, entity *ports.Project
 		label = urn
 	}
 	params := map[string]any{
-		"urn":         urn,
-		"tenant_id":   tenantID,
-		"source_id":   sourceID,
-		"runtime_id":  strings.TrimSpace(entity.RuntimeID),
-		"entity_type": entityType,
-		"label":       label,
+		"urn":                      urn,
+		"tenant_id":                tenantID,
+		"application_workspace_id": strings.TrimSpace(entity.ApplicationWorkspaceID),
+		"source_id":                sourceID,
+		"runtime_id":               strings.TrimSpace(entity.RuntimeID),
+		"entity_type":              entityType,
+		"label":                    label,
 	}
 	incomingAttributes := projectionmeta.ApplyEntityMetadata(entityType, entity.Attributes)
 	for attempt := 0; attempt < maxAttributeMergeRetries; attempt++ {
 		_, err := s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
-			attributesJSON, version, err := mergeEntityAndLoadAttributes(ctx, tx, params)
+			attributesJSON, version, workspaceConflict, err := mergeEntityAndLoadAttributes(ctx, tx, params)
 			if err != nil {
 				return nil, fmt.Errorf("load projected entity %q attributes: %w", urn, err)
+			}
+			if workspaceConflict {
+				return nil, fmt.Errorf("%w: projected entity %q", ports.ErrApplicationWorkspaceConflict, urn)
 			}
 			existing, err := graphAttributesFromJSON(attributesJSON)
 			if err != nil {
@@ -634,13 +645,14 @@ func (s *Store) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLi
 		return err
 	}
 	params := map[string]any{
-		"from_urn":          fromURN,
-		"to_urn":            toURN,
-		"relation":          relation,
-		"tenant_id":         tenantID,
-		"source_id":         sourceID,
-		"runtime_id":        strings.TrimSpace(link.RuntimeID),
-		"reconciliation_id": projectedLinkReconciliationID(link.Attributes),
+		"from_urn":                 fromURN,
+		"to_urn":                   toURN,
+		"relation":                 relation,
+		"tenant_id":                tenantID,
+		"application_workspace_id": strings.TrimSpace(link.ApplicationWorkspaceID),
+		"source_id":                sourceID,
+		"runtime_id":               strings.TrimSpace(link.RuntimeID),
+		"reconciliation_id":        projectedLinkReconciliationID(link.Attributes),
 	}
 	for attempt := 0; attempt < maxAttributeMergeRetries; attempt++ {
 		_, err = s.write(ctx, func(tx neo4jdriver.ManagedTransaction) (any, error) {
@@ -650,6 +662,9 @@ func (s *Store) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLi
 			}
 			if !found {
 				return nil, nil
+			}
+			if current.workspaceConflict {
+				return nil, fmt.Errorf("%w: projected link %q %q %q", ports.ErrApplicationWorkspaceConflict, fromURN, relation, toURN)
 			}
 			existingLogical, err := graphAttributesFromJSON(current.logicalAttributesJSON)
 			if err != nil {
@@ -707,12 +722,19 @@ const defaultProjectionWriteConcurrency = 4
 const mergeProjectedEntitiesQuery = `UNWIND $rows AS row
 MERGE (e:Entity {urn: row.urn})
 ON CREATE SET e.attributes_json = '{}', e.attributes_version = 0
-SET e.tenant_id = row.tenant_id,
+WITH e, row, coalesce(e.tenant_id, '') AS existing_tenant_id, coalesce(e.application_workspace_id, '') AS existing_workspace_id
+WITH e, row, existing_workspace_id,
+     (existing_tenant_id <> '' AND existing_tenant_id <> row.tenant_id)
+       OR (existing_workspace_id <> '' AND existing_workspace_id <> row.application_workspace_id) AS workspace_conflict
+FOREACH (_ IN CASE WHEN workspace_conflict THEN [] ELSE [1] END |
+  SET e.tenant_id = row.tenant_id,
+    e.application_workspace_id = CASE WHEN row.application_workspace_id <> '' THEN row.application_workspace_id ELSE existing_workspace_id END,
     e.source_id = row.source_id,
     e.runtime_id = CASE WHEN row.runtime_id <> '' THEN row.runtime_id ELSE coalesce(e.runtime_id, '') END,
     e.entity_type = row.entity_type,
     e.label = CASE WHEN row.label <> row.urn THEN row.label ELSE coalesce(e.label, row.label) END
-RETURN row.urn AS urn, coalesce(e.attributes_json, '{}') AS attributes_json, coalesce(e.attributes_version, 0) AS attributes_version`
+)
+RETURN row.urn AS urn, workspace_conflict AS workspace_conflict, coalesce(e.attributes_json, '{}') AS attributes_json, coalesce(e.attributes_version, 0) AS attributes_version`
 
 // updateProjectedEntitiesQuery is the batched counterpart of updateEntityAttributes.
 // The version guard is redundant within a single transaction (the MERGE above
@@ -738,16 +760,12 @@ MERGE (src)-[r:RELATION {relation: row.relation}]->(dst)
 ON CREATE SET r.attributes_json = '{}', r.attributes_version = 0, r.assertion_managed = true, r.assertion_quarantined = false
 WITH src, dst, r, row,
      coalesce(r.assertion_managed, false) AS was_assertion_managed,
+     coalesce(r.application_workspace_id, '') AS logical_workspace_id,
      CASE WHEN coalesce(r.tenant_id, '') <> '' THEN r.tenant_id ELSE row.tenant_id END AS legacy_tenant_id,
      coalesce(r.source_id, '') AS legacy_source_id,
      coalesce(r.runtime_id, '') AS legacy_runtime_id
-WITH src, dst, r, row, legacy_tenant_id, legacy_source_id, legacy_runtime_id,
+WITH src, dst, r, row, logical_workspace_id, legacy_tenant_id, legacy_source_id, legacy_runtime_id,
      NOT was_assertion_managed AS preserve_legacy_logical
-SET r.tenant_id = CASE WHEN preserve_legacy_logical THEN legacy_tenant_id ELSE row.tenant_id END,
-    r.source_id = CASE WHEN preserve_legacy_logical THEN legacy_source_id ELSE row.source_id END,
-    r.runtime_id = CASE WHEN preserve_legacy_logical THEN legacy_runtime_id ELSE row.runtime_id END,
-    r.assertion_managed = NOT preserve_legacy_logical,
-    r.assertion_quarantined = preserve_legacy_logical
 MERGE (src)-[a:RELATION_ASSERTION {
     relation: row.relation,
     tenant_id: row.tenant_id,
@@ -755,7 +773,23 @@ MERGE (src)-[a:RELATION_ASSERTION {
     runtime_id: row.runtime_id
 }]->(dst)
 ON CREATE SET a.attributes_json = '{}', a.attributes_version = 0
-SET a.projection_reconciliation_id = row.reconciliation_id
+WITH src, dst, r, a, row, logical_workspace_id, legacy_tenant_id, legacy_source_id, legacy_runtime_id, preserve_legacy_logical,
+     coalesce(a.application_workspace_id, '') AS assertion_workspace_id
+WITH src, dst, r, a, row, logical_workspace_id, assertion_workspace_id, preserve_legacy_logical,
+     (NOT preserve_legacy_logical AND legacy_tenant_id <> '' AND legacy_tenant_id <> row.tenant_id)
+       OR (logical_workspace_id <> '' AND logical_workspace_id <> row.application_workspace_id) AS logical_workspace_conflict,
+     assertion_workspace_id <> '' AND assertion_workspace_id <> row.application_workspace_id AS assertion_workspace_conflict,
+     legacy_tenant_id, legacy_source_id, legacy_runtime_id
+FOREACH (_ IN CASE WHEN logical_workspace_conflict OR assertion_workspace_conflict THEN [] ELSE [1] END |
+  SET r.tenant_id = CASE WHEN preserve_legacy_logical THEN legacy_tenant_id ELSE row.tenant_id END,
+      r.application_workspace_id = CASE WHEN preserve_legacy_logical THEN logical_workspace_id WHEN row.application_workspace_id <> '' THEN row.application_workspace_id ELSE logical_workspace_id END,
+      r.source_id = CASE WHEN preserve_legacy_logical THEN legacy_source_id ELSE row.source_id END,
+      r.runtime_id = CASE WHEN preserve_legacy_logical THEN legacy_runtime_id ELSE row.runtime_id END,
+      r.assertion_managed = NOT preserve_legacy_logical,
+      r.assertion_quarantined = preserve_legacy_logical,
+      a.application_workspace_id = CASE WHEN row.application_workspace_id <> '' THEN row.application_workspace_id ELSE assertion_workspace_id END,
+      a.projection_reconciliation_id = row.reconciliation_id
+)
 RETURN row.from_urn AS from_urn,
        row.relation AS relation,
        row.to_urn AS to_urn,
@@ -766,7 +800,8 @@ RETURN row.from_urn AS from_urn,
        coalesce(r.attributes_version, 0) AS logical_attributes_version,
        coalesce(a.attributes_json, '{}') AS assertion_attributes_json,
        coalesce(a.attributes_version, 0) AS assertion_attributes_version,
-       preserve_legacy_logical AS preserve_legacy_logical`
+       preserve_legacy_logical AS preserve_legacy_logical,
+       logical_workspace_conflict OR assertion_workspace_conflict AS workspace_conflict`
 
 // updateProjectedLinksQuery is the batched counterpart of updateLinkAttributes.
 const updateProjectedLinksQuery = `UNWIND $rows AS row
@@ -775,6 +810,7 @@ WHERE coalesce(r.attributes_version, 0) = row.attributes_version
 SET r.attributes_json = row.attributes_json,
     r.attributes_version = row.next_attributes_version,
     r.tenant_id = row.tenant_id,
+    r.application_workspace_id = CASE WHEN row.application_workspace_id <> '' THEN row.application_workspace_id ELSE coalesce(r.application_workspace_id, '') END,
     r.source_id = row.source_id,
     r.runtime_id = row.runtime_id,
     r.projection_reconciliation_id = row.reconciliation_id,
@@ -792,12 +828,14 @@ MATCH (:Entity {urn: row.from_urn})-[a:RELATION_ASSERTION {
 WHERE coalesce(a.attributes_version, 0) = row.attributes_version
 SET a.attributes_json = row.attributes_json,
     a.attributes_version = row.next_attributes_version,
+    a.application_workspace_id = CASE WHEN row.application_workspace_id <> '' THEN row.application_workspace_id ELSE coalesce(a.application_workspace_id, '') END,
     a.projection_reconciliation_id = row.reconciliation_id
 RETURN count(a)`
 
 type loadedAttributeRow struct {
-	attributesJSON string
-	version        int64
+	attributesJSON    string
+	version           int64
+	workspaceConflict bool
 }
 
 type loadedProjectedLinkRow struct {
@@ -806,26 +844,29 @@ type loadedProjectedLinkRow struct {
 	assertionAttributesJSON string
 	assertionVersion        int64
 	preserveLegacyLogical   bool
+	workspaceConflict       bool
 }
 
 type preparedProjectedEntity struct {
-	urn        string
-	tenantID   string
-	sourceID   string
-	runtimeID  string
-	entityType string
-	label      string
-	attributes map[string]string
+	urn                    string
+	tenantID               string
+	applicationWorkspaceID string
+	sourceID               string
+	runtimeID              string
+	entityType             string
+	label                  string
+	attributes             map[string]string
 }
 
 type preparedProjectedLink struct {
-	fromURN    string
-	toURN      string
-	relation   string
-	tenantID   string
-	sourceID   string
-	runtimeID  string
-	attributes map[string]string
+	fromURN                string
+	toURN                  string
+	relation               string
+	tenantID               string
+	applicationWorkspaceID string
+	sourceID               string
+	runtimeID              string
+	attributes             map[string]string
 }
 
 // UpsertProjectedEntities upserts normalized entities in batches. It preserves
@@ -899,12 +940,13 @@ func (s *Store) writeProjectedEntityChunk(ctx context.Context, chunk []*prepared
 		mergeRows := make([]map[string]any, 0, len(chunk))
 		for _, entity := range chunk {
 			mergeRows = append(mergeRows, map[string]any{
-				"urn":         entity.urn,
-				"tenant_id":   entity.tenantID,
-				"source_id":   entity.sourceID,
-				"runtime_id":  entity.runtimeID,
-				"entity_type": entity.entityType,
-				"label":       entity.label,
+				"urn":                      entity.urn,
+				"tenant_id":                entity.tenantID,
+				"application_workspace_id": entity.applicationWorkspaceID,
+				"source_id":                entity.sourceID,
+				"runtime_id":               entity.runtimeID,
+				"entity_type":              entity.entityType,
+				"label":                    entity.label,
 			})
 		}
 		loaded, err := loadAttributeRows(ctx, tx, mergeProjectedEntitiesQuery, mergeRows, entityAttributeRowKey)
@@ -916,6 +958,9 @@ func (s *Store) writeProjectedEntityChunk(ctx context.Context, chunk []*prepared
 			current, ok := loaded[entity.urn]
 			if !ok {
 				return nil, fmt.Errorf("merge projected entity %q returned no attributes", entity.urn)
+			}
+			if current.workspaceConflict {
+				return nil, fmt.Errorf("%w: projected entity %q", ports.ErrApplicationWorkspaceConflict, entity.urn)
 			}
 			existing, err := graphAttributesFromJSON(current.attributesJSON)
 			if err != nil {
@@ -964,13 +1009,14 @@ func (s *Store) writeProjectedLinkChunk(ctx context.Context, chunk []*preparedPr
 		mergeRows := make([]map[string]any, 0, len(chunk))
 		for _, link := range chunk {
 			mergeRows = append(mergeRows, map[string]any{
-				"from_urn":          link.fromURN,
-				"to_urn":            link.toURN,
-				"relation":          link.relation,
-				"tenant_id":         link.tenantID,
-				"source_id":         link.sourceID,
-				"runtime_id":        link.runtimeID,
-				"reconciliation_id": projectedLinkReconciliationID(link.attributes),
+				"from_urn":                 link.fromURN,
+				"to_urn":                   link.toURN,
+				"relation":                 link.relation,
+				"tenant_id":                link.tenantID,
+				"application_workspace_id": link.applicationWorkspaceID,
+				"source_id":                link.sourceID,
+				"runtime_id":               link.runtimeID,
+				"reconciliation_id":        projectedLinkReconciliationID(link.attributes),
 			})
 		}
 		loaded, err := loadProjectedLinkRows(ctx, tx, mergeRows)
@@ -992,6 +1038,9 @@ func (s *Store) writeProjectedLinkChunk(ctx context.Context, chunk []*preparedPr
 			if !ok {
 				continue
 			}
+			if current.workspaceConflict {
+				return nil, fmt.Errorf("%w: projected link %q %q %q", ports.ErrApplicationWorkspaceConflict, link.fromURN, link.relation, link.toURN)
+			}
 			existingAssertion, err := graphAttributesFromJSON(current.assertionAttributesJSON)
 			if err != nil {
 				return nil, fmt.Errorf("decode projected link assertion %q attributes: %w", key, err)
@@ -1001,16 +1050,17 @@ func (s *Store) writeProjectedLinkChunk(ctx context.Context, chunk []*preparedPr
 				return nil, fmt.Errorf("marshal projected link assertion %q attributes: %w", key, err)
 			}
 			assertionUpdateRows = append(assertionUpdateRows, map[string]any{
-				"from_urn":                link.fromURN,
-				"to_urn":                  link.toURN,
-				"relation":                link.relation,
-				"tenant_id":               link.tenantID,
-				"source_id":               link.sourceID,
-				"runtime_id":              link.runtimeID,
-				"reconciliation_id":       projectedLinkReconciliationID(link.attributes),
-				"attributes_version":      current.assertionVersion,
-				"next_attributes_version": current.assertionVersion + 1,
-				"attributes_json":         assertionJSON,
+				"from_urn":                 link.fromURN,
+				"to_urn":                   link.toURN,
+				"relation":                 link.relation,
+				"tenant_id":                link.tenantID,
+				"application_workspace_id": link.applicationWorkspaceID,
+				"source_id":                link.sourceID,
+				"runtime_id":               link.runtimeID,
+				"reconciliation_id":        projectedLinkReconciliationID(link.attributes),
+				"attributes_version":       current.assertionVersion,
+				"next_attributes_version":  current.assertionVersion + 1,
+				"attributes_json":          assertionJSON,
 			})
 
 			logicalKey := projectedLinkKey(link.fromURN, link.relation, link.toURN)
@@ -1041,16 +1091,17 @@ func (s *Store) writeProjectedLinkChunk(ctx context.Context, chunk []*preparedPr
 				return nil, fmt.Errorf("marshal projected logical link %q attributes: %w", projectedLinkKey(logical.link.fromURN, logical.link.relation, logical.link.toURN), err)
 			}
 			logicalUpdateRows = append(logicalUpdateRows, map[string]any{
-				"from_urn":                logical.link.fromURN,
-				"to_urn":                  logical.link.toURN,
-				"relation":                logical.link.relation,
-				"tenant_id":               logical.link.tenantID,
-				"source_id":               logical.link.sourceID,
-				"runtime_id":              logical.link.runtimeID,
-				"reconciliation_id":       projectedLinkReconciliationID(logical.link.attributes),
-				"attributes_version":      logical.version,
-				"next_attributes_version": logical.version + 1,
-				"attributes_json":         attributesJSON,
+				"from_urn":                 logical.link.fromURN,
+				"to_urn":                   logical.link.toURN,
+				"relation":                 logical.link.relation,
+				"tenant_id":                logical.link.tenantID,
+				"application_workspace_id": logical.link.applicationWorkspaceID,
+				"source_id":                logical.link.sourceID,
+				"runtime_id":               logical.link.runtimeID,
+				"reconciliation_id":        projectedLinkReconciliationID(logical.link.attributes),
+				"attributes_version":       logical.version,
+				"next_attributes_version":  logical.version + 1,
+				"attributes_json":          attributesJSON,
 			})
 		}
 		if len(logicalUpdateRows) != 0 {
@@ -1083,8 +1134,9 @@ func loadAttributeRows(ctx context.Context, tx neo4jdriver.ManagedTransaction, q
 	for result.Next(ctx) {
 		values := result.Record().Values
 		loaded[key(values)] = loadedAttributeRow{
-			attributesJSON: stringValue(values[len(values)-2]),
-			version:        toInt64(values[len(values)-1]),
+			attributesJSON:    stringValue(values[len(values)-2]),
+			version:           toInt64(values[len(values)-1]),
+			workspaceConflict: len(values) >= 4 && boolValue(values[1]),
 		}
 	}
 	return loaded, result.Err()
@@ -1112,6 +1164,7 @@ func loadProjectedLinkRows(ctx context.Context, tx neo4jdriver.ManagedTransactio
 			assertionAttributesJSON: stringValue(values[8]),
 			assertionVersion:        toInt64(values[9]),
 			preserveLegacyLogical:   boolValue(values[10]),
+			workspaceConflict:       boolValue(values[11]),
 		}
 	}
 	return loaded, result.Err()
@@ -1194,12 +1247,25 @@ func prepareProjectedEntities(entities []*ports.ProjectedEntity) ([]*preparedPro
 		if err := ports.ValidateProjectedEntityTenantScope(entity); err != nil {
 			return nil, err
 		}
+		workspaceID, err := ports.ValidateApplicationWorkspaceScope(tenantID, entity.ApplicationWorkspaceID)
+		if err != nil {
+			return nil, err
+		}
 		label := strings.TrimSpace(entity.Label)
 		if label == "" {
 			label = urn
 		}
 		incoming := projectionmeta.ApplyEntityMetadata(entityType, entity.Attributes)
 		if existing, ok := index[urn]; ok {
+			if existing.tenantID != tenantID {
+				return nil, fmt.Errorf("%w: projected entity %q crossed tenants", ports.ErrApplicationWorkspaceConflict, urn)
+			}
+			if existing.applicationWorkspaceID != "" && workspaceID != "" && existing.applicationWorkspaceID != workspaceID {
+				return nil, fmt.Errorf("%w: projected entity %q has multiple workspaces", ports.ErrApplicationWorkspaceConflict, urn)
+			}
+			if workspaceID != "" {
+				existing.applicationWorkspaceID = workspaceID
+			}
 			existing.tenantID = tenantID
 			existing.sourceID = sourceID
 			existing.runtimeID = strings.TrimSpace(entity.RuntimeID)
@@ -1209,13 +1275,14 @@ func prepareProjectedEntities(entities []*ports.ProjectedEntity) ([]*preparedPro
 			continue
 		}
 		entry := &preparedProjectedEntity{
-			urn:        urn,
-			tenantID:   tenantID,
-			sourceID:   sourceID,
-			runtimeID:  strings.TrimSpace(entity.RuntimeID),
-			entityType: entityType,
-			label:      label,
-			attributes: incoming,
+			urn:                    urn,
+			tenantID:               tenantID,
+			applicationWorkspaceID: workspaceID,
+			sourceID:               sourceID,
+			runtimeID:              strings.TrimSpace(entity.RuntimeID),
+			entityType:             entityType,
+			label:                  label,
+			attributes:             incoming,
 		}
 		index[urn] = entry
 		prepared = append(prepared, entry)
@@ -1235,19 +1302,30 @@ func prepareProjectedLinks(links []*ports.ProjectedLink) ([]*preparedProjectedLi
 			return nil, err
 		}
 		runtimeID := strings.TrimSpace(link.RuntimeID)
+		workspaceID, err := ports.ValidateApplicationWorkspaceScope(tenantID, link.ApplicationWorkspaceID)
+		if err != nil {
+			return nil, err
+		}
 		key := projectedLinkAssertionKey(fromURN, relation, toURN, tenantID, sourceID, runtimeID)
 		if existing, ok := index[key]; ok {
+			if existing.applicationWorkspaceID != "" && workspaceID != "" && existing.applicationWorkspaceID != workspaceID {
+				return nil, fmt.Errorf("%w: projected link %q %q %q has multiple workspaces", ports.ErrApplicationWorkspaceConflict, fromURN, relation, toURN)
+			}
+			if workspaceID != "" {
+				existing.applicationWorkspaceID = workspaceID
+			}
 			existing.attributes = mergeGraphAttributes(existing.attributes, link.Attributes)
 			continue
 		}
 		entry := &preparedProjectedLink{
-			fromURN:    fromURN,
-			toURN:      toURN,
-			relation:   relation,
-			tenantID:   tenantID,
-			sourceID:   sourceID,
-			runtimeID:  runtimeID,
-			attributes: mergeGraphAttributes(nil, link.Attributes),
+			fromURN:                fromURN,
+			toURN:                  toURN,
+			relation:               relation,
+			tenantID:               tenantID,
+			applicationWorkspaceID: workspaceID,
+			sourceID:               sourceID,
+			runtimeID:              runtimeID,
+			attributes:             mergeGraphAttributes(nil, link.Attributes),
 		}
 		index[key] = entry
 		prepared = append(prepared, entry)
@@ -2872,19 +2950,19 @@ func normalizeCleanupValues(values []string) []string {
 	return normalized
 }
 
-func mergeEntityAndLoadAttributes(ctx context.Context, tx neo4jdriver.ManagedTransaction, params map[string]any) (string, int64, error) {
+func mergeEntityAndLoadAttributes(ctx context.Context, tx neo4jdriver.ManagedTransaction, params map[string]any) (string, int64, bool, error) {
 	result, err := tx.Run(ctx, mergeEntityAndLoadAttributesQuery, params)
 	if err != nil {
-		return "", 0, err
+		return "", 0, false, err
 	}
 	if !result.Next(ctx) {
 		if err := result.Err(); err != nil {
-			return "", 0, err
+			return "", 0, false, err
 		}
-		return "", 0, errors.New("entity merge returned no rows")
+		return "", 0, false, errors.New("entity merge returned no rows")
 	}
 	values := result.Record().Values
-	return stringValue(values[0]), toInt64(values[1]), result.Err()
+	return stringValue(values[0]), toInt64(values[1]), boolValue(values[2]), result.Err()
 }
 
 // entityTypedPropertyParams maps the derived typed properties onto the node
@@ -2925,16 +3003,12 @@ MERGE (src)-[r:RELATION {relation: $relation}]->(dst)
 ON CREATE SET r.attributes_json = '{}', r.attributes_version = 0, r.assertion_managed = true, r.assertion_quarantined = false
 WITH src, dst, r,
      coalesce(r.assertion_managed, false) AS was_assertion_managed,
+     coalesce(r.application_workspace_id, '') AS logical_workspace_id,
      CASE WHEN coalesce(r.tenant_id, '') <> '' THEN r.tenant_id ELSE $tenant_id END AS legacy_tenant_id,
      coalesce(r.source_id, '') AS legacy_source_id,
      coalesce(r.runtime_id, '') AS legacy_runtime_id
-WITH src, dst, r, legacy_tenant_id, legacy_source_id, legacy_runtime_id,
+WITH src, dst, r, logical_workspace_id, legacy_tenant_id, legacy_source_id, legacy_runtime_id,
      NOT was_assertion_managed AS preserve_legacy_logical
-SET r.tenant_id = CASE WHEN preserve_legacy_logical THEN legacy_tenant_id ELSE $tenant_id END,
-	r.source_id = CASE WHEN preserve_legacy_logical THEN legacy_source_id ELSE $source_id END,
-	r.runtime_id = CASE WHEN preserve_legacy_logical THEN legacy_runtime_id ELSE $runtime_id END,
-	r.assertion_managed = NOT preserve_legacy_logical,
-	r.assertion_quarantined = preserve_legacy_logical
 MERGE (src)-[a:RELATION_ASSERTION {
     relation: $relation,
     tenant_id: $tenant_id,
@@ -2942,12 +3016,28 @@ MERGE (src)-[a:RELATION_ASSERTION {
     runtime_id: $runtime_id
 }]->(dst)
 ON CREATE SET a.attributes_json = '{}', a.attributes_version = 0
-SET a.projection_reconciliation_id = $reconciliation_id
+WITH r, a, logical_workspace_id, preserve_legacy_logical, legacy_tenant_id, legacy_source_id, legacy_runtime_id,
+     coalesce(a.application_workspace_id, '') AS assertion_workspace_id
+WITH r, a, logical_workspace_id, assertion_workspace_id, preserve_legacy_logical, legacy_tenant_id, legacy_source_id, legacy_runtime_id,
+     (NOT preserve_legacy_logical AND legacy_tenant_id <> '' AND legacy_tenant_id <> $tenant_id)
+       OR (logical_workspace_id <> '' AND logical_workspace_id <> $application_workspace_id) AS logical_workspace_conflict,
+     assertion_workspace_id <> '' AND assertion_workspace_id <> $application_workspace_id AS assertion_workspace_conflict
+FOREACH (_ IN CASE WHEN logical_workspace_conflict OR assertion_workspace_conflict THEN [] ELSE [1] END |
+  SET r.tenant_id = CASE WHEN preserve_legacy_logical THEN legacy_tenant_id ELSE $tenant_id END,
+      r.application_workspace_id = CASE WHEN preserve_legacy_logical THEN logical_workspace_id WHEN $application_workspace_id <> '' THEN $application_workspace_id ELSE logical_workspace_id END,
+      r.source_id = CASE WHEN preserve_legacy_logical THEN legacy_source_id ELSE $source_id END,
+      r.runtime_id = CASE WHEN preserve_legacy_logical THEN legacy_runtime_id ELSE $runtime_id END,
+      r.assertion_managed = NOT preserve_legacy_logical,
+      r.assertion_quarantined = preserve_legacy_logical,
+      a.application_workspace_id = CASE WHEN $application_workspace_id <> '' THEN $application_workspace_id ELSE assertion_workspace_id END,
+      a.projection_reconciliation_id = $reconciliation_id
+)
 RETURN coalesce(r.attributes_json, '{}'),
        coalesce(r.attributes_version, 0),
        coalesce(a.attributes_json, '{}'),
        coalesce(a.attributes_version, 0),
-       preserve_legacy_logical`, params)
+       preserve_legacy_logical,
+       logical_workspace_conflict OR assertion_workspace_conflict`, params)
 	if err != nil {
 		return loadedProjectedLinkRow{}, false, err
 	}
@@ -2961,6 +3051,7 @@ RETURN coalesce(r.attributes_json, '{}'),
 		assertionAttributesJSON: stringValue(values[2]),
 		assertionVersion:        toInt64(values[3]),
 		preserveLegacyLogical:   boolValue(values[4]),
+		workspaceConflict:       boolValue(values[5]),
 	}, true, result.Err()
 }
 
@@ -2972,6 +3063,9 @@ func updateLinkAttributes(ctx context.Context, tx neo4jdriver.ManagedTransaction
 	params["next_assertion_attributes_version"] = current.assertionVersion + 1
 	params["assertion_attributes_json"] = assertionAttributesJSON
 	params["preserve_legacy_logical"] = current.preserveLegacyLogical
+	if current.workspaceConflict {
+		return false, ports.ErrApplicationWorkspaceConflict
+	}
 	updated, err := countQuery(ctx, tx, `MATCH (:Entity {urn: $from_urn})-[r:RELATION {relation: $relation}]->(:Entity {urn: $to_urn})
 MATCH (:Entity {urn: $from_urn})-[a:RELATION_ASSERTION {
     relation: $relation,
@@ -2984,6 +3078,7 @@ WHERE coalesce(r.attributes_version, 0) = $logical_attributes_version
 SET r.attributes_json = CASE WHEN $preserve_legacy_logical THEN r.attributes_json ELSE $logical_attributes_json END,
 	r.attributes_version = CASE WHEN $preserve_legacy_logical THEN r.attributes_version ELSE $next_logical_attributes_version END,
 	r.tenant_id = CASE WHEN $preserve_legacy_logical THEN r.tenant_id ELSE $tenant_id END,
+	r.application_workspace_id = CASE WHEN $preserve_legacy_logical THEN coalesce(r.application_workspace_id, '') WHEN $application_workspace_id <> '' THEN $application_workspace_id ELSE coalesce(r.application_workspace_id, '') END,
 	r.source_id = CASE WHEN $preserve_legacy_logical THEN r.source_id ELSE $source_id END,
 	r.runtime_id = CASE WHEN $preserve_legacy_logical THEN r.runtime_id ELSE $runtime_id END,
 	r.projection_reconciliation_id = CASE WHEN $preserve_legacy_logical THEN r.projection_reconciliation_id ELSE $reconciliation_id END,
@@ -2991,6 +3086,7 @@ SET r.attributes_json = CASE WHEN $preserve_legacy_logical THEN r.attributes_jso
 	r.assertion_quarantined = $preserve_legacy_logical,
 	a.attributes_json = $assertion_attributes_json,
 	a.attributes_version = $next_assertion_attributes_version,
+	a.application_workspace_id = CASE WHEN $application_workspace_id <> '' THEN $application_workspace_id ELSE coalesce(a.application_workspace_id, '') END,
 	a.projection_reconciliation_id = $reconciliation_id
 RETURN count(a)`, params)
 	if err != nil {

--- a/internal/graphstore/neo4j/store_test.go
+++ b/internal/graphstore/neo4j/store_test.go
@@ -1106,6 +1106,10 @@ func TestProjectedEntitiesBatchQueryPreservesPerItemSemantics(t *testing.T) {
 		"UNWIND $rows AS row",
 		"MERGE (e:Entity {urn: row.urn})",
 		"ON CREATE SET e.attributes_json = '{}', e.attributes_version = 0",
+		"existing_tenant_id <> '' AND existing_tenant_id <> row.tenant_id",
+		"existing_workspace_id <> '' AND existing_workspace_id <> row.application_workspace_id",
+		"e.application_workspace_id = CASE WHEN row.application_workspace_id <> '' THEN row.application_workspace_id ELSE existing_workspace_id END",
+		"workspace_conflict AS workspace_conflict",
 		"e.label = CASE WHEN row.label <> row.urn THEN row.label ELSE coalesce(e.label, row.label) END",
 		"RETURN row.urn AS urn",
 	} {
@@ -1135,6 +1139,10 @@ func TestProjectedLinksBatchQueryRequiresBothEndpoints(t *testing.T) {
 		"MERGE (src)-[a:RELATION_ASSERTION {",
 		"source_id: row.source_id",
 		"runtime_id: row.runtime_id",
+		"logical_workspace_id <> '' AND logical_workspace_id <> row.application_workspace_id",
+		"assertion_workspace_id <> '' AND assertion_workspace_id <> row.application_workspace_id",
+		"a.application_workspace_id = CASE WHEN row.application_workspace_id <> '' THEN row.application_workspace_id ELSE assertion_workspace_id END",
+		"workspace_conflict",
 		"a.projection_reconciliation_id = row.reconciliation_id",
 		"RETURN row.from_urn AS from_urn",
 	} {
@@ -1273,6 +1281,20 @@ func TestPrepareProjectedEntitiesValidationErrors(t *testing.T) {
 	}
 }
 
+func TestPrepareProjectedEntitiesRejectsWorkspaceLastWriteWins(t *testing.T) {
+	entity := func(workspaceID string) *ports.ProjectedEntity {
+		return &ports.ProjectedEntity{URN: "urn:cerebro:writer:asset:one", TenantID: "writer", ApplicationWorkspaceID: workspaceID, SourceID: "github", EntityType: "asset"}
+	}
+	_, err := prepareProjectedEntities([]*ports.ProjectedEntity{entity("workspace-a"), entity("workspace-b")})
+	if !errors.Is(err, ports.ErrApplicationWorkspaceConflict) {
+		t.Fatalf("prepareProjectedEntities() error = %v, want workspace conflict", err)
+	}
+	prepared, err := prepareProjectedEntities([]*ports.ProjectedEntity{entity(""), entity("workspace-a")})
+	if err != nil || len(prepared) != 1 || prepared[0].applicationWorkspaceID != "workspace-a" {
+		t.Fatalf("blank legacy reprojection = %#v, %v", prepared, err)
+	}
+}
+
 func TestPrepareProjectedLinksCoalescesValidatesAndSorts(t *testing.T) {
 	prepared, err := prepareProjectedLinks([]*ports.ProjectedLink{
 		{
@@ -1334,6 +1356,16 @@ func TestPrepareProjectedLinksValidationErrors(t *testing.T) {
 		if got := err.Error(); !strings.Contains(got, want) {
 			t.Fatalf("prepareProjectedLinks(%#v) error = %q, want %q", link, got, want)
 		}
+	}
+}
+
+func TestPrepareProjectedLinksRejectsWorkspaceLastWriteWins(t *testing.T) {
+	link := func(workspaceID string) *ports.ProjectedLink {
+		return &ports.ProjectedLink{TenantID: "writer", ApplicationWorkspaceID: workspaceID, SourceID: "github", RuntimeID: "runtime-one", FromURN: "urn:cerebro:writer:asset:one", ToURN: "urn:cerebro:writer:asset:two", Relation: "associated_with"}
+	}
+	_, err := prepareProjectedLinks([]*ports.ProjectedLink{link("workspace-a"), link("workspace-b")})
+	if !errors.Is(err, ports.ErrApplicationWorkspaceConflict) {
+		t.Fatalf("prepareProjectedLinks() error = %v, want workspace conflict", err)
 	}
 }
 

--- a/internal/ports/appendlog.go
+++ b/internal/ports/appendlog.go
@@ -12,6 +12,12 @@ import (
 
 const (
 	EventAttributeSourceRuntimeID = "source_runtime_id"
+	// EventAttributeApplicationWorkspaceID is reserved for the trusted
+	// source-runtime and admission hosts. Provider records must not populate it.
+	EventAttributeApplicationWorkspaceID = "cerebro_application_workspace_id"
+	// SourceRuntimeApplicationWorkspaceIDConfigKey assigns every projection
+	// emitted by one runtime to a tenant-qualified Cerebro application workspace.
+	SourceRuntimeApplicationWorkspaceIDConfigKey = "application_workspace_id"
 	// EventAttributeSourceCollectionID joins every normalized event from one
 	// sync to the final durable SourceCollectionManifest for that exact sync.
 	EventAttributeSourceCollectionID = "source_collection_id"

--- a/internal/ports/projection.go
+++ b/internal/ports/projection.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	cerebrourn "github.com/writer/cerebro/internal/urn"
@@ -13,6 +15,12 @@ import (
 // ErrProjectedTenantScope indicates that a Cerebro-owned projection URN does
 // not belong to the tenant receiving the projection.
 var ErrProjectedTenantScope = errors.New("projected URN tenant scope mismatch")
+
+// ErrApplicationWorkspaceConflict marks an attempt to move one tenant-global
+// graph identity between application workspaces without an explicit migration.
+var ErrApplicationWorkspaceConflict = errors.New("application workspace projection conflict")
+
+const maxApplicationWorkspaceIDBytes = 256
 
 // ProjectedTenantScopeError identifies the rejected projection field and both
 // tenant scopes without requiring callers to parse an error string.
@@ -34,24 +42,58 @@ func (err *ProjectedTenantScopeError) Unwrap() error { return ErrProjectedTenant
 
 // ProjectedEntity is the normalized current-state and graph entity shape.
 type ProjectedEntity struct {
-	URN        string
-	TenantID   string
-	SourceID   string
-	RuntimeID  string
-	EntityType string
-	Label      string
-	Attributes map[string]string
+	URN                    string
+	TenantID               string
+	ApplicationWorkspaceID string
+	SourceID               string
+	RuntimeID              string
+	EntityType             string
+	Label                  string
+	Attributes             map[string]string
 }
 
 // ProjectedLink is the normalized graph edge shape.
 type ProjectedLink struct {
-	TenantID   string
-	SourceID   string
-	RuntimeID  string
-	FromURN    string
-	ToURN      string
-	Relation   string
-	Attributes map[string]string
+	TenantID               string
+	ApplicationWorkspaceID string
+	SourceID               string
+	RuntimeID              string
+	FromURN                string
+	ToURN                  string
+	Relation               string
+	Attributes             map[string]string
+}
+
+// NormalizeApplicationWorkspaceID validates one opaque application workspace
+// selector. Blank is the backward-compatible tenant-wide legacy scope.
+func NormalizeApplicationWorkspaceID(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", nil
+	}
+	if len(value) > maxApplicationWorkspaceIDBytes || !utf8.ValidString(value) || value == "*" || strings.Contains(value, ",") {
+		return "", fmt.Errorf("invalid application workspace id")
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return "", fmt.Errorf("invalid application workspace id")
+		}
+	}
+	return value, nil
+}
+
+// ValidateApplicationWorkspaceScope requires application workspaces to remain
+// nested under an explicit tenant. The workspace ID is intentionally opaque;
+// tenant qualification comes from this pair rather than provider payload data.
+func ValidateApplicationWorkspaceScope(tenantID string, workspaceID string) (string, error) {
+	workspaceID, err := NormalizeApplicationWorkspaceID(workspaceID)
+	if err != nil {
+		return "", err
+	}
+	if workspaceID != "" && strings.TrimSpace(tenantID) == "" {
+		return "", fmt.Errorf("application workspace id requires tenant id")
+	}
+	return workspaceID, nil
 }
 
 // ValidateProjectedTenantScopes rejects Cerebro-owned projection URNs that do
@@ -76,6 +118,9 @@ func ValidateProjectedEntityTenantScope(entity *ProjectedEntity) error {
 	if entity == nil {
 		return nil
 	}
+	if _, err := ValidateApplicationWorkspaceScope(entity.TenantID, entity.ApplicationWorkspaceID); err != nil {
+		return err
+	}
 	return validateProjectedCerebroURNScope("projected entity urn", entity.URN, entity.TenantID)
 }
 
@@ -84,6 +129,9 @@ func ValidateProjectedEntityTenantScope(entity *ProjectedEntity) error {
 func ValidateProjectedLinkTenantScope(link *ProjectedLink) error {
 	if link == nil {
 		return nil
+	}
+	if _, err := ValidateApplicationWorkspaceScope(link.TenantID, link.ApplicationWorkspaceID); err != nil {
+		return err
 	}
 	if err := validateProjectedCerebroURNScope("projected link from urn", link.FromURN, link.TenantID); err != nil {
 		return err

--- a/internal/ports/projection_test.go
+++ b/internal/ports/projection_test.go
@@ -66,3 +66,25 @@ func TestValidateProjectedTenantScopesRejectsCrossTenantLinkEndpoint(t *testing.
 	}
 	requireProjectedTenantScopeError(t, err, "projected link to urn", "urn:cerebro:victim:asset:target")
 }
+
+func TestValidateApplicationWorkspaceScopeIsTenantQualifiedAndBounded(t *testing.T) {
+	if got, err := ValidateApplicationWorkspaceScope("tenant-a", " workspace-a "); err != nil || got != "workspace-a" {
+		t.Fatalf("ValidateApplicationWorkspaceScope() = %q, %v", got, err)
+	}
+	for _, test := range []struct {
+		tenantID    string
+		workspaceID string
+	}{
+		{workspaceID: "workspace-a"},
+		{tenantID: "tenant-a", workspaceID: "*"},
+		{tenantID: "tenant-a", workspaceID: "workspace-a,workspace-b"},
+		{tenantID: "tenant-a", workspaceID: "workspace\nother"},
+	} {
+		if _, err := ValidateApplicationWorkspaceScope(test.tenantID, test.workspaceID); err == nil {
+			t.Fatalf("ValidateApplicationWorkspaceScope(%q, %q) error = nil", test.tenantID, test.workspaceID)
+		}
+	}
+	if got, err := ValidateApplicationWorkspaceScope("", ""); err != nil || got != "" {
+		t.Fatalf("blank tenant-wide legacy scope = %q, %v", got, err)
+	}
+}

--- a/internal/sourcehttp/organizationalgraph/projection.go
+++ b/internal/sourcehttp/organizationalgraph/projection.go
@@ -67,23 +67,25 @@ func normalizeBaseURL(raw string) (string, error) {
 }
 
 type legacyProjectedEntity struct {
-	URN        string            `json:"urn"`
-	TenantID   string            `json:"tenant_id"`
-	SourceID   string            `json:"source_id"`
-	RuntimeID  string            `json:"runtime_id"`
-	EntityType string            `json:"entity_type"`
-	Label      string            `json:"label"`
-	Attributes map[string]string `json:"attributes"`
+	URN                    string            `json:"urn"`
+	TenantID               string            `json:"tenant_id"`
+	ApplicationWorkspaceID string            `json:"application_workspace_id"`
+	SourceID               string            `json:"source_id"`
+	RuntimeID              string            `json:"runtime_id"`
+	EntityType             string            `json:"entity_type"`
+	Label                  string            `json:"label"`
+	Attributes             map[string]string `json:"attributes"`
 }
 
 type legacyProjectedLink struct {
-	TenantID   string            `json:"tenant_id"`
-	SourceID   string            `json:"source_id"`
-	RuntimeID  string            `json:"runtime_id"`
-	FromURN    string            `json:"from_urn"`
-	ToURN      string            `json:"to_urn"`
-	Relation   string            `json:"relation"`
-	Attributes map[string]string `json:"attributes"`
+	TenantID               string            `json:"tenant_id"`
+	ApplicationWorkspaceID string            `json:"application_workspace_id"`
+	SourceID               string            `json:"source_id"`
+	RuntimeID              string            `json:"runtime_id"`
+	FromURN                string            `json:"from_urn"`
+	ToURN                  string            `json:"to_urn"`
+	Relation               string            `json:"relation"`
+	Attributes             map[string]string `json:"attributes"`
 }
 
 type legacyCleanupRequest struct {
@@ -480,13 +482,14 @@ func legacyDeltaRequest(delta ports.SourceProjectionDelta) legacyProjectionDelta
 			continue
 		}
 		result.Entities = append(result.Entities, legacyProjectedEntity{
-			URN:        entity.URN,
-			TenantID:   entity.TenantID,
-			SourceID:   entity.SourceID,
-			RuntimeID:  entity.RuntimeID,
-			EntityType: entity.EntityType,
-			Label:      entity.Label,
-			Attributes: cloneAttributes(entity.Attributes),
+			URN:                    entity.URN,
+			TenantID:               entity.TenantID,
+			ApplicationWorkspaceID: entity.ApplicationWorkspaceID,
+			SourceID:               entity.SourceID,
+			RuntimeID:              entity.RuntimeID,
+			EntityType:             entity.EntityType,
+			Label:                  entity.Label,
+			Attributes:             cloneAttributes(entity.Attributes),
 		})
 	}
 	for _, link := range delta.Links {
@@ -517,12 +520,13 @@ func legacyDeltaRequest(delta ports.SourceProjectionDelta) legacyProjectionDelta
 
 func legacyLinkRequest(link *ports.ProjectedLink) legacyProjectedLink {
 	return legacyProjectedLink{
-		TenantID:   link.TenantID,
-		SourceID:   link.SourceID,
-		RuntimeID:  link.RuntimeID,
-		FromURN:    link.FromURN,
-		ToURN:      link.ToURN,
-		Relation:   link.Relation,
-		Attributes: cloneAttributes(link.Attributes),
+		TenantID:               link.TenantID,
+		ApplicationWorkspaceID: link.ApplicationWorkspaceID,
+		SourceID:               link.SourceID,
+		RuntimeID:              link.RuntimeID,
+		FromURN:                link.FromURN,
+		ToURN:                  link.ToURN,
+		Relation:               link.Relation,
+		Attributes:             cloneAttributes(link.Attributes),
 	}
 }

--- a/internal/sourceprojection/projector.go
+++ b/internal/sourceprojection/projector.go
@@ -542,10 +542,53 @@ func (s *Service) projectRecords(event *cerebrov1.EventEnvelope, project func(*R
 func finalizeProjectedRecords(event *cerebrov1.EventEnvelope, entities []*ports.ProjectedEntity, links []*ports.ProjectedLink) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	normalizeProjectedEntityTypes(entities)
 	stampProjectionRuntime(event, entities, links)
+	if err := stampProjectionApplicationWorkspace(event, entities, links); err != nil {
+		return nil, nil, err
+	}
 	if err := validateProjectedFabricContract(links); err != nil {
 		return nil, nil, err
 	}
 	return entities, links, nil
+}
+
+func stampProjectionApplicationWorkspace(event *cerebrov1.EventEnvelope, entities []*ports.ProjectedEntity, links []*ports.ProjectedLink) error {
+	if event == nil {
+		return nil
+	}
+	workspaceID, err := ports.ValidateApplicationWorkspaceScope(
+		event.GetTenantId(),
+		event.GetAttributes()[ports.EventAttributeApplicationWorkspaceID],
+	)
+	if err != nil {
+		return fmt.Errorf("project application workspace: %w", err)
+	}
+	for _, entity := range entities {
+		if entity == nil {
+			continue
+		}
+		candidate, err := ports.ValidateApplicationWorkspaceScope(entity.TenantID, entity.ApplicationWorkspaceID)
+		if err != nil {
+			return fmt.Errorf("projected entity %q application workspace: %w", entity.URN, err)
+		}
+		if candidate != "" {
+			return fmt.Errorf("%w: projected entity %q attempted to supply application workspace", ports.ErrApplicationWorkspaceConflict, entity.URN)
+		}
+		entity.ApplicationWorkspaceID = workspaceID
+	}
+	for _, link := range links {
+		if link == nil {
+			continue
+		}
+		candidate, err := ports.ValidateApplicationWorkspaceScope(link.TenantID, link.ApplicationWorkspaceID)
+		if err != nil {
+			return fmt.Errorf("projected link %q %q %q application workspace: %w", link.FromURN, link.Relation, link.ToURN, err)
+		}
+		if candidate != "" {
+			return fmt.Errorf("%w: projected link %q %q %q attempted to supply application workspace", ports.ErrApplicationWorkspaceConflict, link.FromURN, link.Relation, link.ToURN)
+		}
+		link.ApplicationWorkspaceID = workspaceID
+	}
+	return nil
 }
 
 func validateProjectedFabricContract(links []*ports.ProjectedLink) error {

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -3,6 +3,7 @@ package sourceprojection
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"sort"
@@ -22,6 +23,34 @@ type projectionRecorder struct {
 	deletedEntities map[string]struct{}
 	deletedLinks    map[string]*ports.ProjectedLink
 	cleanupRequests []ports.ProjectionCleanupRequest
+}
+
+func TestFinalizeProjectedRecordsStampsTrustedApplicationWorkspace(t *testing.T) {
+	event := &cerebrov1.EventEnvelope{
+		Id:       "event-one",
+		TenantId: "tenant-a",
+		Attributes: map[string]string{
+			ports.EventAttributeApplicationWorkspaceID: "workspace-a",
+		},
+	}
+	entities := []*ports.ProjectedEntity{{URN: "urn:cerebro:tenant-a:asset:one", TenantID: "tenant-a"}}
+	links := []*ports.ProjectedLink{{TenantID: "tenant-a", FromURN: "urn:cerebro:tenant-a:asset:one", ToURN: "urn:cerebro:tenant-a:asset:two", Relation: relationBelongsTo}}
+	gotEntities, gotLinks, err := finalizeProjectedRecords(event, entities, links)
+	if err != nil {
+		t.Fatalf("finalizeProjectedRecords() error = %v", err)
+	}
+	if gotEntities[0].ApplicationWorkspaceID != "workspace-a" || gotLinks[0].ApplicationWorkspaceID != "workspace-a" {
+		t.Fatalf("workspace stamp missing: entity=%#v link=%#v", gotEntities[0], gotLinks[0])
+	}
+
+	entities[0].ApplicationWorkspaceID = "provider-spoof"
+	if _, _, err := finalizeProjectedRecords(event, entities, nil); !errors.Is(err, ports.ErrApplicationWorkspaceConflict) {
+		t.Fatalf("provider workspace conflict error = %v", err)
+	}
+	equalWorkspaceEntity := []*ports.ProjectedEntity{{URN: "urn:cerebro:tenant-a:asset:two", TenantID: "tenant-a", ApplicationWorkspaceID: "workspace-a"}}
+	if _, _, err := finalizeProjectedRecords(event, equalWorkspaceEntity, nil); !errors.Is(err, ports.ErrApplicationWorkspaceConflict) {
+		t.Fatalf("matching provider workspace must still be rejected, error = %v", err)
+	}
 }
 
 func (r *projectionRecorder) Ping(context.Context) error {
@@ -7218,13 +7247,14 @@ func cloneProjectedEntity(entity *ports.ProjectedEntity) *ports.ProjectedEntity 
 		attributes[key] = value
 	}
 	return &ports.ProjectedEntity{
-		URN:        entity.URN,
-		TenantID:   entity.TenantID,
-		SourceID:   entity.SourceID,
-		RuntimeID:  entity.RuntimeID,
-		EntityType: entity.EntityType,
-		Label:      entity.Label,
-		Attributes: attributes,
+		URN:                    entity.URN,
+		TenantID:               entity.TenantID,
+		ApplicationWorkspaceID: entity.ApplicationWorkspaceID,
+		SourceID:               entity.SourceID,
+		RuntimeID:              entity.RuntimeID,
+		EntityType:             entity.EntityType,
+		Label:                  entity.Label,
+		Attributes:             attributes,
 	}
 }
 
@@ -7237,13 +7267,14 @@ func cloneProjectedLink(link *ports.ProjectedLink) *ports.ProjectedLink {
 		attributes[key] = value
 	}
 	return &ports.ProjectedLink{
-		TenantID:   link.TenantID,
-		SourceID:   link.SourceID,
-		RuntimeID:  link.RuntimeID,
-		FromURN:    link.FromURN,
-		ToURN:      link.ToURN,
-		Relation:   link.Relation,
-		Attributes: attributes,
+		TenantID:               link.TenantID,
+		ApplicationWorkspaceID: link.ApplicationWorkspaceID,
+		SourceID:               link.SourceID,
+		RuntimeID:              link.RuntimeID,
+		FromURN:                link.FromURN,
+		ToURN:                  link.ToURN,
+		Relation:               link.Relation,
+		Attributes:             attributes,
 	}
 }
 

--- a/internal/sourceruntime/deposit.go
+++ b/internal/sourceruntime/deposit.go
@@ -541,7 +541,14 @@ func depositEventEnvelope(runtime *cerebrov1.SourceRuntime, definition connector
 	if _, ok := decoded.(map[string]any); !ok {
 		return nil, fmt.Errorf("%w: record payload must be a JSON object", sourcecdk.ErrInvalidEventEnvelope)
 	}
+	workspaceID, err := applicationWorkspaceIDForRuntime(runtime)
+	if err != nil {
+		return nil, err
+	}
 	attributes := depositRecordAttributes(runtime, definition, family, decoded)
+	if workspaceID != "" {
+		attributes[ports.EventAttributeApplicationWorkspaceID] = workspaceID
+	}
 	if options.FullState {
 		attributes["full_state_sync"] = "true"
 	}

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -228,6 +228,9 @@ func (s *Service) preparePutRuntime(ctx context.Context, input *cerebrov1.Source
 	if runtime.GetId() == "" {
 		return nil, fmt.Errorf("%w: source runtime id is required", ErrInvalidRequest)
 	}
+	if _, err := applicationWorkspaceIDForRuntime(runtime); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidRequest, err)
+	}
 	existing, err := s.lookupRuntime(ctx, runtime.GetId())
 	switch {
 	case err == nil:
@@ -453,7 +456,10 @@ func (s *Service) Sync(ctx context.Context, req *cerebrov1.SyncSourceRuntimeRequ
 		phaseStarted = time.Now()
 		materializedEvents := make([]*cerebrov1.EventEnvelope, 0, len(pull.Events))
 		for _, event := range pull.Events {
-			syncedEvent := materializeEvent(runtime, collectionID, event)
+			syncedEvent, err := materializeEvent(runtime, collectionID, event)
+			if err != nil {
+				return nil, err
+			}
 			if syncedEvent == nil {
 				continue
 			}
@@ -1458,16 +1464,33 @@ func boundedUint32(value int) uint32 {
 	return uint32(value)
 }
 
-func materializeEvent(runtime *cerebrov1.SourceRuntime, collectionID string, event *cerebrov1.EventEnvelope) *cerebrov1.EventEnvelope {
+func materializeEvent(runtime *cerebrov1.SourceRuntime, collectionID string, event *cerebrov1.EventEnvelope) (*cerebrov1.EventEnvelope, error) {
 	if event == nil {
-		return nil
+		return nil, nil
 	}
 	cloned := proto.Clone(event).(*cerebrov1.EventEnvelope)
 	if runtime == nil {
-		return cloned
+		return cloned, nil
+	}
+	workspaceID, err := applicationWorkspaceIDForRuntime(runtime)
+	if err != nil {
+		return nil, err
+	}
+	providerWorkspaceID := strings.TrimSpace(cloned.GetAttributes()[ports.EventAttributeApplicationWorkspaceID])
+	if providerWorkspaceID != "" {
+		return nil, fmt.Errorf("reserved application workspace attribute may only be set by the source runtime")
 	}
 	if strings.TrimSpace(runtime.GetTenantId()) != "" {
 		cloned.TenantId = strings.TrimSpace(runtime.GetTenantId())
+	}
+	if cloned.Attributes != nil {
+		delete(cloned.Attributes, ports.EventAttributeApplicationWorkspaceID)
+	}
+	if workspaceID != "" {
+		if cloned.Attributes == nil {
+			cloned.Attributes = make(map[string]string)
+		}
+		cloned.Attributes[ports.EventAttributeApplicationWorkspaceID] = workspaceID
 	}
 	if strings.TrimSpace(runtime.GetId()) != "" {
 		if cloned.Attributes == nil {
@@ -1481,7 +1504,21 @@ func materializeEvent(runtime *cerebrov1.SourceRuntime, collectionID string, eve
 		}
 		cloned.Attributes[ports.EventAttributeSourceCollectionID] = collectionID
 	}
-	return cloned
+	return cloned, nil
+}
+
+func applicationWorkspaceIDForRuntime(runtime *cerebrov1.SourceRuntime) (string, error) {
+	if runtime == nil {
+		return "", nil
+	}
+	workspaceID, err := ports.ValidateApplicationWorkspaceScope(
+		runtime.GetTenantId(),
+		runtime.GetConfig()[ports.SourceRuntimeApplicationWorkspaceIDConfigKey],
+	)
+	if err != nil {
+		return "", fmt.Errorf("source runtime application_workspace_id: %w", err)
+	}
+	return workspaceID, nil
 }
 
 func sameConfig(left map[string]string, right map[string]string) bool {

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -1451,10 +1451,13 @@ func TestMaterializeEventPinsSyncCollectionProvenance(t *testing.T) {
 			ports.EventAttributeSourceCollectionID: "provider-collection",
 		},
 	}
-	materialized := materializeEvent(&cerebrov1.SourceRuntime{
+	materialized, err := materializeEvent(&cerebrov1.SourceRuntime{
 		Id:       "runtime-authority",
 		TenantId: "tenant-a",
 	}, collectionID, event)
+	if err != nil {
+		t.Fatalf("materializeEvent() error = %v", err)
+	}
 	if got := materialized.GetAttributes()[ports.EventAttributeSourceRuntimeID]; got != "runtime-authority" {
 		t.Fatalf("source_runtime_id = %q, want runtime authority", got)
 	}
@@ -1472,16 +1475,22 @@ func TestMaterializeEventKeepsImmutableMaterialAcrossCollections(t *testing.T) {
 	event := runtimeTestEvent("okta-threat-insight-sha256-stable", "okta", "okta.threat_insight")
 	event.TenantId = "provider-tenant"
 	event.Attributes["resource_id"] = "threat_insight_config"
-	first := materializeEvent(
+	first, err := materializeEvent(
 		&cerebrov1.SourceRuntime{Id: "writer-okta-primary", TenantId: "tenant-a"},
 		"collection-one",
 		event,
 	)
-	second := materializeEvent(
+	if err != nil {
+		t.Fatalf("materializeEvent(first) error = %v", err)
+	}
+	second, err := materializeEvent(
 		&cerebrov1.SourceRuntime{Id: "writer-okta-replacement", TenantId: "tenant-a"},
 		"collection-two",
 		event,
 	)
+	if err != nil {
+		t.Fatalf("materializeEvent(second) error = %v", err)
+	}
 
 	if first.GetId() != second.GetId() {
 		t.Fatalf("immutable event ID changed across collections: %q != %q", first.GetId(), second.GetId())
@@ -1501,6 +1510,38 @@ func TestMaterializeEventKeepsImmutableMaterialAcrossCollections(t *testing.T) {
 	delete(second.Attributes, ports.EventAttributeSourceRuntimeID)
 	if !proto.Equal(first, second) {
 		t.Fatalf("materialized immutable records differ beyond collection provenance: first=%v second=%v", first, second)
+	}
+}
+
+func TestMaterializeEventUsesOnlyTrustedRuntimeApplicationWorkspace(t *testing.T) {
+	t.Parallel()
+
+	runtime := &cerebrov1.SourceRuntime{
+		Id:       "runtime-authority",
+		TenantId: "tenant-a",
+		Config: map[string]string{
+			ports.SourceRuntimeApplicationWorkspaceIDConfigKey: " workspace-a ",
+		},
+	}
+	event := &cerebrov1.EventEnvelope{Attributes: map[string]string{"workspace_id": "provider-workspace"}}
+	materialized, err := materializeEvent(runtime, "collection-one", event)
+	if err != nil {
+		t.Fatalf("materializeEvent() error = %v", err)
+	}
+	if got := materialized.GetAttributes()[ports.EventAttributeApplicationWorkspaceID]; got != "workspace-a" {
+		t.Fatalf("reserved application workspace = %q, want trusted runtime workspace-a", got)
+	}
+	if got := materialized.GetAttributes()["workspace_id"]; got != "provider-workspace" {
+		t.Fatalf("provider workspace attribute changed to %q", got)
+	}
+
+	event.Attributes[ports.EventAttributeApplicationWorkspaceID] = "provider-spoof"
+	if _, err := materializeEvent(runtime, "collection-two", event); err == nil {
+		t.Fatal("materializeEvent() error = nil, want reserved attribute conflict")
+	}
+	event.Attributes[ports.EventAttributeApplicationWorkspaceID] = "workspace-a"
+	if _, err := materializeEvent(runtime, "collection-three", event); err == nil {
+		t.Fatal("materializeEvent() error = nil, want matching provider reserved attribute rejected")
 	}
 }
 

--- a/internal/statestore/postgres/projection.go
+++ b/internal/statestore/postgres/projection.go
@@ -17,6 +17,7 @@ var ensureProjectionStatements = []string{
 	`CREATE TABLE IF NOT EXISTS entities (
   urn TEXT PRIMARY KEY,
   tenant_id TEXT NOT NULL,
+  application_workspace_id TEXT NOT NULL DEFAULT '',
   source_id TEXT NOT NULL,
   runtime_id TEXT NOT NULL DEFAULT '',
   entity_type TEXT NOT NULL,
@@ -25,6 +26,8 @@ var ensureProjectionStatements = []string{
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )`,
 	`CREATE INDEX IF NOT EXISTS entities_tenant_type_idx ON entities (tenant_id, entity_type)`,
+	`ALTER TABLE entities ADD COLUMN IF NOT EXISTS application_workspace_id TEXT NOT NULL DEFAULT ''`,
+	`CREATE INDEX IF NOT EXISTS entities_tenant_workspace_type_idx ON entities (tenant_id, application_workspace_id, entity_type)`,
 	`ALTER TABLE entities ADD COLUMN IF NOT EXISTS runtime_id TEXT NOT NULL DEFAULT ''`,
 	`CREATE INDEX IF NOT EXISTS entities_tenant_runtime_idx ON entities (tenant_id, runtime_id)`,
 	`CREATE INDEX IF NOT EXISTS entities_runtime_evidence_source_event_idx ON entities (tenant_id, runtime_id, (attributes_json ->> 'source_event_id')) WHERE entity_type = 'runtime.evidence'`,
@@ -33,6 +36,7 @@ var ensureProjectionStatements = []string{
   relation TEXT NOT NULL,
   to_urn TEXT NOT NULL,
   tenant_id TEXT NOT NULL,
+  application_workspace_id TEXT NOT NULL DEFAULT '',
   source_id TEXT NOT NULL,
   runtime_id TEXT NOT NULL DEFAULT '',
   attributes_json JSONB NOT NULL DEFAULT '{}'::jsonb,
@@ -40,6 +44,8 @@ var ensureProjectionStatements = []string{
   PRIMARY KEY (from_urn, relation, to_urn)
 )`,
 	`CREATE INDEX IF NOT EXISTS entity_links_tenant_relation_idx ON entity_links (tenant_id, relation)`,
+	`ALTER TABLE entity_links ADD COLUMN IF NOT EXISTS application_workspace_id TEXT NOT NULL DEFAULT ''`,
+	`CREATE INDEX IF NOT EXISTS entity_links_tenant_workspace_relation_idx ON entity_links (tenant_id, application_workspace_id, relation)`,
 	`CREATE INDEX IF NOT EXISTS entity_links_to_urn_idx ON entity_links (to_urn)`,
 	`ALTER TABLE entity_links ADD COLUMN IF NOT EXISTS runtime_id TEXT NOT NULL DEFAULT ''`,
 	`CREATE INDEX IF NOT EXISTS entity_links_tenant_runtime_idx ON entity_links (tenant_id, runtime_id)`,
@@ -47,30 +53,42 @@ var ensureProjectionStatements = []string{
 
 func projectedEntityUpsertSQL() string {
 	return `
-INSERT INTO entities (urn, tenant_id, source_id, runtime_id, entity_type, label, attributes_json)
-VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+INSERT INTO entities (urn, tenant_id, application_workspace_id, source_id, runtime_id, entity_type, label, attributes_json)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
 ON CONFLICT (urn)
 DO UPDATE SET
   tenant_id = EXCLUDED.tenant_id,
+  application_workspace_id = CASE WHEN EXCLUDED.application_workspace_id <> '' THEN EXCLUDED.application_workspace_id ELSE entities.application_workspace_id END,
   source_id = EXCLUDED.source_id,
   runtime_id = CASE WHEN EXCLUDED.runtime_id <> '' THEN EXCLUDED.runtime_id ELSE entities.runtime_id END,
   entity_type = EXCLUDED.entity_type,
   label = CASE WHEN EXCLUDED.label = EXCLUDED.urn THEN entities.label ELSE EXCLUDED.label END,
   attributes_json = entities.attributes_json || EXCLUDED.attributes_json,
-  updated_at = NOW()`
+  updated_at = NOW()
+WHERE entities.tenant_id = EXCLUDED.tenant_id
+  AND (
+    entities.application_workspace_id = ''
+    OR entities.application_workspace_id = EXCLUDED.application_workspace_id
+  )`
 }
 
 func projectedLinkUpsertSQL() string {
 	return `
-INSERT INTO entity_links (from_urn, relation, to_urn, tenant_id, source_id, runtime_id, attributes_json)
-VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
+INSERT INTO entity_links (from_urn, relation, to_urn, tenant_id, application_workspace_id, source_id, runtime_id, attributes_json)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
 ON CONFLICT (from_urn, relation, to_urn)
 DO UPDATE SET
   tenant_id = EXCLUDED.tenant_id,
+  application_workspace_id = CASE WHEN EXCLUDED.application_workspace_id <> '' THEN EXCLUDED.application_workspace_id ELSE entity_links.application_workspace_id END,
   source_id = EXCLUDED.source_id,
   runtime_id = CASE WHEN EXCLUDED.runtime_id <> '' THEN EXCLUDED.runtime_id ELSE entity_links.runtime_id END,
   attributes_json = entity_links.attributes_json || EXCLUDED.attributes_json,
-  updated_at = NOW()`
+  updated_at = NOW()
+WHERE entity_links.tenant_id = EXCLUDED.tenant_id
+  AND (
+    entity_links.application_workspace_id = ''
+    OR entity_links.application_workspace_id = EXCLUDED.application_workspace_id
+  )`
 }
 
 func projectedLinkDeleteSQL() string {
@@ -93,14 +111,14 @@ WHERE urn = $1`
 
 func projectedEntityGetSQL() string {
 	return `
-SELECT urn, tenant_id, source_id, runtime_id, entity_type, label, attributes_json
+SELECT urn, tenant_id, application_workspace_id, source_id, runtime_id, entity_type, label, attributes_json
 FROM entities
 WHERE urn = $1`
 }
 
 func projectedRuntimeEvidenceBySourceEventSQL() string {
 	return `
-SELECT urn, tenant_id, source_id, runtime_id, entity_type, label, attributes_json
+SELECT urn, tenant_id, application_workspace_id, source_id, runtime_id, entity_type, label, attributes_json
 FROM entities
 WHERE tenant_id = $1
   AND entity_type = 'runtime.evidence'
@@ -390,8 +408,16 @@ func (s *Store) UpsertProjectedEntity(ctx context.Context, entity *ports.Project
 	if label == "" {
 		label = urn
 	}
-	if _, err := s.db.ExecContext(ctx, projectedEntityUpsertSQL(), urn, tenantID, sourceID, strings.TrimSpace(entity.RuntimeID), entityType, label, attributesJSON); err != nil {
+	workspaceID, err := ports.ValidateApplicationWorkspaceScope(tenantID, entity.ApplicationWorkspaceID)
+	if err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, projectedEntityUpsertSQL(), urn, tenantID, workspaceID, sourceID, strings.TrimSpace(entity.RuntimeID), entityType, label, attributesJSON)
+	if err != nil {
 		return fmt.Errorf("upsert projected entity %q: %w", urn, err)
+	}
+	if updated, err := result.RowsAffected(); err == nil && updated == 0 {
+		return fmt.Errorf("%w: projected entity %q", ports.ErrApplicationWorkspaceConflict, urn)
 	}
 	return nil
 }
@@ -413,6 +439,7 @@ func (s *Store) GetProjectedEntity(ctx context.Context, urn string) (*ports.Proj
 	err := s.db.QueryRowContext(ctx, projectedEntityGetSQL(), normalizedURN).Scan(
 		&entity.URN,
 		&entity.TenantID,
+		&entity.ApplicationWorkspaceID,
 		&entity.SourceID,
 		&entity.RuntimeID,
 		&entity.EntityType,
@@ -462,6 +489,7 @@ func (s *Store) GetProjectedRuntimeEvidenceBySourceEvent(ctx context.Context, te
 	err := s.db.QueryRowContext(ctx, projectedRuntimeEvidenceBySourceEventSQL(), normalizedTenantID, normalizedSourceRuntimeID, normalizedSourceEventID).Scan(
 		&entity.URN,
 		&entity.TenantID,
+		&entity.ApplicationWorkspaceID,
 		&entity.SourceID,
 		&entity.RuntimeID,
 		&entity.EntityType,
@@ -523,8 +551,16 @@ func (s *Store) UpsertProjectedLink(ctx context.Context, link *ports.ProjectedLi
 	if err != nil {
 		return fmt.Errorf("marshal projected link attributes: %w", err)
 	}
-	if _, err := s.db.ExecContext(ctx, projectedLinkUpsertSQL(), fromURN, relation, toURN, tenantID, sourceID, strings.TrimSpace(link.RuntimeID), attributesJSON); err != nil {
+	workspaceID, err := ports.ValidateApplicationWorkspaceScope(tenantID, link.ApplicationWorkspaceID)
+	if err != nil {
+		return err
+	}
+	result, err := s.db.ExecContext(ctx, projectedLinkUpsertSQL(), fromURN, relation, toURN, tenantID, workspaceID, sourceID, strings.TrimSpace(link.RuntimeID), attributesJSON)
+	if err != nil {
 		return fmt.Errorf("upsert projected link %q %q %q: %w", fromURN, relation, toURN, err)
+	}
+	if updated, err := result.RowsAffected(); err == nil && updated == 0 {
+		return fmt.Errorf("%w: projected link %q %q %q", ports.ErrApplicationWorkspaceConflict, fromURN, relation, toURN)
 	}
 	return nil
 }

--- a/internal/statestore/postgres/projection_test.go
+++ b/internal/statestore/postgres/projection_test.go
@@ -79,6 +79,26 @@ func TestUpsertProjectedLinkRejectsCrossTenantCerebroURNBeforeDatabase(t *testin
 	}
 }
 
+func TestProjectionSQLBackfillsBlankWorkspaceAndRejectsConflicts(t *testing.T) {
+	for name, query := range map[string]string{
+		"entity": projectedEntityUpsertSQL(),
+		"link":   projectedLinkUpsertSQL(),
+	} {
+		for _, clause := range []string{"application_workspace_id", "EXCLUDED.application_workspace_id <> ''", "tenant_id = EXCLUDED.tenant_id", "application_workspace_id = ''", "application_workspace_id = EXCLUDED.application_workspace_id"} {
+			if !strings.Contains(query, clause) {
+				t.Fatalf("%s upsert missing %q:\n%s", name, clause, query)
+			}
+		}
+		if strings.Contains(query, "OR EXCLUDED.application_workspace_id = ''") {
+			t.Fatalf("%s upsert allows an unscoped replay to mutate a scoped row:\n%s", name, query)
+		}
+	}
+	joined := strings.Join(ensureProjectionStatements, "\n")
+	if !strings.Contains(joined, "ADD COLUMN IF NOT EXISTS application_workspace_id TEXT NOT NULL DEFAULT ''") {
+		t.Fatalf("projection migration does not preserve blank tenant-wide legacy rows")
+	}
+}
+
 func TestProjectionUpsertsMergeAttributes(t *testing.T) {
 	entitySQL := projectedEntityUpsertSQL()
 	if !strings.Contains(entitySQL, "attributes_json = entities.attributes_json || EXCLUDED.attributes_json") {


### PR DESCRIPTION
Summary
- stamp application workspace scope only from trusted source-runtime configuration and reject provider use of the reserved event attribute
- persist workspace scope on projected entities and links in Postgres and Neo4j single and batch writes
- fail closed on tenant or workspace conflicts, including scoped rows receiving blank legacy replays
- preserve blank tenant-wide legacy records and allow explicit blank-to-scoped reprojection backfill

Validation
- cargo fmt --all --check
- cargo test -p cerebro-platform legacy_projection_rejects_cross_scope_records
- go test ./internal/ports ./internal/sourceruntime ./internal/sourceprojection ./internal/sourcehttp/organizationalgraph ./internal/statestore/postgres ./internal/graphstore/neo4j -count=1
- git diff --check