### PR TITLE
refactor(sources): retire OpenAI Go projection writer

### DIFF
--- a/crates/source-runtime-next/src/mapper.rs
+++ b/crates/source-runtime-next/src/mapper.rs
@@ -279,6 +279,16 @@ impl CatalogGraphMapper {
             if self.source.id() == "okta" && family.id() == "application" {
                 normalize_okta_application_labels(&mut projected, &record.provider_id);
             }
+            if self.source.id() == "openai"
+                && matches!(family.id(), "api_key" | "admin_api_key" | "project_api_key")
+            {
+                normalize_openai_api_key_posture(
+                    &mut projected,
+                    batch.scope.receipt().tenant_id().as_str(),
+                    family.id(),
+                    &record.provider_id,
+                );
+            }
             match family.projection().template() {
                 "group_membership" | "identity_group_membership" => {
                     let provenance = self.assertion_provenance(batch, record)?;
@@ -709,6 +719,36 @@ fn normalize_okta_application_labels(projected: &mut BTreeMap<String, String>, f
     }
 }
 
+fn normalize_openai_api_key_posture(
+    projected: &mut BTreeMap<String, String>,
+    tenant_id: &str,
+    family: &str,
+    fallback_id: &str,
+) {
+    let credential_id = first(projected, &["api_key_id", "external_id", "id"])
+        .unwrap_or(fallback_id)
+        .to_owned();
+    let privileged = family == "admin_api_key"
+        || first(projected, &["privileged"]).is_some_and(|value| value == "true")
+        || first(projected, &["key_class"])
+            .is_some_and(|value| value.eq_ignore_ascii_case("admin"));
+    let has_owner = first(
+        projected,
+        &["owner_user_id", "owner_service_account_id", "owner_id"],
+    )
+    .is_some_and(|value| !value.trim().is_empty());
+    projected.insert("privileged".to_owned(), privileged.to_string());
+    projected.insert("has_owner".to_owned(), has_owner.to_string());
+    projected.insert(
+        "orphaned_owner".to_owned(),
+        (privileged && !has_owner).to_string(),
+    );
+    projected.insert(
+        "resource_urn".to_owned(),
+        format!("urn:cerebro:{tenant_id}:openai_credential:{credential_id}"),
+    );
+}
+
 fn first_valid_entity_label<'a>(
     values: &'a BTreeMap<String, String>,
     keys: &[&str],
@@ -786,6 +826,136 @@ mod tests {
             Err(CatalogMapperError::ReservedField(field))
                 if field == "application_workspace_id"
         ));
+    }
+
+    #[test]
+    fn openai_admin_api_keys_keep_tenant_scoped_ownership_posture() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let source = catalog.get("openai").unwrap().clone();
+        let collection = CompleteCollection::new(
+            TenantId::parse("writer").unwrap(),
+            SourceRuntimeId::parse("openai-prod").unwrap(),
+            CollectionId::parse("collection-openai-admin-keys").unwrap(),
+            "openai.admin_api_key",
+            10,
+        )
+        .unwrap();
+        let batch = CollectedBatch {
+            scope: CollectedScope::Complete(collection),
+            records: vec![
+                SourceRecord {
+                    observation_id: ObservationId::parse("observation-openai-owned").unwrap(),
+                    family: "admin_api_key".to_owned(),
+                    provider_kind: "openai.admin_api_key".to_owned(),
+                    provider_id: "admin-owned".to_owned(),
+                    fields: BTreeMap::from([
+                        ("api_key_id".to_owned(), "admin-owned".to_owned()),
+                        ("key_class".to_owned(), "admin".to_owned()),
+                        ("name".to_owned(), "Owned admin key".to_owned()),
+                        ("owner_id".to_owned(), "user-1".to_owned()),
+                    ]),
+                    payload: serde_json::json!({"id": "admin-owned"}),
+                },
+                SourceRecord {
+                    observation_id: ObservationId::parse("observation-openai-orphaned").unwrap(),
+                    family: "admin_api_key".to_owned(),
+                    provider_kind: "openai.admin_api_key".to_owned(),
+                    provider_id: "admin-orphaned".to_owned(),
+                    fields: BTreeMap::from([
+                        ("api_key_id".to_owned(), "admin-orphaned".to_owned()),
+                        ("key_class".to_owned(), "admin".to_owned()),
+                        ("name".to_owned(), "Orphaned admin key".to_owned()),
+                    ]),
+                    payload: serde_json::json!({"id": "admin-orphaned"}),
+                },
+            ],
+            next_cursor: None,
+        };
+
+        let delta = CatalogGraphMapper::new(source, "v1")
+            .unwrap()
+            .map(&batch)
+            .unwrap();
+
+        assert_eq!(delta.entities().len(), 2);
+        let owned = delta
+            .entities()
+            .iter()
+            .find(|entity| {
+                entity
+                    .properties()
+                    .get("api_key_id")
+                    .is_some_and(|value| value == "admin-owned")
+            })
+            .unwrap();
+        assert_eq!(
+            owned.agent_key(),
+            "urn:cerebro:writer:openai_credential:admin-owned"
+        );
+        assert_eq!(
+            owned.properties().get("privileged").map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            owned.properties().get("has_owner").map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            owned.properties().get("orphaned_owner").map(String::as_str),
+            Some("false")
+        );
+
+        let orphaned = delta
+            .entities()
+            .iter()
+            .find(|entity| {
+                entity
+                    .properties()
+                    .get("api_key_id")
+                    .is_some_and(|value| value == "admin-orphaned")
+            })
+            .unwrap();
+        assert_eq!(
+            orphaned.agent_key(),
+            "urn:cerebro:writer:openai_credential:admin-orphaned"
+        );
+        assert_eq!(
+            orphaned
+                .properties()
+                .get("orphaned_owner")
+                .map(String::as_str),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn openai_project_api_key_owner_is_not_marked_privileged_or_orphaned() {
+        let mut projected = BTreeMap::from([
+            ("api_key_id".to_owned(), "project-key".to_owned()),
+            (
+                "owner_service_account_id".to_owned(),
+                "service-account-1".to_owned(),
+            ),
+        ]);
+        normalize_openai_api_key_posture(&mut projected, "writer", "project_api_key", "fallback");
+        assert_eq!(
+            projected.get("privileged").map(String::as_str),
+            Some("false")
+        );
+        assert_eq!(projected.get("has_owner").map(String::as_str), Some("true"));
+        assert_eq!(
+            projected.get("orphaned_owner").map(String::as_str),
+            Some("false")
+        );
+        assert_eq!(
+            projected.get("resource_urn").map(String::as_str),
+            Some("urn:cerebro:writer:openai_credential:project-key")
+        );
     }
 
     #[test]

--- a/internal/sourceprojection/ai_access.go
+++ b/internal/sourceprojection/ai_access.go
@@ -18,15 +18,10 @@ type aiInviteProjectMembership struct {
 }
 
 var (
-	openAIAccessProfile    = aiAccessProfile{Provider: "openai"}
 	anthropicAccessProfile = aiAccessProfile{Provider: "anthropic"}
 	langChainAccessProfile = aiAccessProfile{Provider: "langchain"}
 	langfuseAccessProfile  = aiAccessProfile{Provider: "langfuse"}
 )
-
-func openAIUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiUserProjections(event, openAIAccessProfile)
-}
 
 func anthropicUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiUserProjections(event, anthropicAccessProfile)
