### PR TITLE
refactor(sources): retire OpenAI Go projection writer

### DIFF
--- a/internal/sourceprojection/ai_access.go
+++ b/internal/sourceprojection/ai_access.go
@@ -18,15 +18,10 @@ type aiInviteProjectMembership struct {
 }
 
 var (
-	openAIAccessProfile    = aiAccessProfile{Provider: "openai"}
 	anthropicAccessProfile = aiAccessProfile{Provider: "anthropic"}
 	langChainAccessProfile = aiAccessProfile{Provider: "langchain"}
 	langfuseAccessProfile  = aiAccessProfile{Provider: "langfuse"}
 )
-
-func openAIUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiUserProjections(event, openAIAccessProfile)
-}
 
 func anthropicUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiUserProjections(event, anthropicAccessProfile)
@@ -34,10 +29,6 @@ func anthropicUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.Projecte
 
 func langChainOrganizationMemberProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiUserProjections(event, langChainAccessProfile)
-}
-
-func openAIProjectProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiProjectProjections(event, openAIAccessProfile)
 }
 
 func anthropicProjectProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
@@ -68,10 +59,6 @@ func langChainOrganizationProjections(event *cerebrov1.EventEnvelope) ([]*ports.
 	return aiOrganizationProjections(event, langChainAccessProfile)
 }
 
-func openAIInviteProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiInviteProjections(event, openAIAccessProfile)
-}
-
 func anthropicInviteProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiInviteProjections(event, anthropicAccessProfile)
 }
@@ -82,18 +69,6 @@ func anthropicWorkspaceProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pro
 
 func langChainWorkspaceProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiWorkspaceProjections(event, langChainAccessProfile)
-}
-
-func openAIGroupProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiGroupProjections(event, openAIAccessProfile)
-}
-
-func openAIGroupUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiGroupMembershipProjections(event, openAIAccessProfile)
-}
-
-func openAIProjectUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiScopedUserAccessProjections(event, openAIAccessProfile, "project")
 }
 
 func anthropicWorkspaceMemberProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
@@ -112,20 +87,12 @@ func anthropicComplianceGroupMemberProjections(event *cerebrov1.EventEnvelope) (
 	return aiGroupMembershipProjections(event, anthropicAccessProfile)
 }
 
-func openAIServiceAccountProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiServiceAccountProjections(event, openAIAccessProfile, "project")
-}
-
 func anthropicServiceAccountProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiServiceAccountProjections(event, anthropicAccessProfile, "organization")
 }
 
 func langChainServiceAccountProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiServiceAccountProjections(event, langChainAccessProfile, "organization")
-}
-
-func openAICredentialProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiCredentialProjections(event, openAIAccessProfile)
 }
 
 func anthropicCredentialProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
@@ -140,10 +107,6 @@ func langfuseCredentialProjections(event *cerebrov1.EventEnvelope) ([]*ports.Pro
 	return aiCredentialProjections(event, langfuseAccessProfile)
 }
 
-func openAIRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiRoleProjections(event, openAIAccessProfile)
-}
-
 func anthropicComplianceRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiScopedRoleProjections(event, anthropicAccessProfile)
 }
@@ -156,44 +119,12 @@ func anthropicComplianceRolePermissionProjections(event *cerebrov1.EventEnvelope
 	return aiRolePermissionProjections(event, anthropicAccessProfile)
 }
 
-func openAIUserRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiSubjectRoleProjections(event, openAIAccessProfile, "user", "organization")
-}
-
-func openAIGroupRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiSubjectRoleProjections(event, openAIAccessProfile, "group", "organization")
-}
-
-func openAIProjectUserRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiSubjectRoleProjections(event, openAIAccessProfile, "user", "project")
-}
-
-func openAIProjectGroupProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiScopedGroupAccessProjections(event, openAIAccessProfile, "project")
-}
-
-func openAIProjectGroupRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiSubjectRoleProjections(event, openAIAccessProfile, "group", "project")
-}
-
-func openAIProjectEntitlementProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiProjectEntitlementProjections(event, openAIAccessProfile)
-}
-
-func openAIGovernanceControlProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiGovernanceControlProjections(event, openAIAccessProfile)
-}
-
 func anthropicGovernanceControlProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiGovernanceControlProjections(event, anthropicAccessProfile)
 }
 
 func langChainGovernanceControlProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiGovernanceControlProjections(event, langChainAccessProfile)
-}
-
-func openAIUsageMetricProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiUsageMetricProjections(event, openAIAccessProfile)
 }
 
 func anthropicUsageMetricProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
@@ -214,10 +145,6 @@ func anthropicFederationIssuerProjections(event *cerebrov1.EventEnvelope) ([]*po
 
 func anthropicFederationRuleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	return aiFederationRuleProjections(event, anthropicAccessProfile)
-}
-
-func openAIAuditProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return aiAuditProjections(event, openAIAccessProfile)
 }
 
 func anthropicComplianceActivityProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
@@ -404,22 +331,6 @@ func aiWorkspaceProjections(event *cerebrov1.EventEnvelope, profile aiAccessProf
 	return identityProjectionResult(entities, links)
 }
 
-func aiGroupProjections(event *cerebrov1.EventEnvelope, profile aiAccessProfile) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attrs := event.GetAttributes()
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	orgURN := aiEnsureOrganization(entities, tenantID, event.GetSourceId(), profile, attrs)
-	groupURN := aiEnsureGroup(entities, tenantID, event.GetSourceId(), profile, attrs)
-	if groupURN != "" && orgURN != "" {
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), groupURN, orgURN, relationBelongsTo, aiEventLinkAttributes(event, "group_organization")))
-	}
-	return identityProjectionResult(entities, links)
-}
-
 func aiGroupMembershipProjections(event *cerebrov1.EventEnvelope, profile aiAccessProfile) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	tenantID, err := tenantID(event)
 	if err != nil {
@@ -451,20 +362,6 @@ func aiScopedUserAccessProjections(event *cerebrov1.EventEnvelope, profile aiAcc
 	email := strings.TrimSpace(attrs["email"])
 	userURN := aiEnsureUser(entities, links, tenantID, event, profile, userID, email, attrs["name"], attrs["role"])
 	aiLinkPrincipalToScope(links, tenantID, event, userURN, scopeURN, firstNonEmpty(attrs["workspace_role"], attrs["role"]), scopeKind+"_membership")
-	return identityProjectionResult(entities, links)
-}
-
-func aiScopedGroupAccessProjections(event *cerebrov1.EventEnvelope, profile aiAccessProfile, scopeKind string) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attrs := event.GetAttributes()
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	scopeURN := aiEnsureScope(entities, tenantID, event.GetSourceId(), profile, scopeKind, attrs)
-	groupURN := aiEnsureGroup(entities, tenantID, event.GetSourceId(), profile, attrs)
-	aiLinkPrincipalToScope(links, tenantID, event, groupURN, scopeURN, attrs["role"], scopeKind+"_group_membership")
 	return identityProjectionResult(entities, links)
 }
 
@@ -548,17 +445,6 @@ func aiCredentialProjections(event *cerebrov1.EventEnvelope, profile aiAccessPro
 	return identityProjectionResult(entities, links)
 }
 
