### PR TITLE
catalog(digitalocean): fix provider contract path mismatch for full Rust authority

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -3573,6 +3573,7 @@ mod tests {
             "box",
             "conjur",
             "deepseek",
+            "digitalocean",
             "duo",
             "fivetran",
             "jira",

--- a/sources/digitalocean/catalog.yaml
+++ b/sources/digitalocean/catalog.yaml
@@ -37,15 +37,15 @@ provider_api:
   families:
     - id: droplets
       method: GET
-      path: /v2/droplets
+      path: /droplets
       operation: droplets_list
     - id: vpcs
       method: GET
-      path: /v2/vpcs
+      path: /vpcs
       operation: vpcs_list
     - id: firewalls
       method: GET
-      path: /v2/firewalls
+      path: /firewalls
       operation: firewalls_list
 coverage_contract:
   owner_domain: source_runtime


### PR DESCRIPTION
## Summary

DigitalOcean's `droplets`, `vpcs`, and `firewalls` families were compiled as `MissingProviderProof` even though `sources/digitalocean/catalog.yaml` already had a `verified`/`declared` `provider_api` block listing all three families. The proof never actually joined: `provider_api.families[].path` was recorded with the `/v2` prefix baked in (`/v2/droplets`, `/v2/vpcs`, `/v2/firewalls`), but the runtime family locator (`canonical_family_locator` in `crates/source-catalog/src/lib.rs`) is built from the source's transport `base_url` (`https://api.digitalocean.com/v2`) joined with the family's *relative* runtime path (`/droplets`, per `internal/connectorcatalog/catalog/devops-ci-cd/digitalocean.yaml`). DigitalOcean families have no per-family `base_url` override, so `verified_families()` compares against the bare relative path only — the `/v2`-prefixed entries could never match, so `provider_contract_verified` was always false.

The fix drops the redundant `/v2` prefix so the declared contract paths match what the runtime actually requests, following the same convention already used by other base_url-with-path-segment sources (`cloudflare` → `/accounts` against `base_url: .../client/v4`, `deepseek` → `/models` against `base_url: .../` etc.).

## Authority proof

Verified all three endpoints directly against the DigitalOcean public OpenAPI spec (the `spec_url` already declared in `provider_api`), independently of any tool summarization — downloaded the full spec and grepped it directly:

- `droplets` → `GET /v2/droplets` (`operationId: droplets_list`), confirmed at line 13296 of `DigitalOcean-public.v2.yaml`
- `vpcs` → `GET /v2/vpcs` (`operationId: vpcs_list`), confirmed at line 35543
- `firewalls` → `GET /v2/firewalls` (`operationId: firewalls_list`), confirmed at line 15819

All three also already appear in `runtime_families`, and `sources/digitalocean/testdata` has both `discover_*` and `read_*` fixtures for each (`discover_droplets.json`, `read_droplets.json`, `discover_vpcs.json`, `read_vpcs.json`, `discover_firewalls.json`, `read_firewalls.json`), so runtime coverage is genuinely backed by fixtures, not just claimed.

Probe test (`crates/source-catalog/tests/wave2_probe.rs`, written, run, then deleted per instructions) confirmed full authority after the fix:

```
family=droplets authoritative=true projection_authoritative=true unsupported_reasons=[]
family=vpcs authoritative=true projection_authoritative=true unsupported_reasons=[]
family=firewalls authoritative=true projection_authoritative=true unsupported_reasons=[]
```

All three DigitalOcean families are now both collection-authoritative and projection-authoritative, so `digitalocean` was added to the `retired_static_loader_sources_are_fully_rust_authoritative` regression test alongside the other fully-authoritative sources.

## Validation

- `cargo test -p cerebro-source-catalog --test wave2_probe -- --nocapture` (probe passed, then file deleted before commit)
- `cargo test -p cerebro-source-catalog --lib retired` — passes with `digitalocean` added
- `cargo test -p cerebro-source-catalog --lib` — all 27 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)