### PR TITLE
Harden trusted application workspace edge scope

### DIFF
--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -2622,7 +2622,7 @@ fn validate_legacy_projection(
 fn valid_legacy_application_workspace_id(value: &str) -> bool {
     value.is_empty()
         || (value.trim() == value
-            && value.len() <= 256
+            && value.len() <= 128
             && value != "*"
             && !value.contains(',')
             && !value.chars().any(char::is_control))
@@ -5943,6 +5943,11 @@ mod tests {
             },
         };
         assert!(validate_legacy_projection(&tenant_id, &request).is_ok());
+        request.delta.entities[0].application_workspace_id = "w".repeat(128);
+        assert!(validate_legacy_projection(&tenant_id, &request).is_ok());
+        request.delta.entities[0].application_workspace_id = "w".repeat(129);
+        assert!(validate_legacy_projection(&tenant_id, &request).is_err());
+        request.delta.entities[0].application_workspace_id = "workspace-a".to_owned();
         request.delta.entities[0].tenant_id = "tenant-other".to_owned();
         assert!(validate_legacy_projection(&tenant_id, &request).is_err());
     }

--- a/crates/organizational-store/src/neo4j.rs
+++ b/crates/organizational-store/src/neo4j.rs
@@ -374,6 +374,7 @@ CALL {
   WITH root, neighbor, relation.relation AS relation_kind,
        collect(DISTINCT coalesce(relation.tenant_id, '')) AS relation_tenant_ids,
        collect(DISTINCT coalesce(relation.runtime_id, '')) AS typed_runtime_ids,
+       collect(DISTINCT coalesce(relation.application_workspace_id, '')) AS typed_application_workspace_ids,
        collect(DISTINCT coalesce(relation.attributes_json, '{}')) AS relation_properties_values
   RETURN neighbor.urn AS neighbor_urn,
          coalesce(neighbor.entity_type, 'unknown') AS neighbor_kind,
@@ -386,13 +387,14 @@ CALL {
          neighbor.urn AS to_urn,
          relation_tenant_ids,
          typed_runtime_ids,
+         typed_application_workspace_ids,
          relation_properties_values
   ORDER BY neighbor.urn, relation_kind, neighbor.entity_type, neighbor.label
   LIMIT $row_limit
 }
 RETURN root_urn, neighbor_urn, neighbor_kind, neighbor_label, neighbor_properties,
        neighbor_source_id, neighbor_runtime_id,
-       from_urn, relation_kind, to_urn, relation_tenant_ids, typed_runtime_ids, relation_properties_values
+       from_urn, relation_kind, to_urn, relation_tenant_ids, typed_runtime_ids, typed_application_workspace_ids, relation_properties_values
 ORDER BY root_urn, neighbor_urn, relation_kind
 "#;
 
@@ -406,6 +408,7 @@ CALL {
   WITH root, neighbor, relation.relation AS relation_kind,
        collect(DISTINCT coalesce(relation.tenant_id, '')) AS relation_tenant_ids,
        collect(DISTINCT coalesce(relation.runtime_id, '')) AS typed_runtime_ids,
+       collect(DISTINCT coalesce(relation.application_workspace_id, '')) AS typed_application_workspace_ids,
        collect(DISTINCT coalesce(relation.attributes_json, '{}')) AS relation_properties_values
   RETURN neighbor.urn AS neighbor_urn,
          coalesce(neighbor.entity_type, 'unknown') AS neighbor_kind,
@@ -418,13 +421,14 @@ CALL {
          root.urn AS to_urn,
          relation_tenant_ids,
          typed_runtime_ids,
+         typed_application_workspace_ids,
          relation_properties_values
   ORDER BY neighbor.urn, relation_kind, neighbor.entity_type, neighbor.label
   LIMIT $row_limit
 }
 RETURN root_urn, neighbor_urn, neighbor_kind, neighbor_label, neighbor_properties,
        neighbor_source_id, neighbor_runtime_id,
-       from_urn, relation_kind, to_urn, relation_tenant_ids, typed_runtime_ids, relation_properties_values
+       from_urn, relation_kind, to_urn, relation_tenant_ids, typed_runtime_ids, typed_application_workspace_ids, relation_properties_values
 ORDER BY root_urn, neighbor_urn, relation_kind
 "#;
 
@@ -1966,10 +1970,16 @@ ORDER BY runtime_id
                     from,
                     relation,
                     to,
-                    row.get("relation_tenant_ids").map_err(context_decode)?,
-                    row.get("typed_runtime_ids").map_err(context_decode)?,
-                    row.get("relation_properties_values")
-                        .map_err(context_decode)?,
+                    LegacyEdgeMetadata {
+                        tenant_ids: row.get("relation_tenant_ids").map_err(context_decode)?,
+                        runtime_ids: row.get("typed_runtime_ids").map_err(context_decode)?,
+                        application_workspace_ids: row
+                            .get("typed_application_workspace_ids")
+                            .map_err(context_decode)?,
+                        properties_values: row
+                            .get("relation_properties_values")
+                            .map_err(context_decode)?,
+                    },
                 )?);
             }
         }
