### PR TITLE
catalog(jumpcloud): close audit_events provider-proof gap for full Rust authority

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -3576,6 +3576,7 @@ mod tests {
             "duo",
             "fivetran",
             "jira",
+            "jumpcloud",
             "langchain",
             "openai",
         ] {

--- a/internal/connectorcatalog/catalog/identity-access-secrets/jumpcloud.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets/jumpcloud.yaml
@@ -351,6 +351,8 @@ entries:
               - id
             schema_ref: jumpcloud/audit_events/v1
             urn_kind: jumpcloud_audit_events
+          config:
+            base_url: https://api.jumpcloud.com/insights/directory/v1
           id: audit_events
           id_field: id
           label: Directory Insights events


### PR DESCRIPTION
## Summary

JumpCloud's `audit_events` family was the only compiled family carrying `MissingProviderProof`. The provider contract proof already declared the correct, verified Directory Insights endpoint in `sources/jumpcloud/catalog.yaml` (`POST https://api.jumpcloud.com/insights/directory/v1/events`), and that entry was already listed in both `runtime_families` and `provider_api.families`. The gap was on the runtime side: the generic compiled family for `audit_events` in `internal/connectorcatalog/catalog/identity-access-secrets/jumpcloud.yaml` had no `config.base_url` override, so it resolved against the source's default `https://console.jumpcloud.com/api` base instead of the Directory Insights host — the two locators (`console.jumpcloud.com/api/events` vs. `api.jumpcloud.com/insights/directory/v1/events`) never matched, so `verified_families()` never joined this family and it stayed unproven.

The fix adds `config.base_url: https://api.jumpcloud.com/insights/directory/v1` to the `audit_events` family definition (the same pattern already used for Slack's `audit_log` family, which overrides `config.base_url` to `https://api.slack.com/audit/v1`). This makes the compiled family's locator (`https://api.jumpcloud.com/insights/directory/v1/events`) match the already-declared, already-verified provider proof exactly.

Also added `jumpcloud` (alphabetical position) to `retired_static_loader_sources_are_fully_rust_authoritative` in `crates/source-catalog/src/lib.rs`, since all 7 jumpcloud families are now collection- and projection-authoritative.

## Authority proof

- Endpoint verified live against `https://jumpcloud.com/support/directory-insights-api` (listed in `provider_api.references`), which states: *"The API uses a single POST endpoint: `https://api.jumpcloud.com/insights/directory/v1/events`."* This matches the `audit_events` entry already present in `sources/jumpcloud/catalog.yaml`'s `provider_api.families` (method `POST`, path `https://api.jumpcloud.com/insights/directory/v1/events`).
- Cross-checked against the bespoke Rust JumpCloud runtime, which independently validates this exact origin: `crates/source-runtime-next/src/jumpcloud/origin.rs` restricts the "insights" origin to hosts `api.jumpcloud.com` / `api.eu.jumpcloud.com` / `api.in.jumpcloud.com` with expected path `/insights/directory/v1`, and `crates/source-runtime-next/src/jumpcloud/family.rs` maps `AuditEvents` to path `/events` on that origin — i.e. the same URL now declared for the generic compiled family.
- Fixture coverage confirmed: `sources/jumpcloud/testdata/discover_audit_events.json`, `read_audit_events.json`, and `idless_audit_events.json` already exist, so `audit_events` in `runtime_families` is backed by real fixtures.
- No other jumpcloud family needed a proof change — `users`, `groups`, `systems`, `applications`, `system_groups`, and `group_members` were already correctly bound (relative paths against the source's default `https://console.jumpcloud.com/api` base, matching their `provider_api.families` entries).

Probe results (via a throwaway `crates/source-catalog/tests/wave2_probe.rs`, deleted before commit) after the fix, for every jumpcloud family:

```
family=users authoritative=true projection_authoritative=true unsupported_reasons=[]
family=groups authoritative=true projection_authoritative=true unsupported_reasons=[]
family=systems authoritative=true projection_authoritative=true unsupported_reasons=[]
family=applications authoritative=true projection_authoritative=true unsupported_reasons=[]
family=system_groups authoritative=true projection_authoritative=true unsupported_reasons=[]
family=group_members authoritative=true projection_authoritative=true unsupported_reasons=[]
family=audit_events authoritative=true projection_authoritative=true unsupported_reasons=[]
```

## Validation

- `cargo test -p cerebro-source-catalog --test wave2_probe -- --nocapture` (probe, deleted before commit) — all 7 jumpcloud families authoritative=true, projection_authoritative=true, unsupported_reasons=[]
- `cargo test -p cerebro-source-catalog --lib retired` — `retired_static_loader_sources_are_fully_rust_authoritative` passes with `jumpcloud` added
- `cargo test -p cerebro-source-catalog` — full crate suite passes (27 lib tests + contract tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)