### PR TITLE
perf(grc): normalize runtime scope reads

### DIFF
--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -183,7 +183,7 @@ func (a *App) handleGRCDashboard(w http.ResponseWriter, r *http.Request) {
 		var err error
 		return operationtelemetry.RunMainPhase(groupCtx, "grc.dashboard.aggregate", telemetry.Attrs(telemetry.Field{Key: "finding_count", Value: len(findingIDs)}), func(ctx context.Context) (telemetry.Attributes, error) {
 			request := r.WithContext(ctx)
-			aggregate, err = a.grcDashboardAggregate(request, runtimes, grcFindingFilter{Status: "open"}, findingIDs)
+			aggregate, err = a.grcDashboardAggregate(request, scope, runtimes, grcFindingFilter{Status: "open"}, findingIDs)
 			if err == nil && aggregate == nil {
 				findingSummary, err = a.grcFindingSummary(request, runtimes, grcFindingFilter{Status: "open"})
 				if err == nil {
@@ -1202,10 +1202,31 @@ func (a *App) grcEvidenceCountsByFindingID(r *http.Request, runtimes []*cerebrov
 	return counts, true, nil
 }
 
-func (a *App) grcDashboardAggregate(r *http.Request, runtimes []*cerebrov1.SourceRuntime, findingFilter grcFindingFilter, previewFindingIDs []string) (*ports.GRCDashboardAggregate, error) {
+func (a *App) grcDashboardAggregate(r *http.Request, scope grcScope, runtimes []*cerebrov1.SourceRuntime, findingFilter grcFindingFilter, previewFindingIDs []string) (*ports.GRCDashboardAggregate, error) {
 	provider, ok := a.deps.StateStore.(ports.GRCDashboardAggregateStore)
 	if !ok {
 		return nil, nil
+	}
+	if len(runtimes) == 0 {
+		aggregate := ports.GRCDashboardAggregate{}
+		return &aggregate, nil
+	}
+	if tenantID := strings.TrimSpace(scope.TenantID); tenantID != "" {
+		aggregate, err := provider.SummarizeGRCDashboard(r.Context(), ports.GRCDashboardAggregateRequest{
+			FindingRequest:    grcdashboard.AggregateFindingRequest(tenantID, nil, findingFilter),
+			PreviewFindingIDs: previewFindingIDs,
+			RuntimeScope: &ports.SourceRuntimeFilter{
+				RuntimeID:              scope.RuntimeID,
+				RuntimeIDs:             scope.RuntimeIDs,
+				TenantID:               tenantID,
+				ApplicationWorkspaceID: scope.ApplicationWorkspaceID,
+				SourceID:               scope.SourceID,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &aggregate, nil
 	}
 	runtimeIDsByTenant := map[string][]string{}
 	for _, runtime := range runtimes {
@@ -1228,26 +1249,7 @@ func (a *App) grcDashboardAggregate(r *http.Request, runtimes []*cerebrov1.Sourc
 	controlKeys := map[string]struct{}{}
 	for tenantID, runtimeIDs := range runtimeIDsByTenant {
 		item, err := provider.SummarizeGRCDashboard(r.Context(), ports.GRCDashboardAggregateRequest{
-			FindingRequest: ports.ListFindingsRequest{
-				TenantID:            tenantID,
-				RuntimeIDs:          runtimeIDs,
-				FindingID:           findingFilter.FindingID,
-				RuleID:              findingFilter.RuleID,
-				Severity:            findingFilter.Severity,
-				Status:              findingFilter.Status,
-				ResourceURN:         findingFilter.ResourceURN,
-				ResourceURNs:        findingFilter.ResourceURNs,
-				EventID:             findingFilter.EventID,
-				PolicyID:            findingFilter.PolicyID,
-				Framework:           findingFilter.Framework,
-				FirstObservedFrom:   findingFilter.FirstObservedFrom,
-				FirstObservedBefore: findingFilter.FirstObservedBefore,
-				StatusUpdatedFrom:   findingFilter.StatusUpdatedFrom,
-				StatusUpdatedBefore: findingFilter.StatusUpdatedBefore,
-				MinAgeDays:          findingFilter.MinAgeDays,
-				MaxAgeDays:          findingFilter.MaxAgeDays,
-				SLAStatus:           findingFilter.SLAStatus,
-			},
+			FindingRequest:    grcdashboard.AggregateFindingRequest(tenantID, runtimeIDs, findingFilter),
 			PreviewFindingIDs: previewFindingIDs,
 		})
 		if err != nil {

--- a/internal/bootstrap/grc_test.go
+++ b/internal/bootstrap/grc_test.go
@@ -864,6 +864,12 @@ func TestGRCDashboardCapsPreviewWorkToRenderedLimit(t *testing.T) {
 	if store.aggregateCalls != 1 {
 		t.Fatalf("aggregate calls = %d, want 1", store.aggregateCalls)
 	}
+	if store.aggregateRequest.RuntimeScope == nil || store.aggregateRequest.RuntimeScope.TenantID != tenantID {
+		t.Fatalf("aggregate runtime scope = %+v, want tenant %q", store.aggregateRequest.RuntimeScope, tenantID)
+	}
+	if len(store.aggregateRequest.FindingRequest.RuntimeIDs) != 0 {
+		t.Fatalf("aggregate finding request materialized runtime ids %v", store.aggregateRequest.FindingRequest.RuntimeIDs)
+	}
 	if got := len(payload.CoverageBlindSpots); got != 2 {
 		t.Fatalf("coverage blind spots = %d, want 2: %#v", got, payload.CoverageBlindSpots)
 	}
@@ -1875,12 +1881,25 @@ func TestGRCAuditPacketNormalizesForeignReceiptLookup(t *testing.T) {
 
 type stubGRCAggregateStore struct {
 	*stubRuntimeStore
-	aggregateCalls int
+	aggregateCalls   int
+	aggregateRequest ports.GRCDashboardAggregateRequest
 }
 
 func (s *stubGRCAggregateStore) SummarizeGRCDashboard(ctx context.Context, request ports.GRCDashboardAggregateRequest) (ports.GRCDashboardAggregate, error) {
 	s.aggregateCalls++
-	summary, err := s.SummarizeFindings(ctx, request.FindingRequest)
+	s.aggregateRequest = request
+	findingRequest := request.FindingRequest
+	if request.RuntimeScope != nil {
+		runtimes, err := s.ListSourceRuntimes(ctx, *request.RuntimeScope)
+		if err != nil {
+			return ports.GRCDashboardAggregate{}, err
+		}
+		findingRequest.RuntimeIDs = findingRequest.RuntimeIDs[:0]
+		for _, runtime := range runtimes {
+			findingRequest.RuntimeIDs = append(findingRequest.RuntimeIDs, runtime.GetId())
+		}
+	}
+	summary, err := s.SummarizeFindings(ctx, findingRequest)
 	if err != nil {
 		return ports.GRCDashboardAggregate{}, err
 	}
@@ -1888,9 +1907,9 @@ func (s *stubGRCAggregateStore) SummarizeGRCDashboard(ctx context.Context, reque
 	// scope (every matching finding), not the windowed preview finding-id list.
 	countsByFindingID := map[string]int{}
 	total := 0
-	status := strings.TrimSpace(request.FindingRequest.Status)
+	status := strings.TrimSpace(findingRequest.Status)
 	runtimeIDs := map[string]struct{}{}
-	for _, runtimeID := range append(request.FindingRequest.RuntimeIDs, request.FindingRequest.RuntimeID) {
+	for _, runtimeID := range append(findingRequest.RuntimeIDs, findingRequest.RuntimeID) {
 		if runtimeID = strings.TrimSpace(runtimeID); runtimeID != "" {
 			runtimeIDs[runtimeID] = struct{}{}
 		}

--- a/internal/grcdashboard/scope.go
+++ b/internal/grcdashboard/scope.go
@@ -1,0 +1,23 @@
+package grcdashboard
+
+import (
+	"strings"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+// AggregateFindingRequest keeps finding predicates while replacing list-only
+// pagination and ordering with one exact runtime scope for dashboard totals.
+func AggregateFindingRequest(tenantID string, runtimeIDs []string, filter ports.ListFindingsRequest) ports.ListFindingsRequest {
+	request := filter
+	request.TenantID = strings.TrimSpace(tenantID)
+	request.RuntimeID = ""
+	request.RuntimeIDs = append([]string(nil), runtimeIDs...)
+	request.ProfilePredicate = ports.FindingProfilePredicate{}
+	request.LastObservedBefore = time.Time{}
+	request.Limit = 0
+	request.PriorityOrder = false
+	request.Order = ""
+	return request
+}

--- a/internal/grcdashboard/scope_test.go
+++ b/internal/grcdashboard/scope_test.go
@@ -1,0 +1,32 @@
+package grcdashboard
+
+import (
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestAggregateFindingRequestReplacesRuntimeScopeAndListControls(t *testing.T) {
+	filter := ports.ListFindingsRequest{
+		RuntimeID:          "old-runtime",
+		RuntimeIDs:         []string{"old-runtime"},
+		Status:             "open",
+		Severity:           "critical",
+		ProfilePredicate:   ports.FindingProfilePredicate{RuleIDs: []string{"rule-a"}},
+		LastObservedBefore: time.Now().UTC(),
+		Limit:              25,
+		PriorityOrder:      true,
+		Order:              ports.FindingOrderRiskScore,
+	}
+	request := AggregateFindingRequest(" tenant-a ", []string{"runtime-a", "runtime-b"}, filter)
+	if request.TenantID != "tenant-a" || request.RuntimeID != "" || len(request.RuntimeIDs) != 2 {
+		t.Fatalf("aggregate scope = tenant %q runtime %q runtimes %v", request.TenantID, request.RuntimeID, request.RuntimeIDs)
+	}
+	if request.Status != "open" || request.Severity != "critical" {
+		t.Fatalf("aggregate predicates = status %q severity %q", request.Status, request.Severity)
+	}
+	if len(request.ProfilePredicate.RuleIDs) != 0 || !request.LastObservedBefore.IsZero() || request.Limit != 0 || request.PriorityOrder || request.Order != "" {
+		t.Fatalf("aggregate request retained list-only controls: %+v", request)
+	}
+}

--- a/internal/ports/grc.go
+++ b/internal/ports/grc.go
@@ -9,6 +9,10 @@ import (
 type GRCDashboardAggregateRequest struct {
 	FindingRequest    ListFindingsRequest
 	PreviewFindingIDs []string
+	// RuntimeScope lets the Postgres read model resolve runtime IDs inside the
+	// aggregate query. This keeps tenant/workspace authority in one bounded SQL
+	// plan instead of materializing every runtime ID in the Go request heap.
+	RuntimeScope *SourceRuntimeFilter
 }
 
 // GRCDashboardAggregate contains dashboard summary counts fetched without row payloads.

--- a/internal/statestore/postgres/compliance_inputs.go
+++ b/internal/statestore/postgres/compliance_inputs.go
@@ -170,7 +170,7 @@ func (s *Store) ScanSourceRuntimeSnapshot(ctx context.Context, request ports.Inp
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	scopeClauses, scopeArgs := inputSnapshotScopeClauses(normalized, "runtime_json->>'tenant_id'", "id")
+	scopeClauses, scopeArgs := inputSnapshotScopeClauses(normalized, "tenant_id", "id")
 	total, watermark, err := measureInputSnapshot(ctx, tx, "source_runtimes", scopeClauses, scopeArgs)
 	if err != nil {
 		return ports.InputSnapshotPage[*cerebrov1.SourceRuntime]{}, err
@@ -259,7 +259,7 @@ func inputSnapshotScopeClauses(request ports.InputSnapshotRequest, tenantColumn 
 
 func findingEvidenceInputSnapshotScopeClauses(request ports.InputSnapshotRequest) ([]string, []any) {
 	args := []any{request.TenantID}
-	clauses := []string{"EXISTS (SELECT 1 FROM source_runtimes input_runtime WHERE input_runtime.id = finding_evidence.runtime_id AND input_runtime.runtime_json->>'tenant_id' = $1)"}
+	clauses := []string{"EXISTS (SELECT 1 FROM source_runtimes input_runtime WHERE input_runtime.id = finding_evidence.runtime_id AND input_runtime.tenant_id = $1)"}
 	placeholders := make([]string, 0, len(request.RuntimeIDs))
 	for _, runtimeID := range request.RuntimeIDs {
 		args = append(args, runtimeID)

--- a/internal/statestore/postgres/compliance_inputs_test.go
+++ b/internal/statestore/postgres/compliance_inputs_test.go
@@ -94,8 +94,11 @@ func TestFindingEvidenceInputSnapshotClausesEnforceRuntimeTenant(t *testing.T) {
 	}
 	clauses, args := findingEvidenceInputSnapshotScopeClauses(request)
 	joined := strings.Join(clauses, " AND ")
-	if !strings.Contains(joined, "input_runtime.runtime_json->>'tenant_id' = $1") {
+	if !strings.Contains(joined, "input_runtime.tenant_id = $1") {
 		t.Fatalf("clauses do not enforce tenant: %s", joined)
+	}
+	if strings.Contains(joined, "runtime_json->") {
+		t.Fatalf("clauses re-parse runtime scope JSON: %s", joined)
 	}
 	if len(args) != 3 || args[0] != "tenant-a" || args[1] != "runtime-a" || args[2] != "runtime-b" {
 		t.Fatalf("args = %#v", args)

--- a/internal/statestore/postgres/findings.go
+++ b/internal/statestore/postgres/findings.go
@@ -1474,32 +1474,39 @@ func findingFilterClauses(request ports.ListFindingsRequest) ([]string, []any, e
 	clauses := []string{"tenant_id = $1"}
 	args := []any{tenantID}
 	addStringInFilter(&clauses, &args, "runtime_id", runtimeIDs)
-	addFindingFilter(&clauses, &args, "id", request.FindingID)
-	addFindingFilter(&clauses, &args, "rule_id", request.RuleID)
-	if err := addFindingProfilePredicate(&clauses, &args, request.ProfilePredicate.RuleIDs, request.ProfilePredicate.ControlRefs); err != nil {
-		return nil, nil, err
-	}
-	addFindingSeverityFilter(&clauses, &args, request.Severity)
-	addFindingFilter(&clauses, &args, "status", request.Status)
-	addFindingFilter(&clauses, &args, "policy_id", request.PolicyID)
-	addFindingFrameworkFilter(&clauses, &args, request.Framework)
-	addFindingTimeLowerBoundFilter(&clauses, &args, "first_observed_at", request.FirstObservedFrom)
-	addFindingTimeUpperBoundFilter(&clauses, &args, "first_observed_at", request.FirstObservedBefore)
-	addFindingTimeLowerBoundFilter(&clauses, &args, "status_updated_at", request.StatusUpdatedFrom)
-	addFindingTimeUpperBoundFilter(&clauses, &args, "status_updated_at", request.StatusUpdatedBefore)
-	if !request.LastObservedBefore.IsZero() {
-		args = append(args, request.LastObservedBefore.UTC())
-		clauses = append(clauses, fmt.Sprintf("last_observed_at < $%d", len(args)))
-	}
-	addFindingAgeFilter(&clauses, &args, request.MinAgeDays, request.MaxAgeDays)
-	addFindingSLAStatusFilter(&clauses, &args, request.SLAStatus)
-	if err := addFindingArrayContainsAnyFilter(&clauses, &args, "resource_urns_json", append([]string{request.ResourceURN}, request.ResourceURNs...)); err != nil {
-		return nil, nil, err
-	}
-	if err := addFindingArrayContainsFilter(&clauses, &args, "event_ids_json", request.EventID); err != nil {
+	if err := appendFindingFilterClauses(&clauses, &args, request); err != nil {
 		return nil, nil, err
 	}
 	return clauses, args, nil
+}
+
+func appendFindingFilterClauses(clauses *[]string, args *[]any, request ports.ListFindingsRequest) error {
+	addFindingFilter(clauses, args, "id", request.FindingID)
+	addFindingFilter(clauses, args, "rule_id", request.RuleID)
+	if err := addFindingProfilePredicate(clauses, args, request.ProfilePredicate.RuleIDs, request.ProfilePredicate.ControlRefs); err != nil {
+		return err
+	}
+	addFindingSeverityFilter(clauses, args, request.Severity)
+	addFindingFilter(clauses, args, "status", request.Status)
+	addFindingFilter(clauses, args, "policy_id", request.PolicyID)
+	addFindingFrameworkFilter(clauses, args, request.Framework)
+	addFindingTimeLowerBoundFilter(clauses, args, "first_observed_at", request.FirstObservedFrom)
+	addFindingTimeUpperBoundFilter(clauses, args, "first_observed_at", request.FirstObservedBefore)
+	addFindingTimeLowerBoundFilter(clauses, args, "status_updated_at", request.StatusUpdatedFrom)
+	addFindingTimeUpperBoundFilter(clauses, args, "status_updated_at", request.StatusUpdatedBefore)
+	if !request.LastObservedBefore.IsZero() {
+		*args = append(*args, request.LastObservedBefore.UTC())
+		*clauses = append(*clauses, fmt.Sprintf("last_observed_at < $%d", len(*args)))
+	}
+	addFindingAgeFilter(clauses, args, request.MinAgeDays, request.MaxAgeDays)
+	addFindingSLAStatusFilter(clauses, args, request.SLAStatus)
+	if err := addFindingArrayContainsAnyFilter(clauses, args, "resource_urns_json", append([]string{request.ResourceURN}, request.ResourceURNs...)); err != nil {
+		return err
+	}
+	if err := addFindingArrayContainsFilter(clauses, args, "event_ids_json", request.EventID); err != nil {
+		return err
+	}
+	return nil
 }
 
 func addFindingProfilePredicate(clauses *[]string, args *[]any, ruleIDs []string, controlRefs []ports.FindingControlRef) error {

--- a/internal/statestore/postgres/grc_dashboard.go
+++ b/internal/statestore/postgres/grc_dashboard.go
@@ -39,6 +39,11 @@ func (s *Store) SummarizeGRCDashboard(ctx context.Context, request ports.GRCDash
 	if err := s.ensureFindingEvidenceTables(ctx); err != nil {
 		return ports.GRCDashboardAggregate{}, err
 	}
+	if request.RuntimeScope != nil {
+		if err := s.ensureSourceRuntimeTable(ctx); err != nil {
+			return ports.GRCDashboardAggregate{}, err
+		}
+	}
 	query, args, err := grcDashboardAggregateQuery(request)
 	if err != nil {
 		return ports.GRCDashboardAggregate{}, err
@@ -114,12 +119,11 @@ func decodeGRCDashboardEvidenceCounts(evidenceCountsJSON string) (map[string]int
 }
 
 func grcDashboardAggregateQuery(request ports.GRCDashboardAggregateRequest) (string, []any, error) {
-	findingClauses, findingArgs, err := findingFilterClauses(request.FindingRequest)
+	runtimeScopeCTE, findingClauses, args, err := grcDashboardScopeClauses(request)
 	if err != nil {
 		return "", nil, err
 	}
 	whereFindings := strings.Join(findingClauses, " AND ")
-	args := append([]any{}, findingArgs...)
 	previewClauses := []string{"FALSE"}
 	previewFindingIDs := normalizedNonEmptyStrings(request.PreviewFindingIDs)
 	if len(previewFindingIDs) > 0 {
@@ -129,7 +133,7 @@ func grcDashboardAggregateQuery(request ports.GRCDashboardAggregateRequest) (str
 	wherePreview := strings.Join(previewClauses, " AND ")
 	effectiveSeverity := findingEffectiveSeveritySQL()
 	query := `
-WITH finding_scope AS (
+WITH ` + runtimeScopeCTE + `finding_scope AS (
   SELECT id, runtime_id, status, ` + effectiveSeverity + ` AS effective_severity, due_at, assignee
   FROM findings
   WHERE ` + whereFindings + `
@@ -177,4 +181,47 @@ FROM summary
 CROSS JOIN evidence_summary
 CROSS JOIN preview_evidence_counts`
 	return query, args, nil
+}
+
+func grcDashboardScopeClauses(request ports.GRCDashboardAggregateRequest) (string, []string, []any, error) {
+	if request.RuntimeScope == nil {
+		clauses, args, err := findingFilterClauses(request.FindingRequest)
+		return "", clauses, args, err
+	}
+	tenantID := strings.TrimSpace(request.FindingRequest.TenantID)
+	scopeTenantID := strings.TrimSpace(request.RuntimeScope.TenantID)
+	if tenantID == "" || scopeTenantID == "" || tenantID != scopeTenantID {
+		return "", nil, nil, errors.New("dashboard runtime scope must match finding tenant")
+	}
+	applicationWorkspaceID, err := ports.ValidateApplicationWorkspaceScope(scopeTenantID, request.RuntimeScope.ApplicationWorkspaceID)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("dashboard runtime scope: %w", err)
+	}
+	if strings.TrimSpace(request.FindingRequest.RuntimeID) != "" || len(normalizedNonEmptyStrings(request.FindingRequest.RuntimeIDs)) > 0 {
+		return "", nil, nil, errors.New("dashboard finding runtime ids must be carried by runtime scope")
+	}
+	args := []any{tenantID}
+	runtimeClauses := []string{"tenant_id = $1"}
+	runtimeIDs := append([]string(nil), request.RuntimeScope.RuntimeIDs...)
+	runtimeIDs = normalizedNonEmptyStrings(append(runtimeIDs, request.RuntimeScope.RuntimeID))
+	addStringInFilter(&runtimeClauses, &args, "id", runtimeIDs)
+	if sourceID := strings.TrimSpace(request.RuntimeScope.SourceID); sourceID != "" {
+		args = append(args, sourceID)
+		runtimeClauses = append(runtimeClauses, fmt.Sprintf("source_id = $%d", len(args)))
+	}
+	if applicationWorkspaceID != "" {
+		args = append(args, applicationWorkspaceID)
+		runtimeClauses = append(runtimeClauses, fmt.Sprintf("application_workspace_id = $%d", len(args)))
+	}
+	findingClauses := []string{"tenant_id = $1", "runtime_id = ANY(ARRAY(SELECT id FROM runtime_scope))"}
+	if err := appendFindingFilterClauses(&findingClauses, &args, request.FindingRequest); err != nil {
+		return "", nil, nil, err
+	}
+	runtimeScopeCTE := `runtime_scope AS (
+  SELECT id
+  FROM source_runtimes
+  WHERE ` + strings.Join(runtimeClauses, " AND ") + `
+),
+`
+	return runtimeScopeCTE, findingClauses, args, nil
 }

--- a/internal/statestore/postgres/grc_dashboard_benchmark_test.go
+++ b/internal/statestore/postgres/grc_dashboard_benchmark_test.go
@@ -1,0 +1,51 @@
+package postgres
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func BenchmarkGRCDashboardAggregateQueryRuntimeIDs(b *testing.B) {
+	runtimeIDs := make([]string, 500)
+	for index := range runtimeIDs {
+		runtimeIDs[index] = fmt.Sprintf("runtime-%04d", index)
+	}
+	request := ports.GRCDashboardAggregateRequest{
+		FindingRequest: ports.ListFindingsRequest{
+			TenantID:   "tenant-a",
+			RuntimeIDs: runtimeIDs,
+			Status:     "open",
+		},
+		PreviewFindingIDs: []string{"finding-a", "finding-b"},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, _, err := grcDashboardAggregateQuery(request); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGRCDashboardAggregateQueryRuntimeScope(b *testing.B) {
+	request := ports.GRCDashboardAggregateRequest{
+		FindingRequest: ports.ListFindingsRequest{
+			TenantID: "tenant-a",
+			Status:   "open",
+		},
+		PreviewFindingIDs: []string{"finding-a", "finding-b"},
+		RuntimeScope: &ports.SourceRuntimeFilter{
+			TenantID:               "tenant-a",
+			ApplicationWorkspaceID: "workspace-a",
+		},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, _, err := grcDashboardAggregateQuery(request); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/statestore/postgres/grc_dashboard_test.go
+++ b/internal/statestore/postgres/grc_dashboard_test.go
@@ -13,18 +13,26 @@ import (
 func TestGRCDashboardAggregateQueryCombinesFindingAndEvidenceCounts(t *testing.T) {
 	query, args, err := grcDashboardAggregateQuery(ports.GRCDashboardAggregateRequest{
 		FindingRequest: ports.ListFindingsRequest{
-			TenantID:   "example",
-			RuntimeIDs: []string{"tenant-runtime-a", "tenant-runtime-b"},
-			Status:     "open",
+			TenantID: "example",
+			Status:   "open",
 		},
 		PreviewFindingIDs: []string{"finding-a", "finding-b"},
+		RuntimeScope: &ports.SourceRuntimeFilter{
+			TenantID:               "example",
+			ApplicationWorkspaceID: "workspace-a",
+		},
 	})
 	if err != nil {
 		t.Fatalf("grcDashboardAggregateQuery() error = %v", err)
 	}
 	for _, fragment := range []string{
-		"WITH finding_scope AS",
+		"runtime_scope AS",
+		"FROM source_runtimes",
+		"tenant_id = $1",
+		"application_workspace_id = $2",
+		"finding_scope AS",
 		"SELECT id, runtime_id, status,",
+		"runtime_id = ANY(ARRAY(SELECT id FROM runtime_scope))",
 		"COUNT(*) FILTER (WHERE LOWER(status) = 'open') AS open_findings",
 		"JOIN finding_control_refs AS ref ON ref.finding_id = finding.id",
 		"jsonb_build_object('framework_name', framework_name, 'control_id', control_id)",
@@ -33,7 +41,7 @@ func TestGRCDashboardAggregateQueryCombinesFindingAndEvidenceCounts(t *testing.T
 		"jsonb_object_agg(finding.id, counts.evidence_count)",
 		"JOIN finding_evidence_counts AS counts",
 		"counts.runtime_id = finding.runtime_id",
-		"finding.id IN ($5, $6)",
+		"finding.id IN ($4, $5)",
 	} {
 		if !strings.Contains(query, fragment) {
 			t.Fatalf("aggregate query missing %q:\n%s", fragment, query)
@@ -46,8 +54,11 @@ func TestGRCDashboardAggregateQueryCombinesFindingAndEvidenceCounts(t *testing.T
 			t.Fatalf("aggregate query must not contain %q:\n%s", forbidden, query)
 		}
 	}
-	if len(args) != 6 {
-		t.Fatalf("aggregate query args len = %d, want 6 (%v)", len(args), args)
+	if len(args) != 5 {
+		t.Fatalf("aggregate query args len = %d, want 5 (%v)", len(args), args)
+	}
+	if args[0] != "example" || args[1] != "workspace-a" || args[2] != "open" {
+		t.Fatalf("aggregate query scope args = %#v, want tenant/workspace/status first", args)
 	}
 }
 
@@ -108,11 +119,14 @@ func TestGRCDashboardAggregatePlanUsesMaterializedEvidenceCountsPostgresIntegrat
 	}
 	query, args, err := grcDashboardAggregateQuery(ports.GRCDashboardAggregateRequest{
 		FindingRequest: ports.ListFindingsRequest{
-			TenantID:   "dashboard-plan-tenant",
-			RuntimeIDs: []string{"dashboard-plan-runtime"},
-			Status:     "open",
+			TenantID: "dashboard-plan-tenant",
+			Status:   "open",
 		},
 		PreviewFindingIDs: []string{"dashboard-plan-finding"},
+		RuntimeScope: &ports.SourceRuntimeFilter{
+			TenantID:               "dashboard-plan-tenant",
+			ApplicationWorkspaceID: "dashboard-plan-workspace",
+		},
 	})
 	if err != nil {
 		t.Fatalf("grcDashboardAggregateQuery() error = %v", err)
@@ -126,5 +140,18 @@ func TestGRCDashboardAggregatePlanUsesMaterializedEvidenceCountsPostgresIntegrat
 	}
 	if strings.Contains(plan, `"Relation Name": "finding_evidence"`) {
 		t.Fatalf("dashboard aggregate plan scans raw finding evidence: %s", plan)
+	}
+	if !strings.Contains(plan, `"Relation Name": "source_runtimes"`) {
+		t.Fatalf("dashboard aggregate plan does not resolve normalized runtime scope: %s", plan)
+	}
+}
+
+func TestGRCDashboardAggregateScopeRejectsTenantWorkspaceMismatch(t *testing.T) {
+	_, _, err := grcDashboardAggregateQuery(ports.GRCDashboardAggregateRequest{
+		FindingRequest: ports.ListFindingsRequest{TenantID: "tenant-a", Status: "open"},
+		RuntimeScope:   &ports.SourceRuntimeFilter{TenantID: "tenant-b", ApplicationWorkspaceID: "workspace-a"},
+	})
+	if err == nil {
+		t.Fatal("grcDashboardAggregateQuery() error = nil, want tenant mismatch")
 	}
 }

--- a/internal/statestore/postgres/sourceruntime.go
+++ b/internal/statestore/postgres/sourceruntime.go
@@ -17,15 +17,24 @@ import (
 var ensureSourceRuntimeStatements = []string{`CREATE TABLE IF NOT EXISTS source_runtimes (
   id TEXT PRIMARY KEY,
   runtime_json JSONB NOT NULL,
+  tenant_id TEXT GENERATED ALWAYS AS (BTRIM(COALESCE(runtime_json->>'tenant_id', ''))) STORED,
+  source_id TEXT GENERATED ALWAYS AS (BTRIM(COALESCE(runtime_json->>'source_id', ''))) STORED,
+  application_workspace_id TEXT GENERATED ALWAYS AS (BTRIM(COALESCE(runtime_json->'config'->>'application_workspace_id', ''))) STORED,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )`,
 	`ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS lease_owner TEXT`,
 	`ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ`,
 	`ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS lease_generation BIGINT NOT NULL DEFAULT 0 CHECK (lease_generation >= 0)`,
-	`CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_tenant_updated_idx ON source_runtimes ((runtime_json->>'tenant_id'), updated_at ASC, id ASC)`,
-	`CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_tenant_source_updated_idx ON source_runtimes ((runtime_json->>'tenant_id'), (runtime_json->>'source_id'), updated_at ASC, id ASC)`,
-	`CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_tenant_workspace_updated_idx ON source_runtimes ((runtime_json->>'tenant_id'), (runtime_json->'config'->>'application_workspace_id'), updated_at ASC, id ASC)`,
+	`ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS tenant_id TEXT GENERATED ALWAYS AS (BTRIM(COALESCE(runtime_json->>'tenant_id', ''))) STORED`,
+	`ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS source_id TEXT GENERATED ALWAYS AS (BTRIM(COALESCE(runtime_json->>'source_id', ''))) STORED`,
+	`ALTER TABLE source_runtimes ADD COLUMN IF NOT EXISTS application_workspace_id TEXT GENERATED ALWAYS AS (BTRIM(COALESCE(runtime_json->'config'->>'application_workspace_id', ''))) STORED`,
+	`CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_scope_updated_idx ON source_runtimes (tenant_id, updated_at ASC, id ASC)`,
+	`CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_scope_source_updated_idx ON source_runtimes (tenant_id, source_id, updated_at ASC, id ASC)`,
+	`CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_scope_workspace_updated_idx ON source_runtimes (tenant_id, application_workspace_id, updated_at ASC, id ASC)`,
+	`DROP INDEX CONCURRENTLY IF EXISTS source_runtimes_tenant_updated_idx`,
+	`DROP INDEX CONCURRENTLY IF EXISTS source_runtimes_tenant_source_updated_idx`,
+	`DROP INDEX CONCURRENTLY IF EXISTS source_runtimes_tenant_workspace_updated_idx`,
 }
 
 // PutSourceRuntime upserts one source runtime definition.
@@ -181,15 +190,15 @@ func sourceRuntimeListQuery(filter ports.SourceRuntimeFilter) (string, []any, er
 	}
 	if tenantID := strings.TrimSpace(filter.TenantID); tenantID != "" {
 		args = append(args, tenantID)
-		clauses = append(clauses, fmt.Sprintf("runtime_json->>'tenant_id' = $%d", len(args)))
+		clauses = append(clauses, fmt.Sprintf("tenant_id = $%d", len(args)))
 	}
 	if applicationWorkspaceID != "" {
 		args = append(args, applicationWorkspaceID)
-		clauses = append(clauses, fmt.Sprintf("runtime_json->'config'->>'application_workspace_id' = $%d", len(args)))
+		clauses = append(clauses, fmt.Sprintf("application_workspace_id = $%d", len(args)))
 	}
 	if sourceID := strings.TrimSpace(filter.SourceID); sourceID != "" {
 		args = append(args, sourceID)
-		clauses = append(clauses, fmt.Sprintf("runtime_json->>'source_id' = $%d", len(args)))
+		clauses = append(clauses, fmt.Sprintf("source_id = $%d", len(args)))
 	}
 	limit := filter.Limit
 	if limit == 0 {

--- a/internal/statestore/postgres/sourceruntime_test.go
+++ b/internal/statestore/postgres/sourceruntime_test.go
@@ -2,11 +2,13 @@ package postgres
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
 )
 
@@ -70,14 +72,19 @@ func TestSourceRuntimeSchemaIndexesDashboardFilters(t *testing.T) {
 	joined := strings.Join(ensureSourceRuntimeStatements, "\n")
 	for _, fragment := range []string{
 		"lease_generation BIGINT NOT NULL DEFAULT 0",
-		"source_runtimes_tenant_updated_idx",
-		"CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_tenant_updated_idx",
-		"(runtime_json->>'tenant_id'), updated_at ASC, id ASC",
-		"source_runtimes_tenant_source_updated_idx",
-		"CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_tenant_source_updated_idx",
-		"(runtime_json->>'tenant_id'), (runtime_json->>'source_id'), updated_at ASC, id ASC",
-		"source_runtimes_tenant_workspace_updated_idx",
-		"(runtime_json->>'tenant_id'), (runtime_json->'config'->>'application_workspace_id'), updated_at ASC, id ASC",
+		"tenant_id TEXT GENERATED ALWAYS AS",
+		"source_id TEXT GENERATED ALWAYS AS",
+		"application_workspace_id TEXT GENERATED ALWAYS AS",
+		"source_runtimes_scope_updated_idx",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS source_runtimes_scope_updated_idx",
+		"tenant_id, updated_at ASC, id ASC",
+		"source_runtimes_scope_source_updated_idx",
+		"tenant_id, source_id, updated_at ASC, id ASC",
+		"source_runtimes_scope_workspace_updated_idx",
+		"tenant_id, application_workspace_id, updated_at ASC, id ASC",
+		"DROP INDEX CONCURRENTLY IF EXISTS source_runtimes_tenant_updated_idx",
+		"DROP INDEX CONCURRENTLY IF EXISTS source_runtimes_tenant_source_updated_idx",
+		"DROP INDEX CONCURRENTLY IF EXISTS source_runtimes_tenant_workspace_updated_idx",
 	} {
 		if !strings.Contains(joined, fragment) {
 			t.Fatalf("source runtime schema missing %q:\n%s", fragment, joined)
@@ -99,16 +106,107 @@ func TestSourceRuntimeListQueryScopesTenantAndApplicationWorkspace(t *testing.T)
 		t.Fatalf("sourceRuntimeListQuery() error = %v", err)
 	}
 	for _, fragment := range []string{
-		"runtime_json->>'tenant_id' = $1",
-		"runtime_json->'config'->>'application_workspace_id' = $2",
-		"runtime_json->>'source_id' = $3",
+		"tenant_id = $1",
+		"application_workspace_id = $2",
+		"source_id = $3",
 		"LIMIT $4",
 	} {
 		if !strings.Contains(query, fragment) {
 			t.Fatalf("source runtime query missing %q:\n%s", fragment, query)
 		}
 	}
+	if strings.Contains(query, "runtime_json->") {
+		t.Fatalf("source runtime query re-parses JSON scope fields:\n%s", query)
+	}
 	if len(args) != 4 || args[0] != "tenant-a" || args[1] != "workspace-a" || args[2] != "okta" || args[3] != uint32(13) {
 		t.Fatalf("source runtime query args = %#v, want tenant/workspace/source/limit", args)
 	}
+}
+
+func TestSourceRuntimeGeneratedScopeColumnsStayTenantWorkspaceIsolatedPostgresIntegration(t *testing.T) {
+	dsn := strings.TrimSpace(os.Getenv("CEREBRO_POSTGRES_DSN"))
+	if dsn == "" {
+		t.Skip("set CEREBRO_POSTGRES_DSN to run source runtime scope integration test")
+	}
+	store, err := Open(config.StateStoreConfig{Driver: config.StateStoreDriverPostgres, PostgresDSN: dsn})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	ctx := context.Background()
+	unique := strings.ToLower(strings.ReplaceAll(t.Name(), "/", "-")) + "-" + time.Now().UTC().Format("20060102150405.000000000")
+	tenantA := unique + "-tenant-a"
+	tenantB := unique + "-tenant-b"
+	workspaceA := unique + "-workspace-a"
+	workspaceB := unique + "-workspace-b"
+	runtimeA := &cerebrov1.SourceRuntime{
+		Id:       unique + "-runtime-a",
+		TenantId: tenantA,
+		SourceId: "okta",
+		Config:   map[string]string{ports.SourceRuntimeApplicationWorkspaceIDConfigKey: workspaceA},
+	}
+	runtimeOtherTenant := &cerebrov1.SourceRuntime{
+		Id:       unique + "-runtime-other-tenant",
+		TenantId: tenantB,
+		SourceId: "okta",
+		Config:   map[string]string{ports.SourceRuntimeApplicationWorkspaceIDConfigKey: workspaceA},
+	}
+	runtimeOtherWorkspace := &cerebrov1.SourceRuntime{
+		Id:       unique + "-runtime-other-workspace",
+		TenantId: tenantA,
+		SourceId: "okta",
+		Config:   map[string]string{ports.SourceRuntimeApplicationWorkspaceIDConfigKey: workspaceB},
+	}
+	t.Cleanup(func() {
+		_, _ = store.db.ExecContext(ctx, `DELETE FROM source_runtimes WHERE id = ANY($1::text[])`, []string{runtimeA.GetId(), runtimeOtherTenant.GetId(), runtimeOtherWorkspace.GetId()})
+	})
+	if err := store.PutSourceRuntimes(ctx, []*cerebrov1.SourceRuntime{runtimeA, runtimeOtherTenant, runtimeOtherWorkspace}); err != nil {
+		t.Fatalf("PutSourceRuntimes() error = %v", err)
+	}
+
+	assertScopeColumns := func(wantTenant, wantSource, wantWorkspace string) {
+		t.Helper()
+		var tenantID, sourceID, workspaceID string
+		if err := store.db.QueryRowContext(ctx, `
+SELECT tenant_id, source_id, application_workspace_id
+FROM source_runtimes
+WHERE id = $1`, runtimeA.GetId()).Scan(&tenantID, &sourceID, &workspaceID); err != nil {
+			t.Fatalf("read generated source runtime scope: %v", err)
+		}
+		if tenantID != wantTenant || sourceID != wantSource || workspaceID != wantWorkspace {
+			t.Fatalf("generated scope = tenant %q source %q workspace %q, want %q/%q/%q", tenantID, sourceID, workspaceID, wantTenant, wantSource, wantWorkspace)
+		}
+	}
+	assertScopeColumns(tenantA, "okta", workspaceA)
+
+	runtimes, err := store.ListSourceRuntimes(ctx, ports.SourceRuntimeFilter{TenantID: tenantA, ApplicationWorkspaceID: workspaceA})
+	if err != nil {
+		t.Fatalf("ListSourceRuntimes() error = %v", err)
+	}
+	if len(runtimes) != 1 || runtimes[0].GetId() != runtimeA.GetId() {
+		t.Fatalf("tenant/workspace scoped runtimes = %v, want only %q", sourceRuntimeIDs(runtimes), runtimeA.GetId())
+	}
+
+	runtimeA.TenantId = tenantB
+	runtimeA.SourceId = "github"
+	runtimeA.Config[ports.SourceRuntimeApplicationWorkspaceIDConfigKey] = workspaceB
+	if err := store.PutSourceRuntime(ctx, runtimeA); err != nil {
+		t.Fatalf("PutSourceRuntime(update) error = %v", err)
+	}
+	assertScopeColumns(tenantB, "github", workspaceB)
+	runtimes, err = store.ListSourceRuntimes(ctx, ports.SourceRuntimeFilter{TenantID: tenantA, ApplicationWorkspaceID: workspaceA})
+	if err != nil {
+		t.Fatalf("ListSourceRuntimes(old scope) error = %v", err)
+	}
+	if len(runtimes) != 0 {
+		t.Fatalf("old tenant/workspace scope leaked updated runtime ids %v", sourceRuntimeIDs(runtimes))
+	}
+}
+
+func sourceRuntimeIDs(runtimes []*cerebrov1.SourceRuntime) []string {
+	ids := make([]string, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		ids = append(ids, runtime.GetId())
+	}
+	return ids
 }


### PR DESCRIPTION
## Summary

- Materialize bounded tenant, source, and application-workspace scope columns from `source_runtimes.runtime_json`, index those columns concurrently, and retire the replaced JSON-expression indexes.
- Resolve GRC dashboard runtime scope inside Postgres so the aggregate query no longer expands every runtime ID into Go allocations and SQL placeholders.
- Keep tenant and workspace predicates together in the runtime scope, reuse normalized tenant scope for compliance snapshots, and preserve the existing compatibility path for requests without one tenant authority.
- Continue reading materialized `finding_evidence_counts`; the aggregate plan does not scan raw `finding_evidence`.

## Measured result

Exact-head `397003c0293b718768c46e0fe3b205ddabdcd824` synthetic 500-runtime query-construction benchmark, three 2-second runs on darwin/arm64:

| path | median ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| runtime ID expansion | 85,344 | 193,222 | 1,318 |
| normalized runtime scope | 1,089 | 3,288 | 31 |

That is 98.7% less query-construction time, 98.3% fewer allocated bytes, and 97.6% fewer allocations.

Postgres 16 scope-plan comparison over synthetic runtime/finding rows, 12 alternating warm runs:

| path | query bytes | median planning | median execution | shared hits |
| --- | ---: | ---: | ---: | ---: |
| 250 expanded runtime IDs | 3,844 | 1.556 ms | 5.010 ms | 504 |
| tenant + workspace scope | 204 | 1.700 ms | 5.610 ms | 546 |

The normalized plan cuts query text 94.7% and makes scope cardinality independent of runtime count. The measured database tradeoff is +0.600 ms execution and 42 shared-buffer hits on this synthetic corpus.

## Validation

- `CEREBRO_POSTGRES_DSN=... go test ./internal/statestore/postgres -run TestGRCDashboardAggregatePlanUsesMaterializedEvidenceCountsPostgresIntegration -count=1`
- `CEREBRO_POSTGRES_DSN=... go test ./internal/statestore/postgres -run TestSourceRuntimeGeneratedScopeColumnsStayTenantWorkspaceIsolatedPostgresIntegration -count=1`
- `go test ./... -count=1`
- `go test -race ./internal/statestore/postgres ./internal/bootstrap -count=1`
- `make lint-internal`
- `make check-structural check-structural-test check-arch`
- `make changed-check`
