### PR TITLE
catalog(cloudflare): close collection authority gap (unbind spurious tenant_id)

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -3571,6 +3571,7 @@ mod tests {
             "beezup",
             "bitwarden",
             "box",
+            "cloudflare",
             "conjur",
             "deepseek",
             "duo",

--- a/internal/connectorcatalog/catalog/security-posture-vulnerability/cloudflare.yaml
+++ b/internal/connectorcatalog/catalog/security-posture-vulnerability/cloudflare.yaml
@@ -52,7 +52,7 @@ entries:
           read:
             path_params: [account_id]
           config:
-            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+            config_attributes: {account_id: account_id}
             resource_urn_kind: cloudflare_access_application
           pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
           event:
@@ -82,7 +82,7 @@ entries:
           read:
             path_params: [zone_id]
           config:
-            config_attributes: {tenant_id: tenant_id, zone_id: zone_id}
+            config_attributes: {zone_id: zone_id}
             resource_urn_kind: cloudflare_zone_access_application
           pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
           event:
@@ -112,7 +112,7 @@ entries:
           read:
             path_params: [account_id]
           config:
-            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+            config_attributes: {account_id: account_id}
             resource_urn_kind: cloudflare_access_group
           pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
           event:
@@ -142,7 +142,7 @@ entries:
           read:
             path_params: [zone_id]
           config:
-            config_attributes: {tenant_id: tenant_id, zone_id: zone_id}
+            config_attributes: {zone_id: zone_id}
             resource_urn_kind: cloudflare_zone_access_group
           pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
           event:
@@ -169,7 +169,7 @@ entries:
           id_field: id
           name_field: name
           config:
-            config_attributes: {tenant_id: tenant_id}
+            config_attributes: {}
             resource_urn_kind: cloudflare_account
           pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
           event:
@@ -201,7 +201,7 @@ entries:
             detail_path: /accounts/{account_id}/rulesets/{id}
             allow_bare_detail_record: true
           config:
-            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+            config_attributes: {account_id: account_id}
             resource_urn_kind: cloudflare_account_ruleset
           pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
           event:
@@ -230,7 +230,7 @@ entries:
           read:
             path_params: [account_id]
           config:
-            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+            config_attributes: {account_id: account_id}
           pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
           event:
             kind: cloudflare.audit_log
@@ -259,7 +259,7 @@ entries:
           read:
             path_params: [account_id]
           config:
-            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+            config_attributes: {account_id: account_id}
             resource_urn_kind: cloudflare_member
           pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
           event:
@@ -289,7 +289,7 @@ entries:
           read:
             path_params: [account_id]
           config:
-            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+            config_attributes: {account_id: account_id}
             resource_urn_kind: cloudflare_gateway_rule
           pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
           event:
@@ -319,7 +319,7 @@ entries:
           read:
             path_params: [zone_id]
           config:
-            config_attributes: {tenant_id: tenant_id, zone_id: zone_id}
+            config_attributes: {zone_id: zone_id}
             resource_urn_kind: cloudflare_load_balancer
           pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
           event:
@@ -349,7 +349,7 @@ entries:
           read:
             path_params: [account_id]
           config:
-            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+            config_attributes: {account_id: account_id}
             resource_urn_kind: cloudflare_load_balancer_pool
           pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
           event:
@@ -380,7 +380,7 @@ entries:
             detail_path: /accounts/{account_id}/roles/{id}
             allow_bare_detail_record: true
           config:
-            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+            config_attributes: {account_id: account_id}
             resource_urn_kind: cloudflare_role
           pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
           event:
@@ -410,7 +410,7 @@ entries:
           read:
             path_params: [account_id]
           config:
-            config_attributes: {tenant_id: tenant_id, account_id: account_id}
+            config_attributes: {account_id: account_id}
             resource_urn_kind: cloudflare_worker_script
           pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
           event:
@@ -439,7 +439,7 @@ entries:
           name_field: name
           updated_at_field: modified_on
           config:
-            config_attributes: {tenant_id: tenant_id}
+            config_attributes: {}
             resource_urn_kind: cloudflare_zone
           pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
           event:
@@ -471,7 +471,7 @@ entries:
             detail_path: /zones/{zone_id}/rulesets/{id}
             allow_bare_detail_record: true
           config:
-            config_attributes: {tenant_id: tenant_id, zone_id: zone_id}
+            config_attributes: {zone_id: zone_id}
             resource_urn_kind: cloudflare_zone_ruleset
           pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
           event:
@@ -501,7 +501,7 @@ entries:
           read:
             path_params: [zone_id]
           config:
-            config_attributes: {tenant_id: tenant_id, zone_id: zone_id}
+            config_attributes: {zone_id: zone_id}
             resource_urn_kind: cloudflare_dns_record
           pagination: {type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true}
           event:


### PR DESCRIPTION
## Summary

Every Cloudflare family failed collection authority with
`UnsupportedReasonCode::UnboundConfigAttribute`. The root cause: every
family's `config.config_attributes` in
`internal/connectorcatalog/catalog/security-posture-vulnerability/cloudflare.yaml`
bound a `tenant_id` record attribute to a config field literally named
`tenant_id` — but `tenant_id` is not one of the source's declared
`config_fields` (only `account_id` and `zone_id` are), so
`config_binding()` in `crates/source-catalog/src/lib.rs` could never
resolve it, and `config_attributes_configured` was false for every
family.

`tenant_id` is not a per-source config knob at all — it's populated
automatically by the event pipeline (see the fallback in
`internal/sourceregistry/deposit.go`, and `TenantId` handling in
`crates/source-runtime-next/src/append_log.rs`), and no other fully
Rust-authoritative provider's catalog wires a `tenant_id` entry through
`config_attributes` (checked auth0, fivetran, openai, deepseek, etc. —
none do). This was dangling wiring, not missing runtime surface, so
the fix removes the unresolvable `tenant_id: tenant_id` entry from
each family's `config_attributes` map and keeps the already-valid
`account_id`/`zone_id` bindings intact. No new config parameters were
introduced — the runtime's declared `config_fields` (`account_id`,
`zone_id`) are unchanged.

