### PR TITLE
perf(web): parallelize homepage data loading

### DIFF
--- a/apps/web/scripts/grc-scale-benchmark.mjs
+++ b/apps/web/scripts/grc-scale-benchmark.mjs
@@ -43,7 +43,7 @@ const allRouteSpecs = [
   {
     route: "/",
     label: "Home",
-    readySelector: "text=Compliance overview",
+    readySelector: "text=Open work queue",
     usableThresholdMs: 1000,
   },
   {
@@ -502,6 +502,15 @@ function createMockApi({ bounded, recordCount: count, stats }) {
       if (normalizedPath === "user/preferences") {
         return sendJSON(response, stats, normalizedPath, { tenant_id: tenantID, user_id: "scale-benchmark", preferences: {}, generated_at: generatedAt });
       }
+      if (normalizedPath === "grc/dashboard") {
+        return sendJSON(response, stats, normalizedPath, homeDashboardFixture(data, url.searchParams));
+      }
+      if (normalizedPath === "grc/program-readiness") {
+        return sendJSON(response, stats, normalizedPath, homeProgramReadinessFixture(data));
+      }
+      if (normalizedPath === "connectors/coverage") {
+        return sendJSON(response, stats, normalizedPath, homeCoverageFixture(data));
+      }
       if (normalizedPath === "identity/orgs") {
         const organizations = boundedList(filterIdentityOrganizations(data.identityOrganizations, url.searchParams), url.searchParams, bounded);
         return sendJSON(response, stats, normalizedPath, {
@@ -724,6 +733,70 @@ function makeScaleData(count) {
   const identityOrganizations = Array.from({ length: count }, (_, index) => makeIdentityOrganization(index));
   const identityUsers = Array.from({ length: count }, (_, index) => makeIdentityUser(index));
   return { vendors, vendorDiscoveries, evidence, findings, policies, documents, riskRegister, governanceGaps, workQueue, documentWorkQueue, inventoryAssets, lifecycleRecords, connectors, connectorRuntimes, connectorDefinitions, identityOrganizations, identityUsers };
+}
+
+function homeDashboardFixture(data, searchParams) {
+  const limit = Math.max(1, Math.min(12, positiveInteger(searchParams.get("limit"), 12)));
+  const findings = data.findings.slice(0, limit);
+  const controls = controlPacketsFixture(data, new URLSearchParams(`limit=${limit}`), true).controls;
+  const connectors = data.connectorRuntimes.slice(0, limit).map((runtime) => ({
+    runtime_id: runtime.runtime_id,
+    source_id: runtime.source_id,
+    status: runtime.status,
+    freshness: runtime.health === "healthy" ? "fresh" : "stale",
+    watermark_lag_seconds: runtime.watermark_lag_seconds,
+  }));
+  return {
+    summary: {
+      open_findings: data.findings.length,
+      critical_findings: data.findings.filter((finding) => finding.severity === "critical").length,
+      high_findings: data.findings.filter((finding) => finding.severity === "high").length,
+      overdue_findings: data.findings.filter((finding) => finding.sla_status === "overdue").length,
+      unassigned: data.findings.filter((finding) => !finding.owner).length,
+      controls_failing: controls.filter((control) => control.status === "failing").length,
+      evidence_items: data.evidence.length,
+      connectors: data.connectorRuntimes.length,
+      stale_connectors: data.connectorRuntimes.filter((runtime) => runtime.health !== "healthy").length,
+    },
+    findings,
+    controls,
+    evidence: data.evidence.slice(0, limit),
+    connectors,
+    generated_at: generatedAt,
+  };
+}
+
+function homeProgramReadinessFixture(data) {
+  const controls = controlPacketsFixture(data, new URLSearchParams("limit=12"), true).controls;
+  const passing = controls.filter((control) => control.status === "passing").length;
+  return {
+    summary: {
+      controls: controls.length,
+      passing_controls: passing,
+      missing_evidence_items: controls.reduce((total, control) => total + (control.missing_evidence_items ?? 0), 0),
+      stale_evidence_items: controls.reduce((total, control) => total + (control.stale_evidence_items ?? 0), 0),
+      coverage_blind_spots: 1,
+    },
+    frameworks: [{ framework_name: "SOC 2", controls: controls.length, passing_controls: passing }],
+    controls,
+    work_items: [],
+    connectors: data.connectorRuntimes.slice(0, 12),
+    coverage_summaries: [{ source_id: "source-0", blind_spots: 1 }],
+    generated_at: generatedAt,
+  };
+}
+
+function homeCoverageFixture() {
+  const blindSpot = {
+    source_id: "source-0",
+    dimension_id: "coverage-gap-0",
+    dimension_type: "resource",
+    support_level: "partial",
+    state: "partial",
+    title: "Resource coverage",
+    high_value: true,
+  };
+  return { blind_spots: [blindSpot], records: [blindSpot], generated_at: generatedAt };
 }
 
 function inventoryAssetDetail(asset) {

--- a/apps/web/scripts/grc-scale-benchmark.mjs
+++ b/apps/web/scripts/grc-scale-benchmark.mjs
@@ -509,7 +509,7 @@ function createMockApi({ bounded, recordCount: count, stats }) {
         return sendJSON(response, stats, normalizedPath, homeProgramReadinessFixture(data));
       }
       if (normalizedPath === "connectors/coverage") {
-        return sendJSON(response, stats, normalizedPath, homeCoverageFixture(data));
+        return sendJSON(response, stats, normalizedPath, homeCoverageFixture());
       }
       if (normalizedPath === "identity/orgs") {
         const organizations = boundedList(filterIdentityOrganizations(data.identityOrganizations, url.searchParams), url.searchParams, bounded);

--- a/apps/web/src/app/api/cerebro/[...path]/route.test.ts
+++ b/apps/web/src/app/api/cerebro/[...path]/route.test.ts
@@ -45,6 +45,30 @@ describe("Cerebro proxy route", () => {
     expect(new Headers(upstreamInit?.headers).get("cache-control")).toBeNull();
   });
 
+  it("distinguishes cold, warm, tenant, and workspace dashboard reads", async () => {
+    delete process.env.CEREBRO_WEB_FIXTURE_MODE;
+    const fetchMock = vi.fn(async (url: URL | RequestInfo) => new Response(
+      JSON.stringify({ target: url.toString() }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    ));
+    vi.stubGlobal("fetch", fetchMock);
+    const context = { params: Promise.resolve({ path: ["grc", "dashboard"] }) };
+    const request = (tenant: string, workspace: string) => new NextRequest(
+      `http://localhost/api/cerebro/grc/dashboard?cache_contract=cold-warm-scope&tenant_id=${tenant}&workspace_id=${workspace}`,
+    );
+
+    const cold = await GET(request("tenant-a", "workspace-a"), context);
+    const warm = await GET(request("tenant-a", "workspace-a"), context);
+    const otherTenant = await GET(request("tenant-b", "workspace-a"), context);
+    const otherWorkspace = await GET(request("tenant-a", "workspace-b"), context);
+
+    expect(cold.headers.get("x-cerebro-web-cache")).toBe("miss");
+    expect(warm.headers.get("x-cerebro-web-cache")).toBe("hit");
+    expect(otherTenant.headers.get("x-cerebro-web-cache")).toBe("miss");
+    expect(otherWorkspace.headers.get("x-cerebro-web-cache")).toBe("miss");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
   it.each([
     ["GET", GET],
     ["POST", POST],

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -84,19 +84,24 @@ describe("Home review links", () => {
     expect(links.map((link) => link.getAttribute("href"))).toContain("/controls?framework=SOC%202&control=CC6.6");
   });
 
-  it("starts the dashboard before secondary Home queries", async () => {
+  it("starts all independent Home queries on the initial render", async () => {
     await act(async () => {
       root.render(<Home />);
     });
 
     expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([
       grcDashboardPath({ limit: 12, enrichments: "deferred" }),
-      null,
-      null,
+      grcProgramReadinessPath(),
+      grcPath("/connectors/coverage", {
+        coverage_scope: "configured",
+        coverage_view: "page",
+        blind_spots_only: "true",
+        page_size: 3,
+      }),
     ]);
   });
 
-  it("starts secondary Home queries after dashboard data arrives", async () => {
+  it("renders dashboard work while both secondary queries are still pending", async () => {
     const dashboardPath = grcDashboardPath({ limit: 12, enrichments: "deferred" });
     const dashboardData = {
       summary: {
@@ -120,26 +125,17 @@ describe("Home review links", () => {
       data: path === dashboardPath ? dashboardData : null,
       durationMs: null,
       error: null,
-      lastSuccessfulAt: null,
-      loading: Boolean(path),
+      lastSuccessfulAt: path === dashboardPath ? Date.parse(dashboardData.generated_at) : null,
+      loading: path !== dashboardPath,
       reload: mocks.reload,
-      state: path ? "loading" : "empty",
+      state: path === dashboardPath ? "ready" : "loading",
     }));
 
     await act(async () => {
       root.render(<Home />);
     });
 
-    expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([
-      dashboardPath,
-      grcProgramReadinessPath(),
-      grcPath("/connectors/coverage", {
-        coverage_scope: "configured",
-        coverage_view: "page",
-        blind_spots_only: "true",
-        page_size: 3,
-      }),
-    ]);
+    expect(container.textContent).toContain("Open work queue");
     expect(container.textContent).toContain("Loading source coverage.");
   });
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -447,11 +447,9 @@ export default function Home() {
   const compactHome = preferences.display.density === "compact";
   const dashboard = useGRCQuery<GRCDashboard>(grcDashboardPath({ limit: HOME_DASHBOARD_FINDING_LIMIT, enrichments: "deferred" }));
   const data = dashboard.data;
-  const readinessQuery = useGRCQuery<GRCProgramReadiness>(data ? grcProgramReadinessPath() : null);
+  const readinessQuery = useGRCQuery<GRCProgramReadiness>(grcProgramReadinessPath());
   const coverageQuery = useGRCQuery<{ blind_spots?: GRCSourceCoverageRecord[]; records?: GRCSourceCoverageRecord[] }>(
-    data
-      ? grcPath("/connectors/coverage", { coverage_scope: "configured", coverage_view: "page", blind_spots_only: "true", page_size: 3 })
-      : null,
+    grcPath("/connectors/coverage", { coverage_scope: "configured", coverage_view: "page", blind_spots_only: "true", page_size: 3 }),
   );
   const readiness = readinessQuery.data?.summary;
   const priorityFindings = useMemo(() => (data?.findings ?? []).slice().sort(riskSort), [data?.findings]);

--- a/apps/web/src/instrumentation.test.ts
+++ b/apps/web/src/instrumentation.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  warmCerebroProxyCache: vi.fn(),
+}));
+
+vi.mock("@/lib/cerebro-proxy", () => ({
+  warmCerebroProxyCache: mocks.warmCerebroProxyCache,
+}));
+
+type WarmerGlobal = typeof globalThis & {
+  __cerebroProxyCacheWarmer?: ReturnType<typeof setInterval>;
+};
+
+afterEach(() => {
+  const shared = globalThis as WarmerGlobal;
+  if (shared.__cerebroProxyCacheWarmer) {
+    clearInterval(shared.__cerebroProxyCacheWarmer);
+    delete shared.__cerebroProxyCacheWarmer;
+  }
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  mocks.warmCerebroProxyCache.mockReset();
+});
+
+describe("web instrumentation", () => {
+  it("starts the dashboard warm without blocking server readiness", async () => {
+    vi.stubEnv("NEXT_RUNTIME", "nodejs");
+    const pending = Promise.withResolvers<"miss">();
+    mocks.warmCerebroProxyCache.mockReturnValue(pending.promise);
+    const { register } = await import("./instrumentation");
+
+    await expect(register()).resolves.toBeUndefined();
+
+    expect(mocks.warmCerebroProxyCache).toHaveBeenCalledOnce();
+    expect(mocks.warmCerebroProxyCache).toHaveBeenCalledWith(
+      "grc/dashboard",
+      "?limit=12&enrichments=deferred&view=summary",
+    );
+    pending.resolve("miss");
+    await pending.promise;
+  });
+});

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -20,7 +20,9 @@ export async function register() {
     }
   };
 
-  await warm();
+  // Start the first warm immediately without making server readiness depend on
+  // the dashboard backend. The existing interval keeps the cache lifecycle.
+  void warm();
   const shared = globalThis as WarmerGlobal;
   if (!shared.__cerebroProxyCacheWarmer) {
     shared.__cerebroProxyCacheWarmer = setInterval(() => void warm(), WARM_INTERVAL_MS);


### PR DESCRIPTION
## Summary
- keep the existing dashboard cache warm lifecycle while removing the first warm from the server-readiness critical path
- start independent dashboard, readiness, and coverage reads together so secondary data does not form a client waterfall
- make the scale benchmark wait for real homepage work data and serve production-shaped dashboard fixtures
- cover cold/warm cache behavior, tenant and workspace separation, non-blocking secondary stalls, and non-blocking startup warm behavior

## Validation
- `NODE_OPTIONS=--localstorage-file=/tmp/cerebro-dashboard-architecture-vitest-localstorage npm test -- --run` (114 files, 693 tests)
- `npx eslint src/instrumentation.ts src/instrumentation.test.ts src/app/page.tsx src/app/page.test.tsx 'src/app/api/cerebro/[...path]/route.test.ts' scripts/grc-scale-benchmark.mjs`
- `npm run build`
- `CEREBRO_GRC_SCALE_ROUTE=home CEREBRO_GRC_SCALE_USABLE_MS=1000 node scripts/grc-scale-benchmark.mjs --quick --production --artifacts` (Home usable 951ms, API 32ms, 292 DOM nodes)