### PR TITLE
Close remaining GRC workspace cache and edge gaps

### DIFF
--- a/crates/agent-context/src/lib.rs
+++ b/crates/agent-context/src/lib.rs
@@ -96,6 +96,9 @@ pub struct ContextEdge {
     pub to: EntityId,
     /// Collector runtime whose evidence supports the assertion.
     pub source_runtime_id: String,
+    /// Trusted Cerebro application workspace shared by the edge endpoints.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub application_workspace_id: String,
     /// Whether this edge projects an identity-binding assertion.
     pub identity_binding: bool,
 }
@@ -1374,6 +1377,7 @@ fn context_edge(assertion: &GraphAssertion) -> ContextEdge {
             relation: value.relation().as_str().to_owned(),
             to: value.to().clone(),
             source_runtime_id: value.provenance().source_runtime_id().to_string(),
+            application_workspace_id: value.application_workspace_id().to_owned(),
             identity_binding: false,
         },
         GraphAssertion::IdentityBinding(value) => ContextEdge {
@@ -1382,6 +1386,7 @@ fn context_edge(assertion: &GraphAssertion) -> ContextEdge {
             relation: "represents".to_owned(),
             to: value.canonical_identity().clone(),
             source_runtime_id: value.provenance().source_runtime_id().to_string(),
+            application_workspace_id: String::new(),
             identity_binding: true,
         },
     }

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -5831,6 +5831,7 @@ mod tests {
             relation: "can_access".to_owned(),
             to: neighbor.entity_id.clone(),
             source_runtime_id: "github-prod".to_owned(),
+            application_workspace_id: String::new(),
             identity_binding: false,
         };
         (

--- a/crates/cerebro-platform/src/rpc.rs
+++ b/crates/cerebro-platform/src/rpc.rs
@@ -366,13 +366,13 @@ impl GraphRpc {
                             "The in-memory catalog relation omitted its neighbor.",
                         ));
                     };