@@ -34,10 +29,6 @@ func anthropicUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projecte
 
 func langChainOrganizationMemberProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiUserProjections(event, langChainAccessProfile)
-}
-
-func openAIProjectProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiProjectProjections(event, openAIAccessProfile)
 }
 
 func anthropicProjectProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
@@ -68,10 +59,6 @@ func langChainOrganizationProjections(event *cerebrov1.EventEnvelope) ([]*ports.
 	return aiOrganizationProjections(event, langChainAccessProfile)
 }
 
-func openAIInviteProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiInviteProjections(event, openAIAccessProfile)
-}
-
 func anthropicInviteProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiInviteProjections(event, anthropicAccessProfile)
 }
@@ -82,18 +69,6 @@ func anthropicWorkspaceProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pro
 
 func langChainWorkspaceProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiWorkspaceProjections(event, langChainAccessProfile)
-}
-
-func openAIGroupProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiGroupProjections(event, openAIAccessProfile)
-}
-
-func openAIGroupUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiGroupMembershipProjections(event, openAIAccessProfile)
-}
-
-func openAIProjectUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiScopedUserAccessProjections(event, openAIAccessProfile, "project")
 }
 
 func anthropicWorkspaceMemberProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
@@ -112,20 +87,12 @@ func anthropicComplianceGroupMemberProjections(event *cerebrov1.EventEnvelope) (
 	return aiGroupMembershipProjections(event, anthropicAccessProfile)
 }
 
