### PR TITLE
fix(web): honor platform workspace route capabilities

### DIFF
--- a/apps/web/src/components/StatusPanel.test.tsx
+++ b/apps/web/src/components/StatusPanel.test.tsx
@@ -77,7 +77,7 @@ describe("StatusPanel cache behavior", () => {
     expect(probes.find((probe) => probe.key === "healthz")?.path).toBe("/api/cerebro/healthz");
     expect(probes.find((probe) => probe.key === "health")?.path).toBe("/api/cerebro/health");
     expect(probes.find((probe) => probe.key === "source-runtime")?.path)
-      .toBe("/api/cerebro/v1/source-runtimes/health?limit=1&tenant_id=tenant-a&workspace_id=workspace-a");
+      .toBe("/api/cerebro/v1/source-runtimes/health?limit=1&tenant_id=tenant-a");
     expect(probes.find((probe) => probe.key === "inventory")?.path)
       .toBe("/api/cerebro/grc/inventory/categories?limit=1&tenant_id=tenant-a&workspace_id=workspace-a");
     expect(probes.find((probe) => probe.key === "vendors")?.path)

--- a/apps/web/src/components/StatusPanel.tsx
+++ b/apps/web/src/components/StatusPanel.tsx
@@ -33,7 +33,7 @@ const PRODUCT_READ_TIMEOUT_MS = 5000;
 export const statusProbes = (scope: GRCScope) => [
   { key: "healthz", label: "API liveness", path: "/api/cerebro/healthz", timeoutMs: LIVENESS_TIMEOUT_MS },
   { key: "health", label: "API readiness", path: "/api/cerebro/health", timeoutMs: GRC_QUERY_TIMEOUT_MS },
-  { key: "source-runtime", label: "Rust source runtime", path: withGRCScope("/api/cerebro/v1/source-runtimes/health?limit=1", scope), timeoutMs: PRODUCT_READ_TIMEOUT_MS },
+  { key: "source-runtime", label: "Rust source runtime", path: withGRCScope("/api/cerebro/v1/source-runtimes/health?limit=1", { ...scope, workspaceID: "" }), timeoutMs: PRODUCT_READ_TIMEOUT_MS },
   { key: "inventory", label: "Inventory", path: withGRCScope("/api/cerebro/grc/inventory/categories?limit=1", scope), timeoutMs: PRODUCT_READ_TIMEOUT_MS },
   { key: "vendors", label: "Vendor register", path: withGRCScope("/api/cerebro/grc/vendors?limit=1", scope), timeoutMs: PRODUCT_READ_TIMEOUT_MS },
   { key: "policies", label: "Policy lifecycle", path: withGRCScope("/api/cerebro/grc/policy-lifecycle?rule_profile=baseline&limit=1", scope), timeoutMs: PRODUCT_READ_TIMEOUT_MS },

--- a/apps/web/src/lib/cerebro-proxy.test.ts
+++ b/apps/web/src/lib/cerebro-proxy.test.ts
@@ -97,6 +97,17 @@ describe("cerebro proxy cache headers", () => {
     expect(headers.get("x-cerebro-workspace")).toBe("workspace-a");
   });
 
+  it("forwards workspace scope only to the workspace-aware connector coverage route", () => {
+    const request = new NextRequest(
+      "http://localhost/api/cerebro/connectors/coverage?tenant_id=tenant-a&workspace_id=workspace-a",
+    );
+
+    const headers = new Headers(authHeadersFor(request, "connectors/coverage"));
+    expect(headers.get("x-cerebro-tenant")).toBe("tenant-a");
+    expect(headers.get("x-cerebro-workspace")).toBe("workspace-a");
+    expect(() => authHeadersFor(request, "v1/source-runtimes/health")).toThrow("Workspace scope is not supported");
+  });
+
   it.each([
     "http://localhost/api/cerebro/grc/dashboard?workspace_id=workspace-a",
     "http://localhost/api/cerebro/grc/dashboard?tenant_id=tenant-a&workspace_id=workspace-a&workspace_id=workspace-a",

--- a/apps/web/src/lib/cerebro-proxy.ts
+++ b/apps/web/src/lib/cerebro-proxy.ts
@@ -227,7 +227,8 @@ const requiredCerebroProxyScope = (request: NextRequest) => {
 };
 
 export const supportsApplicationWorkspaceScope = (path: string) =>
-  normalizeProxyPath(path).startsWith("grc/");
+  normalizeProxyPath(path).startsWith("grc/")
+  || normalizeProxyPath(path) === "connectors/coverage";
 
 export const getCerebroProxyConfig = () => ({
   apiBase: API_BASE,


### PR DESCRIPTION
## Summary
- forward tenant and application workspace scope for connector coverage
- keep the Rust source-runtime health probe tenant-only
- cover both route capability decisions in proxy and status-panel tests

## Validation
- npx vitest run src/lib/cerebro-proxy.test.ts src/components/StatusPanel.test.tsx src/app/api/cerebro/[...path]/route.test.ts scripts/portable-web-fixture-e2e.test.mjs (90 passed on rebased head)
- npx eslint src/lib/cerebro-proxy.ts src/lib/cerebro-proxy.test.ts src/components/StatusPanel.tsx src/components/StatusPanel.test.tsx
- Practice Registry final gate passed