-                    if !in_memory_catalog_workspace_matches(neighbor, application_workspace_id) {
-                        continue;
-                    }
-                    if !filter.directions.contains(&direction)
-                        || !filter.relations.contains(&edge.relation)
-                        || !filter.neighbor_kinds.contains(&neighbor.entity_kind)
-                    {
+                    if !in_memory_catalog_relation_matches(
+                        edge,
+                        neighbor,
+                        application_workspace_id,
+                        direction,
+                        filter,
+                    ) {
                         continue;
                     }
                     let direction_key = match direction {
@@ -1610,16 +1610,32 @@ fn in_memory_catalog_workspace_matches(
     entity: &ContextEntity,
     application_workspace_id: &str,
 ) -> bool {
-    // ContextEdge has no workspace metadata. The Go projection invariant test
-    // TestFinalizeProjectedRecordsStampsTrustedApplicationWorkspace and the
-    // graph-store duplicate-workspace tests ensure admitted links inherit one
-    // trusted workspace; roots and neighbors are filtered here.
     application_workspace_id.is_empty()
         || entity
             .properties
             .get("application_workspace_id")
             .map(String::as_str)
             == Some(application_workspace_id)
+}
+
+fn in_memory_catalog_relation_matches(
+    edge: &ContextEdge,
+    neighbor: &ContextEntity,
+    application_workspace_id: &str,
+    direction: StoreCatalogDirection,
+    filter: &StoreCatalogRelationCountFilter,
+) -> bool {
+    // A blank edge scope is a pre-workspace projection. The root was selected
+    // from the trusted application_workspace_id stamp and the neighbor match
+    // above requires the same trusted stamp, so legacy edges remain readable
+    // without accepting a conflicting workspace-stamped edge.
+    in_memory_catalog_workspace_matches(neighbor, application_workspace_id)
+        && (application_workspace_id.is_empty()
+            || edge.application_workspace_id == application_workspace_id
+            || edge.application_workspace_id.is_empty())
+        && filter.directions.contains(&direction)
+        && filter.relations.contains(&edge.relation)
+        && filter.neighbor_kinds.contains(&neighbor.entity_kind)
 }
 
 fn in_memory_catalog_entity_matches(entity: &ContextEntity, filter: &StoreCatalogFilter) -> bool {
@@ -2480,6 +2496,7 @@ mod tests {
             relation: "owns".to_owned(),
             to: EntityId::parse("entity-b").unwrap(),
             source_runtime_id: "runtime-a".to_owned(),
+            application_workspace_id: String::new(),
             identity_binding: false,
         }
     }
@@ -2580,12 +2597,55 @@ mod tests {
         assert!(!in_memory_catalog_entity_matches(&entity, &filter));
         filter.application_workspace_id = " workspace-a".to_owned();
         assert!(validate_in_memory_catalog_request(&tenant, &filter, "").is_err());
+        filter.application_workspace_id = "w".repeat(128);
+        assert!(validate_in_memory_catalog_request(&tenant, &filter, "").is_ok());
+        filter.application_workspace_id = "w".repeat(129);
+        assert!(validate_in_memory_catalog_request(&tenant, &filter, "").is_err());
 
         assert!(in_memory_catalog_workspace_matches(&entity, "workspace-a"));
         assert!(!in_memory_catalog_workspace_matches(&entity, "workspace-b"));
         assert!(in_memory_catalog_workspace_matches(&entity, ""));
         entity.properties.remove("application_workspace_id");
         assert!(!in_memory_catalog_workspace_matches(&entity, "workspace-a"));
+    }
+
+    #[test]
+    fn in_memory_catalog_relation_counts_reject_mismatched_edge_workspace() {
+        let mut neighbor = context_entity("entity-b", "contract");
+        neighbor.properties.insert(
+            "application_workspace_id".to_owned(),
+            "workspace-a".to_owned(),
+        );
+        let filter = StoreCatalogRelationCountFilter {
+            directions: vec![StoreCatalogDirection::Outgoing],
+            relations: vec!["owns".to_owned()],
+            neighbor_kinds: vec!["contract".to_owned()],
+        };
+        let mut edge = context_edge("assertion-a");
+        edge.application_workspace_id = "workspace-b".to_owned();
+        assert!(!in_memory_catalog_relation_matches(
+            &edge,
+            &neighbor,
+            "workspace-a",
+            StoreCatalogDirection::Outgoing,
+            &filter,
+        ));
+        edge.application_workspace_id.clear();
+        assert!(in_memory_catalog_relation_matches(
+            &edge,
+            &neighbor,
+            "workspace-a",
+            StoreCatalogDirection::Outgoing,
+            &filter,
+        ));
+        edge.application_workspace_id = "workspace-a".to_owned();
+        assert!(in_memory_catalog_relation_matches(
+            &edge,
+            &neighbor,
+            "workspace-a",
+            StoreCatalogDirection::Outgoing,
+            &filter,
+        ));
     }
 
     #[test]

--- a/crates/organizational-model/src/lib.rs
+++ b/crates/organizational-model/src/lib.rs
@@ -1169,6 +1169,14 @@ impl RelationKind {
     }
 }
 
+fn entity_application_workspace_id(entity: &Entity) -> &str {
+    entity
+        .properties()
+        .get("application_workspace_id")
+        .map(String::as_str)
+        .unwrap_or_default()
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 /// An evidence-backed, directed relationship between two sealed entities.
 pub struct RelationshipAssertion {
@@ -1179,6 +1187,8 @@ pub struct RelationshipAssertion {
     relation: RelationKind,
     to: EntityId,
     to_kind: EntityKind,
+    #[serde(skip_serializing)]
+    application_workspace_id: String,
     provenance: AssertionProvenance,
     observed_at_unix_ms: i64,
 }
@@ -1205,7 +1215,12 @@ impl RelationshipAssertion {
         if from.tenant_id != to.tenant_id || from.tenant_id != *provenance.tenant_id() {
             return Err(ModelError::TenantMismatch);
         }
-        if !relation.accepts(&from.kind, &to.kind) || observed_at_unix_ms <= 0 {
+        let from_workspace = entity_application_workspace_id(from);
+        let to_workspace = entity_application_workspace_id(to);
+        if !relation.accepts(&from.kind, &to.kind)
+            || observed_at_unix_ms <= 0
+            || from_workspace != to_workspace
+        {
             return Err(ModelError::InvalidRelationship);
         }
         let id = AssertionId::parse(deterministic_id(
@@ -1226,6 +1241,7 @@ impl RelationshipAssertion {
             relation,
             to: to.id.clone(),
             to_kind: to.kind.clone(),
+            application_workspace_id: from_workspace.to_owned(),
             provenance,
             observed_at_unix_ms,
         })
@@ -1249,6 +1265,11 @@ impl RelationshipAssertion {
     /// Returns the destination endpoint entity ID.
     pub fn to(&self) -> &EntityId {
         &self.to
+    }
+
+    /// Returns the trusted application workspace shared by both endpoints.
+    pub fn application_workspace_id(&self) -> &str {
+        &self.application_workspace_id
     }
 
     /// Returns the admitted relationship kind.
@@ -1981,6 +2002,52 @@ mod tests {
                 &repository,
                 RelationKind::MemberOf,
                 &group,
+                provenance(receipt.receipt()),
+                10,
+            ),
+            Err(ModelError::InvalidRelationship)
+        );
+    }
+
+    #[test]
+    fn relationship_workspace_scope_must_match_both_endpoints() {
+        let receipt = receipt();
+        let team = Entity::canonical(
+            TenantId::parse("tenant-a").unwrap(),
+            EntityId::parse("group-workspace").unwrap(),
+            EntityKind::Team,
+            "team",
+        )
+        .unwrap()
+        .with_property("application_workspace_id", "workspace-a")
+        .unwrap();
+        let repository = Entity::canonical(
+            TenantId::parse("tenant-a").unwrap(),
+            EntityId::parse("repository-workspace").unwrap(),
+            EntityKind::Repository,
+            "repository",
+        )
+        .unwrap()
+        .with_property("application_workspace_id", "workspace-a")
+        .unwrap();
+        let assertion = RelationshipAssertion::new(
+            &team,
+            RelationKind::Owns,
+            &repository,
+            provenance(receipt.receipt()),
+            10,
+        )
+        .unwrap();
+        assert_eq!(assertion.application_workspace_id(), "workspace-a");
+
+        let other_workspace = repository
+            .with_property("application_workspace_id", "workspace-b")
+            .unwrap();
+        assert_eq!(
+            RelationshipAssertion::new(
+                &team,
+                RelationKind::Owns,
+                &other_workspace,
                 provenance(receipt.receipt()),
                 10,
             ),

--- a/crates/organizational-store/src/neo4j.rs
+++ b/crates/organizational-store/src/neo4j.rs
@@ -113,6 +113,7 @@ MERGE (source)-[assertion:ORGANIZATIONAL_RELATION {
 }]->(target)
 SET assertion.relation = row.relation,
     assertion.source_runtime_id = row.source_runtime_id,
+    assertion.application_workspace_id = row.application_workspace_id,
     assertion.state = row.state,
     assertion.provenance_json = row.provenance_json,
     assertion.observed_at_unix_ms = row.observed_at_unix_ms,
@@ -226,19 +227,20 @@ RETURN root_key,
        coalesce(edge.assertion_id, '') AS assertion_id,
        coalesce(edge.relation, '') AS relation,
        coalesce(edge.source_runtime_id, '') AS source_runtime_id,
+       coalesce(edge.application_workspace_id, '') AS application_workspace_id,
        coalesce(revision.graph_revision, 0) AS graph_revision
 ORDER BY root_key, assertion_id
 "#;
 
 fn expand_statement(depth: usize) -> String {
     format!(
-        "MATCH path=(root:OrganizationalEntity {{tenant_id: $tenant_id, entity_id: $root_id}})-[:ORGANIZATIONAL_RELATION*1..{depth}]-(node:OrganizationalEntity) WITH relationships(path) AS relations UNWIND relations AS edge WITH DISTINCT edge MATCH (source)-[edge]->(target) WHERE source.tenant_id = $tenant_id AND target.tenant_id = $tenant_id RETURN source.entity_id AS from_id, source.entity_kind AS from_kind, source.authority_json AS from_authority, source.label AS from_label, source.properties_json AS from_properties, target.entity_id AS to_id, target.entity_kind AS to_kind, target.authority_json AS to_authority, target.label AS to_label, target.properties_json AS to_properties, edge.assertion_id AS assertion_id, edge.relation AS relation, edge.source_runtime_id AS source_runtime_id ORDER BY assertion_id LIMIT $row_limit"
+        "MATCH path=(root:OrganizationalEntity {{tenant_id: $tenant_id, entity_id: $root_id}})-[:ORGANIZATIONAL_RELATION*1..{depth}]-(node:OrganizationalEntity) WITH relationships(path) AS relations UNWIND relations AS edge WITH DISTINCT edge MATCH (source)-[edge]->(target) WHERE source.tenant_id = $tenant_id AND target.tenant_id = $tenant_id RETURN source.entity_id AS from_id, source.entity_kind AS from_kind, source.authority_json AS from_authority, source.label AS from_label, source.properties_json AS from_properties, target.entity_id AS to_id, target.entity_kind AS to_kind, target.authority_json AS to_authority, target.label AS to_label, target.properties_json AS to_properties, edge.assertion_id AS assertion_id, edge.relation AS relation, edge.source_runtime_id AS source_runtime_id, coalesce(edge.application_workspace_id, '') AS application_workspace_id ORDER BY assertion_id LIMIT $row_limit"
     )
 }
 
 fn paths_statement(max_depth: usize) -> String {
     format!(
-        "MATCH path=(source:OrganizationalEntity {{tenant_id: $tenant_id, entity_id: $from_id}})-[:ORGANIZATIONAL_RELATION*1..{max_depth}]->(target:OrganizationalEntity {{tenant_id: $tenant_id, entity_id: $to_id}}) WHERE all(node IN nodes(path) WHERE node.tenant_id = $tenant_id) AND all(node IN nodes(path) WHERE single(other IN nodes(path) WHERE other = node)) RETURN [node IN nodes(path) | node.entity_id] AS entity_ids, [node IN nodes(path) | node.entity_kind] AS entity_kinds, [node IN nodes(path) | node.authority_json] AS authorities, [node IN nodes(path) | node.label] AS labels, [node IN nodes(path) | node.properties_json] AS properties, [edge IN relationships(path) | edge.assertion_id] AS assertion_ids, [edge IN relationships(path) | edge.relation] AS relations, [edge IN relationships(path) | edge.source_runtime_id] AS runtime_ids ORDER BY length(path), assertion_ids LIMIT $limit"
+        "MATCH path=(source:OrganizationalEntity {{tenant_id: $tenant_id, entity_id: $from_id}})-[:ORGANIZATIONAL_RELATION*1..{max_depth}]->(target:OrganizationalEntity {{tenant_id: $tenant_id, entity_id: $to_id}}) WHERE all(node IN nodes(path) WHERE node.tenant_id = $tenant_id) AND all(node IN nodes(path) WHERE single(other IN nodes(path) WHERE other = node)) RETURN [node IN nodes(path) | node.entity_id] AS entity_ids, [node IN nodes(path) | node.entity_kind] AS entity_kinds, [node IN nodes(path) | node.authority_json] AS authorities, [node IN nodes(path) | node.label] AS labels, [node IN nodes(path) | node.properties_json] AS properties, [edge IN relationships(path) | edge.assertion_id] AS assertion_ids, [edge IN relationships(path) | edge.relation] AS relations, [edge IN relationships(path) | edge.source_runtime_id] AS runtime_ids, [edge IN relationships(path) | coalesce(edge.application_workspace_id, '')] AS application_workspace_ids ORDER BY length(path), assertion_ids LIMIT $limit"
     )
 }
 
@@ -314,6 +316,7 @@ fn fact_query_statement(fact_query: &FactQuery) -> String {
             format!("edge_{index}.relation AS edge_{index}_relation"),
             format!("node_{to}.entity_id AS edge_{index}_to_id"),
             format!("edge_{index}.source_runtime_id AS edge_{index}_source_runtime_id"),
+            format!("coalesce(edge_{index}.application_workspace_id, '') AS edge_{index}_application_workspace_id"),
         ]);
         order.push(format!("edge_{index}.assertion_id"));
     }
@@ -2974,6 +2977,7 @@ impl AgentGraph for Neo4jProjector {
                 to: EntityId::parse(row_string(&row, "to_id")?)
                     .map_err(|error| ContextError::BackendUnavailable(error.to_string()))?,
                 source_runtime_id: row_string(&row, "source_runtime_id")?,
+                application_workspace_id: row_string(&row, "application_workspace_id")?,
                 identity_binding: row_string(&row, "relation")? == "represents",
             });
         }
@@ -3062,6 +3066,9 @@ impl AgentGraph for Neo4jProjector {
             let assertion_ids: Vec<String> = row.get("assertion_ids").map_err(context_decode)?;
             let relations: Vec<String> = row.get("relations").map_err(context_decode)?;
             let runtime_ids: Vec<String> = row.get("runtime_ids").map_err(context_decode)?;
+            let application_workspace_ids: Vec<String> = row
+                .get("application_workspace_ids")
+                .map_err(context_decode)?;
             if !same_len(&[
                 entity_ids.len(),
                 entity_kinds.len(),
@@ -3069,7 +3076,12 @@ impl AgentGraph for Neo4jProjector {
                 labels.len(),
                 properties.len(),
             ]) || entity_ids.len() != assertion_ids.len().saturating_add(1)
-                || !same_len(&[assertion_ids.len(), relations.len(), runtime_ids.len()])
+                || !same_len(&[
+                    assertion_ids.len(),
+                    relations.len(),
+                    runtime_ids.len(),
+                    application_workspace_ids.len(),
+                ])
             {
                 return Err(ContextError::BackendUnavailable(
                     "Neo4j path columns have inconsistent lengths".to_owned(),
@@ -3097,6 +3109,7 @@ impl AgentGraph for Neo4jProjector {
                     relation: relations[index].clone(),
                     to: entities[index + 1].entity_id.clone(),
                     source_runtime_id: runtime_ids[index].clone(),
+                    application_workspace_id: application_workspace_ids[index].clone(),
                     identity_binding: relations[index] == "represents",
                 });
             }
@@ -3136,7 +3149,7 @@ impl AgentGraph for Neo4jProjector {
         let mut stream = self
             .graph
             .execute(
-                query("MATCH (source:OrganizationalEntity)-[edge:ORGANIZATIONAL_RELATION {tenant_id: $tenant_id, assertion_id: $assertion_id}]->(target:OrganizationalEntity) RETURN source.entity_id AS from_id, target.entity_id AS to_id, edge.relation AS relation, edge.source_runtime_id AS source_runtime_id")
+                query("MATCH (source:OrganizationalEntity)-[edge:ORGANIZATIONAL_RELATION {tenant_id: $tenant_id, assertion_id: $assertion_id}]->(target:OrganizationalEntity) RETURN source.entity_id AS from_id, target.entity_id AS to_id, edge.relation AS relation, edge.source_runtime_id AS source_runtime_id, coalesce(edge.application_workspace_id, '') AS application_workspace_id")
                     .param("tenant_id", tenant_id.as_str())
                     .param("assertion_id", assertion_id.as_str()),
             )
@@ -3156,6 +3169,7 @@ impl AgentGraph for Neo4jProjector {
             to: EntityId::parse(row_string(&row, "to_id")?)
                 .map_err(|error| ContextError::BackendUnavailable(error.to_string()))?,
             source_runtime_id: row_string(&row, "source_runtime_id")?,
+            application_workspace_id: row_string(&row, "application_workspace_id")?,
             identity_binding: relation == "represents",
         })
     }
@@ -3234,6 +3248,10 @@ impl AgentGraph for Neo4jProjector {
                         source_runtime_id: row_string(
                             &row,
                             &format!("edge_{index}_source_runtime_id"),
+                        )?,
+                        application_workspace_id: row_string(
+                            &row,
+                            &format!("edge_{index}_application_workspace_id"),
                         )?,
                         identity_binding: relation == "represents",
                     },
@@ -3319,6 +3337,7 @@ impl Neo4jProjector {
                 relation: relation.clone(),
                 to: to.entity_id.clone(),
                 source_runtime_id: row_string(&row, "source_runtime_id")?,
+                application_workspace_id: row_string(&row, "application_workspace_id")?,
                 identity_binding: relation == "represents",
             };
             accumulator.entities.insert(from.entity_id.clone(), from);
@@ -4657,6 +4676,10 @@ fn legacy_context_edge(
         relation,
         to: legacy_entity_id(tenant_id, &to),
         source_runtime_id,
+        application_workspace_id: properties
+            .get("application_workspace_id")
+            .cloned()
+            .unwrap_or_default(),
         identity_binding,
     })
 }
@@ -4815,6 +4838,10 @@ fn assertion_row(assertion: &ProjectionAssertion) -> BoltMap {
         (
             "source_runtime_id",
             assertion.source_runtime_id.clone().into(),
+        ),
+        (
+            "application_workspace_id",
+            assertion.application_workspace_id.clone().into(),
         ),
         ("state", assertion.state.clone().into()),
         ("provenance_json", assertion.provenance_json.clone().into()),
@@ -5156,6 +5183,8 @@ mod tests {
         assert!(validate_catalog_request(&tenant, &filter, 100, "").is_ok());
         filter.application_workspace_id = " workspace-a".to_owned();
         assert!(validate_catalog_request(&tenant, &filter, 100, "").is_err());
+        filter.application_workspace_id = "w".repeat(128);
+        assert!(validate_catalog_request(&tenant, &filter, 100, "").is_ok());
         filter.application_workspace_id = "w".repeat(129);
         assert!(validate_catalog_request(&tenant, &filter, 100, "").is_err());
         filter.application_workspace_id.clear();

--- a/crates/organizational-store/src/postgres.rs
+++ b/crates/organizational-store/src/postgres.rs
@@ -667,6 +667,8 @@ pub(crate) struct ProjectionAssertion {
     pub to_entity_id: String,
     pub relation: String,
     pub source_runtime_id: String,
+    #[serde(default)]
+    pub application_workspace_id: String,
     pub state: String,
     pub provenance_json: String,
     pub observed_at_unix_ms: i64,
@@ -2999,12 +3001,14 @@ pub(crate) fn projection_commit(
         .iter()
         .map(|assertion| {
             let (from, to, relation) = assertion_endpoints(assertion);
-            let (state, observed_at_unix_ms) = match assertion {
-                GraphAssertion::Relationship(value) => {
-                    ("confirmed".to_owned(), value.observed_at_unix_ms())
-                }
+            let (state, observed_at_unix_ms, application_workspace_id) = match assertion {
+                GraphAssertion::Relationship(value) => (
+                    "confirmed".to_owned(),
+                    value.observed_at_unix_ms(),
+                    value.application_workspace_id(),
+                ),
                 GraphAssertion::IdentityBinding(value) => {
-                    (enum_name(&value.state())?, value.observed_at_unix_ms())
+                    (enum_name(&value.state())?, value.observed_at_unix_ms(), "")
                 }
             };
             Ok(ProjectionAssertion {
@@ -3017,6 +3021,7 @@ pub(crate) fn projection_commit(
                     .source_runtime_id()
                     .as_str()
                     .to_owned(),
+                application_workspace_id: application_workspace_id.to_owned(),
                 state,
                 provenance_json: serde_json::to_string(assertion.provenance())?,
                 observed_at_unix_ms,

--- a/internal/applicationworkspace/scope.go
+++ b/internal/applicationworkspace/scope.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	Header             = "X-Cerebro-Workspace"
-	maxSelectorIDBytes = 256
+	maxSelectorIDBytes = 128
 )
 
 var ErrInvalidSelector = errors.New("invalid application workspace selector")

--- a/internal/applicationworkspace/scope_test.go
+++ b/internal/applicationworkspace/scope_test.go
@@ -2,6 +2,7 @@ package applicationworkspace
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/writer/cerebro/internal/config"
@@ -30,6 +31,15 @@ func TestSelectValuesRejectsRepeatedSelectors(t *testing.T) {
 				t.Fatal("SelectValues() error = nil, want repeated-selector rejection")
 			}
 		})
+	}
+}
+
+func TestValidIDUsesShared128ByteContract(t *testing.T) {
+	if !ValidID(strings.Repeat("w", 128)) {
+		t.Fatal("ValidID(128 bytes) = false")
+	}
+	if ValidID(strings.Repeat("w", 129)) {
+		t.Fatal("ValidID(129 bytes) = true")
 	}
 }
 

--- a/internal/bootstrap/grc_cache.go
+++ b/internal/bootstrap/grc_cache.go
@@ -358,7 +358,7 @@ func copyHeaders(dst http.Header, src http.Header) {
 
 func setGRCQueryCacheHeaders(header http.Header, cacheState string, policy grcCachePolicy) {
 	header.Set("X-Cerebro-Cache", cacheState)
-	header.Set("Vary", appendVary(header.Get("Vary"), "Accept-Encoding", "Authorization", "X-Cerebro-API-Key", "X-Cerebro-Tenant"))
+	header.Set("Vary", appendVary(header.Get("Vary"), "Accept-Encoding", "Authorization", "X-Cerebro-API-Key", "X-Cerebro-Tenant", applicationworkspace.Header))
 	if (cacheState == "hit" || cacheState == "miss" || cacheState == "stale") && policy.TTL > 0 {
 		maxAge := int(policy.TTL / time.Second)
 		if maxAge < 1 {

--- a/internal/bootstrap/grc_cache_test.go
+++ b/internal/bootstrap/grc_cache_test.go
@@ -84,6 +84,11 @@ func TestGRCQueryCacheIsolatesApplicationWorkspaceHeader(t *testing.T) {
 	if calls["workspace-a"] != 1 || calls["workspace-b"] != 1 || firstA.Body.String() == firstB.Body.String() {
 		t.Fatalf("workspace cache isolation = calls:%#v A:%q B:%q", calls, firstA.Body.String(), firstB.Body.String())
 	}
+	for _, response := range []*httptest.ResponseRecorder{firstA, secondA, firstB, secondB} {
+		if !strings.Contains(response.Header().Get("Vary"), applicationWorkspaceHeader) {
+			t.Fatalf("Vary = %q, want %q", response.Header().Get("Vary"), applicationWorkspaceHeader)
+		}
+	}
 }
 
 func TestGRCCacheKeyNormalizesWorkspaceSelectorAndBindsGrants(t *testing.T) {


### PR DESCRIPTION
## Summary
- vary private GRC cache responses by the application workspace header
- carry trusted relationship workspace scope through ContextEdge and relation-count reads while preserving pre-workspace edges through exact endpoint scope
- align Go and Rust application workspace identifiers on a 128-byte bound

## Validation
- `go test ./internal/applicationworkspace ./internal/bootstrap -count=1`
- `make lint-shard LINT_PACKAGES='./internal/applicationworkspace ./internal/bootstrap' LINT_SHARD_TOTAL=1 LINT_SHARD_INDEX=0`
- `cargo test -p cerebro-organizational-model -p cerebro-agent-context -p cerebro-organizational-store -p cerebro-platform`
- `cargo clippy -p cerebro-organizational-model -p cerebro-agent-context -p cerebro-organizational-store -p cerebro-platform --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `make check-structural check-arch`