### PR TITLE
fix(web): remove unsupported vendor action contract

### DIFF
--- a/apps/web/src/app/vendors/page.tsx
+++ b/apps/web/src/app/vendors/page.tsx
@@ -14,7 +14,6 @@ import {
   SearchCheck,
   SlidersHorizontal,
   Upload,
-  UserPlus,
   X,
 } from "lucide-react";
 import Link from "next/link";
@@ -29,7 +28,6 @@ import {
   GRCUploadReplayResponse,
   GRCUploadResponse,
   GRCVendor,
-  GRCVendorActionResponse,
   GRCVendorCreateRequest,
   GRCVendorCreateResponse,
   GRCVendorDetailResponse,
@@ -144,12 +142,6 @@ type BulkDiscoveryDraft = {
   reason: string;
 };
 
-type VendorQuickActionDraft = {
-  owner: string;
-  lifecycleState: string;
-  reviewState: string;
-};
-
 type VendorSection = "register" | "discoveries" | "uploads";
 
 const vendorSections: Array<{ id: VendorSection; label: string }> = [
@@ -179,20 +171,10 @@ const defaultBulkDiscoveryDraft = (): BulkDiscoveryDraft => ({
   reason: "",
 });
 
-const defaultVendorQuickActionDraft = (): VendorQuickActionDraft => ({
-  owner: "",
-  lifecycleState: "approved",
-  reviewState: "in_progress",
-});
-
 const createRiskOptions = riskFilters.filter((item) => item.value);
 const createLifecycleOptions = lifecycleFilters.filter((item) =>
   ["active", "approved", "in_review", "conditionally_approved", "restricted"].includes(item.value));
 const createReviewOptions = reviewFilters.filter((item) => item.value);
-const quickReviewOptions = [
-  { value: "in_progress", label: "In progress" },
-  ...createReviewOptions,
-];
 
 const compactAttributes = (attributes: Record<string, string | undefined>) =>
   Object.fromEntries(Object.entries(attributes).filter(([, value]) => Boolean(value))) as Record<string, string>;
@@ -1394,9 +1376,6 @@ function DrawerCount({ label, value }: { label: string; value: number }) {
 }
 
 function VendorDetailDrawer({
-  actionDraft,
-  actionError,
-  actionSaving,
   detail,
   detailError,
   detailLoading,
@@ -1404,15 +1383,10 @@ function VendorDetailDrawer({
   linkedDiscoveriesLoaded,
   onClose,
   onOpenUpload,
-  onQuickAction,
   onReload,
-  onUpdateActionDraft,
   scope,
   vendor,
 }: {
-  actionDraft: VendorQuickActionDraft;
-  actionError: string | null;
-  actionSaving: boolean;
   detail?: GRCVendorDetailResponse | null;
   detailError: string | null;
   detailLoading: boolean;
@@ -1420,9 +1394,7 @@ function VendorDetailDrawer({
   linkedDiscoveriesLoaded: boolean;
   onClose: () => void;
   onOpenUpload: (vendor: GRCVendor) => void;
-  onQuickAction: (action: "assign_owner" | "change_lifecycle" | "start_review") => Promise<void> | void;
   onReload: () => void;
-  onUpdateActionDraft: (patch: Partial<VendorQuickActionDraft>) => void;
   scope: GRCScope;
   vendor?: GRCVendor | null;
 }) {
@@ -1464,7 +1436,6 @@ function VendorDetailDrawer({
 
           <div className="flex-1 overflow-y-auto px-5 py-4">
             {detailError && <ErrorBlock error={detailError} onRetry={onReload} recoveryDetail="Using register data until detail loads." />}
-            {actionError && <ErrorBlock error={actionError} recoveryDetail="Vendor action was not saved." />}
             {detailLoading && !detail && <LoadingBlock label="Loading vendor detail..." />}
 
             <div className="grid gap-3 sm:grid-cols-4">
@@ -1566,43 +1537,6 @@ function VendorDetailDrawer({
               )}
             </section>
 
-            <section className="mt-4 rounded-md border border-[color:var(--border)] p-4">
-              <div className="mb-3 text-[13px] font-semibold text-[var(--text-primary)]">Quick actions</div>
-              <div className="grid gap-3">
-                <label className={labelClass}>
-                  Owner
-                  <div className="mt-1 flex gap-2">
-                    <input value={actionDraft.owner} onChange={(event) => onUpdateActionDraft({ owner: event.target.value })} placeholder={ownerLabel(activeVendor)} className="control-input min-w-0 flex-1 px-3 py-1.5 text-[13px]" />
-                    <button type="button" disabled={actionSaving || !actionDraft.owner.trim()} onClick={() => { void Promise.resolve(onQuickAction("assign_owner")).catch(() => undefined); }} className="secondary-button inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] disabled:opacity-50">
-                      <UserPlus className="h-3.5 w-3.5" aria-hidden="true" />
-                      Assign
-                    </button>
-                  </div>
-                </label>
-                <label className={labelClass}>
-                  Lifecycle
-                  <div className="mt-1 flex gap-2">
-                    <select value={actionDraft.lifecycleState} onChange={(event) => onUpdateActionDraft({ lifecycleState: event.target.value })} className="control-input min-w-0 flex-1 px-3 py-1.5 text-[13px]">
-                      {createLifecycleOptions.map((item) => <option key={item.value} value={item.value}>{item.label}</option>)}
-                    </select>
-                    <button type="button" disabled={actionSaving} onClick={() => { void Promise.resolve(onQuickAction("change_lifecycle")).catch(() => undefined); }} className="secondary-button px-3 py-1.5 text-[13px] disabled:opacity-50">
-                      Change
-                    </button>
-                  </div>
-                </label>
-                <label className={labelClass}>
-                  Review
-                  <div className="mt-1 flex gap-2">
-                    <select value={actionDraft.reviewState} onChange={(event) => onUpdateActionDraft({ reviewState: event.target.value })} className="control-input min-w-0 flex-1 px-3 py-1.5 text-[13px]">
-                      {quickReviewOptions.map((item) => <option key={item.value} value={item.value}>{item.label}</option>)}
-                    </select>
-                    <button type="button" disabled={actionSaving} onClick={() => { void Promise.resolve(onQuickAction("start_review")).catch(() => undefined); }} className="secondary-button px-3 py-1.5 text-[13px] disabled:opacity-50">
-                      Start
-                    </button>
-                  </div>
-                </label>
-              </div>
-            </section>
           </div>
 
           <div className="flex flex-wrap items-center justify-between gap-2 border-t border-[color:var(--border)] px-5 py-4">
@@ -1656,8 +1590,6 @@ export default function VendorsPage() {
   const [bulkDraft, setBulkDraft] = useState<BulkDiscoveryDraft>(() => defaultBulkDiscoveryDraft());
   const [bulkSaving, setBulkSaving] = useState(false);
   const [selectedDiscoveryURNs, setSelectedDiscoveryURNs] = useState<Set<string>>(() => new Set());
-  const [quickActionMessage, setQuickActionMessage] = useState("");
-  const [quickActionDraft, setQuickActionDraft] = useState<VendorQuickActionDraft>(() => defaultVendorQuickActionDraft());
   const uploadPanelRef = useRef<HTMLDivElement>(null);
   const debouncedScope = useDebouncedGRCScope({ tenantID, workspaceID });
   const debouncedQuery = useDebouncedValue(query.trim());
@@ -1713,8 +1645,6 @@ export default function VendorsPage() {
     error: createError,
     setError: setCreateError,
   } = useGRCMutation<GRCVendorCreateResponse>();
-  const { mutate: mutateVendorAction, saving: quickActionSaving, error: quickActionError } = useGRCMutation<GRCVendorActionResponse>();
-
   const vendorRows = useMemo(() => boundedVendorRows(vendorsQuery.data, GRC_WORKLIST_LIMIT), [vendorsQuery.data]);
   const vendors = vendorRows.vendors;
   const vendorMeta = vendorRows.meta;
@@ -1807,23 +1737,13 @@ export default function VendorsPage() {
   };
 
   const openVendorDrawer = useCallback((vendorURN: string) => {
-    const vendor = vendors.find((item) => item.urn === vendorURN) ?? vendorDetailQuery.data?.vendor;
     setSelectedVendorURN(vendorURN);
-    setQuickActionMessage("");
-    setQuickActionDraft({
-      owner: vendor?.owner || vendor?.security_owner_user_id || vendor?.business_owner_user_id || "",
-      lifecycleState: vendor?.lifecycle_state || "approved",
-      reviewState: "in_progress",
-    });
-  }, [vendorDetailQuery.data?.vendor, vendors]);
+  }, []);
   const closeVendorDrawer = useCallback(() => {
     setSelectedVendorURN("");
   }, []);
   const updateBulkDraft = useCallback((patch: Partial<BulkDiscoveryDraft>) => {
     setBulkDraft((current) => ({ ...current, ...patch }));
-  }, []);
-  const updateQuickActionDraft = useCallback((patch: Partial<VendorQuickActionDraft>) => {
-    setQuickActionDraft((current) => ({ ...current, ...patch }));
   }, []);
   const toggleDiscoverySelection = useCallback((urn: string) => {
     setSelectedDiscoveryURNs((current) => {
@@ -1986,20 +1906,6 @@ export default function VendorsPage() {
     }
   }, [bulkDraft.linkedVendorURN, bulkDraft.owner, bulkDraft.reason, bulkDraft.riskLevel, createVendorFromDiscovery, discoveries, selectedDiscoveryURNs, setDiscoveryDecision]);
 
-  const runVendorQuickAction = useCallback(async (action: "assign_owner" | "change_lifecycle" | "start_review") => {
-    if (!selectedVendorURN) return;
-    const response = await mutateVendorAction(grcPath(`/grc/vendors/${encodeURIComponent(selectedVendorURN)}/actions`, grcScopeQuery({ tenantID, workspaceID })), {
-      ...grcScopeQuery({ tenantID, workspaceID }),
-      action,
-      owner: action === "assign_owner" ? quickActionDraft.owner.trim() : undefined,
-      lifecycle_state: action === "change_lifecycle" ? quickActionDraft.lifecycleState : undefined,
-      review_state: action === "start_review" ? quickActionDraft.reviewState : undefined,
-      reason: action === "change_lifecycle" ? "Lifecycle changed from vendor review." : undefined,
-    });
-    setQuickActionMessage(`${response.vendor.name} updated.`);
-    await Promise.all([vendorsQuery.reload(), vendorDetailQuery.reload()]);
-  }, [mutateVendorAction, quickActionDraft.lifecycleState, quickActionDraft.owner, quickActionDraft.reviewState, selectedVendorURN, tenantID, vendorDetailQuery, vendorsQuery, workspaceID]);
-
   const submitVendorUpload = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!vendorUploadFile) {
@@ -2111,9 +2017,6 @@ export default function VendorsPage() {
         saving={createSaving}
       />
       <VendorDetailDrawer
-        actionDraft={quickActionDraft}
-        actionError={quickActionError}
-        actionSaving={quickActionSaving}
         detail={vendorDetailQuery.data}
         detailError={vendorDetailQuery.error}
         detailLoading={vendorDetailQuery.loading}
@@ -2121,9 +2024,7 @@ export default function VendorsPage() {
         linkedDiscoveriesLoaded={Boolean(discoveriesQuery.data)}
         onClose={closeVendorDrawer}
         onOpenUpload={openUploadForVendor}
-        onQuickAction={runVendorQuickAction}
         onReload={() => { void vendorDetailQuery.reload(); }}
-        onUpdateActionDraft={updateQuickActionDraft}
         scope={{ tenantID, workspaceID }}
         vendor={selectedVendor}
       />
@@ -2153,11 +2054,6 @@ export default function VendorsPage() {
           error={createError}
           recoveryDetail="Vendor was not saved."
         />
-      )}
-      {quickActionMessage && (
-        <div className="rounded-md border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-[13px] font-semibold text-emerald-700 dark:text-emerald-200">
-          {quickActionMessage}
-        </div>
       )}
       {createMessage && (
         <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-[13px] font-semibold text-emerald-700 dark:text-emerald-200">

--- a/apps/web/src/lib/cerebro-fixtures.test.ts
+++ b/apps/web/src/lib/cerebro-fixtures.test.ts
@@ -284,40 +284,21 @@ describe("cerebro fixture proxy responses", () => {
     });
   });
 
-  it("updates vendor fixtures through quick actions", () => {
+  it("does not expose unsupported vendor actions for either scope shape", () => {
     withFixtureMode();
     const vendorURN = "urn:cerebro:demo-tenant:vendor:payments-processor";
-    const response = cerebroFixtureResponseFor({
-      method: "POST",
-      path: `grc/vendors/${encodeURIComponent(vendorURN)}/actions`,
-      body: JSON.stringify({ action: "assign_owner", owner: "Finance" }),
-    });
-    expect(response?.status).toBe(200);
-    expect(parseFixture(response!)).toMatchObject({
-      action: "assign_owner",
-      vendor: {
-        name: "Payments Processor",
-        owner: "Finance",
-        owner_state: "assigned",
-      },
-    });
-
-    resetCerebroFixtureStateForTests();
-    const resetResponse = cerebroFixtureResponseFor({
-      method: "GET",
-      path: "grc/vendors",
-      searchParams: new URLSearchParams("q=payments"),
-    });
-    const resetPayload = parseFixture(resetResponse!) as {
-      vendors: Array<{ name: string; owner?: string; owner_state: string }>;
-    };
-    expect(resetPayload).toMatchObject({
-      vendors: [expect.objectContaining({
-        name: "Payments Processor",
-        owner_state: "missing",
-      })],
-    });
-    expect(resetPayload.vendors[0].owner).toBeUndefined();
+    for (const searchParams of [
+      new URLSearchParams("tenant_id=demo-tenant"),
+      new URLSearchParams("tenant_id=demo-tenant&workspace_id=workspace-a"),
+    ]) {
+      const response = cerebroFixtureResponseFor({
+        method: "POST",
+        path: `grc/vendors/${encodeURIComponent(vendorURN)}/actions`,
+        searchParams,
+        body: JSON.stringify({ action: "assign_owner", owner: "Finance" }),
+      });
+      expect(response?.status).toBe(404);
+    }
   });
 
   it("returns and mutates unified questionnaire run fixtures", () => {

--- a/apps/web/src/lib/cerebro-fixtures.ts
+++ b/apps/web/src/lib/cerebro-fixtures.ts
@@ -5,7 +5,6 @@ import type {
   GRCQuestionnaireEvidenceAnswer,
   GRCQuestionnaireRun,
   GRCVendor,
-  GRCVendorActionRequest,
   GRCVendorCreateRequest,
   GRCVendorDiscovery,
 } from "@/lib/grc";
@@ -3601,46 +3600,6 @@ const createVendorFixture = (parsed: Record<string, unknown>) => {
   return jsonFixture({ vendor, generated_at: generatedAt }, 201);
 };
 
-const vendorActionFixture = (rawURN: string, parsed: Record<string, unknown>) => {
-  const vendorURN = safeDecode(rawURN);
-  const vendor = allFixtureVendors().find((item) => item.urn === vendorURN);
-  if (!vendor) {
-    return jsonFixture({ error: `No fixture vendor found for ${vendorURN}`, generated_at: generatedAt }, 404);
-  }
-
-  const request = parsed as GRCVendorActionRequest;
-  const action = stringField(request.action);
-  const reason = stringField(request.reason);
-  if (action === "assign_owner") {
-    const owner = stringField(request.owner);
-    if (!owner) {
-      return jsonFixture({ error: "Owner is required.", generated_at: generatedAt }, 400);
-    }
-    vendor.owner = owner;
-    vendor.owner_state = "assigned";
-    vendor.queue_reasons = (vendor.queue_reasons ?? []).filter((item) => item !== "owner_missing");
-    vendor.next_actions = (vendor.next_actions ?? []).filter((item) => item.action_type !== "assign_owner");
-  } else if (action === "change_lifecycle") {
-    const lifecycleState = stringField(request.lifecycle_state);
-    if (!lifecycleState) {
-      return jsonFixture({ error: "Lifecycle state is required.", generated_at: generatedAt }, 400);
-    }
-    vendor.lifecycle_state = lifecycleState;
-    vendor.lifecycle_reason = reason || "Lifecycle changed from vendor review.";
-  } else if (action === "start_review") {
-    vendor.review_state = stringField(request.review_state) || "in_progress";
-    vendor.assessment_state = "in_progress";
-    vendor.assessment_progress = Math.max(vendor.assessment_progress ?? 0, 10);
-    vendor.open_assessments = Math.max(vendor.open_assessments ?? 0, 1);
-    vendor.next_assessment_at = vendor.next_assessment_at ?? "2026-02-15T12:00:00.000Z";
-  } else {
-    return jsonFixture({ error: "Unsupported vendor action.", generated_at: generatedAt }, 400);
-  }
-
-  vendor.last_material_change_at = generatedAt;
-  return jsonFixture({ action, vendor, generated_at: generatedAt });
-};
-
 const questionnaireQuestionsFromRequest = (parsed: Record<string, unknown>) => {
   const direct = Array.isArray(parsed.questions) ? parsed.questions as Array<Record<string, unknown>> : [];
   const rows = Array.isArray(parsed.intake_rows) ? parsed.intake_rows as Array<Record<string, unknown>> : [];
@@ -4144,11 +4103,6 @@ const writeFixture = (path: string, body?: string) => {
   const runCommentMatch = /^grc\/questionnaire-runs\/([^/]+)\/comments$/.exec(path);
   if (runCommentMatch) {
     return questionnaireRunCommentFixture(runCommentMatch[1], parsed);
-  }
-
-  const vendorActionMatch = /^grc\/vendors\/(.+)\/actions$/.exec(path);
-  if (vendorActionMatch) {
-    return vendorActionFixture(vendorActionMatch[1], parsed);
   }
 
   if (path === "grc/inventory/resource-scope") {

--- a/apps/web/src/lib/grc.ts
+++ b/apps/web/src/lib/grc.ts
@@ -1457,21 +1457,6 @@ export type GRCVendorCreateResponse = {
   generated_at: string;
 };
 
-export type GRCVendorActionRequest = {
-  tenant_id?: string;
-  action: "assign_owner" | "change_lifecycle" | "start_review" | string;
-  owner?: string;
-  lifecycle_state?: string;
-  review_state?: string;
-  reason?: string;
-};
-
-export type GRCVendorActionResponse = {
-  action: string;
-  vendor: GRCVendor;
-  generated_at: string;
-};
-
 export type GRCVendorDetailResponse = {
   vendor: GRCVendor;
   relationships?: GRCVendorRelationships;

--- a/apps/web/src/lib/rbac.test.ts
+++ b/apps/web/src/lib/rbac.test.ts
@@ -104,7 +104,7 @@ describe("Cerebro proxy route permissions", () => {
     expect(permissionForCerebroProxyRequest("POST", "grc/questionnaire-runs/run-1/vendor-link")).toBe("grc:inventory:write");
     expect(permissionForCerebroProxyRequest("POST", "grc/questionnaire-runs/run-1/decisions")).toBe("grc:inventory:write");
     expect(permissionForCerebroProxyRequest("POST", "grc/questionnaire-runs/run-1/comments")).toBe("grc:inventory:write");
-    expect(permissionForCerebroProxyRequest("POST", "grc/vendors/urn%3Acerebro%3Ademo%3Avendor%3Aone/actions")).toBe("grc:inventory:write");
+    expect(permissionForCerebroProxyRequest("POST", "grc/vendors/urn%3Acerebro%3Ademo%3Avendor%3Aone/actions")).toBe("cerebro:write");
     expect(permissionForCerebroProxyRequest("POST", "grc/vendor-discoveries/discovery-1/decision")).toBe("grc:inventory:write");
     expect(permissionForCerebroProxyRequest("POST", "grc/policy-lifecycle/actions")).toBe("grc:policies:write");
     expect(permissionForCerebroProxyRequest("POST", "grc/policy-lifecycle/uploads")).toBe("grc:policies:write");

--- a/apps/web/src/lib/rbac.ts
+++ b/apps/web/src/lib/rbac.ts
@@ -275,7 +275,6 @@ export const permissionForCerebroProxyRequest = (
     normalizedPath.endsWith("/comments")
   )) return "grc:inventory:write";
   if (normalizedPath === "grc/vendors") return "grc:inventory:write";
-  if (normalizedPath.startsWith("grc/vendors/") && normalizedPath.endsWith("/actions")) return "grc:inventory:write";
   if (normalizedPath.startsWith("grc/vendor-discoveries/") && normalizedPath.endsWith("/decision")) return "grc:inventory:write";
   if (normalizedPath === "grc/policy-lifecycle/actions") return "grc:policies:write";
   if (normalizedPath === "grc/policy-lifecycle/uploads") return "grc:policies:write";


### PR DESCRIPTION
## Summary
- remove vendor quick-action controls for an API path with no durable backend contract
- remove the matching fixture mutation types, handler, and RBAC special case
- retain read-only next-action data and prove tenant-only and tenant/workspace POST variants remain absent

## Validation
- npx vitest run src/lib/cerebro-fixtures.test.ts src/lib/rbac.test.ts scripts/portable-web-fixture-e2e.test.mjs (60 passed)
- npx eslint src/app/vendors/page.tsx src/lib/cerebro-fixtures.ts src/lib/cerebro-fixtures.test.ts src/lib/grc.ts src/lib/rbac.ts src/lib/rbac.test.ts
- Practice Registry final gate passed