### PR TITLE
catalog(increase): promote provider_api basis to declared for full Rust authority

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -3575,6 +3575,7 @@ mod tests {
             "deepseek",
             "duo",
             "fivetran",
+            "increase",
             "jira",
             "langchain",
             "openai",

--- a/sources/increase/catalog.yaml
+++ b/sources/increase/catalog.yaml
@@ -54,17 +54,17 @@ kind_lifecycle:
     status: active
 provider_api:
   status: verified
-  basis: discovered
-  verified_at: 2026-07-04T00:00:00Z
+  basis: declared
+  verified_at: 2026-08-25T00:00:00Z
   transport: rest
   auth: bearer_token
   auth_mechanics: bearer_token_authorization_header
   base_url: https://api.increase.com
-  spec_url: https://api.apis.guru/v2/specs/increase.com/0.0.1/openapi.json
+  spec_url: https://increase.com/openapi.json
   spec_kind: openapi
   references:
-    - https://api.apis.guru/v2/specs/increase.com/0.0.1/openapi.json
     - https://increase.com/openapi.json
+    - https://api.apis.guru/v2/specs/increase.com/0.0.1/openapi.json
   families:
     - id: account
       method: GET


### PR DESCRIPTION
## Summary

The Increase `provider_api` block was pinned to `basis: discovered`, which `verified_families()` in `crates/source-catalog/src/lib.rs` never treats as proof (it requires `status: verified && basis: declared`) regardless of family/runtime coverage. That left all 12 compiled Increase families (`event`, `account`, `digital_wallet_token`, `ach_prenotification`, `oauth_connection`, `event_subscription`, `account_number`, `account_statement`, `account_transfer`, `external_account`, `ach_transfer`, `card`) at `MissingProviderProof`, even though every family already had a correct `method`/`path` entry in `provider_api.families`, was listed in `runtime_families`, and had complete path/query/header/json-body/attribute bindings.

`spec_url` pointed only at a third-party apis.guru mirror. Increase publishes its own first-party OpenAPI spec directly at `https://increase.com/openapi.json`. This change:

- Switches `spec_url` to the first-party `https://increase.com/openapi.json`.
- Keeps the apis.guru mirror as a secondary `references` entry.
- Sets `basis: declared` (matching the pattern used by other first-party-spec sources like `openai`, `tailscale`, `slack`).
- Adds `"increase"` (alphabetical position) to the `retired_static_loader_sources_are_fully_rust_authoritative` regression test, since every family now probes fully authoritative for both collection and projection.

No family entries, paths, or methods were added or changed — only the proof basis and spec source were corrected, because the family list was already complete and correct.

## Authority proof

Fetched `https://increase.com/openapi.json` directly (HTTP 200, 4.1MB, valid OpenAPI 0.0.1 JSON, `info.title: "Increase API"`) and confirmed a `GET` operation exists for all 12 family paths already declared in `provider_api.families`:

| family | method | path | found in spec |
|---|---|---|---|
| account | GET | /accounts | yes |
| account_number | GET | /account_numbers | yes |
| account_statement | GET | /account_statements | yes |
| account_transfer | GET | /account_transfers | yes |
| ach_prenotification | GET | /ach_prenotifications | yes |
| ach_transfer | GET | /ach_transfers | yes |
| card | GET | /cards | yes |
| digital_wallet_token | GET | /digital_wallet_tokens | yes |
| event | GET | /events | yes |
| event_subscription | GET | /event_subscriptions | yes |
| external_account | GET | /external_accounts | yes |
| oauth_connection | GET | /oauth_connections | yes |

Cross-checked against the secondary apis.guru mirror (`https://api.apis.guru/v2/specs/increase.com/0.0.1/openapi.json`, HTTP 200) — same `info.title`/`info.version`, and all 12 paths present there too (as a `GET` operation), though that mirror is a stale/partial snapshot (91 paths vs. 206 in the first-party spec), which is why it stays a secondary reference rather than `spec_url`.

Also confirmed `sources/increase/testdata/` has both `discover_<family>.json` and `read_<family>.json` fixtures for all 12 families, so `runtime_families` reflects genuine fixture-backed runtime coverage, not just a claim.

**Probe results** (throwaway `crates/source-catalog/tests/wave2_probe_increase_xq7.rs`, loading `SourceCatalog::load(...)` and printing `is_authoritative()` / `is_projection_authoritative()` / `unsupported_reasons()` per family, deleted before this commit):

```
family=event authoritative=true projection_authoritative=true reasons=[]
family=account authoritative=true projection_authoritative=true reasons=[]
family=digital_wallet_token authoritative=true projection_authoritative=true reasons=[]
family=ach_prenotification authoritative=true projection_authoritative=true reasons=[]
family=oauth_connection authoritative=true projection_authoritative=true reasons=[]
family=event_subscription authoritative=true projection_authoritative=true reasons=[]
family=account_number authoritative=true projection_authoritative=true reasons=[]
family=account_statement authoritative=true projection_authoritative=true reasons=[]
family=account_transfer authoritative=true projection_authoritative=true reasons=[]
family=external_account authoritative=true projection_authoritative=true reasons=[]
family=ach_transfer authoritative=true projection_authoritative=true reasons=[]
family=card authoritative=true projection_authoritative=true reasons=[]
```

All 12 families are now both collection- and projection-authoritative, unblocking the Increase Go projection writer retirement (stacked PR to follow).

## Validation

```
cargo test -p cerebro-source-catalog --test wave2_probe_increase_xq7 -- --nocapture   # 12/12 families authoritative=true, projection_authoritative=true, reasons=[] (probe file deleted before commit)
cargo test -p cerebro-source-catalog --lib retired                                    # retired_static_loader_sources_are_fully_rust_authoritative ... ok
cargo test -p cerebro-source-catalog --lib                                            # 27 passed; 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)