-func openAIServiceAccountProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiServiceAccountProjections(event, openAIAccessProfile, "project")
-}
-
 func anthropicServiceAccountProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiServiceAccountProjections(event, anthropicAccessProfile, "organization")
 }
 
 func langChainServiceAccountProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiServiceAccountProjections(event, langChainAccessProfile, "organization")
-}
-
-func openAICredentialProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiCredentialProjections(event, openAIAccessProfile)
 }
 
 func anthropicCredentialProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
@@ -140,10 +107,6 @@ func langfuseCredentialProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pro
 	return aiCredentialProjections(event, langfuseAccessProfile)
 }
 
-func openAIRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiRoleProjections(event, openAIAccessProfile)
-}
-
 func anthropicComplianceRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiScopedRoleProjections(event, anthropicAccessProfile)
 }
@@ -156,44 +119,12 @@ func anthropicComplianceRolePermissionProjections(event *cerebrov1.EventEnvelope
 	return aiRolePermissionProjections(event, anthropicAccessProfile)
 }
 
-func openAIUserRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiSubjectRoleProjections(event, openAIAccessProfile, "user", "organization")
-}
-
-func openAIGroupRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiSubjectRoleProjections(event, openAIAccessProfile, "group", "organization")
-}
-
-func openAIProjectUserRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiSubjectRoleProjections(event, openAIAccessProfile, "user", "project")
-}
-
-func openAIProjectGroupProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiScopedGroupAccessProjections(event, openAIAccessProfile, "project")
-}
-
-func openAIProjectGroupRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiSubjectRoleProjections(event, openAIAccessProfile, "group", "project")
-}
-
-func openAIProjectEntitlementProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiProjectEntitlementProjections(event, openAIAccessProfile)
-}
-
-func openAIGovernanceControlProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiGovernanceControlProjections(event, openAIAccessProfile)
-}
-
 func anthropicGovernanceControlProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiGovernanceControlProjections(event, anthropicAccessProfile)
 }
 
 func langChainGovernanceControlProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiGovernanceControlProjections(event, langChainAccessProfile)
-}
-
-func openAIUsageMetricProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiUsageMetricProjections(event, openAIAccessProfile)
 }
 
 func anthropicUsageMetricProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
@@ -214,10 +145,6 @@ func anthropicFederationIssuerProjections(event *cerebrov1.EventEnvelope) ([]*po
 
 func anthropicFederationRuleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiFederationRuleProjections(event, anthropicAccessProfile)
-}
-
-func openAIAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiAuditProjections(event, openAIAccessProfile)
 }
 
 func anthropicComplianceActivityProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/ai_access_credential_test.go
