### PR TITLE
refactor(sources): retire Fivetran Go projection writer

### DIFF
--- a/internal/sourceprojection/fivetran.go
+++ b/internal/sourceprojection/fivetran.go
@@ -1,505 +1,54 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-var fivetranIdentityProfile = identityProjectionProfile{Provider: "fivetran"}
+var errFivetranRustProjectionRequired = errors.New("fivetran projection requires Rust authority")
 
-func fivetranUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, fivetranIdentityProfile)
+func fivetranUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errFivetranRustProjectionRequired
 }
 
-func fivetranAccountsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return fivetranGenericAssetProjections(event)
+func fivetranAccountsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errFivetranRustProjectionRequired
 }
 
-func fivetranRecordsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return fivetranGenericAssetProjections(event)
+func fivetranRecordsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errFivetranRustProjectionRequired
 }
 
-func fivetranPoliciesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return fivetranGenericPolicyProjections(event)
+func fivetranPoliciesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errFivetranRustProjectionRequired
 }
 
-func fivetranAuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, fivetranIdentityProfile)
+func fivetranAuditEventsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errFivetranRustProjectionRequired
 }
 
-func fivetranGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        resourceURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."),
-		Label:      firstNonEmpty(attributes["resource_name"], resourceID),
-		Attributes: map[string]string{
-			"resource_id":       resourceID,
-			"resource_type":     resourceType,
-			"source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID]),
-		},
-	})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{
-			URN:        evidenceURN,
-			TenantID:   tenantID,
-			SourceID:   event.GetSourceId(),
-			EntityType: "runtime.evidence",
-			Label:      evidenceID,
-			Attributes: map[string]string{
-				"evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"]),
-				"evidence_cas_uri":    strings.TrimSpace(attributes["evidence_cas_uri"]),
-				"evidence_id":         evidenceID,
-			},
-		})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func fivetranRolesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errFivetranRustProjectionRequired
 }
 
-func fivetranRolesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return fivetranRuntimeAssetProjections(event)
+func fivetranTeamsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errFivetranRustProjectionRequired
 }
 
-func fivetranTeamsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityGroupProjections(event, fivetranIdentityProfile)
+func fivetranGroupsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errFivetranRustProjectionRequired
 }
 
-func fivetranGroupsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityGroupProjections(event, fivetranIdentityProfile)
+func fivetranScopedMembershipProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errFivetranRustProjectionRequired
 }
 
-func fivetranScopedMembershipProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	scopeType, scopeID := fivetranMembershipScope(event, attributes)
-	memberType := fivetranMembershipMemberType(event, attributes)
-	memberID := firstNonEmpty(attributes["member_id"], attributes["resource_id"], attributes["id"], attributes["user_id"], attributes["group_id"], attributes["connection_id"])
-	if scopeID == "" || memberID == "" {
-		return nil, nil, nil
-	}
-
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	scopeURN := fivetranPrincipalOrAssetURN(tenantID, scopeType, scopeID)
-	memberURN := fivetranPrincipalOrAssetURN(tenantID, memberType, memberID)
-	addFivetranMembershipEntity(entities, tenantID, event.GetSourceId(), scopeURN, scopeType, scopeID, firstNonEmpty(attributes["scope_name"], attributes[scopeType+"_name"], scopeID), attributes)
-	addFivetranMembershipEntity(entities, tenantID, event.GetSourceId(), memberURN, memberType, memberID, firstNonEmpty(attributes["member_name"], attributes["resource_name"], attributes["name"], attributes["email"], memberID), attributes)
-	linkMemberType, linkMemberID, linkMemberURN, linkScopeType, linkScopeID, linkScopeURN := fivetranMembershipLinkEndpoints(event, scopeType, scopeID, scopeURN, memberType, memberID, memberURN)
-	addLink(links, projectedLink(tenantID, event.GetSourceId(), linkMemberURN, linkScopeURN, relationMemberOf, compactAttributes(map[string]string{
-		"event_id":      event.GetId(),
-		"match_type":    "fivetran_" + linkScopeType + "_" + linkMemberType + "_membership",
-		"member_id":     linkMemberID,
-		"member_type":   linkMemberType,
-		"role":          strings.TrimSpace(attributes["role"]),
-		"scope_id":      linkScopeID,
-		"scope_type":    linkScopeType,
-		"source_kind":   strings.TrimSpace(event.GetKind()),
-		"source_system": "fivetran",
-	})))
-	return identityProjectionResult(entities, links)
+func fivetranCredentialProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errFivetranRustProjectionRequired
 }
 
