### PR TITLE
fix(web): remove unsupported vendor discovery sync action

### DIFF
--- a/apps/web/src/app/vendors/page.tsx
+++ b/apps/web/src/app/vendors/page.tsx
@@ -8,7 +8,6 @@ import {
   GitMerge,
   Link2,
   PanelRightOpen,
-  Play,
   Plus,
   RefreshCw,
   Search,
@@ -37,7 +36,6 @@ import {
   GRCVendorDiscoveriesResponse,
   GRCVendorDiscovery,
   GRCVendorDiscoverySignal,
-  GRCVendorDiscoverySyncResponse,
   GRCVendorDiscoverySourceSummary,
   GRCVendorsResponse,
   humanize,
@@ -497,18 +495,14 @@ function DiscoverySignals({ signals }: { signals?: GRCVendorDiscoverySignal[] })
 function DiscoverySourceSummary({
   loading,
   onRefresh,
-  onRunSource,
   onSelectSource,
-  runSaving,
   selectedSourceID,
   sources,
   summary,
 }: {
   loading: boolean;
   onRefresh: () => void;
-  onRunSource: (sourceID?: string) => void;
   onSelectSource: (sourceID: string) => void;
-  runSaving: boolean;
   selectedSourceID: string;
   sources: GRCVendorDiscoverySourceSummary[];
   summary?: GRCVendorDiscoveriesResponse["summary"];
@@ -534,13 +528,9 @@ function DiscoverySourceSummary({
           </div>
         </div>
         <div className="flex flex-wrap gap-2">
-          <button type="button" onClick={() => onRunSource()} disabled={runSaving} className="primary-button inline-flex items-center gap-2 px-3 py-1.5 text-[13px] disabled:opacity-50">
-            <Play className="h-3.5 w-3.5" aria-hidden="true" />
-            Run discovery
-          </button>
-          <button type="button" onClick={onRefresh} disabled={loading} className="secondary-button inline-flex items-center gap-2 px-3 py-1.5 text-[13px] disabled:opacity-50">
+          <button type="button" onClick={onRefresh} disabled={loading} className="primary-button inline-flex items-center gap-2 px-3 py-1.5 text-[13px] disabled:opacity-50">
             <RefreshCw className={`h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`} aria-hidden="true" />
-            Refresh
+            Refresh sources
           </button>
         </div>
       </div>
@@ -580,9 +570,6 @@ function DiscoverySourceSummary({
                   <div className="flex gap-2">
                     <button type="button" onClick={() => onSelectSource(selected ? "" : source.source_id)} className="font-semibold text-[var(--primary)] hover:text-[var(--primary-hover)]">
                       {selected ? "Clear filter" : "Filter"}
-                    </button>
-                    <button type="button" onClick={() => onRunSource(source.source_id)} disabled={runSaving} className="font-semibold text-[var(--primary)] hover:text-[var(--primary-hover)] disabled:opacity-50">
-                      Run
                     </button>
                   </div>
                 </div>
@@ -1669,7 +1656,6 @@ export default function VendorsPage() {
   const [bulkDraft, setBulkDraft] = useState<BulkDiscoveryDraft>(() => defaultBulkDiscoveryDraft());
   const [bulkSaving, setBulkSaving] = useState(false);
   const [selectedDiscoveryURNs, setSelectedDiscoveryURNs] = useState<Set<string>>(() => new Set());
-  const [syncMessage, setSyncMessage] = useState("");
   const [quickActionMessage, setQuickActionMessage] = useState("");
   const [quickActionDraft, setQuickActionDraft] = useState<VendorQuickActionDraft>(() => defaultVendorQuickActionDraft());
   const uploadPanelRef = useRef<HTMLDivElement>(null);
@@ -1727,7 +1713,6 @@ export default function VendorsPage() {
     error: createError,
     setError: setCreateError,
   } = useGRCMutation<GRCVendorCreateResponse>();
-  const { mutate: mutateDiscoverySync, saving: syncSaving, error: syncError } = useGRCMutation<GRCVendorDiscoverySyncResponse>();
   const { mutate: mutateVendorAction, saving: quickActionSaving, error: quickActionError } = useGRCMutation<GRCVendorActionResponse>();
 
   const vendorRows = useMemo(() => boundedVendorRows(vendorsQuery.data, GRC_WORKLIST_LIMIT), [vendorsQuery.data]);
@@ -2001,18 +1986,6 @@ export default function VendorsPage() {
     }
   }, [bulkDraft.linkedVendorURN, bulkDraft.owner, bulkDraft.reason, bulkDraft.riskLevel, createVendorFromDiscovery, discoveries, selectedDiscoveryURNs, setDiscoveryDecision]);
 
-  const runDiscoverySync = useCallback(async (runSourceID?: string) => {
-    const response = await mutateDiscoverySync(grcPath("/grc/vendor-discoveries/sync", grcScopeQuery({ tenantID, workspaceID })), {
-      ...grcScopeQuery({ tenantID, workspaceID }),
-      source_id: runSourceID,
-    });
-    const sourceName = runSourceID
-      ? discoverySources.find((source) => source.source_id === runSourceID)?.provider || humanize(runSourceID)
-      : "All sources";
-    setSyncMessage(`${sourceName} discovery ${response.status}.`);
-    await discoveriesQuery.reload();
-  }, [discoveriesQuery, discoverySources, mutateDiscoverySync, tenantID, workspaceID]);
-
   const runVendorQuickAction = useCallback(async (action: "assign_owner" | "change_lifecycle" | "start_review") => {
     if (!selectedVendorURN) return;
     const response = await mutateVendorAction(grcPath(`/grc/vendors/${encodeURIComponent(selectedVendorURN)}/actions`, grcScopeQuery({ tenantID, workspaceID })), {
@@ -2175,12 +2148,6 @@ export default function VendorsPage() {
           recoveryDetail="Discovery decisions need GRC inventory write access."
         />
       )}
-      {syncError && (
-        <ErrorBlock
-          error={syncError}
-          recoveryDetail="Discovery run was not started."
-        />
-      )}
       {createError && !createOpen && (
         <ErrorBlock
           error={createError}
@@ -2190,11 +2157,6 @@ export default function VendorsPage() {
       {quickActionMessage && (
         <div className="rounded-md border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-[13px] font-semibold text-emerald-700 dark:text-emerald-200">
           {quickActionMessage}
-        </div>
-      )}
-      {syncMessage && (
-        <div className="rounded-md border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-[13px] font-semibold text-emerald-700 dark:text-emerald-200">
-          {syncMessage}
         </div>
       )}
       {createMessage && (
@@ -2473,9 +2435,7 @@ export default function VendorsPage() {
           <DiscoverySourceSummary
             loading={discoveriesQuery.loading && !discoveriesQuery.data}
             onRefresh={() => { void discoveriesQuery.reload(); }}
-            onRunSource={(runSourceID) => { void runDiscoverySync(runSourceID).catch(() => undefined); }}
             onSelectSource={setSourceID}
-            runSaving={syncSaving}
             selectedSourceID={sourceID}
             sources={discoverySources}
             summary={discoverySummary}

--- a/apps/web/src/lib/cerebro-fixtures.test.ts
+++ b/apps/web/src/lib/cerebro-fixtures.test.ts
@@ -104,6 +104,25 @@ describe("cerebro fixture proxy responses", () => {
     });
   });
 
+  it("does not advertise the unsupported vendor discovery sync route", () => {
+    withFixtureMode();
+    for (const searchParams of [
+      new URLSearchParams("tenant_id=demo-tenant"),
+      new URLSearchParams("tenant_id=demo-tenant&workspace_id=workspace-a"),
+    ]) {
+      const response = cerebroFixtureResponseFor({
+        method: "POST",
+        path: "grc/vendor-discoveries/sync",
+        searchParams,
+        body: JSON.stringify({ source_id: "okta" }),
+      });
+      expect(response?.status).toBe(404);
+      expect(parseFixture(response!)).toMatchObject({
+        error: "No fixture is registered for grc/vendor-discoveries/sync",
+      });
+    }
+  });
+
   it("filters fixture findings by severity", () => {
     withFixtureMode();
     const response = cerebroFixtureResponseFor({
@@ -216,26 +235,31 @@ describe("cerebro fixture proxy responses", () => {
 
   it("returns source-backed vendor discovery fixtures", () => {
     withFixtureMode();
-    const response = cerebroFixtureResponseFor({ method: "GET", path: "grc/vendor-discoveries" });
-    expect(response?.status).toBe(200);
-    expect(parseFixture(response!)).toMatchObject({
-      summary: { total_discoveries: 4, discovered: 3, linked: 1, source_count: 3, evidence_signals: 6 },
-      source_summaries: expect.arrayContaining([
-        expect.objectContaining({ source_id: "okta", provider: "Okta", total: 2, discovered: 2 }),
-        expect.objectContaining({ source_id: "github", provider: "GitHub", total: 2 }),
-        expect.objectContaining({ source_id: "aws", provider: "AWS", total: 1, linked: 1 }),
-      ]),
-      discoveries: expect.arrayContaining([
-        expect.objectContaining({
-          name: "Design Suite",
-          source_id: "okta",
-          confidence_score: 92,
-          signals: expect.arrayContaining([
-            expect.objectContaining({ source_id: "okta", label: "Okta application assignment" }),
-          ]),
-        }),
-      ]),
-    });
+    for (const searchParams of [
+      new URLSearchParams("tenant_id=demo-tenant"),
+      new URLSearchParams("tenant_id=demo-tenant&workspace_id=workspace-a"),
+    ]) {
+      const response = cerebroFixtureResponseFor({ method: "GET", path: "grc/vendor-discoveries", searchParams });
+      expect(response?.status).toBe(200);
+      expect(parseFixture(response!)).toMatchObject({
+        summary: { total_discoveries: 4, discovered: 3, linked: 1, source_count: 3, evidence_signals: 6 },
+        source_summaries: expect.arrayContaining([
+          expect.objectContaining({ source_id: "okta", provider: "Okta", total: 2, discovered: 2 }),
+          expect.objectContaining({ source_id: "github", provider: "GitHub", total: 2 }),
+          expect.objectContaining({ source_id: "aws", provider: "AWS", total: 1, linked: 1 }),
+        ]),
+        discoveries: expect.arrayContaining([
+          expect.objectContaining({
+            name: "Design Suite",
+            source_id: "okta",
+            confidence_score: 92,
+            signals: expect.arrayContaining([
+              expect.objectContaining({ source_id: "okta", label: "Okta application assignment" }),
+            ]),
+          }),
+        ]),
+      });
+    }
 
     const oktaFiltered = cerebroFixtureResponseFor({
       method: "GET",
@@ -257,21 +281,6 @@ describe("cerebro fixture proxy responses", () => {
     });
     expect(parseFixture(signalSearch!)).toMatchObject({
       discoveries: [expect.objectContaining({ name: "Data Warehouse" })],
-    });
-  });
-
-  it("runs vendor discovery sync fixtures", () => {
-    withFixtureMode();
-    const response = cerebroFixtureResponseFor({
-      method: "POST",
-      path: "grc/vendor-discoveries/sync",
-      body: JSON.stringify({ source_id: "okta" }),
-    });
-    expect(response?.status).toBe(200);
-    expect(parseFixture(response!)).toMatchObject({
-      status: "completed",
-      source_id: "okta",
-      source_summaries: [expect.objectContaining({ source_id: "okta", total: 2 })],
     });
   });
 

--- a/apps/web/src/lib/cerebro-fixtures.ts
+++ b/apps/web/src/lib/cerebro-fixtures.ts
@@ -8,7 +8,6 @@ import type {
   GRCVendorActionRequest,
   GRCVendorCreateRequest,
   GRCVendorDiscovery,
-  GRCVendorDiscoverySyncRequest,
 } from "@/lib/grc";
 
 type FixtureResponse = {
@@ -3642,25 +3641,6 @@ const vendorActionFixture = (rawURN: string, parsed: Record<string, unknown>) =>
   return jsonFixture({ action, vendor, generated_at: generatedAt });
 };
 
-const vendorDiscoverySyncFixture = (parsed: Record<string, unknown>) => {
-  const request = parsed as GRCVendorDiscoverySyncRequest;
-  const sourceID = stringField(request.source_id);
-  vendorDiscoveries.forEach((discovery) => {
-    if (!sourceID || vendorDiscoverySourceIDs(discovery).includes(sourceID)) {
-      discovery.last_observed_at = generatedAt;
-    }
-  });
-  const scopedDiscoveries = sourceID
-    ? vendorDiscoveries.filter((discovery) => vendorDiscoverySourceIDs(discovery).includes(sourceID))
-    : vendorDiscoveries;
-  return jsonFixture({
-    status: "completed",
-    source_id: sourceID || undefined,
-    source_summaries: vendorDiscoverySourceSummaries(scopedDiscoveries),
-    generated_at: generatedAt,
-  });
-};
-
 const questionnaireQuestionsFromRequest = (parsed: Record<string, unknown>) => {
   const direct = Array.isArray(parsed.questions) ? parsed.questions as Array<Record<string, unknown>> : [];
   const rows = Array.isArray(parsed.intake_rows) ? parsed.intake_rows as Array<Record<string, unknown>> : [];
@@ -4169,10 +4149,6 @@ const writeFixture = (path: string, body?: string) => {
   const vendorActionMatch = /^grc\/vendors\/(.+)\/actions$/.exec(path);
   if (vendorActionMatch) {
     return vendorActionFixture(vendorActionMatch[1], parsed);
-  }
-
-  if (path === "grc/vendor-discoveries/sync") {
-    return vendorDiscoverySyncFixture(parsed);
   }
 
   if (path === "grc/inventory/resource-scope") {

--- a/apps/web/src/lib/grc.ts
+++ b/apps/web/src/lib/grc.ts
@@ -1696,18 +1696,6 @@ export type GRCVendorDiscoveriesResponse = {
   generated_at: string;
 };
 
-export type GRCVendorDiscoverySyncRequest = {
-  tenant_id?: string;
-  source_id?: string;
-};
-
-export type GRCVendorDiscoverySyncResponse = {
-  status: string;
-  source_id?: string;
-  source_summaries?: GRCVendorDiscoverySourceSummary[];
-  generated_at: string;
-};
-
 export type GRCVendorRiskVendor = GRCVendor;
 export type GRCVendorRiskSummary = GRCVendorSummary;
 export type GRCVendorRiskRelatedRecord = GRCVendorRelatedRecord;

--- a/apps/web/src/lib/rbac.test.ts
+++ b/apps/web/src/lib/rbac.test.ts
@@ -106,7 +106,6 @@ describe("Cerebro proxy route permissions", () => {
     expect(permissionForCerebroProxyRequest("POST", "grc/questionnaire-runs/run-1/comments")).toBe("grc:inventory:write");
     expect(permissionForCerebroProxyRequest("POST", "grc/vendors/urn%3Acerebro%3Ademo%3Avendor%3Aone/actions")).toBe("grc:inventory:write");
     expect(permissionForCerebroProxyRequest("POST", "grc/vendor-discoveries/discovery-1/decision")).toBe("grc:inventory:write");
-    expect(permissionForCerebroProxyRequest("POST", "grc/vendor-discoveries/sync")).toBe("grc:inventory:write");
     expect(permissionForCerebroProxyRequest("POST", "grc/policy-lifecycle/actions")).toBe("grc:policies:write");
     expect(permissionForCerebroProxyRequest("POST", "grc/policy-lifecycle/uploads")).toBe("grc:policies:write");
     expect(permissionForCerebroProxyRequest("POST", "grc/policy-lifecycle/uploads/upload-1/replay")).toBe("grc:policies:write");

--- a/apps/web/src/lib/rbac.ts
+++ b/apps/web/src/lib/rbac.ts
@@ -277,7 +277,6 @@ export const permissionForCerebroProxyRequest = (
   if (normalizedPath === "grc/vendors") return "grc:inventory:write";
   if (normalizedPath.startsWith("grc/vendors/") && normalizedPath.endsWith("/actions")) return "grc:inventory:write";
   if (normalizedPath.startsWith("grc/vendor-discoveries/") && normalizedPath.endsWith("/decision")) return "grc:inventory:write";
-  if (normalizedPath === "grc/vendor-discoveries/sync") return "grc:inventory:write";
   if (normalizedPath === "grc/policy-lifecycle/actions") return "grc:policies:write";
   if (normalizedPath === "grc/policy-lifecycle/uploads") return "grc:policies:write";
   if (normalizedPath.startsWith("grc/policy-lifecycle/uploads/") && normalizedPath.endsWith("/replay")) return "grc:policies:write";

--- a/apps/web/src/lib/ui-contract.test.ts
+++ b/apps/web/src/lib/ui-contract.test.ts
@@ -248,6 +248,16 @@ describe("product UI contract", () => {
     expect(vendorDetailSource).not.toContain("function ConsoleStatCard");
   });
 
+  it("keeps vendor source coverage on the supported scoped read path", () => {
+    const vendorSource = readProjectFile("src/app/vendors/page.tsx");
+
+    expect(vendorSource).toContain('grcPath("/grc/vendor-discoveries"');
+    expect(vendorSource).toContain("grcScopeQuery(debouncedScope)");
+    expect(vendorSource).toContain("Refresh sources");
+    expect(vendorSource).not.toContain("/grc/vendor-discoveries/sync");
+    expect(vendorSource).not.toContain("Run discovery");
+  });
+
   it("keeps lifecycle details modal and lifecycle records usable at mobile width", () => {
     const lifecycleSource = readProjectFile("src/app/security/lifecycle/page.tsx");
 


### PR DESCRIPTION
## Summary
- remove the vendor discovery sync control because no server route implements it
- remove the fixture-only response and stale client/RBAC contract
- retain scoped vendor discovery refresh through the supported read endpoint

## Validation
- `npx vitest run src/lib/cerebro-fixtures.test.ts src/lib/rbac.test.ts src/lib/ui-contract.test.ts src/lib/grc-scope.test.tsx`
- `npx eslint src/app/vendors/page.tsx src/lib/grc.ts src/lib/cerebro-fixtures.ts src/lib/cerebro-fixtures.test.ts src/lib/rbac.ts src/lib/rbac.test.ts src/lib/ui-contract.test.ts`
- `git diff --check`