@@ -4609,14 +4619,19 @@ fn legacy_context_entity_from_row_prefix(
     .map_err(|error| StoreError::Conflict(error.to_string()))
 }
 
+struct LegacyEdgeMetadata {
+    tenant_ids: Vec<String>,
+    runtime_ids: Vec<String>,
+    application_workspace_ids: Vec<String>,
+    properties_values: Vec<String>,
+}
+
 fn legacy_context_edge(
     tenant_id: &TenantId,
     from: String,
     relation: String,
     to: String,
-    relation_tenant_ids: Vec<String>,
-    typed_runtime_ids: Vec<String>,
-    properties_values: Vec<String>,
+    metadata: LegacyEdgeMetadata,
 ) -> Result<ContextEdge, ContextError> {
     let expected_prefix = format!("urn:cerebro:{}:", tenant_id.as_str());
     if !from.starts_with(&expected_prefix) || !to.starts_with(&expected_prefix) {
@@ -4624,7 +4639,8 @@ fn legacy_context_edge(
             "legacy graph returned a cross-tenant relation".to_owned(),
         ));
     }
-    if relation_tenant_ids
+    if metadata
+        .tenant_ids
         .iter()
         .any(|value| !value.is_empty() && value != tenant_id.as_str())
     {
@@ -4632,21 +4648,41 @@ fn legacy_context_edge(
             "legacy graph returned a cross-tenant relation".to_owned(),
         ));
     }
-    if typed_runtime_ids.len() > 1 || properties_values.len() > 1 {
+    if metadata.runtime_ids.len() > 1
+        || metadata.application_workspace_ids.len() > 1
+        || metadata.properties_values.len() > 1
+    {
         return Err(ContextError::BackendUnavailable(
             "legacy relation metadata conflicts".to_owned(),
         ));
     }
     let properties: BTreeMap<String, String> = parse_json(
-        properties_values
+        metadata
+            .properties_values
             .first()
             .map(String::as_str)
             .unwrap_or("{}"),
     )?;
-    let typed_runtime_id = typed_runtime_ids
+    let typed_runtime_id = metadata
+        .runtime_ids
         .first()
         .map(String::as_str)
         .unwrap_or_default();
+    let application_workspace_id = metadata
+        .application_workspace_ids
+        .first()
+        .map(String::as_str)
+        .unwrap_or_default();
+    if application_workspace_id.len() > 128
+        || application_workspace_id.trim() != application_workspace_id
+        || application_workspace_id == "*"
+        || application_workspace_id.contains(',')
+        || application_workspace_id.chars().any(char::is_control)
+    {
+        return Err(ContextError::BackendUnavailable(
+            "legacy relation application workspace is invalid".to_owned(),
+        ));
+    }
     let attributes_runtime_id = properties
         .get("source_runtime_id")
         .or_else(|| properties.get("runtime_id"))
@@ -4676,10 +4712,7 @@ fn legacy_context_edge(
         relation,
         to: legacy_entity_id(tenant_id, &to),
         source_runtime_id,
-        application_workspace_id: properties
-            .get("application_workspace_id")
-            .cloned()
-            .unwrap_or_default(),
+        application_workspace_id: application_workspace_id.to_owned(),
         identity_binding,
     })
 }
