### PR TITLE
fix(web): wait for fixture process tree cleanup

### DIFF
--- a/apps/web/scripts/portable-web-fixture-e2e.mjs
+++ b/apps/web/scripts/portable-web-fixture-e2e.mjs
@@ -756,15 +756,40 @@ async function waitForExitUntil(exited, expiresAt) {
   }
 }
 
+function processGroupExists(pid) {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    if (error?.code === "EPERM") return true;
+    throw error;
+  }
+}
+
+async function waitForProcessGroupExit(pid, expiresAt, platform) {
+  if (platform === "win32") return true;
+  while (processGroupExists(pid)) {
+    const remainingMs = expiresAt - Date.now();
+    if (remainingMs <= 0) return false;
+    await new Promise((resolve) => {
+      setTimeout(resolve, Math.min(25, remainingMs));
+    });
+  }
+  return true;
+}
+
 export async function stopProcessTree(child, options = {}) {
   if (typeof options === "number") options = { graceMs: options };
-  if (!child || !child.pid || child.exitCode !== null || child.signalCode !== null) return;
   const graceMs = options.graceMs ?? 5_000;
   const deadlineAt = options.deadlineAt ?? Date.now() + graceMs + 5_000;
   const platform = options.platform ?? process.platform;
+  if (!child || !child.pid || (platform === "win32" && (child.exitCode !== null || child.signalCode !== null))) return;
   const taskkillProcess = options.taskkillProcess ?? taskkill;
   const signalProcessGroup = options.signalProcessGroup ?? ((pid, signal) => process.kill(-pid, signal));
-  const exited = new Promise((resolve) => child.once("exit", resolve));
+  const exited = child.exitCode !== null || child.signalCode !== null
+    ? Promise.resolve()
+    : new Promise((resolve) => child.once("exit", resolve));
   const signal = async (force, signalDeadlineAt) => {
     if (platform === "win32") {
       try {
@@ -784,10 +809,15 @@ export async function stopProcessTree(child, options = {}) {
     }
   };
   const graceDeadline = Math.min(deadlineAt, Date.now() + graceMs);
+  const waitForTreeExit = async (expiresAt) => {
+    const childExited = await waitForExitUntil(exited, expiresAt);
+    const groupExited = await waitForProcessGroupExit(child.pid, expiresAt, platform);
+    return childExited && groupExited;
+  };
   await signal(false, graceDeadline);
-  if (await waitForExitUntil(exited, graceDeadline)) return;
+  if (await waitForTreeExit(graceDeadline)) return;
   await signal(true, deadlineAt);
-  if (!await waitForExitUntil(exited, deadlineAt)) {
+  if (!await waitForTreeExit(deadlineAt)) {
     throw timeoutError("forced fixture process-tree termination");
   }
 }

--- a/apps/web/scripts/portable-web-fixture-e2e.test.mjs
+++ b/apps/web/scripts/portable-web-fixture-e2e.test.mjs
@@ -366,6 +366,72 @@ describe("portable web fixture E2E cleanup", () => {
     }
   });
 
+  it.runIf(process.platform !== "win32")("waits for the owned fixture tree before a second run reuses its resource", async () => {
+    const delayedServer = [
+      'const net = require("node:net");',
+      'const port = Number(process.argv[1]);',
+      'process.on("SIGTERM", () => setTimeout(() => process.exit(0), 5_000));',
+      'const server = net.createServer();',
+      'server.on("error", (error) => { console.error(error.message); process.exitCode = 1; process.exit(1); });',
+      'server.listen(port, "127.0.0.1", () => console.log(JSON.stringify({ pid: process.pid, port: server.address().port })));',
+      'setInterval(() => {}, 1_000);',
+    ].join("\n");
+    const startFixture = (port) => {
+      const launcher = [
+        'const { spawn } = require("node:child_process");',
+        `const child = spawn(process.execPath, ["-e", ${JSON.stringify(delayedServer)}, ${JSON.stringify(String(port))}], { stdio: ["ignore", "pipe", "ignore"] });`,
+        'child.stdout.pipe(process.stdout);',
+        'child.once("exit", (code, signal) => { if (code !== 0 || signal) process.exitCode = 1; process.exit(); });',
+        'setInterval(() => {}, 1_000);',
+      ].join("\n");
+      return spawn(process.execPath, ["-e", launcher], {
+        detached: true,
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+    };
+    const waitForReady = (fixture) => new Promise((resolve, reject) => {
+      let buffer = "";
+      const onData = (chunk) => {
+        buffer += chunk.toString();
+        const lines = buffer.split(/\r?\n/);
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          try {
+            const record = JSON.parse(line);
+            if (record?.pid && record?.port) {
+              fixture.stdout.off("data", onData);
+              resolve(record);
+              return;
+            }
+          } catch {}
+        }
+      };
+      fixture.stdout.on("data", onData);
+      fixture.once("error", reject);
+      fixture.once("exit", (code, signal) => reject(new Error(`fixture exited before readiness (${code ?? signal})`)));
+    });
+    let first;
+    let second;
+    try {
+      first = startFixture(0);
+      const firstReady = await waitForReady(first);
+      await stopProcessTree(first, { deadlineAt: Date.now() + 1_000, graceMs: 25 });
+      expect(processExists(firstReady.pid)).toBe(false);
+
+      second = startFixture(firstReady.port);
+      await expect(waitForReady(second)).resolves.toMatchObject({ port: firstReady.port });
+    } finally {
+      for (const fixture of [first, second]) {
+        if (!fixture) continue;
+        try {
+          await stopProcessTree(fixture, { deadlineAt: Date.now() + 1_000, graceMs: 25 });
+        } catch {
+          try { process.kill(-fixture.pid, "SIGKILL"); } catch {}
+        }
+      }
+    }
+  });
+
   it("uses tree-aware Windows termination before forced tree termination", async () => {
     const child = Object.assign(new EventEmitter(), { exitCode: null, pid: 43123, signalCode: null });
     const calls = [];


### PR DESCRIPTION
## Summary
- wait for the complete fixture process group to exit
- force-stop lingering descendants before the harness returns
- cover immediate resource reuse in a focused regression test

## Validation
- `npx vitest run apps/web/scripts/portable-web-fixture-e2e.test.mjs apps/web/scripts/dev-fixtures.test.mjs`
- `npm run lint --workspace @writer/cerebro-web`
- `git diff --check origin/main..HEAD`