### PR TITLE
fix(web): scope Home reads to active workspace

### DIFF
--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -11,6 +11,7 @@ import { defaultUserPreferences } from "@/lib/user-preferences";
 const mocks = vi.hoisted(() => ({
   reload: vi.fn(),
   useGRCQuery: vi.fn(),
+  useGRCScopeQueryState: vi.fn(),
   useUserPreferences: vi.fn(),
 }));
 
@@ -20,6 +21,10 @@ vi.mock("@/components/providers", () => ({
 vi.mock("@/lib/grc-client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/grc-client")>();
   return { ...actual, useGRCQuery: mocks.useGRCQuery };
+});
+vi.mock("@/lib/grc-scope", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/grc-scope")>();
+  return { ...actual, useGRCScopeQueryState: mocks.useGRCScopeQueryState };
 });
 
 import { grcDashboardPath, grcPath, grcProgramReadinessPath } from "@/lib/grc-client";
@@ -36,6 +41,12 @@ describe("Home review links", () => {
 
   beforeEach(() => {
     mocks.reload.mockReset().mockResolvedValue(undefined);
+    mocks.useGRCScopeQueryState.mockReset().mockReturnValue({
+      tenantID: "",
+      workspaceID: "",
+      setTenantID: vi.fn(),
+      setWorkspaceID: vi.fn(),
+    });
     mocks.useUserPreferences.mockReset().mockReturnValue({ preferences: defaultUserPreferences });
     mocks.useGRCQuery.mockReset().mockImplementation((path: string | null) => ({
       data: null,
@@ -99,6 +110,126 @@ describe("Home review links", () => {
         page_size: 3,
       }),
     ]);
+  });
+
+  it("preserves tenant-only Home reads when no workspace is active", async () => {
+    mocks.useGRCScopeQueryState.mockReturnValue({
+      tenantID: "tenant-a",
+      workspaceID: "",
+      setTenantID: vi.fn(),
+      setWorkspaceID: vi.fn(),
+    });
+
+    await act(async () => {
+      root.render(<Home />);
+    });
+
+    expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([
+      grcDashboardPath({ limit: 12, enrichments: "deferred", tenant_id: "tenant-a" }),
+      grcProgramReadinessPath({ tenant_id: "tenant-a" }),
+      grcPath("/connectors/coverage", {
+        coverage_scope: "configured",
+        coverage_view: "page",
+        blind_spots_only: "true",
+        page_size: 3,
+        tenant_id: "tenant-a",
+      }),
+    ]);
+  });
+
+  it("keeps all Home reads isolated when the active workspace changes", async () => {
+    mocks.useGRCScopeQueryState.mockReturnValue({
+      tenantID: "tenant-a",
+      workspaceID: "workspace-a",
+      setTenantID: vi.fn(),
+      setWorkspaceID: vi.fn(),
+    });
+    await act(async () => {
+      root.render(<Home />);
+    });
+
+    expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([
+      grcDashboardPath({ limit: 12, enrichments: "deferred", tenant_id: "tenant-a", workspace_id: "workspace-a" }),
+      grcProgramReadinessPath({ tenant_id: "tenant-a", workspace_id: "workspace-a" }),
+      grcPath("/connectors/coverage", {
+        coverage_scope: "configured",
+        coverage_view: "page",
+        blind_spots_only: "true",
+        page_size: 3,
+        tenant_id: "tenant-a",
+        workspace_id: "workspace-a",
+      }),
+    ]);
+
+    mocks.useGRCQuery.mockClear();
+    mocks.useGRCScopeQueryState.mockReturnValue({
+      tenantID: "tenant-a",
+      workspaceID: "workspace-b",
+      setTenantID: vi.fn(),
+      setWorkspaceID: vi.fn(),
+    });
+    await act(async () => {
+      root.render(<Home />);
+    });
+
+    expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([
+      grcDashboardPath({ limit: 12, enrichments: "deferred", tenant_id: "tenant-a", workspace_id: "workspace-b" }),
+      grcProgramReadinessPath({ tenant_id: "tenant-a", workspace_id: "workspace-b" }),
+      grcPath("/connectors/coverage", {
+        coverage_scope: "configured",
+        coverage_view: "page",
+        blind_spots_only: "true",
+        page_size: 3,
+        tenant_id: "tenant-a",
+        workspace_id: "workspace-b",
+      }),
+    ]);
+  });
+
+  it("fails closed when the backend rejects a tenant and workspace pairing", async () => {
+    mocks.useGRCScopeQueryState.mockReturnValue({
+      tenantID: "tenant-a",
+      workspaceID: "workspace-b",
+      setTenantID: vi.fn(),
+      setWorkspaceID: vi.fn(),
+    });
+    mocks.useGRCQuery.mockImplementation((path: string | null) => ({
+      data: null,
+      durationMs: null,
+      error: path ? "Cerebro request failed (403): forbidden" : null,
+      lastSuccessfulAt: null,
+      loading: false,
+      reload: mocks.reload,
+      state: path ? "permission-denied" : "empty",
+    }));
+
+    await act(async () => {
+      root.render(<Home />);
+    });
+
+    expect(mocks.useGRCQuery).toHaveBeenCalledTimes(3);
+    for (const [path] of mocks.useGRCQuery.mock.calls) {
+      expect(path).toContain("tenant_id=tenant-a");
+      expect(path).toContain("workspace_id=workspace-b");
+    }
+    expect(container.textContent).toContain("Graph data access unavailable");
+    expect(container.textContent).not.toContain("Open work queue");
+  });
+
+  it("does not issue Home reads for a workspace without an explicit tenant", async () => {
+    mocks.useGRCScopeQueryState.mockReturnValue({
+      tenantID: "",
+      workspaceID: "workspace-a",
+      setTenantID: vi.fn(),
+      setWorkspaceID: vi.fn(),
+    });
+
+    await act(async () => {
+      root.render(<Home />);
+    });
+
+    expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([null, null, null]);
+    expect(container.textContent).toContain("Select a tenant before loading a workspace.");
   });
 
   it("renders dashboard work while both secondary queries are still pending", async () => {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -23,9 +23,32 @@ import {
   shortEntity,
 } from "@/lib/grc";
 import { DASHBOARD_FINDING_LIMIT, grcDashboardPath, grcPath, grcProgramReadinessPath, useGRCQuery } from "@/lib/grc-client";
+import { grcScopeQuery, type GRCScope, useGRCScopeQueryState } from "@/lib/grc-scope";
 import { normalizeLegacyControlHref } from "@/lib/navigation";
 
 const HOME_DASHBOARD_FINDING_LIMIT = DASHBOARD_FINDING_LIMIT;
+
+export const homeGRCPaths = (scope: GRCScope) => {
+  const query = grcScopeQuery(scope);
+  if (query.workspace_id && !query.tenant_id) {
+    return { coverage: null, dashboard: null, readiness: null };
+  }
+  return {
+    coverage: grcPath("/connectors/coverage", {
+      coverage_scope: "configured",
+      coverage_view: "page",
+      blind_spots_only: "true",
+      page_size: 3,
+      ...query,
+    }),
+    dashboard: grcDashboardPath({
+      limit: HOME_DASHBOARD_FINDING_LIMIT,
+      enrichments: "deferred",
+      ...query,
+    }),
+    readiness: grcProgramReadinessPath(query),
+  };
+};
 
 type WorkChipTone = "danger" | "warning" | "success" | "neutral";
 
@@ -443,13 +466,16 @@ function ProgramHealthPanel({
 
 export default function Home() {
   const { preferences } = useUserPreferences();
+  const { tenantID, workspaceID } = useGRCScopeQueryState();
   const visibleSections = preferences.homepage.sections;
   const compactHome = preferences.display.density === "compact";
-  const dashboard = useGRCQuery<GRCDashboard>(grcDashboardPath({ limit: HOME_DASHBOARD_FINDING_LIMIT, enrichments: "deferred" }));
+  const paths = homeGRCPaths({ tenantID, workspaceID });
+  const invalidWorkspaceScope = Boolean(workspaceID.trim() && !tenantID.trim());
+  const dashboard = useGRCQuery<GRCDashboard>(paths.dashboard);
   const data = dashboard.data;
-  const readinessQuery = useGRCQuery<GRCProgramReadiness>(grcProgramReadinessPath());
+  const readinessQuery = useGRCQuery<GRCProgramReadiness>(paths.readiness);
   const coverageQuery = useGRCQuery<{ blind_spots?: GRCSourceCoverageRecord[]; records?: GRCSourceCoverageRecord[] }>(
-    grcPath("/connectors/coverage", { coverage_scope: "configured", coverage_view: "page", blind_spots_only: "true", page_size: 3 }),
+    paths.coverage,
   );
   const readiness = readinessQuery.data?.summary;
   const priorityFindings = useMemo(() => (data?.findings ?? []).slice().sort(riskSort), [data?.findings]);
@@ -503,6 +529,7 @@ export default function Home() {
   const readinessLabel = "Control readiness";
 
   const reload = () => {
+    if (invalidWorkspaceScope) return;
     void dashboard.reload();
     void readinessQuery.reload();
     void coverageQuery.reload();
@@ -524,12 +551,14 @@ export default function Home() {
       />
 
       <DataStateBanner
-        state={dashboard.state}
+        state={invalidWorkspaceScope ? "permission-denied" : dashboard.state}
         subject="Graph data"
         error={dashboard.error}
         lastSuccessfulAt={dashboard.lastSuccessfulAt}
-        onRetry={() => void dashboard.reload()}
-        detail={dashboard.state === "loading" ? "Loading risks, controls, evidence, and sources." : undefined}
+        onRetry={invalidWorkspaceScope ? undefined : () => void dashboard.reload()}
+        detail={invalidWorkspaceScope
+          ? "Select a tenant before loading a workspace."
+          : dashboard.state === "loading" ? "Loading risks, controls, evidence, and sources." : undefined}
       />
 
       {data && summary && homeMetrics && (


### PR DESCRIPTION
## Summary

- propagate the existing tenant and workspace URL scope to all Home data reads
- stop Home reads when a workspace has no tenant
- preserve unscoped and tenant-only Home behavior

## Validation

- `npm test -- --run src/app/page.test.tsx src/lib/grc-scope.test.tsx` (11 tests passed)
- `NODE_OPTIONS=--localstorage-file=/tmp/cerebro-home-workspace-scope-vitest-localstorage npm test -- --run` (114 files, 696 tests passed)
- `npx eslint src/app/page.tsx src/app/page.test.tsx src/lib/grc-scope.ts src/lib/grc-scope.test.tsx`
- `npm run build`