### PR TITLE
fix(graph): enforce workspace scope before reads

### DIFF
--- a/internal/applicationworkspace/scope.go
+++ b/internal/applicationworkspace/scope.go
@@ -13,8 +13,10 @@ import (
 )
 
 const (
-	Header             = "X-Cerebro-Workspace"
-	maxSelectorIDBytes = 128
+	Header                   = "X-Cerebro-Workspace"
+	TenantHeader             = "X-Cerebro-Tenant"
+	maxSelectorIDBytes       = 128
+	maxTenantSelectorIDBytes = 256
 )
 
 var ErrInvalidSelector = errors.New("invalid application workspace selector")
@@ -39,6 +41,16 @@ func Select(headerValue, queryValue string) (string, error) {
 // SelectValues rejects ambiguous repeated selectors before reconciling header
 // and query values.
 func SelectValues(headerValues, queryValues []string) (string, error) {
+	return selectValues(headerValues, queryValues, Select)
+}
+
+// SelectTenantValues rejects ambiguous repeated tenant selectors and requires
+// the header and query forms to identify the same tenant.
+func SelectTenantValues(headerValues, queryValues []string) (string, error) {
+	return selectValues(headerValues, queryValues, selectTenant)
+}
+
+func selectValues(headerValues, queryValues []string, selectValue func(string, string) (string, error)) (string, error) {
 	if len(headerValues) > 1 || len(queryValues) > 1 {
 		return "", ErrInvalidSelector
 	}
@@ -49,12 +61,37 @@ func SelectValues(headerValues, queryValues []string) (string, error) {
 	if len(queryValues) == 1 {
 		queryValue = queryValues[0]
 	}
-	return Select(headerValue, queryValue)
+	return selectValue(headerValue, queryValue)
+}
+
+func selectTenant(headerValue, queryValue string) (string, error) {
+	headerValue = strings.TrimSpace(headerValue)
+	queryValue = strings.TrimSpace(queryValue)
+	if headerValue != "" && queryValue != "" && headerValue != queryValue {
+		return "", ErrInvalidSelector
+	}
+	tenantID := queryValue
+	if tenantID == "" {
+		tenantID = headerValue
+	}
+	if tenantID != "" && !ValidTenantID(tenantID) {
+		return "", ErrInvalidSelector
+	}
+	return tenantID, nil
 }
 
 // ValidID reports whether value is a single bounded opaque workspace ID.
 func ValidID(value string) bool {
-	if value == "" || len(value) > maxSelectorIDBytes || !utf8.ValidString(value) || value == "*" || strings.Contains(value, ",") {
+	return validSelectorID(value, maxSelectorIDBytes)
+}
+
+// ValidTenantID reports whether value is a single bounded opaque tenant ID.
+func ValidTenantID(value string) bool {
+	return validSelectorID(value, maxTenantSelectorIDBytes)
+}
+
+func validSelectorID(value string, maxBytes int) bool {
+	if value == "" || len(value) > maxBytes || !utf8.ValidString(value) || value == "*" || strings.Contains(value, ",") {
 		return false
 	}
 	for _, character := range value {

--- a/internal/applicationworkspace/scope_test.go
+++ b/internal/applicationworkspace/scope_test.go
@@ -34,6 +34,31 @@ func TestSelectValuesRejectsRepeatedSelectors(t *testing.T) {
 	}
 }
 
+func TestSelectTenantValuesRequiresOneValidSelector(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		headers []string
+		query   []string
+	}{
+		{name: "mismatch", headers: []string{"tenant-a"}, query: []string{"tenant-b"}},
+		{name: "repeated header", headers: []string{"tenant-a", "tenant-a"}},
+		{name: "repeated query", query: []string{"tenant-a", "tenant-a"}},
+		{name: "wildcard", query: []string{"*"}},
+		{name: "comma separated", query: []string{"tenant-a,tenant-b"}},
+		{name: "control character", query: []string{"tenant-\na"}},
+		{name: "too long", query: []string{strings.Repeat("t", 257)}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := SelectTenantValues(test.headers, test.query); err == nil {
+				t.Fatal("SelectTenantValues() error = nil, want invalid selector")
+			}
+		})
+	}
+	if got, err := SelectTenantValues([]string{"tenant-a"}, []string{"tenant-a"}); err != nil || got != "tenant-a" {
+		t.Fatalf("SelectTenantValues() = %q, %v, want tenant-a, nil", got, err)
+	}
+}
+
 func TestValidIDUsesShared128ByteContract(t *testing.T) {
 	if !ValidID(strings.Repeat("w", 128)) {
 		t.Fatal("ValidID(128 bytes) = false")

--- a/internal/bootstrap/auth.go
+++ b/internal/bootstrap/auth.go
@@ -519,7 +519,7 @@ func randomTokenID() (string, error) {
 }
 
 func requestTenantHint(r *http.Request) string {
-	if tenantID := strings.TrimSpace(r.Header.Get("X-Cerebro-Tenant")); tenantID != "" {
+	if tenantID := strings.TrimSpace(r.Header.Get(applicationworkspace.TenantHeader)); tenantID != "" {
 		return tenantID
 	}
 	if tenantID := strings.TrimSpace(r.URL.Query().Get("tenant_id")); tenantID != "" {
@@ -542,12 +542,30 @@ func requestApplicationWorkspaceSelector(r *http.Request) (string, error) {
 	return workspaceID, nil
 }
 
+func requestTenantWorkspaceSelector(r *http.Request) (string, string, error) {
+	tenantID, err := applicationworkspace.SelectTenantValues(r.Header.Values(applicationworkspace.TenantHeader), r.URL.Query()["tenant_id"])
+	if err != nil {
+		return "", "", fmt.Errorf("%w: tenant_id is invalid", errInvalidHTTPRequest)
+	}
+	workspaceID, err := requestApplicationWorkspaceSelector(r)
+	if err != nil {
+		return "", "", err
+	}
+	if workspaceID != "" && tenantID == "" {
+		return "", "", fmt.Errorf("%w: tenant_id is required with workspace_id", errInvalidHTTPRequest)
+	}
+	return tenantID, workspaceID, nil
+}
+
 func authorizeApplicationWorkspaceID(ctx context.Context, tenantID string, applicationWorkspaceID string) error {
+	tenantID = strings.TrimSpace(tenantID)
+	if err := authorizeTenantID(ctx, tenantID); err != nil {
+		return err
+	}
 	applicationWorkspaceID = strings.TrimSpace(applicationWorkspaceID)
 	if applicationWorkspaceID == "" {
 		return nil
 	}
-	tenantID = strings.TrimSpace(tenantID)
 	if tenantID == "" {
 		return fmt.Errorf("%w: tenant_id is required with workspace_id", errInvalidHTTPRequest)
 	}

--- a/internal/bootstrap/graph_handlers.go
+++ b/internal/bootstrap/graph_handlers.go
@@ -156,13 +156,23 @@ func (a *App) handleGetEntityNeighborhood(w http.ResponseWriter, r *http.Request
 		}
 	}
 	request.RootUrn = r.URL.Query().Get("root_urn")
-	if err := authorizeCerebroURNTenant(r.Context(), request.GetRootUrn()); err != nil { //nolint:contextcheck // r carries the validated parity context above.
+	tenantID, applicationWorkspaceID, err := requestTenantWorkspaceSelector(r)
+	if err != nil {
+		writeGraphQueryError(w, err)
+		return
+	}
+	if tenantID == "" {
+		tenantID = tenantIDFromCerebroURN(request.GetRootUrn())
+	}
+	if err := authorizeApplicationWorkspaceID(r.Context(), tenantID, applicationWorkspaceID); err != nil { //nolint:contextcheck // r carries the validated parity context above.
 		writeGraphQueryError(w, err)
 		return
 	}
 	response, err := a.graphQueryService().GetEntityNeighborhood(r.Context(), graphquery.NeighborhoodRequest{ //nolint:contextcheck // r carries the validated parity context above.
-		RootURN: request.GetRootUrn(),
-		Limit:   request.GetLimit(),
+		RootURN:                request.GetRootUrn(),
+		TenantID:               tenantID,
+		ApplicationWorkspaceID: applicationWorkspaceID,
+		Limit:                  request.GetLimit(),
 	})
 	if err != nil {
 		writeGraphQueryError(w, err)

--- a/internal/bootstrap/graph_workspace_authorization_test.go
+++ b/internal/bootstrap/graph_workspace_authorization_test.go
@@ -1,0 +1,176 @@
+package bootstrap
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/writer/cerebro/internal/applicationworkspace"
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestGraphNeighborhoodWorkspaceScopeQualifiesRootWithoutNeighborhoodRead(t *testing.T) {
+	const (
+		tenantID    = "tenant-a"
+		workspaceID = "workspace-a"
+		rootURN     = "urn:cerebro:tenant-a:asset:root"
+	)
+	graph := &stubGraphStore{cypherRows: [][]ports.CypherRow{{{Values: map[string]any{
+		"urn": rootURN, "tenant_id": tenantID, "application_workspace_id": workspaceID,
+		"runtime_id": "runtime-a", "source_id": "source-a", "entity_type": "asset", "label": "Root", "attributes_json": `{}`,
+	}}}}}
+	app := New(config.Config{}, Dependencies{GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph)}, nil)
+	request := graphWorkspaceRequest(t, tenantID, workspaceID, rootURN, []config.ApplicationWorkspaceGrant{{
+		TenantID: tenantID, ApplicationWorkspaceIDs: []string{workspaceID},
+	}})
+	response := httptest.NewRecorder()
+
+	app.handleGetEntityNeighborhood(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("workspace graph status = %d, want %d: %s", response.Code, http.StatusOK, response.Body.String())
+	}
+	if graph.neighborhoodRootURN != "" {
+		t.Fatalf("neighborhood root = %q, want no tenant-wide neighborhood read", graph.neighborhoodRootURN)
+	}
+	if len(graph.entityRequests) != 1 {
+		t.Fatalf("entity catalog requests = %d, want 1 scoped qualification", len(graph.entityRequests))
+	}
+	filter := graph.entityRequests[0].Filter
+	if filter.TenantID != tenantID || filter.ApplicationWorkspaceID != workspaceID || filter.ExactAgentKey != rootURN {
+		t.Fatalf("workspace qualification filter = %#v", filter)
+	}
+}
+
+func TestGraphNeighborhoodWorkspaceFailuresSkipNeighborhoodRead(t *testing.T) {
+	const rootURN = "urn:cerebro:tenant-a:asset:root"
+	tests := []struct {
+		name        string
+		tenantID    string
+		workspaceID string
+		header      string
+		grants      []config.ApplicationWorkspaceGrant
+		wantStatus  int
+		wantCatalog int
+	}{
+		{name: "orphan workspace", tenantID: "tenant-a", workspaceID: "workspace-orphan", grants: []config.ApplicationWorkspaceGrant{{TenantID: "tenant-a", ApplicationWorkspaceIDs: []string{"workspace-orphan"}}}, wantStatus: http.StatusNotFound, wantCatalog: 1},
+		{name: "workspace outside grant", tenantID: "tenant-a", workspaceID: "workspace-b", grants: []config.ApplicationWorkspaceGrant{{TenantID: "tenant-a", ApplicationWorkspaceIDs: []string{"workspace-a"}}}, wantStatus: http.StatusForbidden},
+		{name: "tenant selector mismatch", tenantID: "tenant-a", workspaceID: "workspace-a", header: "tenant-b", grants: []config.ApplicationWorkspaceGrant{{TenantID: "tenant-a", ApplicationWorkspaceIDs: []string{"workspace-a"}}}, wantStatus: http.StatusBadRequest},
+		{name: "root tenant mismatch", tenantID: "tenant-b", workspaceID: "workspace-a", grants: []config.ApplicationWorkspaceGrant{{TenantID: "tenant-b", ApplicationWorkspaceIDs: []string{"workspace-a"}}}, wantStatus: http.StatusNotFound},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			graph := &stubGraphStore{}
+			app := New(config.Config{}, Dependencies{GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph)}, nil)
+			request := graphWorkspaceRequest(t, test.tenantID, test.workspaceID, rootURN, test.grants)
+			if test.header != "" {
+				request.Header.Set(applicationworkspace.TenantHeader, test.header)
+			}
+			response := httptest.NewRecorder()
+
+			app.handleGetEntityNeighborhood(response, request)
+
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d: %s", response.Code, test.wantStatus, response.Body.String())
+			}
+			if graph.neighborhoodRootURN != "" {
+				t.Fatalf("neighborhood root = %q, want zero neighborhood reads", graph.neighborhoodRootURN)
+			}
+			if len(graph.entityRequests) != test.wantCatalog {
+				t.Fatalf("entity catalog requests = %d, want %d", len(graph.entityRequests), test.wantCatalog)
+			}
+		})
+	}
+}
+
+func TestGraphNeighborhoodAuthMiddlewarePreservesWorkspaceIsolation(t *testing.T) {
+	const (
+		tenantID    = "tenant-a"
+		workspaceID = "workspace-orphan"
+		rootURN     = "urn:cerebro:tenant-a:asset:root"
+	)
+	graph := &stubGraphStore{}
+	app := New(config.Config{Auth: config.AuthConfig{Enabled: true, APICredentials: []config.APICredential{{
+		Key: "workspace-token", Principal: "workspace-user", TenantID: tenantID, Scopes: []string{scopeCosmoSecurityRead},
+		ApplicationWorkspaceGrants: []config.ApplicationWorkspaceGrant{{TenantID: tenantID, ApplicationWorkspaceIDs: []string{workspaceID}}},
+	}}}}, Dependencies{GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph)}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	request, err := http.NewRequest(http.MethodGet, server.URL+"/platform/graph/neighborhood?tenant_id="+tenantID+"&workspace_id="+workspaceID+"&root_urn="+url.QueryEscape(rootURN), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", "Bearer workspace-token")
+	response, err := server.Client().Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusNotFound {
+		t.Fatalf("workspace graph status = %d, want %d", response.StatusCode, http.StatusNotFound)
+	}
+	if graph.neighborhoodRootURN != "" {
+		t.Fatalf("neighborhood root = %q, want zero unscoped neighborhood reads", graph.neighborhoodRootURN)
+	}
+	if len(graph.entityRequests) != 1 || graph.entityRequests[0].Filter.ApplicationWorkspaceID != workspaceID {
+		t.Fatalf("workspace catalog requests = %#v, want one exact workspace qualification", graph.entityRequests)
+	}
+}
+
+func TestGRCEntityImpactWorkspaceFailuresSkipNeighborhoodAndLegacyFallback(t *testing.T) {
+	const rootURN = "urn:cerebro:tenant-a:github_repo:legacy"
+	tests := []struct {
+		name        string
+		tenantID    string
+		workspaceID string
+		header      string
+		grants      []config.ApplicationWorkspaceGrant
+		wantStatus  int
+		wantCatalog int
+	}{
+		{name: "orphan workspace", tenantID: "tenant-a", workspaceID: "workspace-orphan", grants: []config.ApplicationWorkspaceGrant{{TenantID: "tenant-a", ApplicationWorkspaceIDs: []string{"workspace-orphan"}}}, wantStatus: http.StatusNotFound, wantCatalog: 1},
+		{name: "workspace outside grant", tenantID: "tenant-a", workspaceID: "workspace-b", grants: []config.ApplicationWorkspaceGrant{{TenantID: "tenant-a", ApplicationWorkspaceIDs: []string{"workspace-a"}}}, wantStatus: http.StatusForbidden},
+		{name: "tenant selector mismatch", tenantID: "tenant-a", workspaceID: "workspace-a", header: "tenant-b", grants: []config.ApplicationWorkspaceGrant{{TenantID: "tenant-a", ApplicationWorkspaceIDs: []string{"workspace-a"}}}, wantStatus: http.StatusBadRequest},
+		{name: "root tenant mismatch", tenantID: "tenant-b", workspaceID: "workspace-a", grants: []config.ApplicationWorkspaceGrant{{TenantID: "tenant-b", ApplicationWorkspaceIDs: []string{"workspace-a"}}}, wantStatus: http.StatusNotFound},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			graph := &stubGraphStore{}
+			app := New(config.Config{}, Dependencies{GraphStore: graph, GraphReads: NewGraphReadCapabilities(graph)}, nil)
+			request := httptest.NewRequest(http.MethodGet, "/grc/entities/impact?tenant_id="+url.QueryEscape(test.tenantID)+"&workspace_id="+url.QueryEscape(test.workspaceID), nil)
+			request.SetPathValue("entityID", rootURN)
+			request = request.WithContext(context.WithValue(request.Context(), authContextKey{}, authContext{principal: authPrincipal{
+				TenantID: test.tenantID, ApplicationWorkspaceGrants: test.grants,
+			}}))
+			if test.header != "" {
+				request.Header.Set(applicationworkspace.TenantHeader, test.header)
+			}
+			response := httptest.NewRecorder()
+
+			app.handleGRCEntityImpact(response, request)
+
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d: %s", response.Code, test.wantStatus, response.Body.String())
+			}
+			if graph.neighborhoodRootURN != "" {
+				t.Fatalf("neighborhood root = %q, want zero unscoped neighborhood reads", graph.neighborhoodRootURN)
+			}
+			if len(graph.entityRequests) != test.wantCatalog {
+				t.Fatalf("entity catalog requests = %d, want %d (legacy fallback must remain disabled)", len(graph.entityRequests), test.wantCatalog)
+			}
+		})
+	}
+}
+
+func graphWorkspaceRequest(t *testing.T, tenantID, workspaceID, rootURN string, grants []config.ApplicationWorkspaceGrant) *http.Request {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodGet, "/platform/graph/neighborhood?tenant_id="+url.QueryEscape(tenantID)+"&workspace_id="+url.QueryEscape(workspaceID)+"&root_urn="+url.QueryEscape(rootURN), nil)
+	return request.WithContext(context.WithValue(request.Context(), authContextKey{}, authContext{principal: authPrincipal{
+		TenantID: tenantID, ApplicationWorkspaceGrants: grants,
+	}}))
+}

--- a/internal/bootstrap/grc.go
+++ b/internal/bootstrap/grc.go
@@ -561,39 +561,15 @@ func (a *App) handleGRCEntityImpact(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, fmt.Errorf("%w: entity urn is required", errInvalidHTTPRequest))
 		return
 	}
