### PR TITLE
Recognize Rust graph routes in MCP parity

### DIFF
--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -614,6 +614,10 @@ func mcpDomainSurfaceCorpus(t *testing.T) string {
 		builder.Write(body)
 		builder.WriteByte('\n')
 	}
+	for _, entry := range rustAuthorityHTTPContractEntries(t, root, openAPIHTTPMethods(t, root)) {
+		builder.WriteString(entry.Identity)
+		builder.WriteByte('\n')
+	}
 	return builder.String()
 }
 


### PR DESCRIPTION
## Summary

- Include validated Rust-authority HTTP identities in the MCP domain-surface parity corpus.
- Preserve the existing exact method/path marker for the graph-neighborhood MCP tool after the Go HTTP registration was retired.

## Validation

- `go test ./internal/bootstrap -run '^TestMCPToolsDeclareDomainSurfaceParity$' -count=1`
- `GO_TEST_SHARD_TOTAL=12 GO_TEST_SHARD_INDEX=3 make test`
- `git diff --check origin/main...HEAD`

This is the forward repair for the Go test shard exposed after #2659 merged.