### PR TITLE
test(openai): repair projection oracle lint

### DIFF
--- a/internal/sourceprojection/ai_access_credential_test.go
+++ b/internal/sourceprojection/ai_access_credential_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestProjectAIUsageMetricNormalizesCredentialRuntimeUsage(t *testing.T) {
 	state := &projectionRecorder{}
-	service := newOpenAIOracleService(t, state, nil)
+	service := newOpenAIOracleService(t, state)
 	occurred := time.Date(2026, time.June, 18, 12, 45, 0, 0, time.UTC)
 
 	event := &cerebrov1.EventEnvelope{

--- a/internal/sourceprojection/ai_access_test.go
+++ b/internal/sourceprojection/ai_access_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestProjectOpenAIProjectAccessEdges(t *testing.T) {
 	state := &projectionRecorder{}
-	service := newOpenAIOracleService(t, state, nil)
+	service := newOpenAIOracleService(t, state)
 	occurred := time.Date(2026, time.June, 18, 12, 0, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -95,7 +95,7 @@ func TestProjectOpenAIProjectAccessEdges(t *testing.T) {
 
 func TestProjectOpenAIAuditDeepAccessEvidence(t *testing.T) {
 	state := &projectionRecorder{}
-	service := newOpenAIOracleService(t, state, nil)
+	service := newOpenAIOracleService(t, state)
 	occurred := time.Date(2026, time.June, 18, 12, 5, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -182,7 +182,7 @@ func TestProjectOpenAIAuditDeepAccessEvidence(t *testing.T) {
 
 func TestProjectAnthropicComplianceActivityResourceEvidence(t *testing.T) {
 	state := &projectionRecorder{}
-	service := newOpenAIOracleService(t, state, nil)
+	service := newOpenAIOracleService(t, state)
 	occurred := time.Date(2026, time.June, 18, 12, 7, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -245,7 +245,7 @@ func TestProjectAnthropicComplianceActivityResourceEvidence(t *testing.T) {
 
 func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 	state := &projectionRecorder{}
-	service := newOpenAIOracleService(t, state, nil)
+	service := newOpenAIOracleService(t, state)
 	occurred := time.Date(2026, time.June, 18, 12, 10, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -409,7 +409,7 @@ func TestProjectAIOrganizationInviteAccessIntent(t *testing.T) {
 
 func TestProjectAnthropicProjectCollaboratorAccessEdges(t *testing.T) {
 	state := &projectionRecorder{}
-	service := newOpenAIOracleService(t, state, nil)
+	service := newOpenAIOracleService(t, state)
 	occurred := time.Date(2026, time.June, 18, 12, 15, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -512,7 +512,7 @@ func TestProjectAnthropicProjectCollaboratorAccessEdges(t *testing.T) {
 
 func TestProjectAIGovernanceControlEdges(t *testing.T) {
 	state := &projectionRecorder{}
-	service := newOpenAIOracleService(t, state, nil)
+	service := newOpenAIOracleService(t, state)
 	occurred := time.Date(2026, time.June, 18, 12, 30, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -644,7 +644,7 @@ func TestProjectAIGovernanceControlEdges(t *testing.T) {
 
 func TestProjectAIUsageAndCostMetricEdges(t *testing.T) {
 	state := &projectionRecorder{}
-	service := newOpenAIOracleService(t, state, nil)
+	service := newOpenAIOracleService(t, state)
 	occurred := time.Date(2026, time.June, 18, 12, 45, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -727,7 +727,7 @@ func TestProjectAIUsageAndCostMetricEdges(t *testing.T) {
 
 func TestProjectAnthropicWorkspaceCredentialFederationAndComplianceEdges(t *testing.T) {
 	state := &projectionRecorder{}
-	service := newOpenAIOracleService(t, state, nil)
+	service := newOpenAIOracleService(t, state)
 	occurred := time.Date(2026, time.June, 18, 13, 0, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -828,7 +828,7 @@ func TestProjectAnthropicWorkspaceCredentialFederationAndComplianceEdges(t *test
 
 func TestProjectAnthropicComplianceDirectoryGroupMembership(t *testing.T) {
 	state := &projectionRecorder{}
-	service := newOpenAIOracleService(t, state, nil)
+	service := newOpenAIOracleService(t, state)
 	occurred := time.Date(2026, time.June, 18, 14, 0, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -1280,7 +1280,7 @@ func TestProjectAnthropicRemainingRuntimeFamilies(t *testing.T) {
 func projectAnthropicInventoryEvent(t *testing.T, event *cerebrov1.EventEnvelope) *projectionRecorder {
 	t.Helper()
 	state := &projectionRecorder{}
-	service := newOpenAIOracleService(t, state, nil)
+	service := newOpenAIOracleService(t, state)
 	if _, err := service.Project(context.Background(), event); err != nil {
 		t.Fatalf("Project(%q) error = %v", event.GetId(), err)
 	}

--- a/internal/sourceprojection/openai_oracle_test.go
+++ b/internal/sourceprojection/openai_oracle_test.go
@@ -13,7 +13,6 @@ var openAIOracleAccessProfile = aiAccessProfile{Provider: "openai"}
 func newOpenAIOracleService(
 	t *testing.T,
 	state ports.ProjectionStateStore,
-	graph ports.ProjectionGraphStore,
 ) *Service {
 	t.Helper()
 	builtinRegistry.mu.RLock()
@@ -29,7 +28,7 @@ func newOpenAIOracleService(
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}
-	return NewWithRegistry(state, graph, registry)
+	return NewWithRegistry(state, nil, registry)
 }
 
 var openAIOracleProjectors = map[string]ProjectFunc{

--- a/internal/sourceprojection/openai_test.go
+++ b/internal/sourceprojection/openai_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestProjectOpenAIKeyOwnershipAndPostureEnrichment(t *testing.T) {
 	state := &projectionRecorder{}
-	service := newOpenAIOracleService(t, state, nil)
+	service := newOpenAIOracleService(t, state)
 	occurred := time.Date(2026, time.June, 18, 12, 0, 0, 0, time.UTC)
 
 	events := []*cerebrov1.EventEnvelope{
@@ -235,7 +235,7 @@ func TestProjectOpenAIDeclaredKindsProduceGraphEntities(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			state := &projectionRecorder{}
-			service := newOpenAIOracleService(t, state, nil)
+			service := newOpenAIOracleService(t, state)
 			attrs := openAIProjectionCoverageAttributes(tc.family)
 			event := &cerebrov1.EventEnvelope{
 				Id:         "openai-" + tc.name,


### PR DESCRIPTION
## Summary

- repair the exact-head Go lint failure left after OpenAI deletion PR #2697 merged
- remove the unused graph parameter from the test-only OpenAI parity-oracle constructor
- keep production code and the merged deletion semantics unchanged

## Failure receipt

PR #2697 merged from head `e3995dbcd48bac08e4c31a91acee975f2114a8c3` before its hosted lint aggregate completed. `lint-internal-0` then failed because the oracle helper's graph argument was always nil. This forward repair narrows the helper and its call sites.

## Local validation

- `go test ./internal/sourceprojection -count=1`
- `golangci-lint run ./internal/sourceprojection/...` — 0 issues
- `git diff --check origin/main...HEAD`

No production paths, shared registries, generators, fixtures, or public contracts change.
