### PR TITLE
Fix vendor creation bootstrap CI gates

### DIFF
--- a/internal/bootstrap/grc_vendor_create.go
+++ b/internal/bootstrap/grc_vendor_create.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -65,7 +66,7 @@ func (a *App) handleCreateGRCVendor(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var extra any
-	if err := decoder.Decode(&extra); err != io.EOF {
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
 		if err == nil {
 			err = fmt.Errorf("request body must contain one JSON object")
 		}

--- a/tools/archtests/bootstrap_surface_test.go
+++ b/tools/archtests/bootstrap_surface_test.go
@@ -176,7 +176,10 @@ import (
 // tenant authorization, dependency wiring, response mapping, and cache
 // invalidation. Resolver mapping, receipt verification, and closure decisions
 // remain in internal/securitylifecyclefindings and internal/findings.
-const bootstrapProductionGoLineBudget = 29817
+// Manual GRC vendor creation adds bounded request decoding, resolved-scope
+// authorization, event-envelope mapping, append/projection wiring, and response
+// mapping. Portable vendor state and read behavior remain in internal/grcvendor.
+const bootstrapProductionGoLineBudget = 30143
 
 type bootstrapFileLineCount struct {
 	path  string


### PR DESCRIPTION
## Summary
- handle wrapped EOF values in bounded vendor-create request decoding
- record the manual vendor creation composition boundary and reset the bootstrap surface budget to the measured 30,143 lines

## Validation
- `make lint-shard LINT_PACKAGES='./internal/...' LINT_SHARD_TOTAL=4 LINT_SHARD_INDEX=1`
- `go test ./internal/bootstrap -run '^(TestCreateGRCVendor|TestBuildGRCVendorCreateEvent)' -count=1`
- `go test ./tools/archtests -run '^TestBootstrapProductionSurfaceDoesNotGrow$' -count=1`
- `go test -race ./tools/archtests -run '^TestBootstrapProductionSurfaceDoesNotGrow$' -count=1`
- `git diff --check`