### PR TITLE
fix(orchestrator): require persisted projection authority

### DIFF
--- a/cmd/cerebro/orchestrator.go
+++ b/cmd/cerebro/orchestrator.go
@@ -483,13 +483,11 @@ func newOrchestratorSyncProjector(
 	stateStore ports.StateStore,
 	projectors ...*organizationalgraph.ProjectionClient,
 ) ports.SourceProjector {
-	// Source sync runs after append-log commit. The persisted family authority
-	// selects either the compatibility state projector or the Rust writer.
-	legacy := sourceProjector(stateStore, nil)
-	if len(projectors) == 0 || projectors[0] == nil {
-		return legacy
+	var authority *organizationalgraph.ProjectionClient
+	if len(projectors) > 0 {
+		authority = projectors[0]
 	}
-	return organizationalgraph.NewAppendLogProjector(legacy, projectors[0])
+	return organizationalgraph.NewAppendLogProjector(sourceProjector(stateStore, nil), authority)
 }
 
 func orchestratorGraphPageLimit(configured uint32, syncedPages uint32) uint32 {

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -512,7 +512,7 @@ func TestNewOrchestratorRuntimeServiceDoesNotFallBackWithoutRustAuthority(t *tes
 	service := newOrchestratorRuntimeService(registry, store, &orchestratorEventLog{}, stateStore, "")
 
 	_, err = service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "runtime-1", PageLimit: 1})
-	if err == nil || !strings.Contains(err.Error(), "rust projection authority client is required") {
+	if !errors.Is(err, organizationalgraph.ErrProjectionAuthorityUnavailable) {
 		t.Fatalf("Sync() error = %v, want missing Rust authority", err)
 	}
 	if len(stateStore.entities) != 0 || len(stateStore.links) != 0 {

--- a/cmd/cerebro/orchestrator_test.go
+++ b/cmd/cerebro/orchestrator_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strconv"
 	"strings"
@@ -19,6 +21,7 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourcehealth"
+	"github.com/writer/cerebro/internal/sourcehttp/organizationalgraph"
 	"github.com/writer/cerebro/internal/sourceprojection"
 	"github.com/writer/cerebro/internal/sourceruntime"
 	"github.com/writer/cerebro/internal/telemetry"
@@ -418,7 +421,7 @@ func commandTelemetryPayloads(t *testing.T, stderr string, kind string, name str
 	return payloads
 }
 
-func TestNewOrchestratorRuntimeServiceProjectsSourceSyncToStateOnly(t *testing.T) {
+func TestNewOrchestratorRuntimeServiceProjectsAfterTenantBoundRustAuthority(t *testing.T) {
 	registry, err := sourcecdk.NewRegistry(orchestratorTestSource{})
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
@@ -432,8 +435,51 @@ func TestNewOrchestratorRuntimeServiceProjectsSourceSyncToStateOnly(t *testing.T
 	}
 	eventLog := &orchestratorEventLog{}
 	stateStore := newGraphTestStore()
+	var authorityRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/projections/authority":
+			authorityRequests++
+			if r.Header.Get("X-Cerebro-Tenant") != "writer" ||
+				r.URL.Query().Get("tenant_id") != "writer" ||
+				r.URL.Query().Get("source_id") != "github" ||
+				r.URL.Query().Get("family_id") != "pull_request" {
+				http.Error(w, "authority scope mismatch", http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"tenant_id":           "writer",
+				"source_id":           "github",
+				"family_id":           "pull_request",
+				"authority":           "legacy",
+				"evidence_digest":     "",
+				"promoted_at_unix_ms": nil,
+			})
+		case "/v1/projections/legacy-deltas":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"recorded":     true,
+				"delta_digest": strings.Repeat("a", 64),
+			})
+		case "/v1/projections/collections":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"recorded":        true,
+				"manifest_digest": strings.Repeat("b", 64),
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	authority, err := organizationalgraph.NewProjectionClient(
+		server.URL,
+		"orchestrator-authority-test-secret-32-bytes",
+		time.Second,
+	)
+	if err != nil {
+		t.Fatalf("NewProjectionClient() error = %v", err)
+	}
 
-	service := newOrchestratorRuntimeService(registry, store, eventLog, stateStore, "")
+	service := newOrchestratorRuntimeService(registry, store, eventLog, stateStore, "", authority)
 	result, err := service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "runtime-1", PageLimit: 1})
 	if err != nil {
 		t.Fatalf("Sync() error = %v", err)
@@ -447,11 +493,30 @@ func TestNewOrchestratorRuntimeServiceProjectsSourceSyncToStateOnly(t *testing.T
 	if len(stateStore.entities) == 0 || len(stateStore.links) == 0 {
 		t.Fatalf("state projections not stored: entities=%d links=%d", len(stateStore.entities), len(stateStore.links))
 	}
+	if authorityRequests != 1 {
+		t.Fatalf("authority requests = %d, want 1", authorityRequests)
+	}
 }
 
-func TestNewOrchestratorSyncProjectorDoesNotCreateGraphOnlyProjector(t *testing.T) {
-	if projector := newOrchestratorSyncProjector(nil); projector != nil {
-		t.Fatalf("newOrchestratorSyncProjector(nil) = %#v, want nil", projector)
+func TestNewOrchestratorRuntimeServiceDoesNotFallBackWithoutRustAuthority(t *testing.T) {
+	registry, err := sourcecdk.NewRegistry(orchestratorTestSource{})
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	store := &orchestratorRuntimeStore{runtime: &cerebrov1.SourceRuntime{
+		Id:       "runtime-1",
+		SourceId: "github",
+		TenantId: "writer",
+	}}
+	stateStore := newGraphTestStore()
+	service := newOrchestratorRuntimeService(registry, store, &orchestratorEventLog{}, stateStore, "")
+
+	_, err = service.Sync(context.Background(), &cerebrov1.SyncSourceRuntimeRequest{Id: "runtime-1", PageLimit: 1})
+	if err == nil || !strings.Contains(err.Error(), "rust projection authority client is required") {
+		t.Fatalf("Sync() error = %v, want missing Rust authority", err)
+	}
+	if len(stateStore.entities) != 0 || len(stateStore.links) != 0 {
+		t.Fatalf("Go projection ran without Rust authority: entities=%d links=%d", len(stateStore.entities), len(stateStore.links))
 	}
 }
 

--- a/internal/sourcehttp/organizationalgraph/projection.go
+++ b/internal/sourcehttp/organizationalgraph/projection.go
@@ -151,7 +151,12 @@ type sourceCollectionResponse struct {
 type sourceCollectionManifestResponse = sourceCollectionRequest
 
 type authorityResponse struct {
-	Authority string `json:"authority"`
+	TenantID         string `json:"tenant_id"`
+	SourceID         string `json:"source_id"`
+	FamilyID         string `json:"family_id"`
+	Authority        string `json:"authority"`
+	EvidenceDigest   string `json:"evidence_digest"`
+	PromotedAtUnixMS *int64 `json:"promoted_at_unix_ms"`
 }
 
 func (c *ProjectionClient) recordLegacyProjection(ctx context.Context, event *cerebrov1.EventEnvelope, delta ports.SourceProjectionDelta) error {
@@ -325,9 +330,11 @@ func (c *ProjectionClient) authority(ctx context.Context, event *cerebrov1.Event
 	if err != nil {
 		return "", err
 	}
+	tenantID := strings.TrimSpace(event.GetTenantId())
+	sourceID := strings.TrimSpace(event.GetSourceId())
 	query := url.Values{
-		"tenant_id": {strings.TrimSpace(event.GetTenantId())},
-		"source_id": {strings.TrimSpace(event.GetSourceId())},
+		"tenant_id": {tenantID},
+		"source_id": {sourceID},
 		"family_id": {familyID},
 	}
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/projections/authority?"+query.Encode(), nil)
@@ -340,6 +347,11 @@ func (c *ProjectionClient) authority(ctx context.Context, event *cerebrov1.Event
 	var response authorityResponse
 	if err := c.doJSON(request, &response); err != nil {
 		return "", err
+	}
+	if strings.TrimSpace(response.TenantID) != tenantID ||
+		strings.TrimSpace(response.SourceID) != sourceID ||
+		strings.TrimSpace(response.FamilyID) != familyID {
+		return "", errors.New("rust projection authority response scope does not match the request")
 	}
 	if response.Authority != projectionAuthorityLegacy && response.Authority != projectionAuthorityRust {
 		return "", fmt.Errorf("rust projection returned invalid authority %q", response.Authority)
@@ -374,11 +386,18 @@ func (c *ProjectionClient) doJSON(request *http.Request, target any) (err error)
 // delta. Rust-authoritative events are consumed and projected directly from
 // JetStream by the Rust runtime; this path cannot submit their payload.
 type AppendLogProjector struct {
-	legacy ports.SourceProjector
-	rust   *ProjectionClient
+	legacy            ports.SourceProjector
+	rust              *ProjectionClient
+	recordLegacyDelta bool
 }
 
 func NewAppendLogProjector(legacy ports.SourceProjector, rust *ProjectionClient) *AppendLogProjector {
+	return &AppendLogProjector{legacy: legacy, rust: rust, recordLegacyDelta: true}
+}
+
+// NewLegacyWriteGuard prevents replay/refetch jobs from restoring a Go write
+// path after a family has moved to Rust, without recording another parity delta.
+func NewLegacyWriteGuard(legacy ports.SourceProjector, rust *ProjectionClient) *AppendLogProjector {
 	return &AppendLogProjector{legacy: legacy, rust: rust}
 }
 
@@ -392,6 +411,9 @@ func (p *AppendLogProjector) RecordSourceCollection(ctx context.Context, manifes
 }
 
 func (p *AppendLogProjector) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (ports.ProjectionResult, error) {
+	if p == nil || p.rust == nil {
+		return ports.ProjectionResult{}, errors.New("rust projection authority client is required")
+	}
 	authority, err := p.rust.authority(ctx, event)
 	if err != nil {
 		return ports.ProjectionResult{}, err
@@ -402,7 +424,7 @@ func (p *AppendLogProjector) Project(ctx context.Context, event *cerebrov1.Event
 	if p.legacy == nil {
 		return ports.ProjectionResult{}, nil
 	}
-	if projector, ok := p.legacy.(ports.SourceProjectorWithDelta); ok {
+	if projector, ok := p.legacy.(ports.SourceProjectorWithDelta); ok && p.recordLegacyDelta {
 		result, delta, err := projector.ProjectWithDelta(ctx, event)
 		if err != nil {
 			return ports.ProjectionResult{}, err
@@ -411,31 +433,6 @@ func (p *AppendLogProjector) Project(ctx context.Context, event *cerebrov1.Event
 			return ports.ProjectionResult{}, err
 		}
 		return result, nil
-	}
-	return p.legacy.Project(ctx, event)
-}
-
-// LegacyWriteGuard prevents replay/refetch jobs from restoring a Go write path
-// after a family has moved to Rust.
-type LegacyWriteGuard struct {
-	legacy ports.SourceProjector
-	rust   *ProjectionClient
-}
-
-func NewLegacyWriteGuard(legacy ports.SourceProjector, rust *ProjectionClient) *LegacyWriteGuard {
-	return &LegacyWriteGuard{legacy: legacy, rust: rust}
-}
-
-func (p *LegacyWriteGuard) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (ports.ProjectionResult, error) {
-	authority, err := p.rust.authority(ctx, event)
-	if err != nil {
-		return ports.ProjectionResult{}, err
-	}
-	if authority == projectionAuthorityRust {
-		return ports.ProjectionResult{}, nil
-	}
-	if p.legacy == nil {
-		return ports.ProjectionResult{}, nil
 	}
 	return p.legacy.Project(ctx, event)
 }

--- a/internal/sourcehttp/organizationalgraph/projection.go
+++ b/internal/sourcehttp/organizationalgraph/projection.go
@@ -26,6 +26,8 @@ const (
 var (
 	ErrSourceCollectionNotFound           = errors.New("source collection receipt not found")
 	ErrSourceCollectionProvenanceMismatch = errors.New("source collection receipt provenance mismatch")
+	ErrProjectionAuthorityUnavailable     = errors.New("rust projection authority client is required")
+	ErrProjectionAuthorityScopeMismatch   = errors.New("rust projection authority response scope does not match the request")
 )
 
 // ProjectionClient talks only to the Rust projection authority boundary.
@@ -351,7 +353,7 @@ func (c *ProjectionClient) authority(ctx context.Context, event *cerebrov1.Event
 	if strings.TrimSpace(response.TenantID) != tenantID ||
 		strings.TrimSpace(response.SourceID) != sourceID ||
 		strings.TrimSpace(response.FamilyID) != familyID {
-		return "", errors.New("rust projection authority response scope does not match the request")
+		return "", ErrProjectionAuthorityScopeMismatch
 	}
 	if response.Authority != projectionAuthorityLegacy && response.Authority != projectionAuthorityRust {
 		return "", fmt.Errorf("rust projection returned invalid authority %q", response.Authority)
@@ -412,7 +414,7 @@ func (p *AppendLogProjector) RecordSourceCollection(ctx context.Context, manifes
 
 func (p *AppendLogProjector) Project(ctx context.Context, event *cerebrov1.EventEnvelope) (ports.ProjectionResult, error) {
 	if p == nil || p.rust == nil {
-		return ports.ProjectionResult{}, errors.New("rust projection authority client is required")
+		return ports.ProjectionResult{}, ErrProjectionAuthorityUnavailable
 	}
 	authority, err := p.rust.authority(ctx, event)
 	if err != nil {

--- a/internal/sourcehttp/organizationalgraph/projection_test.go
+++ b/internal/sourcehttp/organizationalgraph/projection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -50,6 +51,15 @@ func (s *sourceProjectorStub) callCount() int {
 	return s.calls
 }
 
+func projectionAuthorityResponse(authority string) authorityResponse {
+	return authorityResponse{
+		TenantID:  "tenant-a",
+		SourceID:  "box",
+		FamilyID:  "content_assets",
+		Authority: authority,
+	}
+}
+
 func TestAppendLogProjectorUsesExactlyOneAuthority(t *testing.T) {
 	var authority = projectionAuthorityLegacy
 	var authorityRequests int
@@ -64,7 +74,7 @@ func TestAppendLogProjectorUsesExactlyOneAuthority(t *testing.T) {
 			http.Error(w, "event payload handoff is retired", http.StatusGone)
 		case "/v1/projections/authority":
 			authorityRequests++
-			_ = json.NewEncoder(w).Encode(authorityResponse{Authority: authority})
+			_ = json.NewEncoder(w).Encode(projectionAuthorityResponse(authority))
 		default:
 			http.NotFound(w, r)
 		}
@@ -92,6 +102,68 @@ func TestAppendLogProjectorUsesExactlyOneAuthority(t *testing.T) {
 	}
 }
 
+func TestAppendLogProjectorAuthorityReadIsTenantScopedUnderRace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tenantID := r.URL.Query().Get("tenant_id")
+		if r.URL.Path != "/v1/projections/authority" ||
+			r.Header.Get(tenantAuthHeader) != tenantID ||
+			(tenantID != "tenant-a" && tenantID != "tenant-b") {
+			http.Error(w, "authority scope mismatch", http.StatusBadRequest)
+			return
+		}
+		authority := projectionAuthorityRust
+		if tenantID == "tenant-a" {
+			authority = projectionAuthorityLegacy
+		}
+		_ = json.NewEncoder(w).Encode(authorityResponse{
+			TenantID:  tenantID,
+			SourceID:  r.URL.Query().Get("source_id"),
+			FamilyID:  r.URL.Query().Get("family_id"),
+			Authority: authority,
+		})
+	}))
+	defer server.Close()
+	client, err := NewProjectionClient(server.URL, testSharedSecret, time.Second)
+	if err != nil {
+		t.Fatalf("NewProjectionClient() error = %v", err)
+	}
+	legacy := &sourceProjectorStub{}
+	projector := NewAppendLogProjector(legacy, client)
+
+	const iterations = 32
+	errorsByCall := make(chan error, iterations*2)
+	var wait sync.WaitGroup
+	for _, tenantID := range []string{"tenant-a", "tenant-b"} {
+		for range iterations {
+			wait.Add(1)
+			go func(tenantID string) {
+				defer wait.Done()
+				event := projectionEvent()
+				event.TenantId = tenantID
+				result, err := projector.Project(context.Background(), event)
+				if err != nil {
+					errorsByCall <- fmt.Errorf("tenant %s: %w", tenantID, err)
+					return
+				}
+				if tenantID == "tenant-a" && result.EntitiesProjected != 7 {
+					errorsByCall <- fmt.Errorf("tenant-a result = %#v, want legacy projection", result)
+				}
+				if tenantID == "tenant-b" && result != (ports.ProjectionResult{}) {
+					errorsByCall <- fmt.Errorf("tenant-b result = %#v, want Rust authority", result)
+				}
+			}(tenantID)
+		}
+	}
+	wait.Wait()
+	close(errorsByCall)
+	for err := range errorsByCall {
+		t.Error(err)
+	}
+	if calls := legacy.callCount(); calls != iterations {
+		t.Fatalf("legacy calls = %d, want exactly tenant-a calls %d", calls, iterations)
+	}
+}
+
 func TestProjectionClientRequiresAFixedHTTPOrigin(t *testing.T) {
 	for _, value := range []string{
 		"",
@@ -112,7 +184,7 @@ func TestAppendLogProjectorRecordsExactLegacyDelta(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/projections/authority":
-			_ = json.NewEncoder(w).Encode(authorityResponse{Authority: projectionAuthorityLegacy})
+			_ = json.NewEncoder(w).Encode(projectionAuthorityResponse(projectionAuthorityLegacy))
 		case "/v1/projections/legacy-deltas":
 			deltaRequests++
 			var request legacyProjectionRequest
@@ -309,7 +381,7 @@ func TestProjectionClientRejectsMismatchedSourceCollectionProvenance(t *testing.
 
 func TestLegacyWriteGuardSuppressesGoAfterPromotion(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(authorityResponse{Authority: projectionAuthorityRust})
+		_ = json.NewEncoder(w).Encode(projectionAuthorityResponse(projectionAuthorityRust))
 	}))
 	defer server.Close()
 	client, err := NewProjectionClient(server.URL, testSharedSecret, time.Second)
@@ -336,6 +408,24 @@ func TestRustAuthorityFailureDoesNotFallBackToGo(t *testing.T) {
 	_, err = NewAppendLogProjector(legacy, client).Project(context.Background(), projectionEvent())
 	if err == nil || legacy.callCount() != 0 {
 		t.Fatalf("Project() error = %v calls=%d", err, legacy.callCount())
+	}
+}
+
+func TestRustAuthorityScopeMismatchDoesNotFallBackToGo(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		response := projectionAuthorityResponse(projectionAuthorityLegacy)
+		response.TenantID = "tenant-b"
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+	client, err := NewProjectionClient(server.URL, testSharedSecret, time.Second)
+	if err != nil {
+		t.Fatalf("NewProjectionClient() error = %v", err)
+	}
+	legacy := &sourceProjectorStub{err: errors.New("must not run")}
+	_, err = NewAppendLogProjector(legacy, client).Project(context.Background(), projectionEvent())
+	if err == nil || !strings.Contains(err.Error(), "scope does not match") || legacy.callCount() != 0 {
+		t.Fatalf("Project() error = %v calls=%d, want scope rejection without Go fallback", err, legacy.callCount())
 	}
 }
 

--- a/internal/sourcehttp/organizationalgraph/projection_test.go
+++ b/internal/sourcehttp/organizationalgraph/projection_test.go
@@ -424,7 +424,7 @@ func TestRustAuthorityScopeMismatchDoesNotFallBackToGo(t *testing.T) {
 	}
 	legacy := &sourceProjectorStub{err: errors.New("must not run")}
 	_, err = NewAppendLogProjector(legacy, client).Project(context.Background(), projectionEvent())
-	if err == nil || !strings.Contains(err.Error(), "scope does not match") || legacy.callCount() != 0 {
+	if !errors.Is(err, ErrProjectionAuthorityScopeMismatch) || legacy.callCount() != 0 {
 		t.Fatalf("Project() error = %v calls=%d, want scope rejection without Go fallback", err, legacy.callCount())
 	}
 }


### PR DESCRIPTION
## Summary

- require orchestrator source-sync projection to read persisted Rust family authority instead of directly selecting the Go projector when the authority client is absent
- decode and correlate the full authority record to the requested tenant, source, and family before allowing a legacy write
- share one authority decision implementation between append-log projection and replay/refetch guarding while retaining legacy parity-delta recording only on the append path

## Validation

- `go test ./internal/sourcehttp/organizationalgraph -run 'Test(AppendLogProjector|ProjectionClient|LegacyWriteGuard|RustAuthority|ProjectionRejects)' -count=1 -v`
- `go test ./cmd/cerebro -run 'TestNewOrchestratorRuntimeService' -count=1 -v`
- `go test -race ./internal/sourcehttp/organizationalgraph -run 'TestAppendLogProjectorAuthorityReadIsTenantScopedUnderRace' -count=1 -v`
- `go test -race ./cmd/cerebro -run 'TestNewOrchestratorRuntimeService(ProjectsAfterTenantBoundRustAuthority|DoesNotFallBackWithoutRustAuthority)' -count=1 -v`

Broader hosted validation remains pending on this draft head.