+++ b/internal/sourceprojection/ai_access_credential_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestProjectAIUsageMetricNormalizesCredentialRuntimeUsage(t *testing.T) {
 	state := &projectionRecorder{}
-	service := New(state, nil)
+	service := newOpenAIOracleService(t, state, nil)
 	occurred := time.Date(2026, time.June, 18, 12, 45, 0, 0, time.UTC)
 
 	event := &cerebrov1.EventEnvelope{

--- a/internal/sourceprojection/ai_access_test.go
+++ b/internal/sourceprojection/ai_access_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestProjectOpenAIProjectAccessEdges(t *testing.T) {
 	state := &projectionRecorder{}
-	service := New(state, nil)
+	service := newOpenAIOracleService(t, state, nil)
 	occurred := time.Date(2026, time.June, 18, 12, 0, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -95,7 +95,7 @@ func TestProjectOpenAIProjectAccessEdges(t *testing.T) {
 
 func TestProjectOpenAIAuditDeepAccessEvidence(t *testing.T) {
 	state := &projectionRecorder{}
-	service := New(state, nil)
+	service := newOpenAIOracleService(t, state, nil)
 	occurred := time.Date(2026, time.June, 18, 12, 5, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -182,7 +182,7 @@ func TestProjectOpenAIAuditDeepAccessEvidence(t *testing.T) {
 
 func TestProjectAnthropicComplianceActivityResourceEvidence(t *testing.T) {
 	state := &projectionRecorder{}
-	service := New(state, nil)
+	service := newOpenAIOracleService(t, state, nil)
 	occurred := time.Date(2026, time.June, 18, 12, 7, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -245,7 +245,7 @@ func TestProjectAnthropicComplianceActivityResourceEvidence(t *testing.T) {
 
 func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 	state := &projectionRecorder{}
-	service := New(state, nil)
+	service := newOpenAIOracleService(t, state, nil)
 	occurred := time.Date(2026, time.June, 18, 12, 10, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -409,7 +409,7 @@ func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 
 func TestProjectAnthropicProjectCollaboratorAccessEdges(t *testing.T) {
 	state := &projectionRecorder{}
-	service := New(state, nil)
+	service := newOpenAIOracleService(t, state, nil)
 	occurred := time.Date(2026, time.June, 18, 12, 15, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -512,7 +512,7 @@ func TestProjectAnthropicProjectCollaboratorAccessEdges(t *testing.T) {
 
 func TestProjectAIGovernanceControlEdges(t *testing.T) {
 	state := &projectionRecorder{}
-	service := New(state, nil)
+	service := newOpenAIOracleService(t, state, nil)
 	occurred := time.Date(2026, time.June, 18, 12, 30, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -644,7 +644,7 @@ func TestProjectAIGovernanceControlEdges(t *testing.T) {
 
 func TestProjectAIUsageAndCostMetricEdges(t *testing.T) {
 	state := &projectionRecorder{}
-	service := New(state, nil)
+	service := newOpenAIOracleService(t, state, nil)
 	occurred := time.Date(2026, time.June, 18, 12, 45, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -727,7 +727,7 @@ func TestProjectAIUsageAndCostMetricEdges(t *testing.T) {
 
 func TestProjectAnthropicWorkspaceCredentialFederationAndComplianceEdges(t *testing.T) {
 	state := &projectionRecorder{}
-	service := New(state, nil)
+	service := newOpenAIOracleService(t, state, nil)
 	occurred := time.Date(2026, time.June, 18, 13, 0, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -828,7 +828,7 @@ func TestProjectAnthropicWorkspaceCredentialFederationAndComplianceEdges(t *test
 
 func TestProjectAnthropicComplianceDirectoryGroupMembership(t *testing.T) {
 	state := &projectionRecorder{}
-	service := New(state, nil)
+	service := newOpenAIOracleService(t, state, nil)
 	occurred := time.Date(2026, time.June, 18, 14, 0, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -1280,7 +1280,7 @@ func TestProjectAnthropicRemainingRuntimeFamilies(t *testing.T) {
 func projectAnthropicInventoryEvent(t *testing.T, event *cerebrov1.EventEnvelope) *projectionRecorder {
 	t.Helper()
 	state := &projectionRecorder{}
-	service := New(state, nil)
+	service := newOpenAIOracleService(t, state, nil)
 	if _, err := service.Project(context.Background(), event); err != nil {
 		t.Fatalf("Project(%q) error = %v", event.GetId(), err)
 	}

--- a/internal/sourceprojection/openai.go
+++ b/internal/sourceprojection/openai.go
@@ -1,61 +1,35 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-// openAIAPIKeyProjections materializes the shared AI credential graph slice for
-// OpenAI API keys and then annotates the credential node with current ownership
-// posture (privilege class, owner type, and whether the key has an accountable
-// owner). Durable orphaned-privileged-key findings anchor on this projected
-// state so they reflect the key's current ownership rather than transient audit
-// events.
-func openAIAPIKeyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	entities, links, err := openAICredentialProjections(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	enrichOpenAICredentialPosture(entities, event)
-	return entities, links, nil
+var errOpenAIRustProjectionRequired = errors.New("openai projection requires Rust authority")
+
+func openAIRustProjectionRequired(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
 }
 
-func enrichOpenAICredentialPosture(entities []*ports.ProjectedEntity, event *cerebrov1.EventEnvelope) {
-	tenant, err := tenantID(event)
-	if err != nil {
-		return
-	}
-	attrs := event.GetAttributes()
-	credentialID := firstNonEmpty(attrs["api_key_id"], attrs["external_key_id"], attrs["credential_id"], attrs["id"])
-	credentialURN := projectionURN(tenant, "openai_credential", credentialID)
-	if credentialURN == "" {
-		return
-	}
-	privileged := openAICredentialPrivileged(event.GetKind(), attrs)
-	hasOwner := strings.TrimSpace(attrs["owner_user_id"]) != "" || strings.TrimSpace(attrs["owner_service_account_id"]) != "" || strings.TrimSpace(attrs["owner_id"]) != ""
-	for _, entity := range entities {
-		if entity == nil || entity.URN != credentialURN {
-			continue
-		}
-		if entity.Attributes == nil {
-			entity.Attributes = map[string]string{}
-		}
-		entity.Attributes["privileged"] = boolString(privileged)
-		entity.Attributes["has_owner"] = boolString(hasOwner)
-		entity.Attributes["orphaned_owner"] = boolString(privileged && !hasOwner)
-		addEndpointAttribute(entity.Attributes, "owner_type", attrs["owner_type"])
-		addEndpointAttribute(entity.Attributes, "key_class", attrs["key_class"])
-	}
-}
-
-func openAICredentialPrivileged(kind string, attrs map[string]string) bool {
-	if strings.TrimSpace(kind) == "openai.admin_api_key" {
-		return true
-	}
-	if projectionBool(attrs["privileged"]) {
-		return true
-	}
-	return strings.EqualFold(strings.TrimSpace(attrs["key_class"]), "admin")
-}
+var (
+	openAIAPIKeyProjections             = openAIRustProjectionRequired
+	openAIAuditProjections              = openAIRustProjectionRequired
+	openAIGovernanceControlProjections  = openAIRustProjectionRequired
+	openAIGroupProjections              = openAIRustProjectionRequired
+	openAIGroupRoleProjections          = openAIRustProjectionRequired
+	openAIGroupUserProjections          = openAIRustProjectionRequired
+	openAIInviteProjections             = openAIRustProjectionRequired
+	openAIProjectEntitlementProjections = openAIRustProjectionRequired
+	openAIProjectGroupProjections       = openAIRustProjectionRequired
+	openAIProjectGroupRoleProjections   = openAIRustProjectionRequired
+	openAIProjectProjections            = openAIRustProjectionRequired
+	openAIProjectUserProjections        = openAIRustProjectionRequired
+	openAIProjectUserRoleProjections    = openAIRustProjectionRequired
+	openAIRoleProjections               = openAIRustProjectionRequired
+	openAIServiceAccountProjections     = openAIRustProjectionRequired
+	openAIUsageMetricProjections        = openAIRustProjectionRequired
+	openAIUserProjections               = openAIRustProjectionRequired
+	openAIUserRoleProjections           = openAIRustProjectionRequired
+)

--- a/internal/sourceprojection/openai_oracle_test.go
+++ b/internal/sourceprojection/openai_oracle_test.go
@@ -1,0 +1,169 @@
+package sourceprojection
+
+import (
+	"strings"
+	"testing"
+
+	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
+	"github.com/writer/cerebro/internal/ports"
+)
+
+var openAIOracleAccessProfile = aiAccessProfile{Provider: "openai"}
+
+func newOpenAIOracleService(
+	t *testing.T,
+	state ports.ProjectionStateStore,
+	graph ports.ProjectionGraphStore,
+) *Service {
+	t.Helper()
+	builtinRegistry.mu.RLock()
+	projectors := make([]EventProjector, 0, len(builtinRegistry.projectors))
+	for kind, projector := range builtinRegistry.projectors {
+		if oracle := openAIOracleProjectors[kind]; oracle != nil {
+			projector = oracle
+		}
+		projectors = append(projectors, EventProjector{Kind: kind, Project: projector})
+	}
+	builtinRegistry.mu.RUnlock()
+	registry, err := NewRegistry(projectors...)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	return NewWithRegistry(state, graph, registry)
+}
+
+var openAIOracleProjectors = map[string]ProjectFunc{
+	"openai.admin_api_key":                  openAIOracleAPIKeyProjections,
+	"openai.api_key":                        openAIOracleAPIKeyProjections,
+	"openai.audit_log":                      openAIOracleAuditProjections,
+	"openai.certificate":                    openAIOracleGovernanceControlProjections,
+	"openai.cost":                           openAIOracleUsageMetricProjections,
+	"openai.data_retention":                 openAIOracleGovernanceControlProjections,
+	"openai.group":                          openAIOracleGroupProjections,
+	"openai.group_role":                     openAIOracleGroupRoleProjections,
+	"openai.group_user":                     openAIOracleGroupUserProjections,
+	"openai.invite":                         openAIOracleInviteProjections,
+	"openai.project":                        openAIOracleProjectProjections,
+	"openai.project_api_key":                openAIOracleAPIKeyProjections,
+	"openai.project_certificate":            openAIOracleGovernanceControlProjections,
+	"openai.project_data_retention":         openAIOracleGovernanceControlProjections,
+	"openai.project_group":                  openAIOracleProjectGroupProjections,
+	"openai.project_group_role":             openAIOracleProjectGroupRoleProjections,
+	"openai.project_hosted_tool_permission": openAIOracleProjectEntitlementProjections,
+	"openai.project_model_permission":       openAIOracleProjectEntitlementProjections,
+	"openai.project_rate_limit":             openAIOracleGovernanceControlProjections,
+	"openai.project_role":                   openAIOracleRoleProjections,
+	"openai.project_service_account":        openAIOracleServiceAccountProjections,
+	"openai.project_spend_alert":            openAIOracleGovernanceControlProjections,
+	"openai.project_user":                   openAIOracleProjectUserProjections,
+	"openai.project_user_role":              openAIOracleProjectUserRoleProjections,
+	"openai.role":                           openAIOracleRoleProjections,
+	"openai.service_account":                openAIOracleServiceAccountProjections,
+	"openai.spend_alert":                    openAIOracleGovernanceControlProjections,
+	"openai.usage_audio_speech":             openAIOracleUsageMetricProjections,
+	"openai.usage_audio_transcription":      openAIOracleUsageMetricProjections,
+	"openai.usage_code_interpreter_session": openAIOracleUsageMetricProjections,
+	"openai.usage_completion":               openAIOracleUsageMetricProjections,
+	"openai.usage_embedding":                openAIOracleUsageMetricProjections,
+	"openai.usage_file_search_call":         openAIOracleUsageMetricProjections,
+	"openai.usage_image":                    openAIOracleUsageMetricProjections,
+	"openai.usage_moderation":               openAIOracleUsageMetricProjections,
+	"openai.usage_vector_store":             openAIOracleUsageMetricProjections,
+	"openai.usage_web_search_call":          openAIOracleUsageMetricProjections,
+	"openai.user":                           openAIOracleUserProjections,
+	"openai.user_role":                      openAIOracleUserRoleProjections,
+}
+
+func openAIOracleUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiUserProjections(event, openAIOracleAccessProfile)
+}
+
+func openAIOracleProjectProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiProjectProjections(event, openAIOracleAccessProfile)
+}
+
+func openAIOracleInviteProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiInviteProjections(event, openAIOracleAccessProfile)
+}
+
+func openAIOracleGroupProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiGroupProjections(event, openAIOracleAccessProfile)
+}
+
+func openAIOracleGroupUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiGroupMembershipProjections(event, openAIOracleAccessProfile)
+}
+
+func openAIOracleProjectUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiScopedUserAccessProjections(event, openAIOracleAccessProfile, "project")
+}
+
+func openAIOracleServiceAccountProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiServiceAccountProjections(event, openAIOracleAccessProfile, "project")
+}
+
+func openAIOracleRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiRoleProjections(event, openAIOracleAccessProfile)
+}
+
+func openAIOracleUserRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiSubjectRoleProjections(event, openAIOracleAccessProfile, "user", "organization")
+}
+
+func openAIOracleGroupRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiSubjectRoleProjections(event, openAIOracleAccessProfile, "group", "organization")
+}
+
+func openAIOracleProjectUserRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiSubjectRoleProjections(event, openAIOracleAccessProfile, "user", "project")
+}
+
+func openAIOracleProjectGroupProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiScopedGroupAccessProjections(event, openAIOracleAccessProfile, "project")
+}
+
+func openAIOracleProjectGroupRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiSubjectRoleProjections(event, openAIOracleAccessProfile, "group", "project")
+}
+
+func openAIOracleProjectEntitlementProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiProjectEntitlementProjections(event, openAIOracleAccessProfile)
+}
+
+func openAIOracleGovernanceControlProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiGovernanceControlProjections(event, openAIOracleAccessProfile)
+}
+
+func openAIOracleUsageMetricProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiUsageMetricProjections(event, openAIOracleAccessProfile)
+}
+
+func openAIOracleAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return aiAuditProjections(event, openAIOracleAccessProfile)
+}
+
+func openAIOracleAPIKeyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	entities, links, err := aiCredentialProjections(event, openAIOracleAccessProfile)
+	if err != nil {
+		return nil, nil, err
+	}
+	attrs := event.GetAttributes()
+	credentialID := firstNonEmpty(attrs["api_key_id"], attrs["external_key_id"], attrs["credential_id"], attrs["id"])
+	credentialURN := projectionURN(event.GetTenantId(), "openai_credential", credentialID)
+	privileged := event.GetKind() == "openai.admin_api_key" || projectionBool(attrs["privileged"]) || strings.EqualFold(strings.TrimSpace(attrs["key_class"]), "admin")
+	hasOwner := strings.TrimSpace(attrs["owner_user_id"]) != "" || strings.TrimSpace(attrs["owner_service_account_id"]) != "" || strings.TrimSpace(attrs["owner_id"]) != ""
+	for _, entity := range entities {
+		if entity == nil || entity.URN != credentialURN {
+			continue
+		}
+		if entity.Attributes == nil {
+			entity.Attributes = map[string]string{}
+		}
+		entity.Attributes["privileged"] = boolString(privileged)
+		entity.Attributes["has_owner"] = boolString(hasOwner)
+		entity.Attributes["orphaned_owner"] = boolString(privileged && !hasOwner)
+		addEndpointAttribute(entity.Attributes, "owner_type", attrs["owner_type"])
+		addEndpointAttribute(entity.Attributes, "key_class", attrs["key_class"])
+	}
+	return entities, links, nil
+}

--- a/internal/sourceprojection/openai_test.go
+++ b/internal/sourceprojection/openai_test.go
@@ -2,6 +2,7 @@ package sourceprojection
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -12,7 +13,7 @@ import (
 
 func TestProjectOpenAIKeyOwnershipAndPostureEnrichment(t *testing.T) {
 	state := &projectionRecorder{}
-	service := New(state, nil)
+	service := newOpenAIOracleService(t, state, nil)
 	occurred := time.Date(2026, time.June, 18, 12, 0, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -164,6 +165,25 @@ func TestRegistryRoutesOpenAIDeclaredKinds(t *testing.T) {
 	}
 }
 
+func TestOpenAIGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for kind := range openAIOracleProjectors {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "writer",
+				SourceId: "openai",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errOpenAIRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
+	}
+}
+
 func TestProjectOpenAIDeclaredKindsProduceGraphEntities(t *testing.T) {
 	occurred := time.Date(2026, time.June, 18, 13, 30, 0, 0, time.UTC)
 	cases := []struct {
@@ -215,7 +235,7 @@ func TestProjectOpenAIDeclaredKindsProduceGraphEntities(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			state := &projectionRecorder{}
-			service := New(state, nil)
+			service := newOpenAIOracleService(t, state, nil)
 			attrs := openAIProjectionCoverageAttributes(tc.family)
 			event := &cerebrov1.EventEnvelope{
 				Id:         "openai-" + tc.name,


### PR DESCRIPTION
## Summary

- remove every production OpenAI-specific Go projection wrapper across all 39 closed families
- route every static Go registry symbol to one fail-closed Rust-authority sentinel
- preserve the retired Go graph behavior in a test-only oracle registry
- add native Rust catalog-mapper enrichment for tenant-scoped OpenAI credential ownership posture

## Replacement proof

- the closed Rust dispatcher owns collection for all 39 OpenAI families, including origin restriction, credential isolation, pagination, cursor validation, restart, deduplication, tenant scope, and event contracts
- the native Rust catalog mapper preserves the credential posture fields required by the existing finding rule
- every static production Go OpenAI projector emits zero entities or links
- production Go diff: +24/-123 (net -99); test-only Go retains the parity oracle

## Shared authority blocker

This deleting draft is not merge-ready by itself. The Go host still invokes its projector after appending Rust-collected events, and connector-definition registration can install a dynamic catalog Go projector ahead of the static sentinel. The shared registry/authority lane must fence that alternate writer and route the authoritative native Rust projection path before this PR can merge. This branch intentionally does not edit shared registry or generator files.

## Validation

- `go test ./internal/sourceprojection -count=1`
- `go test ./internal/findings -run 'OpenAI|orphaned.*privileged' -count=1`
- `go test ./internal/sourceops ./internal/sourceruntime ./internal/sourceruntime/sourceworker -run 'OpenAI|RustAuthoritative|Credential|Authority' -count=1`
- `rustfmt --edition 2024 --check crates/source-runtime-next/src/mapper.rs`
- `git diff --check`

The managed local Cargo wrapper was blocked before compilation because its safe-capacity gate lacked sufficient space. Hosted Rust checks are required before readiness.
