### PR TITLE
fix(graph): fail closed and restore Rust demo compatibility

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -23,7 +23,7 @@ Run the browser against the Rust-owned organizational graph without Docker or pr
 make rust-product-demo
 ```
 
-The command prints a graph explorer URL and stops both local processes on `Ctrl-C`. With Chromium installed, `make rust-product-demo-check` validates the direct Rust response, the web proxy, and the rendered graph, then writes `tmp/rust-product-demo/receipt.json` without the ephemeral authentication secret.
+The command prints graph explorer and vendor register URLs and stops all local processes on `Ctrl-C`. With Chromium installed, `make rust-product-demo-check` validates the direct Rust response, the web proxy, the rendered graph, and the Go-compatible GRC vendor read backed by the Rust graph, then writes `tmp/rust-product-demo/receipt.json` without the ephemeral authentication secret.
 
 ## Check
 

--- a/apps/web/scripts/rust-product-demo.mjs
+++ b/apps/web/scripts/rust-product-demo.mjs
@@ -533,25 +533,37 @@ export async function runRustProductDemo(options = {}) {
   const processes = [];
   let failed = true;
   try {
-    const [rustPort, webPort] = await Promise.all([
+    const [rustPort, apiPort, webPort] = await Promise.all([
+      reserveLoopbackPort(),
       reserveLoopbackPort(),
       reserveLoopbackPort(),
     ]);
-    expect(new Set([rustPort, webPort]).size === 2, "Reserved ports collided");
+    expect(new Set([rustPort, apiPort, webPort]).size === 3, "Reserved ports collided");
 
     const rustBinary = await cargoBinary(deadlineAt);
+    const eventAdmissionBinary = path.join(
+      path.dirname(rustBinary),
+      process.platform === "win32"
+        ? "cerebro-event-admission-worker.exe"
+        : "cerebro-event-admission-worker",
+    );
     await run(
       "cargo",
       [
         "build", "--locked",
         "-p", "cerebro-platform",
+        "-p", "cerebro-sourceruntime-eventadmission",
         "--bin", "cerebro-platform",
+        "--bin", "cerebro-event-admission-worker",
       ],
       { cwd: repositoryRoot },
       deadlineAt,
     );
     await access(rustBinary).catch(() => {
       throw new Error(`Cargo did not produce the Rust platform binary at ${rustBinary}`);
+    });
+    await access(eventAdmissionBinary).catch(() => {
+      throw new Error(`Cargo did not produce the event admission binary at ${eventAdmissionBinary}`);
     });
     const { neighborhood, rootURN } = parseDemoNeighborhood(
       await run(
@@ -586,6 +598,43 @@ export async function runRustProductDemo(options = {}) {
       deadlineAt,
     );
 
+    const apiBinary = path.join(
+      workDir,
+      process.platform === "win32" ? "cerebro-demo-api.exe" : "cerebro-demo-api",
+    );
+    await run(
+      "go",
+      ["build", "-o", apiBinary, "./cmd/cerebro"],
+      { cwd: repositoryRoot },
+      deadlineAt,
+    );
+    const api = startLogged(
+      "go-grc-compatibility-adapter",
+      apiBinary,
+      ["serve"],
+      {
+        cwd: repositoryRoot,
+        env: portableEnvironment(process.env, {
+          CEREBRO_DEV_MODE: "1",
+          CEREBRO_DEV_MODE_ACK: "1",
+          CEREBRO_EVENT_ADMISSION_WORKER: eventAdmissionBinary,
+          CEREBRO_HTTP_ADDR: `127.0.0.1:${apiPort}`,
+          CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE: "authority",
+          CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL: `http://127.0.0.1:${rustPort}`,
+          CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET: sharedSecret,
+          CEREBRO_ORGANIZATIONAL_GRAPH_TIMEOUT: "30s",
+        }),
+      },
+      logDir,
+    );
+    processes.push(api);
+    await waitFor(
+      "Go GRC compatibility adapter",
+      async () => (await request(`http://127.0.0.1:${apiPort}/healthz`)).status === 200,
+      api,
+      deadlineAt,
+    );
+
     const graphQuery = `/platform/graph/neighborhood?root_urn=${encodeURIComponent(rootURN)}&limit=50`;
     const directGraphResponse = await request(
       `http://127.0.0.1:${rustPort}${graphQuery}`,
@@ -610,7 +659,7 @@ export async function runRustProductDemo(options = {}) {
       {
         cwd: webRoot,
         env: portableEnvironment(process.env, {
-          CEREBRO_API_BASE: `http://127.0.0.1:${rustPort}`,
+          CEREBRO_API_BASE: `http://127.0.0.1:${apiPort}`,
           CEREBRO_FORWARD_AUTH_HEADERS: "false",
           CEREBRO_IDENTITY_REQUIRED: "false",
           CEREBRO_LOCAL_IDENTITY_FALLBACK: "true",
@@ -682,6 +731,7 @@ export async function runRustProductDemo(options = {}) {
         graph_authority: "rust",
         persistence: "memory",
         product_adapter: "rust_http",
+        grc_compatibility_adapter: "go_http",
       },
       authentication: {
         kind: "ephemeral_hmac",

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -38,7 +38,7 @@ use aws_sdk_secretsmanager::Client as AwsSecretsManagerClient;
 use axum::{
     Extension, Json, Router,
     extract::{Path, Query, Request, State},
-    http::{Method, StatusCode, header::AUTHORIZATION},
+    http::{HeaderMap, Method, StatusCode, header::AUTHORIZATION},
     middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::{get, post},
@@ -100,6 +100,7 @@ use tokio::sync::{Mutex, oneshot};
 use zeroize::Zeroize;
 
 const TENANT_AUTH_HEADER: &str = "x-cerebro-tenant";
+const WORKSPACE_AUTH_HEADER: &str = "x-cerebro-workspace";
 const TENANT_AUTH_CONTEXT: &[u8] = b"cerebro-organizational-graph/tenant/v1\0";
 const MAX_LEGACY_DELTA_RECORDS: usize = 100_000;
 const MIN_SHARED_SECRET_BYTES: usize = 32;
@@ -1244,6 +1245,8 @@ struct PathsResponse {
 #[derive(Deserialize)]
 struct ProductNeighborhoodQuery {
     root_urn: String,
+    tenant_id: Option<String>,
+    workspace_id: Option<String>,
     limit: Option<u32>,
 }
 
@@ -3928,14 +3931,30 @@ async fn find_paths(
 async fn product_neighborhood_route(
     State(state): State<AppState>,
     Extension(authenticated): Extension<AuthenticatedTenant>,
+    headers: HeaderMap,
     Query(query): Query<ProductNeighborhoodQuery>,
 ) -> Result<Json<ProductNeighborhood>, (StatusCode, Json<ErrorResponse>)> {
+    if query.workspace_id.is_some() || headers.contains_key(WORKSPACE_AUTH_HEADER) {
+        return Err(bad_request(
+            "workspace_scope_unsupported",
+            "Application workspace scope is not supported for graph neighborhood reads.",
+        ));
+    }
     let tenant = product_urn_tenant(&query.root_urn).ok_or_else(|| {
         bad_request(
             "invalid_root_urn",
             "root_urn must be a tenant-scoped Cerebro URN.",
         )
     })?;
+    if let Some(query_tenant) = query.tenant_id {
+        let query_tenant = parse_tenant(query_tenant)?;
+        if query_tenant.as_str() != tenant {
+            return Err(bad_request(
+                "tenant_selector_mismatch",
+                "The tenant selector does not match the graph root tenant.",
+            ));
+        }
+    }
     let tenant_id = authorized_tenant(&authenticated, tenant.to_owned())?;
     let limit = normalize_product_neighborhood_limit(query.limit);
     let mut neighborhoods = state
@@ -6253,6 +6272,55 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(cross_tenant.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn product_neighborhood_route_rejects_scope_mismatch_before_graph_read() {
+        let root_urn = "urn:cerebro:tenant-demo:asset:one";
+        let app = router_with_backend(
+            Arc::new(UnavailableGraph),
+            None,
+            None,
+            PlatformStores::default(),
+            ActionBackends::default(),
+            TenantRequestAuth::new(TEST_SHARED_SECRET.to_owned()).unwrap(),
+            None,
+        );
+        for request in [
+            authenticated(Request::builder(), "tenant-demo")
+                .uri(format!(
+                    "/platform/graph/neighborhood?root_urn={root_urn}&workspace_id=workspace-a"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+            authenticated(Request::builder(), "tenant-demo")
+                .header(WORKSPACE_AUTH_HEADER, "workspace-a")
+                .uri(format!("/platform/graph/neighborhood?root_urn={root_urn}"))
+                .body(Body::empty())
+                .unwrap(),
+            authenticated(Request::builder(), "tenant-demo")
+                .uri(format!(
+                    "/platform/graph/neighborhood?root_urn={root_urn}&tenant_id=tenant-other"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        ] {
+            let response = app.clone().oneshot(request).await.unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+
+        let matching_tenant = app
+            .oneshot(
+                authenticated(Request::builder(), "tenant-demo")
+                    .uri(format!(
+                        "/platform/graph/neighborhood?root_urn={root_urn}&tenant_id=tenant-demo"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(matching_tenant.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -5511,7 +5511,22 @@ mod tests {
         assert_eq!(config.get("family").map(String::as_str), Some("resources"));
     }
 
-    struct UnavailableGraph;
+    #[derive(Default)]
+    struct UnavailableGraph {
+        reads: Option<Arc<AtomicUsize>>,
+    }
+
+    impl UnavailableGraph {
+        fn counting(reads: Arc<AtomicUsize>) -> Self {
+            Self { reads: Some(reads) }
+        }
+
+        fn record_read(&self) {
+            if let Some(reads) = &self.reads {
+                reads.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
 
     struct FixtureSourceRuntimeSync;
 
@@ -5661,10 +5676,12 @@ mod tests {
     #[async_trait]
     impl AgentGraph for UnavailableGraph {
         async fn health(&self) -> Result<(), ContextError> {
+            self.record_read();
             Err(unavailable())
         }
 
         async fn revision(&self, _tenant_id: &TenantId) -> Result<u64, ContextError> {
+            self.record_read();
             Err(unavailable())
         }
 
@@ -5675,6 +5692,7 @@ mod tests {
             _kinds: &[String],
             _limit: usize,
         ) -> Result<Vec<ContextEntity>, ContextError> {
+            self.record_read();
             Err(unavailable())
         }
 
@@ -5683,6 +5701,7 @@ mod tests {
             _tenant_id: &TenantId,
             _entity_id: &EntityId,
         ) -> Result<ContextEntity, ContextError> {
+            self.record_read();
             Err(unavailable())
         }
 
@@ -5691,6 +5710,7 @@ mod tests {
             _tenant_id: &TenantId,
             _key: &str,
         ) -> Result<ContextEntity, ContextError> {
+            self.record_read();
             Err(unavailable())
         }
 
@@ -5701,6 +5721,7 @@ mod tests {
             _depth: usize,
             _limit: usize,
         ) -> Result<Neighborhood, ContextError> {
+            self.record_read();
             Err(unavailable())
         }
 
@@ -5712,6 +5733,7 @@ mod tests {
             _max_depth: usize,
             _limit: usize,
         ) -> Result<Vec<GraphPath>, ContextError> {
+            self.record_read();
             Err(unavailable())
         }
 
@@ -5720,6 +5742,7 @@ mod tests {
             _tenant_id: &TenantId,
             _assertion_id: &AssertionId,
         ) -> Result<ContextEdge, ContextError> {
+            self.record_read();
             Err(unavailable())
         }
 
@@ -5728,6 +5751,7 @@ mod tests {
             _tenant_id: &TenantId,
             _query: &cerebro_agent_context::FactQuery,
         ) -> Result<cerebro_agent_context::QueryResult, ContextError> {
+            self.record_read();
             Err(unavailable())
         }
     }
@@ -6277,8 +6301,9 @@ mod tests {
     #[tokio::test]
     async fn product_neighborhood_route_rejects_scope_mismatch_before_graph_read() {
         let root_urn = "urn:cerebro:tenant-demo:asset:one";
+        let graph_reads = Arc::new(AtomicUsize::new(0));
         let app = router_with_backend(
-            Arc::new(UnavailableGraph),
+            Arc::new(UnavailableGraph::counting(graph_reads.clone())),
             None,
             None,
             PlatformStores::default(),
@@ -6304,9 +6329,16 @@ mod tests {
                 ))
                 .body(Body::empty())
                 .unwrap(),
+            authenticated(Request::builder(), "tenant-demo")
+                .uri(format!(
+                    "/platform/graph/neighborhood?root_urn={root_urn}&tenant_id=tenant-other&workspace_id=workspace-a"
+                ))
+                .body(Body::empty())
+                .unwrap(),
         ] {
             let response = app.clone().oneshot(request).await.unwrap();
             assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            assert_eq!(graph_reads.load(Ordering::Relaxed), 0);
         }
 
         let matching_tenant = app
@@ -6321,6 +6353,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(matching_tenant.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(graph_reads.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test]
@@ -6380,7 +6413,7 @@ mod tests {
     #[tokio::test]
     async fn product_neighborhood_route_surfaces_backend_failure_as_unavailable() {
         let app = router_with_backend(
-            Arc::new(UnavailableGraph),
+            Arc::new(UnavailableGraph::default()),
             None,
             None,
             PlatformStores::default(),
@@ -7562,7 +7595,7 @@ mod tests {
     #[tokio::test]
     async fn readiness_fails_without_breaking_process_liveness() {
         let app = router_with_backend(
-            Arc::new(UnavailableGraph),
+            Arc::new(UnavailableGraph::default()),
             None,
             None,
             PlatformStores::default(),


### PR DESCRIPTION
Summary
- Reject workspace query and header selectors at the protected Rust graph-neighborhood boundary before graph access.
- Reconcile an optional tenant query selector with the root URN tenant before traversal.
- Count graph calls in the regression test and prove workspace, tenant, and combined selector mismatches produce zero backend reads.
- Restore the credential-free Rust product demo's Vendor browser proof by retaining the existing Go GRC API as a compatibility adapter while Rust remains the graph-neighborhood authority.

Regression repaired
- Exact main `fec878b7f4c83ab38f642e09547c05acbf275624` failed run `32932883739`, job `98068533515`: the Vendor browser query returned HTTP 404 after the web proxy's API base was pointed entirely at the Rust process.
- The demo now starts separate Rust graph and Go GRC compatibility processes. `CEREBRO_RUST_PLATFORM_API_BASE` still targets Rust; `CEREBRO_API_BASE` targets the Go adapter for the retained Vendor routes.
- The demo receipt names both roles: `product_adapter: rust_http` and `grc_compatibility_adapter: go_http`.

Security proof
- Workspace query, workspace header, tenant mismatch, and combined tenant/workspace mismatch requests return 400 with zero graph calls.
- A matching tenant reaches the backend and increments the call counter once.
- The unsupported workspace path has no tenant-wide fallback.

Hosted regression receipt
- Pre-rebase head `11e2702d4` run `32934632472`, job `98073579232`: authenticated browser-to-Rust authority passed; credential-free Rust product demo passed; receipt upload passed.
- Artifact `9594661383`, `cerebro-rust-product-demo`, was created at `2026-08-26T05:47:42Z`.
- The same three scoped commits are rebased without conflict onto main `50f0c3a90` as exact head `e21aa603d`; refreshed exact-head checks are running.

Local validation
- `node --check apps/web/scripts/rust-product-demo.mjs`: passed on head `e21aa603d`.
- `go test ./cmd/cerebro -run '^$' -count=1`: passed on head `e21aa603d`.
- `git diff origin/main...HEAD --check`: passed on head `e21aa603d`.
- Before the call-counter assertion was added, `cargo test -p cerebro-platform product_neighborhood_route -- --nocapture`: 6 passed; `cargo clippy -p cerebro-platform --all-targets -- -D warnings`: passed; `cargo fmt --all -- --check`: passed.

Environment note
- The managed Cargo gate blocked the post-rebase format/test attempt before execution because its shared cache was 6,524,451,430 bytes below the safety threshold. No wrapper bypass or checkout-local target directory was used. Hosted Rust checks on the exact head are the execution authority for the final assertion change.

Ownership
- This pull request does not modify release PR #2668's files or branch.
- PR #2671 owns Vendor creation and does not modify this demo script or Rust graph handler.
- Draft PR #2665 owns the MCP/domain marker for the Rust graph route. It remains separate and is not folded into this branch.
