### PR TITLE
test(catalog): pin full Rust authority for backstage and langchain

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -3567,6 +3567,7 @@ mod tests {
             "aircall",
             "airfocus",
             "akeyless",
+            "backstage",
             "beezup",
             "bitwarden",
             "box",
@@ -3575,6 +3576,7 @@ mod tests {
             "duo",
             "fivetran",
             "jira",
+            "langchain",
             "openai",
         ] {
             let source = catalog.get(source_id).unwrap();


### PR DESCRIPTION
## Summary

- pin `backstage` and `langchain` in `retired_static_loader_sources_are_fully_rust_authoritative`
- both already compile with every family collection-authoritative and projection-authoritative; this locks that in (follow-on to #2699)

## Authority proof

- compiled catalog probe over `internal/connectorcatalog/catalog` + `sources`: backstage (2 families), langchain (13) — all families `is_authoritative()` and `is_projection_authoritative()`
- both are in `TestBuiltinRetiresCoveredProviderGoLoaders` (Go static loaders already retired)
- neither has a Go projection writer left in `internal/sourceprojection`, so no retirement PR is needed behind this pin

## Validation

- cargo fmt -p cerebro-source-catalog --check
- cargo test -p cerebro-source-catalog --lib retired

🤖 Generated with [Claude Code](https://claude.com/claude-code)