-func aiRoleProjections(event *cerebrov1.EventEnvelope, profile aiAccessProfile) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attrs := event.GetAttributes()
-	entities := map[string]*ports.ProjectedEntity{}
-	aiEnsureRole(entities, tenantID, event.GetSourceId(), profile, attrs, aiRoleScopeKind(attrs, event.GetKind()))
-	return identityProjectionResult(entities, nil)
-}
-
 func aiScopedRoleProjections(event *cerebrov1.EventEnvelope, profile aiAccessProfile) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
 	tenantID, err := tenantID(event)
 	if err != nil {
@@ -574,36 +460,6 @@ func aiScopedRoleProjections(event *cerebrov1.EventEnvelope, profile aiAccessPro
 	if roleURN != "" && scopeURN != "" {
 		addLink(links, projectedLink(tenantID, event.GetSourceId(), roleURN, scopeURN, relationBelongsTo, aiEventLinkAttributes(event, "role_scope_container")))
 	}
-	return identityProjectionResult(entities, links)
-}
-
-func aiSubjectRoleProjections(event *cerebrov1.EventEnvelope, profile aiAccessProfile, subjectKind string, scopeKind string) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attrs := event.GetAttributes()
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	scopeURN := aiEnsureScope(entities, tenantID, event.GetSourceId(), profile, scopeKind, attrs)
-	roleURN := aiEnsureRole(entities, tenantID, event.GetSourceId(), profile, attrs, scopeKind)
-	subjectURN := ""
-	switch subjectKind {
-	case "group":
-		subjectURN = aiEnsureGroup(entities, tenantID, event.GetSourceId(), profile, attrs)
-	default:
-		subjectURN = aiEnsureUser(entities, links, tenantID, event, profile, attrs["user_id"], attrs["email"], attrs["name"], attrs["role"])
-	}
-	if subjectURN != "" && roleURN != "" {
-		role := aiRoleID(attrs)
-		relation := relationAssignedTo
-		if aiRoleIsAdmin(role) {
-			relation = relationCanAdmin
-		}
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), subjectURN, roleURN, relation, aiEventLinkAttributes(event, subjectKind+"_role")))
-	}
-	aiLinkRoleToScope(links, tenantID, event, roleURN, scopeURN, aiRoleID(attrs), "role_scope")
-	aiLinkPrincipalToScope(links, tenantID, event, subjectURN, scopeURN, aiRoleID(attrs), subjectKind+"_"+scopeKind+"_role_access")
 	return identityProjectionResult(entities, links)
 }
 
@@ -722,51 +578,6 @@ func aiProjectCollaboratorProjections(event *cerebrov1.EventEnvelope, profile ai
 	}
 	aiLinkRoleToScope(links, tenantID, event, roleURN, projectURN, firstNonEmpty(roleName, roleID), "project_collaborator_role_scope")
 	aiLinkPrincipalToScope(links, tenantID, event, principalURN, projectURN, firstNonEmpty(roleName, roleID), "project_collaborator_project_access")
-	return identityProjectionResult(entities, links)
-}
-
-func aiProjectEntitlementProjections(event *cerebrov1.EventEnvelope, profile aiAccessProfile) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attrs := event.GetAttributes()
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	projectURN := aiEnsureProject(entities, tenantID, event.GetSourceId(), profile, attrs)
-	switch strings.TrimSpace(attrs["family"]) {
-	case "project_model_permission":
-		for _, modelID := range splitAttributeList(attrs["model_ids"]) {
-			modelURN := projectionURN(tenantID, profile.Provider+"_model", modelID)
-			addEntity(entities, &ports.ProjectedEntity{
-				URN:        modelURN,
-				TenantID:   tenantID,
-				SourceID:   event.GetSourceId(),
-				EntityType: profile.Provider + ".model",
-				Label:      modelID,
-				Attributes: map[string]string{"model_id": modelID},
-			})
-			addLink(links, projectedLink(tenantID, event.GetSourceId(), projectURN, modelURN, relationCanPerform, aiEventLinkAttributes(event, "project_model_permission")))
-		}
-	case "project_hosted_tool_permission":
-		for _, tool := range []string{"code_interpreter", "file_search", "image_generation", "mcp", "web_search"} {
-			if !projectionBool(attrs[tool+"_enabled"]) {
-				continue
-			}
-			toolURN := projectionURN(tenantID, profile.Provider+"_hosted_tool", tool)
-			addEntity(entities, &ports.ProjectedEntity{
-				URN:        toolURN,
-				TenantID:   tenantID,
-				SourceID:   event.GetSourceId(),
-				EntityType: profile.Provider + ".hosted_tool",
-				Label:      strings.ReplaceAll(tool, "_", " "),
-				Attributes: map[string]string{"tool": tool, "enabled": "true"},
-			})
-			addLink(links, projectedLink(tenantID, event.GetSourceId(), projectURN, toolURN, relationCanPerform, aiEventLinkAttributes(event, "project_hosted_tool_permission")))
-		}
-	default:
-		return genericInventoryProjections(event)
-	}
 	return identityProjectionResult(entities, links)
 }
 

