### PR TITLE
perf(grc): defer optional overview enrichment

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1639,15 +1639,6 @@ paths:
             type: string
         - $ref: '#/components/parameters/responseViewQuery'
         - $ref: '#/components/parameters/coverageScopeQuery'
-        - name: enrichments
-          in: query
-          schema:
-            type: string
-            enum:
-              - inline
-              - deferred
-            default: inline
-          description: Use deferred to return findings, controls, evidence, and connectors without waiting for source health and coverage enrichment.
         - $ref: '#/components/parameters/limitQuery'
       responses:
         '200':
@@ -2623,6 +2614,7 @@ paths:
         - $ref: '#/components/parameters/limitQuery'
         - $ref: '#/components/parameters/responseViewQuery'
         - $ref: '#/components/parameters/coverageScopeQuery'
+        - $ref: '#/components/parameters/enrichmentsQuery'
       responses:
         '200':
           description: GRC dashboard summary, priority findings, controls, evidence, and connector health.
@@ -2642,6 +2634,7 @@ paths:
         - $ref: '#/components/parameters/limitQuery'
         - $ref: '#/components/parameters/responseViewQuery'
         - $ref: '#/components/parameters/coverageScopeQuery'
+        - $ref: '#/components/parameters/enrichmentsQuery'
         - name: profile
           in: query
           schema:
@@ -7599,6 +7592,14 @@ components:
         type: string
         enum: [catalog, configured]
       description: Use configured for sources with a visible runtime or catalog for every registered source. Summary responses default to configured; expanded responses default to catalog.
+    enrichmentsQuery:
+      name: enrichments
+      in: query
+      schema:
+        type: string
+        enum: [inline, deferred]
+        default: inline
+      description: Use deferred to omit optional source-health enrichment from the initial response. Omit this parameter or use inline to preserve the complete response.
     inventorySurfaceQuery:
       name: surface
       in: query

