### PR TITLE
refactor(sources): retire the DeepSeek Go projection writer

### DIFF
--- a/internal/sourceprojection/deepseek.go
+++ b/internal/sourceprojection/deepseek.go
@@ -1,36 +1,18 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func deepseekModelCatalogProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return deepseekGenericAssetProjections(event)
+var errDeepSeekRustProjectionRequired = errors.New("deepseek projection requires Rust authority")
+
+func deepseekModelCatalogProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errDeepSeekRustProjectionRequired
 }
 
-func deepseekAccountBalancesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return deepseekGenericAssetProjections(event)
-}
-
-func deepseekGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func deepseekAccountBalancesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errDeepSeekRustProjectionRequired
 }

--- a/internal/sourceprojection/deepseek_test.go
+++ b/internal/sourceprojection/deepseek_test.go
@@ -1,21 +1,27 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestDeepseekAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "deepseek", Kind: "deepseek.model_catalog", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := deepseekModelCatalogProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
+func TestDeepSeekGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{"deepseek.model_catalog", "deepseek.account_balances"} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "deepseek",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errDeepSeekRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- remove the production DeepSeek Go projection implementation for model_catalog and account_balances
- fail closed if the compatibility projector is invoked for either Rust-authoritative family
- preserve the existing provider fixtures and Go-oracle parity inputs consumed by the Rust runtime tests

## Authority proof

- Rust source catalog marks both DeepSeek families collection-authoritative and projection-authoritative
- source operations route DeepSeek check, discover, and read through Rust with zero legacy calls
- compatibility projection attempts now return a typed Rust-authority error before emitting graph writes

## Validation

- go test ./internal/sourceprojection -run TestDeepSeek -count=1 -v
- go test ./internal/sourceprojection -count=1
- go test ./internal/sourceops -run TestDeepSeek -count=1 -v
- go test ./internal/sourceruntime -run Test.*DeepSeek -count=1 -v
- go test ./internal/sourceops ./internal/sourceruntime -run DeepSeek\|RustAuthoritativeFamily\|SourceFamilyAuthority -count=1

The managed local Cargo readiness gate blocked Rust compilation before tests began. Exact-head hosted checks remain authoritative for Rust validation.