--- a/internal/sourceprojection/ai_access_credential_test.go
+++ b/internal/sourceprojection/ai_access_credential_test.go
@@ -15,28 +15,27 @@ func TestProjectAIUsageMetricNormalizesCredentialRuntimeUsage(t *testing.T) {
 	occurred := time.Date(2026, time.June, 18, 12, 45, 0, 0, time.UTC)
 
 	event := &cerebrov1.EventEnvelope{
-		Id:         "openai-usage-runtime-credential",
+		Id:         "anthropic-usage-runtime-credential",
 		TenantId:   "writer",
-		SourceId:   "openai",
-		Kind:       "openai.usage_completion",
+		SourceId:   "anthropic",
+		Kind:       "anthropic.cost_report",
 		OccurredAt: timestamppb.New(occurred),
 		Attributes: map[string]string{
-			"api_key_id":         "usage_runtime_key",
-			"end_time":           "2026-06-18T13:00:00Z",
-			"family":             "usage_completion",
-			"id":                 "usage_runtime_1",
-			"input_tokens":       "1200",
-			"model":              "gpt-4o",
-			"num_model_requests": "5",
-			"project_id":         "proj_runtime",
-			"start_time":         "2026-06-18T12:00:00Z",
+			"api_key_id": "usage_runtime_key",
+			"cost_usd":   "1.20",
+			"end_time":   "2026-06-18T13:00:00Z",
+			"family":     "cost_report",
+			"id":         "usage_runtime_1",
+			"model":      "claude-sonnet-4-20250514",
+			"project_id": "proj_runtime",
+			"start_time": "2026-06-18T12:00:00Z",
 		},
 	}
 	if _, err := service.Project(context.Background(), event); err != nil {
 		t.Fatalf("Project(%q) error = %v", event.GetId(), err)
 	}
 
-	credentialURN := "urn:cerebro:writer:openai_credential:usage_runtime_key" // #nosec G101 -- test credential identifier, not credential material.
+	credentialURN := "urn:cerebro:writer:anthropic_credential:usage_runtime_key" // #nosec G101 -- test credential identifier, not credential material.
 	credential := state.entities[credentialURN]
 	if credential == nil {
 		t.Fatalf("credential entity %q missing", credentialURN)

--- a/internal/sourceprojection/ai_access_test.go
+++ b/internal/sourceprojection/ai_access_test.go
@@ -10,176 +10,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func TestProjectOpenAIProjectAccessEdges(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-	occurred := time.Date(2026, time.June, 18, 12, 0, 0, 0, time.UTC)
-
-	events := []*cerebrov1.EventEnvelope{
-		{
-			Id:         "openai-project",
-			TenantId:   "writer",
-			SourceId:   "openai",
-			Kind:       "openai.project",
-			OccurredAt: timestamppb.New(occurred),
-			Attributes: map[string]string{
-				"family":     "project",
-				"project_id": "proj_123",
-				"name":       "Production",
-				"status":     "active",
-			},
-		},
-		{
-			Id:         "openai-project-user-owner",
-			TenantId:   "writer",
-			SourceId:   "openai",
-			Kind:       "openai.project_user",
-			OccurredAt: timestamppb.New(occurred),
-			Attributes: map[string]string{
-				"email":      "alice@example.com",
-				"family":     "project_user",
-				"name":       "Alice Example",
-				"project_id": "proj_123",
-				"role":       "owner",
-				"user_id":    "user_123",
-			},
-		},
-		{
-			Id:         "openai-project-key",
-			TenantId:   "writer",
-			SourceId:   "openai",
-			Kind:       "openai.project_api_key",
-			OccurredAt: timestamppb.New(occurred),
-			Attributes: map[string]string{
-				"api_key_id":    "fixture_123",
-				"family":        "project_api_key",
-				"name":          "prod-key",
-				"owner_user_id": "user_123",
-				"project_id":    "proj_123",
-			},
-		},
-		{
-			Id:         "openai-project-models",
-			TenantId:   "writer",
-			SourceId:   "openai",
-			Kind:       "openai.project_model_permission",
-			OccurredAt: timestamppb.New(occurred),
-			Attributes: map[string]string{
-				"family":     "project_model_permission",
-				"model_ids":  "gpt-4.1,gpt-4o",
-				"project_id": "proj_123",
-			},
-		},
-	}
-	for _, event := range events {
-		if _, err := service.Project(context.Background(), event); err != nil {
-			t.Fatalf("Project(%q) error = %v", event.GetId(), err)
-		}
-	}
-
-	userURN := "urn:cerebro:writer:openai_user:user_123"
-	projectURN := "urn:cerebro:writer:openai_project:proj_123"
-	credentialURN := "urn:cerebro:writer:openai_credential:fixture_123" // #nosec G101 -- test credential URN fixture, not credential material.
-	identityURN := "urn:cerebro:writer:identity:email:alice@example.com"
-	modelURN := "urn:cerebro:writer:openai_model:gpt-4.1"
-
-	if entity := state.entities[projectURN]; entity == nil || entity.EntityType != "openai.project" {
-		t.Fatalf("project entity missing or wrong: %#v", entity)
-	}
-	assertProjectedLink(t, state, userURN, relationRepresentsIdentity, identityURN)
-	assertProjectedLink(t, state, userURN, relationCanAdmin, projectURN)
-	assertProjectedLink(t, state, userURN, relationAssignedTo, credentialURN)
-	assertProjectedLink(t, state, credentialURN, relationCanPerform, projectURN)
-	assertProjectedLink(t, state, projectURN, relationCanPerform, modelURN)
-}
-
-func TestProjectOpenAIAuditDeepAccessEvidence(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-	occurred := time.Date(2026, time.June, 18, 12, 5, 0, 0, time.UTC)
-
-	events := []*cerebrov1.EventEnvelope{
-		{
-			Id:         "openai-audit-api-key",
-			TenantId:   "writer",
-			SourceId:   "openai",
-			Kind:       "openai.audit_log",
-			OccurredAt: timestamppb.New(occurred),
-			Attributes: map[string]string{
-				"actor_api_key_id":         "key_actor",
-				"actor_service_account_id": "sa_123",
-				"api_key_id":               "key_target",
-				"event_type":               "api_key.updated",
-				"family":                   "audit_log",
-			},
-		},
-		{
-			Id:         "openai-audit-role-assignment",
-			TenantId:   "writer",
-			SourceId:   "openai",
-			Kind:       "openai.audit_log",
-			OccurredAt: timestamppb.New(occurred),
-			Attributes: map[string]string{
-				"actor_email":    "admin@example.com",
-				"actor_user_id":  "user_admin",
-				"event_type":     "role.assignment.created",
-				"family":         "audit_log",
-				"principal_id":   "group_123",
-				"principal_type": "group",
-				"resource_id":    "proj_456",
-				"resource_type":  "project",
-			},
-		},
-		{
-			Id:         "openai-audit-group",
-			TenantId:   "writer",
-			SourceId:   "openai",
-			Kind:       "openai.audit_log",
-			OccurredAt: timestamppb.New(occurred),
-			Attributes: map[string]string{
-				"actor_email":   "admin@example.com",
-				"actor_user_id": "user_admin",
-				"event_type":    "group.updated",
-				"family":        "audit_log",
-				"group_id":      "group_999",
-				"group_name":    "Engineering",
-			},
-		},
-	}
-	for _, event := range events {
-		if _, err := service.Project(context.Background(), event); err != nil {
-			t.Fatalf("Project(%q) error = %v", event.GetId(), err)
-		}
-	}
-
-	actorCredentialURN := "urn:cerebro:writer:openai_credential:key_actor"   // #nosec G101 -- test credential URN fixture, not credential material.
-	targetCredentialURN := "urn:cerebro:writer:openai_credential:key_target" // #nosec G101 -- test credential URN fixture, not credential material.
-	serviceAccountURN := "urn:cerebro:writer:openai_service_account:sa_123"
-	userURN := "urn:cerebro:writer:openai_user:user_admin"
-	projectURN := "urn:cerebro:writer:openai_project:proj_456"
-	groupURN := "urn:cerebro:writer:openai_group:group_123"
-	identityURN := "urn:cerebro:writer:identity:email:admin@example.com"
-
-	assertProjectedLink(t, state, serviceAccountURN, relationAssignedTo, actorCredentialURN)
-	assertProjectedLink(t, state, actorCredentialURN, relationActedOn, targetCredentialURN)
-	assertProjectedLink(t, state, userURN, relationRepresentsIdentity, identityURN)
-	assertProjectedLink(t, state, userURN, relationActedOn, projectURN)
-	assertProjectedLink(t, state, userURN, relationActedOn, groupURN)
-	if got := state.entities[actorCredentialURN].Attributes["actor_service_account_id"]; got != "sa_123" {
-		t.Fatalf("actor credential actor_service_account_id = %q, want sa_123", got)
-	}
-	if got := state.entities[targetCredentialURN].Attributes["actor_service_account_id"]; got != "" {
-		t.Fatalf("target credential actor_service_account_id = %q, want empty", got)
-	}
-	link := state.links[actorCredentialURN+"|"+relationActedOn+"|"+targetCredentialURN]
-	if got := link.Attributes["event_type"]; got != "api_key.updated" {
-		t.Fatalf("acted_on event_type = %q, want api_key.updated", got)
-	}
-	if got := link.Attributes["actor_type"]; got != "credential" {
-		t.Fatalf("acted_on actor_type = %q, want credential", got)
-	}
-}
-
 func TestProjectAnthropicComplianceActivityResourceEvidence(t *testing.T) {
 	state := &projectionRecorder{}
 	service := New(state, nil)
@@ -250,13 +80,13 @@ func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 
 	events := []*cerebrov1.EventEnvelope{
 		{
-			Id:         "openai-pending-invite",
+			Id:         "anthropic-pending-invite-with-projects",
 			TenantId:   "writer",
-			SourceId:   "openai",
-			Kind:       "openai.invite",
+			SourceId:   "anthropic",
+			Kind:       "anthropic.invite",
 			OccurredAt: timestamppb.New(occurred),
 			Payload: []byte(`{
-				"id": "invite_openai_123",
+				"id": "invite_anthropic_pending_projects",
 				"email": "future-owner@example.com",
 				"role": "owner",
 				"status": "pending",
@@ -268,7 +98,7 @@ func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 			Attributes: map[string]string{
 				"email":      "future-owner@example.com",
 				"family":     "invite",
-				"invite_id":  "invite_openai_123",
+				"invite_id":  "invite_anthropic_pending_projects",
 				"role":       "owner",
 				"status":     "pending",
 				"created_at": "2026-06-18T12:10:00Z",
@@ -276,13 +106,13 @@ func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 			},
 		},
 		{
-			Id:         "openai-expired-invite",
+			Id:         "anthropic-expired-invite-with-projects",
 			TenantId:   "writer",
-			SourceId:   "openai",
-			Kind:       "openai.invite",
+			SourceId:   "anthropic",
+			Kind:       "anthropic.invite",
 			OccurredAt: timestamppb.New(occurred),
 			Payload: []byte(`{
-				"id": "invite_openai_expired",
+				"id": "invite_anthropic_expired_projects",
 				"email": "expired-owner@example.com",
 				"role": "owner",
 				"status": "expired",
@@ -293,19 +123,19 @@ func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 			Attributes: map[string]string{
 				"email":     "expired-owner@example.com",
 				"family":    "invite",
-				"invite_id": "invite_openai_expired",
+				"invite_id": "invite_anthropic_expired_projects",
 				"role":      "owner",
 				"status":    "expired",
 			},
 		},
 		{
-			Id:         "openai-accepted-invite",
+			Id:         "anthropic-accepted-invite-with-projects",
 			TenantId:   "writer",
-			SourceId:   "openai",
-			Kind:       "openai.invite",
+			SourceId:   "anthropic",
+			Kind:       "anthropic.invite",
 			OccurredAt: timestamppb.New(occurred),
 			Payload: []byte(`{
-				"id": "invite_openai_accepted",
+				"id": "invite_anthropic_accepted_projects",
 				"email": "accepted-member@example.com",
 				"role": "member",
 				"status": "accepted",
@@ -316,7 +146,7 @@ func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 			Attributes: map[string]string{
 				"email":       "accepted-member@example.com",
 				"family":      "invite",
-				"invite_id":   "invite_openai_accepted",
+				"invite_id":   "invite_anthropic_accepted_projects",
 				"role":        "member",
 				"status":      "accepted",
 				"accepted_at": "2026-06-18T12:12:00Z",
@@ -359,52 +189,51 @@ func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 		}
 	}
 
-	openAIInviteURN := "urn:cerebro:writer:openai_invite:invite_openai_123"
-	openAIExpiredInviteURN := "urn:cerebro:writer:openai_invite:invite_openai_expired"
-	openAIOrgURN := "urn:cerebro:writer:openai_org:openai"
-	openAIRoleURN := "urn:cerebro:writer:openai_role:organization:owner"
-	openAIProjectOwnerRoleURN := "urn:cerebro:writer:openai_role:project:owner"
-	openAIProjectMemberRoleURN := "urn:cerebro:writer:openai_role:project:member"
-	openAIProjectOwnerURN := "urn:cerebro:writer:openai_project:proj_123"
-	openAIProjectMemberURN := "urn:cerebro:writer:openai_project:proj_456"
-	openAIExpiredProjectURN := "urn:cerebro:writer:openai_project:proj_expired"
-	openAIAcceptedInviteURN := "urn:cerebro:writer:openai_invite:invite_openai_accepted"
-	openAIAcceptedProjectURN := "urn:cerebro:writer:openai_project:proj_accepted"
+	pendingProjectsInviteURN := "urn:cerebro:writer:anthropic_invite:invite_anthropic_pending_projects"
+	expiredProjectsInviteURN := "urn:cerebro:writer:anthropic_invite:invite_anthropic_expired_projects"
+	orgURN := "urn:cerebro:writer:anthropic_org:anthropic"
+	ownerRoleURN := "urn:cerebro:writer:anthropic_role:organization:owner"
+	projectOwnerRoleURN := "urn:cerebro:writer:anthropic_role:project:owner"
+	projectMemberRoleURN := "urn:cerebro:writer:anthropic_role:project:member"
+	projectOwnerURN := "urn:cerebro:writer:anthropic_project:proj_123"
+	projectMemberURN := "urn:cerebro:writer:anthropic_project:proj_456"
+	expiredProjectURN := "urn:cerebro:writer:anthropic_project:proj_expired"
+	acceptedInviteURN := "urn:cerebro:writer:anthropic_invite:invite_anthropic_accepted_projects"
+	acceptedProjectURN := "urn:cerebro:writer:anthropic_project:proj_accepted"
 	anthropicInviteURN := "urn:cerebro:writer:anthropic_invite:invite_anthropic_123"
 	anthropicExpiredInviteURN := "urn:cerebro:writer:anthropic_invite:invite_anthropic_expired"
-	anthropicOrgURN := "urn:cerebro:writer:anthropic_org:anthropic"
 	anthropicRoleURN := "urn:cerebro:writer:anthropic_role:organization:developer"
-	openAIIdentityURN := "urn:cerebro:writer:identity:email:future-owner@example.com"
+	pendingProjectsIdentityURN := "urn:cerebro:writer:identity:email:future-owner@example.com"
 	anthropicIdentityURN := "urn:cerebro:writer:identity:email:future-dev@example.com"
 
-	if entity := state.entities[openAIInviteURN]; entity == nil || entity.EntityType != "openai.invite" || entity.Attributes["access_state"] != "invited" {
-		t.Fatalf("openai invite entity missing or wrong: %#v", entity)
+	if entity := state.entities[pendingProjectsInviteURN]; entity == nil || entity.EntityType != "anthropic.invite" || entity.Attributes["access_state"] != "invited" {
+		t.Fatalf("pending invite entity missing or wrong: %#v", entity)
 	}
 	if entity := state.entities[anthropicExpiredInviteURN]; entity == nil || entity.Attributes["access_state"] != "expired" {
 		t.Fatalf("expired invite entity missing or wrong: %#v", entity)
 	}
-	if entity := state.entities[openAIAcceptedInviteURN]; entity == nil || entity.Attributes["access_state"] != "accepted" {
+	if entity := state.entities[acceptedInviteURN]; entity == nil || entity.Attributes["access_state"] != "accepted" {
 		t.Fatalf("accepted invite entity missing or wrong: %#v", entity)
 	}
-	assertProjectedLink(t, state, openAIInviteURN, relationBelongsTo, openAIOrgURN)
-	assertProjectedLink(t, state, openAIInviteURN, relationRepresentsIdentity, openAIIdentityURN)
-	assertProjectedLink(t, state, openAIInviteURN, relationCanAdmin, openAIRoleURN)
-	assertProjectedLink(t, state, openAIRoleURN, relationGrantsEntitlement, openAIOrgURN)
-	assertProjectedLink(t, state, openAIInviteURN, relationCanAdmin, openAIOrgURN)
-	assertProjectedLink(t, state, openAIInviteURN, relationCanAdmin, openAIProjectOwnerRoleURN)
-	assertProjectedLink(t, state, openAIProjectOwnerRoleURN, relationGrantsEntitlement, openAIProjectOwnerURN)
-	assertProjectedLink(t, state, openAIInviteURN, relationCanAdmin, openAIProjectOwnerURN)
-	assertProjectedLink(t, state, openAIInviteURN, relationAssignedTo, openAIProjectMemberRoleURN)
-	assertProjectedLink(t, state, openAIProjectMemberRoleURN, relationGrantsEntitlement, openAIProjectMemberURN)
-	assertProjectedLink(t, state, openAIInviteURN, relationCanPerform, openAIProjectMemberURN)
-	assertProjectedLinkMissing(t, state, openAIExpiredInviteURN, relationCanAdmin, openAIExpiredProjectURN)
-	assertProjectedLink(t, state, openAIAcceptedInviteURN, relationCanPerform, openAIOrgURN)
-	assertProjectedLink(t, state, openAIAcceptedInviteURN, relationCanPerform, openAIAcceptedProjectURN)
-	assertProjectedLink(t, state, anthropicInviteURN, relationBelongsTo, anthropicOrgURN)
+	assertProjectedLink(t, state, pendingProjectsInviteURN, relationBelongsTo, orgURN)
+	assertProjectedLink(t, state, pendingProjectsInviteURN, relationRepresentsIdentity, pendingProjectsIdentityURN)
+	assertProjectedLink(t, state, pendingProjectsInviteURN, relationCanAdmin, ownerRoleURN)
+	assertProjectedLink(t, state, ownerRoleURN, relationGrantsEntitlement, orgURN)
+	assertProjectedLink(t, state, pendingProjectsInviteURN, relationCanAdmin, orgURN)
+	assertProjectedLink(t, state, pendingProjectsInviteURN, relationCanAdmin, projectOwnerRoleURN)
+	assertProjectedLink(t, state, projectOwnerRoleURN, relationGrantsEntitlement, projectOwnerURN)
+	assertProjectedLink(t, state, pendingProjectsInviteURN, relationCanAdmin, projectOwnerURN)
+	assertProjectedLink(t, state, pendingProjectsInviteURN, relationAssignedTo, projectMemberRoleURN)
+	assertProjectedLink(t, state, projectMemberRoleURN, relationGrantsEntitlement, projectMemberURN)
+	assertProjectedLink(t, state, pendingProjectsInviteURN, relationCanPerform, projectMemberURN)
+	assertProjectedLinkMissing(t, state, expiredProjectsInviteURN, relationCanAdmin, expiredProjectURN)
+	assertProjectedLink(t, state, acceptedInviteURN, relationCanPerform, orgURN)
+	assertProjectedLink(t, state, acceptedInviteURN, relationCanPerform, acceptedProjectURN)
+	assertProjectedLink(t, state, anthropicInviteURN, relationBelongsTo, orgURN)
 	assertProjectedLink(t, state, anthropicInviteURN, relationRepresentsIdentity, anthropicIdentityURN)
 	assertProjectedLink(t, state, anthropicInviteURN, relationAssignedTo, anthropicRoleURN)
-	assertProjectedLink(t, state, anthropicInviteURN, relationCanPerform, anthropicOrgURN)
-	assertProjectedLinkMissing(t, state, anthropicExpiredInviteURN, relationCanAdmin, anthropicOrgURN)
+	assertProjectedLink(t, state, anthropicInviteURN, relationCanPerform, orgURN)
+	assertProjectedLinkMissing(t, state, anthropicExpiredInviteURN, relationCanAdmin, orgURN)
 }
 
 func TestProjectAnthropicProjectCollaboratorAccessEdges(t *testing.T) {
@@ -517,21 +346,6 @@ func TestProjectAIGovernanceControlEdges(t *testing.T) {
 
 	events := []*cerebrov1.EventEnvelope{
 		{
-			Id:         "openai-project-rate-limit",
-			TenantId:   "writer",
-			SourceId:   "openai",
-			Kind:       "openai.project_rate_limit",
-			OccurredAt: timestamppb.New(occurred),
-			Attributes: map[string]string{
-				"family":                       "project_rate_limit",
-				"max_requests_per_1_minute":    "500",
-				"model":                        "gpt-4o",
-				"project_id":                   "proj_123",
-				"rate_limit_id":                "rl_123",
-				"batch_1_day_max_input_tokens": "1000000",
-			},
-		},
-		{
 			Id:         "anthropic-workspace-rate-limit",
 			TenantId:   "writer",
 			SourceId:   "anthropic",
@@ -574,33 +388,6 @@ func TestProjectAIGovernanceControlEdges(t *testing.T) {
 				"setting_value":     "false",
 			},
 		},
-		{
-			Id:         "openai-data-retention",
-			TenantId:   "writer",
-			SourceId:   "openai",
-			Kind:       "openai.data_retention",
-			OccurredAt: timestamppb.New(occurred),
-			Attributes: map[string]string{
-				"family":          "data_retention",
-				"object":          "chat",
-				"organization_id": "org_123",
-				"retention_type":  "30d",
-			},
-		},
-		{
-			Id:         "openai-data-retention-with-org-uuid",
-			TenantId:   "writer",
-			SourceId:   "openai",
-			Kind:       "openai.data_retention",
-			OccurredAt: timestamppb.New(occurred),
-			Attributes: map[string]string{
-				"family":            "data_retention",
-				"object":            "chat",
-				"organization_id":   "org_123",
-				"organization_uuid": "org_uuid_123",
-				"retention_type":    "30d",
-			},
-		},
 	}
 	for _, event := range events {
 		if _, err := service.Project(context.Background(), event); err != nil {
@@ -608,35 +395,19 @@ func TestProjectAIGovernanceControlEdges(t *testing.T) {
 		}
 	}
 
-	openAIControlURN := "urn:cerebro:writer:openai_project_rate_limit:proj_123:rl_123:gpt-4o"
-	openAIProjectURN := "urn:cerebro:writer:openai_project:proj_123"
-	openAIModelURN := "urn:cerebro:writer:openai_model:gpt-4o"
 	anthropicRateLimitURN := "urn:cerebro:writer:anthropic_workspace_rate_limit:ws_123:rl_456:claude-sonnet-4-20250514"
 	anthropicWorkspaceURN := "urn:cerebro:writer:anthropic_workspace:ws_123"
 	anthropicModelURN := "urn:cerebro:writer:anthropic_model:claude-sonnet-4-20250514"
 	anthropicSettingURN := "urn:cerebro:writer:anthropic_compliance_organization_setting:org-uuid-1:data_retention"
 	anthropicUnstableSettingURN := "urn:cerebro:writer:anthropic_compliance_organization_setting:org-uuid-1:org-id-1:data_retention"
 	anthropicOrgURN := "urn:cerebro:writer:anthropic_org:org-uuid-1"
-	openAIDataRetentionURN := "urn:cerebro:writer:openai_data_retention:org_123:30d:chat"
-	openAIUnstableDataRetentionURN := "urn:cerebro:writer:openai_data_retention:org_123:org_uuid_123:30d:chat"
 
-	if entity := state.entities[openAIControlURN]; entity == nil || entity.EntityType != "openai.project_rate_limit" || entity.Attributes["control_type"] != "rate_limit" || entity.Attributes["scope_kind"] != "project" {
-		t.Fatalf("openai control entity missing or wrong: %#v", entity)
-	}
 	if entity := state.entities[anthropicSettingURN]; entity == nil || entity.EntityType != "anthropic.compliance_organization_setting" || entity.Attributes["control_type"] != "setting" {
 		t.Fatalf("anthropic setting entity missing or wrong: %#v", entity)
 	}
 	if entity := state.entities[anthropicUnstableSettingURN]; entity != nil {
 		t.Fatalf("anthropic setting projected unstable dual-org URN: %#v", entity)
 	}
-	if entity := state.entities[openAIDataRetentionURN]; entity == nil || entity.EntityType != "openai.data_retention" || entity.Attributes["control_type"] != "data_retention" {
-		t.Fatalf("openai data retention entity missing or wrong: %#v", entity)
-	}
-	if entity := state.entities[openAIUnstableDataRetentionURN]; entity != nil {
-		t.Fatalf("openai data retention projected unstable dual-org URN: %#v", entity)
-	}
-	assertProjectedLink(t, state, openAIControlURN, relationBelongsTo, openAIProjectURN)
-	assertProjectedLink(t, state, openAIControlURN, relationAssociatedWith, openAIModelURN)
 	assertProjectedLink(t, state, anthropicRateLimitURN, relationBelongsTo, anthropicWorkspaceURN)
 	assertProjectedLink(t, state, anthropicRateLimitURN, relationAssociatedWith, anthropicModelURN)
 	assertProjectedLink(t, state, anthropicSettingURN, relationBelongsTo, anthropicOrgURN)
@@ -648,26 +419,6 @@ func TestProjectAIUsageAndCostMetricEdges(t *testing.T) {
 	occurred := time.Date(2026, time.June, 18, 12, 45, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
-		{
-			Id:         "openai-usage-completion",
-			TenantId:   "writer",
-			SourceId:   "openai",
-			Kind:       "openai.usage_completion",
-			OccurredAt: timestamppb.New(occurred),
-			Attributes: map[string]string{
-				"api_key_id":         "fixture_123",
-				"end_time":           "2026-06-18T13:00:00Z",
-				"family":             "usage_completion",
-				"id":                 "usage_123",
-				"input_tokens":       "1200",
-				"model":              "gpt-4o",
-				"num_model_requests": "5",
-				"output_tokens":      "320",
-				"project_id":         "proj_123",
-				"start_time":         "2026-06-18T12:00:00Z",
-				"user_id":            "user_123",
-			},
-		},
 		{
 			Id:         "anthropic-cost-report",
 			TenantId:   "writer",
@@ -694,12 +445,6 @@ func TestProjectAIUsageAndCostMetricEdges(t *testing.T) {
 		}
 	}
 
-	openAIMetricURN := "urn:cerebro:writer:openai_usage_completion:usage_123"
-	openAIOrgURN := "urn:cerebro:writer:openai_org:openai"
-	openAIProjectURN := "urn:cerebro:writer:openai_project:proj_123"
-	openAIUserURN := "urn:cerebro:writer:openai_user:user_123"
-	openAICredentialURN := "urn:cerebro:writer:openai_credential:fixture_123" // #nosec G101 -- test credential URN fixture, not credential material.
-	openAIModelURN := "urn:cerebro:writer:openai_model:gpt-4o"
 	anthropicMetricURN := "urn:cerebro:writer:anthropic_cost_report:cost_123"
 	anthropicOrgURN := "urn:cerebro:writer:anthropic_org:org_123"
 	anthropicWorkspaceURN := "urn:cerebro:writer:anthropic_workspace:ws_123"
@@ -707,17 +452,9 @@ func TestProjectAIUsageAndCostMetricEdges(t *testing.T) {
 	anthropicCredentialURN := "urn:cerebro:writer:anthropic_credential:fixture_456" // #nosec G101 -- test credential URN fixture, not credential material.
 	anthropicModelURN := "urn:cerebro:writer:anthropic_model:claude-sonnet-4-20250514"
 
-	if entity := state.entities[openAIMetricURN]; entity == nil || entity.EntityType != "openai.usage_completion" || entity.Attributes["metric_type"] != "usage" {
-		t.Fatalf("openai usage metric entity missing or wrong: %#v", entity)
-	}
 	if entity := state.entities[anthropicMetricURN]; entity == nil || entity.EntityType != "anthropic.cost_report" || entity.Attributes["metric_type"] != "cost" {
 		t.Fatalf("anthropic cost metric entity missing or wrong: %#v", entity)
 	}
-	assertProjectedLink(t, state, openAIMetricURN, relationBelongsTo, openAIOrgURN)
-	assertProjectedLink(t, state, openAIMetricURN, relationObservedOn, openAIProjectURN)
-	assertProjectedLink(t, state, openAIMetricURN, relationObservedOn, openAIUserURN)
-	assertProjectedLink(t, state, openAIMetricURN, relationObservedOn, openAICredentialURN)
-	assertProjectedLink(t, state, openAIMetricURN, relationAssociatedWith, openAIModelURN)
 	assertProjectedLink(t, state, anthropicMetricURN, relationBelongsTo, anthropicOrgURN)
 	assertProjectedLink(t, state, anthropicMetricURN, relationObservedOn, anthropicWorkspaceURN)
 	assertProjectedLink(t, state, anthropicMetricURN, relationObservedOn, anthropicUserURN)

--- a/internal/sourceprojection/openai.go
+++ b/internal/sourceprojection/openai.go
@@ -1,61 +1,82 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-// openAIAPIKeyProjections materializes the shared AI credential graph slice for
-// OpenAI API keys and then annotates the credential node with current ownership
-// posture (privilege class, owner type, and whether the key has an accountable
-// owner). Durable orphaned-privileged-key findings anchor on this projected
-// state so they reflect the key's current ownership rather than transient audit
-// events.
-func openAIAPIKeyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	entities, links, err := openAICredentialProjections(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	enrichOpenAICredentialPosture(entities, event)
-	return entities, links, nil
+var errOpenAIRustProjectionRequired = errors.New("openai projection requires Rust authority")
+
+func openAIAPIKeyProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
 }
 
-func enrichOpenAICredentialPosture(entities []*ports.ProjectedEntity, event *cerebrov1.EventEnvelope) {
-	tenant, err := tenantID(event)
-	if err != nil {
-		return
-	}
-	attrs := event.GetAttributes()
-	credentialID := firstNonEmpty(attrs["api_key_id"], attrs["external_key_id"], attrs["credential_id"], attrs["id"])
-	credentialURN := projectionURN(tenant, "openai_credential", credentialID)
-	if credentialURN == "" {
-		return
-	}
-	privileged := openAICredentialPrivileged(event.GetKind(), attrs)
-	hasOwner := strings.TrimSpace(attrs["owner_user_id"]) != "" || strings.TrimSpace(attrs["owner_service_account_id"]) != "" || strings.TrimSpace(attrs["owner_id"]) != ""
-	for _, entity := range entities {
-		if entity == nil || entity.URN != credentialURN {
-			continue
-		}
-		if entity.Attributes == nil {
-			entity.Attributes = map[string]string{}
-		}
-		entity.Attributes["privileged"] = boolString(privileged)
-		entity.Attributes["has_owner"] = boolString(hasOwner)
-		entity.Attributes["orphaned_owner"] = boolString(privileged && !hasOwner)
-		addEndpointAttribute(entity.Attributes, "owner_type", attrs["owner_type"])
-		addEndpointAttribute(entity.Attributes, "key_class", attrs["key_class"])
-	}
+func openAIAuditProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
 }
 
-func openAICredentialPrivileged(kind string, attrs map[string]string) bool {
-	if strings.TrimSpace(kind) == "openai.admin_api_key" {
-		return true
-	}
-	if projectionBool(attrs["privileged"]) {
-		return true
-	}
-	return strings.EqualFold(strings.TrimSpace(attrs["key_class"]), "admin")
+func openAIGovernanceControlProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
+}
+
+func openAIGroupProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
+}
+
+func openAIGroupRoleProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
+}
+
+func openAIGroupUserProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
+}
+
+func openAIInviteProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
+}
+
+func openAIProjectProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
+}
+
+func openAIProjectEntitlementProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
+}
+
+func openAIProjectGroupProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
+}
+
+func openAIProjectGroupRoleProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
+}
+
+func openAIProjectUserProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
+}
+
+func openAIProjectUserRoleProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
+}
+
+func openAIRoleProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
+}
+
+func openAIServiceAccountProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
+}
+
+func openAIUsageMetricProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
+}
+
+func openAIUserProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
+}
+
+func openAIUserRoleProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errOpenAIRustProjectionRequired
 }

--- a/internal/sourceprojection/openai_test.go
+++ b/internal/sourceprojection/openai_test.go
@@ -1,312 +1,67 @@
 package sourceprojection
 
 import (
-	"context"
-	"strings"
+	"errors"
 	"testing"
-	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func TestProjectOpenAIKeyOwnershipAndPostureEnrichment(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-	occurred := time.Date(2026, time.June, 18, 12, 0, 0, 0, time.UTC)
-
-	events := []*cerebrov1.EventEnvelope{
-		{
-			Id:         "openai-owned-admin-key",
-			TenantId:   "writer",
-			SourceId:   "openai",
-			Kind:       "openai.admin_api_key",
-			OccurredAt: timestamppb.New(occurred),
-			Attributes: map[string]string{
-				"api_key_id":   "admin_owned",
-				"family":       "admin_api_key",
-				"key_class":    "admin",
-				"name":         "owned-admin-key",
-				"owner_id":     "user_123",
-				"owner_name":   "Ada Lovelace",
-				"owner_object": "organization.user",
-				"owner_type":   "user",
-				"privileged":   "true",
-			},
-		},
-		{
-			Id:         "openai-orphaned-admin-key",
-			TenantId:   "writer",
-			SourceId:   "openai",
-			Kind:       "openai.admin_api_key",
-			OccurredAt: timestamppb.New(occurred),
-			Attributes: map[string]string{
-				"api_key_id": "admin_orphaned",
-				"family":     "admin_api_key",
-				"key_class":  "admin",
-				"name":       "orphaned-admin-key",
-				"privileged": "true",
-			},
-		},
-		{
-			Id:         "openai-project-key",
-			TenantId:   "writer",
-			SourceId:   "openai",
-			Kind:       "openai.project_api_key",
-			OccurredAt: timestamppb.New(occurred),
-			Attributes: map[string]string{
-				"api_key_id":               "proj_key",
-				"family":                   "project_api_key",
-				"name":                     "prod-key",
-				"owner_type":               "service_account",
-				"owner_service_account_id": "sa_9",
-				"project_id":               "proj_123",
-			},
-		},
-	}
-	for _, event := range events {
-		if _, err := service.Project(context.Background(), event); err != nil {
-			t.Fatalf("Project(%q) error = %v", event.GetId(), err)
-		}
-	}
-
-	ownedURN := "urn:cerebro:writer:openai_credential:admin_owned"       // #nosec G101 -- test credential URN fixture, not credential material.
-	orphanedURN := "urn:cerebro:writer:openai_credential:admin_orphaned" // #nosec G101 -- test credential URN fixture, not credential material.
-	projKeyURN := "urn:cerebro:writer:openai_credential:proj_key"        // #nosec G101 -- test credential URN fixture, not credential material.
-	userURN := "urn:cerebro:writer:openai_user:user_123"
-	serviceAccountURN := "urn:cerebro:writer:openai_service_account:sa_9"
-	orgURN := "urn:cerebro:writer:openai_org:openai"
-	projectURN := "urn:cerebro:writer:openai_project:proj_123"
-
-	owned := state.entities[ownedURN]
-	if owned == nil || owned.EntityType != "openai.credential" {
-		t.Fatalf("owned credential entity missing or wrong: %#v", owned)
-	}
-	for key, want := range map[string]string{"privileged": "true", "has_owner": "true", "orphaned_owner": "false", "owner_type": "user"} {
-		if got := owned.Attributes[key]; got != want {
-			t.Fatalf("owned credential attribute %q = %q, want %q", key, got, want)
-		}
-	}
-	assertProjectedLink(t, state, userURN, relationAssignedTo, ownedURN)
-	assertProjectedLink(t, state, ownedURN, relationCanPerform, orgURN)
-
-	orphaned := state.entities[orphanedURN]
-	if orphaned == nil {
-		t.Fatalf("orphaned credential entity missing")
-	}
-	for key, want := range map[string]string{"privileged": "true", "has_owner": "false", "orphaned_owner": "true"} {
-		if got := orphaned.Attributes[key]; got != want {
-			t.Fatalf("orphaned credential attribute %q = %q, want %q", key, got, want)
-		}
-	}
-
-	projKey := state.entities[projKeyURN]
-	if projKey == nil {
-		t.Fatalf("project credential entity missing")
-	}
-	if got := projKey.Attributes["has_owner"]; got != "true" {
-		t.Fatalf("project credential has_owner = %q, want true", got)
-	}
-	assertProjectedLink(t, state, serviceAccountURN, relationAssignedTo, projKeyURN)
-	assertProjectedLink(t, state, projKeyURN, relationCanPerform, projectURN)
-}
-
-func TestRegistryRoutesOpenAIDeclaredKinds(t *testing.T) {
-	declared := []string{
-		"openai.user",
-		"openai.project",
-		"openai.service_account",
-		"openai.api_key",
+func TestOpenAIGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
 		"openai.admin_api_key",
+		"openai.api_key",
 		"openai.audit_log",
-		"openai.invite",
-		"openai.role",
-		"openai.user_role",
-		"openai.group",
-		"openai.group_user",
-		"openai.group_role",
-		"openai.data_retention",
-		"openai.spend_alert",
 		"openai.certificate",
+		"openai.cost",
+		"openai.data_retention",
+		"openai.group",
+		"openai.group_role",
+		"openai.group_user",
+		"openai.invite",
+		"openai.project",
+		"openai.project_api_key",
+		"openai.project_certificate",
+		"openai.project_data_retention",
+		"openai.project_group",
+		"openai.project_group_role",
+		"openai.project_hosted_tool_permission",
+		"openai.project_model_permission",
+		"openai.project_rate_limit",
+		"openai.project_role",
+		"openai.project_service_account",
+		"openai.project_spend_alert",
+		"openai.project_user",
+		"openai.project_user_role",
+		"openai.role",
+		"openai.service_account",
+		"openai.spend_alert",
 		"openai.usage_audio_speech",
 		"openai.usage_audio_transcription",
 		"openai.usage_code_interpreter_session",
 		"openai.usage_completion",
 		"openai.usage_embedding",
+		"openai.usage_file_search_call",
 		"openai.usage_image",
 		"openai.usage_moderation",
 		"openai.usage_vector_store",
-		"openai.usage_file_search_call",
 		"openai.usage_web_search_call",
-		"openai.cost",
-		"openai.project_user",
-		"openai.project_user_role",
-		"openai.project_service_account",
-		"openai.project_api_key",
-		"openai.project_rate_limit",
-		"openai.project_model_permission",
-		"openai.project_hosted_tool_permission",
-		"openai.project_group",
-		"openai.project_group_role",
-		"openai.project_role",
-		"openai.project_data_retention",
-		"openai.project_spend_alert",
-		"openai.project_certificate",
-	}
-	registered := make(map[string]struct{})
-	for _, kind := range BuiltinRegistry().Kinds() {
-		registered[kind] = struct{}{}
-	}
-	for _, kind := range declared {
-		if _, ok := registered[kind]; !ok {
-			t.Fatalf("declared OpenAI kind %q is not routed in the projection registry", kind)
-		}
-	}
-}
-
-func TestProjectOpenAIDeclaredKindsProduceGraphEntities(t *testing.T) {
-	occurred := time.Date(2026, time.June, 18, 13, 30, 0, 0, time.UTC)
-	cases := []struct {
-		name   string
-		family string
-		kind   string
-	}{
-		{name: "user", family: "user", kind: "openai.user"},
-		{name: "project", family: "project", kind: "openai.project"},
-		{name: "service_account", family: "service_account", kind: "openai.service_account"},
-		{name: "api_key", family: "api_key", kind: "openai.api_key"},
-		{name: "admin_api_key", family: "admin_api_key", kind: "openai.admin_api_key"},
-		{name: "audit_log", family: "audit_log", kind: "openai.audit_log"},
-		{name: "invite", family: "invite", kind: "openai.invite"},
-		{name: "role", family: "role", kind: "openai.role"},
-		{name: "user_role", family: "user_role", kind: "openai.user_role"},
-		{name: "group", family: "group", kind: "openai.group"},
-		{name: "group_user", family: "group_user", kind: "openai.group_user"},
-		{name: "group_role", family: "group_role", kind: "openai.group_role"},
-		{name: "data_retention", family: "data_retention", kind: "openai.data_retention"},
-		{name: "spend_alert", family: "spend_alert", kind: "openai.spend_alert"},
-		{name: "certificate", family: "certificate", kind: "openai.certificate"},
-		{name: "usage_audio_speech", family: "usage_audio_speech", kind: "openai.usage_audio_speech"},
-		{name: "usage_audio_transcription", family: "usage_audio_transcription", kind: "openai.usage_audio_transcription"},
-		{name: "usage_code_interpreter_session", family: "usage_code_interpreter_session", kind: "openai.usage_code_interpreter_session"},
-		{name: "usage_completion", family: "usage_completion", kind: "openai.usage_completion"},
-		{name: "usage_embedding", family: "usage_embedding", kind: "openai.usage_embedding"},
-		{name: "usage_image", family: "usage_image", kind: "openai.usage_image"},
-		{name: "usage_moderation", family: "usage_moderation", kind: "openai.usage_moderation"},
-		{name: "usage_vector_store", family: "usage_vector_store", kind: "openai.usage_vector_store"},
-		{name: "usage_file_search_call", family: "usage_file_search_call", kind: "openai.usage_file_search_call"},
-		{name: "usage_web_search_call", family: "usage_web_search_call", kind: "openai.usage_web_search_call"},
-		{name: "cost", family: "cost", kind: "openai.cost"},
-		{name: "project_user", family: "project_user", kind: "openai.project_user"},
-		{name: "project_user_role", family: "project_user_role", kind: "openai.project_user_role"},
-		{name: "project_service_account", family: "project_service_account", kind: "openai.project_service_account"},
-		{name: "project_api_key", family: "project_api_key", kind: "openai.project_api_key"},
-		{name: "project_rate_limit", family: "project_rate_limit", kind: "openai.project_rate_limit"},
-		{name: "project_model_permission", family: "project_model_permission", kind: "openai.project_model_permission"},
-		{name: "project_hosted_tool_permission", family: "project_hosted_tool_permission", kind: "openai.project_hosted_tool_permission"},
-		{name: "project_group", family: "project_group", kind: "openai.project_group"},
-		{name: "project_group_role", family: "project_group_role", kind: "openai.project_group_role"},
-		{name: "project_role", family: "project_role", kind: "openai.project_role"},
-		{name: "project_data_retention", family: "project_data_retention", kind: "openai.project_data_retention"},
-		{name: "project_spend_alert", family: "project_spend_alert", kind: "openai.project_spend_alert"},
-		{name: "project_certificate", family: "project_certificate", kind: "openai.project_certificate"},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			state := &projectionRecorder{}
-			service := New(state, nil)
-			attrs := openAIProjectionCoverageAttributes(tc.family)
-			event := &cerebrov1.EventEnvelope{
-				Id:         "openai-" + tc.name,
-				TenantId:   "writer",
-				SourceId:   "openai",
-				Kind:       tc.kind,
-				OccurredAt: timestamppb.New(occurred),
-				Attributes: attrs,
+		"openai.user",
+		"openai.user_role",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "openai",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errOpenAIRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
 			}
-
-			result, err := service.Project(context.Background(), event)
-			if err != nil {
-				t.Fatalf("Project(%q) error = %v", tc.kind, err)
-			}
-			if result.EntitiesProjected == 0 {
-				t.Fatalf("Project(%q) projected no entities", tc.kind)
-			}
-			if !hasOpenAIProviderEntity(state) {
-				t.Fatalf("Project(%q) did not produce an OpenAI graph entity; projected types: %v", tc.kind, projectedEntityTypes(state))
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
 			}
 		})
 	}
-}
-
-func openAIProjectionCoverageAttributes(family string) map[string]string {
-	return map[string]string{
-		"actor_email":               "admin@example.com",
-		"actor_user_id":             "user_admin",
-		"api_key_id":                "credential_coverage",
-		"amount_currency":           "usd",
-		"amount_value":              "12.34",
-		"certificate_id":            "certificate_coverage",
-		"code_interpreter_enabled":  "true",
-		"email":                     "alice@example.com",
-		"end_time":                  "2026-06-18T13:00:00Z",
-		"event_type":                "role.assignment.created",
-		"family":                    family,
-		"file_search_enabled":       "true",
-		"group_id":                  "group_coverage",
-		"id":                        family + "_coverage",
-		"image_generation_enabled":  "true",
-		"input_tokens":              "100",
-		"invite_id":                 "invite_coverage",
-		"line_item":                 "usage",
-		"max_requests_per_1_minute": "500",
-		"mcp_enabled":               "true",
-		"member_user_id":            "user_coverage",
-		"model":                     "gpt-4o",
-		"model_ids":                 "gpt-4o",
-		"name":                      "Coverage Fixture",
-		"num_model_requests":        "2",
-		"object":                    "chat",
-		"organization_id":           "org_coverage",
-		"output_tokens":             "25",
-		"owner_type":                "user",
-		"owner_user_id":             "user_coverage",
-		"principal_id":              "group_coverage",
-		"principal_type":            "group",
-		"project_id":                "project_coverage",
-		"rate_limit_id":             "rate_limit_coverage",
-		"resource_id":               "project_coverage",
-		"resource_type":             "project",
-		"retention_type":            "30d",
-		"role":                      "owner",
-		"role_id":                   "owner",
-		"roles":                     "owner,member",
-		"service_account_id":        "service_account_coverage",
-		"spend_alert_id":            "spend_alert_coverage",
-		"start_time":                "2026-06-18T12:00:00Z",
-		"status":                    "active",
-		"user_id":                   "user_coverage",
-		"web_search_enabled":        "true",
-	}
-}
-
-func hasOpenAIProviderEntity(state *projectionRecorder) bool {
-	for _, entity := range state.entities {
-		if entity != nil && entity.SourceID == "openai" && strings.HasPrefix(entity.EntityType, "openai.") {
-			return true
-		}
-	}
-	return false
-}
-
-func projectedEntityTypes(state *projectionRecorder) []string {
-	types := make([]string, 0, len(state.entities))
-	for _, entity := range state.entities {
-		if entity == nil {
-			continue
-		}
-		types = append(types, entity.EntityType)
-	}
-	return types
 }


### PR DESCRIPTION
## Summary

- remove the production OpenAI Go projection implementation for all closed families
- fail closed if the compatibility projector is invoked for a Rust-authoritative OpenAI event
- preserve provider fixtures

## Authority proof

- the compiled Rust source catalog marks all 39 OpenAI families collection-authoritative and projection-authoritative (pinned in #2699)
- the provider-specific Go source loader is already retired (TestBuiltinRetiresCoveredProviderGoLoaders)
- compatibility projection attempts now return a typed Rust-authority error before emitting graph writes

## Validation

- gofmt -l internal/sourceprojection
- go build ./internal/sourceprojection
- go test ./internal/sourceprojection -run OpenAI -count=1 -v
- go test ./internal/sourceprojection -count=1
- go test ./internal/sourceregistry -run TestBuiltinRetiresCoveredProviderGoLoaders -count=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
