### PR TITLE
Add exhaustive local API route 404 probes

### DIFF
--- a/apps/web/scripts/local-grc-e2e.mjs
+++ b/apps/web/scripts/local-grc-e2e.mjs
@@ -3,12 +3,14 @@
 import { execFile, spawn } from "node:child_process";
 import { randomBytes, randomUUID } from "node:crypto";
 import { createWriteStream } from "node:fs";
-import { access, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import http from "node:http";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { parse as parseYAML } from "yaml";
 
 import { grcBrowserRouteContracts } from "./grc-route-contract.mjs";
 
@@ -324,6 +326,7 @@ async function main(options) {
 
   step("validating backend GRC endpoints");
   assertChildHealthy(backendProcess, "Cerebro API");
+  await validateRegisteredOpenAPIRoutes();
   await validateBackend();
   assertChildHealthy(backendProcess, "Cerebro API");
 
@@ -848,6 +851,48 @@ async function validateBackend() {
 
   const invalidLimit = await request(`${apiBase}/grc/dashboard?tenant_id=${tenantID}&limit=1000`);
   expect(invalidLimit.status === 400, `invalid limit status ${invalidLimit.status}`);
+}
+
+export function openAPIRouteProbePaths(document) {
+  const paths = document?.paths;
+  if (!paths || typeof paths !== "object" || Array.isArray(paths)) {
+    throw new Error("OpenAPI document has no paths object");
+  }
+  return Object.keys(paths).sort().map((template) => {
+    if (!template.startsWith("/")) throw new Error(`OpenAPI path is not absolute: ${template}`);
+    const concrete = template.replace(/\{[^{}]+\}/g, "route-probe");
+    if (concrete.includes("{") || concrete.includes("}")) throw new Error(`OpenAPI path has an invalid template: ${template}`);
+    return { concrete, template };
+  });
+}
+
+export function assertRegisteredOpenAPIRouteResponses(results) {
+  for (const { status, template } of results) {
+    expect(status !== 404, `OpenAPI route ${template} is not registered`);
+  }
+}
+
+async function validateRegisteredOpenAPIRoutes() {
+  const spec = parseYAML(await readFile(path.join(backendRoot, "api", "openapi.yaml"), "utf8"));
+  const probes = openAPIRouteProbePaths(spec);
+  const concurrency = 16;
+  for (let offset = 0; offset < probes.length; offset += concurrency) {
+    const batch = probes.slice(offset, offset + concurrency);
+    const responses = await Promise.all(batch.map(async ({ concrete, template }) => ({
+      response: await request(`${apiBase}${concrete}`, {
+        headers: {
+          "X-Cerebro-Tenant": tenantID,
+          "X-Cerebro-Workspace": "e2e-workspace",
+        },
+        method: "OPTIONS",
+      }),
+      template,
+    })));
+    assertRegisteredOpenAPIRouteResponses(responses.map(({ response, template }) => ({
+      status: response.status,
+      template,
+    })));
+  }
 }
 
 async function validateProxyCache() {

--- a/apps/web/scripts/local-grc-e2e.test.mjs
+++ b/apps/web/scripts/local-grc-e2e.test.mjs
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   acquireAbortableResource,
+  assertRegisteredOpenAPIRouteResponses,
   assertChildHealthy,
   assertConcurrentProxyResponses,
   browserDataContract,
@@ -15,6 +16,7 @@ import {
   handoffLoopbackReservation,
   internalLoopbackPort,
   localRelayPath,
+  openAPIRouteProbePaths,
   parseArgs,
   parseDockerLoopbackPort,
   portableChildEnvironment,
@@ -168,6 +170,29 @@ describe("real-service E2E isolation", () => {
 });
 
 describe("real-service E2E contracts", () => {
+  it("materializes every OpenAPI path for runtime 404 probing", () => {
+    expect(openAPIRouteProbePaths({ paths: {
+      "/health": { get: {} },
+      "/grc/entities/{entityID}/impact": { get: {} },
+    } })).toEqual([
+      { concrete: "/grc/entities/route-probe/impact", template: "/grc/entities/{entityID}/impact" },
+      { concrete: "/health", template: "/health" },
+    ]);
+    expect(() => openAPIRouteProbePaths({})).toThrow("no paths object");
+    expect(() => openAPIRouteProbePaths({ paths: { relative: {} } })).toThrow("not absolute");
+    expect(() => openAPIRouteProbePaths({ paths: { "/broken/{id": {} } })).toThrow("invalid template");
+  });
+
+  it("fails only when a documented runtime path resolves as unregistered", () => {
+    expect(() => assertRegisteredOpenAPIRouteResponses([
+      { status: 200, template: "/health" },
+      { status: 405, template: "/grc/entities/{entityID}/impact" },
+    ])).not.toThrow();
+    expect(() => assertRegisteredOpenAPIRouteResponses([
+      { status: 404, template: "/ghost" },
+    ])).toThrow("OpenAPI route /ghost is not registered");
+  });
+
   it("requires every declared health component to report ready", () => {
     expect(componentReady({ components: [{ name: "state_store", status: "ready" }] }, "state_store")).toBe(true);
     expect(componentReady({ components: [{ name: "state_store", status: "degraded" }] }, "state_store")).toBe(false);

--- a/scripts/openapi_route_parity.go
+++ b/scripts/openapi_route_parity.go
@@ -37,20 +37,12 @@ func main() {
 	if err != nil {
 		fail(err)
 	}
-	var missing []route
-	for _, route := range routes {
-		if !paths[route.Path] {
-			missing = append(missing, route)
-			continue
-		}
-		if route.Method != "" && !methods[route] {
-			missing = append(missing, route)
-		}
-	}
-	if len(missing) == 0 {
+	missing := missingOpenAPIRoutes(routes, paths, methods)
+	unregistered := unregisteredOpenAPIRoutes(routes, methods)
+	if len(missing) == 0 && len(unregistered) == 0 {
 		return
 	}
-	if *write {
+	if *write && len(unregistered) == 0 {
 		if err := appendPlaceholders(missing); err != nil {
 			fail(err)
 		}
@@ -63,7 +55,46 @@ func main() {
 		}
 		fmt.Fprintf(os.Stderr, "OpenAPI missing route: %s %s\n", method, route.Path)
 	}
+	for _, route := range unregistered {
+		fmt.Fprintf(os.Stderr, "OpenAPI route is not registered: %s %s\n", strings.ToUpper(route.Method), route.Path)
+	}
 	os.Exit(1)
+}
+
+func missingOpenAPIRoutes(routes []route, paths map[string]bool, methods map[route]bool) []route {
+	var missing []route
+	for _, route := range routes {
+		if !paths[route.Path] || (route.Method != "" && !methods[route]) {
+			missing = append(missing, route)
+		}
+	}
+	return missing
+}
+
+func unregisteredOpenAPIRoutes(routes []route, methods map[route]bool) []route {
+	registered := make(map[route]bool, len(routes))
+	wildcardPaths := make(map[string]bool)
+	for _, route := range routes {
+		if route.Method == "" {
+			wildcardPaths[route.Path] = true
+			continue
+		}
+		registered[route] = true
+	}
+
+	var unregistered []route
+	for route := range methods {
+		if !registered[route] && !wildcardPaths[route.Path] {
+			unregistered = append(unregistered, route)
+		}
+	}
+	sort.Slice(unregistered, func(i, j int) bool {
+		if unregistered[i].Path == unregistered[j].Path {
+			return unregistered[i].Method < unregistered[j].Method
+		}
+		return unregistered[i].Path < unregistered[j].Path
+	})
+	return unregistered
 }
 
 func registeredRoutes(paths ...string) ([]route, error) {

--- a/scripts/openapi_route_parity_test.go
+++ b/scripts/openapi_route_parity_test.go
@@ -85,3 +85,42 @@ paths:
 		t.Fatal("openAPIPaths() error = nil, want invalid spec error")
 	}
 }
+
+func TestRouteParityIsBidirectional(t *testing.T) {
+	routes := []route{
+		{Method: "get", Path: "/v1/registered"},
+		{Method: "", Path: "/v1/wildcard"},
+		{Method: "post", Path: "/v1/missing-doc"},
+	}
+	paths := map[string]bool{
+		"/v1/registered":   true,
+		"/v1/wildcard":     true,
+		"/v1/ghost":        true,
+		"/v1/wrong-method": true,
+	}
+	methods := map[route]bool{
+		{Method: "get", Path: "/v1/registered"}:    true,
+		{Method: "get", Path: "/v1/wildcard"}:      true,
+		{Method: "delete", Path: "/v1/ghost"}:      true,
+		{Method: "post", Path: "/v1/wrong-method"}: true,
+	}
+
+	missing := missingOpenAPIRoutes(routes, paths, methods)
+	if len(missing) != 1 || missing[0] != (route{Method: "post", Path: "/v1/missing-doc"}) {
+		t.Fatalf("missingOpenAPIRoutes() = %#v", missing)
+	}
+
+	unregistered := unregisteredOpenAPIRoutes(routes, methods)
+	want := []route{
+		{Method: "delete", Path: "/v1/ghost"},
+		{Method: "post", Path: "/v1/wrong-method"},
+	}
+	if len(unregistered) != len(want) {
+		t.Fatalf("unregisteredOpenAPIRoutes() = %#v, want %#v", unregistered, want)
+	}
+	for index := range want {
+		if unregistered[index] != want[index] {
+			t.Fatalf("unregisteredOpenAPIRoutes()[%d] = %#v, want %#v", index, unregistered[index], want[index])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- make OpenAPI route parity bidirectional so documented but unregistered operations fail CI
- probe every documented path through the disposable local API stack
- exercise tenant and application-workspace routing headers while detecting route-level 404s

## Validation
- `npm test --workspace @writer/cerebro-web -- --run scripts/local-grc-e2e.test.mjs`
- `npm run lint --workspace @writer/cerebro-web -- --quiet scripts/local-grc-e2e.mjs scripts/local-grc-e2e.test.mjs`
- `go test ./scripts -count=1`
- `go run ./scripts/openapi_route_parity.go`
- `git diff --check`

The full Docker-backed runner requires a local Docker daemon and remains covered by the existing hosted web integration job.