### PR TITLE
Serve graph neighborhoods directly from Rust

### DIFF
--- a/apps/web/scripts/rust-product-demo.mjs
+++ b/apps/web/scripts/rust-product-demo.mjs
@@ -533,37 +533,25 @@ export async function runRustProductDemo(options = {}) {
   const processes = [];
   let failed = true;
   try {
-    const [rustPort, apiPort, webPort] = await Promise.all([
-      reserveLoopbackPort(),
+    const [rustPort, webPort] = await Promise.all([
       reserveLoopbackPort(),
       reserveLoopbackPort(),
     ]);
-    expect(new Set([rustPort, apiPort, webPort]).size === 3, "Reserved ports collided");
+    expect(new Set([rustPort, webPort]).size === 2, "Reserved ports collided");
 
     const rustBinary = await cargoBinary(deadlineAt);
-    const eventAdmissionBinary = path.join(
-      path.dirname(rustBinary),
-      process.platform === "win32"
-        ? "cerebro-event-admission-worker.exe"
-        : "cerebro-event-admission-worker",
-    );
     await run(
       "cargo",
       [
         "build", "--locked",
         "-p", "cerebro-platform",
-        "-p", "cerebro-sourceruntime-eventadmission",
         "--bin", "cerebro-platform",
-        "--bin", "cerebro-event-admission-worker",
       ],
       { cwd: repositoryRoot },
       deadlineAt,
     );
     await access(rustBinary).catch(() => {
       throw new Error(`Cargo did not produce the Rust platform binary at ${rustBinary}`);
-    });
-    await access(eventAdmissionBinary).catch(() => {
-      throw new Error(`Cargo did not produce the event admission binary at ${eventAdmissionBinary}`);
     });
     const { neighborhood, rootURN } = parseDemoNeighborhood(
       await run(
@@ -598,43 +586,6 @@ export async function runRustProductDemo(options = {}) {
       deadlineAt,
     );
 
-    const apiBinary = path.join(
-      workDir,
-      process.platform === "win32" ? "cerebro-demo-api.exe" : "cerebro-demo-api",
-    );
-    await run(
-      "go",
-      ["build", "-o", apiBinary, "./cmd/cerebro"],
-      { cwd: repositoryRoot },
-      deadlineAt,
-    );
-    const api = startLogged(
-      "go-api-adapter",
-      apiBinary,
-      ["serve"],
-      {
-        cwd: repositoryRoot,
-        env: portableEnvironment(process.env, {
-          CEREBRO_DEV_MODE: "1",
-          CEREBRO_DEV_MODE_ACK: "1",
-          CEREBRO_EVENT_ADMISSION_WORKER: eventAdmissionBinary,
-          CEREBRO_HTTP_ADDR: `127.0.0.1:${apiPort}`,
-          CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE: "authority",
-          CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL: `http://127.0.0.1:${rustPort}`,
-          CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET: sharedSecret,
-          CEREBRO_ORGANIZATIONAL_GRAPH_TIMEOUT: "30s",
-        }),
-      },
-      logDir,
-    );
-    processes.push(api);
-    await waitFor(
-      "Go product adapter",
-      async () => (await request(`http://127.0.0.1:${apiPort}/healthz`)).status === 200,
-      api,
-      deadlineAt,
-    );
-
     const graphQuery = `/platform/graph/neighborhood?root_urn=${encodeURIComponent(rootURN)}&limit=50`;
     const directGraphResponse = await request(
       `http://127.0.0.1:${rustPort}${graphQuery}`,
@@ -659,12 +610,14 @@ export async function runRustProductDemo(options = {}) {
       {
         cwd: webRoot,
         env: portableEnvironment(process.env, {
-          CEREBRO_API_BASE: `http://127.0.0.1:${apiPort}`,
+          CEREBRO_API_BASE: `http://127.0.0.1:${rustPort}`,
           CEREBRO_FORWARD_AUTH_HEADERS: "false",
           CEREBRO_IDENTITY_REQUIRED: "false",
           CEREBRO_LOCAL_IDENTITY_FALLBACK: "true",
           CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID: tenantID,
+          CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET: sharedSecret,
           CEREBRO_PROXY_CACHE_TTL_MS: "0",
+          CEREBRO_RUST_PLATFORM_API_BASE: `http://127.0.0.1:${rustPort}`,
           NEXT_PUBLIC_CEREBRO_API_BASE: "/api/cerebro",
         }),
       },
@@ -728,7 +681,7 @@ export async function runRustProductDemo(options = {}) {
         command: "cerebro-platform serve-demo",
         graph_authority: "rust",
         persistence: "memory",
-        product_adapter: "go_http",
+        product_adapter: "rust_http",
       },
       authentication: {
         kind: "ephemeral_hmac",

--- a/apps/web/src/app/api/cerebro/[...path]/route.test.ts
+++ b/apps/web/src/app/api/cerebro/[...path]/route.test.ts
@@ -309,6 +309,51 @@ describe("Cerebro proxy route", () => {
     expect(upstreamHeaders.get("x-cerebro-api-key")).toBeNull();
   });
 
+  it("routes the graph neighborhood product response directly to Rust", async () => {
+    vi.stubEnv("CEREBRO_RUST_PLATFORM_API_BASE", "http://rust-platform.internal:8080");
+    vi.stubEnv("CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID", "tenant-a");
+    vi.stubEnv(
+      "CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET",
+      "test-organizational-graph-secret-32-bytes",
+    );
+    const rootUrn = "urn:cerebro:tenant-a:asset:one";
+    const neighborhood = {
+      root: { urn: rootUrn, entity_type: "asset", label: "one" },
+      neighbors: [{ urn: "urn:cerebro:tenant-a:user:alice", entity_type: "user", label: "Alice" }],
+      relations: [{ from_urn: rootUrn, relation: "owned_by", to_urn: "urn:cerebro:tenant-a:user:alice" }],
+    };
+    let upstreamURL = "";
+    let upstreamHeaders = new Headers();
+    vi.stubGlobal("fetch", vi.fn(async (url: URL | RequestInfo, init?: RequestInit) => {
+      upstreamURL = url.toString();
+      upstreamHeaders = new Headers(init?.headers);
+      return new Response(JSON.stringify(neighborhood), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }));
+
+    const response = await GET(
+      new NextRequest(
+        `http://localhost/api/cerebro/platform/graph/neighborhood?root_urn=${encodeURIComponent(rootUrn)}&limit=50`,
+        { headers: { "cache-control": "no-cache" } },
+      ),
+      { params: Promise.resolve({ path: ["platform", "graph", "neighborhood"] }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(neighborhood);
+    expect(upstreamURL).toBe(
+      `http://rust-platform.internal:8080/platform/graph/neighborhood?root_urn=${encodeURIComponent(rootUrn)}&limit=50`,
+    );
+    expect(upstreamHeaders.get("x-cerebro-tenant")).toBe("tenant-a");
+    expect(upstreamHeaders.get("authorization")).toBe(
+      "Bearer 34b1625abbaa7a28cbca5f0a4803c1ba5360a998e5cc2f5b28d37bd32ba131d6",
+    );
+    expect(upstreamHeaders.get("x-cerebro-api-key")).toBeNull();
+    expect(upstreamHeaders.get("x-cerebro-workspace")).toBeNull();
+  });
+
   it("relays signed Rust-authority writes without authorizing or stamping in Next", async () => {
     process.env.CEREBRO_AUTHORITY_MODE = "rust";
     process.env.CEREBRO_IDENTITY_REQUIRED = "true";

--- a/apps/web/src/lib/cerebro-proxy.test.ts
+++ b/apps/web/src/lib/cerebro-proxy.test.ts
@@ -132,11 +132,14 @@ describe("cerebro proxy cache headers", () => {
     expect(new Set([unscoped, workspaceA, workspaceB]).size).toBe(3);
   });
 
-  it("routes only runtime health to the configured Rust platform origin", () => {
+  it("routes only Rust-owned public reads to the configured Rust platform origin", () => {
     vi.stubEnv("CEREBRO_RUST_PLATFORM_API_BASE", "http://rust-platform.internal:8080");
 
     expect(buildCerebroUrl("/v1/source-runtimes/health", "?limit=500").toString()).toBe(
       "http://rust-platform.internal:8080/v1/source-runtimes/health?limit=500",
+    );
+    expect(buildCerebroUrl("/platform/graph/neighborhood", "?root_urn=urn%3Acerebro%3Atenant-a%3Aasset%3Aone&limit=50").toString()).toBe(
+      "http://rust-platform.internal:8080/platform/graph/neighborhood?root_urn=urn%3Acerebro%3Atenant-a%3Aasset%3Aone&limit=50",
     );
     expect(buildCerebroUrl("/grc/dashboard").origin).not.toBe("http://rust-platform.internal:8080");
   });
@@ -153,21 +156,27 @@ describe("cerebro proxy cache headers", () => {
     );
   });
 
-  it("uses only server-owned Rust tenant auth for runtime health", () => {
+  it.each([
+    "v1/source-runtimes/health",
+    "platform/graph/neighborhood",
+  ])("uses only server-owned Rust tenant auth for %s", (path) => {
     vi.stubEnv("CEREBRO_RUST_PLATFORM_API_BASE", "http://rust-platform.internal:8080");
     vi.stubEnv("CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID", "tenant-a");
     vi.stubEnv(
       "CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET",
       "test-organizational-graph-secret-32-bytes",
     );
-    const headers = new Headers(authHeadersFor(new NextRequest("http://localhost"), "v1/source-runtimes/health"));
+    const headers = new Headers(authHeadersFor(new NextRequest("http://localhost"), path));
 
     expect(headers.get("x-cerebro-tenant")).toBe("tenant-a");
     expect(headers.get("authorization")).toMatch(/^Bearer [0-9a-f]{64}$/);
     expect(headers.get("x-cerebro-api-key")).toBeNull();
   });
 
-  it("rejects a runtime health selector that conflicts with the server-owned tenant", () => {
+  it.each([
+    "v1/source-runtimes/health",
+    "platform/graph/neighborhood",
+  ])("rejects a %s selector that conflicts with the server-owned tenant", (path) => {
     vi.stubEnv("CEREBRO_RUST_PLATFORM_API_BASE", "http://rust-platform.internal:8080");
     vi.stubEnv("CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID", "tenant-a");
     vi.stubEnv(
@@ -178,7 +187,7 @@ describe("cerebro proxy cache headers", () => {
       headers: { "X-Cerebro-Tenant": "tenant-b" },
     });
 
-    expect(() => authHeadersFor(request, "v1/source-runtimes/health")).toThrow(
+    expect(() => authHeadersFor(request, path)).toThrow(
       "does not match the active Cerebro authority",
     );
   });

--- a/apps/web/src/lib/cerebro-proxy.ts
+++ b/apps/web/src/lib/cerebro-proxy.ts
@@ -10,6 +10,7 @@ const API_BASE =
   "http://localhost:8080";
 
 const RUST_RUNTIME_HEALTH_PATH = "v1/source-runtimes/health";
+const RUST_PRODUCT_GRAPH_NEIGHBORHOOD_PATH = "platform/graph/neighborhood";
 const RUST_TENANT_AUTH_CONTEXT = Buffer.from(
   "cerebro-organizational-graph/tenant/v1\0",
   "utf8",
@@ -79,7 +80,7 @@ export const configuredRustPlatformApiBase = (
 export const rustTenantAuthHeaders = (tenantID: string, sharedSecret: string): HeadersInit => {
   const tenant = configuredOrganizationalGraphTenant(tenantID);
   if (!tenant) {
-    throw new Error("CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID is required for Rust runtime health");
+    throw new Error("CEREBRO_ORGANIZATIONAL_GRAPH_TENANT_ID is required for Rust platform authentication");
   }
   if (Buffer.byteLength(sharedSecret, "utf8") < MIN_RUST_SHARED_SECRET_BYTES) {
     throw new Error(
@@ -100,12 +101,15 @@ export const rustTenantAuthHeaders = (tenantID: string, sharedSecret: string): H
   };
 };
 
-const isRustRuntimeHealthPath = (path: string) =>
-  normalizeProxyPath(path) === RUST_RUNTIME_HEALTH_PATH;
+const isRustPlatformPath = (path: string) => {
+  const normalizedPath = normalizeProxyPath(path);
+  return normalizedPath === RUST_RUNTIME_HEALTH_PATH
+    || normalizedPath === RUST_PRODUCT_GRAPH_NEIGHBORHOOD_PATH;
+};
 
 const usesOrganizationalGraphTenant = (path: string) => {
   const normalizedPath = normalizeProxyPath(path);
-  return normalizedPath === "platform/graph/neighborhood" || normalizedPath.startsWith("grc/");
+  return normalizedPath === RUST_PRODUCT_GRAPH_NEIGHBORHOOD_PATH || normalizedPath.startsWith("grc/");
 };
 
 const forwardRequestAuth =
@@ -243,7 +247,7 @@ export const rustOwnsWebAuthority = () =>
 export const buildCerebroUrl = (path: string, search = "") => {
   const normalizedPath = normalizeProxyPath(path);
   const rustPlatformBase = configuredRustPlatformApiBase();
-  const apiBase = rustPlatformBase && normalizedPath === RUST_RUNTIME_HEALTH_PATH
+  const apiBase = rustPlatformBase && isRustPlatformPath(normalizedPath)
     ? rustPlatformBase
     : API_BASE;
   const base = new URL(apiBase.endsWith("/") ? apiBase : `${apiBase}/`);
@@ -266,7 +270,7 @@ export const authHeadersFor = (request: NextRequest, upstreamPath = ""): Headers
     Accept: "application/json, text/plain;q=0.9, */*;q=0.8",
     ...scope.headers,
   };
-  if (configuredRustPlatformApiBase() && isRustRuntimeHealthPath(upstreamPath)) {
+  if (configuredRustPlatformApiBase() && isRustPlatformPath(upstreamPath)) {
     const configuredTenantID = configuredOrganizationalGraphTenant();
     if (scope.tenantID && scope.tenantID !== configuredTenantID) {
       throw new CerebroProxyError("The requested tenant does not match the active Cerebro authority.", 400);

--- a/docs/contracts/platform-public-route-inventory.json
+++ b/docs/contracts/platform-public-route-inventory.json
@@ -1,8 +1,9 @@
 {
   "schema_version": 1,
-  "description": "Deterministic public platform contract inventory for Go compatibility and Rust authority transition gates.",
+  "description": "Deterministic public platform contract inventory for Go compatibility and Rust authority routes.",
   "generated_from": [
     "internal/bootstrap/routes.go",
+    "crates/cerebro-platform/src/main.rs",
     "api/openapi.yaml",
     "proto/cerebro/v1/bootstrap.proto",
     "gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go"
@@ -12,13 +13,15 @@
     "connect_mounts": 1,
     "connect_rpcs": 47,
     "by_surface": {
-      "bridged-to-rust-authority": 23,
+      "bridged-to-rust-authority": 22,
       "protected": 285,
-      "public-exempt": 15
+      "public-exempt": 15,
+      "rust-authority": 1
     },
     "by_authority_owner": {
-      "bridged-to-rust-authority": 23,
-      "go-compatibility": 300
+      "bridged-to-rust-authority": 22,
+      "go-compatibility": 300,
+      "rust-authority": 1
     },
     "by_auth_class": {
       "api-key-bearer-or-oauth": 2,
@@ -2041,8 +2044,8 @@
       "kind": "http",
       "method": "GET",
       "path": "/platform/graph/neighborhood",
-      "surface": "bridged-to-rust-authority",
-      "authority_owner": "bridged-to-rust-authority",
+      "surface": "rust-authority",
+      "authority_owner": "rust-authority",
       "owner": "graph",
       "auth_class": "api-key-or-bearer",
       "tenant_scope_rule": "tenant-id-required",

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -2972,7 +2972,6 @@ func TestAccessAuditOperationClassifiesFamiliesAndSensitiveActions(t *testing.T)
 	}{
 		{method: http.MethodGet, path: "/sources/github/read", route: "GET /sources/{sourceID}/read", family: "source", operationType: "read", sensitive: true},
 		{method: http.MethodPost, path: "/source-runtimes/runtime-1/sync", route: "POST /source-runtimes/{runtimeID}/sync", family: "source_runtime", operationType: "write", sensitive: true},
-		{method: http.MethodGet, path: "/platform/graph/neighborhood", route: "GET /platform/graph/neighborhood", family: "graph", operationType: "read", sensitive: false},
 		{method: http.MethodPost, path: "/cerebro.v1.BootstrapService/SyncSourceRuntime", route: "/cerebro.v1.BootstrapService/{Procedure}", family: "source_runtime", operationType: "write", sensitive: true},
 		{method: http.MethodPost, path: "/cerebro.v1.BootstrapService/GetEntityNeighborhood", route: "/cerebro.v1.BootstrapService/{Procedure}", family: "graph", operationType: "read", sensitive: false},
 	} {
@@ -3024,7 +3023,6 @@ func TestScopedCosmoCredentialAllowsOnlyReadRoutes(t *testing.T) {
 
 	for _, path := range []string{
 		"/sources",
-		"/platform/graph/neighborhood?root_urn=urn:cerebro:writer:asset:app",
 		"/platform/graph/crown-jewel-rankings?tenant_id=writer",
 		"/source-runtimes/writer-runtime",
 	} {
@@ -3041,20 +3039,6 @@ func TestScopedCosmoCredentialAllowsOnlyReadRoutes(t *testing.T) {
 		if resp.StatusCode != http.StatusOK {
 			t.Fatalf("GET %s status = %d, want %d", path, resp.StatusCode, http.StatusOK)
 		}
-	}
-
-	otherTenantReq, err := http.NewRequest(http.MethodGet, server.URL+"/platform/graph/neighborhood?root_urn=urn:cerebro:other:asset:app", nil)
-	if err != nil {
-		t.Fatalf("NewRequest other tenant: %v", err)
-	}
-	otherTenantReq.Header.Set("Authorization", "Bearer scoped-token")
-	otherTenantResp, err := server.Client().Do(otherTenantReq)
-	if err != nil {
-		t.Fatalf("GET other tenant graph error = %v", err)
-	}
-	_ = otherTenantResp.Body.Close()
-	if otherTenantResp.StatusCode != http.StatusForbidden {
-		t.Fatalf("GET other tenant graph status = %d, want %d", otherTenantResp.StatusCode, http.StatusForbidden)
 	}
 
 	for _, tt := range []struct {
@@ -3304,7 +3288,7 @@ func TestCapabilityTokenRequiresSecurityGroup(t *testing.T) {
 		"client_id":     "cosmo",
 		"credential_id": "cosmo-capability",
 	})
-	req, err := http.NewRequest(http.MethodGet, server.URL+"/platform/graph/neighborhood?root_urn=urn:cerebro:writer:asset:app", nil)
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/sources", nil)
 	if err != nil {
 		t.Fatalf("NewRequest authorized: %v", err)
 	}
@@ -3326,7 +3310,7 @@ func TestCapabilityTokenRequiresSecurityGroup(t *testing.T) {
 		"scopes":    []string{scopeCosmoSecurityRead},
 		"groups":    []string{"engineering"},
 	})
-	forbiddenReq, err := http.NewRequest(http.MethodGet, server.URL+"/platform/graph/neighborhood?root_urn=urn:cerebro:writer:asset:app", nil)
+	forbiddenReq, err := http.NewRequest(http.MethodGet, server.URL+"/sources", nil)
 	if err != nil {
 		t.Fatalf("NewRequest forbidden: %v", err)
 	}
@@ -3348,7 +3332,7 @@ func TestCapabilityTokenRequiresSecurityGroup(t *testing.T) {
 		"scopes":    []string{scopeCosmoSecurityRead},
 		"groups":    []string{"security"},
 	})
-	expiredReq, err := http.NewRequest(http.MethodGet, server.URL+"/platform/graph/neighborhood?root_urn=urn:cerebro:writer:asset:app", nil)
+	expiredReq, err := http.NewRequest(http.MethodGet, server.URL+"/sources", nil)
 	if err != nil {
 		t.Fatalf("NewRequest expired: %v", err)
 	}
@@ -3369,7 +3353,7 @@ func TestCapabilityTokenRequiresSecurityGroup(t *testing.T) {
 		"tenant_id": "writer",
 		"groups":    []string{"security"},
 	})
-	noScopesReq, err := http.NewRequest(http.MethodGet, server.URL+"/platform/graph/neighborhood?root_urn=urn:cerebro:writer:asset:app", nil)
+	noScopesReq, err := http.NewRequest(http.MethodGet, server.URL+"/sources", nil)
 	if err != nil {
 		t.Fatalf("NewRequest no scopes: %v", err)
 	}
@@ -4114,7 +4098,7 @@ func TestAuthMiddlewareEnforcesTenantOnReportRunLookups(t *testing.T) {
 	}
 }
 
-func TestAuthMiddlewareEnforcesTenantOnGraphRootURN(t *testing.T) {
+func TestConnectAuthMiddlewareEnforcesTenantOnGraphRootURN(t *testing.T) {
 	cfg := config.Config{
 		HTTPAddr:        "127.0.0.1:0",
 		ShutdownTimeout: time.Second,
@@ -4129,20 +4113,6 @@ func TestAuthMiddlewareEnforcesTenantOnGraphRootURN(t *testing.T) {
 	app := New(cfg, Dependencies{GraphStore: &stubGraphStore{}}, nil)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
-
-	req, err := http.NewRequest(http.MethodGet, server.URL+"/platform/graph/neighborhood?root_urn=urn:cerebro:other:github_user:alice", nil)
-	if err != nil {
-		t.Fatalf("NewRequest: %v", err)
-	}
-	req.Header.Set("Authorization", "Bearer writer-key")
-	resp, err := server.Client().Do(req)
-	if err != nil {
-		t.Fatalf("GET /platform/graph/neighborhood error = %v", err)
-	}
-	_ = resp.Body.Close()
-	if resp.StatusCode != http.StatusForbidden {
-		t.Fatalf("GET /platform/graph/neighborhood status = %d, want %d", resp.StatusCode, http.StatusForbidden)
-	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	neighborhoodReq := connect.NewRequest(&cerebrov1.GetEntityNeighborhoodRequest{
@@ -5903,14 +5873,12 @@ func TestGraphIngestArchetypeRuntimeProjectsFindingsEndToEnd(t *testing.T) {
 	assertBootstrapProjectedLink(t, graphStore, findingURN, "affects", repoURN)
 	assertBootstrapProjectedLink(t, graphStore, noteURN, "belongs_to", scanURN)
 
-	neighborhoodResp, err := server.Client().Get(server.URL + "/platform/graph/neighborhood?root_urn=" + url.QueryEscape(findingURN) + "&limit=10")
+	neighborhood, err := graphStore.GetEntityNeighborhood(context.Background(), findingURN, 10)
 	if err != nil {
-		t.Fatalf("GET /platform/graph/neighborhood error = %v", err)
+		t.Fatalf("GetEntityNeighborhood() error = %v", err)
 	}
-	defer func() { _ = neighborhoodResp.Body.Close() }()
-	if neighborhoodResp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(neighborhoodResp.Body)
-		t.Fatalf("graph neighborhood status = %d, want 200: %s", neighborhoodResp.StatusCode, body)
+	if neighborhood.Root == nil || neighborhood.Root.URN != findingURN {
+		t.Fatalf("graph neighborhood root = %#v, want %q", neighborhood.Root, findingURN)
 	}
 	if graphStore.neighborhoodRootURN != findingURN {
 		t.Fatalf("graph neighborhood root = %q, want %q", graphStore.neighborhoodRootURN, findingURN)
@@ -8109,7 +8077,7 @@ func TestWriteClaimsReplaceExistingReportsRetractedClaims(t *testing.T) {
 	}
 }
 
-func TestGraphNeighborhoodEndpoints(t *testing.T) {
+func TestConnectGraphNeighborhoodEndpoint(t *testing.T) {
 	registry, err := newFixtureRegistry()
 	if err != nil {
 		t.Fatalf("newFixtureRegistry() error = %v", err)
@@ -8139,37 +8107,6 @@ func TestGraphNeighborhoodEndpoints(t *testing.T) {
 	}, registry)
 	server := httptest.NewServer(app.Handler())
 	defer server.Close()
-
-	resp, err := server.Client().Get(server.URL + "/platform/graph/neighborhood?root_urn=urn:cerebro:writer:github_pull_request:writer/cerebro%23447&limit=5")
-	if err != nil {
-		t.Fatalf("GET /platform/graph/neighborhood error = %v", err)
-	}
-	defer func() {
-		if closeErr := resp.Body.Close(); closeErr != nil {
-			t.Fatalf("close /platform/graph/neighborhood response body: %v", closeErr)
-		}
-	}()
-	var payload map[string]any
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		t.Fatalf("decode /platform/graph/neighborhood response: %v", err)
-	}
-	rootPayload, ok := payload["root"].(map[string]any)
-	if !ok {
-		t.Fatalf("graph root payload = %#v, want object", payload["root"])
-	}
-	if got := rootPayload["entity_type"]; got != "github.pull_request" {
-		t.Fatalf("graph root entity_type = %#v, want github.pull_request", got)
-	}
-	neighborsPayload, ok := payload["neighbors"].([]any)
-	if !ok || len(neighborsPayload) != 2 {
-		t.Fatalf("graph neighbors payload = %#v, want 2 entries", payload["neighbors"])
-	}
-	if graphStore.neighborhoodRootURN != "urn:cerebro:writer:github_pull_request:writer/cerebro#447" {
-		t.Fatalf("graph neighborhood root urn = %q, want pull request urn", graphStore.neighborhoodRootURN)
-	}
-	if graphStore.neighborhoodLimit != 5 {
-		t.Fatalf("graph neighborhood limit = %d, want 5", graphStore.neighborhoodLimit)
-	}
 
 	client := cerebrov1connect.NewBootstrapServiceClient(server.Client(), server.URL)
 	neighborhoodResp, err := client.GetEntityNeighborhood(context.Background(), connect.NewRequest(&cerebrov1.GetEntityNeighborhoodRequest{

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -166,7 +166,6 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodPost, Prefix: "/grc/vendors/uploads/", Suffix: "/replay", Scope: scopeGRCInventoryWrite},
 	{Method: http.MethodPost, Prefix: "/grc/vendor-discoveries/", Suffix: "/decision", Scope: scopeGRCInventoryWrite},
 	{Method: http.MethodGet, Exact: "/platform/runtime-freshness", Scope: scopeCosmoSecurityRead, Static: true},
-	{Method: http.MethodGet, Exact: "/platform/graph/neighborhood", Scope: scopeCosmoSecurityRead, Static: true},
 	{Method: http.MethodPost, Exact: "/platform/graph/actions", Scope: scopeGraphActionsWrite, Static: true},
 	{Method: http.MethodPost, Exact: "/platform/graph/actions/reconcile", Scope: scopeGraphActionsWrite, Static: true},
 	{Method: http.MethodGet, Exact: "/platform/graph/provenance", Scope: scopeCosmoSecurityRead, Static: true},

--- a/internal/bootstrap/graph_handlers.go
+++ b/internal/bootstrap/graph_handlers.go
@@ -140,37 +140,6 @@ func (a *App) handleReplayWorkflowEvents(w http.ResponseWriter, r *http.Request)
 	writeProtoJSON(w, http.StatusOK, workflowReplayResponse(result))
 }
 
-func (a *App) handleGetEntityNeighborhood(w http.ResponseWriter, r *http.Request) {
-	ctx, err := withParityCorrelation(r)
-	if err != nil {
-		writeGraphQueryError(w, fmt.Errorf("%w: %w", graphquery.ErrInvalidRequest, err))
-		return
-	}
-	r = r.WithContext(ctx) //nolint:contextcheck // ctx is derived from the inbound request context after validating parity headers.
-	request := &cerebrov1.GetEntityNeighborhoodRequest{}
-	if limit := r.URL.Query().Get("limit"); limit != "" {
-		body := []byte(`{"limit":` + limit + `}`)
-		if err := unmarshalHTTPProtoJSON(body, request); err != nil {
-			writeGraphQueryError(w, err)
-			return
-		}
-	}
-	request.RootUrn = r.URL.Query().Get("root_urn")
-	if err := authorizeCerebroURNTenant(r.Context(), request.GetRootUrn()); err != nil { //nolint:contextcheck // r carries the validated parity context above.
-		writeGraphQueryError(w, err)
-		return
-	}
-	response, err := a.graphQueryService().GetEntityNeighborhood(r.Context(), graphquery.NeighborhoodRequest{ //nolint:contextcheck // r carries the validated parity context above.
-		RootURN: request.GetRootUrn(),
-		Limit:   request.GetLimit(),
-	})
-	if err != nil {
-		writeGraphQueryError(w, err)
-		return
-	}
-	writeProtoJSON(w, http.StatusOK, graphNeighborhoodResponse(response))
-}
-
 func (a *App) handleGetVulnerabilityImpact(w http.ResponseWriter, r *http.Request) {
 	tenantID := r.URL.Query().Get("tenant_id")
 	if err := authorizeTenantID(r.Context(), tenantID); err != nil {

--- a/internal/bootstrap/public_contract_inventory_test.go
+++ b/internal/bootstrap/public_contract_inventory_test.go
@@ -295,7 +295,9 @@ func buildPlatformContractInventory(t *testing.T, root string) platformContractI
 	t.Helper()
 	openAPI := openAPIHTTPMethods(t, root)
 	entries := registeredHTTPContractEntries(t, root, openAPI)
+	entries = append(entries, rustAuthorityHTTPContractEntries(t, root, openAPI)...)
 	entries = append(entries, bootstrapConnectContractEntries(t, root)...)
+	assertUniqueContractEntries(t, entries)
 	sort.Slice(entries, func(i, j int) bool {
 		if entries[i].Kind == entries[j].Kind {
 			return entries[i].Identity < entries[j].Identity
@@ -304,9 +306,10 @@ func buildPlatformContractInventory(t *testing.T, root string) platformContractI
 	})
 	inventory := platformContractInventory{
 		SchemaVersion: 1,
-		Description:   "Deterministic public platform contract inventory for Go compatibility and Rust authority transition gates.",
+		Description:   "Deterministic public platform contract inventory for Go compatibility and Rust authority routes.",
 		GeneratedFrom: []string{
 			"internal/bootstrap/routes.go",
+			"crates/cerebro-platform/src/main.rs",
 			"api/openapi.yaml",
 			"proto/cerebro/v1/bootstrap.proto",
 			"gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go",
@@ -315,6 +318,57 @@ func buildPlatformContractInventory(t *testing.T, root string) platformContractI
 	}
 	inventory.Summary = summarizePlatformContractInventory(entries)
 	return inventory
+}
+
+func rustAuthorityHTTPContractEntries(t *testing.T, root string, openAPI map[string]map[string]struct{}) []platformContractEntry {
+	t.Helper()
+	// #nosec G304 -- fixed repo-relative guardrail path derived from runtime.Caller.
+	body, err := os.ReadFile(filepath.Join(root, "crates", "cerebro-platform", "src", "main.rs"))
+	if err != nil {
+		t.Fatalf("read Rust platform router: %v", err)
+	}
+	routes := []struct {
+		method string
+		path   string
+		marker string
+	}{
+		{method: http.MethodGet, path: "/platform/graph/neighborhood", marker: "get(product_neighborhood_route)"},
+	}
+	entries := make([]platformContractEntry, 0, len(routes))
+	for _, route := range routes {
+		if !strings.Contains(string(body), `"`+route.path+`"`) || !strings.Contains(string(body), route.marker) {
+			t.Fatalf("Rust platform router is missing %s %s", route.method, route.path)
+		}
+		methods := openAPI[route.path]
+		if _, ok := methods[strings.ToLower(route.method)]; !ok {
+			t.Fatalf("Rust authority route %s %s is missing from OpenAPI", route.method, route.path)
+		}
+		entries = append(entries, platformContractEntry{
+			Identity:        route.method + " " + route.path,
+			Kind:            "http",
+			Method:          route.method,
+			Path:            route.path,
+			Surface:         "rust-authority",
+			AuthorityOwner:  "rust-authority",
+			Owner:           contractOwnerForPath(route.path),
+			AuthClass:       "api-key-or-bearer",
+			TenantScopeRule: "tenant-id-required",
+			ContractSource:  "OpenAPI",
+		})
+	}
+	return entries
+}
+
+func assertUniqueContractEntries(t *testing.T, entries []platformContractEntry) {
+	t.Helper()
+	seen := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		key := entry.Kind + " " + entry.Identity
+		if _, ok := seen[key]; ok {
+			t.Fatalf("duplicate public contract entry %s", key)
+		}
+		seen[key] = struct{}{}
+	}
 }
 
 func registeredHTTPContractEntries(t *testing.T, root string, openAPI map[string]map[string]struct{}) []platformContractEntry {

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -355,7 +355,6 @@ func (app *App) registerAuditEventRoutes(mux *http.ServeMux) {
 
 func (app *App) registerGraphRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /platform/runtime-freshness", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("runtime.freshness", 30*time.Second, grcCacheScopeRuntime, grcCacheScopeGraph, grcCacheScopeFindings), app.handleListRuntimeFreshness))
-	registerHTTPRoute(mux, "GET /platform/graph/neighborhood", routeSurfacePlatformHTTP, app.handleGetEntityNeighborhood)
 	registerHTTPRoute(mux, "POST /platform/graph/actions", routeSurfacePlatformHTTP, app.handleExecuteGraphAction)
 	registerHTTPRoute(mux, "POST /platform/graph/actions/reconcile", routeSurfacePlatformHTTP, app.handleReconcileGraphAction)
 	registerHTTPRoute(mux, "GET /platform/graph/provenance", routeSurfacePlatformHTTP, app.handleGetGraphProvenance)

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -611,7 +611,6 @@ var exactRouteLabels = map[string]struct{}{
 	"/platform/knowledge/outcomes":                                        {},
 	"/platform/workflow/replay":                                           {},
 	"/platform/runtime-freshness":                                         {},
-	"/platform/graph/neighborhood":                                        {},
 	"/platform/graph/impact/package":                                      {},
 	"/platform/graph/impact/asset":                                        {},
 	"/platform/graph/attack-paths":                                        {},

--- a/scripts/openapi_route_parity.go
+++ b/scripts/openapi_route_parity.go
@@ -33,6 +33,11 @@ func main() {
 	if err != nil {
 		fail(err)
 	}
+	rustRoutes, err := registeredRustAuthorityRoutes("crates/cerebro-platform/src/main.rs")
+	if err != nil {
+		fail(err)
+	}
+	routes = append(routes, rustRoutes...)
 	paths, methods, err := openAPIPaths(openAPIPath)
 	if err != nil {
 		fail(err)
@@ -59,6 +64,27 @@ func main() {
 		fmt.Fprintf(os.Stderr, "OpenAPI route is not registered: %s %s\n", strings.ToUpper(route.Method), route.Path)
 	}
 	os.Exit(1)
+}
+
+func registeredRustAuthorityRoutes(path string) ([]route, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	routes := []struct {
+		route  route
+		marker string
+	}{
+		{route: route{Method: "get", Path: "/platform/graph/neighborhood"}, marker: "get(product_neighborhood_route)"},
+	}
+	registered := make([]route, 0, len(routes))
+	for _, candidate := range routes {
+		if !bytes.Contains(payload, []byte(`"`+candidate.route.Path+`"`)) || !bytes.Contains(payload, []byte(candidate.marker)) {
+			return nil, fmt.Errorf("Rust authority route is not registered: %s %s", strings.ToUpper(candidate.route.Method), candidate.route.Path)
+		}
+		registered = append(registered, candidate.route)
+	}
+	return registered, nil
 }
 
 func missingOpenAPIRoutes(routes []route, paths map[string]bool, methods map[route]bool) []route {

--- a/scripts/openapi_route_parity_test.go
+++ b/scripts/openapi_route_parity_test.go
@@ -124,3 +124,31 @@ func TestRouteParityIsBidirectional(t *testing.T) {
 		}
 	}
 }
+
+func TestRegisteredRustAuthorityRoutesRequiresTheNativeHandler(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "main.rs")
+	if err := os.WriteFile(sourcePath, []byte(`
+Router::new().route(
+    "/platform/graph/neighborhood",
+    get(product_neighborhood_route),
+)
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	routes, err := registeredRustAuthorityRoutes(sourcePath)
+	if err != nil {
+		t.Fatalf("registeredRustAuthorityRoutes() error = %v", err)
+	}
+	want := route{Method: "get", Path: "/platform/graph/neighborhood"}
+	if len(routes) != 1 || routes[0] != want {
+		t.Fatalf("registeredRustAuthorityRoutes() = %#v, want %#v", routes, []route{want})
+	}
+
+	if err := os.WriteFile(sourcePath, []byte(`Router::new()`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if _, err := registeredRustAuthorityRoutes(sourcePath); err == nil {
+		t.Fatal("registeredRustAuthorityRoutes() error = nil, want missing handler error")
+	}
+}

--- a/sdk/python/tests/test_graph_neighborhood_contract.py
+++ b/sdk/python/tests/test_graph_neighborhood_contract.py
@@ -1,0 +1,124 @@
+import io
+import json
+import unittest
+from urllib.error import HTTPError
+from unittest.mock import patch
+
+from cerebro.graph.v1 import organizational_graph_pb2
+from cerebro_sdk.client import APIError, Client
+
+
+class FakeResponse:
+    headers = {"Content-Type": "application/json"}
+
+    def __init__(self, payload):
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._body
+
+    def close(self):
+        pass
+
+
+class GraphNeighborhoodContractTests(unittest.TestCase):
+    def test_caller_uses_bounded_product_route_and_preserves_auth_and_scope(self) -> None:
+        seen = {}
+        root_urn = "urn:cerebro:tenant-a:repository:writer/cerebro"
+        fixture_token = "-".join(("fixture", "sdk", "token"))
+
+        def fake_urlopen(req, timeout):
+            seen["url"] = req.full_url
+            seen["method"] = req.get_method()
+            seen["headers"] = {key.lower(): value for key, value in req.header_items()}
+            seen["timeout"] = timeout
+            return FakeResponse(
+                {
+                    "root": {"urn": root_urn, "entity_type": "repository", "label": "cerebro"},
+                    "neighbors": [{"urn": "urn:cerebro:tenant-a:user:alice", "entity_type": "user", "label": "Alice"}],
+                    "relations": [{"from_urn": root_urn, "relation": "owned_by", "to_urn": "urn:cerebro:tenant-a:user:alice"}],
+                }
+            )
+
+        client = Client("https://cerebro.example.com/api/", api_key=fixture_token, timeout=7)
+        with patch("cerebro_sdk.client.request.urlopen", fake_urlopen):
+            result = client.get_entity_neighborhood(f" {root_urn} ", 50)
+
+        self.assertEqual(result["root"]["urn"], root_urn)
+        self.assertEqual(result["neighbors"][0]["entity_type"], "user")
+        self.assertEqual(result["relations"][0]["relation"], "owned_by")
+        self.assertEqual(seen["method"], "GET")
+        self.assertEqual(
+            seen["url"],
+            "https://cerebro.example.com/api/platform/graph/neighborhood?root_urn=urn%3Acerebro%3Atenant-a%3Arepository%3Awriter%2Fcerebro&limit=50",
+        )
+        self.assertEqual(seen["headers"]["authorization"], f"Bearer {fixture_token}")
+        self.assertEqual(seen["headers"]["accept"], "application/json")
+        self.assertNotIn("tenant_id", seen["url"])
+        self.assertNotIn("workspace_id", seen["url"])
+        self.assertEqual(seen["timeout"], 7)
+
+    def test_caller_forwards_limits_for_authority_clamping_and_preserves_errors(self) -> None:
+        seen = {}
+        fixture_token = "-".join(("fixture", "sdk", "token"))
+
+        def fake_urlopen(req, timeout):
+            seen["url"] = req.full_url
+            seen["headers"] = {key.lower(): value for key, value in req.header_items()}
+            raise HTTPError(
+                req.full_url,
+                503,
+                "Service Unavailable",
+                {"Content-Type": "application/json"},
+                io.BytesIO(
+                    b'{"error":"graph runtime unavailable","code":"graph_unavailable"}'
+                ),
+            )
+
+        client = Client("https://cerebro.example.com", api_key=fixture_token)
+        with patch("cerebro_sdk.client.request.urlopen", fake_urlopen):
+            with self.assertRaises(APIError) as raised:
+                client.get_entity_neighborhood("urn:cerebro:tenant-a:repository:writer/cerebro", 51)
+
+        self.assertEqual(raised.exception.status_code, 503)
+        self.assertEqual(raised.exception.code, "graph_unavailable")
+        self.assertIn("graph runtime unavailable", str(raised.exception))
+        self.assertNotIn(fixture_token, str(raised.exception))
+        self.assertIn("limit=51", seen["url"])
+        self.assertEqual(seen["headers"]["authorization"], f"Bearer {fixture_token}")
+
+    def test_caller_rejects_an_empty_root_before_request(self) -> None:
+        requests = 0
+
+        def fake_urlopen(req, timeout):
+            nonlocal requests
+            requests += 1
+            return FakeResponse({})
+
+        client = Client("https://cerebro.example.com")
+        with patch("cerebro_sdk.client.request.urlopen", fake_urlopen):
+            with self.assertRaisesRegex(ValueError, "root_urn is required"):
+                client.get_entity_neighborhood("  \t")
+
+        self.assertEqual(requests, 0)
+
+
+class GeneratedGraphContractTests(unittest.TestCase):
+    def test_generated_connect_descriptor_keeps_typed_expand_contract(self) -> None:
+        service = organizational_graph_pb2.DESCRIPTOR.services_by_name["OrganizationalGraphService"]
+        expand = service.methods_by_name["Expand"]
+
+        self.assertEqual(expand.input_type.full_name, "cerebro.graph.v1.ExpandRequest")
+        self.assertEqual(expand.output_type.full_name, "cerebro.graph.v1.ExpandResponse")
+        self.assertEqual(
+            [(field.name, field.number) for field in expand.input_type.fields],
+            [("tenant_id", 1), ("root_key", 2), ("depth", 3), ("limit", 4)],
+        )
+        self.assertEqual(
+            [(field.name, field.number) for field in expand.output_type.fields],
+            [("tenant_id", 1), ("graph_revision", 2), ("root", 3), ("entities", 4), ("edges", 5), ("truncated", 6)],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/typescript/test/graph-neighborhood-contract.test.mjs
+++ b/sdk/typescript/test/graph-neighborhood-contract.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { APIError, Client } from "../src/index.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const generatedOpenAPIPath = path.resolve(here, "../src/generated/openapi-types.ts");
+
+const fixtureToken = ["fixture", "sdk", "token"].join("-");
+const rootUrn = "urn:cerebro:tenant-a:repository:writer/cerebro";
+
+test("graph neighborhood caller uses the bounded product route and preserves auth and scope", async () => {
+  const requests = [];
+  const client = new Client({
+    baseUrl: "https://cerebro.example.com/api/",
+    apiKey: fixtureToken,
+    fetchImpl: async (url, init = {}) => {
+      requests.push({ url: String(url), headers: new Headers(init.headers) });
+      return new Response(JSON.stringify({
+        root: { urn: rootUrn, entity_type: "repository", label: "cerebro" },
+        neighbors: [{ urn: "urn:cerebro:tenant-a:user:alice", entity_type: "user", label: "Alice" }],
+        relations: [{ from_urn: rootUrn, relation: "owned_by", to_urn: "urn:cerebro:tenant-a:user:alice" }],
+      }), { status: 200, headers: { "Content-Type": "application/json" } });
+    },
+  });
+
+  const response = await client.getEntityNeighborhood(` ${rootUrn} `, 50);
+
+  assert.deepEqual(response, {
+    root: { urn: rootUrn, entity_type: "repository", label: "cerebro" },
+    neighbors: [{ urn: "urn:cerebro:tenant-a:user:alice", entity_type: "user", label: "Alice" }],
+    relations: [{ from_urn: rootUrn, relation: "owned_by", to_urn: "urn:cerebro:tenant-a:user:alice" }],
+  });
+  assert.equal(requests.length, 1);
+  assert.equal(
+    requests[0].url,
+    "https://cerebro.example.com/api/platform/graph/neighborhood?root_urn=urn%3Acerebro%3Atenant-a%3Arepository%3Awriter%2Fcerebro&limit=50",
+  );
+  assert.equal(requests[0].headers.get("authorization"), `Bearer ${fixtureToken}`);
+  assert.equal(requests[0].headers.get("accept"), "application/json");
+  assert.equal(requests[0].headers.get("x-cerebro-tenant"), null);
+  assert.equal(requests[0].headers.get("x-cerebro-workspace"), null);
+  const requestURL = new URL(requests[0].url);
+  assert.equal(requestURL.searchParams.has("tenant_id"), false);
+  assert.equal(requestURL.searchParams.has("workspace_id"), false);
+});
+
+test("graph neighborhood caller forwards limits for authority-side clamping and preserves typed errors", async () => {
+  const requests = [];
+  const client = new Client({
+    baseUrl: "https://cerebro.example.com",
+    apiKey: fixtureToken,
+    fetchImpl: async (url, init = {}) => {
+      requests.push({ url: String(url), headers: new Headers(init.headers) });
+      return new Response(JSON.stringify({
+        error: "graph runtime unavailable",
+        code: "graph_unavailable",
+      }), { status: 503, headers: { "Content-Type": "application/json" } });
+    },
+  });
+
+  await assert.rejects(
+    client.getEntityNeighborhood(rootUrn, 51),
+    (error) => {
+      assert.ok(error instanceof APIError);
+      assert.equal(error.statusCode, 503);
+      assert.equal(error.code, "graph_unavailable");
+      assert.match(error.message, /graph runtime unavailable/);
+      assert.doesNotMatch(error.message, new RegExp(fixtureToken));
+      return true;
+    },
+  );
+  assert.equal(new URL(requests[0].url).pathname, "/platform/graph/neighborhood");
+  assert.equal(new URL(requests[0].url).searchParams.get("limit"), "51");
+  assert.equal(requests[0].headers.get("authorization"), `Bearer ${fixtureToken}`);
+});
+
+test("graph neighborhood caller rejects an empty root before making a request", async () => {
+  let requests = 0;
+  const client = new Client({
+    baseUrl: "https://cerebro.example.com",
+    fetchImpl: async () => {
+      requests += 1;
+      return new Response("{}", { status: 200 });
+    },
+  });
+
+  await assert.rejects(client.getEntityNeighborhood("  \t"), /rootUrn is required/);
+  assert.equal(requests, 0);
+});
+
+test("generated OpenAPI graph types retain the public neighborhood wire contract", async () => {
+  const generated = await readFile(generatedOpenAPIPath, "utf8");
+  const generatedType = (name) => {
+    const match = generated.match(new RegExp(`export type ${name} = \\{([\\s\\S]*?)\\n\\};`));
+    assert.ok(match, `generated type ${name} is missing`);
+    return match[1];
+  };
+
+  const entity = generatedType("GraphEntity");
+  assert.match(entity, /\n  entity_type: string;/);
+  assert.match(entity, /\n  label: string;/);
+  assert.match(entity, /\n  urn: string;/);
+
+  const relation = generatedType("GraphRelation");
+  assert.match(relation, /\n  from_urn: string;/);
+  assert.match(relation, /\n  relation: string;/);
+  assert.match(relation, /\n  to_urn: string;/);
+
+  const response = generatedType("GetEntityNeighborhoodResponse");
+  assert.match(response, /\n  neighbors\?: GraphEntity\[\];/);
+  assert.match(response, /\n  relations\?: GraphRelation\[\];/);
+  assert.match(response, /\n  root\?: GraphEntity;/);
+  assert.doesNotMatch(response, /tenant_id|workspace_id/);
+});


### PR DESCRIPTION
## Summary

- Route the Web graph-neighborhood product call directly to the existing Rust platform authority with server-owned tenant authentication.
- Remove the retired Go HTTP handler, route registration, auth policy entry, and route metric while retaining generated Connect and MCP compatibility surfaces.
- Keep OpenAPI and public-contract inventory parity aware of the Rust-owned route, and remove the Go adapter from the Rust product demo.
- Add focused TypeScript and Python SDK contract coverage for route, response, auth, scope, limit, and typed-error behavior.

## Validation

- `npm exec --workspace apps/web -- vitest run src/lib/cerebro-proxy.test.ts src/app/api/cerebro/[...path]/route.test.ts` (57 passed)
- `go test ./scripts -run TestRegisteredRustAuthorityRoutesRequiresTheNativeHandler|TestRouteParityIsBidirectional -count=1`
- `go run ./scripts/openapi_route_parity.go`
- `go test ./internal/bootstrap -run TestPublicContractInventoryGolden|TestConnectGraphNeighborhoodEndpoint|TestGRCEntityImpactWorkspaceFailuresSkipNeighborhoodAndLegacyFallback -count=1`
- `go test ./internal/sourcehttp/organizationalgraph -run TestQueryStoreReturnsRustNeighborhoodAndDelegatesRawCypher|TestProductNeighborhoodRejectsAmbiguousRustIdentity -count=1`
- `node --test sdk/typescript/test/graph-neighborhood-contract.test.mjs` (4 passed)
- `PYTHONPATH=sdk/python python3 -m unittest sdk/python/tests/test_graph_neighborhood_contract.py` (4 passed)
- `node --check apps/web/scripts/rust-product-demo.mjs`
- inventory authority/count assertions, `gofmt -d`, and `git diff --check`
- Practice Registry final diff gate: allowed, no findings

The initial local Go compilation attempt was capacity-blocked before test execution. Capacity recovered after the current-main merge, and the focused Go checks above passed; hosted checks remain authoritative for the full suite.