@@ -5474,12 +5507,18 @@ mod tests {
             from.to_owned(),
             "represents".to_owned(),
             to.to_owned(),
-            vec![String::new()],
-            vec!["runtime-a".to_owned()],
-            vec![r#"{"source_runtime_id":"runtime-a","identity_binding":"true"}"#.to_owned()],
+            LegacyEdgeMetadata {
+                tenant_ids: vec![String::new()],
+                runtime_ids: vec!["runtime-a".to_owned()],
+                application_workspace_ids: vec!["workspace-a".to_owned()],
+                properties_values: vec![
+                    r#"{"source_runtime_id":"runtime-a","identity_binding":"true"}"#.to_owned(),
+                ],
+            },
         )
         .expect("legacy edge");
         assert_eq!(edge.source_runtime_id, "runtime-a");
+        assert_eq!(edge.application_workspace_id, "workspace-a");
         assert!(edge.identity_binding);
         assert_eq!(
             edge.assertion_id,
@@ -5492,9 +5531,12 @@ mod tests {
                 from.to_owned(),
                 "owns".to_owned(),
                 to.to_owned(),
-                vec!["writer".to_owned()],
-                vec!["runtime-a".to_owned(), "runtime-b".to_owned()],
-                vec!["{}".to_owned()],
+                LegacyEdgeMetadata {
+                    tenant_ids: vec!["writer".to_owned()],
+                    runtime_ids: vec!["runtime-a".to_owned(), "runtime-b".to_owned()],
+                    application_workspace_ids: vec![String::new()],
+                    properties_values: vec!["{}".to_owned()],
+                },
             )
             .is_err()
         );
@@ -5504,9 +5546,15 @@ mod tests {
                 from.to_owned(),
                 "owns".to_owned(),
                 to.to_owned(),
-                vec!["writer".to_owned()],
-                vec!["runtime-a".to_owned()],
-                vec![r#"{"source_runtime_id":"runtime-b"}"#.to_owned()],
+                LegacyEdgeMetadata {
+                    tenant_ids: vec!["writer".to_owned()],
+                    runtime_ids: vec!["runtime-a".to_owned()],
+                    application_workspace_ids: vec![
+                        "workspace-a".to_owned(),
+                        "workspace-b".to_owned(),
+                    ],
+                    properties_values: vec!["{}".to_owned()],
+                },
             )
             .is_err()
         );
@@ -5516,9 +5564,42 @@ mod tests {
                 from.to_owned(),
                 "owns".to_owned(),
                 to.to_owned(),
-                vec!["other".to_owned()],
-                vec!["runtime-a".to_owned()],
-                vec!["{}".to_owned()],
+                LegacyEdgeMetadata {
+                    tenant_ids: vec!["writer".to_owned()],
+                    runtime_ids: vec!["runtime-a".to_owned()],
+                    application_workspace_ids: vec!["w".repeat(129)],
+                    properties_values: vec!["{}".to_owned()],
+                },
+            )
+            .is_err()
+        );
+        assert!(
+            legacy_context_edge(
+                &tenant_id,
+                from.to_owned(),
+                "owns".to_owned(),
+                to.to_owned(),
+                LegacyEdgeMetadata {
+                    tenant_ids: vec!["writer".to_owned()],
+                    runtime_ids: vec!["runtime-a".to_owned()],
+                    application_workspace_ids: vec![String::new()],
+                    properties_values: vec![r#"{"source_runtime_id":"runtime-b"}"#.to_owned()],
+                },
+            )
+            .is_err()
+        );
+        assert!(
+            legacy_context_edge(
+                &tenant_id,
+                from.to_owned(),
+                "owns".to_owned(),
+                to.to_owned(),
+                LegacyEdgeMetadata {
+                    tenant_ids: vec!["other".to_owned()],
+                    runtime_ids: vec!["runtime-a".to_owned()],
+                    application_workspace_ids: vec![String::new()],
+                    properties_values: vec!["{}".to_owned()],
+                },
             )
             .is_err()
         );
@@ -5528,9 +5609,12 @@ mod tests {
                 from.to_owned(),
                 "owns".to_owned(),
                 "urn:cerebro:other:finding:two".to_owned(),
-                vec![String::new()],
-                vec!["runtime-a".to_owned()],
-                vec!["{}".to_owned()],
+                LegacyEdgeMetadata {
+                    tenant_ids: vec![String::new()],
+                    runtime_ids: vec!["runtime-a".to_owned()],
+                    application_workspace_ids: vec![String::new()],
+                    properties_values: vec!["{}".to_owned()],
+                },
             )
             .is_err()
         );
@@ -5544,6 +5628,7 @@ mod tests {
             assert!(statement.contains("[relation:RELATION]"));
             assert!(statement.contains("coalesce(relation.tenant_id, '') IN ['', $tenant_id]"));
             assert!(statement.contains("relation_tenant_ids"));
+            assert!(statement.contains("typed_application_workspace_ids"));
             assert!(statement.contains("LIMIT $row_limit"));
             assert!(statement.contains("ORDER BY neighbor.urn, relation_kind"));
         }

--- a/crates/source-runtime-next/src/mapper.rs
+++ b/crates/source-runtime-next/src/mapper.rs
@@ -31,6 +31,8 @@ pub enum CatalogMapperError {
     },
     /// The catalog selected a template without a generic Rust mapper.
     UnsupportedTemplate(String),
+    /// Provider-owned fields attempted to set trusted runtime scope.
+    ReservedField(String),
     /// The projected value violates an organizational-model invariant.
     Domain(ModelError),
     /// One verified claim points at two different canonical identities.
@@ -54,6 +56,9 @@ impl fmt::Display for CatalogMapperError {
                     formatter,
                     "projection template {template} requires a bespoke Rust mapper"
                 )