-func fivetranMembershipLinkEndpoints(event *cerebrov1.EventEnvelope, scopeType string, scopeID string, scopeURN string, memberType string, memberID string, memberURN string) (string, string, string, string, string, string) {
-	switch fivetranKindFamily(event) {
-	case "user_groups", "team_groups":
-		return scopeType, scopeID, scopeURN, memberType, memberID, memberURN
-	default:
-		return memberType, memberID, memberURN, scopeType, scopeID, scopeURN
-	}
-}
-
-func fivetranCredentialProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	entities, links, err := fivetranRuntimeAssetProjections(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	connectionID := strings.TrimSpace(attributes["connection_id"])
-	destinationID := strings.TrimSpace(attributes["destination_id"])
-	groupID := strings.TrimSpace(attributes["group_id"])
-	credentialID := firstNonEmpty(attributes["credential_id"], attributes["resource_id"], attributes["id"], attributes["hash"], attributes["public_key"])
-	targetType := "connection"
-	targetID := connectionID
-	if targetID == "" {
-		targetType = "destination"
-		targetID = destinationID
-	}
-	if targetID == "" {
-		targetType = "group"
-		targetID = groupID
-	}
-	targetURN := fivetranPrincipalOrAssetURN(tenantID, targetType, targetID)
-	credentialURN := fivetranRuntimeAssetURN(tenantID, firstNonEmpty(attributes["resource_type"], "credential"), credentialID)
-	if targetURN == "" || credentialURN == "" {
-		return entities, links, nil
-	}
-	entityMap, linkMap := projectionMaps(entities, links)
-	addEntity(entityMap, &ports.ProjectedEntity{
-		URN:        targetURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: fivetranEntityType(targetType),
-		Label:      targetID,
-		Attributes: compactAttributes(map[string]string{
-			"resource_id":       targetID,
-			"resource_type":     targetType,
-			"source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID]),
-			"source_system":     "fivetran",
-		}),
-	})
-	addLink(linkMap, projectedLink(tenantID, event.GetSourceId(), credentialURN, targetURN, relationAssignedTo, compactAttributes(map[string]string{
-		"event_id":        event.GetId(),
-		"match_type":      "fivetran_" + targetType + "_credential",
-		"connection_id":   connectionID,
-		"destination_id":  destinationID,
-		"group_id":        groupID,
-		"credential_id":   credentialID,
-		"credential_type": firstNonEmpty(attributes["resource_type"], "credential"),
-		"target_type":     targetType,
-	})))
-	outEntities, outLinks := entitiesAndLinks(entityMap, linkMap)
-	return outEntities, outLinks, nil
-}
-
-func fivetranRuntimeAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], fivetranKindFamily(event), "asset")
-	resourceID := fivetranRuntimeResourceID(event, attributes, resourceType)
-	resourceURN := fivetranRuntimeAssetURN(tenantID, resourceType, resourceID)
-	if resourceURN == "" {
-		return nil, nil, nil
-	}
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        resourceURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: "runtime.fivetran." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."),
-		Label:      firstNonEmpty(attributes["resource_name"], attributes["role_name"], attributes["group_name"], attributes["name"], resourceID),
-		Attributes: compactAttributes(map[string]string{
-			"destination_id":    strings.TrimSpace(attributes["destination_id"]),
-			"group_id":          strings.TrimSpace(attributes["group_id"]),
-			"paused":            strings.TrimSpace(attributes["paused"]),
-			"record_class":      strings.TrimSpace(attributes["record_class"]),
-			"resource_id":       resourceID,
-			"resource_name":     firstNonEmpty(attributes["resource_name"], attributes["role_name"], attributes["group_name"], attributes["name"]),
-			"resource_type":     resourceType,
-			"role_id":           strings.TrimSpace(attributes["role_id"]),
-			"role_name":         strings.TrimSpace(attributes["role_name"]),
-			"schedule_type":     strings.TrimSpace(attributes["schedule_type"]),
-			"schema":            strings.TrimSpace(attributes["schema"]),
-			"service":           strings.TrimSpace(attributes["service"]),
-			"source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID]),
-			"source_system":     "fivetran",
-			"status":            strings.TrimSpace(attributes["status"]),
-			"sync_frequency":    strings.TrimSpace(attributes["sync_frequency"]),
-			"transformation_id": strings.TrimSpace(attributes["transformation_id"]),
-		}),
-	})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{
-			URN:        evidenceURN,
-			TenantID:   tenantID,
-			SourceID:   event.GetSourceId(),
-			EntityType: "runtime.evidence",
-			Label:      firstNonEmpty(attributes["evidence_type"], evidenceID),
-			Attributes: compactAttributes(map[string]string{
-				"evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"]),
-				"evidence_cas_uri":    strings.TrimSpace(attributes["evidence_cas_uri"]),
-				"evidence_id":         evidenceID,
-			}),
-		})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), evidenceURN, resourceURN, relationObservedOn, map[string]string{"event_id": event.GetId()}))
-	}
-	fivetranRuntimeAssetRelationshipProjections(event, tenantID, resourceURN, resourceType, attributes, entities, links)
-	return identityProjectionResult(entities, links)
-}
-
-func fivetranRuntimeResourceID(event *cerebrov1.EventEnvelope, attributes map[string]string, resourceType string) string {
-	if fivetranUsesCompositeRuntimeID(resourceType) {
-		parts := fivetranIDParts(
-			attributes["connection_id"],
-			attributes["schema_name"],
-			attributes["table_name"],
-			firstNonEmpty(attributes["column_name"], attributes["resource_id"], attributes["external_id"], attributes["id"], attributes["name"]),
-		)
-		if len(parts) > 0 {
-			return strings.Join(parts, "/")
-		}
-	}
-	return firstNonEmpty(attributes["resource_id"], attributes["external_id"], attributes["id"], attributes["name"], event.GetId())
-}
-
-func fivetranIDParts(values ...string) []string {
-	parts := []string{}
-	for _, value := range values {
-		if value = strings.TrimSpace(value); value != "" {
-			parts = append(parts, value)
-		}
-	}
-	return parts
-}
-
-func fivetranUsesCompositeRuntimeID(resourceType string) bool {
-	return normalizeCloudType(resourceType) == "connection_table_column"
-}
-
-func fivetranGenericPolicyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	policyID := firstNonEmpty(attributes["policy_id"], event.GetId())
-	policyURN := projectionURN(tenantID, "policy", policyID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        policyURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: "policy",
-		Label:      firstNonEmpty(attributes["policy_name"], policyID),
-		Attributes: compactAttributes(map[string]string{
-			"policy_id":         policyID,
-			"policy_severity":   strings.TrimSpace(attributes["policy_severity"]),
-			"policy_status":     strings.TrimSpace(attributes["policy_status"]),
-			"policy_type":       strings.TrimSpace(attributes["policy_type"]),
-			"source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID]),
-		}),
-	})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{
-			URN:        evidenceURN,
-			TenantID:   tenantID,
-			SourceID:   event.GetSourceId(),
-			EntityType: "runtime.evidence",
-			Label:      evidenceID,
-			Attributes: compactAttributes(map[string]string{
-				"evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"]),
-				"evidence_cas_uri":    strings.TrimSpace(attributes["evidence_cas_uri"]),
-				"evidence_id":         evidenceID,
-			}),
-		})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), policyURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func fivetranRuntimeAssetRelationshipProjections(event *cerebrov1.EventEnvelope, tenantID string, resourceURN string, resourceType string, attributes map[string]string, entities map[string]*ports.ProjectedEntity, links map[string]*ports.ProjectedLink) {
-	groupID := strings.TrimSpace(attributes["group_id"])
-	if groupID != "" && normalizeCloudType(resourceType) != "group" {
-		groupURN := fivetranPrincipalOrAssetURN(tenantID, "group", groupID)
-		addFivetranMembershipEntity(entities, tenantID, event.GetSourceId(), groupURN, "group", groupID, firstNonEmpty(attributes["group_name"], groupID), attributes)
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, groupURN, relationBelongsTo, fivetranAssetRelationAttributes(event, attributes, "fivetran_asset_group")))
-	}
-	destinationID := strings.TrimSpace(attributes["destination_id"])
-	if destinationID != "" && normalizeCloudType(resourceType) != "destination" {
-		destinationURN := fivetranRuntimeAssetURN(tenantID, "destination", destinationID)
-		addFivetranRuntimeAssetReference(entities, tenantID, event.GetSourceId(), destinationURN, "destination", destinationID, attributes)
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, destinationURN, relationBelongsTo, fivetranAssetRelationAttributes(event, attributes, "fivetran_asset_destination")))
-	}
-	connectionID := strings.TrimSpace(attributes["connection_id"])
-	if connectionID != "" && normalizeCloudType(resourceType) != "connection" {
-		connectionURN := fivetranRuntimeAssetURN(tenantID, "connection", connectionID)
-		addFivetranRuntimeAssetReference(entities, tenantID, event.GetSourceId(), connectionURN, "connection", connectionID, attributes)
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, connectionURN, relationBelongsTo, fivetranAssetRelationAttributes(event, attributes, "fivetran_asset_connection")))
-	}
-	proxyAgentID := strings.TrimSpace(attributes["proxy_agent_id"])
-	if proxyAgentID != "" && normalizeCloudType(resourceType) != "proxy_agent" {
-		proxyURN := fivetranRuntimeAssetURN(tenantID, "proxy_agent", proxyAgentID)
-		addFivetranRuntimeAssetReference(entities, tenantID, event.GetSourceId(), proxyURN, "proxy_agent", proxyAgentID, attributes)
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, proxyURN, relationBelongsTo, fivetranAssetRelationAttributes(event, attributes, "fivetran_asset_proxy_agent")))
-		if connectionID == "" {
-			connectionID = firstNonEmpty(attributes["resource_id"], attributes["id"])
-		}
-		if connectionID != "" && normalizeCloudType(resourceType) == "proxy_agent_connection" {
-			connectionURN := fivetranRuntimeAssetURN(tenantID, "connection", connectionID)
-			addFivetranRuntimeAssetReference(entities, tenantID, event.GetSourceId(), connectionURN, "connection", connectionID, attributes)
-			addLink(links, projectedLink(tenantID, event.GetSourceId(), connectionURN, proxyURN, relationAttachedTo, fivetranAssetRelationAttributes(event, attributes, "fivetran_proxy_connection")))
-		}
-	}
-	projectID := firstNonEmpty(attributes["project_id"], attributes["transformation_project_id"])
-	if projectID != "" && normalizeCloudType(resourceType) != "transformation_project" {
-		projectURN := fivetranRuntimeAssetURN(tenantID, "transformation_project", projectID)
-		addFivetranRuntimeAssetReference(entities, tenantID, event.GetSourceId(), projectURN, "transformation_project", projectID, attributes)
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, projectURN, relationBelongsTo, fivetranAssetRelationAttributes(event, attributes, "fivetran_transformation_project")))
-	}
-	externalSecretManagerID := strings.TrimSpace(attributes["external_secret_manager_id"])
-	if externalSecretManagerID != "" && normalizeCloudType(resourceType) != "external_secret_manager" {
-		managerURN := fivetranRuntimeAssetURN(tenantID, "external_secret_manager", externalSecretManagerID)
-		addFivetranRuntimeAssetReference(entities, tenantID, event.GetSourceId(), managerURN, "external_secret_manager", externalSecretManagerID, attributes)
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, managerURN, relationDependsOn, fivetranAssetRelationAttributes(event, attributes, "fivetran_external_secret_manager_usage")))
-		usingType := normalizeCloudType(firstNonEmpty(attributes["entity_type"], attributes["entity_resource_type"]))
-		usingID := firstNonEmpty(attributes["connection_id"], attributes["destination_id"], attributes["entity_id"], attributes["resource_id"])
-		if (usingType == "connection" || usingType == "destination") && usingID != "" {
-			usingURN := fivetranRuntimeAssetURN(tenantID, usingType, usingID)
-			addFivetranRuntimeAssetReference(entities, tenantID, event.GetSourceId(), usingURN, usingType, usingID, attributes)
-			addLink(links, projectedLink(tenantID, event.GetSourceId(), usingURN, managerURN, relationDependsOn, fivetranAssetRelationAttributes(event, attributes, "fivetran_external_secret_manager_resource")))
-		}
-	}
-}
-
-func addFivetranRuntimeAssetReference(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, urn string, resourceType string, id string, eventAttributes map[string]string) {
-	if urn == "" {
-		return
-	}
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        urn,
-		TenantID:   tenantID,
-		SourceID:   sourceID,
-		EntityType: fivetranEntityType(resourceType),
-		Label:      firstNonEmpty(eventAttributes[resourceType+"_name"], eventAttributes["resource_name"], id),
-		Attributes: compactAttributes(map[string]string{
-			"resource_id":       id,
-			"resource_type":     resourceType,
-			"source_runtime_id": strings.TrimSpace(eventAttributes[ports.EventAttributeSourceRuntimeID]),
-			"source_system":     "fivetran",
-		}),
-	})
-}
-
-func fivetranAssetRelationAttributes(event *cerebrov1.EventEnvelope, attributes map[string]string, matchType string) map[string]string {
-	return compactAttributes(map[string]string{
-		"connection_id":              strings.TrimSpace(attributes["connection_id"]),
-		"destination_id":             strings.TrimSpace(attributes["destination_id"]),
-		"event_id":                   event.GetId(),
-		"external_secret_manager_id": strings.TrimSpace(attributes["external_secret_manager_id"]),
-		"group_id":                   strings.TrimSpace(attributes["group_id"]),
-		"match_type":                 matchType,
-		"project_id":                 firstNonEmpty(attributes["project_id"], attributes["transformation_project_id"]),
-		"proxy_agent_id":             strings.TrimSpace(attributes["proxy_agent_id"]),
-		"source_kind":                strings.TrimSpace(event.GetKind()),
-		"source_system":              "fivetran",
-	})
-}
-
-func fivetranMembershipScope(event *cerebrov1.EventEnvelope, attributes map[string]string) (string, string) {
-	kind := fivetranKindFamily(event)
-	switch {
-	case strings.HasPrefix(kind, "user_"):
-		return "user", strings.TrimSpace(attributes["user_id"])
-	case strings.HasPrefix(kind, "team_"):
-		return "team", strings.TrimSpace(attributes["team_id"])
-	case strings.HasPrefix(kind, "group_"):
-		return "group", strings.TrimSpace(attributes["group_id"])
-	default:
-		return "scope", firstNonEmpty(attributes["scope_id"], attributes["user_id"], attributes["team_id"], attributes["group_id"])
-	}
-}
-
-func fivetranMembershipMemberType(event *cerebrov1.EventEnvelope, attributes map[string]string) string {
-	if memberType := strings.TrimSpace(attributes["member_type"]); memberType != "" && memberType != "membership" {
-		return normalizeCloudType(memberType)
-	}
-	kind := fivetranKindFamily(event)
-	switch {
-	case strings.HasSuffix(kind, "_users"):
-		return "user"
-	case strings.HasSuffix(kind, "_groups"):
-		return "group"
-	case strings.HasSuffix(kind, "_connections"):
-		return "connection"
-	default:
-		return "member"
-	}
-}
-
-func addFivetranMembershipEntity(entities map[string]*ports.ProjectedEntity, tenantID string, sourceID string, urn string, entityType string, id string, label string, eventAttributes map[string]string) {
-	if urn == "" {
-		return
-	}
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        urn,
-		TenantID:   tenantID,
-		SourceID:   sourceID,
-		EntityType: fivetranEntityType(entityType),
-		Label:      firstNonEmpty(label, id),
-		Attributes: compactAttributes(map[string]string{
-			"email":             strings.TrimSpace(eventAttributes["email"]),
-			"entity_id":         id,
-			"entity_type":       entityType,
-			"resource_id":       id,
-			"source_runtime_id": strings.TrimSpace(eventAttributes[ports.EventAttributeSourceRuntimeID]),
-			"source_system":     "fivetran",
-			"status":            strings.TrimSpace(eventAttributes["status"]),
-		}),
-	})
-}
-
-func fivetranPrincipalOrAssetURN(tenantID string, entityType string, id string) string {
-	switch fivetranIdentityKind(entityType) {
-	case "user":
-		return identityUserURN(tenantID, fivetranIdentityProfile.Provider, id, "")
-	case "group":
-		return identityGroupURN(tenantID, fivetranIdentityProfile.Provider, id, "")
-	default:
-		return fivetranRuntimeAssetURN(tenantID, entityType, id)
-	}
-}
-
-func fivetranRuntimeAssetURN(tenantID string, resourceType string, id string) string {
-	if strings.TrimSpace(id) == "" {
-		return ""
-	}
-	return projectionURN(tenantID, "runtime_fivetran_"+normalizeCloudType(resourceType), id)
-}
-
-func fivetranEntityType(entityType string) string {
-	if identityKind := fivetranIdentityKind(entityType); identityKind != "" {
-		return fivetranIdentityProfile.entityType(identityKind)
-	}
-	return "runtime.fivetran." + strings.ReplaceAll(normalizeCloudType(entityType), "_", ".")
-}
-
-func fivetranIdentityKind(entityType string) string {
-	switch normalizeCloudType(entityType) {
-	case "user", "users":
-		return "user"
-	case "group", "groups", "team", "teams":
-		return "group"
-	default:
-		return ""
-	}
-}
-
-func fivetranKindFamily(event *cerebrov1.EventEnvelope) string {
-	kind := strings.TrimSpace(event.GetKind())
-	if strings.HasPrefix(kind, "fivetran.") {
-		return strings.TrimPrefix(kind, "fivetran.")
-	}
-	if _, family, ok := strings.Cut(kind, "."); ok {
-		return family
-	}
-	return kind
+func fivetranRuntimeAssetProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errFivetranRustProjectionRequired
 }

