### PR TITLE
test(catalog): pin full Rust authority for six retired-loader sources

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -3566,9 +3566,15 @@ mod tests {
             "adobe_workfront",
             "aircall",
             "airfocus",
+            "akeyless",
             "beezup",
             "bitwarden",
+            "box",
+            "conjur",
             "deepseek",
+            "duo",
+            "fivetran",
+            "jira",
             "openai",
         ] {
             let source = catalog.get(source_id).unwrap();


### PR DESCRIPTION
## Summary

- pin `akeyless`, `box`, `conjur`, `duo`, `fivetran`, and `jira` in `retired_static_loader_sources_are_fully_rust_authoritative`
- all six already compile with every family collection-authoritative and projection-authoritative; this locks that in ahead of retiring their Go projection writers (wave following #2658/#2675)

## Authority proof

- compiled catalog probe over `internal/connectorcatalog/catalog` + `sources`: akeyless (4 families), box (5), conjur (4), duo (11), fivetran (42), jira (7) — all families `is_authoritative()` and `is_projection_authoritative()`
- all six are in `TestBuiltinRetiresCoveredProviderGoLoaders` (Go static loaders already retired)

## Validation

- cargo test -p cerebro-source-catalog --lib retired

🤖 Generated with [Claude Code](https://claude.com/claude-code)