### PR TITLE
fix(api): implement vendor creation route

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4863,6 +4863,37 @@ paths:
               schema:
                 $ref: '#/components/schemas/GRCQuestionnaireRunResponse'
   /grc/vendors:
+    post:
+      summary: Create a vendor
+      tags:
+        - GRC
+      parameters:
+        - $ref: '#/components/parameters/tenantIDQuery'
+        - name: workspace_id
+          in: query
+          schema:
+            type: string
+        - $ref: '#/components/parameters/runtimeIDQuery'
+        - $ref: '#/components/parameters/sourceIDQuery'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GRCVendorCreateRequest'
+      responses:
+        '201':
+          description: Vendor event appended and projected.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GRCVendorCreateResponse'
+        '400':
+          description: Invalid vendor or scope request.
+        '403':
+          description: The caller is not authorized for the tenant or workspace.
+        '503':
+          description: The append-log or projection runtime is unavailable.
     get:
       summary: Vendors
       tags:
@@ -17234,6 +17265,101 @@ components:
           type: integer
         projection_failures:
           type: integer
+    GRCVendorCreateRequest:
+      type: object
+      required:
+        - name
+      properties:
+        tenant_id:
+          type: string
+        workspace_id:
+          type: string
+        name:
+          type: string
+        vendor_id:
+          type: string
+        source_id:
+          type: string
+        runtime_id:
+          type: string
+        provider:
+          type: string
+        status:
+          type: string
+        category:
+          type: string
+        website_url:
+          type: string
+        services_provided:
+          type: string
+        owner:
+          type: string
+        security_owner_user_id:
+          type: string
+        business_owner_user_id:
+          type: string
+        lifecycle_state:
+          type: string
+        review_state:
+          type: string
+        risk_level:
+          type: string
+        discovery_urn:
+          type: string
+        attributes:
+          type: object
+          additionalProperties:
+            type: string
+    GRCVendorCreateResponse:
+      type: object
+      required:
+        - vendor
+        - generated_at
+      properties:
+        vendor:
+          type: object
+          required:
+            - urn
+            - name
+          additionalProperties: true
+          properties:
+            urn:
+              type: string
+            vendor_id:
+              type: string
+            name:
+              type: string
+            source_id:
+              type: string
+            runtime_id:
+              type: string
+            provider:
+              type: string
+            status:
+              type: string
+            category:
+              type: string
+            website_url:
+              type: string
+            services_provided:
+              type: string
+            lifecycle_state:
+              type: string
+            owner:
+              type: string
+            owner_state:
+              type: string
+            risk_level:
+              type: string
+            review_state:
+              type: string
+            attributes:
+              type: object
+              additionalProperties:
+                type: string
+        generated_at:
+          type: string
+          format: date-time
     GRCQuestionnaireRunSummary:
       type: object
       properties:

--- a/docs/contracts/platform-public-route-inventory.json
+++ b/docs/contracts/platform-public-route-inventory.json
@@ -9,29 +9,29 @@
     "gen/cerebro/v1/cerebrov1connect/bootstrap.connect.go"
   ],
   "summary": {
-    "http_routes": 275,
+    "http_routes": 276,
     "connect_mounts": 1,
     "connect_rpcs": 47,
     "by_surface": {
       "bridged-to-rust-authority": 22,
-      "protected": 285,
+      "protected": 286,
       "public-exempt": 15,
       "rust-authority": 1
     },
     "by_authority_owner": {
       "bridged-to-rust-authority": 22,
-      "go-compatibility": 300,
+      "go-compatibility": 301,
       "rust-authority": 1
     },
     "by_auth_class": {
       "api-key-bearer-or-oauth": 2,
-      "api-key-or-bearer": 258,
+      "api-key-or-bearer": 259,
       "connect-api-key-or-bearer": 48,
       "public-exempt": 15
     },
     "by_contract_source": {
       "MCP schema": 2,
-      "OpenAPI": 273,
+      "OpenAPI": 274,
       "proto": 48
     },
     "deprecated_surfaces": 0
@@ -3400,6 +3400,18 @@
       "kind": "http",
       "method": "POST",
       "path": "/grc/vendor-discoveries/{discoveryID}/decision",
+      "surface": "protected",
+      "authority_owner": "go-compatibility",
+      "owner": "grc",
+      "auth_class": "api-key-or-bearer",
+      "tenant_scope_rule": "tenant-id-required",
+      "contract_source": "OpenAPI"
+    },
+    {
+      "identity": "POST /grc/vendors",
+      "kind": "http",
+      "method": "POST",
+      "path": "/grc/vendors",
       "surface": "protected",
       "authority_owner": "go-compatibility",
       "owner": "grc",

--- a/internal/bootstrap/auth_route_policy.go
+++ b/internal/bootstrap/auth_route_policy.go
@@ -162,6 +162,7 @@ var httpAuthRoutePolicies = []httpAuthRoutePolicy{
 	{Method: http.MethodPost, Exact: "/grc/inventory/accountability", Scope: scopeGRCInventoryWrite, Static: true},
 	{Method: http.MethodPost, Exact: "/grc/inventory/asset-reports", Scope: scopeGRCInventoryWrite, Static: true},
 	{Method: http.MethodPatch, Prefix: "/grc/inventory/asset-reports/", Suffix: "/triage", Scope: scopeGRCInventoryWrite},
+	{Method: http.MethodPost, Exact: "/grc/vendors", Scope: scopeGRCInventoryWrite, Static: true},
 	{Method: http.MethodPost, Exact: "/grc/vendors/uploads", Scope: scopeGRCInventoryWrite, Static: true},
 	{Method: http.MethodPost, Prefix: "/grc/vendors/uploads/", Suffix: "/replay", Scope: scopeGRCInventoryWrite},
 	{Method: http.MethodPost, Prefix: "/grc/vendor-discoveries/", Suffix: "/decision", Scope: scopeGRCInventoryWrite},

--- a/internal/bootstrap/grc_vendor_create.go
+++ b/internal/bootstrap/grc_vendor_create.go
@@ -1,0 +1,372 @@
+package bootstrap
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/grcvendor"
+	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/sourcecdk"
+	cerebrourn "github.com/writer/cerebro/internal/urn"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	maxGRCVendorCreateBodyBytes       = 32 << 10
+	maxGRCVendorCreateAttributes      = 32
+	maxGRCVendorCreateAttributeKey    = 128
+	maxGRCVendorCreateAttributeLength = 1024
+	maxGRCVendorCreateFieldLength     = 1024
+	grcVendorEventSourceID            = "grc"
+	grcVendorEventKind                = "grc.vendor"
+	grcVendorEventSchemaRef           = "grc/vendor/v1"
+)
+
+type grcVendorCreateRequest struct {
+	TenantID            string            `json:"tenant_id,omitempty"`
+	WorkspaceID         string            `json:"workspace_id,omitempty"`
+	Name                string            `json:"name"`
+	VendorID            string            `json:"vendor_id,omitempty"`
+	SourceID            string            `json:"source_id,omitempty"`
+	RuntimeID           string            `json:"runtime_id,omitempty"`
+	Provider            string            `json:"provider,omitempty"`
+	Status              string            `json:"status,omitempty"`
+	Category            string            `json:"category,omitempty"`
+	WebsiteURL          string            `json:"website_url,omitempty"`
+	ServicesProvided    string            `json:"services_provided,omitempty"`
+	Owner               string            `json:"owner,omitempty"`
+	SecurityOwnerUserID string            `json:"security_owner_user_id,omitempty"`
+	BusinessOwnerUserID string            `json:"business_owner_user_id,omitempty"`
+	LifecycleState      string            `json:"lifecycle_state,omitempty"`
+	ReviewState         string            `json:"review_state,omitempty"`
+	RiskLevel           string            `json:"risk_level,omitempty"`
+	DiscoveryURN        string            `json:"discovery_urn,omitempty"`
+	Attributes          map[string]string `json:"attributes,omitempty"`
+}
+
+type grcVendorCreateResponse struct {
+	Vendor      grcvendor.Vendor `json:"vendor"`
+	GeneratedAt time.Time        `json:"generated_at"`
+}
+
+func (a *App) handleCreateGRCVendor(w http.ResponseWriter, r *http.Request) {
+	var request grcVendorCreateRequest
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxGRCVendorCreateBodyBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		writeGRCError(w, fmt.Errorf("%w: decode vendor request: %w", grcvendor.ErrInvalidRequest, err))
+		return
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			err = fmt.Errorf("request body must contain one JSON object")
+		}
+		writeGRCError(w, fmt.Errorf("%w: decode vendor request: %w", grcvendor.ErrInvalidRequest, err))
+		return
+	}
+
+	request.normalize()
+	scopeRequest := r
+	if request.TenantID != "" && strings.TrimSpace(r.URL.Query().Get("tenant_id")) == "" && strings.TrimSpace(r.Header.Get("X-Cerebro-Tenant")) == "" {
+		clone := new(http.Request)
+		*clone = *r
+		clonedURL := *r.URL
+		query := clonedURL.Query()
+		query.Set("tenant_id", request.TenantID)
+		clonedURL.RawQuery = query.Encode()
+		clone.URL = &clonedURL
+		scopeRequest = clone
+	}
+	scope, err := grcScopeFromRequest(scopeRequest)
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	if request.TenantID != "" && scope.TenantID != "" && request.TenantID != scope.TenantID {
+		writeGRCError(w, fmt.Errorf("%w: tenant_id must match the resolved vendor scope", grcvendor.ErrInvalidRequest))
+		return
+	}
+	if request.WorkspaceID != "" && request.WorkspaceID != scope.ApplicationWorkspaceID {
+		writeGRCError(w, fmt.Errorf("%w: workspace_id must match the resolved vendor scope", grcvendor.ErrInvalidRequest))
+		return
+	}
+	if scope.TenantID == "" {
+		writeGRCError(w, fmt.Errorf("%w: tenant_id is required", grcvendor.ErrInvalidRequest))
+		return
+	}
+	if err := authorizeTenantID(r.Context(), scope.TenantID); err != nil {
+		writeGRCError(w, err)
+		return
+	}
+
+	event, vendor, err := buildGRCVendorCreateEvent(request, scope, time.Now().UTC())
+	if err != nil {
+		writeGRCError(w, err)
+		return
+	}
+	if a.deps.AppendLog == nil {
+		writeGRCError(w, grcvendor.ErrRuntimeUnavailable)
+		return
+	}
+	projector := appendLogSourceProjector(a.deps)
+	if projector == nil {
+		writeGRCError(w, grcvendor.ErrRuntimeUnavailable)
+		return
+	}
+	if err := a.deps.AppendLog.Append(r.Context(), event); err != nil {
+		writeGRCError(w, fmt.Errorf("%w: append vendor event: %w", grcvendor.ErrRuntimeUnavailable, err))
+		return
+	}
+	if _, err := projector.Project(r.Context(), event); err != nil {
+		writeGRCError(w, fmt.Errorf("%w: project vendor event: %w", grcvendor.ErrRuntimeUnavailable, err))
+		return
+	}
+	a.bumpGRCCacheVersions(r.Context(), scope.TenantID, grcCacheScopeGraph)
+	writeJSON(w, http.StatusCreated, grcVendorCreateResponse{Vendor: vendor, GeneratedAt: event.GetOccurredAt().AsTime()})
+}
+
+func (r *grcVendorCreateRequest) normalize() {
+	if r == nil {
+		return
+	}
+	r.TenantID = strings.TrimSpace(r.TenantID)
+	r.WorkspaceID = strings.TrimSpace(r.WorkspaceID)
+	r.Name = strings.TrimSpace(r.Name)
+	r.VendorID = strings.TrimSpace(r.VendorID)
+	r.SourceID = strings.TrimSpace(r.SourceID)
+	r.RuntimeID = strings.TrimSpace(r.RuntimeID)
+	r.Provider = strings.TrimSpace(r.Provider)
+	r.Status = strings.TrimSpace(r.Status)
+	r.Category = strings.TrimSpace(r.Category)
+	r.WebsiteURL = strings.TrimSpace(r.WebsiteURL)
+	r.ServicesProvided = strings.TrimSpace(r.ServicesProvided)
+	r.Owner = strings.TrimSpace(r.Owner)
+	r.SecurityOwnerUserID = strings.TrimSpace(r.SecurityOwnerUserID)
+	r.BusinessOwnerUserID = strings.TrimSpace(r.BusinessOwnerUserID)
+	r.LifecycleState = strings.TrimSpace(r.LifecycleState)
+	r.ReviewState = strings.TrimSpace(r.ReviewState)
+	r.RiskLevel = strings.TrimSpace(r.RiskLevel)
+	r.DiscoveryURN = strings.TrimSpace(r.DiscoveryURN)
+}
+
+func buildGRCVendorCreateEvent(request grcVendorCreateRequest, scope grcScope, now time.Time) (*cerebrov1.EventEnvelope, grcvendor.Vendor, error) {
+	request.normalize()
+	now = now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if request.Name == "" {
+		return nil, grcvendor.Vendor{}, fmt.Errorf("%w: name is required", grcvendor.ErrInvalidRequest)
+	}
+	if err := validateGRCVendorCreateFields(request); err != nil {
+		return nil, grcvendor.Vendor{}, err
+	}
+	tenantID := strings.TrimSpace(scope.TenantID)
+	if tenantID == "" {
+		return nil, grcvendor.Vendor{}, fmt.Errorf("%w: tenant_id is required", grcvendor.ErrInvalidRequest)
+	}
+	vendorID := grcVendorCreateSlug(firstNonEmpty(request.VendorID, request.Name))
+	if vendorID == "" {
+		return nil, grcvendor.Vendor{}, fmt.Errorf("%w: vendor_id is required", grcvendor.ErrInvalidRequest)
+	}
+	sourceID := firstNonEmpty(request.SourceID, scope.SourceID, grcVendorEventSourceID)
+	runtimeID := firstNonEmpty(request.RuntimeID, scope.RuntimeID)
+	provider := firstNonEmpty(request.Provider, sourceID)
+	if request.Provider == "" && request.SourceID == "" && scope.SourceID == "" {
+		provider = "manual"
+	}
+	provider = grcVendorCreateSlug(provider)
+	if provider == "" {
+		provider = "manual"
+	}
+	status := firstNonEmpty(request.Status, "active")
+	category := firstNonEmpty(request.Category, "uncategorized")
+	lifecycleState := firstNonEmpty(request.LifecycleState, grcvendor.LifecycleStateInReview)
+	reviewState := firstNonEmpty(request.ReviewState, grcvendor.ReviewStateNotScheduled)
+	riskLevel := firstNonEmpty(request.RiskLevel, grcvendor.FreshnessStateUnknown)
+	ownerState := "missing"
+	if firstNonEmpty(request.Owner, request.SecurityOwnerUserID, request.BusinessOwnerUserID) != "" {
+		ownerState = grcvendor.OwnerStateAssigned
+	}
+
+	attrs, err := grcVendorCreateAttributes(request, scope, vendorID, sourceID, runtimeID, provider, status, category, lifecycleState, reviewState, riskLevel)
+	if err != nil {
+		return nil, grcvendor.Vendor{}, err
+	}
+	seed := strings.Join([]string{tenantID, vendorID, provider, now.Format(time.RFC3339Nano)}, "\x00")
+	digest := sha256.Sum256([]byte(seed))
+	eventID := "grc-vendor-create-" + hex.EncodeToString(digest[:8])
+	recordURN, err := cerebrourn.Mint(tenantID, "vendor", provider, vendorID)
+	if err != nil {
+		return nil, grcvendor.Vendor{}, fmt.Errorf("%w: vendor identity is invalid", grcvendor.ErrInvalidRequest)
+	}
+	attrs["record_urn"] = recordURN
+	attrs["source_event_id"] = eventID
+	payload, err := json.Marshal(map[string]string{"record_id": vendorID, "record_kind": grcVendorEventKind})
+	if err != nil {
+		return nil, grcvendor.Vendor{}, fmt.Errorf("%w: encode vendor event: %w", grcvendor.ErrInvalidRequest, err)
+	}
+	event := &cerebrov1.EventEnvelope{
+		Id:         eventID,
+		TenantId:   tenantID,
+		SourceId:   grcVendorEventSourceID,
+		Kind:       grcVendorEventKind,
+		OccurredAt: timestamppb.New(now),
+		SchemaRef:  grcVendorEventSchemaRef,
+		Payload:    payload,
+		Attributes: attrs,
+	}
+	if err := sourcecdk.ValidateEventEnvelope(event); err != nil {
+		return nil, grcvendor.Vendor{}, fmt.Errorf("%w: %w", grcvendor.ErrInvalidRequest, err)
+	}
+	vendor := grcvendor.Vendor{
+		VendorIdentity: grcvendor.VendorIdentity{
+			URN: recordURN, VendorID: vendorID, Name: request.Name, SourceID: sourceID,
+			RuntimeID: runtimeID, Provider: provider, Status: status, Category: category,
+			WebsiteURL: request.WebsiteURL, ServicesProvided: request.ServicesProvided,
+		},
+		VendorLifecycle: grcvendor.VendorLifecycle{
+			SourceStatus: status, LifecycleState: lifecycleState,
+			LifecycleReason: "Created from vendor review.",
+		},
+		VendorOwnership: grcvendor.VendorOwnership{
+			SecurityOwnerUserID: request.SecurityOwnerUserID, BusinessOwnerUserID: request.BusinessOwnerUserID,
+			Owner: request.Owner, OwnerState: ownerState,
+		},
+		VendorRiskPosture: grcvendor.VendorRiskPosture{
+			InherentRiskLevel: riskLevel, ResidualRiskLevel: riskLevel, RiskLevel: riskLevel,
+		},
+		VendorReviewPosture: grcvendor.VendorReviewPosture{ReviewState: reviewState},
+		Attributes:          cloneGRCVendorCreateAttrs(attrs),
+	}
+	vendor = grcvendor.RefreshVendorQueuePosture(vendor, now)
+	return event, vendor, nil
+}
+
+func grcVendorCreateAttributes(request grcVendorCreateRequest, scope grcScope, vendorID, sourceID, runtimeID, provider, status, category, lifecycleState, reviewState, riskLevel string) (map[string]string, error) {
+	attrs := make(map[string]string, len(request.Attributes)+16)
+	for key, value := range request.Attributes {
+		key = strings.ToLower(strings.TrimSpace(key))
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		if len(attrs) >= maxGRCVendorCreateAttributes {
+			return nil, fmt.Errorf("%w: attributes exceed %d entries", grcvendor.ErrInvalidRequest, maxGRCVendorCreateAttributes)
+		}
+		if len(key) > maxGRCVendorCreateAttributeKey {
+			return nil, fmt.Errorf("%w: attribute key exceeds %d characters", grcvendor.ErrInvalidRequest, maxGRCVendorCreateAttributeKey)
+		}
+		if len(value) > maxGRCVendorCreateAttributeLength {
+			return nil, fmt.Errorf("%w: attribute %q exceeds %d characters", grcvendor.ErrInvalidRequest, key, maxGRCVendorCreateAttributeLength)
+		}
+		if grcVendorCreateReservedAttribute(key) {
+			continue
+		}
+		attrs[key] = value
+	}
+	attrs["vendor_id"] = vendorID
+	attrs["vendor_name"] = request.Name
+	attrs["name"] = request.Name
+	attrs["title"] = request.Name
+	attrs["provider"] = provider
+	attrs["source_system"] = provider
+	attrs["source_id"] = sourceID
+	attrs["status"] = status
+	attrs["source_status"] = status
+	attrs["category"] = category
+	attrs["lifecycle_state"] = lifecycleState
+	attrs["review_state"] = reviewState
+	attrs["risk_level"] = riskLevel
+	if request.WebsiteURL != "" {
+		attrs["website_url"] = request.WebsiteURL
+	}
+	if request.ServicesProvided != "" {
+		attrs["services_provided"] = request.ServicesProvided
+	}
+	if request.Owner != "" {
+		attrs["owner"] = request.Owner
+	}
+	if request.SecurityOwnerUserID != "" {
+		attrs["security_owner_user_id"] = request.SecurityOwnerUserID
+	}
+	if request.BusinessOwnerUserID != "" {
+		attrs["business_owner_user_id"] = request.BusinessOwnerUserID
+	}
+	if request.DiscoveryURN != "" {
+		attrs["discovery_urn"] = request.DiscoveryURN
+	}
+	if runtimeID != "" {
+		attrs[ports.EventAttributeSourceRuntimeID] = runtimeID
+	}
+	if scope.ApplicationWorkspaceID != "" {
+		attrs[ports.EventAttributeApplicationWorkspaceID] = scope.ApplicationWorkspaceID
+	}
+	return attrs, nil
+}
+
+func validateGRCVendorCreateFields(request grcVendorCreateRequest) error {
+	fields := map[string]string{
+		"tenant_id": request.TenantID, "workspace_id": request.WorkspaceID, "name": request.Name,
+		"vendor_id": request.VendorID, "source_id": request.SourceID, "runtime_id": request.RuntimeID,
+		"provider": request.Provider, "status": request.Status, "category": request.Category,
+		"website_url": request.WebsiteURL, "services_provided": request.ServicesProvided, "owner": request.Owner,
+		"security_owner_user_id": request.SecurityOwnerUserID, "business_owner_user_id": request.BusinessOwnerUserID,
+		"lifecycle_state": request.LifecycleState, "review_state": request.ReviewState,
+		"risk_level": request.RiskLevel, "discovery_urn": request.DiscoveryURN,
+	}
+	for field, value := range fields {
+		if len(value) > maxGRCVendorCreateFieldLength {
+			return fmt.Errorf("%w: %s exceeds %d characters", grcvendor.ErrInvalidRequest, field, maxGRCVendorCreateFieldLength)
+		}
+	}
+	return nil
+}
+
+func grcVendorCreateReservedAttribute(key string) bool {
+	switch key {
+	case "tenant_id", "workspace_id", ports.EventAttributeApplicationWorkspaceID, ports.EventAttributeSourceRuntimeID,
+		"vendor_id", "vendor_name", "name", "title", "provider", "source_system", "source_id", "runtime_id",
+		"status", "source_status", "category", "website_url", "services_provided", "owner",
+		"security_owner_user_id", "business_owner_user_id", "lifecycle_state", "review_state", "risk_level",
+		"discovery_urn", "record_urn", "source_event_id":
+		return true
+	default:
+		return false
+	}
+}
+
+func grcVendorCreateSlug(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	mapped := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r
+		case r >= '0' && r <= '9':
+			return r
+		default:
+			return '-'
+		}
+	}, value)
+	mapped = strings.Trim(mapped, "-")
+	for strings.Contains(mapped, "--") {
+		mapped = strings.ReplaceAll(mapped, "--", "-")
+	}
+	return mapped
+}
+
+func cloneGRCVendorCreateAttrs(values map[string]string) map[string]string {
+	clone := make(map[string]string, len(values))
+	for key, value := range values {
+		clone[key] = value
+	}
+	return clone
+}

