### PR TITLE
perf(postgres): stream compliance projection children

### DIFF
--- a/internal/statestore/postgres/compliance_review_projection_test.go
+++ b/internal/statestore/postgres/compliance_review_projection_test.go
@@ -1,7 +1,9 @@
 package postgres
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -80,10 +82,14 @@ func TestComplianceReviewProjectionPostgresIntegration(t *testing.T) {
 		t.Fatalf("NewComplianceReviewProjector() error = %v", err)
 	}
 	tenantID := fmt.Sprintf("compliance-review-test-%d", time.Now().UnixNano())
+	foreignTenantID := tenantID + "-foreign"
 	if err := store.ensureComplianceReviewTables(ctx); err != nil {
 		t.Fatalf("ensureComplianceReviewTables() error = %v", err)
 	}
-	t.Cleanup(func() { cleanupComplianceReviewTenant(t, store, tenantID) })
+	t.Cleanup(func() {
+		cleanupComplianceReviewTenant(t, store, tenantID)
+		cleanupComplianceReviewTenant(t, store, foreignTenantID)
+	})
 	now := time.Now().UTC().Truncate(time.Millisecond)
 
 	review, firstRevision, err := complianceassessment.NewReview(tenantID, "run-a", "result-a", "sha256:"+strings.Repeat("a", 64), complianceassessment.ReviewRevisionInput{
@@ -188,6 +194,42 @@ func TestComplianceReviewProjectionPostgresIntegration(t *testing.T) {
 	if _, err := projector.ProjectWorkOccurrence(ctx, ComplianceProjectionMetadata{EventID: "work-observed", ExpectedVersion: 0, OccurredAt: now}, item, occurrence); err != nil {
 		t.Fatalf("ProjectWorkOccurrence() error = %v", err)
 	}
+	initialWork, err := store.GetWorkItem(ctx, tenantID, item.ID)
+	if err != nil {
+		t.Fatalf("GetWorkItem(initial) error = %v", err)
+	}
+	initialWorkJSON, err := json.Marshal(initialWork)
+	if err != nil {
+		t.Fatalf("marshal initial work item: %v", err)
+	}
+	if !bytes.Contains(initialWorkJSON, []byte(`"actions":[]`)) {
+		t.Fatalf("initial work item actions changed wire shape: %s", initialWorkJSON)
+	}
+	foreignItem, foreignOccurrence, err := complianceassessment.NewWorkItem(complianceassessment.WorkItemInput{
+		Basis: complianceassessment.WorkFingerprintInput{
+			TenantID: foreignTenantID, ProgramID: "program-a", ScopeRevisionID: "scope-r1", ControlID: "CC-1",
+			ObjectiveID: "objective-a", Kind: complianceassessment.WorkRemediateFinding,
+			SubjectID: "subject-a", Reason: complianceassessment.ReasonActiveFinding, SourceID: "source-a",
+		},
+		OwnerID: "owner-foreign", DueAt: now.Add(24 * time.Hour), Priority: "high", RiskID: risk.ID,
+		Occurrence: complianceassessment.WorkOccurrenceInput{
+			AssessmentRunID: "run-foreign", ObjectiveResultID: "result-foreign",
+			AutomatedResultHash: "sha256:" + strings.Repeat("c", 64), OccurredAt: now,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewWorkItem(foreign tenant) error = %v", err)
+	}
+	foreignItem.ID = item.ID
+	foreignOccurrence.WorkItemID = item.ID
+	foreignItem.Occurrences[0].WorkItemID = item.ID
+	if _, err := projector.ProjectWorkOccurrence(ctx, ComplianceProjectionMetadata{EventID: "work-observed", ExpectedVersion: 0, OccurredAt: now}, foreignItem, foreignOccurrence); err != nil {
+		t.Fatalf("ProjectWorkOccurrence(foreign tenant) error = %v", err)
+	}
+	foreignStoredWork, err := store.GetComplianceWorkItem(ctx, foreignTenantID, item.ID)
+	if err != nil || len(foreignStoredWork.Occurrences) != 1 || foreignStoredWork.Occurrences[0].AssessmentRunID != "run-foreign" {
+		t.Fatalf("GetComplianceWorkItem(foreign tenant) = %+v, %v", foreignStoredWork, err)
+	}
 	item, action, err := complianceassessment.ApplyWorkAction(item, item.Version, complianceassessment.WorkActionInput{
 		Action: complianceassessment.WorkActionRemediate, Rationale: "Apply the corrective change.", ActorID: "owner-a", At: now.Add(time.Minute),
 	})
@@ -202,11 +244,11 @@ func TestComplianceReviewProjectionPostgresIntegration(t *testing.T) {
 		t.Fatalf("ProjectWorkAction(replay) = %+v, %v", replay, err)
 	}
 	storedWork, err := store.GetComplianceWorkItem(ctx, tenantID, item.ID)
-	if err != nil || storedWork.Item.Version != 2 || len(storedWork.Occurrences) != 1 || len(storedWork.Actions) != 1 {
+	if err != nil || storedWork.Item.Version != 2 || len(storedWork.Item.Occurrences) != 1 || len(storedWork.Occurrences) != 1 || storedWork.Occurrences[0].AssessmentRunID != "run-a" || len(storedWork.Actions) != 1 {
 		t.Fatalf("GetComplianceWorkItem() = %+v, %v", storedWork, err)
 	}
 	page, err := store.ListWorkItems(ctx, tenantID, complianceremediation.WorkItemListFilter{State: complianceassessment.WorkInProgress, OwnerID: "owner-a", Limit: 1})
-	if err != nil || len(page.Items) != 1 || page.Items[0].ID != item.ID || page.NextCursor != "" {
+	if err != nil || len(page.Items) != 1 || page.Items[0].ID != item.ID || len(page.Items[0].Occurrences) != 1 || page.NextCursor != "" {
 		t.Fatalf("ListWorkItems() = %+v, %v", page, err)
 	}
 
@@ -225,6 +267,25 @@ func TestComplianceReviewProjectionPostgresIntegration(t *testing.T) {
 	if _, err := projector.ProjectRemediationPlan(ctx, ComplianceProjectionMetadata{EventID: "plan-created", ExpectedVersion: 0, OccurredAt: now}, plan); err != nil {
 		t.Fatalf("ProjectRemediationPlan(create) error = %v", err)
 	}
+	foreignPlan, err := complianceassessment.NewRemediationPlan(complianceassessment.RemediationPlanInput{
+		ID: plan.ID, TenantID: foreignTenantID, ProgramID: "program-a", ScopeRevisionID: "scope-r1",
+		RiskID: risk.ID, WorkItemID: item.ID, Treatment: complianceassessment.RiskTreatmentMitigate,
+		OwnerID: "owner-foreign", TargetAt: now.Add(30 * 24 * time.Hour), VerificationRequired: true,
+		Milestones: []complianceassessment.RemediationMilestoneInput{{
+			ID: "milestone-a", Title: "Apply foreign change", OwnerID: "owner-foreign",
+			TargetAt: now.Add(7 * 24 * time.Hour), PlannedAction: "Apply the foreign corrective change.",
+		}}, CreatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("NewRemediationPlan(foreign tenant) error = %v", err)
+	}
+	if _, err := projector.ProjectRemediationPlan(ctx, ComplianceProjectionMetadata{EventID: "plan-created", ExpectedVersion: 0, OccurredAt: now}, foreignPlan); err != nil {
+		t.Fatalf("ProjectRemediationPlan(foreign tenant) error = %v", err)
+	}
+	foreignStoredPlan, err := store.GetComplianceRemediationPlan(ctx, foreignTenantID, plan.ID)
+	if err != nil || len(foreignStoredPlan.Milestones) != 1 || foreignStoredPlan.Milestones[0].OwnerID != "owner-foreign" {
+		t.Fatalf("GetComplianceRemediationPlan(foreign tenant) = %+v, %v", foreignStoredPlan, err)
+	}
 	plan, err = complianceassessment.ActivateRemediationPlan(plan, plan.Version, "owner-a", now.Add(time.Minute))
 	if err != nil {
 		t.Fatalf("ActivateRemediationPlan() error = %v", err)
@@ -233,7 +294,7 @@ func TestComplianceReviewProjectionPostgresIntegration(t *testing.T) {
 		t.Fatalf("ProjectRemediationPlan(activate) error = %v", err)
 	}
 	storedPlan, err := store.GetComplianceRemediationPlan(ctx, tenantID, plan.ID)
-	if err != nil || storedPlan.Plan.Version != 2 || len(storedPlan.Milestones) != 1 || storedPlan.Milestones[0].ID != "milestone-a" {
+	if err != nil || storedPlan.Plan.Version != 2 || len(storedPlan.Plan.Milestones) != 1 || len(storedPlan.Milestones) != 1 || storedPlan.Milestones[0].ID != "milestone-a" || storedPlan.Milestones[0].OwnerID != "owner-a" {
 		t.Fatalf("GetComplianceRemediationPlan() = %+v, %v", storedPlan, err)
 	}
 	storedReceipt, err := store.GetComplianceProjectionReceipt(ctx, tenantID, reviewEvent.EventID)

--- a/internal/statestore/postgres/compliance_review_read.go
+++ b/internal/statestore/postgres/compliance_review_read.go
@@ -32,7 +32,7 @@ type ComplianceRemediationProjection struct {
 
 // GetComplianceReview loads one tenant-scoped review and all immutable revisions.
 func (s *Store) GetComplianceReview(ctx context.Context, tenantID, reviewID string) (ComplianceReviewProjection, error) {
-	var projection ComplianceReviewProjection
+	projection := ComplianceReviewProjection{Revisions: []complianceassessment.ReviewRevision{}}
 	body, err := s.getComplianceCurrentBody(ctx, "compliance_reviews", tenantID, reviewID)
 	if err != nil {
 		return projection, err
@@ -40,17 +40,16 @@ func (s *Store) GetComplianceReview(ctx context.Context, tenantID, reviewID stri
 	if err := json.Unmarshal(body, &projection.Review); err != nil {
 		return projection, fmt.Errorf("decode compliance review: %w", err)
 	}
-	bodies, err := s.listComplianceImmutableBodies(ctx, "compliance_review_revisions", tenantID, reviewID)
-	if err != nil {
-		return projection, err
-	}
-	projection.Revisions = make([]complianceassessment.ReviewRevision, 0, len(bodies))
-	for _, body := range bodies {
+	err = s.visitComplianceImmutableBodies(ctx, "compliance_review_revisions", tenantID, reviewID, func(body []byte) error {
 		var revision complianceassessment.ReviewRevision
 		if err := json.Unmarshal(body, &revision); err != nil {
-			return ComplianceReviewProjection{}, fmt.Errorf("decode compliance review revision: %w", err)
+			return fmt.Errorf("decode compliance review revision: %w", err)
 		}
 		projection.Revisions = append(projection.Revisions, revision)
+		return nil
+	})
+	if err != nil {
+		return ComplianceReviewProjection{}, err
 	}
 	return projection, nil
 }
@@ -83,38 +82,39 @@ func (s *Store) GetComplianceException(ctx context.Context, tenantID, exceptionI
 
 // GetComplianceWorkItem loads one tenant-scoped work item and retained child records.
 func (s *Store) GetComplianceWorkItem(ctx context.Context, tenantID, workItemID string) (ComplianceWorkItemProjection, error) {
-	var projection ComplianceWorkItemProjection
-	body, err := s.getComplianceCurrentBody(ctx, "compliance_work_items", tenantID, workItemID)
+	projection := ComplianceWorkItemProjection{
+		Occurrences: []complianceassessment.WorkOccurrence{},
+		Actions:     []complianceassessment.WorkActionRecord{},
+	}
+	body, err := s.getComplianceCurrentBodyWithoutChildren(ctx, "compliance_work_items", tenantID, workItemID)
 	if err != nil {
 		return projection, err
 	}
 	if err := json.Unmarshal(body, &projection.Item); err != nil {
 		return projection, fmt.Errorf("decode compliance work item: %w", err)
 	}
-	occurrenceBodies, err := s.listComplianceImmutableBodies(ctx, "compliance_work_occurrences", tenantID, workItemID)
-	if err != nil {
-		return projection, err
-	}
-	projection.Occurrences = make([]complianceassessment.WorkOccurrence, 0, len(occurrenceBodies))
-	for _, childBody := range occurrenceBodies {
+	err = s.visitComplianceImmutableBodies(ctx, "compliance_work_occurrences", tenantID, workItemID, func(body []byte) error {
 		var occurrence complianceassessment.WorkOccurrence
-		if err := json.Unmarshal(childBody, &occurrence); err != nil {
-			return ComplianceWorkItemProjection{}, fmt.Errorf("decode compliance work occurrence: %w", err)
+		if err := json.Unmarshal(body, &occurrence); err != nil {
+			return fmt.Errorf("decode compliance work occurrence: %w", err)
 		}
 		projection.Occurrences = append(projection.Occurrences, occurrence)
+		return nil
+	})
+	if err != nil {
+		return ComplianceWorkItemProjection{}, err
 	}
 	projection.Item.Occurrences = append([]complianceassessment.WorkOccurrence(nil), projection.Occurrences...)
-	actionBodies, err := s.listComplianceImmutableBodies(ctx, "compliance_work_actions", tenantID, workItemID)
-	if err != nil {
-		return projection, err
-	}
-	projection.Actions = make([]complianceassessment.WorkActionRecord, 0, len(actionBodies))
-	for _, childBody := range actionBodies {
+	err = s.visitComplianceImmutableBodies(ctx, "compliance_work_actions", tenantID, workItemID, func(body []byte) error {
 		var action complianceassessment.WorkActionRecord
-		if err := json.Unmarshal(childBody, &action); err != nil {
-			return ComplianceWorkItemProjection{}, fmt.Errorf("decode compliance work action: %w", err)
+		if err := json.Unmarshal(body, &action); err != nil {
+			return fmt.Errorf("decode compliance work action: %w", err)
 		}
 		projection.Actions = append(projection.Actions, action)
+		return nil
+	})
+	if err != nil {
+		return ComplianceWorkItemProjection{}, err
 	}
 	return projection, nil
 }
@@ -122,7 +122,7 @@ func (s *Store) GetComplianceWorkItem(ctx context.Context, tenantID, workItemID 
 // GetComplianceRemediationPlan loads one tenant-scoped plan and current milestones.
 func (s *Store) GetComplianceRemediationPlan(ctx context.Context, tenantID, planID string) (ComplianceRemediationProjection, error) {
 	var projection ComplianceRemediationProjection
-	body, err := s.getComplianceCurrentBody(ctx, "compliance_remediation_plans", tenantID, planID)
+	body, err := s.getComplianceCurrentBodyWithoutChildren(ctx, "compliance_remediation_plans", tenantID, planID)
 	if err != nil {
 		return projection, err
 	}
@@ -188,11 +188,29 @@ WHERE tenant_id = $1 AND event_id = $2`, tenantID, eventID).Scan(
 }
 
 func (s *Store) getComplianceCurrentBody(ctx context.Context, table, tenantID, id string) ([]byte, error) {
+	return s.getComplianceCurrentBodyProjection(ctx, table, tenantID, id, "")
+}
+
+func (s *Store) getComplianceCurrentBodyWithoutChildren(ctx context.Context, table, tenantID, id string) ([]byte, error) {
+	childField, ok := complianceCurrentChildField(table)
+	if !ok {
+		return nil, fmt.Errorf("%w: current projection table has no normalized children", ErrComplianceProjectionInvalid)
+	}
+	return s.getComplianceCurrentBodyProjection(ctx, table, tenantID, id, childField)
+}
+
+func (s *Store) getComplianceCurrentBodyProjection(ctx context.Context, table, tenantID, id, omittedField string) ([]byte, error) {
 	if s == nil || s.db == nil {
 		return nil, errors.New("postgres is not configured")
 	}
 	if !complianceCurrentTableAllowed(table) {
 		return nil, fmt.Errorf("%w: current projection table is invalid", ErrComplianceProjectionInvalid)
+	}
+	if omittedField != "" {
+		childField, ok := complianceCurrentChildField(table)
+		if !ok || childField != omittedField {
+			return nil, fmt.Errorf("%w: current projection child field is invalid", ErrComplianceProjectionInvalid)
+		}
 	}
 	if err := s.ensureComplianceReviewTables(ctx); err != nil {
 		return nil, err
@@ -202,10 +220,16 @@ func (s *Store) getComplianceCurrentBody(ctx context.Context, table, tenantID, i
 	if tenantID == "" || id == "" {
 		return nil, fmt.Errorf("%w: tenant and aggregate ids are required", ErrComplianceProjectionInvalid)
 	}
-	// #nosec G201 -- table is restricted by complianceCurrentTableAllowed; identifiers are not interpolated.
-	query := fmt.Sprintf(`SELECT body_json FROM %s WHERE tenant_id = $1 AND id = $2`, table)
+	selectExpression := "body_json"
+	args := []any{tenantID, id}
+	if omittedField != "" {
+		selectExpression = "body_json - $3"
+		args = append(args, omittedField)
+	}
+	// #nosec G201 -- table is restricted by complianceCurrentTableAllowed and the select expression is closed above.
+	query := fmt.Sprintf(`SELECT %s FROM %s WHERE tenant_id = $1 AND id = $2`, selectExpression, table)
 	var body []byte
-	if err := s.db.QueryRowContext(ctx, query, tenantID, id).Scan(&body); err != nil {
+	if err := s.db.QueryRowContext(ctx, query, args...).Scan(&body); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrComplianceProjectionNotFound
 		}
@@ -214,27 +238,42 @@ func (s *Store) getComplianceCurrentBody(ctx context.Context, table, tenantID, i
 	return body, nil
 }
 
-func (s *Store) listComplianceImmutableBodies(ctx context.Context, table, tenantID, parentID string) ([][]byte, error) {
+func (s *Store) visitComplianceImmutableBodies(ctx context.Context, table, tenantID, parentID string, visit func([]byte) error) error {
 	if !complianceImmutableTableAllowed(table) {
-		return nil, fmt.Errorf("%w: immutable projection table is invalid", ErrComplianceProjectionInvalid)
+		return fmt.Errorf("%w: immutable projection table is invalid", ErrComplianceProjectionInvalid)
+	}
+	if visit == nil {
+		return fmt.Errorf("%w: immutable projection visitor is required", ErrComplianceProjectionInvalid)
 	}
 	// #nosec G201 -- table and parent column are restricted by fixed allowlists; values are parameterized.
 	query := fmt.Sprintf(`SELECT body_json FROM %s WHERE tenant_id = $1 AND %s = $2 ORDER BY sequence`, table, complianceImmutableParentColumn(table))
 	rows, err := s.db.QueryContext(ctx, query, strings.TrimSpace(tenantID), strings.TrimSpace(parentID))
 	if err != nil {
-		return nil, fmt.Errorf("list %s immutable projections: %w", table, err)
+		return fmt.Errorf("list %s immutable projections: %w", table, err)
 	}
 	defer func() { _ = rows.Close() }()
-	bodies := make([][]byte, 0)
 	for rows.Next() {
 		var body []byte
 		if err := rows.Scan(&body); err != nil {
-			return nil, fmt.Errorf("scan %s immutable projection: %w", table, err)
+			return fmt.Errorf("scan %s immutable projection: %w", table, err)
 		}
-		bodies = append(bodies, body)
+		if err := visit(body); err != nil {
+			return err
+		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate %s immutable projections: %w", table, err)
+		return fmt.Errorf("iterate %s immutable projections: %w", table, err)
 	}
-	return bodies, nil
+	return nil
+}
+
+func complianceCurrentChildField(table string) (string, bool) {
+	switch table {
+	case "compliance_work_items":
+		return "occurrences", true
+	case "compliance_remediation_plans":
+		return "milestones", true
+	default:
+		return "", false
+	}
 }

--- a/internal/statestore/postgres/compliance_review_read_test.go
+++ b/internal/statestore/postgres/compliance_review_read_test.go
@@ -1,0 +1,139 @@
+package postgres
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/complianceassessment"
+)
+
+func TestComplianceCurrentChildField(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		table string
+		want  string
+		ok    bool
+	}{
+		{table: "compliance_work_items", want: "occurrences", ok: true},
+		{table: "compliance_remediation_plans", want: "milestones", ok: true},
+		{table: "compliance_reviews"},
+		{table: "unknown"},
+	}
+	for _, test := range tests {
+		t.Run(test.table, func(t *testing.T) {
+			t.Parallel()
+			got, ok := complianceCurrentChildField(test.table)
+			if got != test.want || ok != test.ok {
+				t.Fatalf("complianceCurrentChildField(%q) = %q, %v, want %q, %v", test.table, got, ok, test.want, test.ok)
+			}
+		})
+	}
+}
+
+func BenchmarkComplianceWorkItemOccurrenceReadMaterialization(b *testing.B) {
+	fullBody, currentBody, childBodies := benchmarkComplianceWorkItemBodies(b, 256)
+	totalChildBytes := 0
+	for _, body := range childBodies {
+		totalChildBytes += len(body)
+	}
+
+	b.Run("duplicated_current_jsonb", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(fullBody) + totalChildBytes))
+		b.ReportMetric(float64(len(fullBody)), "current-jsonb-bytes")
+		for range b.N {
+			var projection ComplianceWorkItemProjection
+			currentRow := append([]byte(nil), fullBody...)
+			if err := json.Unmarshal(currentRow, &projection.Item); err != nil {
+				b.Fatal(err)
+			}
+			buffered := make([][]byte, 0)
+			for _, body := range childBodies {
+				buffered = append(buffered, append([]byte(nil), body...))
+			}
+			projection.Occurrences = make([]complianceassessment.WorkOccurrence, 0, len(buffered))
+			for _, body := range buffered {
+				var occurrence complianceassessment.WorkOccurrence
+				if err := json.Unmarshal(body, &occurrence); err != nil {
+					b.Fatal(err)
+				}
+				projection.Occurrences = append(projection.Occurrences, occurrence)
+			}
+			projection.Item.Occurrences = append([]complianceassessment.WorkOccurrence(nil), projection.Occurrences...)
+			runtime.KeepAlive(projection)
+		}
+	})
+
+	b.Run("canonical_child_stream", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(currentBody) + totalChildBytes))
+		b.ReportMetric(float64(len(currentBody)), "current-jsonb-bytes")
+		for range b.N {
+			var projection ComplianceWorkItemProjection
+			currentRow := append([]byte(nil), currentBody...)
+			if err := json.Unmarshal(currentRow, &projection.Item); err != nil {
+				b.Fatal(err)
+			}
+			for _, body := range childBodies {
+				rowBody := append([]byte(nil), body...)
+				var occurrence complianceassessment.WorkOccurrence
+				if err := json.Unmarshal(rowBody, &occurrence); err != nil {
+					b.Fatal(err)
+				}
+				projection.Occurrences = append(projection.Occurrences, occurrence)
+			}
+			projection.Item.Occurrences = append([]complianceassessment.WorkOccurrence(nil), projection.Occurrences...)
+			runtime.KeepAlive(projection)
+		}
+	})
+}
+
+func benchmarkComplianceWorkItemBodies(b *testing.B, childCount int) ([]byte, []byte, [][]byte) {
+	b.Helper()
+	now := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	item := complianceassessment.WorkItem{
+		ID: "work-item", FingerprintVersion: "v1", Fingerprint: "sha256:fingerprint",
+		Basis: complianceassessment.WorkFingerprintInput{
+			TenantID: "tenant-a", ProgramID: "program-a", ScopeRevisionID: "scope-a",
+			ControlID: "control-a", ObjectiveID: "objective-a", Kind: complianceassessment.WorkRemediateFinding,
+			SubjectID: "subject-a", Reason: complianceassessment.ReasonActiveFinding, SourceID: "source-a",
+		},
+		State: complianceassessment.WorkOpen, OwnerID: "owner-a", DueAt: now.Add(24 * time.Hour),
+		Priority: "high", Version: uint64(childCount), UpdatedAt: now,
+	}
+	childBodies := make([][]byte, 0, childCount)
+	for index := range childCount {
+		occurrence := complianceassessment.WorkOccurrence{
+			ID: fmt.Sprintf("occurrence-%04d", index), WorkItemID: item.ID,
+			AssessmentRunID: fmt.Sprintf("assessment-%04d", index), ObjectiveResultID: fmt.Sprintf("result-%04d", index),
+			AutomatedResultHash: fmt.Sprintf("sha256:%064d", index),
+			EvidenceIDs:         []string{fmt.Sprintf("evidence-%04d-a", index), fmt.Sprintf("evidence-%04d-b", index)},
+			FindingIDs:          []string{fmt.Sprintf("finding-%04d-a", index), fmt.Sprintf("finding-%04d-b", index)},
+			OccurredAt:          now.Add(time.Duration(index) * time.Minute),
+			OccurrenceHash:      fmt.Sprintf("sha256:%064d", index+1),
+		}
+		item.Occurrences = append(item.Occurrences, occurrence)
+		body, err := json.Marshal(occurrence)
+		if err != nil {
+			b.Fatal(err)
+		}
+		childBodies = append(childBodies, body)
+	}
+	fullBody, err := json.Marshal(item)
+	if err != nil {
+		b.Fatal(err)
+	}
+	var currentProjection map[string]json.RawMessage
+	if err := json.Unmarshal(fullBody, &currentProjection); err != nil {
+		b.Fatal(err)
+	}
+	delete(currentProjection, "occurrences")
+	currentBody, err := json.Marshal(currentProjection)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return fullBody, currentBody, childBodies
+}

--- a/internal/statestore/postgres/compliance_review_read_test.go
+++ b/internal/statestore/postgres/compliance_review_read_test.go
@@ -102,7 +102,7 @@ func benchmarkComplianceWorkItemBodies(b *testing.B, childCount int) ([]byte, []
 			SubjectID: "subject-a", Reason: complianceassessment.ReasonActiveFinding, SourceID: "source-a",
 		},
 		State: complianceassessment.WorkOpen, OwnerID: "owner-a", DueAt: now.Add(24 * time.Hour),
-		Priority: "high", Version: uint64(childCount), UpdatedAt: now,
+		Priority: "high", Version: 1, UpdatedAt: now,
 	}
 	childBodies := make([][]byte, 0, childCount)
 	for index := range childCount {


### PR DESCRIPTION
## Summary
- omit normalized occurrence and milestone arrays from current JSONB only while loading detail projections
- decode immutable revision, occurrence, and action rows as SQL rows arrive instead of buffering raw JSON bodies
- preserve tenant and parent predicates, ordering, stored records, list behavior, and response shape

## Validation
- go test ./internal/statestore/postgres -count=1
- go test ./internal/complianceremediation -count=1
- go test ./internal/bootstrap -run Compliance(Remediation|Work)|GRC -count=1
- go test -race ./internal/statestore/postgres -run focused compliance tests -count=1
- make check-structural check-structural-test check-arch
- BenchmarkComplianceWorkItemOccurrenceReadMaterialization: 759783 to 474256 B/op; 9003 to 5409 allocs/op

Full local make verify stopped before Cargo execution at the managed capacity gate; hosted required checks remain authoritative.