### PR TITLE
refactor(sources): retire Acunetix Go projection writer

### DIFF
--- a/internal/sourceprojection/acunetix.go
+++ b/internal/sourceprojection/acunetix.go
@@ -1,88 +1,30 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func acunetixTargetsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return acunetixGenericAssetProjections(event)
+var errAcunetixRustProjectionRequired = errors.New("acunetix projection requires Rust authority")
+
+func acunetixTargetsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAcunetixRustProjectionRequired
 }
 
-func acunetixScansProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return acunetixGenericFindingProjections(event)
+func acunetixScansProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAcunetixRustProjectionRequired
 }
 
-func acunetixVulnerabilitiesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return acunetixGenericFindingProjections(event)
+func acunetixVulnerabilitiesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAcunetixRustProjectionRequired
 }
 
-func acunetixScanningProfilesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return acunetixGenericPolicyProjections(event)
+func acunetixScanningProfilesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAcunetixRustProjectionRequired
 }
 
-func acunetixReportsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return acunetixGenericAssetProjections(event)
-}
-
-func acunetixGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func acunetixGenericFindingProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	findingID := firstNonEmpty(attributes["finding_id"], event.GetId())
-	findingURN := projectionURN(tenantID, "finding", findingID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: findingURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "finding", Label: firstNonEmpty(attributes["title"], findingID), Attributes: map[string]string{"finding_id": findingID, "severity": strings.TrimSpace(attributes["severity"]), "status": strings.TrimSpace(attributes["status"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if resourceURN := strings.TrimSpace(attributes["resource_urn"]); resourceURN != "" {
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), findingURN, resourceURN, relationAffects, map[string]string{"event_id": event.GetId()}))
-	}
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), evidenceURN, findingURN, relationSupports, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-func acunetixGenericPolicyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	policyID := firstNonEmpty(attributes["policy_id"], event.GetId())
-	policyURN := projectionURN(tenantID, "policy", policyID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: policyURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "policy", Label: firstNonEmpty(attributes["policy_name"], policyID), Attributes: map[string]string{"policy_id": policyID, "policy_type": strings.TrimSpace(attributes["policy_type"]), "policy_status": strings.TrimSpace(attributes["policy_status"]), "policy_severity": strings.TrimSpace(attributes["policy_severity"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), policyURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func acunetixReportsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAcunetixRustProjectionRequired
 }

--- a/internal/sourceprojection/acunetix_test.go
+++ b/internal/sourceprojection/acunetix_test.go
@@ -1,14 +1,17 @@
 package sourceprojection
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
 )
 
 func TestAcunetixTargetProjection(t *testing.T) {
 	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "acunetix", Kind: "acunetix.targets", Attributes: map[string]string{"resource_id": "target-1", "resource_type": "target", "resource_name": "https://app.example.test", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := acunetixTargetsProjections(event)
+	entities, links, err := acunetixOracleAssetProjections(event)
 	if err != nil {
 		t.Fatalf("projection error = %v", err)
 	}
@@ -22,7 +25,7 @@ func TestAcunetixTargetProjection(t *testing.T) {
 
 func TestAcunetixScanProjection(t *testing.T) {
 	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "acunetix", Kind: "acunetix.scans", Attributes: map[string]string{"finding_id": "scan-1", "title": "Full Scan", "status": "completed", "resource_urn": "urn:cerebro:tenant:runtime_target:target-1", "evidence_id": "evidence-1"}}
-	entities, links, err := acunetixScansProjections(event)
+	entities, links, err := acunetixOracleFindingProjections(event)
 	if err != nil {
 		t.Fatalf("projection error = %v", err)
 	}
@@ -39,7 +42,7 @@ func TestAcunetixScanProjection(t *testing.T) {
 
 func TestAcunetixVulnerabilityProjection(t *testing.T) {
 	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "acunetix", Kind: "acunetix.vulnerabilities", Attributes: map[string]string{"finding_id": "vuln-1", "title": "Cross-site scripting", "severity": "high", "status": "open", "resource_urn": "urn:cerebro:tenant:runtime_target:target-1", "evidence_id": "evidence-1"}}
-	entities, links, err := acunetixVulnerabilitiesProjections(event)
+	entities, links, err := acunetixOracleFindingProjections(event)
 	if err != nil {
 		t.Fatalf("projection error = %v", err)
 	}
@@ -56,7 +59,7 @@ func TestAcunetixVulnerabilityProjection(t *testing.T) {
 
 func TestAcunetixScanningProfileProjection(t *testing.T) {
 	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "acunetix", Kind: "acunetix.scanning_profiles", Attributes: map[string]string{"policy_id": "profile-1", "policy_name": "Full Scan", "policy_type": "scanning_profile", "policy_status": "enabled", "evidence_id": "evidence-1"}}
-	entities, links, err := acunetixScanningProfilesProjections(event)
+	entities, links, err := acunetixOraclePolicyProjections(event)
 	if err != nil {
 		t.Fatalf("projection error = %v", err)
 	}
@@ -70,11 +73,99 @@ func TestAcunetixScanningProfileProjection(t *testing.T) {
 
 func TestAcunetixReportProjection(t *testing.T) {
 	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "acunetix", Kind: "acunetix.reports", Attributes: map[string]string{"resource_id": "report-1", "resource_type": "report", "resource_name": "Developer Report", "evidence_id": "evidence-1"}}
-	entities, links, err := acunetixReportsProjections(event)
+	entities, links, err := acunetixOracleAssetProjections(event)
 	if err != nil {
 		t.Fatalf("projection error = %v", err)
 	}
 	if len(entities) == 0 || len(links) == 0 {
 		t.Fatalf("entities/links = %d/%d, want report projection", len(entities), len(links))
 	}
+}
+
+func TestAcunetixGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"acunetix.reports",
+		"acunetix.scanning_profiles",
+		"acunetix.scans",
+		"acunetix.targets",
+		"acunetix.vulnerabilities",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "acunetix",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAcunetixRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
+	}
+}
+
+// The oracle functions preserve the retired Go writer's semantic output for
+// fixture parity without leaving that writer reachable from production.
+func acunetixOracleAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attributes := event.GetAttributes()
+	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
+	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
+	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
+	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
+		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
+		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
+	}
+	return identityProjectionResult(entities, links)
+}
+
+func acunetixOracleFindingProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attributes := event.GetAttributes()
+	findingID := firstNonEmpty(attributes["finding_id"], event.GetId())
+	findingURN := projectionURN(tenantID, "finding", findingID)
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	addEntity(entities, &ports.ProjectedEntity{URN: findingURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "finding", Label: firstNonEmpty(attributes["title"], findingID), Attributes: map[string]string{"finding_id": findingID, "severity": strings.TrimSpace(attributes["severity"]), "status": strings.TrimSpace(attributes["status"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
+	if resourceURN := strings.TrimSpace(attributes["resource_urn"]); resourceURN != "" {
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), findingURN, resourceURN, relationAffects, map[string]string{"event_id": event.GetId()}))
+	}
+	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
+		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
+		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), evidenceURN, findingURN, relationSupports, map[string]string{"event_id": event.GetId()}))
+	}
+	return identityProjectionResult(entities, links)
+}
+
+func acunetixOraclePolicyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	tenantID, err := tenantID(event)
+	if err != nil {
+		return nil, nil, err
+	}
+	attributes := event.GetAttributes()
+	policyID := firstNonEmpty(attributes["policy_id"], event.GetId())
+	policyURN := projectionURN(tenantID, "policy", policyID)
+	entities := map[string]*ports.ProjectedEntity{}
+	links := map[string]*ports.ProjectedLink{}
+	addEntity(entities, &ports.ProjectedEntity{URN: policyURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "policy", Label: firstNonEmpty(attributes["policy_name"], policyID), Attributes: map[string]string{"policy_id": policyID, "policy_type": strings.TrimSpace(attributes["policy_type"]), "policy_status": strings.TrimSpace(attributes["policy_status"]), "policy_severity": strings.TrimSpace(attributes["policy_severity"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
+	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
+		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
+		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
+		addLink(links, projectedLink(tenantID, event.GetSourceId(), policyURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
+	}
+	return identityProjectionResult(entities, links)
 }


### PR DESCRIPTION
## Summary

- remove the production Acunetix Go projection implementation for all five families
- make every static Acunetix compatibility projector fail closed with a typed Rust-authority error
- preserve the retired asset, finding, and policy semantics as test-only parity oracles

## Deletion proof

- Acunetix has provider-specific Rust collection and projection kernels with closed-family, origin, credential-isolation, tenant, cursor, restart, deduplication, and fixture-parity tests
- the static Go projection entry points emit zero entities or links
- production Go diff: +12/-70 (net -58); test oracle diff: +96/-5

## Shared authority blockers

This deleting draft is not merge-ready by itself. Registry authority cutover remains owned by draft PR #2662, and connector-definition registration can still install a dynamic catalog Go projector ahead of the static sentinel. The shared registry/authority lane must close those routes before this PR can merge. This branch intentionally does not edit or duplicate the shared registry or generator files.

## Validation

- `go test ./internal/sourceprojection -run 'TestAcunetix' -count=1`
- `go test ./internal/sourceprojection -count=1`
- `go test ./internal/sourceregistry -run 'TestBuiltinRetiresCoveredProviderGoLoaders' -count=1`
- `git diff --check`

The managed local Cargo wrapper was blocked before compilation by its capacity gate; hosted Rust checks are required before readiness.
