### PR TITLE
Keep disabled device routes addressable

### DIFF
--- a/internal/bootstrap/device_handlers_test.go
+++ b/internal/bootstrap/device_handlers_test.go
@@ -71,6 +71,46 @@ func newAppForDeviceTest(t *testing.T) *App {
 	return app
 }
 
+func TestDeviceRoutesRemainRegisteredWhenDeviceAuthIsDisabled(t *testing.T) {
+	app := &App{}
+	mux := http.NewServeMux()
+	app.registerDeviceRoutes(mux)
+
+	tests := []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodPost, path: "/platform/devices/enroll"},
+		{method: http.MethodPost, path: "/platform/devices/token"},
+		{method: http.MethodPost, path: "/platform/devices/bootstrap-tokens"},
+		{method: http.MethodPost, path: "/platform/devices/device-a/revoke"},
+		{method: http.MethodPost, path: "/platform/telemetry/ingest"},
+		{method: http.MethodGet, path: "/.well-known/device-jwks.json"},
+	}
+	for _, test := range tests {
+		t.Run(test.method+" "+test.path, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			mux.ServeHTTP(response, httptest.NewRequest(test.method, test.path, nil))
+			if response.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusServiceUnavailable)
+			}
+			var payload map[string]string
+			if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if payload["error"] != "device_auth_disabled" {
+				t.Fatalf("error = %q, want device_auth_disabled", payload["error"])
+			}
+
+			options := httptest.NewRecorder()
+			mux.ServeHTTP(options, httptest.NewRequest(http.MethodOptions, test.path, nil))
+			if options.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("OPTIONS status = %d, want %d", options.Code, http.StatusMethodNotAllowed)
+			}
+		})
+	}
+}
+
 // deviceAuthMemStore wraps deviceauth.MemStore and implements ports.StateStore
 // (Ping) so it can be passed via Dependencies.
 type deviceAuthMemStore struct {

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -407,15 +407,16 @@ func (app *App) registerMCPRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "POST /api/v1/mcp", routeSurfacePlatformHTTP, app.handleMCP)
 }
 func (app *App) registerDeviceRoutes(mux *http.ServeMux) {
-	if app.deviceHandler == nil {
-		return
+	handler := app.deviceHandler
+	if handler == nil {
+		handler = &deviceAuthHTTPHandler{}
 	}
-	registerHTTPRoute(mux, "POST /platform/devices/enroll", routeSurfacePlatformHTTP, app.deviceHandler.handleEnroll)
-	registerHTTPRoute(mux, "POST /platform/devices/token", routeSurfacePlatformHTTP, app.deviceHandler.handleToken)
-	registerHTTPRoute(mux, "POST /platform/devices/bootstrap-tokens", routeSurfacePlatformHTTP, app.deviceHandler.handleIssueBootstrapToken)
-	registerHTTPRoute(mux, "POST /platform/devices/{deviceID}/revoke", routeSurfacePlatformHTTP, app.deviceHandler.handleRevoke)
-	registerHTTPRoute(mux, "POST /platform/telemetry/ingest", routeSurfacePlatformHTTP, app.deviceHandler.handleIngestTelemetry)
-	registerHTTPRoute(mux, "GET /.well-known/device-jwks.json", routeSurfacePublicHTTP, app.deviceHandler.handleJWKS)
+	registerHTTPRoute(mux, "POST /platform/devices/enroll", routeSurfacePlatformHTTP, handler.handleEnroll)
+	registerHTTPRoute(mux, "POST /platform/devices/token", routeSurfacePlatformHTTP, handler.handleToken)
+	registerHTTPRoute(mux, "POST /platform/devices/bootstrap-tokens", routeSurfacePlatformHTTP, handler.handleIssueBootstrapToken)
+	registerHTTPRoute(mux, "POST /platform/devices/{deviceID}/revoke", routeSurfacePlatformHTTP, handler.handleRevoke)
+	registerHTTPRoute(mux, "POST /platform/telemetry/ingest", routeSurfacePlatformHTTP, handler.handleIngestTelemetry)
+	registerHTTPRoute(mux, "GET /.well-known/device-jwks.json", routeSurfacePublicHTTP, handler.handleJWKS)
 }
 func registerHTTPRoute(mux *http.ServeMux, pattern string, _ bootstrapRouteSurface, handler http.HandlerFunc) {
 	mux.HandleFunc(pattern, handler)


### PR DESCRIPTION
## Summary
- keep documented device endpoints registered when device authentication is disabled
- return the existing typed `device_auth_disabled` 503 response instead of a route-level 404
- cover all six documented device route methods plus OPTIONS routing

## Validation
- `go test ./internal/bootstrap -count=1`
- `go test ./scripts -count=1`
- `go run ./scripts/openapi_route_parity.go`
- `git diff --check`