+            }
+            Self::ReservedField(field) => {
+                write!(formatter, "provider record contains reserved field {field}")
             }
             Self::Domain(error) => write!(formatter, "catalog projection is invalid: {error}"),
             Self::IdentityConflict(claim) => {
@@ -733,6 +738,9 @@ fn add_properties(
     projected: BTreeMap<String, String>,
 ) -> Result<Entity, CatalogMapperError> {
     for (key, value) in projected {
+        if key == "application_workspace_id" {
+            return Err(CatalogMapperError::ReservedField(key));
+        }
         entity = entity.with_property(key, value)?;
     }
     Ok(entity)
@@ -755,6 +763,29 @@ mod tests {
             .join("../..")
             .canonicalize()
             .unwrap()
+    }
+
+    #[test]
+    fn provider_fields_cannot_assign_application_workspace_scope() {
+        let entity = Entity::canonical(
+            TenantId::parse("tenant-a").unwrap(),
+            cerebro_organizational_model::EntityId::parse("entity-a").unwrap(),
+            EntityKind::Application,
+            "Application",
+        )
+        .unwrap();
+        let result = add_properties(
+            entity,
+            BTreeMap::from([(
+                "application_workspace_id".to_owned(),
+                "workspace-provider".to_owned(),
+            )]),
+        );
+        assert!(matches!(
+            result,
+            Err(CatalogMapperError::ReservedField(field))
+                if field == "application_workspace_id"
+        ));
     }
 
     #[test]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,7 @@ const defaultHTTPAddr = ":8080"
 const defaultShutdownTimeout = 10 * time.Second
 const defaultJetStreamSubjectPrefix = "events"
 const defaultSourceEventAdmissionWorkers = 4
-const maxApplicationWorkspaceIDBytes = 256
+const maxApplicationWorkspaceIDBytes = 128
 
 const (
 	defaultPostgresMaxOpenConns        = 25

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1104,6 +1104,7 @@ func TestLoadRejectsInvalidApplicationWorkspaceGrants(t *testing.T) {
 		{name: "foreign tenant", grants: `[{"tenant_id":"other","application_workspace_ids":["workspace-a"]}]`},
 		{name: "wildcard workspace", grants: `[{"tenant_id":"writer","application_workspace_ids":["*"]}]`},
 		{name: "ambiguous workspace list", grants: `[{"tenant_id":"writer","application_workspace_ids":["workspace-a,workspace-b"]}]`},
+		{name: "overlong workspace", grants: `[{"tenant_id":"writer","application_workspace_ids":["` + strings.Repeat("w", 129) + `"]}]`},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			clearDependencyEnv(t)

--- a/internal/ports/projection.go
+++ b/internal/ports/projection.go
@@ -20,7 +20,7 @@ var ErrProjectedTenantScope = errors.New("projected URN tenant scope mismatch")
 // graph identity between application workspaces without an explicit migration.
 var ErrApplicationWorkspaceConflict = errors.New("application workspace projection conflict")
 
-const maxApplicationWorkspaceIDBytes = 256
+const maxApplicationWorkspaceIDBytes = 128
 
 // ProjectedTenantScopeError identifies the rejected projection field and both
 // tenant scopes without requiring callers to parse an error string.

--- a/internal/ports/projection_test.go
+++ b/internal/ports/projection_test.go
@@ -2,6 +2,7 @@ package ports
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -86,5 +87,11 @@ func TestValidateApplicationWorkspaceScopeIsTenantQualifiedAndBounded(t *testing
 	}
 	if got, err := ValidateApplicationWorkspaceScope("", ""); err != nil || got != "" {
 		t.Fatalf("blank tenant-wide legacy scope = %q, %v", got, err)
+	}
+	if got, err := ValidateApplicationWorkspaceScope("tenant-a", strings.Repeat("w", 128)); err != nil || len(got) != 128 {
+		t.Fatalf("128-byte workspace scope = %q, %v", got, err)
+	}
+	if _, err := ValidateApplicationWorkspaceScope("tenant-a", strings.Repeat("w", 129)); err == nil {
+		t.Fatal("129-byte workspace scope error = nil")
 	}
 }


### PR DESCRIPTION
## Summary
- reject provider-projected application_workspace_id fields before generic Rust graph mapping
- preserve the trusted typed Neo4j relationship workspace through legacy ContextEdge reads and fail closed on conflicting or invalid metadata
- align Go configuration, Go projection, and Rust legacy projection workspace identifiers to the shared 128-byte contract

## Validation
- go test ./internal/config ./internal/ports -count=1
- cargo test -p cerebro-source-runtime-next -p cerebro-organizational-store -p cerebro-platform
- cargo test -p cerebro-organizational-store
- cargo clippy -p cerebro-source-runtime-next -p cerebro-organizational-store -p cerebro-platform --all-targets -- -D warnings
- cargo fmt --all --check
- make lint-shard LINT_PACKAGES="./internal/config ./internal/ports" LINT_SHARD_TOTAL=1 LINT_SHARD_INDEX=0
- make check-structural check-arch