--- a/internal/sourceprojection/fivetran_test.go
+++ b/internal/sourceprojection/fivetran_test.go
@@ -1,562 +1,74 @@
 package sourceprojection
 
 import (
-	"context"
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestFivetranProviderFamiliesProjectToGraph(t *testing.T) {
-	publicKeyType := fivetranPublicKeyResourceType()
-	cases := []struct {
-		name      string
-		kind      string
-		project   ProjectFunc
-		attrs     map[string]string
-		wantLinks bool
-	}{
-		{name: "users", kind: "fivetran.users", project: fivetranUsersProjections, attrs: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}},
-		{name: "account_info", kind: "fivetran.account_info", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"account_id": "account-1", "resource_id": "account-1", "resource_type": "account", "resource_name": "Primary account"}},
-		{name: "legacy_accounts", kind: "fivetran.accounts", project: fivetranAccountsProjections, attrs: map[string]string{"resource_id": "account-1", "resource_type": "account", "resource_name": "Primary account"}},
-		{name: "legacy_records", kind: "fivetran.records", project: fivetranRecordsProjections, attrs: map[string]string{"resource_id": "record-1", "resource_type": "record", "resource_name": "Runtime record"}},
-		{name: "legacy_policies", kind: "fivetran.policies", project: fivetranPoliciesProjections, attrs: map[string]string{"policy_id": "policy-1", "policy_name": "Access policy"}},
-		{name: "legacy_audit_events", kind: "fivetran.audit_events", project: fivetranAuditEventsProjections, attrs: map[string]string{"audit_event_id": "audit-1", "actor_id": "user-1", "action": "connection.updated"}},
-		{name: "user_connections", kind: "fivetran.user_connections", project: fivetranScopedMembershipProjections, attrs: map[string]string{"user_id": "user-1", "member_id": "connection-1", "member_type": "connection", "resource_name": "Customer warehouse", "role": "owner"}, wantLinks: true},
-		{name: "user_groups", kind: "fivetran.user_groups", project: fivetranScopedMembershipProjections, attrs: map[string]string{"user_id": "user-1", "member_id": "group-1", "member_type": "group", "resource_name": "Finance"}, wantLinks: true},
-		{name: "roles", kind: "fivetran.roles", project: fivetranRolesProjections, attrs: map[string]string{"role_id": "role-1", "role_name": "Account Reviewer", "resource_id": "role-1", "resource_type": "role"}},
-		{name: "teams", kind: "fivetran.teams", project: fivetranTeamsProjections, attrs: map[string]string{"team_id": "team-1", "group_id": "team-1", "group_name": "Data Platform"}},
-		{name: "team_users", kind: "fivetran.team_users", project: fivetranScopedMembershipProjections, attrs: map[string]string{"team_id": "team-1", "member_id": "user-1", "member_type": "user", "email": "user@example.test"}, wantLinks: true},
-		{name: "team_connections", kind: "fivetran.team_connections", project: fivetranScopedMembershipProjections, attrs: map[string]string{"team_id": "team-1", "member_id": "connection-1", "member_type": "connection"}, wantLinks: true},
-		{name: "team_groups", kind: "fivetran.team_groups", project: fivetranScopedMembershipProjections, attrs: map[string]string{"team_id": "team-1", "member_id": "group-1", "member_type": "group"}, wantLinks: true},
-		{name: "groups", kind: "fivetran.groups", project: fivetranGroupsProjections, attrs: map[string]string{"group_id": "group-1", "group_name": "Finance"}},
-		{name: "group_users", kind: "fivetran.group_users", project: fivetranScopedMembershipProjections, attrs: map[string]string{"group_id": "group-1", "member_id": "user-1", "member_type": "user", "email": "user@example.test"}, wantLinks: true},
-		{name: "group_connections", kind: "fivetran.group_connections", project: fivetranScopedMembershipProjections, attrs: map[string]string{"group_id": "group-1", "member_id": "connection-1", "member_type": "connection"}, wantLinks: true},
-		{name: "group_public_keys", kind: "fivetran.group_public_keys", project: fivetranCredentialProjections, attrs: map[string]string{"credential_id": "public-ref-1", "group_id": "group-1", "resource_id": "public-ref-1", "resource_type": publicKeyType}, wantLinks: true}, // #nosec G101 -- public-key fixture attributes are identifiers, not key material.
-		{name: "group_service_accounts", kind: "fivetran.group_service_accounts", project: fivetranCredentialProjections, attrs: map[string]string{"credential_id": "group-1", "group_id": "group-1", "resource_id": "group-1", "resource_type": "service_account"}, wantLinks: true},
-		{name: "destinations", kind: "fivetran.destinations", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "dest-1", "resource_type": "destination", "resource_name": "Warehouse"}},
-		{name: "connections", kind: "fivetran.connections", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "connection-1", "resource_type": "connection", "resource_name": "Salesforce"}},
-		{name: "connection_certificates", kind: "fivetran.connection_certificates", project: fivetranCredentialProjections, attrs: map[string]string{"connection_id": "connection-1", "credential_id": "proof-1", "resource_id": "proof-1", "resource_type": "certificate"}, wantLinks: true},
-		{name: "connection_fingerprints", kind: "fivetran.connection_fingerprints", project: fivetranCredentialProjections, attrs: map[string]string{"connection_id": "connection-1", "credential_id": "fingerprint-1", "resource_id": "fingerprint-1", "resource_type": "fingerprint"}, wantLinks: true},
-		{name: "connection_schemas", kind: "fivetran.connection_schemas", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"connection_id": "connection-1", "resource_id": "connection-1", "resource_type": "connection_schema"}},
-		{name: "connection_state", kind: "fivetran.connection_state", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"connection_id": "connection-1", "resource_id": "connection-1", "resource_type": "connection_state", "status": "connected"}},
-		{name: "connection_table_columns", kind: "fivetran.connection_table_columns", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"column_name": "EMAIL", "connection_id": "connection-1", "resource_id": "EMAIL", "resource_type": "connection_table_column", "schema_name": "public", "table_name": "users"}, wantLinks: true},
-		{name: "connector_sdk_packages", kind: "fivetran.connector_sdk_packages", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "package-1", "resource_type": "connector_sdk_package", "resource_name": "Custom package"}},
-		{name: "destination_certificates", kind: "fivetran.destination_certificates", project: fivetranCredentialProjections, attrs: map[string]string{"destination_id": "destination-1", "credential_id": "destination-proof-1", "resource_id": "destination-proof-1", "resource_type": "certificate"}, wantLinks: true},
-		{name: "destination_fingerprints", kind: "fivetran.destination_fingerprints", project: fivetranCredentialProjections, attrs: map[string]string{"destination_id": "destination-1", "credential_id": "dest-fingerprint-1", "resource_id": "dest-fingerprint-1", "resource_type": "fingerprint"}, wantLinks: true},
-		{name: "account_log_service", kind: "fivetran.account_log_service", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "log-1", "resource_type": "log_service", "resource_name": "Datadog", "status": "true"}},
-		{name: "log_services", kind: "fivetran.log_services", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "log-1", "resource_type": "log_service", "resource_name": "Datadog"}},
-		{name: "webhooks", kind: "fivetran.webhooks", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "webhook-1", "resource_type": "webhook", "resource_name": "Sync alerts"}},
-		{name: "external_secret_managers", kind: "fivetran.external_secret_managers", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "esm-1", "resource_type": "external_secret_manager", "resource_name": "Vault production"}},
-		{name: "external_secret_manager_entities", kind: "fivetran.external_secret_manager_entities", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "esm-entity-1", "resource_type": "external_secret_manager_entity", "resource_name": "Salesforce connection"}},
-		{name: "external_secret_manager_assignments", kind: "fivetran.external_secret_manager_assignments", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"external_secret_manager_id": "esm-1", "resource_id": "connection-1", "resource_type": "external_secret_manager_assignment", "resource_name": "Salesforce connection"}},
-		{name: "private_links", kind: "fivetran.private_links", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "plink-1", "resource_type": "private_link", "resource_name": "AWS PrivateLink"}},
-		{name: "proxy_agents", kind: "fivetran.proxy_agents", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "proxy-1", "resource_type": "proxy_agent", "resource_name": "Proxy Agent"}},
-		{name: "proxy_agent_connections", kind: "fivetran.proxy_agent_connections", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"proxy_agent_id": "proxy-1", "resource_id": "connection-1", "resource_type": "proxy_agent_connection", "resource_name": "Salesforce connection"}},
-		{name: "hybrid_deployment_agents", kind: "fivetran.hybrid_deployment_agents", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "hybrid-1", "resource_type": "hybrid_deployment_agent", "resource_name": "Hybrid Agent"}},
-		{name: "public_connector_types", kind: "fivetran.public_connector_types", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "postgres", "resource_type": "public_connector_type", "service": "postgres"}},
-		{name: "connector_metadata", kind: "fivetran.connector_metadata", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "postgres", "resource_type": "connector_metadata", "service": "postgres"}},
-		{name: "connector_metadata_details", kind: "fivetran.connector_metadata_details", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "postgres", "resource_type": "connector_metadata_detail", "service": "postgres", "status": "general_availability"}},
-		{name: "system_keys", kind: "fivetran.system_keys", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "key-1", "resource_type": "system_key", "resource_name": "Automation key"}},
-		{name: "transformations", kind: "fivetran.transformations", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "transformation-1", "resource_type": "transformation", "resource_name": "Normalize accounts"}},
-		{name: "transformation_projects", kind: "fivetran.transformation_projects", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "project-1", "resource_type": "transformation_project", "resource_name": "dbt production"}},
-		{name: "transformation_package_metadata", kind: "fivetran.transformation_package_metadata", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"resource_id": "package-definition-1", "resource_type": "transformation_package_metadata", "resource_name": "Quickstart package"}},
-		{name: "transformation_package_details", kind: "fivetran.transformation_package_details", project: fivetranRuntimeAssetProjections, attrs: map[string]string{"package_definition_id": "package-definition-1", "resource_id": "package-definition-1", "resource_type": "transformation_package_detail", "resource_name": "Quickstart package"}},
-	}
-
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "fivetran", Kind: tt.kind, Attributes: tt.attrs}
-			entities, links, err := tt.project(event)
-			if err != nil {
-				t.Fatalf("projection error = %v", err)
-			}
-			if len(entities) == 0 {
-				t.Fatalf("%s projected no entities", tt.kind)
-			}
-			if tt.wantLinks && len(links) == 0 {
-				t.Fatalf("%s projected no links", tt.kind)
-			}
-		})
-	}
-}
-
-func TestFivetranRegistryContainsProviderFamilies(t *testing.T) {
-	registry := BuiltinRegistry()
+func TestFivetranGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
 	for _, kind := range []string{
-		"fivetran.users",
-		"fivetran.account_info",
 		"fivetran.accounts",
+		"fivetran.account_info",
+		"fivetran.account_log_service",
 		"fivetran.audit_events",
-		"fivetran.policies",
-		"fivetran.records",
-		"fivetran.user_connections",
-		"fivetran.user_groups",
-		"fivetran.roles",
-		"fivetran.teams",
-		"fivetran.team_users",
-		"fivetran.team_connections",
-		"fivetran.team_groups",
-		"fivetran.groups",
-		"fivetran.group_users",
-		"fivetran.group_connections",
-		"fivetran.group_public_keys",
-		"fivetran.group_service_accounts",
-		"fivetran.destinations",
-		"fivetran.connections",
 		"fivetran.connection_certificates",
 		"fivetran.connection_fingerprints",
 		"fivetran.connection_schemas",
 		"fivetran.connection_state",
 		"fivetran.connection_table_columns",
-		"fivetran.connector_sdk_packages",
-		"fivetran.destination_certificates",
-		"fivetran.destination_fingerprints",
-		"fivetran.account_log_service",
-		"fivetran.log_services",
-		"fivetran.webhooks",
-		"fivetran.external_secret_managers",
-		"fivetran.external_secret_manager_entities",
-		"fivetran.external_secret_manager_assignments",
-		"fivetran.private_links",
-		"fivetran.proxy_agents",
-		"fivetran.proxy_agent_connections",
-		"fivetran.hybrid_deployment_agents",
-		"fivetran.public_connector_types",
+		"fivetran.connections",
 		"fivetran.connector_metadata",
 		"fivetran.connector_metadata_details",
+		"fivetran.connector_sdk_packages",
+		"fivetran.destinations",
+		"fivetran.destination_certificates",
+		"fivetran.destination_fingerprints",
+		"fivetran.external_secret_manager_assignments",
+		"fivetran.external_secret_manager_entities",
+		"fivetran.external_secret_managers",
+		"fivetran.group_connections",
+		"fivetran.group_public_keys",
+		"fivetran.group_service_accounts",
+		"fivetran.group_users",
+		"fivetran.groups",
+		"fivetran.hybrid_deployment_agents",
+		"fivetran.log_services",
+		"fivetran.private_links",
+		"fivetran.policies",
+		"fivetran.proxy_agent_connections",
+		"fivetran.proxy_agents",
+		"fivetran.public_connector_types",
+		"fivetran.records",
+		"fivetran.roles",
 		"fivetran.system_keys",
-		"fivetran.transformations",
-		"fivetran.transformation_projects",
-		"fivetran.transformation_package_metadata",
+		"fivetran.team_connections",
+		"fivetran.team_groups",
+		"fivetran.team_users",
+		"fivetran.teams",
 		"fivetran.transformation_package_details",
+		"fivetran.transformation_package_metadata",
+		"fivetran.transformation_projects",
+		"fivetran.transformations",
+		"fivetran.user_connections",
+		"fivetran.user_groups",
+		"fivetran.users",
+		"fivetran.webhooks",
 	} {
-		if registry.projectors[kind] == nil {
-			t.Fatalf("missing projector for %s", kind)
-		}
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "fivetran",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errFivetranRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
-}
-
-func TestFivetranLegacyAssetsKeepGenericRuntimeURNs(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-	events := []*cerebrov1.EventEnvelope{
-		{
-			Id:       "account-event",
-			TenantId: "writer",
-			SourceId: "fivetran",
-			Kind:     "fivetran.accounts",
-			Attributes: map[string]string{
-				"resource_id":   "account-1",
-				"resource_name": "Primary account",
-				"resource_type": "account",
-			},
-		},
-		{
-			Id:       "record-event",
-			TenantId: "writer",
-			SourceId: "fivetran",
-			Kind:     "fivetran.records",
-			Attributes: map[string]string{
-				"resource_id":   "record-1",
-				"resource_name": "Runtime record",
-				"resource_type": "record",
-			},
-		},
-	}
-	for _, event := range events {
-		if _, err := service.Project(context.Background(), event); err != nil {
-			t.Fatalf("Project(%s) error = %v", event.GetKind(), err)
-		}
-	}
-
-	assertProjectedEntityType(t, state, "urn:cerebro:writer:runtime_account:account-1", "runtime.account")
-	assertProjectedEntityType(t, state, "urn:cerebro:writer:runtime_record:record-1", "runtime.record")
-	assertProjectedEntityMissing(t, state, "urn:cerebro:writer:runtime_fivetran_account:account-1")
-	assertProjectedEntityMissing(t, state, "urn:cerebro:writer:runtime_fivetran_record:record-1")
-}
-
-func TestFivetranLegacyPolicyEvidenceUsesDottedRuntimeEntityType(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-	event := &cerebrov1.EventEnvelope{
-		Id:       "policy-event",
-		TenantId: "writer",
-		SourceId: "fivetran",
-		Kind:     "fivetran.policies",
-		Attributes: map[string]string{
-			"evidence_id": "evidence-1",
-			"policy_id":   "policy-1",
-			"policy_name": "Access policy",
-		},
-	}
-	if _, err := service.Project(context.Background(), event); err != nil {
-		t.Fatalf("Project() error = %v", err)
-	}
-
-	policyURN := "urn:cerebro:writer:policy:policy-1"
-	evidenceURN := "urn:cerebro:writer:runtime_evidence:evidence-1"
-	assertProjectedEntityType(t, state, policyURN, "policy")
-	assertProjectedEntityType(t, state, evidenceURN, "runtime.evidence")
-	assertProjectedLink(t, state, policyURN, relationHasEvidence, evidenceURN)
-}
-
-func TestFivetranMembershipEdgesUseStandaloneEntityURNs(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-	events := []*cerebrov1.EventEnvelope{
-		{
-			Id:       "team-event",
-			TenantId: "writer",
-			SourceId: "fivetran",
-			Kind:     "fivetran.teams",
-			Attributes: map[string]string{
-				"group_id":   "team-1",
-				"group_name": "Data Platform",
-				"team_id":    "team-1",
-			},
-		},
-		{
-			Id:       "connection-event",
-			TenantId: "writer",
-			SourceId: "fivetran",
-			Kind:     "fivetran.connections",
-			Attributes: map[string]string{
-				"resource_id":   "connection-1",
-				"resource_name": "Salesforce production sync",
-				"resource_type": "connection",
-			},
-		},
-		{
-			Id:       "membership-event",
-			TenantId: "writer",
-			SourceId: "fivetran",
-			Kind:     "fivetran.team_connections",
-			Attributes: map[string]string{
-				"member_id":     "connection-1",
-				"member_type":   "connection",
-				"resource_name": "Salesforce production sync",
-				"role":          "owner",
-				"team_id":       "team-1",
-			},
-		},
-	}
-	for _, event := range events {
-		if _, err := service.Project(context.Background(), event); err != nil {
-			t.Fatalf("Project(%s) error = %v", event.GetId(), err)
-		}
-	}
-
-	teamURN := "urn:cerebro:writer:fivetran_group:team-1"
-	connectionURN := "urn:cerebro:writer:runtime_fivetran_connection:connection-1"
-	assertProjectedEntityType(t, state, teamURN, "fivetran.group")
-	assertProjectedEntityType(t, state, connectionURN, "runtime.fivetran.connection")
-	assertProjectedLink(t, state, connectionURN, relationMemberOf, teamURN)
-	assertProjectedEntityMissing(t, state, "urn:cerebro:writer:fivetran_user:team-1")
-	assertProjectedEntityMissing(t, state, "urn:cerebro:writer:fivetran_user:connection-1")
-}
-
-func TestFivetranUserAndTeamGroupsLinkPrincipalToGroup(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-	events := []*cerebrov1.EventEnvelope{
-		{
-			Id:       "user-group-event",
-			TenantId: "writer",
-			SourceId: "fivetran",
-			Kind:     "fivetran.user_groups",
-			Attributes: map[string]string{
-				"member_id":   "group-1",
-				"member_type": "group",
-				"resource_id": "group-1",
-				"role":        "member",
-				"user_id":     "user-1",
-			},
-		},
-		{
-			Id:       "team-group-event",
-			TenantId: "writer",
-			SourceId: "fivetran",
-			Kind:     "fivetran.team_groups",
-			Attributes: map[string]string{
-				"member_id":   "group-2",
-				"member_type": "group",
-				"resource_id": "group-2",
-				"role":        "member",
-				"team_id":     "team-1",
-			},
-		},
-	}
-	for _, event := range events {
-		if _, err := service.Project(context.Background(), event); err != nil {
-			t.Fatalf("Project(%s) error = %v", event.GetId(), err)
-		}
-	}
-
-	userURN := "urn:cerebro:writer:fivetran_user:user-1"
-	teamURN := "urn:cerebro:writer:fivetran_group:team-1"
-	group1URN := "urn:cerebro:writer:fivetran_group:group-1"
-	group2URN := "urn:cerebro:writer:fivetran_group:group-2"
-	assertProjectedLink(t, state, userURN, relationMemberOf, group1URN)
-	assertProjectedLink(t, state, teamURN, relationMemberOf, group2URN)
-	assertProjectedLinkMissing(t, state, group1URN, relationMemberOf, userURN)
-	assertProjectedLinkMissing(t, state, group2URN, relationMemberOf, teamURN)
-}
-
-func TestFivetranRoleTargetsUseRuntimeAssetURNs(t *testing.T) {
-	if got, want := fivetranPrincipalOrAssetURN("writer", "role", "role-1"), "urn:cerebro:writer:runtime_fivetran_role:role-1"; got != want {
-		t.Fatalf("role URN = %q, want %q", got, want)
-	}
-	if got, want := fivetranEntityType("role"), "runtime.fivetran.role"; got != want {
-		t.Fatalf("role entity type = %q, want %q", got, want)
-	}
-}
-
-func TestFivetranDestinationCredentialsLinkToDestination(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-	event := &cerebrov1.EventEnvelope{
-		Id:       "destination-certificate-event",
-		TenantId: "writer",
-		SourceId: "fivetran",
-		Kind:     "fivetran.destination_certificates",
-		Attributes: map[string]string{
-			"credential_id":  "destination-proof-1",
-			"destination_id": "destination-1",
-			"resource_id":    "destination-proof-1",
-			"resource_type":  "certificate",
-		},
-	}
-	if _, err := service.Project(context.Background(), event); err != nil {
-		t.Fatalf("Project() error = %v", err)
-	}
-
-	certificateURN := "urn:cerebro:writer:runtime_fivetran_certificate:destination-proof-1"
-	destinationURN := "urn:cerebro:writer:runtime_fivetran_destination:destination-1"
-	assertProjectedEntityType(t, state, certificateURN, "runtime.fivetran.certificate")
-	assertProjectedEntityType(t, state, destinationURN, "runtime.fivetran.destination")
-	assertProjectedLink(t, state, certificateURN, relationAssignedTo, destinationURN)
-}
-
-func TestFivetranGroupCredentialsLinkToGroup(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-	event := &cerebrov1.EventEnvelope{
-		Id:       "group-public-key-event",
-		TenantId: "writer",
-		SourceId: "fivetran",
-		Kind:     "fivetran.group_public_keys",
-		Attributes: map[string]string{ // #nosec G101 -- public-key fixture attributes are identifiers, not key material.
-			"credential_id": "public-ref-1",
-			"group_id":      "group-1",
-			"resource_id":   "public-ref-1",
-			"resource_type": fivetranPublicKeyResourceType(),
-		},
-	}
-	if _, err := service.Project(context.Background(), event); err != nil {
-		t.Fatalf("Project() error = %v", err)
-	}
-
-	publicKeyURN := "urn:cerebro:writer:runtime_fivetran_public_key:public-ref-1"
-	groupURN := "urn:cerebro:writer:fivetran_group:group-1"
-	assertProjectedEntityType(t, state, publicKeyURN, "runtime.fivetran.public.key")
-	assertProjectedEntityType(t, state, groupURN, "fivetran.group")
-	assertProjectedLink(t, state, publicKeyURN, relationAssignedTo, groupURN)
-}
-
-func fivetranPublicKeyResourceType() string {
-	return "public_" + "key"
-}
-
-func TestFivetranTableColumnUsesCompositeRuntimeURN(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-	event := &cerebrov1.EventEnvelope{
-		Id:       "column-event",
-		TenantId: "writer",
-		SourceId: "fivetran",
-		Kind:     "fivetran.connection_table_columns",
-		Attributes: map[string]string{
-			"column_name":   "EMAIL",
-			"connection_id": "connection-1",
-			"resource_id":   "EMAIL",
-			"resource_type": "connection_table_column",
-			"resource_urn":  "urn:cerebro:writer:fivetran_connection_table_columns:EMAIL",
-			"schema_name":   "public",
-			"table_name":    "users",
-		},
-	}
-	if _, err := service.Project(context.Background(), event); err != nil {
-		t.Fatalf("Project() error = %v", err)
-	}
-
-	columnURN := "urn:cerebro:writer:runtime_fivetran_connection_table_column:connection-1/public/users/EMAIL"
-	connectionURN := "urn:cerebro:writer:runtime_fivetran_connection:connection-1"
-	assertProjectedEntityType(t, state, columnURN, "runtime.fivetran.connection.table.column")
-	assertProjectedEntityMissing(t, state, "urn:cerebro:writer:fivetran_connection_table_columns:EMAIL")
-	assertProjectedLink(t, state, columnURN, relationBelongsTo, connectionURN)
-}
-
-func TestFivetranRuntimeAssetIgnoresSourceFamilyURN(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-	event := &cerebrov1.EventEnvelope{
-		Id:       "connection-event",
-		TenantId: "writer",
-		SourceId: "fivetran",
-		Kind:     "fivetran.connections",
-		Attributes: map[string]string{
-			"destination_id": "destination-1",
-			"group_id":       "group-1",
-			"resource_id":    "connection-1",
-			"resource_name":  "Salesforce production sync",
-			"resource_type":  "connection",
-			"resource_urn":   "urn:cerebro:writer:fivetran_connections:connection-1",
-		},
-	}
-	if _, err := service.Project(context.Background(), event); err != nil {
-		t.Fatalf("Project() error = %v", err)
-	}
-
-	connectionURN := "urn:cerebro:writer:runtime_fivetran_connection:connection-1"
-	destinationURN := "urn:cerebro:writer:runtime_fivetran_destination:destination-1"
-	groupURN := "urn:cerebro:writer:fivetran_group:group-1"
-	assertProjectedEntityType(t, state, connectionURN, "runtime.fivetran.connection")
-	assertProjectedEntityMissing(t, state, "urn:cerebro:writer:fivetran_connections:connection-1")
-	assertProjectedLink(t, state, connectionURN, relationBelongsTo, destinationURN)
-	assertProjectedLink(t, state, connectionURN, relationBelongsTo, groupURN)
-}
-
-func TestFivetranCredentialUsesCanonicalRuntimeURNForAssignment(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-	event := &cerebrov1.EventEnvelope{
-		Id:       "certificate-event",
-		TenantId: "writer",
-		SourceId: "fivetran",
-		Kind:     "fivetran.connection_certificates",
-		Attributes: map[string]string{
-			"connection_id": "connection-1",
-			"credential_id": "proof-1",
-			"resource_id":   "proof-1",
-			"resource_type": "certificate",
-			"resource_urn":  "urn:cerebro:writer:fivetran_connection_certificates:proof-1",
-		},
-	}
-	if _, err := service.Project(context.Background(), event); err != nil {
-		t.Fatalf("Project() error = %v", err)
-	}
-
-	certificateURN := "urn:cerebro:writer:runtime_fivetran_certificate:proof-1"
-	connectionURN := "urn:cerebro:writer:runtime_fivetran_connection:connection-1"
-	assertProjectedEntityType(t, state, certificateURN, "runtime.fivetran.certificate")
-	assertProjectedEntityMissing(t, state, "urn:cerebro:writer:fivetran_connection_certificates:proof-1")
-	assertProjectedLink(t, state, certificateURN, relationAssignedTo, connectionURN)
-}
-
-func TestFivetranConnectionGroupDoesNotCreateDestination(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-	event := &cerebrov1.EventEnvelope{
-		Id:       "connection-event",
-		TenantId: "writer",
-		SourceId: "fivetran",
-		Kind:     "fivetran.connections",
-		Attributes: map[string]string{
-			"group_id":      "group-1",
-			"resource_id":   "connection-1",
-			"resource_name": "Salesforce production sync",
-			"resource_type": "connection",
-		},
-	}
-	if _, err := service.Project(context.Background(), event); err != nil {
-		t.Fatalf("Project() error = %v", err)
-	}
-
-	connectionURN := "urn:cerebro:writer:runtime_fivetran_connection:connection-1"
-	groupURN := "urn:cerebro:writer:fivetran_group:group-1"
-	assertProjectedEntityType(t, state, connectionURN, "runtime.fivetran.connection")
-	assertProjectedEntityType(t, state, groupURN, "fivetran.group")
-	assertProjectedLink(t, state, connectionURN, relationBelongsTo, groupURN)
-	assertProjectedEntityMissing(t, state, "urn:cerebro:writer:runtime_fivetran_destination:group-1")
-	assertProjectedLinkMissing(t, state, connectionURN, relationBelongsTo, "urn:cerebro:writer:runtime_fivetran_destination:group-1")
-}
-
-func TestFivetranAssetRelationshipsProjectToGraph(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-	events := []*cerebrov1.EventEnvelope{
-		{
-			Id:       "connection-event",
-			TenantId: "writer",
-			SourceId: "fivetran",
-			Kind:     "fivetran.connections",
-			Attributes: map[string]string{
-				"destination_id": "destination-1",
-				"group_id":       "group-1",
-				"resource_id":    "connection-1",
-				"resource_name":  "Salesforce production sync",
-				"resource_type":  "connection",
-			},
-		},
-		{
-			Id:       "proxy-attachment-event",
-			TenantId: "writer",
-			SourceId: "fivetran",
-			Kind:     "fivetran.proxy_agent_connections",
-			Attributes: map[string]string{
-				"proxy_agent_id": "proxy-1",
-				"resource_id":    "connection-1",
-				"resource_name":  "Salesforce production sync",
-				"resource_type":  "proxy_agent_connection",
-			},
-		},
-		{
-			Id:       "transformation-event",
-			TenantId: "writer",
-			SourceId: "fivetran",
-			Kind:     "fivetran.transformations",
-			Attributes: map[string]string{
-				"connection_id": "connection-1",
-				"group_id":      "group-1",
-				"project_id":    "project-1",
-				"resource_id":   "transformation-1",
-				"resource_name": "Normalize accounts",
-				"resource_type": "transformation",
-			},
-		},
-		{
-			Id:       "esm-assignment-event",
-			TenantId: "writer",
-			SourceId: "fivetran",
-			Kind:     "fivetran.external_secret_manager_assignments",
-			Attributes: map[string]string{
-				"entity_type":                "connection",
-				"external_secret_manager_id": "esm-1",
-				"resource_id":                "connection-1",
-				"resource_name":              "Salesforce production sync",
-				"resource_type":              "external_secret_manager_assignment",
-			},
-		},
-	}
-	for _, event := range events {
-		if _, err := service.Project(context.Background(), event); err != nil {
-			t.Fatalf("Project(%s) error = %v", event.GetId(), err)
-		}
-	}
-
-	connectionURN := "urn:cerebro:writer:runtime_fivetran_connection:connection-1"
-	destinationURN := "urn:cerebro:writer:runtime_fivetran_destination:destination-1"
-	groupURN := "urn:cerebro:writer:fivetran_group:group-1"
-	proxyURN := "urn:cerebro:writer:runtime_fivetran_proxy_agent:proxy-1"
-	transformationURN := "urn:cerebro:writer:runtime_fivetran_transformation:transformation-1"
-	projectURN := "urn:cerebro:writer:runtime_fivetran_transformation_project:project-1"
-	esmURN := "urn:cerebro:writer:runtime_fivetran_external_secret_manager:esm-1"
-	assertProjectedLink(t, state, connectionURN, relationBelongsTo, groupURN)
-	assertProjectedLink(t, state, connectionURN, relationBelongsTo, destinationURN)
-	assertProjectedLink(t, state, connectionURN, relationAttachedTo, proxyURN)
-	assertProjectedLink(t, state, transformationURN, relationBelongsTo, projectURN)
-	assertProjectedLink(t, state, transformationURN, relationBelongsTo, connectionURN)
-	assertProjectedLink(t, state, transformationURN, relationBelongsTo, groupURN)
-	assertProjectedLink(t, state, connectionURN, relationDependsOn, esmURN)
 }


### PR DESCRIPTION
## Summary

- remove the production Fivetran Go projection implementation for all closed families
- fail closed if the compatibility projector is invoked for a Rust-authoritative Fivetran event
- preserve provider fixtures

## Authority proof

- the compiled Rust source catalog marks all 42 Fivetran families collection-authoritative and projection-authoritative (pinned in #2699)
- the provider-specific Go source loader is already retired (TestBuiltinRetiresCoveredProviderGoLoaders)
- compatibility projection attempts now return a typed Rust-authority error before emitting graph writes

## Validation

- `gofmt -l internal/sourceprojection`
- `go build ./internal/sourceprojection`
- `go test ./internal/sourceprojection -run Fivetran -count=1 -v`
- `go test ./internal/sourceprojection -count=1`
- `go test ./internal/sourceregistry -run TestBuiltinRetiresCoveredProviderGoLoaders -count=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