-	if err := authorizeCerebroURNTenant(r.Context(), entityURN); err != nil {
+	scope, err := grcScopeFromRequest(r)
+	if err != nil {
 		writeGRCError(w, err)
 		return
 	}
 	requestedEntityURN := entityURN
-	limit, err := grcLimitFromRequest(r)
-	if err != nil {
-		writeGRCError(w, err)
-		return
-	}
-	graphStore := a.deps.GraphReads.Neighborhoods
-	if graphStore == nil {
-		writeGRCError(w, graphquery.ErrRuntimeUnavailable)
-		return
-	}
-	graph, err := graphStore.GetEntityNeighborhood(r.Context(), entityURN, int(limit))
-	if errors.Is(err, ports.ErrGraphEntityNotFound) {
-		for _, candidateURN := range graphquery.LegacyEntityImpactFallbackURNs(entityURN) {
-			graph, err = graphStore.GetEntityNeighborhood(r.Context(), candidateURN, int(limit))
-			if err == nil {
-				entityURN = candidateURN
-				break
-			}
-			if !errors.Is(err, ports.ErrGraphEntityNotFound) {
-				break
-			}
-		}
-	}
-	if err != nil {
-		writeGRCError(w, err)
-		return
-	}
-	scope, err := grcScopeFromRequest(r)
+	graph, entityURN, err := a.graphQueryService().GetEntityImpactNeighborhood(r.Context(), graphquery.NeighborhoodRequest{
+		RootURN: entityURN, TenantID: scope.TenantID, ApplicationWorkspaceID: scope.ApplicationWorkspaceID, Limit: scope.Limit,
+	})
 	if err != nil {
 		writeGRCError(w, err)
 		return
@@ -603,7 +579,7 @@ func (a *App) handleGRCEntityImpact(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	findingFilter := grcFindingFilter{ResourceURN: entityURN, Limit: limit}
+	findingFilter := grcFindingFilter{ResourceURN: entityURN, Limit: scope.Limit}
 	if requestedEntityURN != entityURN {
 		findingFilter.ResourceURN = ""
 		findingFilter.ResourceURNs = []string{entityURN, requestedEntityURN}
@@ -613,7 +589,7 @@ func (a *App) handleGRCEntityImpact(w http.ResponseWriter, r *http.Request) {
 		writeGRCError(w, err)
 		return
 	}
-	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings), Limit: limit})
+	evidence, err := a.grcListEvidenceRecords(r, runtimes, grcEvidenceFilter{FindingIDs: grcFindingIDs(findings), Limit: scope.Limit})
 	if err != nil {
 		writeGRCError(w, err)
 		return
@@ -821,16 +797,9 @@ func grcScopeFromRequest(r *http.Request) (grcScope, error) {
 	if err != nil {
 		return grcScope{}, err
 	}
-	applicationWorkspaceID, err := requestApplicationWorkspaceSelector(r)
+	tenantID, applicationWorkspaceID, err := requestTenantWorkspaceSelector(r)
 	if err != nil {
 		return grcScope{}, err
-	}
-	tenantID := strings.TrimSpace(r.URL.Query().Get("tenant_id"))
-	if tenantID == "" {
-		tenantID = strings.TrimSpace(r.Header.Get("X-Cerebro-Tenant"))
-	}
-	if applicationWorkspaceID != "" && tenantID == "" {
-		return grcScope{}, fmt.Errorf("%w: tenant_id is required with workspace_id", errInvalidHTTPRequest)
 	}
 	if tenantID == "" {
 		if auth, ok := r.Context().Value(authContextKey{}).(authContext); ok {
@@ -839,9 +808,6 @@ func grcScopeFromRequest(r *http.Request) (grcScope, error) {
 	}
 	if tenantID == "" && requiresTenantFilter(r.Context()) {
 		return grcScope{}, errTenantForbidden
-	}
-	if err := authorizeTenantID(r.Context(), tenantID); err != nil {
-		return grcScope{}, err
 	}
 	if err := authorizeApplicationWorkspaceID(r.Context(), tenantID, applicationWorkspaceID); err != nil {
 		return grcScope{}, err

--- a/internal/graphquery/legacy_urn.go
+++ b/internal/graphquery/legacy_urn.go
@@ -1,10 +1,33 @@
 package graphquery
 
 import (
+	"context"
+	"errors"
 	"strings"
 
+	"github.com/writer/cerebro/internal/ports"
 	cerebrourn "github.com/writer/cerebro/internal/urn"
 )
+
+// GetEntityImpactNeighborhood resolves legacy tenant-wide entity URLs but
+// never falls back outside a selected application workspace.
+func (s *Service) GetEntityImpactNeighborhood(ctx context.Context, request NeighborhoodRequest) (*ports.EntityNeighborhood, string, error) {
+	graph, err := s.GetEntityNeighborhood(ctx, request)
+	if err == nil || strings.TrimSpace(request.ApplicationWorkspaceID) != "" || !errors.Is(err, ports.ErrGraphEntityNotFound) {
+		return graph, request.RootURN, err
+	}
+	for _, candidateURN := range LegacyEntityImpactFallbackURNs(request.RootURN) {
+		request.RootURN = candidateURN
+		graph, err = s.GetEntityNeighborhood(ctx, request)
+		if err == nil {
+			return graph, candidateURN, nil
+		}
+		if !errors.Is(err, ports.ErrGraphEntityNotFound) {
+			break
+		}
+	}
+	return nil, request.RootURN, err
+}
 
 // LegacyEntityImpactFallbackURNs returns current graph root candidates for
 // legacy impact URLs that were minted before GitHub entity kinds stabilized.

--- a/internal/graphquery/service.go
+++ b/internal/graphquery/service.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/writer/cerebro/internal/ports"
+	cerebrourn "github.com/writer/cerebro/internal/urn"
 )
 
 const (
@@ -34,8 +35,10 @@ type Service struct {
 
 // NeighborhoodRequest scopes one bounded root-centered graph query.
 type NeighborhoodRequest struct {
-	RootURN string
-	Limit   uint32
+	RootURN                string
+	TenantID               string
+	ApplicationWorkspaceID string
+	Limit                  uint32
 }
 
 // New constructs a bounded graph neighborhood service.
@@ -128,7 +131,7 @@ func firstPersonAccessCapability(stores []ports.PersonAccessPathStore) ports.Per
 
 // GetEntityNeighborhood loads one bounded root-centered graph neighborhood.
 func (s *Service) GetEntityNeighborhood(ctx context.Context, request NeighborhoodRequest) (*ports.EntityNeighborhood, error) {
-	if s == nil || s.neighborhoods == nil {
+	if s == nil {
 		return nil, ErrRuntimeUnavailable
 	}
 	if strings.TrimSpace(request.RootURN) == "" {
@@ -137,6 +140,25 @@ func (s *Service) GetEntityNeighborhood(ctx context.Context, request Neighborhoo
 	rootURN := request.RootURN
 	if err := validateCerebroURN(rootURN); err != nil {
 		return nil, err
+	}
+	resourceTenantID := cerebrourn.TenantID(rootURN)
+	tenantID := strings.TrimSpace(request.TenantID)
+	if tenantID != "" && tenantID != resourceTenantID {
+		return nil, ports.ErrGraphEntityNotFound
+	}
+	if tenantID == "" {
+		tenantID = resourceTenantID
+	}
+	if workspaceID := strings.TrimSpace(request.ApplicationWorkspaceID); workspaceID != "" {
+		return s.QualifyWorkspaceResources(ctx, WorkspaceResourceRequest{
+			TenantID:               tenantID,
+			ResourceTenantID:       resourceTenantID,
+			ApplicationWorkspaceID: workspaceID,
+			URNs:                   []string{rootURN},
+		})
+	}
+	if s.neighborhoods == nil {
+		return nil, ErrRuntimeUnavailable
 	}
 	return s.neighborhoods.GetEntityNeighborhood(ctx, rootURN, normalizeNeighborhoodLimit(request.Limit))
 }


### PR DESCRIPTION
Summary
- reconcile tenant and workspace selectors before graph authorization
- authorize the selected tenant and workspace before entity-impact or neighborhood reads
- qualify workspace roots through the exact tenant and workspace catalog boundary
- disable legacy URN fallback whenever a workspace is selected

Security invariants
- orphan workspaces perform zero unscoped neighborhood reads
- tenant, workspace, and root mismatches fail closed
- tenant-only requests preserve bounded neighborhood traversal and legacy URL compatibility

Validation
- go test ./internal/applicationworkspace ./internal/graphquery ./internal/bootstrap -count=1
- go test -race ./internal/bootstrap -run TestGraphNeighborhoodWorkspace|TestGRCEntityImpactWorkspace|TestGRCEntityImpactResolvesLegacy -count=1
- make check-structural check-structural-test check-arch
- golangci-lint run -j 4 --timeout 20m ./internal/applicationworkspace ./internal/graphquery ./internal/bootstrap
- git diff --check