### PR TITLE
fix(web): preserve scoped proxy selectors

### DIFF
--- a/apps/web/src/app/api/audit-log/route.test.ts
+++ b/apps/web/src/app/api/audit-log/route.test.ts
@@ -126,6 +126,24 @@ describe("audit events API", () => {
     expect(fetcher).not.toHaveBeenCalled();
   });
 
+  it("rejects an unsupported workspace selector before fixture or upstream reads", async () => {
+    vi.mocked(isCerebroFixtureMode).mockReturnValue(true);
+    const fetcher = vi.fn();
+    vi.stubGlobal("fetch", fetcher);
+
+    const response = await GET(new NextRequest(
+      "http://localhost/api/audit-log?tenant_id=tenant-a&workspace_id=workspace-a",
+      { headers: { "x-user-email": "reader@example.com" } },
+    ));
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Workspace scope is not supported for this Cerebro route.",
+    });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
   it("does not expose upstream response details", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => new Response(
       "provider-specific failure detail",

--- a/apps/web/src/app/api/audit-log/route.ts
+++ b/apps/web/src/app/api/audit-log/route.ts
@@ -7,7 +7,7 @@ import {
   createHttpAuditLogReader,
 } from "@/lib/audit-log-reader";
 import { authorizationErrorResponse, authorizeCurrentUser } from "@/lib/authorization";
-import { authHeadersFor, buildCerebroUrl } from "@/lib/cerebro-proxy";
+import { authHeadersFor, buildCerebroUrl, CerebroProxyError } from "@/lib/cerebro-proxy";
 import { isCerebroFixtureMode } from "@/lib/cerebro-fixtures";
 import { resolveCurrentUserFromHeadersWithFallback } from "@/lib/identity";
 import {
@@ -46,6 +46,24 @@ export async function GET(request: NextRequest) {
     return authorizationErrorResponse(decision);
   }
 
+  let upstreamAuthHeaders: HeadersInit;
+  try {
+    upstreamAuthHeaders = authHeadersFor(request);
+  } catch (error) {
+    if (!(error instanceof CerebroProxyError)) throw error;
+    span.end("failed", {
+      audit_event_page_state: "invalid_scope",
+      "http.response.status_code": error.status,
+    });
+    return NextResponse.json(
+      { error: error.message },
+      {
+        headers: responseHeadersWithTrace({ "cache-control": "private, no-store" }, span),
+        status: error.status,
+      },
+    );
+  }
+
   if (isCerebroFixtureMode()) {
     span.end("completed", {
       audit_event_count: 0,
@@ -73,7 +91,7 @@ export async function GET(request: NextRequest) {
   const query = auditLogQueryFromSearchParams(request.nextUrl.searchParams);
   const reader = createHttpAuditLogReader({
     endpoint: buildCerebroUrl(AUDIT_EVENT_CONTRACT_PATH),
-    headers: headersWithTrace(authHeadersFor(request), span),
+    headers: headersWithTrace(upstreamAuthHeaders, span),
   });
 
   try {

--- a/apps/web/src/app/api/cerebro/[...path]/route.test.ts
+++ b/apps/web/src/app/api/cerebro/[...path]/route.test.ts
@@ -69,6 +69,97 @@ describe("Cerebro proxy route", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
+  it("forwards header-selected tenant and workspace scope into the upstream cache boundary", async () => {
+    delete process.env.CEREBRO_WEB_FIXTURE_MODE;
+    let upstreamHeaders = new Headers();
+    const fetchMock = vi.fn(async (_url: URL | RequestInfo, init?: RequestInit) => {
+      upstreamHeaders = new Headers(init?.headers);
+      return new Response(JSON.stringify({ findings: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/cerebro/grc/findings?scope_contract=header", {
+        headers: {
+          "X-Cerebro-Tenant": "tenant-a",
+          "X-Cerebro-Workspace": "workspace-a",
+        },
+      }),
+      { params: Promise.resolve({ path: ["grc", "findings"] }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(upstreamHeaders.get("x-cerebro-tenant")).toBe("tenant-a");
+    expect(upstreamHeaders.get("x-cerebro-workspace")).toBe("workspace-a");
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["orphan workspace", "http://localhost/api/cerebro/grc/dashboard?workspace_id=workspace-a", {}],
+    ["mismatched workspace", "http://localhost/api/cerebro/grc/dashboard?tenant_id=tenant-a&workspace_id=workspace-a", { "X-Cerebro-Workspace": "workspace-b" }],
+  ])("rejects %s without an upstream read", async (_name, url, headers) => {
+    delete process.env.CEREBRO_WEB_FIXTURE_MODE;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await GET(
+      new NextRequest(url, { headers }),
+      { params: Promise.resolve({ path: ["grc", "dashboard"] }) },
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(fetchMock).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Provide one matching tenant and workspace selector. A workspace requires an explicit tenant.",
+    });
+  });
+
+  it("passes a tenant-workspace authorization failure through without an unscoped fallback", async () => {
+    delete process.env.CEREBRO_WEB_FIXTURE_MODE;
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ code: "forbidden" }), {
+      status: 403,
+      headers: { "content-type": "application/json" },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await GET(
+      new NextRequest("http://localhost/api/cerebro/grc/dashboard?tenant_id=tenant-a&workspace_id=workspace-b&scope_contract=forbidden"),
+      { params: Promise.resolve({ path: ["grc", "dashboard"] }) },
+    );
+
+    expect(response.status).toBe(403);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    await expect(response.json()).resolves.toEqual({ code: "forbidden" });
+  });
+
+  it.each([
+    ["POST", POST],
+    ["PATCH", PATCH],
+    ["PUT", PUT],
+  ] as const)("does not read a %s body for an invalid workspace scope", async (method, handler) => {
+    delete process.env.CEREBRO_WEB_FIXTURE_MODE;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const request = new NextRequest("http://localhost/api/cerebro/grc/findings?workspace_id=workspace-a", {
+      method,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ status: "resolved" }),
+    });
+    const readBody = vi.spyOn(request, "text");
+
+    const response = await handler(request, {
+      params: Promise.resolve({ path: ["grc", "findings"] }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(readBody).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["GET", GET],
     ["POST", POST],

--- a/apps/web/src/app/api/cerebro/[...path]/route.ts
+++ b/apps/web/src/app/api/cerebro/[...path]/route.ts
@@ -4,6 +4,7 @@ import {
   authHeadersFor,
   buildCerebroUrl,
   cachedResponseHeaders,
+  cerebroProxyScopeFor,
   cerebroProxyCacheKey,
   fetchCerebro,
   isCacheableCerebroPath,
@@ -15,6 +16,7 @@ import {
   rustOwnsWebAuthority,
   signedIdentityHeadersFor,
   shouldBypassCerebroProxyCache,
+  supportsApplicationWorkspaceScope,
   trackCerebroProxyInflight,
   withCerebroCacheBypassHeader,
   writeCerebroProxyCache,
@@ -67,6 +69,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
       return tracedAuthorizationError(decision, span);
     }
   }
+  const scopeError = tracedProxyScopeError(request, path, rustAuthority, span);
+  if (scopeError) return scopeError;
   const url = new URL(request.url);
   const fixture = tracedFixtureResponse("GET", path, request, span);
   if (fixture) {
@@ -268,6 +272,8 @@ export async function POST(request: NextRequest, context: RouteContext) {
     console.warn("cerebro proxy post denied", { ...currentUserServerAuditFields(currentUser), permission: requiredPermission });
     return tracedAuthorizationError(decision, span);
   }
+  const scopeError = tracedProxyScopeError(request, path, rustAuthority, span);
+  if (scopeError) return scopeError;
   const url = new URL(request.url);
   let body: string | ArrayBuffer;
   const acceptsEventStream = (request.headers.get("accept") ?? "").includes("text/event-stream");
@@ -383,6 +389,8 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     console.warn("cerebro proxy write denied", { ...currentUserServerAuditFields(currentUser), permission: requiredPermission });
     return tracedAuthorizationError(decision, span);
   }
+  const scopeError = tracedProxyScopeError(request, path, false, span);
+  if (scopeError) return scopeError;
   const requestBody = await request.text();
   const url = new URL(request.url);
   let body = requestBody;
@@ -448,6 +456,8 @@ export async function PUT(request: NextRequest, context: RouteContext) {
     console.warn("cerebro proxy put denied", { ...currentUserServerAuditFields(currentUser), permission: requiredPermission });
     return tracedAuthorizationError(decision, span);
   }
+  const scopeError = tracedProxyScopeError(request, path, false, span);
+  if (scopeError) return scopeError;
   const requestBody = await request.text();
   const url = new URL(request.url);
   const body = stampCurrentUserOnWriteBody(
@@ -512,6 +522,8 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
     console.warn("cerebro proxy delete denied", { ...currentUserServerAuditFields(currentUser), permission: requiredPermission });
     return tracedAuthorizationError(decision, span);
   }
+  const scopeError = tracedProxyScopeError(request, path, false, span);
+  if (scopeError) return scopeError;
   const url = new URL(request.url);
   const fixture = tracedFixtureResponse("DELETE", path, request, span);
   if (fixture) {
@@ -631,6 +643,26 @@ function tracedAuthorizationError(decision: AuthorizationDecision, span: WebSpan
   span.end("completed", {
     ...authorizationDecisionAttributes(decision),
     ...responseSpanAttributes(response.status, Object.fromEntries(response.headers.entries())),
+    "http.response.status_code": response.status,
+  });
+  return response;
+}
+
+function tracedProxyScopeError(request: NextRequest, path: string, rustAuthority: boolean, span: WebSpan) {
+  const scope = cerebroProxyScopeFor(request);
+  let error = scope.ok ? "" : scope.error;
+  if (scope.ok && scope.workspaceID && !supportsApplicationWorkspaceScope(path)) {
+    error = "Workspace scope is not supported for this Cerebro route.";
+  }
+  if (scope.ok && scope.workspaceID && rustAuthority) {
+    error = "Workspace scope is not supported by the active Cerebro authority.";
+  }
+  if (!error) return null;
+  const response = NextResponse.json({ error }, { status: 400 });
+  response.headers.set("cache-control", "private, no-store");
+  response.headers.set("x-cerebro-web-trace-id", span.traceId);
+  span.end("completed", {
+    proxy_scope_valid: false,
     "http.response.status_code": response.status,
   });
   return response;

--- a/apps/web/src/lib/cerebro-client.test.ts
+++ b/apps/web/src/lib/cerebro-client.test.ts
@@ -35,4 +35,24 @@ describe("fetchCerebro", () => {
     const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
     expect(init?.cache).toBe("no-store");
   });
+
+  it("preserves caller-supplied tenant and workspace selectors", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    fetchMock.mockResolvedValue(new Response("{}", {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchCerebro("/grc/dashboard", undefined, {
+      headers: {
+        "X-Cerebro-Tenant": "tenant-a",
+        "X-Cerebro-Workspace": "workspace-a",
+      },
+    });
+
+    const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    expect(headers.get("x-cerebro-tenant")).toBe("tenant-a");
+    expect(headers.get("x-cerebro-workspace")).toBe("workspace-a");
+  });
 });

--- a/apps/web/src/lib/cerebro-proxy-warm.test.ts
+++ b/apps/web/src/lib/cerebro-proxy-warm.test.ts
@@ -78,7 +78,8 @@ describe("server-authenticated Cerebro cache warming", () => {
     expect(upstreamFetch).toHaveBeenCalledTimes(1);
     expect(observedTarget).toBe(`https://api.example.com/grc/dashboard${search}`);
     expect(observedHeaders.get("x-cerebro-api-key")).toBe("server-owned-test-key");
-    expect(observedHeaders.get("x-cerebro-tenant")).toBeNull();
+    expect(observedHeaders.get("x-cerebro-tenant")).toBe("tenant-a");
+    expect(observedHeaders.get("x-cerebro-workspace")).toBe("workspace-a");
   });
 
   it("does not warm legacy service credentials while Rust owns web authority", async () => {

--- a/apps/web/src/lib/cerebro-proxy.test.ts
+++ b/apps/web/src/lib/cerebro-proxy.test.ts
@@ -5,6 +5,7 @@ import {
   authHeadersFor,
   buildCerebroUrl,
   cachedResponseHeaders,
+  cerebroProxyScopeFor,
   cerebroProxyCacheKey,
   configuredOrganizationalGraphTenant,
   configuredRustPlatformApiBase,
@@ -14,6 +15,7 @@ import {
   responseHeadersFor,
   rustTenantAuthHeaders,
   rustOwnsWebAuthority,
+  signedIdentityHeadersFor,
   shouldRetryUpstreamResponse,
   shouldBypassCerebroProxyCache,
   warmCerebroProxyCache,
@@ -75,8 +77,59 @@ describe("cerebro proxy cache headers", () => {
 
     const selectedTenantRequest = new NextRequest("http://localhost/api/cerebro/grc/vendors?tenant_id=tenant-selected");
 
-    expect(new Headers(authHeadersFor(selectedTenantRequest, "grc/vendors")).get("x-cerebro-tenant")).toBeNull();
-    expect(new Headers(authHeadersFor(selectedTenantRequest, "user/preferences")).get("x-cerebro-tenant")).toBeNull();
+    expect(new Headers(authHeadersFor(selectedTenantRequest, "grc/vendors")).get("x-cerebro-tenant")).toBe("tenant-selected");
+    expect(new Headers(authHeadersFor(selectedTenantRequest, "user/preferences")).get("x-cerebro-tenant")).toBe("tenant-selected");
+  });
+
+  it("reconciles and forwards matching tenant and workspace selectors", () => {
+    const request = new NextRequest(
+      "http://localhost/api/cerebro/grc/dashboard?tenant_id=tenant-a&workspace_id=workspace-a",
+      { headers: { "X-Cerebro-Tenant": "tenant-a", "X-Cerebro-Workspace": "workspace-a" } },
+    );
+
+    expect(cerebroProxyScopeFor(request)).toMatchObject({
+      ok: true,
+      tenantID: "tenant-a",
+      workspaceID: "workspace-a",
+    });
+    const headers = new Headers(authHeadersFor(request, "grc/dashboard"));
+    expect(headers.get("x-cerebro-tenant")).toBe("tenant-a");
+    expect(headers.get("x-cerebro-workspace")).toBe("workspace-a");
+  });
+
+  it.each([
+    "http://localhost/api/cerebro/grc/dashboard?workspace_id=workspace-a",
+    "http://localhost/api/cerebro/grc/dashboard?tenant_id=tenant-a&workspace_id=workspace-a&workspace_id=workspace-a",
+  ])("rejects orphan or repeated workspace selectors: %s", (url) => {
+    expect(cerebroProxyScopeFor(new NextRequest(url)).ok).toBe(false);
+  });
+
+  it("rejects mismatched query and header selectors", () => {
+    const request = new NextRequest(
+      "http://localhost/api/cerebro/grc/dashboard?tenant_id=tenant-a&workspace_id=workspace-a",
+      { headers: { "X-Cerebro-Workspace": "workspace-b" } },
+    );
+
+    expect(cerebroProxyScopeFor(request).ok).toBe(false);
+    expect(() => authHeadersFor(request, "grc/dashboard")).toThrow("Provide one matching tenant and workspace selector");
+  });
+
+  it("keeps workspace scope out of unsupported and Rust-authority routes", () => {
+    const request = new NextRequest(
+      "http://localhost/api/cerebro/platform/graph/neighborhood?tenant_id=tenant-a&workspace_id=workspace-a",
+    );
+
+    expect(() => authHeadersFor(request, "platform/graph/neighborhood")).toThrow("Workspace scope is not supported");
+    expect(() => signedIdentityHeadersFor(request)).toThrow("active Cerebro authority");
+  });
+
+  it("partitions cache keys by canonical workspace headers", () => {
+    const target = new URL("https://api.example.com/grc/dashboard?tenant_id=tenant-a");
+    const unscoped = cerebroProxyCacheKey(target, { authorization: "Bearer shared" });
+    const workspaceA = cerebroProxyCacheKey(target, { authorization: "Bearer shared", "X-Cerebro-Workspace": "workspace-a" });
+    const workspaceB = cerebroProxyCacheKey(target, { authorization: "Bearer shared", "X-Cerebro-Workspace": "workspace-b" });
+
+    expect(new Set([unscoped, workspaceA, workspaceB]).size).toBe(3);
   });
 
   it("routes only runtime health to the configured Rust platform origin", () => {
@@ -112,6 +165,22 @@ describe("cerebro proxy cache headers", () => {
     expect(headers.get("x-cerebro-tenant")).toBe("tenant-a");
     expect(headers.get("authorization")).toMatch(/^Bearer [0-9a-f]{64}$/);
     expect(headers.get("x-cerebro-api-key")).toBeNull();
+  });
+
+  it("rejects a runtime health selector that conflicts with the server-owned tenant", () => {
+    vi.stubEnv("CEREBRO_RUST_PLATFORM_API_BASE", "http://rust-platform.internal:8080");
+    vi.stubEnv("CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID", "tenant-a");
+    vi.stubEnv(
+      "CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET",
+      "test-organizational-graph-secret-32-bytes",
+    );
+    const request = new NextRequest("http://localhost", {
+      headers: { "X-Cerebro-Tenant": "tenant-b" },
+    });
+
+    expect(() => authHeadersFor(request, "v1/source-runtimes/health")).toThrow(
+      "does not match the active Cerebro authority",
+    );
   });
 
   it("rejects an invalid server-owned tenant header", () => {

--- a/apps/web/src/lib/cerebro-proxy.ts
+++ b/apps/web/src/lib/cerebro-proxy.ts
@@ -118,6 +118,10 @@ const PROXY_CACHE_TTL_MS = parseNonNegativeMs(process.env.CEREBRO_PROXY_CACHE_TT
 const PROXY_CACHE_STALE_MS = parseNonNegativeMs(process.env.CEREBRO_PROXY_CACHE_STALE_MS, 300000);
 const PROXY_CACHE_MAX_ENTRIES = 400;
 const RETRY_STATUSES = new Set([502, 504]);
+const CEREBRO_TENANT_HEADER = "X-Cerebro-Tenant";
+const CEREBRO_WORKSPACE_HEADER = "X-Cerebro-Workspace";
+const MAX_TENANT_ID_BYTES = 256;
+const MAX_WORKSPACE_ID_BYTES = 128;
 
 export const shouldRetryUpstreamResponse = (response: Response) =>
   RETRY_STATUSES.has(response.status)
@@ -144,7 +148,7 @@ const USER_STAMP_HEADERS = [
   "x-cerebro-user-subject",
 ] as const;
 
-class CerebroProxyError extends Error {
+export class CerebroProxyError extends Error {
   status: number;
 
   constructor(message: string, status: number) {
@@ -152,6 +156,74 @@ class CerebroProxyError extends Error {
     this.status = status;
   }
 }
+
+export type CerebroProxyScope =
+  | {
+      ok: true;
+      headers: Record<string, string>;
+      tenantID: string;
+      workspaceID: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+const invalidScope = (): CerebroProxyScope => ({
+  ok: false,
+  error: "Provide one matching tenant and workspace selector. A workspace requires an explicit tenant.",
+});
+
+const validScopeID = (value: string, maxBytes: number) =>
+  value !== "*"
+  && !value.includes(",")
+  && Buffer.byteLength(value, "utf8") <= maxBytes
+  && !/[\u0000-\u001f\u007f]/.test(value);
+
+const selectScopeID = (
+  request: NextRequest,
+  queryName: string,
+  headerName: string,
+  maxBytes: number,
+) => {
+  const queryValues = request.nextUrl.searchParams.getAll(queryName);
+  if (queryValues.length > 1) return null;
+  const queryValue = queryValues[0]?.trim() ?? "";
+  const headerValue = request.headers.get(headerName)?.trim() ?? "";
+  if (
+    (queryValue !== "" && !validScopeID(queryValue, maxBytes))
+    || (headerValue !== "" && !validScopeID(headerValue, maxBytes))
+    || (queryValue !== "" && headerValue !== "" && queryValue !== headerValue)
+  ) {
+    return null;
+  }
+  return queryValue || headerValue;
+};
+
+// cerebroProxyScopeFor reconciles the public selector forms before the proxy
+// can drop a header, inject a tenant, or construct a shared cache key.
+export const cerebroProxyScopeFor = (request: NextRequest): CerebroProxyScope => {
+  const tenantID = selectScopeID(request, "tenant_id", CEREBRO_TENANT_HEADER, MAX_TENANT_ID_BYTES);
+  const workspaceID = selectScopeID(request, "workspace_id", CEREBRO_WORKSPACE_HEADER, MAX_WORKSPACE_ID_BYTES);
+  if (tenantID === null || workspaceID === null || (workspaceID !== "" && tenantID === "")) {
+    return invalidScope();
+  }
+  const headers: Record<string, string> = {};
+  if (tenantID) headers[CEREBRO_TENANT_HEADER] = tenantID;
+  if (workspaceID) headers[CEREBRO_WORKSPACE_HEADER] = workspaceID;
+  return { ok: true, headers, tenantID, workspaceID };
+};
+
+const requiredCerebroProxyScope = (request: NextRequest) => {
+  const scope = cerebroProxyScopeFor(request);
+  if (!scope.ok) {
+    throw new CerebroProxyError(scope.error, 400);
+  }
+  return scope;
+};
+
+export const supportsApplicationWorkspaceScope = (path: string) =>
+  normalizeProxyPath(path).startsWith("grc/");
 
 export const getCerebroProxyConfig = () => ({
   apiBase: API_BASE,
@@ -186,12 +258,23 @@ export const buildCerebroUrl = (path: string, search = "") => {
 };
 
 export const authHeadersFor = (request: NextRequest, upstreamPath = ""): HeadersInit => {
-  const headers: Record<string, string> = { Accept: "application/json, text/plain;q=0.9, */*;q=0.8" };
+  const scope = requiredCerebroProxyScope(request);
+  if (scope.workspaceID && !supportsApplicationWorkspaceScope(upstreamPath)) {
+    throw new CerebroProxyError("Workspace scope is not supported for this Cerebro route.", 400);
+  }
+  const headers: Record<string, string> = {
+    Accept: "application/json, text/plain;q=0.9, */*;q=0.8",
+    ...scope.headers,
+  };
   if (configuredRustPlatformApiBase() && isRustRuntimeHealthPath(upstreamPath)) {
+    const configuredTenantID = configuredOrganizationalGraphTenant();
+    if (scope.tenantID && scope.tenantID !== configuredTenantID) {
+      throw new CerebroProxyError("The requested tenant does not match the active Cerebro authority.", 400);
+    }
     return {
       ...headers,
       ...rustTenantAuthHeaders(
-        process.env.CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID ?? "",
+        configuredTenantID ?? "",
         process.env.CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET ?? "",
       ),
     };
@@ -216,17 +299,22 @@ export const authHeadersFor = (request: NextRequest, upstreamPath = ""): Headers
   if (
     organizationalGraphTenant &&
     usesOrganizationalGraphTenant(upstreamPath) &&
-    !request.nextUrl.searchParams.get("tenant_id")?.trim()
+    !scope.tenantID
   ) {
-    headers["X-Cerebro-Tenant"] = organizationalGraphTenant;
+    headers[CEREBRO_TENANT_HEADER] = organizationalGraphTenant;
   }
 
   return headers;
 };
 
 export const signedIdentityHeadersFor = (request: NextRequest): HeadersInit => {
+  const scope = requiredCerebroProxyScope(request);
+  if (scope.workspaceID) {
+    throw new CerebroProxyError("Workspace scope is not supported by the active Cerebro authority.", 400);
+  }
   const headers: Record<string, string> = {
     Accept: "application/json, text/plain;q=0.9, */*;q=0.8",
+    ...scope.headers,
   };
   const authorization = request.headers.get("authorization");
   if (authorization) {


### PR DESCRIPTION
Summary
- Reconcile documented request selectors at the web proxy boundary.
- Forward canonical scope headers and partition proxy cache entries by scope.
- Reject incomplete, conflicting, or unsupported scope before fixtures, request bodies, or upstream calls.

Validation
- npm run lint --workspace @writer/cerebro-web
- NODE_OPTIONS=--no-experimental-webstorage VITE_CONFIG_NATIVE_IGNORE_WARNING=true npm test --workspace @writer/cerebro-web (114 files, 716 tests)
- npm run build --workspace @writer/cerebro-web
- make app-workspace-check check-structural check-structural-test check-arch
- ./scripts/leak_check.sh range origin/main...HEAD