### PR TITLE
Fix finding Wasm lifecycle context propagation

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -23,7 +23,7 @@ Run the browser against the Rust-owned organizational graph without Docker or pr
 make rust-product-demo
 ```
 
-The command prints a graph explorer URL and stops both local processes on `Ctrl-C`. With Chromium installed, `make rust-product-demo-check` validates the direct Rust response, the web proxy, and the rendered graph, then writes `tmp/rust-product-demo/receipt.json` without the ephemeral authentication secret.
+The command prints graph explorer and vendor register URLs and stops all local processes on `Ctrl-C`. With Chromium installed, `make rust-product-demo-check` validates the direct Rust response, the web proxy, the rendered graph, and the Go-compatible GRC vendor read backed by the Rust graph, then writes `tmp/rust-product-demo/receipt.json` without the ephemeral authentication secret.
 
 ## Check
 

--- a/apps/web/scripts/rust-product-demo.mjs
+++ b/apps/web/scripts/rust-product-demo.mjs
@@ -533,25 +533,37 @@ export async function runRustProductDemo(options = {}) {
   const processes = [];
   let failed = true;
   try {
-    const [rustPort, webPort] = await Promise.all([
+    const [rustPort, apiPort, webPort] = await Promise.all([
+      reserveLoopbackPort(),
       reserveLoopbackPort(),
       reserveLoopbackPort(),
     ]);
-    expect(new Set([rustPort, webPort]).size === 2, "Reserved ports collided");
+    expect(new Set([rustPort, apiPort, webPort]).size === 3, "Reserved ports collided");
 
     const rustBinary = await cargoBinary(deadlineAt);
+    const eventAdmissionBinary = path.join(
+      path.dirname(rustBinary),
+      process.platform === "win32"
+        ? "cerebro-event-admission-worker.exe"
+        : "cerebro-event-admission-worker",
+    );
     await run(
       "cargo",
       [
         "build", "--locked",
         "-p", "cerebro-platform",
+        "-p", "cerebro-sourceruntime-eventadmission",
         "--bin", "cerebro-platform",
+        "--bin", "cerebro-event-admission-worker",
       ],
       { cwd: repositoryRoot },
       deadlineAt,
     );
     await access(rustBinary).catch(() => {
       throw new Error(`Cargo did not produce the Rust platform binary at ${rustBinary}`);
+    });
+    await access(eventAdmissionBinary).catch(() => {
+      throw new Error(`Cargo did not produce the event admission binary at ${eventAdmissionBinary}`);
     });
     const { neighborhood, rootURN } = parseDemoNeighborhood(
       await run(
@@ -586,6 +598,43 @@ export async function runRustProductDemo(options = {}) {
       deadlineAt,
     );
 
+    const apiBinary = path.join(
+      workDir,
+      process.platform === "win32" ? "cerebro-demo-api.exe" : "cerebro-demo-api",
+    );
+    await run(
+      "go",
+      ["build", "-o", apiBinary, "./cmd/cerebro"],
+      { cwd: repositoryRoot },
+      deadlineAt,
+    );
+    const api = startLogged(
+      "go-grc-compatibility-adapter",
+      apiBinary,
+      ["serve"],
+      {
+        cwd: repositoryRoot,
+        env: portableEnvironment(process.env, {
+          CEREBRO_DEV_MODE: "1",
+          CEREBRO_DEV_MODE_ACK: "1",
+          CEREBRO_EVENT_ADMISSION_WORKER: eventAdmissionBinary,
+          CEREBRO_HTTP_ADDR: `127.0.0.1:${apiPort}`,
+          CEREBRO_ORGANIZATIONAL_GRAPH_READ_MODE: "authority",
+          CEREBRO_ORGANIZATIONAL_GRAPH_READ_URL: `http://127.0.0.1:${rustPort}`,
+          CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET: sharedSecret,
+          CEREBRO_ORGANIZATIONAL_GRAPH_TIMEOUT: "30s",
+        }),
+      },
+      logDir,
+    );
+    processes.push(api);
+    await waitFor(
+      "Go GRC compatibility adapter",
+      async () => (await request(`http://127.0.0.1:${apiPort}/healthz`)).status === 200,
+      api,
+      deadlineAt,
+    );
+
     const graphQuery = `/platform/graph/neighborhood?root_urn=${encodeURIComponent(rootURN)}&limit=50`;
     const directGraphResponse = await request(
       `http://127.0.0.1:${rustPort}${graphQuery}`,
@@ -610,7 +659,7 @@ export async function runRustProductDemo(options = {}) {
       {
         cwd: webRoot,
         env: portableEnvironment(process.env, {
-          CEREBRO_API_BASE: `http://127.0.0.1:${rustPort}`,
+          CEREBRO_API_BASE: `http://127.0.0.1:${apiPort}`,
           CEREBRO_FORWARD_AUTH_HEADERS: "false",
           CEREBRO_IDENTITY_REQUIRED: "false",
           CEREBRO_LOCAL_IDENTITY_FALLBACK: "true",
@@ -682,6 +731,7 @@ export async function runRustProductDemo(options = {}) {
         graph_authority: "rust",
         persistence: "memory",
         product_adapter: "rust_http",
+        grc_compatibility_adapter: "go_http",
       },
       authentication: {
         kind: "ephemeral_hmac",

--- a/cmd/cerebro/finding_rule_test.go
+++ b/cmd/cerebro/finding_rule_test.go
@@ -6,6 +6,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,6 +19,8 @@ import (
 	"github.com/writer/cerebro/internal/ports"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+const maxShadowEmbeddedFileBytes = 8 << 20
 
 func TestParseFindingRuleNewArgsAppliesDefaults(t *testing.T) {
 	request, err := parseFindingRuleNewArgs([]string{
@@ -332,6 +335,14 @@ func TestRenderFindingRuleGo_RetiredEmitsRetiredEventRule(t *testing.T) {
 func TestScaffoldFindingRule_RetiredGeneratedTestPasses(t *testing.T) {
 	repoRoot := testRepoRoot(t)
 	outputDir := shadowRepoForFindingRuleScaffold(t, repoRoot)
+	shadowWasmPath := filepath.Join(outputDir, "internal", "findings", "findingrule.wasm")
+	shadowWasm, err := os.Lstat(shadowWasmPath)
+	if err != nil {
+		t.Fatalf("lstat shadow findingrule.wasm: %v", err)
+	}
+	if !shadowWasm.Mode().IsRegular() || shadowWasm.Size() <= 0 || shadowWasm.Size() > maxShadowEmbeddedFileBytes {
+		t.Fatalf("shadow findingrule.wasm mode/size = %s/%d, want a non-empty bounded regular file", shadowWasm.Mode(), shadowWasm.Size())
+	}
 	request, err := parseFindingRuleNewArgs([]string{
 		"retired-scaffold-contract",
 		"source_id=github",
@@ -505,19 +516,23 @@ func shadowRepoForFindingRuleScaffold(t *testing.T, repoRoot string) string {
 		"correlation_patterns": true,
 		"testdata":             true,
 	}
-	// go:embed cannot resolve through symlinks, so embedded data files must be
-	// copied into the shadow package as real files (mirrors correlation_patterns).
-	embedYAMLFiles, err := filepath.Glob(filepath.Join(repoRoot, "internal", "findings", "*.yaml"))
-	if err != nil {
-		t.Fatalf("glob findings embed files: %v", err)
+	// go:embed rejects symlinks, so embedded package files must be copied into
+	// the shadow package as bounded regular files.
+	var embedFiles []string
+	for _, pattern := range []string{"*.yaml", "*.wasm"} {
+		matches, err := filepath.Glob(filepath.Join(repoRoot, "internal", "findings", pattern))
+		if err != nil {
+			t.Fatalf("glob findings embed files %q: %v", pattern, err)
+		}
+		embedFiles = append(embedFiles, matches...)
 	}
-	for _, embedFile := range embedYAMLFiles {
+	for _, embedFile := range embedFiles {
 		findingsSkip[filepath.Base(embedFile)] = true
 	}
 	linkRepoEntries(t, filepath.Join(repoRoot, "internal", "findings"), findingsDir, findingsSkip)
 	copyRepoTree(t, filepath.Join(repoRoot, "internal", "findings", "correlation_patterns"), filepath.Join(findingsDir, "correlation_patterns"))
-	for _, embedFile := range embedYAMLFiles {
-		copyRepoFile(t, embedFile, filepath.Join(findingsDir, filepath.Base(embedFile)))
+	for _, embedFile := range embedFiles {
+		copyRepoFileBounded(t, embedFile, filepath.Join(findingsDir, filepath.Base(embedFile)), maxShadowEmbeddedFileBytes)
 	}
 	linkRepoEntries(t, filepath.Join(repoRoot, "internal", "findings", "testdata"), filepath.Join(findingsDir, "testdata"), map[string]bool{
 		"rules": true,
@@ -578,17 +593,31 @@ func copyRepoTree(t *testing.T, srcDir, dstDir string) {
 	}
 }
 
-func copyRepoFile(t *testing.T, src, dst string) {
+func copyRepoFileBounded(t *testing.T, src, dst string, maxBytes int64) {
 	t.Helper()
-	dstDir := filepath.Dir(dst)
-	if rel, err := filepath.Rel(dstDir, dst); err != nil || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || rel == ".." {
-		t.Fatalf("copy destination %q escaped %q", dst, dstDir)
+	if maxBytes <= 0 {
+		t.Fatalf("copy bound for %q must be positive", src)
 	}
-	payload, err := os.ReadFile(src) // #nosec G304 -- source path is a repository fixture copied into a temp shadow repo.
+	source, err := os.Open(src) // #nosec G304 -- source is a repository embed file selected by a fixed glob.
+	if err != nil {
+		t.Fatalf("open file %q: %v", src, err)
+	}
+	defer func() { _ = source.Close() }()
+	info, err := source.Stat()
+	if err != nil {
+		t.Fatalf("stat file %q: %v", src, err)
+	}
+	if !info.Mode().IsRegular() {
+		t.Fatalf("embedded source %q is not a regular file", src)
+	}
+	payload, err := io.ReadAll(io.LimitReader(source, maxBytes+1))
 	if err != nil {
 		t.Fatalf("read file %q: %v", src, err)
 	}
-	if err := os.WriteFile(dst, payload, 0o600); err != nil { // #nosec G703 -- destination is validated to remain in the requested temp shadow repo directory.
+	if int64(len(payload)) > maxBytes {
+		t.Fatalf("embedded source %q is %d bytes, limit is %d", src, len(payload), maxBytes)
+	}
+	if err := os.WriteFile(dst, payload, 0o600); err != nil { // #nosec G703 -- destination remains in the requested temp shadow repo directory.
 		t.Fatalf("write file %q: %v", dst, err)
 	}
 }

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -38,7 +38,7 @@ use aws_sdk_secretsmanager::Client as AwsSecretsManagerClient;
 use axum::{
     Extension, Json, Router,
     extract::{Path, Query, Request, State},
-    http::{Method, StatusCode, header::AUTHORIZATION},
+    http::{HeaderMap, Method, StatusCode, header::AUTHORIZATION},
     middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::{get, post},
@@ -100,6 +100,7 @@ use tokio::sync::{Mutex, oneshot};
 use zeroize::Zeroize;
 
 const TENANT_AUTH_HEADER: &str = "x-cerebro-tenant";
+const WORKSPACE_AUTH_HEADER: &str = "x-cerebro-workspace";
 const TENANT_AUTH_CONTEXT: &[u8] = b"cerebro-organizational-graph/tenant/v1\0";
 const MAX_LEGACY_DELTA_RECORDS: usize = 100_000;
 const MIN_SHARED_SECRET_BYTES: usize = 32;
@@ -1244,6 +1245,8 @@ struct PathsResponse {
 #[derive(Deserialize)]
 struct ProductNeighborhoodQuery {
     root_urn: String,
+    tenant_id: Option<String>,
+    workspace_id: Option<String>,
     limit: Option<u32>,
 }
 
@@ -3928,14 +3931,30 @@ async fn find_paths(
 async fn product_neighborhood_route(
     State(state): State<AppState>,
     Extension(authenticated): Extension<AuthenticatedTenant>,
+    headers: HeaderMap,
     Query(query): Query<ProductNeighborhoodQuery>,
 ) -> Result<Json<ProductNeighborhood>, (StatusCode, Json<ErrorResponse>)> {
+    if query.workspace_id.is_some() || headers.contains_key(WORKSPACE_AUTH_HEADER) {
+        return Err(bad_request(
+            "workspace_scope_unsupported",
+            "Application workspace scope is not supported for graph neighborhood reads.",
+        ));
+    }
     let tenant = product_urn_tenant(&query.root_urn).ok_or_else(|| {
         bad_request(
             "invalid_root_urn",
             "root_urn must be a tenant-scoped Cerebro URN.",
         )
     })?;
+    if let Some(query_tenant) = query.tenant_id {
+        let query_tenant = parse_tenant(query_tenant)?;
+        if query_tenant.as_str() != tenant {
+            return Err(bad_request(
+                "tenant_selector_mismatch",
+                "The tenant selector does not match the graph root tenant.",
+            ));
+        }
+    }
     let tenant_id = authorized_tenant(&authenticated, tenant.to_owned())?;
     let limit = normalize_product_neighborhood_limit(query.limit);
     let mut neighborhoods = state
@@ -6253,6 +6272,55 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(cross_tenant.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn product_neighborhood_route_rejects_scope_mismatch_before_graph_read() {
+        let root_urn = "urn:cerebro:tenant-demo:asset:one";
+        let app = router_with_backend(
+            Arc::new(UnavailableGraph),
+            None,
+            None,
+            PlatformStores::default(),
+            ActionBackends::default(),
+            TenantRequestAuth::new(TEST_SHARED_SECRET.to_owned()).unwrap(),
+            None,
+        );
+        for request in [
+            authenticated(Request::builder(), "tenant-demo")
+                .uri(format!(
+                    "/platform/graph/neighborhood?root_urn={root_urn}&workspace_id=workspace-a"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+            authenticated(Request::builder(), "tenant-demo")
+                .header(WORKSPACE_AUTH_HEADER, "workspace-a")
+                .uri(format!("/platform/graph/neighborhood?root_urn={root_urn}"))
+                .body(Body::empty())
+                .unwrap(),
+            authenticated(Request::builder(), "tenant-demo")
+                .uri(format!(
+                    "/platform/graph/neighborhood?root_urn={root_urn}&tenant_id=tenant-other"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        ] {
+            let response = app.clone().oneshot(request).await.unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+
+        let matching_tenant = app
+            .oneshot(
+                authenticated(Request::builder(), "tenant-demo")
+                    .uri(format!(
+                        "/platform/graph/neighborhood?root_urn={root_urn}&tenant_id=tenant-demo"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(matching_tenant.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -5511,7 +5511,22 @@ mod tests {
         assert_eq!(config.get("family").map(String::as_str), Some("resources"));
     }
 
-    struct UnavailableGraph;
+    #[derive(Default)]
+    struct UnavailableGraph {
+        reads: Option<Arc<AtomicUsize>>,
+    }
+
+    impl UnavailableGraph {
+        fn counting(reads: Arc<AtomicUsize>) -> Self {
+            Self { reads: Some(reads) }
+        }
+
+        fn record_read(&self) {
+            if let Some(reads) = &self.reads {
+                reads.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
 
     struct FixtureSourceRuntimeSync;
 
@@ -5661,10 +5676,12 @@ mod tests {
     #[async_trait]
     impl AgentGraph for UnavailableGraph {
         async fn health(&self) -> Result<(), ContextError> {
+            self.record_read();
             Err(unavailable())
         }
 
         async fn revision(&self, _tenant_id: &TenantId) -> Result<u64, ContextError> {
+            self.record_read();
             Err(unavailable())
         }
 
@@ -5675,6 +5692,7 @@ mod tests {
             _kinds: &[String],
             _limit: usize,
         ) -> Result<Vec<ContextEntity>, ContextError> {
+            self.record_read();
             Err(unavailable())
         }
 
@@ -5683,6 +5701,7 @@ mod tests {
             _tenant_id: &TenantId,
             _entity_id: &EntityId,
         ) -> Result<ContextEntity, ContextError> {
+            self.record_read();
             Err(unavailable())
         }
 
@@ -5691,6 +5710,7 @@ mod tests {
             _tenant_id: &TenantId,
             _key: &str,
         ) -> Result<ContextEntity, ContextError> {
+            self.record_read();
             Err(unavailable())
         }
 
@@ -5701,6 +5721,7 @@ mod tests {
             _depth: usize,
             _limit: usize,
         ) -> Result<Neighborhood, ContextError> {
+            self.record_read();
             Err(unavailable())
         }
 
@@ -5712,6 +5733,7 @@ mod tests {
             _max_depth: usize,
             _limit: usize,
         ) -> Result<Vec<GraphPath>, ContextError> {
+            self.record_read();
             Err(unavailable())
         }
 
@@ -5720,6 +5742,7 @@ mod tests {
             _tenant_id: &TenantId,
             _assertion_id: &AssertionId,
         ) -> Result<ContextEdge, ContextError> {
+            self.record_read();
             Err(unavailable())
         }
 
@@ -5728,6 +5751,7 @@ mod tests {
             _tenant_id: &TenantId,
             _query: &cerebro_agent_context::FactQuery,
         ) -> Result<cerebro_agent_context::QueryResult, ContextError> {
+            self.record_read();
             Err(unavailable())
         }
     }
@@ -6277,8 +6301,9 @@ mod tests {
     #[tokio::test]
     async fn product_neighborhood_route_rejects_scope_mismatch_before_graph_read() {
         let root_urn = "urn:cerebro:tenant-demo:asset:one";
+        let graph_reads = Arc::new(AtomicUsize::new(0));
         let app = router_with_backend(
-            Arc::new(UnavailableGraph),
+            Arc::new(UnavailableGraph::counting(graph_reads.clone())),
             None,
             None,
             PlatformStores::default(),
@@ -6304,9 +6329,16 @@ mod tests {
                 ))
                 .body(Body::empty())
                 .unwrap(),
+            authenticated(Request::builder(), "tenant-demo")
+                .uri(format!(
+                    "/platform/graph/neighborhood?root_urn={root_urn}&tenant_id=tenant-other&workspace_id=workspace-a"
+                ))
+                .body(Body::empty())
+                .unwrap(),
         ] {
             let response = app.clone().oneshot(request).await.unwrap();
             assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            assert_eq!(graph_reads.load(Ordering::Relaxed), 0);
         }
 
         let matching_tenant = app
@@ -6321,6 +6353,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(matching_tenant.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(graph_reads.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test]
@@ -6380,7 +6413,7 @@ mod tests {
     #[tokio::test]
     async fn product_neighborhood_route_surfaces_backend_failure_as_unavailable() {
         let app = router_with_backend(
-            Arc::new(UnavailableGraph),
+            Arc::new(UnavailableGraph::default()),
             None,
             None,
             PlatformStores::default(),
@@ -7562,7 +7595,7 @@ mod tests {
     #[tokio::test]
     async fn readiness_fails_without_breaking_process_liveness() {
         let app = router_with_backend(
-            Arc::new(UnavailableGraph),
+            Arc::new(UnavailableGraph::default()),
             None,
             None,
             PlatformStores::default(),

--- a/internal/bootstrap/mcp_test.go
+++ b/internal/bootstrap/mcp_test.go
@@ -614,6 +614,10 @@ func mcpDomainSurfaceCorpus(t *testing.T) string {
 		builder.Write(body)
 		builder.WriteByte('\n')
 	}
+	for _, entry := range rustAuthorityHTTPContractEntries(t, root, openAPIHTTPMethods(t, root)) {
+		builder.WriteString(entry.Identity)
+		builder.WriteByte('\n')
+	}
 	return builder.String()
 }
 

--- a/internal/bootstrap/source_runtime_health.go
+++ b/internal/bootstrap/source_runtime_health.go
@@ -319,8 +319,8 @@ func (a *App) listVisibleSourceRuntimes(r *http.Request, filter ports.SourceRunt
 	if !ok || isNilInterface(lister) {
 		return nil, sourceruntime.ErrRuntimeUnavailable
 	}
-	return sourceruntime.ListVisibleRuntimes(r.Context(), lister, filter, func(tenantID string) bool {
-		return !requiresTenantFilter(r.Context()) || tenantAllowedByContext(r.Context(), tenantID)
+	return sourceruntime.ListVisibleRuntimes(r.Context(), lister, filter, func(ctx context.Context, tenantID string) bool {
+		return !requiresTenantFilter(ctx) || tenantAllowedByContext(ctx, tenantID)
 	})
 }
 

--- a/internal/findings/event_rule.go
+++ b/internal/findings/event_rule.go
@@ -25,6 +25,15 @@ type CounterEventRule interface {
 	CloseOnEvent(event Event) (anchor string, closes bool)
 }
 
+// ContextCounterEventRule is the context-aware lifecycle boundary for rules
+// whose open and close decisions execute outside the Go process, including
+// Wasm authorities. Errors fail the evaluation closed instead of being
+// converted into a missing anchor or a non-closing event.
+type ContextCounterEventRule interface {
+	OpenAnchorContext(ctx context.Context, attributes map[string]string) (string, error)
+	CloseOnEventContext(ctx context.Context, event Event) (anchor string, closes bool, err error)
+}
+
 // CounterEventStateUpdate lets aggregate durable-state rules describe which
 // subcontrol at an anchor an event made compliant or non-compliant.
 type CounterEventStateUpdate struct {

--- a/internal/findings/rust_tailscale_tailnet_rule.go
+++ b/internal/findings/rust_tailscale_tailnet_rule.go
@@ -23,19 +23,21 @@ const (
 var tailscaleTailnetDeviceApprovalDisabledDefinition = RuleDefinition{
 	ID: tailscaleTailnetDeviceApprovalDisabledRuleID, Name: "Tailscale Tailnet Device Approval Disabled",
 	Description: "Detect Tailscale tailnets whose device approval is currently disabled, allowing new devices to join the tailnet without administrator review.",
-	SourceID: "tailscale", EventKinds: []string{"tailscale.tailnet"}, OutputKind: "finding.tailscale_tailnet_device_approval_disabled",
+	SourceID:    "tailscale", EventKinds: []string{"tailscale.tailnet"}, OutputKind: "finding.tailscale_tailnet_device_approval_disabled",
 	Severity: "MEDIUM", Status: "open", Maturity: "test", Tags: []string{"tailscale", "tailnet", "device-approval", "access-control"},
 	References: []string{"https://tailscale.com/kb/1099/device-approval"}, FalsePositives: []string{"Tailnets that intentionally rely on tag/ACL-based authorization instead of manual device approval."},
-	Runbook: "Confirm whether device approval should be enforced for this tailnet; if so, enable device approval so new devices require administrator review before joining.",
+	Runbook:            "Confirm whether device approval should be enforced for this tailnet; if so, enable device approval so new devices require administrator review before joining.",
 	RequiredAttributes: []string{"tailnet"}, FingerprintFields: []string{"tailscale_tailnet_urn"},
 	ControlRefs: []ports.FindingControlRef{{FrameworkName: "SOC 2", ControlID: "CC6.1"}, {FrameworkName: "ISO 27001:2022", ControlID: "A.8.2"}},
-	Lifecycle: Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorSourceState},
+	Lifecycle:   Lifecycle{Kind: LifecycleDurableState, Anchor: AnchorSourceState},
 }
 
 //go:embed findingrule.wasm
 var findingRuleWasm []byte
 
-type findingRuleEvaluator interface{ Evaluate(context.Context, []byte) ([]byte, error) }
+type findingRuleEvaluator interface {
+	Evaluate(context.Context, []byte) ([]byte, error)
+}
 
 var rustFindingRuleEvaluator = wasmjson.New(wasmjson.Config{
 	Name: "embedded Rust finding-rule evaluator", Module: findingRuleWasm, ABIVersion: 1,
@@ -69,65 +71,113 @@ type rustFindingResponse struct {
 	Finding          *ports.FindingRecord `json:"finding"`
 }
 
-func newTailscaleTailnetDeviceApprovalDisabledRule() Rule { return &rustTailscaleRule{evaluator: rustFindingRuleEvaluator} }
-func (r *rustTailscaleRule) Spec() *cerebrov1.RuleSpec      { return tailscaleTailnetDeviceApprovalDisabledDefinition.RuleSpec() }
-func (r *rustTailscaleRule) RuleMetadata() RuleDefinition   { return cloneRuleDefinition(tailscaleTailnetDeviceApprovalDisabledDefinition) }
+func newTailscaleTailnetDeviceApprovalDisabledRule() Rule {
+	return &rustTailscaleRule{evaluator: rustFindingRuleEvaluator}
+}
+func (r *rustTailscaleRule) Spec() *cerebrov1.RuleSpec {
+	return tailscaleTailnetDeviceApprovalDisabledDefinition.RuleSpec()
+}
+func (r *rustTailscaleRule) RuleMetadata() RuleDefinition {
+	return cloneRuleDefinition(tailscaleTailnetDeviceApprovalDisabledDefinition)
+}
 func (r *rustTailscaleRule) SupportsRuntime(runtime *cerebrov1.SourceRuntime) bool {
 	return runtime != nil && strings.EqualFold(strings.TrimSpace(runtime.GetSourceId()), "tailscale") && runtimeMayEmitEventKind(runtime, []string{"tailscale.tailnet"})
 }
 func (r *rustTailscaleRule) Evaluate(ctx context.Context, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
 	response, err := r.run(ctx, rustTailscaleRequest("evaluate", runtime, event, nil))
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	switch response.Action {
-	case "none": return nil, nil
+	case "none":
+		return nil, nil
 	case "open":
-		if response.Finding == nil { return nil, fmt.Errorf("Rust finding-rule authority returned an empty open decision") }
+		if response.Finding == nil {
+			return nil, fmt.Errorf("rust finding-rule authority returned an empty open decision")
+		}
 		return []*ports.FindingRecord{response.Finding}, nil
-	default: return nil, fmt.Errorf("Rust finding-rule authority returned unexpected action %q", response.Action)
+	default:
+		return nil, fmt.Errorf("rust finding-rule authority returned unexpected action %q", response.Action)
 	}
 }
-func (r *rustTailscaleRule) OpenAnchor(attributes map[string]string) string {
-	response, err := r.run(context.Background(), rustTailscaleRequest("open_anchor", nil, nil, attributes))
-	if err != nil || response.Action != "open_anchor" { return "" }
-	return strings.TrimSpace(response.Anchor)
+func (r *rustTailscaleRule) OpenAnchorContext(ctx context.Context, attributes map[string]string) (string, error) {
+	response, err := r.run(ctx, rustTailscaleRequest("open_anchor", nil, nil, attributes))
+	if err != nil {
+		return "", err
+	}
+	if response.Action != "open_anchor" {
+		return "", fmt.Errorf("rust finding-rule authority returned unexpected action %q", response.Action)
+	}
+	return strings.TrimSpace(response.Anchor), nil
 }
-func (r *rustTailscaleRule) CloseOnEvent(event Event) (string, bool) {
-	response, err := r.run(context.Background(), rustTailscaleRequest("close", nil, event, nil))
-	if err != nil || response.Action != "close" || strings.TrimSpace(response.Anchor) == "" { return "", false }
-	return strings.TrimSpace(response.Anchor), true
+func (r *rustTailscaleRule) CloseOnEventContext(ctx context.Context, event Event) (string, bool, error) {
+	response, err := r.run(ctx, rustTailscaleRequest("close", nil, event, nil))
+	if err != nil {
+		return "", false, err
+	}
+	if response.Action == "none" {
+		return "", false, nil
+	}
+	if response.Action != "close" || strings.TrimSpace(response.Anchor) == "" {
+		return "", false, fmt.Errorf("rust finding-rule authority returned invalid close decision")
+	}
+	return strings.TrimSpace(response.Anchor), true, nil
 }
 func (r *rustTailscaleRule) run(ctx context.Context, request rustFindingRequest) (rustFindingResponse, error) {
 	requestBody, err := json.Marshal(request)
-	if err != nil { return rustFindingResponse{}, err }
+	if err != nil {
+		return rustFindingResponse{}, err
+	}
 	inputDigest := fmt.Sprintf("sha256:%x", sha256.Sum256(requestBody))
 	payload, err := json.Marshal(struct {
 		SchemaVersion string             `json:"schema_version"`
 		InputDigest   string             `json:"input_digest"`
 		Request       rustFindingRequest `json:"request"`
 	}{tailscaleRustAuthoritySchema, inputDigest, request})
-	if err != nil { return rustFindingResponse{}, err }
+	if err != nil {
+		return rustFindingResponse{}, err
+	}
 	output, err := r.evaluator.Evaluate(ctx, payload)
-	if err != nil { return rustFindingResponse{}, fmt.Errorf("Rust finding-rule authority unavailable: %w", err) }
+	if err != nil {
+		return rustFindingResponse{}, fmt.Errorf("rust finding-rule authority unavailable: %w", err)
+	}
 	var response rustFindingResponse
-	if err := json.Unmarshal(output, &response); err != nil { return rustFindingResponse{}, fmt.Errorf("decode Rust finding-rule authority: %w", err) }
+	if err := json.Unmarshal(output, &response); err != nil {
+		return rustFindingResponse{}, fmt.Errorf("decode Rust finding-rule authority: %w", err)
+	}
 	fingerprint := ""
-	if response.Finding != nil { fingerprint = response.Finding.Fingerprint }
+	if response.Finding != nil {
+		fingerprint = response.Finding.Fingerprint
+	}
 	if response.SchemaVersion != tailscaleRustAuthoritySchema || response.RuleID != tailscaleTailnetDeviceApprovalDisabledRuleID || response.DefinitionDigest != tailscaleRustDefinitionDigest || response.InputDigest != inputDigest || response.DecisionDigest != rustFindingDecisionDigest(response.Action, response.Anchor, fingerprint) {
-		return rustFindingResponse{}, fmt.Errorf("Rust finding-rule authority receipt mismatch")
+		return rustFindingResponse{}, fmt.Errorf("rust finding-rule authority receipt mismatch")
 	}
 	return response, nil
 }
 
 func rustTailscaleRequest(operation string, runtime *cerebrov1.SourceRuntime, event *cerebrov1.EventEnvelope, attributes map[string]string) rustFindingRequest {
 	request := rustFindingRequest{Operation: operation, RuleID: tailscaleTailnetDeviceApprovalDisabledRuleID, Attributes: attributes}
-	if runtime != nil { request.RuntimeID, request.RuntimeSourceID, request.RuntimeTenantID = runtime.GetId(), runtime.GetSourceId(), runtime.GetTenantId(); request.RuntimeWorkspaceID = runtime.GetConfig()[ports.SourceRuntimeApplicationWorkspaceIDConfigKey] }
-	if event != nil { request.EventID, request.EventTenantID, request.EventSourceID, request.EventKind, request.Attributes = event.GetId(), event.GetTenantId(), event.GetSourceId(), event.GetKind(), event.GetAttributes(); if event.GetOccurredAt() != nil { request.OccurredAt = event.GetOccurredAt().AsTime().UTC().Format(time.RFC3339Nano) } }
-	if request.Attributes == nil { request.Attributes = map[string]string{} }
+	if runtime != nil {
+		request.RuntimeID, request.RuntimeSourceID, request.RuntimeTenantID = runtime.GetId(), runtime.GetSourceId(), runtime.GetTenantId()
+		request.RuntimeWorkspaceID = runtime.GetConfig()[ports.SourceRuntimeApplicationWorkspaceIDConfigKey]
+	}
+	if event != nil {
+		request.EventID, request.EventTenantID, request.EventSourceID, request.EventKind, request.Attributes = event.GetId(), event.GetTenantId(), event.GetSourceId(), event.GetKind(), event.GetAttributes()
+		if event.GetOccurredAt() != nil {
+			request.OccurredAt = event.GetOccurredAt().AsTime().UTC().Format(time.RFC3339Nano)
+		}
+	}
+	if request.Attributes == nil {
+		request.Attributes = map[string]string{}
+	}
 	return request
 }
 
 func rustFindingDecisionDigest(action string, anchor string, fingerprint string) string {
 	hash := sha256.New()
-	for _, value := range []string{action, anchor, fingerprint} { _, _ = hash.Write([]byte(strings.TrimSpace(value))); _, _ = hash.Write([]byte{0}) }
+	for _, value := range []string{action, anchor, fingerprint} {
+		_, _ = hash.Write([]byte(strings.TrimSpace(value)))
+		_, _ = hash.Write([]byte{0})
+	}
 	return fmt.Sprintf("sha256:%x", hash.Sum(nil))
 }

--- a/internal/findings/service_closeout.go
+++ b/internal/findings/service_closeout.go
@@ -100,7 +100,7 @@ type counterAnchorLatestEvent struct {
 	eventIDs   []string
 }
 
-func (s *Service) resolveCounterEventOpenFindings(ctx context.Context, runtime *cerebrov1.SourceRuntime, rule Rule, counterRule CounterEventRule, evaluatedEvents []*cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
+func (s *Service) resolveCounterEventOpenFindings(ctx context.Context, runtime *cerebrov1.SourceRuntime, rule Rule, counterRule ContextCounterEventRule, evaluatedEvents []*cerebrov1.EventEnvelope) ([]*ports.FindingRecord, error) {
 	if counterRule == nil || runtime == nil || rule == nil || len(evaluatedEvents) == 0 {
 		return nil, nil
 	}
@@ -137,7 +137,11 @@ func (s *Service) resolveCounterEventOpenFindings(ctx context.Context, runtime *
 		if finding.Tombstoned {
 			continue
 		}
-		openAnchor := strings.TrimSpace(counterRule.OpenAnchor(finding.Attributes))
+		openAnchor, err := counterRule.OpenAnchorContext(ctx, finding.Attributes)
+		if err != nil {
+			return nil, fmt.Errorf("derive counter-event open anchor for finding %q: %w", strings.TrimSpace(finding.ID), err)
+		}
+		openAnchor = strings.TrimSpace(openAnchor)
 		if openAnchor == "" {
 			continue
 		}
@@ -166,8 +170,8 @@ func (s *Service) resolveCounterEventOpenFindings(ctx context.Context, runtime *
 	return resolved, nil
 }
 
-func latestCounterAnchorEvents(ctx context.Context, runtime *cerebrov1.SourceRuntime, rule Rule, counterRule CounterEventRule, evaluatedEvents []*cerebrov1.EventEnvelope) (map[string]counterAnchorLatestEvent, error) {
-	if aggregateRule, ok := counterRule.(AggregateCounterEventRule); ok {
+func latestCounterAnchorEvents(ctx context.Context, runtime *cerebrov1.SourceRuntime, rule Rule, counterRule ContextCounterEventRule, evaluatedEvents []*cerebrov1.EventEnvelope) (map[string]counterAnchorLatestEvent, error) {
+	if aggregateRule, ok := rule.(AggregateCounterEventRule); ok {
 		if latestByAnchor, handled := latestAggregateCounterAnchorEvents(aggregateRule, evaluatedEvents); handled {
 			return latestByAnchor, nil
 		}
@@ -190,7 +194,11 @@ func latestCounterAnchorEvents(ctx context.Context, runtime *cerebrov1.SourceRun
 			if record == nil {
 				continue
 			}
-			openAnchor := strings.TrimSpace(counterRule.OpenAnchor(record.Attributes))
+			openAnchor, err := counterRule.OpenAnchorContext(ctx, record.Attributes)
+			if err != nil {
+				return nil, fmt.Errorf("derive counter-event chronology open anchor for rule %q event %q: %w", ruleID, strings.TrimSpace(event.GetId()), err)
+			}
+			openAnchor = strings.TrimSpace(openAnchor)
 			if openAnchor == "" {
 				continue
 			}
@@ -199,7 +207,10 @@ func latestCounterAnchorEvents(ctx context.Context, runtime *cerebrov1.SourceRun
 				sequence:   sequence,
 			})
 		}
-		anchor, closes := counterRule.CloseOnEvent(event)
+		anchor, closes, err := counterRule.CloseOnEventContext(ctx, event)
+		if err != nil {
+			return nil, fmt.Errorf("evaluate counter-event close for rule %q event %q: %w", ruleID, strings.TrimSpace(event.GetId()), err)
+		}
 		anchor = strings.TrimSpace(anchor)
 		if closes && anchor != "" {
 			eventIDs := []string(nil)
@@ -347,7 +358,7 @@ func (s *Service) resolveRuleOpenFindings(ctx context.Context, runtime *cerebrov
 	}
 	if rule.SupportsRuntime(runtime) {
 		var resolvedCounterFindings []*ports.FindingRecord
-		if counterRule, ok := durableStateCounterEventRule(rule); ok {
+		if counterRule, ok := durableStateContextCounterEventRule(rule); ok {
 			resolved, err := s.resolveCounterEventOpenFindings(ctx, runtime, rule, counterRule, evaluatedEvents)
 			if err != nil {
 				return nil, err
@@ -437,6 +448,37 @@ func durableStateCounterEventRule(rule Rule) (CounterEventRule, bool) {
 		return nil, false
 	}
 	return counterRule, true
+}
+
+type legacyCounterEventRuleContextAdapter struct {
+	CounterEventRule
+}
+
+func (r legacyCounterEventRuleContextAdapter) OpenAnchorContext(_ context.Context, attributes map[string]string) (string, error) {
+	return r.OpenAnchor(attributes), nil
+}
+
+func (r legacyCounterEventRuleContextAdapter) CloseOnEventContext(_ context.Context, event Event) (string, bool, error) {
+	anchor, closes := r.CloseOnEvent(event)
+	return anchor, closes, nil
+}
+
+func durableStateContextCounterEventRule(rule Rule) (ContextCounterEventRule, bool) {
+	metadataRule, ok := rule.(MetadataRule)
+	if !ok {
+		return nil, false
+	}
+	lifecycleKind := LifecycleKind(strings.TrimSpace(string(metadataRule.RuleMetadata().Lifecycle.Kind)))
+	if lifecycleKind != LifecycleDurableState {
+		return nil, false
+	}
+	if counterRule, ok := rule.(ContextCounterEventRule); ok {
+		return counterRule, true
+	}
+	if counterRule, ok := rule.(CounterEventRule); ok {
+		return legacyCounterEventRuleContextAdapter{CounterEventRule: counterRule}, true
+	}
+	return nil, false
 }
 
 func counterEventCloseLookupRuntimeScoped(rule Rule) bool {

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -998,6 +998,22 @@ type counterAnchorRule struct {
 	sourceID   string
 }
 
+type contextTrackingCounterAnchorRule struct {
+	*counterAnchorRule
+	contexts []context.Context
+}
+
+func (r *contextTrackingCounterAnchorRule) OpenAnchorContext(ctx context.Context, attributes map[string]string) (string, error) {
+	r.contexts = append(r.contexts, ctx)
+	return r.OpenAnchor(attributes), nil
+}
+
+func (r *contextTrackingCounterAnchorRule) CloseOnEventContext(ctx context.Context, event Event) (string, bool, error) {
+	r.contexts = append(r.contexts, ctx)
+	anchor, closes := r.CloseOnEvent(event)
+	return anchor, closes, nil
+}
+
 var _ CounterEventRule = (*counterAnchorRule)(nil)
 
 func newCounterAnchorRule(ruleID string) *counterAnchorRule {
@@ -1857,6 +1873,39 @@ func TestCounterEventRule_AnchorClose(t *testing.T) {
 	}
 	if got := len(sameRunEvidence.Evidence); got == 0 {
 		t.Fatalf("ListEvidence(same-run close event) returned %d rows, want close-event evidence", got)
+	}
+}
+
+func TestLatestCounterAnchorEventsPropagatesEvaluationContext(t *testing.T) {
+	type contextKey struct{}
+	key := contextKey{}
+	ctx := context.WithValue(context.Background(), key, "evaluation-request")
+	rule := &contextTrackingCounterAnchorRule{counterAnchorRule: newCounterAnchorRule("context-counter-rule")}
+	runtime := &cerebrov1.SourceRuntime{Id: "runtime-1", SourceId: "github", TenantId: "writer"}
+	events := []*cerebrov1.EventEnvelope{{
+		Id: "open", TenantId: "writer", SourceId: "github", Kind: "github.audit",
+		Attributes: map[string]string{"action": "open", "repo": "writer/cerebro", "user": "alice"},
+		OccurredAt: timestamppb.New(time.Date(2026, 5, 7, 19, 54, 0, 0, time.UTC)),
+	}, {
+		Id: "close", TenantId: "writer", SourceId: "github", Kind: "github.audit",
+		Attributes: map[string]string{"action": "close", "repo": "writer/cerebro", "user": "alice"},
+		OccurredAt: timestamppb.New(time.Date(2026, 5, 7, 20, 54, 0, 0, time.UTC)),
+	}}
+
+	latest, err := latestCounterAnchorEvents(ctx, runtime, rule, rule, events)
+	if err != nil {
+		t.Fatalf("latestCounterAnchorEvents() error = %v", err)
+	}
+	if !hasLatestCounterAnchorClose(latest) {
+		t.Fatalf("latestCounterAnchorEvents() = %#v, want a closing anchor", latest)
+	}
+	if len(rule.contexts) == 0 {
+		t.Fatal("context-aware lifecycle methods were not called")
+	}
+	for _, got := range rule.contexts {
+		if got.Value(key) != "evaluation-request" {
+			t.Fatalf("lifecycle context value = %v, want evaluation-request", got.Value(key))
+		}
 	}
 }
 

--- a/internal/findings/tailscale_tailnet_device_approval_disabled_rule_test.go
+++ b/internal/findings/tailscale_tailnet_device_approval_disabled_rule_test.go
@@ -73,17 +73,27 @@ func TestTailscaleTailnetDeviceApprovalReopensOnRecurrence(t *testing.T) {
 		t.Fatal("opened finding has empty fingerprint")
 	}
 
-	counterRule, ok := rule.(CounterEventRule)
+	counterRule, ok := rule.(ContextCounterEventRule)
 	if !ok {
-		t.Fatal("rule does not implement CounterEventRule")
+		t.Fatal("rule does not implement ContextCounterEventRule")
+	}
+	if _, ok := rule.(CounterEventRule); ok {
+		t.Fatal("Rust-authoritative rule must not expose the legacy context-free CounterEventRule path")
 	}
 	restoredEvent := tailscaleTailnetEvent("ts-tailnet-restored", "true", time.Date(2026, 4, 23, 13, 0, 0, 0, time.UTC))
-	closeAnchor, closes := counterRule.CloseOnEvent(restoredEvent)
-	if !closes || closeAnchor == "" {
-		t.Fatalf("CloseOnEvent(restored) = (%q, %v), want a non-empty closing anchor", closeAnchor, closes)
+	closeAnchor, closes, err := counterRule.CloseOnEventContext(context.Background(), restoredEvent)
+	if err != nil {
+		t.Fatalf("CloseOnEventContext(restored) error = %v", err)
 	}
-	if openAnchor := counterRule.OpenAnchor(opened.Attributes); openAnchor != closeAnchor {
-		t.Fatalf("OpenAnchor(open finding) = %q, want match close anchor %q", openAnchor, closeAnchor)
+	if !closes || closeAnchor == "" {
+		t.Fatalf("CloseOnEventContext(restored) = (%q, %v), want a non-empty closing anchor", closeAnchor, closes)
+	}
+	openAnchor, err := counterRule.OpenAnchorContext(context.Background(), opened.Attributes)
+	if err != nil {
+		t.Fatalf("OpenAnchorContext(open finding) error = %v", err)
+	}
+	if openAnchor != closeAnchor {
+		t.Fatalf("OpenAnchorContext(open finding) = %q, want match close anchor %q", openAnchor, closeAnchor)
 	}
 
 	reopened := emitOpen(tailscaleTailnetEvent("ts-tailnet-disabled-2", "false", time.Date(2026, 4, 23, 14, 0, 0, 0, time.UTC)))
@@ -130,6 +140,21 @@ func TestTailscaleTailnetRustAuthorityFailsClosedWithoutGoFallback(t *testing.T)
 	}
 }
 
+func TestTailscaleTailnetRustLifecyclePropagatesContextAndFailsClosed(t *testing.T) {
+	type contextKey struct{}
+	evaluator := &recordingFindingRuleEvaluator{err: context.Canceled}
+	rule := &rustTailscaleRule{evaluator: evaluator}
+	evaluationContext := context.WithValue(context.Background(), contextKey{}, "service-evaluation")
+
+	_, err := rule.OpenAnchorContext(evaluationContext, map[string]string{"tailscale_tailnet_urn": "urn:cerebro:tenant-a:tailscale_tailnet:example.com"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("OpenAnchorContext() error = %v, want context.Canceled", err)
+	}
+	if len(evaluator.contexts) != 1 || evaluator.contexts[0].Value(contextKey{}) != "service-evaluation" {
+		t.Fatalf("Wasm evaluator contexts = %#v, want the service evaluation context", evaluator.contexts)
+	}
+}
+
 func TestTailscaleTailnetRustAuthorityRejectsCrossScopeReplay(t *testing.T) {
 	rule := newTailscaleTailnetDeviceApprovalDisabledRule()
 	runtime := &cerebrov1.SourceRuntime{
@@ -152,12 +177,14 @@ func TestTailscaleTailnetRustAuthorityRejectsCrossScopeReplay(t *testing.T) {
 }
 
 type recordingFindingRuleEvaluator struct {
-	calls int
-	err   error
+	calls    int
+	err      error
+	contexts []context.Context
 }
 
-func (e *recordingFindingRuleEvaluator) Evaluate(context.Context, []byte) ([]byte, error) {
+func (e *recordingFindingRuleEvaluator) Evaluate(ctx context.Context, _ []byte) ([]byte, error) {
 	e.calls++
+	e.contexts = append(e.contexts, ctx)
 	return nil, e.err
 }
 

--- a/internal/sourceruntime/visibility.go
+++ b/internal/sourceruntime/visibility.go
@@ -14,7 +14,7 @@ type runtimeLister interface {
 
 // ListVisibleRuntimes applies tenant and workspace boundaries even when a
 // runtime store returns rows outside the requested filter.
-func ListVisibleRuntimes(ctx context.Context, lister runtimeLister, filter ports.SourceRuntimeFilter, tenantAllowed func(string) bool) ([]*cerebrov1.SourceRuntime, error) {
+func ListVisibleRuntimes(ctx context.Context, lister runtimeLister, filter ports.SourceRuntimeFilter, tenantAllowed func(context.Context, string) bool) ([]*cerebrov1.SourceRuntime, error) {
 	runtimes, err := lister.ListSourceRuntimes(ctx, filter)
 	if err != nil {
 		return nil, err
@@ -23,7 +23,7 @@ func ListVisibleRuntimes(ctx context.Context, lister runtimeLister, filter ports
 	for _, runtime := range runtimes {
 		if runtime == nil || (filter.TenantID != "" && strings.TrimSpace(runtime.GetTenantId()) != filter.TenantID) ||
 			(filter.ApplicationWorkspaceID != "" && strings.TrimSpace(runtime.GetConfig()[ports.SourceRuntimeApplicationWorkspaceIDConfigKey]) != filter.ApplicationWorkspaceID) ||
-			(tenantAllowed != nil && !tenantAllowed(runtime.GetTenantId())) {
+			(tenantAllowed != nil && !tenantAllowed(ctx, runtime.GetTenantId())) {
 			continue
 		}
 		visible = append(visible, runtime)

--- a/internal/sourceruntime/visibility_test.go
+++ b/internal/sourceruntime/visibility_test.go
@@ -26,7 +26,7 @@ func TestListVisibleRuntimesEnforcesTenantAndWorkspaceBoundaries(t *testing.T) {
 
 	runtimes, err := ListVisibleRuntimes(t.Context(), lister, ports.SourceRuntimeFilter{
 		TenantID: "writer", ApplicationWorkspaceID: "workspace-a",
-	}, func(tenantID string) bool { return tenantID == "writer" })
+	}, func(_ context.Context, tenantID string) bool { return tenantID == "writer" })
 	if err != nil {
 		t.Fatalf("ListVisibleRuntimes() error = %v", err)
 	}


### PR DESCRIPTION
## Summary
- add a context-aware counter-event lifecycle seam while preserving the legacy Go interface for unmigrated rules
- propagate the service evaluation context and lifecycle errors through the Rust/Wasm Tailscale authority with no fallback
- copy embedded Wasm artifacts into scaffold shadow repositories as bounded regular files
- fix Go formatting and staticcheck errors introduced by the merged authority change

## Validation
- `go test ./internal/findings -run 'Test(TailscaleTailnet|LatestCounterAnchorEventsPropagatesEvaluationContext)' -count=1`\n- `go test -race ./internal/findings -run 'Test(TailscaleTailnet|LatestCounterAnchorEventsPropagatesEvaluationContext)' -count=1`\n- `go test ./cmd/cerebro -run '^TestScaffoldFindingRule_RetiredGeneratedTestPasses$' -count=1`\n- `go test -race ./cmd/cerebro -run '^TestScaffoldFindingRule_RetiredGeneratedTestPasses$' -count=1`\n- `make lint-shard LINT_PACKAGES="./internal/..." LINT_SHARD_TOTAL=4 LINT_SHARD_INDEX=3`\n- `make lint-shard LINT_PACKAGES="./api/... ./cmd/..." LINT_SHARD_TOTAL=4 LINT_SHARD_INDEX=3`\n- `make check-structural check-structural-test check-arch`