### PR TITLE
perf(grc): materialize dashboard evidence counts

### DIFF
--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -945,6 +945,9 @@ func (s *stubRuntimeStore) ListSourceRuntimes(_ context.Context, filter ports.So
 		if filter.TenantID != "" && runtime.GetTenantId() != filter.TenantID {
 			continue
 		}
+		if filter.ApplicationWorkspaceID != "" && strings.TrimSpace(runtime.GetConfig()[ports.SourceRuntimeApplicationWorkspaceIDConfigKey]) != filter.ApplicationWorkspaceID {
+			continue
+		}
 		if filter.SourceID != "" && runtime.GetSourceId() != filter.SourceID {
 			continue
 		}

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -183,7 +183,7 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		var err error
 		return operationtelemetry.RunMainPhase(groupCtx, "grc.dashboard.aggregate", telemetry.Attrs(telemetry.Field{Key: "finding_count", Value: len(findingIDs)}), func(ctx context.Context) (telemetry.Attributes, error) {
 			request := r.WithContext(ctx)
-			aggregate, err = a.grcDashboardAggregate(request, runtimes, grcFindingFilter{Status: "open"}, grcEvidenceFilter{})
+			aggregate, err = a.grcDashboardAggregate(request, runtimes, grcFindingFilter{Status: "open"}, findingIDs)
 			if err == nil && aggregate == nil {
 				findingSummary, err = a.grcFindingSummary(request, runtimes, grcFindingFilter{Status: "open"})
 				if err == nil {
@@ -889,10 +889,11 @@ func grcLimitFromRequest(r *http.Request) (uint32, error) {
 
 func (a *App) grcListRuntimes(r *http.Request, scope grcScope) ([]*cerebrov1.SourceRuntime, error) {
 	runtimes, err := a.runtimeService().List(r.Context(), ports.SourceRuntimeFilter{
-		RuntimeID:  scope.RuntimeID,
-		RuntimeIDs: scope.RuntimeIDs,
-		TenantID:   scope.TenantID,
-		SourceID:   scope.SourceID,
+		RuntimeID:              scope.RuntimeID,
+		RuntimeIDs:             scope.RuntimeIDs,
+		TenantID:               scope.TenantID,
+		ApplicationWorkspaceID: scope.ApplicationWorkspaceID,
+		SourceID:               scope.SourceID,
 		// Runtime scope is independent from the response row limit. Otherwise a
 		// small page can silently exclude findings from later runtimes.
 		Limit: grcRuntimeScopeFetchLimit,
@@ -912,11 +913,12 @@ func (a *App) grcReportScopeRuntimes(r *http.Request, scope grcScope, fallback [
 		return grccontrol.ReportScopeRuntimeSnapshots(fallback)
 	}
 	runtimes, err := store.ListSourceRuntimes(r.Context(), ports.SourceRuntimeFilter{
-		RuntimeID:  scope.RuntimeID,
-		RuntimeIDs: scope.RuntimeIDs,
-		TenantID:   scope.TenantID,
-		SourceID:   scope.SourceID,
-		Limit:      grcMaxRuntimeScope,
+		RuntimeID:              scope.RuntimeID,
+		RuntimeIDs:             scope.RuntimeIDs,
+		TenantID:               scope.TenantID,
+		ApplicationWorkspaceID: scope.ApplicationWorkspaceID,
+		SourceID:               scope.SourceID,
+		Limit:                  grcMaxRuntimeScope,
 	})
 	if err != nil {
 		return grccontrol.ReportScopeRuntimeSnapshots(fallback)
@@ -1200,14 +1202,10 @@ func (a *App) grcEvidenceCountsByFindingID(r *http.Request, runtimes []*cerebrov
 	return counts, true, nil
 }
 
-func (a *App) grcDashboardAggregate(r *http.Request, runtimes []*cerebrov1.SourceRuntime, findingFilter grcFindingFilter, evidenceFilter grcEvidenceFilter) (*ports.GRCDashboardAggregate, error) {
+func (a *App) grcDashboardAggregate(r *http.Request, runtimes []*cerebrov1.SourceRuntime, findingFilter grcFindingFilter, previewFindingIDs []string) (*ports.GRCDashboardAggregate, error) {
 	provider, ok := a.deps.StateStore.(ports.GRCDashboardAggregateStore)
 	if !ok {
 		return nil, nil
-	}
-	if evidenceFilter.FindingIDs != nil && strings.TrimSpace(evidenceFilter.FindingID) == "" && len(grcNonEmptyFindingIDs(evidenceFilter.FindingIDs)) == 0 {
-		aggregate := ports.GRCDashboardAggregate{}
-		return &aggregate, nil
 	}
 	runtimeIDsByTenant := map[string][]string{}
 	for _, runtime := range runtimes {
@@ -1250,15 +1248,7 @@ func (a *App) grcDashboardAggregate(r *http.Request, runtimes []*cerebrov1.Sourc
 				MaxAgeDays:          findingFilter.MaxAgeDays,
 				SLAStatus:           findingFilter.SLAStatus,
 			},
-			EvidenceRequest: ports.ListFindingEvidenceRequest{
-				RuntimeIDs:   runtimeIDs,
-				FindingID:    evidenceFilter.FindingID,
-				FindingIDs:   evidenceFilter.FindingIDs,
-				RunID:        evidenceFilter.RunID,
-				RuleID:       evidenceFilter.RuleID,
-				GraphRootURN: evidenceFilter.GraphRootURN,
-				Limit:        0,
-			},
+			PreviewFindingIDs: previewFindingIDs,
 		})
 		if err != nil {
 			return nil, err

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -145,6 +145,26 @@ func TestGRCScopeRejectsConflictingOrInvalidApplicationWorkspaceSelectors(t *tes
 	}
 }
 
+func TestGRCDashboardRuntimeScopeExcludesOtherApplicationWorkspaces(t *testing.T) {
+	store := &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"runtime-a": {Id: "runtime-a", TenantId: "tenant-a", SourceId: "okta", Config: map[string]string{ports.SourceRuntimeApplicationWorkspaceIDConfigKey: "workspace-a"}},
+		"runtime-b": {Id: "runtime-b", TenantId: "tenant-a", SourceId: "github", Config: map[string]string{ports.SourceRuntimeApplicationWorkspaceIDConfigKey: "workspace-b"}},
+		"runtime-c": {Id: "runtime-c", TenantId: "tenant-b", SourceId: "aws", Config: map[string]string{ports.SourceRuntimeApplicationWorkspaceIDConfigKey: "workspace-a"}},
+	}}
+	app := New(config.Config{}, Dependencies{StateStore: store}, nil)
+	request := httptest.NewRequest(http.MethodGet, "/grc/dashboard", nil)
+	runtimes, err := app.grcListRuntimes(request, grcScope{TenantID: "tenant-a", ApplicationWorkspaceID: "workspace-a", Limit: 12})
+	if err != nil {
+		t.Fatalf("grcListRuntimes() error = %v", err)
+	}
+	if len(runtimes) != 1 || runtimes[0].GetId() != "runtime-a" {
+		t.Fatalf("grcListRuntimes() = %#v, want only tenant-a/workspace-a runtime", runtimes)
+	}
+	if got := store.sourceRuntimeListFilter; got.TenantID != "tenant-a" || got.ApplicationWorkspaceID != "workspace-a" {
+		t.Fatalf("runtime list filter = %#v, want tenant-a/workspace-a", got)
+	}
+}
+
 func TestGRCDashboardAggregatesOperatorView(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	store := &stubRuntimeStore{
@@ -1869,8 +1889,23 @@ func (s *stubGRCAggregateStore) SummarizeGRCDashboard(ctx context.Context, reque
 	countsByFindingID := map[string]int{}
 	total := 0
 	status := strings.TrimSpace(request.FindingRequest.Status)
+	runtimeIDs := map[string]struct{}{}
+	for _, runtimeID := range append(request.FindingRequest.RuntimeIDs, request.FindingRequest.RuntimeID) {
+		if runtimeID = strings.TrimSpace(runtimeID); runtimeID != "" {
+			runtimeIDs[runtimeID] = struct{}{}
+		}
+	}
+	previewFindingIDs := map[string]struct{}{}
+	for _, findingID := range request.PreviewFindingIDs {
+		if findingID = strings.TrimSpace(findingID); findingID != "" {
+			previewFindingIDs[findingID] = struct{}{}
+		}
+	}
 	for _, evidence := range s.findingEvidence {
-		if evidence == nil || !findingEvidenceMatches(request.EvidenceRequest, evidence) {
+		if evidence == nil {
+			continue
+		}
+		if _, ok := runtimeIDs[strings.TrimSpace(evidence.GetRuntimeId())]; !ok {
 			continue
 		}
 		finding, ok := s.findings[evidence.GetFindingId()]
@@ -1880,7 +1915,9 @@ func (s *stubGRCAggregateStore) SummarizeGRCDashboard(ctx context.Context, reque
 		if status != "" && !strings.EqualFold(strings.TrimSpace(finding.Status), status) {
 			continue
 		}
-		countsByFindingID[evidence.GetFindingId()]++
+		if _, ok := previewFindingIDs[evidence.GetFindingId()]; ok {
+			countsByFindingID[evidence.GetFindingId()]++
+		}
 		total++
 	}
 	return ports.GRCDashboardAggregate{FindingSummary: summary, EvidenceCount: total, EvidenceCountsByFindingID: countsByFindingID}, nil

--- a/internal/ports/grc.go
+++ b/internal/ports/grc.go
@@ -7,8 +7,8 @@ import (
 
 // GRCDashboardAggregateRequest scopes aggregate counts needed by the GRC dashboard.
 type GRCDashboardAggregateRequest struct {
-	FindingRequest  ListFindingsRequest
-	EvidenceRequest ListFindingEvidenceRequest
+	FindingRequest    ListFindingsRequest
+	PreviewFindingIDs []string
 }
 
 // GRCDashboardAggregate contains dashboard summary counts fetched without row payloads.

--- a/internal/ports/sourceruntime.go
+++ b/internal/ports/sourceruntime.go
@@ -120,11 +120,12 @@ type SourceRuntimeFencedPageCommitter interface {
 
 // SourceRuntimeFilter scopes persisted source runtime listing.
 type SourceRuntimeFilter struct {
-	RuntimeID  string
-	RuntimeIDs []string
-	TenantID   string
-	SourceID   string
-	Limit      uint32
+	RuntimeID              string
+	RuntimeIDs             []string
+	TenantID               string
+	ApplicationWorkspaceID string
+	SourceID               string
+	Limit                  uint32
 }
 
 // SourceRuntimeListStore lists persisted source runtime definitions.

--- a/internal/sourceruntime/service.go
+++ b/internal/sourceruntime/service.go
@@ -1361,12 +1361,18 @@ func normalizeListFilter(filter ports.SourceRuntimeFilter) (ports.SourceRuntimeF
 	if err != nil {
 		return ports.SourceRuntimeFilter{}, err
 	}
+	tenantID := strings.TrimSpace(filter.TenantID)
+	applicationWorkspaceID, err := ports.ValidateApplicationWorkspaceScope(tenantID, filter.ApplicationWorkspaceID)
+	if err != nil {
+		return ports.SourceRuntimeFilter{}, fmt.Errorf("%w: %w", ErrInvalidRequest, err)
+	}
 	normalized := ports.SourceRuntimeFilter{
-		RuntimeID:  strings.TrimSpace(filter.RuntimeID),
-		RuntimeIDs: runtimeIDs,
-		TenantID:   strings.TrimSpace(filter.TenantID),
-		SourceID:   strings.TrimSpace(filter.SourceID),
-		Limit:      filter.Limit,
+		RuntimeID:              strings.TrimSpace(filter.RuntimeID),
+		RuntimeIDs:             runtimeIDs,
+		TenantID:               tenantID,
+		ApplicationWorkspaceID: applicationWorkspaceID,
+		SourceID:               strings.TrimSpace(filter.SourceID),
+		Limit:                  filter.Limit,
 	}
 	if normalized.Limit == 0 {
 		normalized.Limit = defaultListLimit

--- a/internal/sourceruntime/service_test.go
+++ b/internal/sourceruntime/service_test.go
@@ -94,6 +94,9 @@ func (s *runtimeStore) ListSourceRuntimes(_ context.Context, filter ports.Source
 		if filter.TenantID != "" && runtime.GetTenantId() != filter.TenantID {
 			continue
 		}
+		if filter.ApplicationWorkspaceID != "" && strings.TrimSpace(runtime.GetConfig()[ports.SourceRuntimeApplicationWorkspaceIDConfigKey]) != filter.ApplicationWorkspaceID {
+			continue
+		}
 		if filter.SourceID != "" && runtime.GetSourceId() != filter.SourceID {
 			continue
 		}
@@ -1009,6 +1012,26 @@ func TestListSupportsRuntimeIDsFilter(t *testing.T) {
 	sort.Strings(got)
 	if len(got) != 2 || got[0] != "runtime-a" || got[1] != "runtime-b" {
 		t.Fatalf("List(runtime_ids) ids = %#v, want runtime-a/runtime-b", got)
+	}
+}
+
+func TestListScopesApplicationWorkspaceWithinTenant(t *testing.T) {
+	service := New(nil, &runtimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"runtime-a": {Id: "runtime-a", SourceId: "okta", TenantId: "writer", Config: map[string]string{ports.SourceRuntimeApplicationWorkspaceIDConfigKey: "workspace-a"}},
+		"runtime-b": {Id: "runtime-b", SourceId: "github", TenantId: "writer", Config: map[string]string{ports.SourceRuntimeApplicationWorkspaceIDConfigKey: "workspace-b"}},
+		"runtime-c": {Id: "runtime-c", SourceId: "aws", TenantId: "other", Config: map[string]string{ports.SourceRuntimeApplicationWorkspaceIDConfigKey: "workspace-a"}},
+	}}, nil, nil)
+
+	runtimes, err := service.List(context.Background(), ports.SourceRuntimeFilter{TenantID: "writer", ApplicationWorkspaceID: "workspace-a"})
+	if err != nil {
+		t.Fatalf("List(application workspace) error = %v", err)
+	}
+	if len(runtimes) != 1 || runtimes[0].GetId() != "runtime-a" {
+		t.Fatalf("List(application workspace) = %#v, want runtime-a", runtimes)
+	}
+
+	if _, err := service.List(context.Background(), ports.SourceRuntimeFilter{ApplicationWorkspaceID: "workspace-a"}); !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("List(application workspace without tenant) error = %v, want invalid request", err)
 	}
 }
 

--- a/internal/statestore/postgres/findingevidence.go
+++ b/internal/statestore/postgres/findingevidence.go
@@ -66,6 +66,84 @@ var ensureFindingEvidenceStatements = []string{
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evidence_runtime_finding_observed_idx ON finding_evidence (runtime_id, finding_id, last_observed_at DESC, created_at DESC, id)`,
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evidence_runtime_finding_created_idx ON finding_evidence (runtime_id, finding_id, created_at DESC, id)`,
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evidence_runtime_rule_observed_idx ON finding_evidence (runtime_id, rule_id, last_observed_at DESC, created_at DESC, id)`,
+	`CREATE TABLE IF NOT EXISTS finding_evidence_counts (
+  runtime_id TEXT NOT NULL,
+  finding_id TEXT NOT NULL,
+  evidence_count BIGINT NOT NULL CHECK (evidence_count >= 0),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (runtime_id, finding_id)
+)`,
+	`CREATE OR REPLACE FUNCTION sync_finding_evidence_count() RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'DELETE' OR (
+    TG_OP = 'UPDATE' AND (
+      OLD.runtime_id IS DISTINCT FROM NEW.runtime_id OR
+      OLD.finding_id IS DISTINCT FROM NEW.finding_id
+    )
+  ) THEN
+    UPDATE finding_evidence_counts
+    SET evidence_count = evidence_count - 1, updated_at = NOW()
+    WHERE runtime_id = OLD.runtime_id AND finding_id = OLD.finding_id;
+    DELETE FROM finding_evidence_counts
+    WHERE runtime_id = OLD.runtime_id AND finding_id = OLD.finding_id AND evidence_count <= 0;
+  END IF;
+
+  IF TG_OP = 'INSERT' OR (
+    TG_OP = 'UPDATE' AND (
+      OLD.runtime_id IS DISTINCT FROM NEW.runtime_id OR
+      OLD.finding_id IS DISTINCT FROM NEW.finding_id
+    )
+  ) THEN
+    INSERT INTO finding_evidence_counts (runtime_id, finding_id, evidence_count)
+    VALUES (NEW.runtime_id, NEW.finding_id, 1)
+    ON CONFLICT (runtime_id, finding_id) DO UPDATE
+      SET evidence_count = finding_evidence_counts.evidence_count + 1,
+          updated_at = NOW();
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql`,
+	`DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'finding_evidence_count_sync'
+      AND tgrelid = 'finding_evidence'::regclass
+      AND NOT tgisinternal
+  ) THEN
+    CREATE TRIGGER finding_evidence_count_sync
+      AFTER INSERT OR UPDATE OF runtime_id, finding_id OR DELETE ON finding_evidence
+      FOR EACH ROW EXECUTE FUNCTION sync_finding_evidence_count();
+  END IF;
+END $$`,
+	`CREATE TABLE IF NOT EXISTS finding_evidence_count_migrations (
+  id TEXT PRIMARY KEY,
+  completed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+	`DO $$
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('finding_evidence_counts'), hashtext('backfill-v1'));
+  IF NOT EXISTS (SELECT 1 FROM finding_evidence_count_migrations WHERE id = 'backfill-v1') THEN
+    LOCK TABLE finding_evidence IN SHARE ROW EXCLUSIVE MODE;
+    INSERT INTO finding_evidence_counts (runtime_id, finding_id, evidence_count, updated_at)
+      SELECT runtime_id, finding_id, COUNT(*), NOW()
+      FROM finding_evidence
+      GROUP BY runtime_id, finding_id
+      ON CONFLICT (runtime_id, finding_id) DO UPDATE
+        SET evidence_count = EXCLUDED.evidence_count, updated_at = EXCLUDED.updated_at;
+    DELETE FROM finding_evidence_counts AS counts
+      WHERE NOT EXISTS (
+        SELECT 1 FROM finding_evidence AS evidence
+        WHERE evidence.runtime_id = counts.runtime_id AND evidence.finding_id = counts.finding_id
+      );
+    INSERT INTO finding_evidence_count_migrations (id) VALUES ('backfill-v1');
+  END IF;
+END $$`,
 }
 
 func findingEvidenceUpsertSQL() string {

--- a/internal/statestore/postgres/findingevidence_test.go
+++ b/internal/statestore/postgres/findingevidence_test.go
@@ -371,6 +371,16 @@ func TestFindingEvidenceSchemaPersistsEnrichedEvidence(t *testing.T) {
 		"finding_evidence_runtime_rule_observed_idx",
 		"CREATE INDEX CONCURRENTLY IF NOT EXISTS finding_evidence_runtime_rule_observed_idx",
 		"runtime_id, rule_id, last_observed_at DESC, created_at DESC, id",
+		"CREATE TABLE IF NOT EXISTS finding_evidence_counts",
+		"PRIMARY KEY (runtime_id, finding_id)",
+		"CREATE OR REPLACE FUNCTION sync_finding_evidence_count()",
+		"CREATE TRIGGER finding_evidence_count_sync",
+		"AFTER INSERT OR UPDATE OF runtime_id, finding_id OR DELETE ON finding_evidence",
+		"CREATE TABLE IF NOT EXISTS finding_evidence_count_migrations",
+		"pg_advisory_xact_lock",
+		"LOCK TABLE finding_evidence IN SHARE ROW EXCLUSIVE MODE",
+		"GROUP BY runtime_id, finding_id",
+		"INSERT INTO finding_evidence_count_migrations (id) VALUES ('backfill-v1')",
 	} {
 		if !strings.Contains(joined, fragment) {
 			t.Fatalf("finding evidence schema missing %q:\n%s", fragment, joined)
@@ -452,6 +462,15 @@ func TestRuntimeTopNQueriesPostgresIntegration(t *testing.T) {
 		}
 		if err := store.PutFindingEvidence(ctx, evidence); err != nil {
 			t.Fatalf("PutFindingEvidence(%q) error = %v", evidence.GetId(), err)
+		}
+	}
+	for _, runtimeID := range runtimeIDs {
+		var count int
+		if err := store.db.QueryRowContext(ctx, `SELECT evidence_count FROM finding_evidence_counts WHERE runtime_id = $1 AND finding_id = 'finding-a'`, runtimeID).Scan(&count); err != nil {
+			t.Fatalf("query materialized evidence count for %q: %v", runtimeID, err)
+		}
+		if count != 2 {
+			t.Fatalf("materialized evidence count for %q = %d, want 2", runtimeID, count)
 		}
 	}
 	evidence, err := store.ListGRCFindingEvidence(ctx, ports.ListFindingEvidenceRequest{

--- a/internal/statestore/postgres/grc_dashboard.go
+++ b/internal/statestore/postgres/grc_dashboard.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/writer/cerebro/internal/ports"
@@ -119,14 +118,15 @@ func grcDashboardAggregateQuery(request ports.GRCDashboardAggregateRequest) (str
 	if err != nil {
 		return "", nil, err
 	}
-	evidenceClauses, evidenceArgs, err := findingEvidenceFilterClauses(request.EvidenceRequest)
-	if err != nil {
-		return "", nil, err
-	}
 	whereFindings := strings.Join(findingClauses, " AND ")
-	whereEvidence := rebasePostgresPlaceholders(strings.Join(evidenceClauses, " AND "), len(findingArgs))
 	args := append([]any{}, findingArgs...)
-	args = append(args, evidenceArgs...)
+	previewClauses := []string{"FALSE"}
+	previewFindingIDs := normalizedNonEmptyStrings(request.PreviewFindingIDs)
+	if len(previewFindingIDs) > 0 {
+		previewClauses = nil
+		addStringInFilter(&previewClauses, &args, "finding.id", previewFindingIDs)
+	}
+	wherePreview := strings.Join(previewClauses, " AND ")
 	effectiveSeverity := findingEffectiveSeveritySQL()
 	query := `
 WITH finding_scope AS (
@@ -152,16 +152,17 @@ control_refs AS (
   WHERE LOWER(finding.status) = 'open'
 ),
 evidence_summary AS (
-  SELECT
-    COALESCE(SUM(evidence_count), 0)::bigint AS evidence_count,
-    COALESCE(jsonb_object_agg(finding_id, evidence_count), '{}'::jsonb)::text AS evidence_counts_json
-  FROM (
-    SELECT finding_id, COUNT(*) AS evidence_count
-    FROM finding_evidence
-    WHERE ` + whereEvidence + `
-      AND finding_id IN (SELECT id FROM finding_scope)
-    GROUP BY finding_id
-  ) counts
+  SELECT COALESCE(SUM(counts.evidence_count), 0)::bigint AS evidence_count
+  FROM finding_scope AS finding
+  JOIN finding_evidence_counts AS counts
+    ON counts.runtime_id = finding.runtime_id AND counts.finding_id = finding.id
+),
+preview_evidence_counts AS (
+  SELECT COALESCE(jsonb_object_agg(finding.id, counts.evidence_count), '{}'::jsonb)::text AS evidence_counts_json
+  FROM finding_scope AS finding
+  JOIN finding_evidence_counts AS counts
+    ON counts.runtime_id = finding.runtime_id AND counts.finding_id = finding.id
+  WHERE ` + wherePreview + `
 )
 SELECT
   summary.open_findings,
@@ -171,39 +172,9 @@ SELECT
   summary.unassigned,
   COALESCE((SELECT jsonb_agg(jsonb_build_object('framework_name', framework_name, 'control_id', control_id) ORDER BY framework_name, control_id)::text FROM control_refs), '[]'),
   evidence_summary.evidence_count,
-  evidence_summary.evidence_counts_json
+  preview_evidence_counts.evidence_counts_json
 FROM summary
-CROSS JOIN evidence_summary`
+CROSS JOIN evidence_summary
+CROSS JOIN preview_evidence_counts`
 	return query, args, nil
-}
-
-func rebasePostgresPlaceholders(query string, offset int) string {
-	if offset == 0 || query == "" {
-		return query
-	}
-	var out strings.Builder
-	for i := 0; i < len(query); i++ {
-		if query[i] != '$' {
-			out.WriteByte(query[i])
-			continue
-		}
-		j := i + 1
-		for j < len(query) && query[j] >= '0' && query[j] <= '9' {
-			j++
-		}
-		if j == i+1 {
-			out.WriteByte(query[i])
-			continue
-		}
-		index, err := strconv.Atoi(query[i+1 : j])
-		if err != nil {
-			out.WriteString(query[i:j])
-			i = j - 1
-			continue
-		}
-		out.WriteByte('$')
-		out.WriteString(strconv.Itoa(index + offset))
-		i = j - 1
-	}
-	return out.String()
 }

--- a/internal/statestore/postgres/grc_dashboard.go
+++ b/internal/statestore/postgres/grc_dashboard.go
@@ -130,7 +130,7 @@ func grcDashboardAggregateQuery(request ports.GRCDashboardAggregateRequest) (str
 	effectiveSeverity := findingEffectiveSeveritySQL()
 	query := `
 WITH finding_scope AS (
-  SELECT id, status, ` + effectiveSeverity + ` AS effective_severity, due_at, assignee
+  SELECT id, runtime_id, status, ` + effectiveSeverity + ` AS effective_severity, due_at, assignee
   FROM findings
   WHERE ` + whereFindings + `
 ),

--- a/internal/statestore/postgres/grc_dashboard_test.go
+++ b/internal/statestore/postgres/grc_dashboard_test.go
@@ -1,9 +1,12 @@
 package postgres
 
 import (
+	"context"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -14,9 +17,7 @@ func TestGRCDashboardAggregateQueryCombinesFindingAndEvidenceCounts(t *testing.T
 			RuntimeIDs: []string{"tenant-runtime-a", "tenant-runtime-b"},
 			Status:     "open",
 		},
-		EvidenceRequest: ports.ListFindingEvidenceRequest{
-			RuntimeIDs: []string{"tenant-runtime-a", "tenant-runtime-b"},
-		},
+		PreviewFindingIDs: []string{"finding-a", "finding-b"},
 	})
 	if err != nil {
 		t.Fatalf("grcDashboardAggregateQuery() error = %v", err)
@@ -28,11 +29,11 @@ func TestGRCDashboardAggregateQueryCombinesFindingAndEvidenceCounts(t *testing.T
 		"JOIN finding_control_refs AS ref ON ref.finding_id = finding.id",
 		"jsonb_build_object('framework_name', framework_name, 'control_id', control_id)",
 		"evidence_summary AS",
-		"jsonb_object_agg(finding_id, evidence_count)",
-		"GROUP BY finding_id",
-		"FROM finding_evidence",
-		"runtime_id IN ($5, $6)",
-		"finding_id IN (SELECT id FROM finding_scope)",
+		"preview_evidence_counts AS",
+		"jsonb_object_agg(finding.id, counts.evidence_count)",
+		"JOIN finding_evidence_counts AS counts",
+		"counts.runtime_id = finding.runtime_id",
+		"finding.id IN ($5, $6)",
 	} {
 		if !strings.Contains(query, fragment) {
 			t.Fatalf("aggregate query missing %q:\n%s", fragment, query)
@@ -40,7 +41,7 @@ func TestGRCDashboardAggregateQueryCombinesFindingAndEvidenceCounts(t *testing.T
 	}
 	// The dashboard evidence total must follow finding_scope (all open findings),
 	// not a windowed preview finding-id list, so no positional finding_id filter.
-	for _, forbidden := range []string{`E'\x00'`, `|| E'`, "control_key", "finding_id IN ($7", "jsonb_array_elements"} {
+	for _, forbidden := range []string{`E'\x00'`, `|| E'`, "control_key", "FROM finding_evidence\n", "GROUP BY finding_id", "jsonb_array_elements"} {
 		if strings.Contains(query, forbidden) {
 			t.Fatalf("aggregate query must not contain %q:\n%s", forbidden, query)
 		}
@@ -91,10 +92,39 @@ func TestDecodeGRCDashboardEvidenceCounts(t *testing.T) {
 	}
 }
 
-func TestRebasePostgresPlaceholders(t *testing.T) {
-	got := rebasePostgresPlaceholders("runtime_id IN ($1, $2) AND finding_id = $3", 4)
-	want := "runtime_id IN ($5, $6) AND finding_id = $7"
-	if got != want {
-		t.Fatalf("rebasePostgresPlaceholders() = %q, want %q", got, want)
+func TestGRCDashboardAggregatePlanUsesMaterializedEvidenceCountsPostgresIntegration(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("CEREBRO_POSTGRES_DSN"))
+	if dsn == "" {
+		t.Skip("set CEREBRO_POSTGRES_DSN to run dashboard aggregate plan integration test")
+	}
+	store, err := Open(config.StateStoreConfig{Driver: config.StateStoreDriverPostgres, PostgresDSN: dsn})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	ctx := context.Background()
+	if err := store.PrepareGRCReadModels(ctx); err != nil {
+		t.Fatalf("PrepareGRCReadModels() error = %v", err)
+	}
+	query, args, err := grcDashboardAggregateQuery(ports.GRCDashboardAggregateRequest{
+		FindingRequest: ports.ListFindingsRequest{
+			TenantID:   "dashboard-plan-tenant",
+			RuntimeIDs: []string{"dashboard-plan-runtime"},
+			Status:     "open",
+		},
+		PreviewFindingIDs: []string{"dashboard-plan-finding"},
+	})
+	if err != nil {
+		t.Fatalf("grcDashboardAggregateQuery() error = %v", err)
+	}
+	var plan string
+	if err := store.db.QueryRowContext(ctx, "EXPLAIN (FORMAT JSON) "+query, args...).Scan(&plan); err != nil {
+		t.Fatalf("EXPLAIN dashboard aggregate: %v", err)
+	}
+	if !strings.Contains(plan, `"Relation Name": "finding_evidence_counts"`) {
+		t.Fatalf("dashboard aggregate plan does not read the materialized count table: %s", plan)
+	}
+	if strings.Contains(plan, `"Relation Name": "finding_evidence"`) {
+		t.Fatalf("dashboard aggregate plan scans raw finding evidence: %s", plan)
 	}
 }

--- a/internal/statestore/postgres/grc_dashboard_test.go
+++ b/internal/statestore/postgres/grc_dashboard_test.go
@@ -24,7 +24,7 @@ func TestGRCDashboardAggregateQueryCombinesFindingAndEvidenceCounts(t *testing.T
 	}
 	for _, fragment := range []string{
 		"WITH finding_scope AS",
-		"SELECT id, status,",
+		"SELECT id, runtime_id, status,",
 		"COUNT(*) FILTER (WHERE LOWER(status) = 'open') AS open_findings",
 		"JOIN finding_control_refs AS ref ON ref.finding_id = finding.id",
 		"jsonb_build_object('framework_name', framework_name, 'control_id', control_id)",

--- a/internal/statestore/postgres/sourceruntime.go
+++ b/internal/statestore/postgres/sourceruntime.go
@@ -25,6 +25,7 @@ var ensureSourceRuntimeStatements = []string{`CREATE TABLE IF NOT EXISTS source_
 	`ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS lease_generation BIGINT NOT NULL DEFAULT 0 CHECK (lease_generation >= 0)`,
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_tenant_updated_idx ON source_runtimes ((runtime_json->>'tenant_id'), updated_at ASC, id ASC)`,
 	`CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_tenant_source_updated_idx ON source_runtimes ((runtime_json->>'tenant_id'), (runtime_json->>'source_id'), updated_at ASC, id ASC)`,
+	`CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_tenant_workspace_updated_idx ON source_runtimes ((runtime_json->>'tenant_id'), (runtime_json->'config'->>'application_workspace_id'), updated_at ASC, id ASC)`,
 }
 
 // PutSourceRuntime upserts one source runtime definition.
@@ -130,40 +131,10 @@ func (s *Store) ListSourceRuntimes(ctx context.Context, filter ports.SourceRunti
 	if err := s.ensureSourceRuntimeTable(ctx); err != nil {
 		return nil, err
 	}
-	clauses := []string{"1=1"}
-	args := []any{}
-	runtimeIDs := normalizedNonEmptyStrings(append(filter.RuntimeIDs, filter.RuntimeID))
-	if len(runtimeIDs) == 1 {
-		args = append(args, runtimeIDs[0])
-		clauses = append(clauses, fmt.Sprintf("id = $%d", len(args)))
-	} else if len(runtimeIDs) > 1 {
-		placeholders := make([]string, 0, len(runtimeIDs))
-		for _, runtimeID := range runtimeIDs {
-			args = append(args, runtimeID)
-			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
-		}
-		clauses = append(clauses, fmt.Sprintf("id IN (%s)", strings.Join(placeholders, ", ")))
+	query, args, err := sourceRuntimeListQuery(filter)
+	if err != nil {
+		return nil, err
 	}
-	if tenantID := strings.TrimSpace(filter.TenantID); tenantID != "" {
-		args = append(args, tenantID)
-		clauses = append(clauses, fmt.Sprintf("runtime_json->>'tenant_id' = $%d", len(args)))
-	}
-	if sourceID := strings.TrimSpace(filter.SourceID); sourceID != "" {
-		args = append(args, sourceID)
-		clauses = append(clauses, fmt.Sprintf("runtime_json->>'source_id' = $%d", len(args)))
-	}
-	limit := filter.Limit
-	if limit == 0 {
-		limit = 100
-	}
-	args = append(args, limit)
-	// #nosec G201 -- clauses and order are fixed predicates; values remain parameterized.
-	query := fmt.Sprintf(`
-SELECT runtime_json::text
-FROM source_runtimes
-WHERE %s
-ORDER BY %s
-LIMIT $%d`, strings.Join(clauses, " AND "), sourceRuntimeListOrderClause(), len(args))
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list source runtimes: %w", err)
@@ -187,6 +158,52 @@ LIMIT $%d`, strings.Join(clauses, " AND "), sourceRuntimeListOrderClause(), len(
 		return nil, fmt.Errorf("iterate source runtimes: %w", err)
 	}
 	return runtimes, nil
+}
+
+func sourceRuntimeListQuery(filter ports.SourceRuntimeFilter) (string, []any, error) {
+	applicationWorkspaceID, err := ports.ValidateApplicationWorkspaceScope(filter.TenantID, filter.ApplicationWorkspaceID)
+	if err != nil {
+		return "", nil, fmt.Errorf("list source runtimes: %w", err)
+	}
+	clauses := []string{"1=1"}
+	args := []any{}
+	runtimeIDs := normalizedNonEmptyStrings(append(filter.RuntimeIDs, filter.RuntimeID))
+	if len(runtimeIDs) == 1 {
+		args = append(args, runtimeIDs[0])
+		clauses = append(clauses, fmt.Sprintf("id = $%d", len(args)))
+	} else if len(runtimeIDs) > 1 {
+		placeholders := make([]string, 0, len(runtimeIDs))
+		for _, runtimeID := range runtimeIDs {
+			args = append(args, runtimeID)
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		clauses = append(clauses, fmt.Sprintf("id IN (%s)", strings.Join(placeholders, ", ")))
+	}
+	if tenantID := strings.TrimSpace(filter.TenantID); tenantID != "" {
+		args = append(args, tenantID)
+		clauses = append(clauses, fmt.Sprintf("runtime_json->>'tenant_id' = $%d", len(args)))
+	}
+	if applicationWorkspaceID != "" {
+		args = append(args, applicationWorkspaceID)
+		clauses = append(clauses, fmt.Sprintf("runtime_json->'config'->>'application_workspace_id' = $%d", len(args)))
+	}
+	if sourceID := strings.TrimSpace(filter.SourceID); sourceID != "" {
+		args = append(args, sourceID)
+		clauses = append(clauses, fmt.Sprintf("runtime_json->>'source_id' = $%d", len(args)))
+	}
+	limit := filter.Limit
+	if limit == 0 {
+		limit = 100
+	}
+	args = append(args, limit)
+	// #nosec G201 -- clauses and order are fixed predicates; values remain parameterized.
+	query := fmt.Sprintf(`
+SELECT runtime_json::text
+FROM source_runtimes
+WHERE %s
+ORDER BY %s
+LIMIT $%d`, strings.Join(clauses, " AND "), sourceRuntimeListOrderClause(), len(args))
+	return query, args, nil
 }
 
 // AcquireSourceRuntimeLease leases one source runtime without replacing runtime JSON.

--- a/internal/statestore/postgres/sourceruntime_test.go
+++ b/internal/statestore/postgres/sourceruntime_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
 )
 
 func TestPutSourceRuntimeRejectsNilRuntime(t *testing.T) {
@@ -75,6 +76,8 @@ func TestSourceRuntimeSchemaIndexesDashboardFilters(t *testing.T) {
 		"source_runtimes_tenant_source_updated_idx",
 		"CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_tenant_source_updated_idx",
 		"(runtime_json->>'tenant_id'), (runtime_json->>'source_id'), updated_at ASC, id ASC",
+		"source_runtimes_tenant_workspace_updated_idx",
+		"(runtime_json->>'tenant_id'), (runtime_json->'config'->>'application_workspace_id'), updated_at ASC, id ASC",
 	} {
 		if !strings.Contains(joined, fragment) {
 			t.Fatalf("source runtime schema missing %q:\n%s", fragment, joined)
@@ -82,5 +85,30 @@ func TestSourceRuntimeSchemaIndexesDashboardFilters(t *testing.T) {
 	}
 	if strings.Contains(joined, "source_runtimes_lease_expiry_idx") {
 		t.Fatalf("source runtime schema includes unused lease expiry index:\n%s", joined)
+	}
+}
+
+func TestSourceRuntimeListQueryScopesTenantAndApplicationWorkspace(t *testing.T) {
+	query, args, err := sourceRuntimeListQuery(ports.SourceRuntimeFilter{
+		TenantID:               "tenant-a",
+		ApplicationWorkspaceID: "workspace-a",
+		SourceID:               "okta",
+		Limit:                  13,
+	})
+	if err != nil {
+		t.Fatalf("sourceRuntimeListQuery() error = %v", err)
+	}
+	for _, fragment := range []string{
+		"runtime_json->>'tenant_id' = $1",
+		"runtime_json->'config'->>'application_workspace_id' = $2",
+		"runtime_json->>'source_id' = $3",
+		"LIMIT $4",
+	} {
+		if !strings.Contains(query, fragment) {
+			t.Fatalf("source runtime query missing %q:\n%s", fragment, query)
+		}
+	}
+	if len(args) != 4 || args[0] != "tenant-a" || args[1] != "workspace-a" || args[2] != "okta" || args[3] != uint32(13) {
+		t.Fatalf("source runtime query args = %#v, want tenant/workspace/source/limit", args)
 	}
 }


### PR DESCRIPTION
## Summary

- maintain per-runtime finding evidence counts for dashboard reads
- scope runtime selection to the authorized application workspace
- bound per-finding count serialization to the rendered preview

## Validation

- `make test`
- `make check-structural check-structural-test check-arch`
- focused internal package lint and tests
- dashboard aggregate SQL-shape and optional PostgreSQL plan tests