### PR TITLE
perf(web): parallelize scoped GRC overview reads

### DIFF
--- a/apps/web/src/app/grc/page.test.ts
+++ b/apps/web/src/app/grc/page.test.ts
@@ -8,7 +8,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GRCControl, GRCProgramReadiness, GRCProgramReadinessSummary } from "@/lib/grc";
 
 const mocks = vi.hoisted(() => ({
-  reload: vi.fn(),
+  dashboardReload: vi.fn(),
+  readinessReload: vi.fn(),
   useGRCQuery: vi.fn(),
   useSearchParams: vi.fn(),
 }));
@@ -171,7 +172,8 @@ describe("GRC page loading", () => {
   let root: Root;
 
   beforeEach(() => {
-    mocks.reload.mockReset().mockResolvedValue(undefined);
+    mocks.dashboardReload.mockReset().mockResolvedValue(undefined);
+    mocks.readinessReload.mockReset().mockResolvedValue(undefined);
     mocks.useSearchParams.mockReset().mockReturnValue(new URLSearchParams());
     mocks.useGRCQuery.mockReset().mockImplementation((path: string | null) => ({
       data: null,
@@ -179,7 +181,7 @@ describe("GRC page loading", () => {
       error: null,
       lastSuccessfulAt: null,
       loading: Boolean(path),
-      reload: mocks.reload,
+      reload: path?.includes("program-readiness") ? mocks.readinessReload : mocks.dashboardReload,
       state: path ? "loading" : "empty",
     }));
     reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
@@ -207,6 +209,15 @@ describe("GRC page loading", () => {
       grcDashboardPath({ limit: 12, tenant_id: "tenant-a", workspace_id: "workspace-a" }),
       grcProgramReadinessPath({ tenant_id: "tenant-a", workspace_id: "workspace-a" }),
     ]);
+
+    const refresh = [...container.querySelectorAll("button")]
+      .find((button) => button.textContent === "Refresh");
+    expect(refresh).toBeDefined();
+    await act(async () => {
+      refresh?.click();
+    });
+    expect(mocks.dashboardReload).toHaveBeenCalledOnce();
+    expect(mocks.readinessReload).toHaveBeenCalledOnce();
   });
 
   it("does not issue GRC reads for a workspace without an explicit tenant", async () => {
@@ -218,5 +229,11 @@ describe("GRC page loading", () => {
 
     expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([null, null]);
     expect(container.textContent).toContain("Select a tenant before loading a workspace.");
+    const refresh = [...container.querySelectorAll("button")]
+      .find((button) => button.textContent === "Refresh");
+    expect(refresh?.disabled).toBe(true);
+    refresh?.click();
+    expect(mocks.dashboardReload).not.toHaveBeenCalled();
+    expect(mocks.readinessReload).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/grc/page.test.ts
+++ b/apps/web/src/app/grc/page.test.ts
@@ -1,8 +1,27 @@
-import { describe, expect, it } from "vitest";
+/**
+ * @vitest-environment jsdom
+ */
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { GRCControl, GRCProgramReadiness, GRCProgramReadinessSummary } from "@/lib/grc";
 
-import { buildIssueQueue, buildReadinessChecks } from "./page";
+const mocks = vi.hoisted(() => ({
+  reload: vi.fn(),
+  useGRCQuery: vi.fn(),
+  useSearchParams: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({ useSearchParams: mocks.useSearchParams }));
+vi.mock("@/lib/grc-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/grc-client")>();
+  return { ...actual, useGRCQuery: mocks.useGRCQuery };
+});
+
+import { grcDashboardPath, grcProgramReadinessPath } from "@/lib/grc-client";
+
+import GRCPage, { buildIssueQueue, buildReadinessChecks } from "./page";
 
 const summary = (patch: Partial<GRCProgramReadinessSummary> = {}): GRCProgramReadinessSummary => ({
   status: "needs_attention",
@@ -140,5 +159,64 @@ describe("GRC page helpers", () => {
         value: "Clear",
       }),
     ]);
+  });
+});
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+describe("GRC page loading", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    mocks.reload.mockReset().mockResolvedValue(undefined);
+    mocks.useSearchParams.mockReset().mockReturnValue(new URLSearchParams());
+    mocks.useGRCQuery.mockReset().mockImplementation((path: string | null) => ({
+      data: null,
+      durationMs: null,
+      error: null,
+      lastSuccessfulAt: null,
+      loading: Boolean(path),
+      reload: mocks.reload,
+      state: path ? "loading" : "empty",
+    }));
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("starts scoped dashboard and readiness reads together", async () => {
+    mocks.useSearchParams.mockReturnValue(new URLSearchParams({
+      tenant_id: "tenant-a",
+      workspace_id: "workspace-a",
+    }));
+
+    await act(async () => {
+      root.render(createElement(GRCPage));
+    });
+
+    expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([
+      grcDashboardPath({ limit: 12, tenant_id: "tenant-a", workspace_id: "workspace-a" }),
+      grcProgramReadinessPath({ tenant_id: "tenant-a", workspace_id: "workspace-a" }),
+    ]);
+  });
+
+  it("does not issue GRC reads for a workspace without an explicit tenant", async () => {
+    mocks.useSearchParams.mockReturnValue(new URLSearchParams({ workspace_id: "workspace-a" }));
+
+    await act(async () => {
+      root.render(createElement(GRCPage));
+    });
+
+    expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([null, null]);
+    expect(container.textContent).toContain("Select a tenant before loading a workspace.");
   });
 });

--- a/apps/web/src/app/grc/page.tsx
+++ b/apps/web/src/app/grc/page.tsx
@@ -493,7 +493,14 @@ export default function GRCPage() {
         description={pageDescription}
         action={
           <div className="flex items-center gap-2">
-            <button type="button" onClick={reload} className="secondary-button px-3 py-1.5 text-[13px]">Refresh</button>
+            <button
+              type="button"
+              onClick={reload}
+              disabled={invalidWorkspaceScope}
+              className="secondary-button px-3 py-1.5 text-[13px] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Refresh
+            </button>
           </div>
         }
       />

--- a/apps/web/src/app/grc/page.tsx
+++ b/apps/web/src/app/grc/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 
 import { AttentionBanner, Badge, DataStateBanner, MetricCard, PageHeader, Panel } from "@/components/grc/Primitives";
@@ -20,6 +21,11 @@ import { DASHBOARD_FINDING_LIMIT, grcDashboardPath, grcProgramReadinessPath, use
 import { frameworkRouteSegment } from "@/lib/grc-frameworks";
 import { normalizeLegacyControlHref } from "@/lib/navigation";
 import type { RuntimeState } from "@/lib/runtime-state";
+
+type GRCScope = {
+  tenantID: string;
+  workspaceID: string;
+};
 
 type IssueQueueItem = {
   action: string;
@@ -45,6 +51,22 @@ type ReadinessCheck = {
   status: string;
   tone: "danger" | "warning" | "success" | "neutral";
   value: string;
+};
+
+export const grcOverviewPaths = (scope: GRCScope) => {
+  const tenantID = scope.tenantID.trim();
+  const workspaceID = scope.workspaceID.trim();
+  const query = {
+    tenant_id: tenantID || undefined,
+    workspace_id: workspaceID || undefined,
+  };
+  if (query.workspace_id && !query.tenant_id) {
+    return { dashboard: null, readiness: null };
+  }
+  return {
+    dashboard: grcDashboardPath({ limit: DASHBOARD_FINDING_LIMIT, ...query }),
+    readiness: grcProgramReadinessPath(query),
+  };
 };
 
 const controlHref = (control: GRCControl) =>
@@ -434,8 +456,13 @@ function FrameworkPosturePanel({ frameworks }: { frameworks: GRCProgramFramework
 }
 
 export default function GRCPage() {
-  const dashboard = useGRCQuery<GRCDashboard>(grcDashboardPath({ limit: DASHBOARD_FINDING_LIMIT }));
-  const readinessQuery = useGRCQuery<GRCProgramReadiness>(dashboard.data ? grcProgramReadinessPath() : null);
+  const searchParams = useSearchParams();
+  const tenantID = searchParams.get("tenant_id") ?? "";
+  const workspaceID = searchParams.get("workspace_id") ?? "";
+  const paths = grcOverviewPaths({ tenantID, workspaceID });
+  const invalidWorkspaceScope = Boolean(workspaceID.trim() && !tenantID.trim());
+  const dashboard = useGRCQuery<GRCDashboard>(paths.dashboard);
+  const readinessQuery = useGRCQuery<GRCProgramReadiness>(paths.readiness);
   const dashboardControls = useMemo(() => dashboard.data?.controls ?? [], [dashboard.data?.controls]);
   const fallbackSummary = useMemo(() => controlSummaryFromDashboard(dashboardControls), [dashboardControls]);
   const summary = readinessQuery.data?.summary ?? fallbackSummary;
@@ -453,6 +480,7 @@ export default function GRCPage() {
     : "Open control issues, packet status, evidence gaps, and source freshness.";
 
   const reload = () => {
+    if (invalidWorkspaceScope) return;
     void dashboard.reload();
     void readinessQuery.reload();
   };
@@ -471,12 +499,14 @@ export default function GRCPage() {
       />
 
       <DataStateBanner
-        state={dashboard.state}
+        state={invalidWorkspaceScope ? "permission-denied" : dashboard.state}
         subject="Compliance data"
         error={dashboard.error}
         lastSuccessfulAt={dashboard.lastSuccessfulAt}
-        onRetry={() => void dashboard.reload()}
-        detail={dashboard.state === "loading" ? "Loading controls, findings, evidence, and sources." : undefined}
+        onRetry={invalidWorkspaceScope ? undefined : () => void dashboard.reload()}
+        detail={invalidWorkspaceScope
+          ? "Select a tenant before loading a workspace."
+          : dashboard.state === "loading" ? "Loading controls, findings, evidence, and sources." : undefined}
       />
 
       {readinessQuery.error && dashboard.data && (


### PR DESCRIPTION
## Summary

- start the GRC dashboard and readiness reads together instead of waiting for dashboard data
- apply the active tenant and workspace selectors to both request paths
- reject workspace-only scope before issuing GRC reads and disable Refresh for that invalid state
- cover parallel loading, scope isolation, and both Refresh paths in the GRC page test

## Validation

- focused ESLint for the changed page and test
- 18 focused Home, GRC, and scope tests
- fixture E2E: 13 route contracts with Chromium checks
- optimized Next.js build and standalone smoke
- browser waterfall: both scoped GRC reads start in the same millisecond and complete successfully
- route entry bundle: 7 chunks, 257,404 raw bytes (+517 bytes versus the measured base)

The repository-wide test run reaches 700 passing tests and one existing Node 26 localStorage setup failure in the GRC client mutation test; the changed-path suite passes.