### PR TITLE
refactor(sources): retire DigitalOcean Go projection writer

### DIFF
--- a/internal/sourceprojection/digitalocean.go
+++ b/internal/sourceprojection/digitalocean.go
@@ -1,96 +1,22 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func digitaloceanDropletsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenant, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	dropletURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenant, "digitalocean_droplets", attributes["resource_id"]))
-	if dropletURN == "" {
-		return nil, nil, nil
-	}
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        dropletURN,
-		TenantID:   tenant,
-		SourceID:   event.GetSourceId(),
-		EntityType: "runtime.compute.droplet",
-		Label:      firstNonEmpty(attributes["resource_name"], attributes["resource_id"]),
-		Attributes: map[string]string{"resource_id": attributes["resource_id"], "resource_type": "droplet", "region": attributes["region"]},
-	})
-	if vpc := strings.TrimSpace(attributes["vpc_uuid"]); vpc != "" {
-		if vpcURN := projectionURN(tenant, "digitalocean_vpcs", vpc); vpcURN != "" {
-			addLink(links, projectedLink(tenant, event.GetSourceId(), dropletURN, vpcURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
-		}
-	}
-	return identityProjectionResult(entities, links)
+var errDigitalOceanRustProjectionRequired = errors.New("digitalocean projection requires Rust authority")
+
+func digitaloceanDropletsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errDigitalOceanRustProjectionRequired
 }
 
-func digitaloceanVPCsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenant, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	vpcURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenant, "digitalocean_vpcs", attributes["resource_id"]))
-	if vpcURN == "" {
-		return nil, nil, nil
-	}
-	entities := map[string]*ports.ProjectedEntity{}
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        vpcURN,
-		TenantID:   tenant,
-		SourceID:   event.GetSourceId(),
-		EntityType: "runtime.network.vpc",
-		Label:      firstNonEmpty(attributes["resource_name"], attributes["resource_id"]),
-		Attributes: map[string]string{"resource_id": attributes["resource_id"], "resource_type": "vpc", "region": attributes["region"]},
-	})
-	return identityProjectionResult(entities, map[string]*ports.ProjectedLink{})
+func digitaloceanVPCsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errDigitalOceanRustProjectionRequired
 }
 
-func digitaloceanFirewallsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenant, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	firewallURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenant, "digitalocean_firewalls", attributes["resource_id"]))
-	if firewallURN == "" {
-		return nil, nil, nil
-	}
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	public := strings.EqualFold(strings.TrimSpace(attributes["public_ingress"]), "true")
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        firewallURN,
-		TenantID:   tenant,
-		SourceID:   event.GetSourceId(),
-		EntityType: "runtime.network.firewall",
-		Label:      firstNonEmpty(attributes["resource_name"], attributes["resource_id"]),
-		Attributes: map[string]string{"resource_id": attributes["resource_id"], "resource_type": "firewall", "public_ingress": attributes["public_ingress"]},
-	})
-	for _, raw := range strings.Split(attributes["droplet_ids"], ",") {
-		dropletID := strings.TrimSpace(raw)
-		if dropletID == "" {
-			continue
-		}
-		dropletURN := projectionURN(tenant, "digitalocean_droplets", dropletID)
-		if dropletURN == "" {
-			continue
-		}
-		addLink(links, projectedLink(tenant, event.GetSourceId(), firewallURN, dropletURN, relationAttachedTo, map[string]string{"event_id": event.GetId()}))
-		if public {
-			addLink(links, projectedLink(tenant, event.GetSourceId(), firewallURN, dropletURN, relationCanReach, map[string]string{"event_id": event.GetId(), "exposure": "public"}))
-		}
-	}
-	return identityProjectionResult(entities, links)
+func digitaloceanFirewallsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errDigitalOceanRustProjectionRequired
 }

