### PR TITLE
refactor(sources): retire Adobe Workfront Go projection writer

### DIFF
--- a/internal/sourceprojection/adobe_workfront.go
+++ b/internal/sourceprojection/adobe_workfront.go
@@ -1,48 +1,30 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func adobeWorkfrontUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "adobe_workfront"})
+var errAdobeWorkfrontRustProjectionRequired = errors.New("adobe_workfront projection requires Rust authority")
+
+func adobeWorkfrontUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAdobeWorkfrontRustProjectionRequired
 }
 
-func adobeWorkfrontGroupsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityGroupProjections(event, identityProjectionProfile{Provider: "adobe_workfront"})
+func adobeWorkfrontGroupsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAdobeWorkfrontRustProjectionRequired
 }
 
-func adobeWorkfrontProjectsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return adobeWorkfrontGenericAssetProjections(event)
+func adobeWorkfrontProjectsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAdobeWorkfrontRustProjectionRequired
 }
 
-func adobeWorkfrontDocumentsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return adobeWorkfrontGenericAssetProjections(event)
+func adobeWorkfrontDocumentsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAdobeWorkfrontRustProjectionRequired
 }
 
-func adobeWorkfrontAuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "adobe_workfront"})
-}
-
-func adobeWorkfrontGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func adobeWorkfrontAuditEventsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAdobeWorkfrontRustProjectionRequired
 }

--- a/internal/sourceprojection/adobe_workfront_test.go
+++ b/internal/sourceprojection/adobe_workfront_test.go
@@ -1,14 +1,17 @@
 package sourceprojection
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
 )
 
 func TestAdobeWorkfrontAssetProjection(t *testing.T) {
 	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "adobe_workfront", Kind: "adobe_workfront.projects", Attributes: map[string]string{"resource_id": "project-1", "resource_type": "project", "resource_name": "Project One", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := adobeWorkfrontProjectsProjections(event)
+	entities, links, err := adobeWorkfrontOracleProjectsProjections(event)
 	if err != nil {
 		t.Fatalf("projection error = %v", err)
 	}
@@ -22,7 +25,7 @@ func TestAdobeWorkfrontAssetProjection(t *testing.T) {
 
 func TestAdobeWorkfrontDocumentProjection(t *testing.T) {
 	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "adobe_workfront", Kind: "adobe_workfront.documents", Attributes: map[string]string{"resource_id": "document-1", "resource_type": "document", "resource_name": "Document One", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := adobeWorkfrontDocumentsProjections(event)
+	entities, links, err := adobeWorkfrontOracleDocumentsProjections(event)
 	if err != nil {
 		t.Fatalf("projection error = %v", err)
 	}
@@ -36,7 +39,7 @@ func TestAdobeWorkfrontDocumentProjection(t *testing.T) {
 
 func TestAdobeWorkfrontIdentityUserProjection(t *testing.T) {
 	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "adobe_workfront", Kind: "adobe_workfront.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := adobeWorkfrontUsersProjections(event)
+	entities, _, err := adobeWorkfrontOracleUsersProjections(event)
 	if err != nil {
 		t.Fatalf("projection error = %v", err)
 	}
@@ -47,7 +50,7 @@ func TestAdobeWorkfrontIdentityUserProjection(t *testing.T) {
 
 func TestAdobeWorkfrontIdentityGroupProjection(t *testing.T) {
 	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "adobe_workfront", Kind: "adobe_workfront.groups", Attributes: map[string]string{"group_id": "group-1", "group_email": "group@example.test", "group_name": "Group One"}}
-	entities, _, err := adobeWorkfrontGroupsProjections(event)
+	entities, _, err := adobeWorkfrontOracleGroupsProjections(event)
 	if err != nil {
 		t.Fatalf("projection error = %v", err)
 	}
@@ -58,11 +61,78 @@ func TestAdobeWorkfrontIdentityGroupProjection(t *testing.T) {
 
 func TestAdobeWorkfrontAuditProjection(t *testing.T) {
 	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "adobe_workfront", Kind: "adobe_workfront.audit_events", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := adobeWorkfrontAuditEventsProjections(event)
+	entities, links, err := adobeWorkfrontOracleAuditEventsProjections(event)
 	if err != nil {
 		t.Fatalf("projection error = %v", err)
 	}
 	if len(entities) == 0 || len(links) == 0 {
 		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
 	}
+}
+
+func TestAdobeWorkfrontGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"adobe_workfront.audit_events",
+		"adobe_workfront.documents",
+		"adobe_workfront.groups",
+		"adobe_workfront.projects",
+		"adobe_workfront.users",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "adobe_workfront",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAdobeWorkfrontRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
+	}
+}
+
+// The oracle functions preserve the retired Go writer's semantic output for
+// fixture parity without leaving that writer reachable from production.
+func adobeWorkfrontOracleUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return identityUserProjections(event, identityProjectionProfile{Provider: "adobe_workfront"})
+}
+
+func adobeWorkfrontOracleGroupsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return identityGroupProjections(event, identityProjectionProfile{Provider: "adobe_workfront"})
+}
+
+func adobeWorkfrontOracleProjectsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return adobeWorkfrontOracleGenericAssetProjections(event)
+}
+
+func adobeWorkfrontOracleDocumentsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return adobeWorkfrontOracleGenericAssetProjections(event)
+}
+
+func adobeWorkfrontOracleAuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return identityAuditProjections(event, identityProjectionProfile{Provider: "adobe_workfront"})
+}
+
+func adobeWorkfrontOracleGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attributes := event.GetAttributes()
+	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
+	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
+	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
+	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
+		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
+		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
+	}
+	return identityProjectionResult(entities, links)
 }


### PR DESCRIPTION
## Summary

- remove the production Adobe Workfront Go projection implementation for all five closed families
- make every static Adobe Workfront compatibility projector fail closed with a typed Rust-authority error
- preserve the retired writer semantics as test-only parity oracles and retain all provider fixtures

## Deletion proof

- the compiled Rust source catalog declares all five Adobe Workfront families collection- and projection-authoritative
- the provider-local Go collection loader is already retired
- the static Go projection entry points emit zero entities or links
- production Go diff: +12/-30 (net -18); test oracle diff: +75/-5

## Shared authority blocker

This deleting draft is not merge-ready by itself. The Go host still has two shared compatibility routes outside this provider-owned diff: Adobe Workfront is absent from the closed `RustAuthoritativeFamily` runtime fence, and connector-definition registration can install a dynamic catalog Go projector ahead of the static sentinel. The shared registry/authority lane must close both routes before this PR can merge. This branch intentionally does not edit those shared registry or generator files.

## Validation

- `go test ./internal/sourceprojection -run 'TestAdobeWorkfront|TestWorkfront' -count=1`
- `go test ./internal/sourceprojection -count=1`
- `go test ./internal/sourceregistry -run 'TestBuiltinRetiresCoveredProviderGoLoaders' -count=1`
- `git diff --check`

Exact-head hosted checks remain authoritative for Rust catalog and platform validation.
