### PR TITLE
test(web): lock coverage workspace scope route

### DIFF
--- a/apps/web/src/app/api/cerebro/[...path]/route.test.ts
+++ b/apps/web/src/app/api/cerebro/[...path]/route.test.ts
@@ -97,6 +97,31 @@ describe("Cerebro proxy route", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
+  it("forwards tenant and workspace scope for connector coverage", async () => {
+    delete process.env.CEREBRO_WEB_FIXTURE_MODE;
+    let upstreamHeaders = new Headers();
+    const fetchMock = vi.fn(async (_url: URL | RequestInfo, init?: RequestInit) => {
+      upstreamHeaders = new Headers(init?.headers);
+      return new Response(JSON.stringify({ records: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await GET(
+      new NextRequest(
+        "http://localhost/api/cerebro/connectors/coverage?tenant_id=tenant-a&workspace_id=workspace-a",
+      ),
+      { params: Promise.resolve({ path: ["connectors", "coverage"] }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(upstreamHeaders.get("x-cerebro-tenant")).toBe("tenant-a");
+    expect(upstreamHeaders.get("x-cerebro-workspace")).toBe("workspace-a");
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
   it.each([
     ["orphan workspace", "http://localhost/api/cerebro/grc/dashboard?workspace_id=workspace-a", {}],
     ["mismatched workspace", "http://localhost/api/cerebro/grc/dashboard?tenant_id=tenant-a&workspace_id=workspace-a", { "X-Cerebro-Workspace": "workspace-b" }],


### PR DESCRIPTION
## Scope

- Add a route-level regression test for `GET /api/cerebro/connectors/coverage`.
- Prove `tenant_id` and `workspace_id` reach the upstream request as `X-Cerebro-Tenant` and `X-Cerebro-Workspace`.
- Keep the production implementation on current `main`; duplicated production and helper-test work from #2669 was dropped during the forward rebase.

## Why

Home requests connector coverage with application workspace scope. The production predicate now lives on current `main`; this PR locks the public route handler and upstream header boundary so that selector forwarding cannot regress independently of the helper.

## Validation

- `npm exec eslint -- src/app/api/cerebro/[...path]/route.test.ts`
- `npm test -- src/app/page.test.tsx src/app/grc/page.test.ts src/lib/cerebro-proxy.test.ts src/app/api/cerebro/[...path]/route.test.ts` — 75 passed
- `npm run build` — 49 pages, 77 standalone chunks
- `npm run e2e:web:fixtures` — 13 route contracts, 5 application chunks
- `bash scripts/leak_check.sh range origin/main...HEAD`
- Practice Registry final gate #3000 — allowed, zero findings
- Fresh Chromium render on `da37a510`: Home dashboard, readiness, and coverage requests all carried exact tenant/workspace scope, returned 200, and started within 1 ms; GRC successful dashboard/readiness requests started in the same millisecond. No console warnings or errors.