`crates/source-catalog/src/lib.rs` also adds `cloudflare` (alphabetical
position) to the `retired_static_loader_sources_are_fully_rust_authoritative`
test, since all 16 families are now fully authoritative.

## Authority proof

Provider contract verification comes from `sources/cloudflare/catalog.yaml`'s
`provider_api` block: `status: verified`, `basis: declared`, spec at
https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json
(reference: https://github.com/cloudflare/api-schemas/blob/main/openapi.json),
joined per family against `runtime_families` and `provider_api.families`
method+path pairs (`verified_families()`, lib.rs ~2145) — this was already
true pre-fix; only collection authority was blocked.

Probe results (throwaway `crates/source-catalog/tests/wave2_probe.rs`,
deleted before commit, run via
`cargo test -p cerebro-source-catalog --test wave2_probe -- --nocapture`)
after the fix — all 16 families both collection- and projection-authoritative
with zero unsupported reasons:

```
family=access_application authoritative=true projection_authoritative=true unsupported_reasons=[]
family=zone_access_application authoritative=true projection_authoritative=true unsupported_reasons=[]
family=access_group authoritative=true projection_authoritative=true unsupported_reasons=[]
family=zone_access_group authoritative=true projection_authoritative=true unsupported_reasons=[]
family=account authoritative=true projection_authoritative=true unsupported_reasons=[]
family=account_ruleset authoritative=true projection_authoritative=true unsupported_reasons=[]
family=audit_log authoritative=true projection_authoritative=true unsupported_reasons=[]
family=member authoritative=true projection_authoritative=true unsupported_reasons=[]
family=gateway_rule authoritative=true projection_authoritative=true unsupported_reasons=[]
family=load_balancer authoritative=true projection_authoritative=true unsupported_reasons=[]
family=load_balancer_pool authoritative=true projection_authoritative=true unsupported_reasons=[]
family=role authoritative=true projection_authoritative=true unsupported_reasons=[]
family=worker_script authoritative=true projection_authoritative=true unsupported_reasons=[]
family=zone authoritative=true projection_authoritative=true unsupported_reasons=[]
family=zone_ruleset authoritative=true projection_authoritative=true unsupported_reasons=[]
family=dns_record authoritative=true projection_authoritative=true unsupported_reasons=[]
```

## Validation

- `cargo test -p cerebro-source-catalog --test wave2_probe -- --nocapture` (throwaway probe, deleted before commit) — all 16 families authoritative=true / projection_authoritative=true, unsupported_reasons=[]
- `cargo test -p cerebro-source-catalog --lib retired` — `retired_static_loader_sources_are_fully_rust_authoritative` passes with `cloudflare` added
- `cargo test -p cerebro-source-catalog --lib` — all 27 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)