### PR TITLE
test(bench): move Go projection corpus off retired Box path

### DIFF
--- a/internal/graphrebuild/organizational_platform_benchmark_test.go
+++ b/internal/graphrebuild/organizational_platform_benchmark_test.go
@@ -25,7 +25,7 @@ func BenchmarkOrganizationalPlatformGo(b *testing.B) {
 	for _, recordCount := range []int{100, 1_000, 5_000} {
 		events := organizationalBenchmarkAssetEvents(recordCount)
 		verifyOrganizationalBenchmarkProjection(b, events)
-		b.Run(fmt.Sprintf("projection/box_assets/records_%d", recordCount), func(b *testing.B) {
+		b.Run(fmt.Sprintf("projection/content_assets/records_%d", recordCount), func(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for range b.N {
@@ -39,7 +39,7 @@ func BenchmarkOrganizationalPlatformGo(b *testing.B) {
 				"ns/record",
 			)
 		})
-		b.Run(fmt.Sprintf("admission/box_assets/records_%d", recordCount), func(b *testing.B) {
+		b.Run(fmt.Sprintf("admission/content_assets/records_%d", recordCount), func(b *testing.B) {
 			ctx := context.Background()
 			b.ReportAllocs()
 			b.ResetTimer()
@@ -142,8 +142,8 @@ func organizationalBenchmarkAssetEvents(recordCount int) []*cerebrov1.EventEnvel
 		events = append(events, &cerebrov1.EventEnvelope{
 			Id:       fmt.Sprintf("observation-%05d", index),
 			TenantId: "benchmark-tenant",
-			SourceId: "box",
-			Kind:     "box.content_assets",
+			SourceId: "dropbox_business",
+			Kind:     "dropbox_business.content_assets",
 			Attributes: map[string]string{
 				"resource_id":   id,
 				"resource_name": fmt.Sprintf("Asset %05d", index),

--- a/internal/sourceruntime/organizational_platform_benchmark_test.go
+++ b/internal/sourceruntime/organizational_platform_benchmark_test.go
@@ -16,7 +16,7 @@ var (
 )
 
 func TestOrganizationalPlatformRawBenchmarkCorpus(t *testing.T) {
-	definition, family := organizationalBenchmarkBoxAssetDefinition(t)
+	definition, family := organizationalBenchmarkContentAssetDefinition(t)
 	runtime := organizationalBenchmarkRuntime()
 	for _, recordCount := range []int{100, 1_000, 5_000} {
 		records := organizationalBenchmarkRawAssets(recordCount)
@@ -39,7 +39,7 @@ func TestOrganizationalPlatformRawBenchmarkCorpus(t *testing.T) {
 }
 
 func BenchmarkOrganizationalPlatformGoRawProjection(b *testing.B) {
-	definition, family := organizationalBenchmarkBoxAssetDefinition(b)
+	definition, family := organizationalBenchmarkContentAssetDefinition(b)
 	runtime := organizationalBenchmarkRuntime()
 	for _, recordCount := range []int{100, 1_000, 5_000} {
 		records := organizationalBenchmarkRawAssets(recordCount)
@@ -58,7 +58,7 @@ func BenchmarkOrganizationalPlatformGoRawProjection(b *testing.B) {
 				recordCount,
 			)
 		}
-		b.Run(fmt.Sprintf("projection/box_assets/records_%d", recordCount), func(b *testing.B) {
+		b.Run(fmt.Sprintf("projection/content_assets/records_%d", recordCount), func(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for range b.N {
@@ -97,7 +97,7 @@ func projectOrganizationalRawBenchmarkRecords(
 			Id:         fmt.Sprintf("observation-%05d", index),
 			TenantId:   runtime.GetTenantId(),
 			SourceId:   runtime.GetSourceId(),
-			Kind:       "box.content_assets",
+			Kind:       "dropbox_business.content_assets",
 			Attributes: attributes,
 		}
 		entities, links, err := sourceprojection.ProjectEvent(event)
@@ -110,31 +110,31 @@ func projectOrganizationalRawBenchmarkRecords(
 	return entityCount, linkCount
 }
 
-func organizationalBenchmarkBoxAssetDefinition(
+func organizationalBenchmarkContentAssetDefinition(
 	tb testing.TB,
 ) (connectordefinitions.Definition, connectordefinitions.ResourceFamily) {
 	tb.Helper()
-	entry, ok, err := connectorcatalog.BuiltinEntry("box")
+	entry, ok, err := connectorcatalog.BuiltinEntry("dropbox_business")
 	if err != nil {
 		tb.Fatal(err)
 	}
 	if !ok {
-		tb.Fatal("Box connector definition is missing")
+		tb.Fatal("Dropbox Business connector definition is missing")
 	}
 	for _, family := range entry.Definition.ResourceFamilies {
 		if family.ID == "content_assets" {
 			return entry.Definition, family
 		}
 	}
-	tb.Fatal("Box content_assets family is missing")
+	tb.Fatal("Dropbox Business content_assets family is missing")
 	return connectordefinitions.Definition{}, connectordefinitions.ResourceFamily{}
 }
 
 func organizationalBenchmarkRuntime() *cerebrov1.SourceRuntime {
 	return &cerebrov1.SourceRuntime{
-		Id:       "box-benchmark",
+		Id:       "dropbox-business-benchmark",
 		TenantId: "benchmark-tenant",
-		SourceId: "box",
+		SourceId: "dropbox_business",
 	}
 }
 


### PR DESCRIPTION
## Summary

- rebuild the Go organizational-platform benchmark corpus on `dropbox_business.content_assets`
- fixes `TestOrganizationalPlatformRawBenchmarkCorpus` (internal/sourceruntime) and `TestOrganizationalPlatformBenchmarkCorpus` (internal/graphrebuild), red on `main` since #2702 retired the Box Go projection writer
- unblocks the race/test shards on every open PR (they all inherit this failure through the merge ref)

## Why dropbox_business

- `dropbox_business.content_assets` uses the same generic asset projection template (`projection.template: asset`) as Box did, so the measured workload shape is unchanged: one entity per record, zero links
- `dropbox_business` is not in `TestBuiltinRetiresCoveredProviderGoLoaders` or any retirement lane, so the Go compatibility path stays live for this corpus
- the Rust side of `make rust-organizational-platform-benchmark` keeps its `box_assets` corpus — Box *is* Rust-authoritative, which is exactly why the Go side had to move; the paired comparison remains same-shape (generic raw asset projection), and the Go sub-benchmark labels are now `projection/content_assets/...`

## Validation

- gofmt -l internal/sourceruntime internal/graphrebuild
- go vet ./internal/sourceruntime ./internal/graphrebuild
- go test ./internal/sourceruntime -run TestOrganizationalPlatformRawBenchmarkCorpus -count=1
- go test ./internal/graphrebuild -run TestOrganizationalPlatformBenchmarkCorpus -count=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)