### PR TITLE
test(mcp): include Rust routes in domain surface parity

### DIFF
--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -602,6 +602,7 @@ func mcpDomainSurfaceCorpus(t *testing.T) string {
 		"internal/bootstrap/routes.go",
 		"proto/cerebro/v1/bootstrap.proto",
 		"api/openapi.yaml",
+		"docs/contracts/platform-public-route-inventory.json",
 		"docs/domains/mcp-droid-setup.md",
 		"docs/domains/agent-platform-contract.md",
 		"docs/domains/findings-platform-architecture.md",


### PR DESCRIPTION
## Summary

- include the generated public contract inventory in the MCP domain-surface parity corpus
- keep Rust-authoritative public routes visible to the parity guardrail

## Validation

- `go test ./internal/bootstrap -run TestMCPToolsDeclareDomainSurfaceParity -count=1`
- `go test ./internal/bootstrap -count=1`
- `git diff --check`