--- a/apps/web/src/app/grc/page.test.ts
+++ b/apps/web/src/app/grc/page.test.ts
@@ -22,7 +22,7 @@ vi.mock("@/lib/grc-client", async (importOriginal) => {
 
 import { grcDashboardPath, grcProgramReadinessPath } from "@/lib/grc-client";
 
-import GRCPage, { buildIssueQueue, buildReadinessChecks } from "./page";
+import GRCPage, { buildIssueQueue, buildReadinessChecks, grcOverviewPaths } from "./page";
 
 const summary = (patch: Partial<GRCProgramReadinessSummary> = {}): GRCProgramReadinessSummary => ({
   status: "needs_attention",
@@ -46,6 +46,13 @@ const summary = (patch: Partial<GRCProgramReadinessSummary> = {}): GRCProgramRea
 });
 
 describe("GRC page helpers", () => {
+  it("defers optional graph enrichments for the overview reads", () => {
+    expect(grcOverviewPaths({ tenantID: "", workspaceID: "" })).toEqual({
+      dashboard: "/grc/dashboard?limit=12&enrichments=deferred&view=summary",
+      readiness: "/grc/program-readiness?enrichments=deferred&view=summary",
+    });
+  });
+
   it("builds issue queue rows with owner, assignee, due date, SLA, and source", () => {
     const readinessData = {
       work_items: [
@@ -206,8 +213,8 @@ describe("GRC page loading", () => {
     });
 
     expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([
-      grcDashboardPath({ limit: 12, tenant_id: "tenant-a", workspace_id: "workspace-a" }),
-      grcProgramReadinessPath({ tenant_id: "tenant-a", workspace_id: "workspace-a" }),
+      grcDashboardPath({ limit: 12, enrichments: "deferred", tenant_id: "tenant-a", workspace_id: "workspace-a" }),
+      grcProgramReadinessPath({ enrichments: "deferred", tenant_id: "tenant-a", workspace_id: "workspace-a" }),
     ]);
 
     const refresh = [...container.querySelectorAll("button")]

--- a/apps/web/src/app/grc/page.tsx
+++ b/apps/web/src/app/grc/page.tsx
@@ -64,8 +64,8 @@ export const grcOverviewPaths = (scope: GRCScope) => {
     return { dashboard: null, readiness: null };
   }
   return {
-    dashboard: grcDashboardPath({ limit: DASHBOARD_FINDING_LIMIT, ...query }),
-    readiness: grcProgramReadinessPath(query),
+    dashboard: grcDashboardPath({ limit: DASHBOARD_FINDING_LIMIT, enrichments: "deferred", ...query }),
+    readiness: grcProgramReadinessPath({ enrichments: "deferred", ...query }),
   };
 };
 

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -102,7 +102,7 @@ describe("Home review links", () => {
 
     expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([
       grcDashboardPath({ limit: 12, enrichments: "deferred" }),
-      grcProgramReadinessPath(),
+      grcProgramReadinessPath({ enrichments: "deferred" }),
       grcPath("/connectors/coverage", {
         coverage_scope: "configured",
         coverage_view: "page",
@@ -126,7 +126,7 @@ describe("Home review links", () => {
 
     expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([
       grcDashboardPath({ limit: 12, enrichments: "deferred", tenant_id: "tenant-a" }),
-      grcProgramReadinessPath({ tenant_id: "tenant-a" }),
+      grcProgramReadinessPath({ enrichments: "deferred", tenant_id: "tenant-a" }),
       grcPath("/connectors/coverage", {
         coverage_scope: "configured",
         coverage_view: "page",
@@ -150,7 +150,7 @@ describe("Home review links", () => {
 
     expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([
       grcDashboardPath({ limit: 12, enrichments: "deferred", tenant_id: "tenant-a", workspace_id: "workspace-a" }),
-      grcProgramReadinessPath({ tenant_id: "tenant-a", workspace_id: "workspace-a" }),
+      grcProgramReadinessPath({ enrichments: "deferred", tenant_id: "tenant-a", workspace_id: "workspace-a" }),
       grcPath("/connectors/coverage", {
         coverage_scope: "configured",
         coverage_view: "page",
@@ -174,7 +174,7 @@ describe("Home review links", () => {
 
     expect(mocks.useGRCQuery.mock.calls.map(([path]) => path)).toEqual([
       grcDashboardPath({ limit: 12, enrichments: "deferred", tenant_id: "tenant-a", workspace_id: "workspace-b" }),
-      grcProgramReadinessPath({ tenant_id: "tenant-a", workspace_id: "workspace-b" }),
+      grcProgramReadinessPath({ enrichments: "deferred", tenant_id: "tenant-a", workspace_id: "workspace-b" }),
       grcPath("/connectors/coverage", {
         coverage_scope: "configured",
         coverage_view: "page",
@@ -304,7 +304,7 @@ describe("Home review links", () => {
       connectors: [],
     };
     mocks.useGRCQuery.mockImplementation((path: string | null) => ({
-      data: path === dashboardPath ? dashboardData : path === grcProgramReadinessPath() ? readinessData : null,
+      data: path === dashboardPath ? dashboardData : path === grcProgramReadinessPath({ enrichments: "deferred" }) ? readinessData : null,
       durationMs: null,
       error: null,
       lastSuccessfulAt: null,

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -46,7 +46,7 @@ export const homeGRCPaths = (scope: GRCScope) => {
       enrichments: "deferred",
       ...query,
     }),
-    readiness: grcProgramReadinessPath(query),
+    readiness: grcProgramReadinessPath({ enrichments: "deferred", ...query }),
   };
 };
 

--- a/internal/bootstrap/grc_program_readiness.go
+++ b/internal/bootstrap/grc_program_readiness.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/writer/cerebro/internal/grcdashboard"
 	"github.com/writer/cerebro/internal/grcfindings"
 	"github.com/writer/cerebro/internal/grcprogram"
 	"github.com/writer/cerebro/internal/ports"
@@ -31,6 +32,11 @@ func (a *App) handleGRCProgramReadiness(w http.ResponseWriter, r *http.Request) 
 		writeGRCError(w, errors.Join(errInvalidHTTPRequest, err))
 		return
 	}
+	enrichments, err := grcdashboard.ParseEnrichments(r.URL.Query())
+	if err != nil {
+		writeGRCError(w, errors.Join(errInvalidHTTPRequest, err))
+		return
+	}
 	scope, err := grcScopeFromRequest(r)
 	if err != nil {
 		writeGRCError(w, err)
@@ -47,10 +53,10 @@ func (a *App) handleGRCProgramReadiness(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	generatedAt := time.Now().UTC()
-	coverage, sourceSummaries, err := grcprogram.RunReadinessEnrichments(r.Context(), grcRuntimeHealthEnrichmentTimeout, func(ctx context.Context) ([]sourcecoverage.Record, error) {
+	coverage, sourceSummaries, err := grcprogram.RunReadinessEnrichments(r.Context(), grcRuntimeHealthEnrichmentTimeout, enrichments != grcdashboard.EnrichmentsDeferred, func(ctx context.Context) ([]sourcecoverage.Record, error) {
 		return a.sourceCoverageRecordsScoped(ctx, runtimes, ports.SourceRuntimeFilter{
 			RuntimeID: scope.RuntimeID, RuntimeIDs: scope.RuntimeIDs, TenantID: scope.TenantID,
-			SourceID: scope.SourceID, Limit: scope.Limit,
+			ApplicationWorkspaceID: scope.ApplicationWorkspaceID, SourceID: scope.SourceID, Limit: scope.Limit,
 		}, generatedAt, coverageScope)
 	}, func(ctx context.Context) ([]sourceRuntimeHealthSummary, error) {
 		return a.grcSourceRuntimeHealthSummaries(ctx, runtimes, generatedAt)

--- a/internal/bootstrap/grc_program_readiness_test.go
+++ b/internal/bootstrap/grc_program_readiness_test.go
@@ -12,6 +12,7 @@ import (
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecdk"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -94,6 +95,9 @@ func TestGRCProgramReadinessEndpointReturnsProofBundleWorkQueue(t *testing.T) {
 	if len(payload.ProductAreas) == 0 {
 		t.Fatalf("product areas = 0, want backend product area taxonomy")
 	}
+	if len(payload.SourceSummaries) != 1 || payload.SourceSummaries[0].SourceID != "okta" {
+		t.Fatalf("source summaries = %#v, want default inline runtime health", payload.SourceSummaries)
+	}
 	if payload.ProductAreas[0].ID != "compliance" || payload.ProductAreas[0].Status == "" {
 		t.Fatalf("first product area = %+v, want compliance area with status", payload.ProductAreas[0])
 	}
@@ -142,5 +146,74 @@ func TestGRCProgramReadinessReturnsCoreDataWhenRuntimeHealthUnavailable(t *testi
 
 	if !strings.Contains(stderr, `"name":"sourcehealth.latest_graph_runs"`) {
 		t.Fatalf("runtime health failure telemetry missing: %s", stderr)
+	}
+}
+
+func TestGRCProgramReadinessDefersRuntimeHealthLookup(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(sourceCoverageHealthSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &stubRuntimeStore{
+		runtimes: map[string]*cerebrov1.SourceRuntime{
+			"writer-okta": {
+				Id:       "writer-okta",
+				SourceId: "okta",
+				TenantId: "writer",
+				Config:   map[string]string{"family": "user"},
+			},
+		},
+		findings:        map[string]*ports.FindingRecord{},
+		findingEvidence: map[string]*cerebrov1.FindingEvidence{},
+	}
+	app := New(
+		config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second},
+		Dependencies{
+			StateStore: store,
+			GraphStore: &stubGraphStore{err: errors.New("deferred runtime health graph read must not run")},
+		},
+		registry,
+	)
+	server := httptest.NewServer(app.Handler())
+
+	stderr := captureBootstrapStderr(t, func() {
+		defer server.Close()
+		resp, err := server.Client().Get(server.URL + "/grc/program-readiness?tenant_id=writer&limit=1&enrichments=deferred")
+		if err != nil {
+			t.Fatalf("GET /grc/program-readiness error = %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET /grc/program-readiness status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		var payload grcProgramReadinessResponse
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode /grc/program-readiness: %v", err)
+		}
+		if len(payload.SourceSummaries) != 0 {
+			t.Fatalf("source summaries = %#v, want deferred enrichment omitted", payload.SourceSummaries)
+		}
+		if len(payload.CoverageSummaries) == 0 || len(payload.ProductAreas) == 0 {
+			t.Fatalf("required coverage summaries/product areas = %d/%d, want populated", len(payload.CoverageSummaries), len(payload.ProductAreas))
+		}
+	})
+
+	if strings.Contains(stderr, `"name":"sourcehealth.latest_graph_runs"`) {
+		t.Fatalf("deferred runtime health lookup ran: %s", stderr)
+	}
+}
+
+func TestGRCProgramReadinessRejectsInvalidEnrichments(t *testing.T) {
+	app := New(config.Config{HTTPAddr: "127.0.0.1:0", ShutdownTimeout: time.Second}, Dependencies{}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	resp, err := server.Client().Get(server.URL + "/grc/program-readiness?enrichments=eventually")
+	if err != nil {
+		t.Fatalf("GET /grc/program-readiness error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("GET /grc/program-readiness status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
 	}
 }

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -166,24 +166,38 @@ func (a *App) handleListRuntimeFreshness(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, runtimeFreshnessFromHealth(health))
 }
 func (a *App) handleGetConnectorCoverage(w http.ResponseWriter, r *http.Request) {
-	health, err := a.listSourceRuntimeHealth(r)
-	if err != nil {
-		writeSourceRuntimeError(w, err)
-		return
-	}
-	coverage := health.coverageRecords
-	if coverage == nil {
-		coverage = health.Coverage
-	}
-	report := sourcecoverage.BuildScopedReport(coverage, r.URL.Query().Get("tenant_id"), r.URL.Query().Get("source_id"), health.GeneratedAt)
-	emitSourceCoverageGateTelemetry(r.Context(), report)
-	response := nhicoverage.WithSourceCoverage(report)
-	view, err := coverageview.FromRequest(r)
+	coverageScope, err := responseview.CoverageScopeForRequest(r)
 	if err != nil {
 		writeSourceRuntimeError(w, errors.Join(sourceruntime.ErrInvalidRequest, err))
 		return
 	}
-	switch view {
+	filter, empty, err := a.sourceRuntimeHealthFilterFromRequest(r)
+	if err != nil {
+		writeSourceRuntimeError(w, err)
+		return
+	}
+	generatedAt, coverage := time.Now().UTC(), []sourcecoverage.Record(nil)
+	if !empty {
+		runtimes, err := a.listVisibleSourceRuntimes(r, filter)
+		if err != nil {
+			writeSourceRuntimeError(w, err)
+			return
+		}
+		coverage, err = a.sourceCoverageRecordsScoped(r.Context(), runtimes, filter, generatedAt, coverageScope)
+		if err != nil {
+			writeSourceRuntimeError(w, err)
+			return
+		}
+	}
+	report := sourcecoverage.BuildScopedReport(coverage, filter.TenantID, filter.SourceID, generatedAt.Format(time.RFC3339Nano))
+	emitSourceCoverageGateTelemetry(r.Context(), report)
+	response := nhicoverage.WithSourceCoverage(report)
+	coverageView, err := coverageview.FromRequest(r)
+	if err != nil {
+		writeSourceRuntimeError(w, errors.Join(sourceruntime.ErrInvalidRequest, err))
+		return
+	}
+	switch coverageView {
 	case coverageview.Expanded:
 		writeJSON(w, http.StatusOK, response)
 	case coverageview.Summary:
@@ -206,74 +220,18 @@ func (a *App) listSourceRuntimeHealth(r *http.Request) (sourceRuntimeHealthRespo
 	if err != nil {
 		return sourceRuntimeHealthResponse{}, errors.Join(sourceruntime.ErrInvalidRequest, err)
 	}
-	limit, err := uint32QueryParam(r, "limit")
+	filter, empty, err := a.sourceRuntimeHealthFilterFromRequest(r)
 	if err != nil {
 		return sourceRuntimeHealthResponse{}, err
 	}
-	filter := ports.SourceRuntimeFilter{
-		RuntimeID:  strings.TrimSpace(r.URL.Query().Get("runtime_id")),
-		RuntimeIDs: csvQueryValues(r.URL.Query().Get("runtime_ids")),
-		TenantID:   strings.TrimSpace(r.URL.Query().Get("tenant_id")),
-		SourceID:   strings.TrimSpace(r.URL.Query().Get("source_id")),
-		Limit:      limit,
+	if empty {
+		return sourceRuntimeHealthResponse{GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano)}, nil
 	}
-	if filter.TenantID == "" {
-		if auth, ok := r.Context().Value(authContextKey{}).(authContext); ok && strings.TrimSpace(auth.principal.TenantID) != "" {
-			filter.TenantID = strings.TrimSpace(auth.principal.TenantID)
-		}
-	}
-	if filter.TenantID == "" {
-		filter.TenantID = strings.TrimSpace(r.Header.Get("X-Cerebro-Tenant"))
-	}
-	if filter.TenantID == "" && filter.RuntimeID != "" && requiresTenantFilter(r.Context()) {
-		store := sourceRuntimeStore(a.deps.StateStore)
-		if store == nil {
-			return sourceRuntimeHealthResponse{}, sourceruntime.ErrRuntimeUnavailable
-		}
-		runtime, err := store.GetSourceRuntime(r.Context(), filter.RuntimeID)
-		if errors.Is(err, ports.ErrSourceRuntimeNotFound) {
-			return sourceRuntimeHealthResponse{GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano)}, nil
-		}
-		if err != nil {
-			return sourceRuntimeHealthResponse{}, err
-		}
-		if !tenantAllowedByContext(r.Context(), runtime.GetTenantId()) {
-			return sourceRuntimeHealthResponse{GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano)}, nil
-		}
-		filter.TenantID = strings.TrimSpace(runtime.GetTenantId())
-	}
-	if filter.TenantID == "" && filter.RuntimeID == "" && len(filter.RuntimeIDs) == 0 && requiresTenantFilter(r.Context()) {
-		return sourceRuntimeHealthResponse{}, errTenantForbidden
-	}
-	if err := authorizeTenantID(r.Context(), filter.TenantID); err != nil {
-		return sourceRuntimeHealthResponse{}, err
-	}
-	store := sourceRuntimeStore(a.deps.StateStore)
-	if store == nil {
-		return sourceRuntimeHealthResponse{}, sourceruntime.ErrRuntimeUnavailable
-	}
-	lister, ok := store.(ports.SourceRuntimeListStore)
-	if !ok {
-		return sourceRuntimeHealthResponse{}, sourceruntime.ErrRuntimeUnavailable
-	}
-	if filter.Limit == 0 {
-		filter.Limit = 100
-	}
-	runtimes, err := lister.ListSourceRuntimes(r.Context(), filter)
+	visibleRuntimes, err := a.listVisibleSourceRuntimes(r, filter)
 	if err != nil {
 		return sourceRuntimeHealthResponse{}, err
 	}
 	generatedAt := time.Now().UTC()
-	visibleRuntimes := make([]*cerebrov1.SourceRuntime, 0, len(runtimes))
-	for _, runtime := range runtimes {
-		if runtime == nil {
-			continue
-		}
-		if requiresTenantFilter(r.Context()) && !tenantAllowedByContext(r.Context(), runtime.GetTenantId()) {
-			continue
-		}
-		visibleRuntimes = append(visibleRuntimes, runtime)
-	}
 	records, err := a.sourceRuntimeHealthRecords(r.Context(), visibleRuntimes, generatedAt)
 	if err != nil {
 		return sourceRuntimeHealthResponse{}, err
@@ -295,6 +253,75 @@ func (a *App) listSourceRuntimeHealth(r *http.Request) (sourceRuntimeHealthRespo
 		view:            view,
 		coverageRecords: coverage,
 	}, nil
+}
+
+func (a *App) sourceRuntimeHealthFilterFromRequest(r *http.Request) (ports.SourceRuntimeFilter, bool, error) {
+	limit, err := uint32QueryParam(r, "limit")
+	if err != nil {
+		return ports.SourceRuntimeFilter{}, false, err
+	}
+	workspaceID, err := requestApplicationWorkspaceSelector(r)
+	if err != nil {
+		return ports.SourceRuntimeFilter{}, false, err
+	}
+	explicitTenantID := strings.TrimSpace(r.URL.Query().Get("tenant_id"))
+	if explicitTenantID == "" {
+		explicitTenantID = strings.TrimSpace(r.Header.Get("X-Cerebro-Tenant"))
+	}
+	if workspaceID != "" && explicitTenantID == "" {
+		return ports.SourceRuntimeFilter{}, false, fmt.Errorf("%w: tenant_id is required with workspace_id", errInvalidHTTPRequest)
+	}
+	filter := ports.SourceRuntimeFilter{
+		RuntimeID: strings.TrimSpace(r.URL.Query().Get("runtime_id")), RuntimeIDs: csvQueryValues(r.URL.Query().Get("runtime_ids")),
+		TenantID: strings.TrimSpace(r.URL.Query().Get("tenant_id")), ApplicationWorkspaceID: workspaceID,
+		SourceID: strings.TrimSpace(r.URL.Query().Get("source_id")), Limit: limit,
+	}
+	if filter.TenantID == "" {
+		if auth, ok := r.Context().Value(authContextKey{}).(authContext); ok {
+			filter.TenantID = strings.TrimSpace(auth.principal.TenantID)
+		}
+	}
+	if filter.TenantID == "" {
+		filter.TenantID = strings.TrimSpace(r.Header.Get("X-Cerebro-Tenant"))
+	}
+	if filter.TenantID == "" && filter.RuntimeID != "" && requiresTenantFilter(r.Context()) {
+		store := sourceRuntimeStore(a.deps.StateStore)
+		if store == nil {
+			return ports.SourceRuntimeFilter{}, false, sourceruntime.ErrRuntimeUnavailable
+		}
+		runtime, err := store.GetSourceRuntime(r.Context(), filter.RuntimeID)
+		if errors.Is(err, ports.ErrSourceRuntimeNotFound) || (err == nil && !tenantAllowedByContext(r.Context(), runtime.GetTenantId())) {
+			return filter, true, nil
+		}
+		if err != nil {
+			return ports.SourceRuntimeFilter{}, false, err
+		}
+		filter.TenantID = strings.TrimSpace(runtime.GetTenantId())
+	}
+	if filter.TenantID == "" && filter.RuntimeID == "" && len(filter.RuntimeIDs) == 0 && requiresTenantFilter(r.Context()) {
+		return ports.SourceRuntimeFilter{}, false, errTenantForbidden
+	}
+	if err := authorizeTenantID(r.Context(), filter.TenantID); err != nil {
+		return ports.SourceRuntimeFilter{}, false, err
+	}
+	if err := authorizeApplicationWorkspaceID(r.Context(), filter.TenantID, filter.ApplicationWorkspaceID); err != nil {
+		return ports.SourceRuntimeFilter{}, false, err
+	}
+	if filter.Limit == 0 {
+		filter.Limit = 100
+	}
+	return filter, false, nil
+}
+
+func (a *App) listVisibleSourceRuntimes(r *http.Request, filter ports.SourceRuntimeFilter) ([]*cerebrov1.SourceRuntime, error) {
+	store := sourceRuntimeStore(a.deps.StateStore)
+	lister, ok := store.(ports.SourceRuntimeListStore)
+	if !ok || isNilInterface(lister) {
+		return nil, sourceruntime.ErrRuntimeUnavailable
+	}
+	return sourceruntime.ListVisibleRuntimes(r.Context(), lister, filter, func(tenantID string) bool {
+		return !requiresTenantFilter(r.Context()) || tenantAllowedByContext(r.Context(), tenantID)
+	})
 }
 
 func emptySourceRuntimeHealthResponse() sourceRuntimeHealthResponse {
@@ -341,37 +368,12 @@ func (a *App) sourceCoverageRecords(ctx context.Context, runtimes []*cerebrov1.S
 }
 
 func (a *App) sourceCoverageRecordsScoped(ctx context.Context, runtimes []*cerebrov1.SourceRuntime, filter ports.SourceRuntimeFilter, generatedAt time.Time, scope responseview.CoverageScope) ([]sourcecoverage.Record, error) {
-	if a == nil || a.sources == nil {
-		return nil, nil
-	}
-	contracts := sourcecoverage.ContractsFromRegistry(a.sources)
-	if scope == responseview.CoverageConfigured {
-		configuredSources := make(map[string]struct{}, len(runtimes))
-		for _, runtime := range runtimes {
-			if runtime == nil {
-				continue
-			}
-			if sourceID := strings.TrimSpace(runtime.GetSourceId()); sourceID != "" {
-				configuredSources[sourceID] = struct{}{}
-			}
-		}
-		configuredContracts := contracts[:0]
-		for _, contract := range contracts {
-			if _, ok := configuredSources[strings.TrimSpace(contract.SourceID)]; ok {
-				configuredContracts = append(configuredContracts, contract)
-			}
-		}
-		contracts = configuredContracts
-	}
-	if len(contracts) == 0 {
-		return nil, nil
-	}
-	observations := sourcecoverage.ObservationsFromRuntimes(runtimes, func(runtime *cerebrov1.SourceRuntime) string {
-		return runtimeHealthStatus(runtime, generatedAt)
-	})
-	records, err := sourcecoverage.Evaluate(ctx, contracts, observations, sourcecoverage.Options{
-		TenantID: strings.TrimSpace(filter.TenantID),
-		SourceID: strings.TrimSpace(filter.SourceID),
+	records, err := sourcecoverage.EvaluateRuntimes(ctx, a.sources, runtimes, sourcecoverage.RuntimeEvaluationOptions{
+		Options:        sourcecoverage.Options{TenantID: strings.TrimSpace(filter.TenantID), SourceID: strings.TrimSpace(filter.SourceID)},
+		ConfiguredOnly: scope == responseview.CoverageConfigured,
+		Status: func(runtime *cerebrov1.SourceRuntime) string {
+			return runtimeHealthStatus(runtime, generatedAt)
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("%w: evaluate source coverage: %w", sourceruntime.ErrRuntimeUnavailable, err)

--- a/internal/bootstrap/source_runtime_health_test.go
+++ b/internal/bootstrap/source_runtime_health_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/config"
 	"github.com/writer/cerebro/internal/graphstore"
 	"github.com/writer/cerebro/internal/nhicoverage"
 	"github.com/writer/cerebro/internal/ports"
@@ -23,6 +24,19 @@ import (
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+type unfilteredRuntimeListStore struct {
+	*stubRuntimeStore
+}
+
+func (s *unfilteredRuntimeListStore) ListSourceRuntimes(_ context.Context, filter ports.SourceRuntimeFilter) ([]*cerebrov1.SourceRuntime, error) {
+	s.sourceRuntimeListFilter = filter
+	runtimes := make([]*cerebrov1.SourceRuntime, 0, len(s.runtimes))
+	for _, runtime := range s.runtimes {
+		runtimes = append(runtimes, runtime)
+	}
+	return runtimes, nil
+}
 
 func TestSourceRuntimeHealthRecordIncludesScheduleReceipt(t *testing.T) {
 	now := time.Date(2026, 6, 9, 12, 0, 0, 0, time.UTC)
@@ -641,7 +655,7 @@ func TestSourceRuntimeHealthRecordsBatchLatestRunQueries(t *testing.T) {
 	}
 }
 
-func TestConnectorCoverageReportUsesAuthenticatedTenantAndBlindSpotTotals(t *testing.T) {
+func TestConnectorCoverageReportUsesAuthenticatedTenantWithoutRuntimeHealthLookups(t *testing.T) {
 	registry, err := sourcecdk.NewRegistry(sourceCoverageHealthSource{})
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
@@ -663,7 +677,10 @@ func TestConnectorCoverageReportUsesAuthenticatedTenantAndBlindSpotTotals(t *tes
 			Config:       map[string]string{"family": "application"},
 		},
 	}}
-	app := &App{deps: Dependencies{StateStore: store}, sources: registry}
+	app := &App{deps: Dependencies{
+		StateStore: store,
+		GraphStore: &stubGraphStore{err: errors.New("connector coverage must not query runtime health")},
+	}, sources: registry}
 	recorder := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/connectors/coverage?source_id=okta", nil)
 	req = req.WithContext(context.WithValue(req.Context(), authContextKey{}, authContext{
@@ -704,6 +721,129 @@ func TestConnectorCoverageReportUsesAuthenticatedTenantAndBlindSpotTotals(t *tes
 		if record.TenantID == "other" || record.RuntimeID == "other-okta-application" {
 			t.Fatalf("report leaked other tenant record: %#v", record)
 		}
+	}
+	if got := store.findingEvaluationRunListRequest; got.LatestByRuntime || len(got.RuntimeIDs) != 0 {
+		t.Fatalf("connector coverage queried finding runtime health: %#v", got)
+	}
+}
+
+func TestConnectorCoverageResolvesAuthorizedTenantFromRuntimeID(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(sourceCoverageHealthSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-okta-user": {
+			Id: "writer-okta-user", SourceId: "okta", TenantId: "writer", Config: map[string]string{"family": "user"},
+		},
+	}}
+	app := &App{deps: Dependencies{StateStore: store}, sources: registry}
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/connectors/coverage?runtime_id=writer-okta-user", nil)
+	req = req.WithContext(context.WithValue(req.Context(), authContextKey{}, authContext{
+		principal: authPrincipal{AllowedTenants: []string{"writer"}},
+	}))
+
+	app.handleGetConnectorCoverage(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	if got := store.sourceRuntimeListFilter; got.TenantID != "writer" || got.RuntimeID != "writer-okta-user" {
+		t.Fatalf("runtime filter = %#v, want resolved writer runtime", got)
+	}
+	var report nhicoverage.SourceCoverageResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&report); err != nil {
+		t.Fatalf("decode report: %v", err)
+	}
+	if report.TenantID != "writer" {
+		t.Fatalf("report tenant = %q, want writer", report.TenantID)
+	}
+}
+
+func TestConnectorCoverageFiltersRuntimesByAuthorizedApplicationWorkspace(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(sourceCoverageHealthSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	baseStore := &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{
+		"writer-okta-user": {
+			Id:       "writer-okta-user",
+			SourceId: "okta",
+			TenantId: "writer",
+			Config: map[string]string{
+				"family": "user",
+				ports.SourceRuntimeApplicationWorkspaceIDConfigKey: "workspace-a",
+			},
+		},
+		"writer-okta-application": {
+			Id:       "writer-okta-application",
+			SourceId: "okta",
+			TenantId: "writer",
+			Config: map[string]string{
+				"family": "application",
+				ports.SourceRuntimeApplicationWorkspaceIDConfigKey: "workspace-b",
+			},
+		},
+		"other-okta-user": {
+			Id:       "other-okta-user",
+			SourceId: "okta",
+			TenantId: "other",
+			Config: map[string]string{
+				"family": "user",
+				ports.SourceRuntimeApplicationWorkspaceIDConfigKey: "workspace-a",
+			},
+		},
+	}}
+	store := &unfilteredRuntimeListStore{stubRuntimeStore: baseStore}
+	app := &App{deps: Dependencies{StateStore: store}, sources: registry}
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/connectors/coverage?tenant_id=writer&workspace_id=workspace-a&source_id=okta", nil)
+	req = req.WithContext(context.WithValue(req.Context(), authContextKey{}, authContext{
+		principal: authPrincipal{
+			AllowedTenants: []string{"writer"},
+			ApplicationWorkspaceGrants: []config.ApplicationWorkspaceGrant{{
+				TenantID: "writer", ApplicationWorkspaceIDs: []string{"workspace-a"},
+			}},
+		},
+	}))
+
+	app.handleGetConnectorCoverage(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	if got := store.sourceRuntimeListFilter; got.TenantID != "writer" || got.ApplicationWorkspaceID != "workspace-a" {
+		t.Fatalf("runtime filter = %#v, want writer/workspace-a", got)
+	}
+	var report nhicoverage.SourceCoverageResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&report); err != nil {
+		t.Fatalf("decode report: %v", err)
+	}
+	for _, record := range report.Records {
+		if record.RuntimeID == "writer-okta-application" || record.RuntimeID == "other-okta-user" {
+			t.Fatalf("coverage leaked runtime outside writer/workspace-a: %#v", record)
+		}
+	}
+}
+
+func TestConnectorCoverageRejectsApplicationWorkspaceOutsidePrincipalGrant(t *testing.T) {
+	app := &App{deps: Dependencies{StateStore: &stubRuntimeStore{runtimes: map[string]*cerebrov1.SourceRuntime{}}}}
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/connectors/coverage?tenant_id=writer&workspace_id=workspace-b", nil)
+	req = req.WithContext(context.WithValue(req.Context(), authContextKey{}, authContext{
+		principal: authPrincipal{
+			AllowedTenants: []string{"writer"},
+			ApplicationWorkspaceGrants: []config.ApplicationWorkspaceGrant{{
+				TenantID: "writer", ApplicationWorkspaceIDs: []string{"workspace-a"},
+			}},
+		},
+	}))
+
+	app.handleGetConnectorCoverage(recorder, req)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusForbidden, recorder.Body.String())
 	}
 }
 

--- a/internal/grcprogram/enrichment.go
+++ b/internal/grcprogram/enrichment.go
@@ -9,9 +9,14 @@ import (
 
 // RunReadinessEnrichments runs required enrichment alongside bounded optional
 // enrichment. Optional failure degrades the response; required failure stops it.
-func RunReadinessEnrichments[Required, Optional any](ctx context.Context, optionalTimeout time.Duration, required func(context.Context) (Required, error), optional func(context.Context) (Optional, error)) (Required, Optional, error) {
+// Callers can defer optional work when the response does not need it inline.
+func RunReadinessEnrichments[Required, Optional any](ctx context.Context, optionalTimeout time.Duration, includeOptional bool, required func(context.Context) (Required, error), optional func(context.Context) (Optional, error)) (Required, Optional, error) {
 	var requiredResult Required
 	var optionalResult Optional
+	if !includeOptional {
+		requiredResult, err := required(ctx)
+		return requiredResult, optionalResult, err
+	}
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.Go(func() error {
 		var err error

--- a/internal/grcprogram/enrichment_test.go
+++ b/internal/grcprogram/enrichment_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestRunReadinessEnrichmentsIgnoresOptionalFailure(t *testing.T) {
 	optionalErr := errors.New("optional enrichment unavailable")
-	required, optional, err := RunReadinessEnrichments(t.Context(), time.Second, func(context.Context) (string, error) { return "required", nil }, func(context.Context) (string, error) { return "partial", optionalErr })
+	required, optional, err := RunReadinessEnrichments(t.Context(), time.Second, true, func(context.Context) (string, error) { return "required", nil }, func(context.Context) (string, error) { return "partial", optionalErr })
 	if err != nil {
 		t.Fatalf("RunReadinessEnrichments() error = %v, want nil", err)
 	}
@@ -20,7 +20,7 @@ func TestRunReadinessEnrichmentsIgnoresOptionalFailure(t *testing.T) {
 
 func TestRunReadinessEnrichmentsReturnsRequiredFailure(t *testing.T) {
 	requiredErr := errors.New("required enrichment unavailable")
-	_, _, err := RunReadinessEnrichments(t.Context(), time.Second, func(context.Context) (string, error) { return "", requiredErr }, func(context.Context) (string, error) { return "optional", nil })
+	_, _, err := RunReadinessEnrichments(t.Context(), time.Second, true, func(context.Context) (string, error) { return "", requiredErr }, func(context.Context) (string, error) { return "optional", nil })
 	if !errors.Is(err, requiredErr) {
 		t.Fatalf("RunReadinessEnrichments() error = %v, want %v", err, requiredErr)
 	}
@@ -28,7 +28,7 @@ func TestRunReadinessEnrichmentsReturnsRequiredFailure(t *testing.T) {
 
 func TestRunReadinessEnrichmentsBoundsOptionalWork(t *testing.T) {
 	startedAt := time.Now()
-	_, _, err := RunReadinessEnrichments(t.Context(), time.Millisecond, func(context.Context) (string, error) { return "required", nil }, func(ctx context.Context) (string, error) {
+	_, _, err := RunReadinessEnrichments(t.Context(), time.Millisecond, true, func(context.Context) (string, error) { return "required", nil }, func(ctx context.Context) (string, error) {
 		<-ctx.Done()
 		return "", ctx.Err()
 	})
@@ -37,5 +37,24 @@ func TestRunReadinessEnrichmentsBoundsOptionalWork(t *testing.T) {
 	}
 	if elapsed := time.Since(startedAt); elapsed > time.Second {
 		t.Fatalf("RunReadinessEnrichments() elapsed = %s, want bounded optional work", elapsed)
+	}
+}
+
+func TestRunReadinessEnrichmentsDefersOptionalWork(t *testing.T) {
+	optionalCalled := false
+	required, optional, err := RunReadinessEnrichments(t.Context(), time.Second, false, func(context.Context) (string, error) {
+		return "required", nil
+	}, func(context.Context) (string, error) {
+		optionalCalled = true
+		return "optional", nil
+	})
+	if err != nil {
+		t.Fatalf("RunReadinessEnrichments() error = %v, want nil", err)
+	}
+	if required != "required" || optional != "" {
+		t.Fatalf("RunReadinessEnrichments() = %q, %q, want required result and omitted optional result", required, optional)
+	}
+	if optionalCalled {
+		t.Fatal("RunReadinessEnrichments() called deferred optional work")
 	}
 }

--- a/internal/sourcecoverage/coverage.go
+++ b/internal/sourcecoverage/coverage.go
@@ -26,6 +26,12 @@ type Options struct {
 	SourceID string
 }
 
+type RuntimeEvaluationOptions struct {
+	Options
+	ConfiguredOnly bool
+	Status         func(*cerebrov1.SourceRuntime) string
+}
+
 type RuntimeObservation struct {
 	RuntimeID           string
 	SourceID            string
@@ -139,6 +145,34 @@ func ObservationsFromRuntimes(runtimes []*cerebrov1.SourceRuntime, status func(*
 
 func Evaluate(ctx context.Context, contracts []sourcecdk.CoverageContract, observations []RuntimeObservation, options Options) ([]Record, error) {
 	return evaluateCoverage(ctx, contracts, observations, options)
+}
+
+// EvaluateRuntimes evaluates catalog contracts against visible runtime state.
+func EvaluateRuntimes(ctx context.Context, registry *sourcecdk.Registry, runtimes []*cerebrov1.SourceRuntime, options RuntimeEvaluationOptions) ([]Record, error) {
+	contracts := ContractsFromRegistry(registry)
+	if options.ConfiguredOnly {
+		configuredSources := make(map[string]struct{}, len(runtimes))
+		for _, runtime := range runtimes {
+			if runtime != nil && strings.TrimSpace(runtime.GetSourceId()) != "" {
+				configuredSources[strings.TrimSpace(runtime.GetSourceId())] = struct{}{}
+			}
+		}
+		configuredContracts := make([]sourcecdk.CoverageContract, 0, len(contracts))
+		for _, contract := range contracts {
+			if _, ok := configuredSources[strings.TrimSpace(contract.SourceID)]; ok {
+				configuredContracts = append(configuredContracts, contract)
+			}
+		}
+		contracts = configuredContracts
+	}
+	if len(contracts) == 0 {
+		return nil, nil
+	}
+	status := options.Status
+	if status == nil {
+		status = func(*cerebrov1.SourceRuntime) string { return "" }
+	}
+	return Evaluate(ctx, contracts, ObservationsFromRuntimes(runtimes, status), options.Options)
 }
 
 func runtimeCertificationTier(value string) CertificationTier {

--- a/internal/sourcehttp/responseview/response_view.go
+++ b/internal/sourcehttp/responseview/response_view.go
@@ -60,6 +60,14 @@ func CoverageScopeFromRequest(r *http.Request, view View) (CoverageScope, error)
 	}
 }
 
+func CoverageScopeForRequest(r *http.Request) (CoverageScope, error) {
+	view, err := FromRequest(r)
+	if err != nil {
+		return CoverageCatalog, err
+	}
+	return CoverageScopeFromRequest(r, view)
+}
+
 func CompactProductAreas(views []grcproductareas.View) []grcproductareas.View {
 	for index := range views {
 		views[index].BlindSpots = nil

--- a/internal/sourcehttp/responseview/response_view_test.go
+++ b/internal/sourcehttp/responseview/response_view_test.go
@@ -40,4 +40,7 @@ func TestViewRejectsUnsupportedValues(t *testing.T) {
 	if _, err := FromRequest(request); err == nil {
 		t.Fatal("FromRequest() error = nil, want invalid view")
 	}
+	if _, err := CoverageScopeForRequest(request); err == nil {
+		t.Fatal("CoverageScopeForRequest() error = nil, want invalid view")
+	}
 }

--- a/internal/sourceruntime/visibility.go
+++ b/internal/sourceruntime/visibility.go
@@ -1,0 +1,32 @@
+package sourceruntime
+
+import (
+	"context"
+	"strings"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type runtimeLister interface {
+	ListSourceRuntimes(context.Context, ports.SourceRuntimeFilter) ([]*cerebrov1.SourceRuntime, error)
+}
+
+// ListVisibleRuntimes applies tenant and workspace boundaries even when a
+// runtime store returns rows outside the requested filter.
+func ListVisibleRuntimes(ctx context.Context, lister runtimeLister, filter ports.SourceRuntimeFilter, tenantAllowed func(string) bool) ([]*cerebrov1.SourceRuntime, error) {
+	runtimes, err := lister.ListSourceRuntimes(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	visible := make([]*cerebrov1.SourceRuntime, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		if runtime == nil || (filter.TenantID != "" && strings.TrimSpace(runtime.GetTenantId()) != filter.TenantID) ||
+			(filter.ApplicationWorkspaceID != "" && strings.TrimSpace(runtime.GetConfig()[ports.SourceRuntimeApplicationWorkspaceIDConfigKey]) != filter.ApplicationWorkspaceID) ||
+			(tenantAllowed != nil && !tenantAllowed(runtime.GetTenantId())) {
+			continue
+		}
+		visible = append(visible, runtime)
+	}
+	return visible, nil
+}

--- a/internal/sourceruntime/visibility_test.go
+++ b/internal/sourceruntime/visibility_test.go
@@ -1,0 +1,36 @@
+package sourceruntime
+
+import (
+	"context"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+type unfilteredRuntimeLister struct {
+	runtimes []*cerebrov1.SourceRuntime
+}
+
+func (s unfilteredRuntimeLister) ListSourceRuntimes(context.Context, ports.SourceRuntimeFilter) ([]*cerebrov1.SourceRuntime, error) {
+	return s.runtimes, nil
+}
+
+func TestListVisibleRuntimesEnforcesTenantAndWorkspaceBoundaries(t *testing.T) {
+	lister := unfilteredRuntimeLister{runtimes: []*cerebrov1.SourceRuntime{
+		{Id: "visible", TenantId: "writer", Config: map[string]string{ports.SourceRuntimeApplicationWorkspaceIDConfigKey: "workspace-a"}},
+		{Id: "other-workspace", TenantId: "writer", Config: map[string]string{ports.SourceRuntimeApplicationWorkspaceIDConfigKey: "workspace-b"}},
+		{Id: "other-tenant", TenantId: "other", Config: map[string]string{ports.SourceRuntimeApplicationWorkspaceIDConfigKey: "workspace-a"}},
+		nil,
+	}}
+
+	runtimes, err := ListVisibleRuntimes(t.Context(), lister, ports.SourceRuntimeFilter{
+		TenantID: "writer", ApplicationWorkspaceID: "workspace-a",
+	}, func(tenantID string) bool { return tenantID == "writer" })
+	if err != nil {
+		t.Fatalf("ListVisibleRuntimes() error = %v", err)
+	}
+	if len(runtimes) != 1 || runtimes[0].GetId() != "visible" {
+		t.Fatalf("ListVisibleRuntimes() = %#v, want only visible runtime", runtimes)
+	}
+}


### PR DESCRIPTION
Summary
- Request deferred optional graph enrichment for authenticated Home and GRC overview dashboard and readiness reads while keeping both reads concurrent.
- Build connector coverage directly from visible runtimes and catalog contracts instead of running graph-backed runtime and finding health.
- Preserve runtime_id compatibility and enforce tenant and workspace scope before coverage evaluation, including a post-list visibility guard.

Validation
- Exact head: go test ./internal/bootstrap ./internal/grcprogram ./internal/sourcecoverage ./internal/sourcehttp/responseview ./internal/sourceruntime -count=1
- Exact head: npx vitest run src/app/page.test.tsx src/app/grc/page.test.ts
- Same patch before the final unrelated main refresh: race tests for all affected Go packages; full web lint plus 723 tests; OpenAPI, bootstrap lint, structural, structural-test, and architecture gates.
- Practice Registry final scan passed with no required follow-up.

Hosted checks on this pull request are the exact-head authority.