--- a/internal/bootstrap/grc_vendor_create_test.go
+++ b/internal/bootstrap/grc_vendor_create_test.go
@@ -1,0 +1,174 @@
+package bootstrap
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/config"
+	"github.com/writer/cerebro/internal/grcvendor"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+func TestCreateGRCVendorSupportsTenantOnlyAndWorkspaceScopes(t *testing.T) {
+	tests := []struct {
+		name          string
+		query         string
+		body          map[string]any
+		wantWorkspace string
+	}{
+		{
+			name:  "tenant only",
+			query: "tenant_id=writer",
+			body: map[string]any{
+				"tenant_id":  "writer",
+				"name":       "Acme Vendor",
+				"owner":      "security",
+				"risk_level": "medium",
+			},
+		},
+		{
+			name:  "tenant and workspace",
+			query: "tenant_id=writer&workspace_id=workspace-a",
+			body: map[string]any{
+				"tenant_id":    "writer",
+				"workspace_id": "workspace-a",
+				"name":         "Workspace Vendor",
+				"source_id":    "okta",
+				"provider":     "Okta",
+				"runtime_id":   "okta-runtime",
+			},
+			wantWorkspace: "workspace-a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appendLog := &recordingAppendLog{}
+			graph := &stubGraphStore{}
+			app := New(config.Config{}, Dependencies{AppendLog: appendLog, GraphStore: graph}, nil)
+			server := httptest.NewServer(app.Handler())
+			defer server.Close()
+
+			payload, err := json.Marshal(tt.body)
+			if err != nil {
+				t.Fatalf("marshal request: %v", err)
+			}
+			response, err := server.Client().Post(server.URL+"/grc/vendors?"+tt.query, "application/json", bytes.NewReader(payload))
+			if err != nil {
+				t.Fatalf("POST /grc/vendors error: %v", err)
+			}
+			defer func() { _ = response.Body.Close() }()
+			if response.StatusCode != http.StatusCreated {
+				body, _ := io.ReadAll(response.Body)
+				t.Fatalf("POST /grc/vendors status = %d, want %d; body = %s", response.StatusCode, http.StatusCreated, body)
+			}
+
+			var result struct {
+				Vendor      grcvendor.Vendor `json:"vendor"`
+				GeneratedAt string           `json:"generated_at"`
+			}
+			if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if result.Vendor.Name != tt.body["name"] || result.GeneratedAt == "" {
+				t.Fatalf("response = %#v, want created vendor", result)
+			}
+			if len(appendLog.events) != 1 {
+				t.Fatalf("append log events = %d, want 1", len(appendLog.events))
+			}
+			event := appendLog.events[0]
+			if event.GetTenantId() != "writer" || event.GetSourceId() != grcVendorEventSourceID || event.GetKind() != grcVendorEventKind || event.GetSchemaRef() != grcVendorEventSchemaRef {
+				t.Fatalf("event identity = tenant %q source %q kind %q schema %q", event.GetTenantId(), event.GetSourceId(), event.GetKind(), event.GetSchemaRef())
+			}
+			if got := event.GetAttributes()[ports.EventAttributeApplicationWorkspaceID]; got != tt.wantWorkspace {
+				t.Fatalf("event workspace = %q, want %q", got, tt.wantWorkspace)
+			}
+			if len(graph.entities) == 0 {
+				t.Fatal("projected vendor entity missing")
+			}
+		})
+	}
+}
+
+func TestCreateGRCVendorRejectsMalformedAndOversizedFields(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "unknown field", body: `{"name":"Acme Vendor","unknown":"value"}`},
+		{name: "oversized name", body: `{"name":"` + strings.Repeat("x", maxGRCVendorCreateFieldLength+1) + `"}`},
+		{name: "oversized attribute key", body: `{"name":"Acme Vendor","attributes":{"` + strings.Repeat("k", maxGRCVendorCreateAttributeKey+1) + `":"value"}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := New(config.Config{}, Dependencies{AppendLog: &recordingAppendLog{}, GraphStore: &stubGraphStore{}}, nil)
+			server := httptest.NewServer(app.Handler())
+			defer server.Close()
+
+			response, err := server.Client().Post(server.URL+"/grc/vendors?tenant_id=writer", "application/json", strings.NewReader(tt.body))
+			if err != nil {
+				t.Fatalf("POST /grc/vendors error: %v", err)
+			}
+			defer func() { _ = response.Body.Close() }()
+			if response.StatusCode != http.StatusBadRequest {
+				t.Fatalf("POST /grc/vendors status = %d, want %d", response.StatusCode, http.StatusBadRequest)
+			}
+		})
+	}
+}
+
+func TestBuildGRCVendorCreateEventDoesNotAllowStandardAttributeOverrides(t *testing.T) {
+	event, vendor, err := buildGRCVendorCreateEvent(grcVendorCreateRequest{
+		Name: "Acme Vendor",
+		Attributes: map[string]string{
+			"source_status": "disabled",
+			"owner":         "untrusted-owner",
+			"custom_field":  "kept",
+		},
+	}, grcScope{TenantID: "writer"}, testNow())
+	if err != nil {
+		t.Fatalf("buildGRCVendorCreateEvent() error = %v", err)
+	}
+	if got := event.GetAttributes()["source_status"]; got != "active" {
+		t.Fatalf("source_status = %q, want active", got)
+	}
+	if got := event.GetAttributes()["owner"]; got != "" {
+		t.Fatalf("owner = %q, want reserved attribute omitted", got)
+	}
+	if got := event.GetAttributes()["custom_field"]; got != "kept" {
+		t.Fatalf("custom_field = %q, want kept", got)
+	}
+	if vendor.Owner != "" {
+		t.Fatalf("vendor owner = %q, want empty", vendor.Owner)
+	}
+}
+
+func testNow() time.Time {
+	return time.Date(2026, time.August, 26, 0, 0, 0, 0, time.UTC)
+}
+
+func TestCreateGRCVendorRejectsBodyWorkspaceWithoutResolvedScope(t *testing.T) {
+	appendLog := &recordingAppendLog{}
+	graph := &stubGraphStore{}
+	app := New(config.Config{}, Dependencies{AppendLog: appendLog, GraphStore: graph}, nil)
+	server := httptest.NewServer(app.Handler())
+	defer server.Close()
+
+	response, err := server.Client().Post(server.URL+"/grc/vendors?tenant_id=writer", "application/json", bytes.NewBufferString(`{"tenant_id":"writer","workspace_id":"workspace-a","name":"Acme Vendor"}`))
+	if err != nil {
+		t.Fatalf("POST /grc/vendors error: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusBadRequest {
+		t.Fatalf("POST /grc/vendors status = %d, want %d", response.StatusCode, http.StatusBadRequest)
+	}
+	if len(appendLog.events) != 0 {
+		t.Fatalf("append log events = %d, want 0", len(appendLog.events))
+	}
+}

--- a/internal/bootstrap/routes.go
+++ b/internal/bootstrap/routes.go
@@ -247,6 +247,7 @@ func (app *App) registerGRCRoutes(mux *http.ServeMux) {
 	registerHTTPRoute(mux, "GET /grc/inventory/assets", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("inventory.assets", 2*time.Minute, grcCacheScopeGraph, grcCacheScopeInventory, grcCacheScopeFindings, grcCacheScopeEvidence), app.handleGRCInventoryAssets))
 	registerHTTPRoute(mux, "GET /grc/inventory/assets/detail", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("inventory.asset.detail", 5*time.Minute, grcCacheScopeGraph, grcCacheScopeInventory, grcCacheScopeFindings, grcCacheScopeEvidence), app.handleGRCInventoryAssetDetail))
 	registerHTTPRoute(mux, "GET /grc/vendors", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("vendors", 2*time.Minute, grcCacheScopeGraph, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime), app.handleGRCVendors))
+	registerHTTPRoute(mux, "POST /grc/vendors", routeSurfacePlatformHTTP, app.handleCreateGRCVendor)
 	registerHTTPRoute(mux, "POST /grc/vendors/uploads", routeSurfacePlatformHTTP, app.grcUploadHandler(grcupload.TargetVendor).ServeHTTP)
 	registerHTTPRoute(mux, "POST /grc/vendors/uploads/{uploadID}/replay", routeSurfacePlatformHTTP, app.grcUploadReplayHandler().ServeHTTP)
 	registerHTTPRoute(mux, "GET /grc/vendors/{vendorID}", routeSurfacePlatformHTTP, app.cacheGRCJSON(app.grcCachePolicy("vendor.detail", 5*time.Minute, grcCacheScopeGraph, grcCacheScopeFindings, grcCacheScopeEvidence, grcCacheScopeRuntime), app.handleGRCVendorDetail))

--- a/sdk/typescript/src/generated/openapi-types.ts
+++ b/sdk/typescript/src/generated/openapi-types.ts
@@ -4244,6 +4244,33 @@ export type GRCUploadStructuredField = {
   value?: string;
 };
 
+export type GRCVendorCreateRequest = {
+  attributes?: Record<string, string>;
+  business_owner_user_id?: string;
+  category?: string;
+  discovery_urn?: string;
+  lifecycle_state?: string;
+  name: string;
+  owner?: string;
+  provider?: string;
+  review_state?: string;
+  risk_level?: string;
+  runtime_id?: string;
+  security_owner_user_id?: string;
+  services_provided?: string;
+  source_id?: string;
+  status?: string;
+  tenant_id?: string;
+  vendor_id?: string;
+  website_url?: string;
+  workspace_id?: string;
+};
+
+export type GRCVendorCreateResponse = {
+  generated_at: string;
+  vendor: Record<string, unknown>;
+};
+
 export type GetEntityNeighborhoodResponse = {
   neighbors?: GraphEntity[];
   relations?: GraphRelation[];


### PR DESCRIPTION
## Summary
- implement POST /grc/vendors as a bounded authenticated platform route
- append and project a tenant-scoped vendor event before returning 201
- publish the OpenAPI, generated TypeScript, auth-policy, and public-route contracts

## Validation
- go test ./internal/bootstrap -run "Test(CreateGRCVendor|BuildGRCVendorCreateEvent)" -count=1
- go test -race ./internal/bootstrap -run "Test(CreateGRCVendor|BuildGRCVendorCreateEvent)" -count=1
- go test ./internal/sourceprojection ./internal/grcvendor -count=1
- make openapi-check openapi-ts-check docs-drift-check

Current main independently fails TestMCPToolsDeclareDomainSurfaceParity for the newly merged graph-neighborhood domain marker; the same failure reproduces on the web-only branch.