### PR TITLE
refactor(sources): retire Airfocus Go projection writer

### DIFF
--- a/internal/sourceprojection/airfocus.go
+++ b/internal/sourceprojection/airfocus.go
@@ -1,48 +1,30 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func airfocusUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "airfocus"})
+var errAirfocusRustProjectionRequired = errors.New("airfocus projection requires Rust authority")
+
+func airfocusUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirfocusRustProjectionRequired
 }
 
-func airfocusWorkspacesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return airfocusGenericAssetProjections(event)
+func airfocusWorkspacesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirfocusRustProjectionRequired
 }
 
-func airfocusWorkspaceGroupsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return airfocusGenericAssetProjections(event)
+func airfocusWorkspaceGroupsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirfocusRustProjectionRequired
 }
 
-func airfocusLinkTypesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return airfocusGenericAssetProjections(event)
+func airfocusLinkTypesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirfocusRustProjectionRequired
 }
 
-func airfocusAPIKeysProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return airfocusGenericAssetProjections(event)
-}
-
-func airfocusGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func airfocusAPIKeysProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirfocusRustProjectionRequired
 }

--- a/internal/sourceprojection/airfocus_test.go
+++ b/internal/sourceprojection/airfocus_test.go
@@ -1,6 +1,8 @@
 package sourceprojection
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -9,7 +11,7 @@ import (
 
 func TestAirfocusIdentityUserProjection(t *testing.T) {
 	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "airfocus", Kind: "airfocus.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := airfocusUsersProjections(event)
+	entities, _, err := airfocusOracleUsersProjections(event)
 	if err != nil {
 		t.Fatalf("projection error = %v", err)
 	}
@@ -20,25 +22,25 @@ func TestAirfocusIdentityUserProjection(t *testing.T) {
 
 func TestAirfocusWorkspaceProjection(t *testing.T) {
 	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "airfocus", Kind: "airfocus.workspaces", Attributes: airfocusAssetAttributes("workspace-1", "workspace")}
-	entities, links, err := airfocusWorkspacesProjections(event)
+	entities, links, err := airfocusOracleWorkspacesProjections(event)
 	assertAirfocusAssetProjection(t, entities, links, err)
 }
 
 func TestAirfocusWorkspaceGroupsProjection(t *testing.T) {
 	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "airfocus", Kind: "airfocus.workspace_groups", Attributes: airfocusAssetAttributes("group-1", "workspace_group")}
-	entities, links, err := airfocusWorkspaceGroupsProjections(event)
+	entities, links, err := airfocusOracleWorkspaceGroupsProjections(event)
 	assertAirfocusAssetProjection(t, entities, links, err)
 }
 
 func TestAirfocusLinkTypesProjection(t *testing.T) {
 	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "airfocus", Kind: "airfocus.link_types", Attributes: airfocusAssetAttributes("link-type-1", "link_type")}
-	entities, links, err := airfocusLinkTypesProjections(event)
+	entities, links, err := airfocusOracleLinkTypesProjections(event)
 	assertAirfocusAssetProjection(t, entities, links, err)
 }
 
 func TestAirfocusAPIKeysProjection(t *testing.T) {
 	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "airfocus", Kind: "airfocus.api_keys", Attributes: airfocusAssetAttributes("api-key-1", "api_key")}
-	entities, links, err := airfocusAPIKeysProjections(event)
+	entities, links, err := airfocusOracleAPIKeysProjections(event)
 	assertAirfocusAssetProjection(t, entities, links, err)
 }
 
@@ -57,4 +59,71 @@ func assertAirfocusAssetProjection(t *testing.T, entities []*ports.ProjectedEnti
 	if len(links) == 0 {
 		t.Fatal("expected projected evidence links")
 	}
+}
+
+func TestAirfocusGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"airfocus.api_keys",
+		"airfocus.link_types",
+		"airfocus.users",
+		"airfocus.workspace_groups",
+		"airfocus.workspaces",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "airfocus",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAirfocusRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
+	}
+}
+
+// The oracle functions preserve the retired Go writer's semantic output for
+// fixture parity without leaving that writer reachable from production.
+func airfocusOracleUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return identityUserProjections(event, identityProjectionProfile{Provider: "airfocus"})
+}
+
+func airfocusOracleWorkspacesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return airfocusOracleGenericAssetProjections(event)
+}
+
+func airfocusOracleWorkspaceGroupsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return airfocusOracleGenericAssetProjections(event)
+}
+
+func airfocusOracleLinkTypesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return airfocusOracleGenericAssetProjections(event)
+}
+
+func airfocusOracleAPIKeysProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return airfocusOracleGenericAssetProjections(event)
+}
+
+func airfocusOracleGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attributes := event.GetAttributes()
+	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
+	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
+	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
+	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
+		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
+		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
+	}
+	return identityProjectionResult(entities, links)
 }


### PR DESCRIPTION
## Summary

- remove the production Airfocus Go projection implementation for all five closed families
- make every static Airfocus compatibility projector fail closed with a typed Rust-authority error
- preserve the retired writer semantics as test-only parity oracles and retain all provider fixtures

## Deletion proof

- the compiled Rust source catalog declares all five Airfocus families collection- and projection-authoritative
- the provider-local Go collection loader is already retired
- the static Go projection entry points emit zero entities or links
- production Go diff: +12/-30 (net -18); test oracle diff: +74/-5

## Shared authority blocker

This deleting draft is not merge-ready by itself. The Go host still has two shared compatibility routes outside this provider-owned diff: Airfocus is absent from the closed `RustAuthoritativeFamily` runtime fence, and connector-definition registration can install a dynamic catalog Go projector ahead of the static sentinel. The shared registry/authority lane must close both routes before this PR can merge. This branch intentionally does not edit those shared registry or generator files.

## Validation

- `go test ./internal/sourceprojection -run 'TestAirfocus' -count=1`
- `go test ./internal/sourceprojection -count=1`
- `go test ./internal/sourceregistry -run 'TestBuiltinRetiresCoveredProviderGoLoaders' -count=1`
- `git diff --check`

Exact-head hosted checks remain authoritative for Rust catalog and platform validation.