--- a/internal/sourceprojection/digitalocean_test.go
+++ b/internal/sourceprojection/digitalocean_test.go
@@ -1,62 +1,27 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestDigitaloceanDropletProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{
-		Id: "event-1", TenantId: "tenant", SourceId: "digitalocean", Kind: "digitalocean.droplets",
-		Attributes: map[string]string{"resource_id": "3164444", "resource_type": "droplet", "resource_name": "web-01", "vpc_uuid": "vpc-1111", "region": "nyc3"},
-	}
-	entities, links, err := digitaloceanDropletsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected droplet entity")
-	}
-	dropletURN := projectionURN("tenant", "digitalocean_droplets", "3164444")
-	vpcURN := projectionURN("tenant", "digitalocean_vpcs", "vpc-1111")
-	if !projectedLinksContain(links, dropletURN, relationBelongsTo, vpcURN) {
-		t.Fatalf("expected droplet %q belongs_to vpc %q, got %+v", dropletURN, vpcURN, links)
-	}
-}
-
-func TestDigitaloceanVPCProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{
-		Id: "event-1", TenantId: "tenant", SourceId: "digitalocean", Kind: "digitalocean.vpcs",
-		Attributes: map[string]string{"resource_id": "vpc-1111", "resource_type": "vpc", "resource_name": "default-nyc3", "region": "nyc3"},
-	}
-	entities, _, err := digitaloceanVPCsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected vpc entity")
-	}
-}
-
-func TestDigitaloceanFirewallProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{
-		Id: "event-1", TenantId: "tenant", SourceId: "digitalocean", Kind: "digitalocean.firewalls",
-		Attributes: map[string]string{"resource_id": "fw-2222", "resource_type": "firewall", "resource_name": "web-fw", "droplet_ids": "3164444,3164445", "public_ingress": "true"},
-	}
-	entities, links, err := digitaloceanFirewallsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected firewall entity")
-	}
-	firewallURN := projectionURN("tenant", "digitalocean_firewalls", "fw-2222")
-	dropletURN := projectionURN("tenant", "digitalocean_droplets", "3164444")
-	if !projectedLinksContain(links, firewallURN, relationCanReach, dropletURN) {
-		t.Fatalf("expected firewall %q can_reach droplet %q, got %+v", firewallURN, dropletURN, links)
-	}
-	if !projectedLinksContain(links, firewallURN, relationAttachedTo, dropletURN) {
-		t.Fatalf("expected firewall %q attached_to droplet %q", firewallURN, dropletURN)
+func TestDigitalOceanGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{"digitalocean.droplets", "digitalocean.vpcs", "digitalocean.firewalls"} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "digitalocean",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errDigitalOceanRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

DigitalOcean's `droplets`, `vpcs`, and `firewalls` families are now fully collection- and projection-authoritative in the Rust source catalog (see stacked authority PR #2716), so the Go projection writer in `internal/sourceprojection/digitalocean.go` is redundant and now retired following the same pattern used for `deepseek` (`internal/sourceprojection/deepseek.go` / `deepseek_test.go`).

Each projection function (`digitaloceanDropletsProjections`, `digitaloceanVPCsProjections`, `digitaloceanFirewallsProjections`) keeps its exact name and signature — so `registry_builtins.go` wiring is untouched — but now unconditionally fails closed with a new typed error `errDigitalOceanRustProjectionRequired`, rather than doing entity/link projection in Go. The previous entity/link construction logic (droplet-to-VPC `belongs_to`, firewall-to-droplet `attached_to`/`can_reach`) is fully superseded by the Rust runtime's authoritative collection + projection path.

The `strings`-based helper logic that only DigitalOcean used is removed along with it; all other helpers referenced (`projectionURN`, `addEntity`, `addLink`, `projectedLink`, `identityProjectionResult`, `relationBelongsTo`, `relationAttachedTo`, `relationCanReach`, `tenantID`, `firstNonEmpty`, `projectedLinksContain`) are shared across many other providers (verified via grep across `internal/sourceprojection`) and are left untouched.

## Authority proof

Stacked on #2716, which made all three DigitalOcean families (`droplets`, `vpcs`, `firewalls`) both collection-authoritative and projection-authoritative in `crates/source-catalog/src/lib.rs`, verified against the DigitalOcean public OpenAPI spec (`droplets_list` → `GET /v2/droplets`, `vpcs_list` → `GET /v2/vpcs`, `firewalls_list` → `GET /v2/firewalls`) and backed by fixture coverage in `sources/digitalocean/testdata`. `digitalocean` was added to the `retired_static_loader_sources_are_fully_rust_authoritative` regression test in that PR. This PR will retarget to `main` once #2716 merges.

## Validation

- `gofmt -l internal/sourceprojection` — empty
- `go build ./internal/sourceprojection` — passes
- `go test ./internal/sourceprojection -count=1` — passes
- `go test ./internal/sourceregistry -run TestBuiltinRetiresCoveredProviderGoLoaders -count=1` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)