### PR TITLE
catalog(twilio): add provider_api proof for full Rust authority

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -3578,6 +3578,7 @@ mod tests {
             "jira",
             "langchain",
             "openai",
+            "twilio",
         ] {
             let source = catalog.get(source_id).unwrap();
             assert_eq!(

--- a/sources/twilio/catalog.yaml
+++ b/sources/twilio/catalog.yaml
@@ -5,6 +5,32 @@ emitted_kinds:
   - twilio.accounts
   - twilio.keys
   - twilio.audit_events
+provider_api:
+  status: verified
+  basis: declared
+  verified_at: 2026-08-25T00:00:00Z
+  transport: rest
+  auth: basic
+  auth_mechanics: http_basic_account_sid_auth_token_header
+  base_url: https://api.twilio.com
+  spec_url: https://www.twilio.com/docs/iam/api/account
+  spec_kind: api_reference_html
+  references:
+    - https://www.twilio.com/docs/iam/api/account
+    - https://www.twilio.com/docs/iam/api-keys/key-resource-v2010
+    - https://www.twilio.com/docs/usage/monitor-events
+  auth_evidence:
+    - https://www.twilio.com/docs/iam/api/account
+  families:
+    - id: accounts
+      method: GET
+      path: /2010-04-01/Accounts.json
+    - id: keys
+      method: GET
+      path: /2010-04-01/Accounts/${config.account_sid}/Keys.json
+    - id: audit_events
+      method: GET
+      path: /v1/Events
 runtime_families:
   - accounts
   - audit_events


### PR DESCRIPTION
## Summary

Twilio's three compiled families (`accounts`, `keys`, `audit_events`) were missing provider-contract proof, so `verified_families()` returned empty and every family carried `MissingProviderProof` / `IncompleteRuntimeFamilyProof`. This adds a `provider_api` block to `sources/twilio/catalog.yaml` declaring the same method+path already used by `internal/connectorcatalog/catalog/collaboration-productivity/twilio.yaml`, joined against `runtime_families` (unchanged — all three families already had fixture coverage), which lets `verified_families()` prove the provider contract for all three families and closes the authority gap.

## Authority proof

Each family's method+path was verified against Twilio's own documentation before being added to `provider_api.families`:

- `accounts` — `GET /2010-04-01/Accounts.json` — confirmed against https://www.twilio.com/docs/iam/api/account ("Retrieve all Account resources that belong to the account making the API request, including its subaccounts.")
- `keys` — `GET /2010-04-01/Accounts/{AccountSid}/Keys.json` — confirmed against https://www.twilio.com/docs/iam/api-keys/key-resource-v2010 (ListKey operation; `${config.account_sid}` binds to `{AccountSid}`)
- `audit_events` — `GET /v1/Events` — confirmed against https://www.twilio.com/docs/usage/monitor-events ("Returns a list of Events in this account, sorted by `event-date`.")

Note for reviewers: Twilio's Monitor Events resource is actually served from `https://monitor.twilio.com/v1/Events`, a different host than the connector's declared `transport.base_url` (`https://api.twilio.com`). The Rust authority check only compares the family's relative `path` (config-parameter-canonicalized) against `provider_api.families[].path` — it does not join a per-family `base_url` for `audit_events` here, matching the existing pattern used by every other provider's `provider_api` block (e.g. `mailchimp`, `deepseek`) which also list bare relative paths. This is worth a look as a possible separate runtime correctness issue (whether the `audit_events` collector actually resolves against `monitor.twilio.com` at request time), but it is orthogonal to the authority-proof scope of this PR and I did not change collector runtime behavior.

Fixture coverage: `sources/twilio/testdata` already has `discover_accounts.json`/`read_accounts.json`, `discover_keys.json`/`read_keys.json`, and `discover_audit_events.json`/`read_audit_events.json`, so all three families in `runtime_families` are backed by real fixtures — no family was added to `runtime_families` without existing coverage.

Probe results (throwaway `crates/source-catalog/tests/wave2_probe_twilio_only.rs`, deleted before this commit — renamed from the `wave2_probe.rs` the task template suggested because the shared `CARGO_TARGET_DIR` used across concurrently-running sibling tasks produces a colliding artifact hash for that exact filename, corrupting results with another provider's test output; a uniquely-named file avoided the collision and was verified stable across three consecutive runs):

```
family=accounts authoritative=true projection_authoritative=true unsupported_reasons=[]
family=keys authoritative=true projection_authoritative=true unsupported_reasons=[]
family=audit_events authoritative=true projection_authoritative=true unsupported_reasons=[]
```

All three families are now both collection- and projection-authoritative, so `twilio` was added (alphabetical position, after `openai`) to the `retired_static_loader_sources_are_fully_rust_authoritative` regression test.

## Validation

- `cargo test -p cerebro-source-catalog --test wave2_probe_twilio_only -- --nocapture` (throwaway probe, run 4x for stability, deleted before commit)
- `cargo test -p cerebro-source-catalog --lib retired`
- `cargo test -p cerebro-source-catalog --lib` (all 27 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)