### PR TITLE
Decouple effective access from raw Cypher capability

### DIFF
--- a/internal/graphquery/effective_access.go
+++ b/internal/graphquery/effective_access.go
@@ -321,10 +321,13 @@ func EffectiveAccessPathRequestFromQuery(values url.Values) (EffectiveAccessPath
 }
 
 func (s *Service) GetEffectiveAccessPaths(ctx context.Context, request EffectiveAccessPathRequest) (*EffectiveAccessPathResult, error) {
-	if s == nil || s.rawCypher == nil {
+	if s == nil {
 		return nil, ErrRuntimeUnavailable
 	}
-	typedStore, ok := s.rawCypher.(ports.EffectiveAccessPathStore)
+	typedStore, ok := s.neighborhoods.(ports.EffectiveAccessPathStore)
+	if !ok || typedStore == nil {
+		typedStore, ok = s.rawCypher.(ports.EffectiveAccessPathStore)
+	}
 	if !ok || typedStore == nil {
 		return nil, ErrRuntimeUnavailable
 	}

--- a/internal/graphquery/effective_access_test.go
+++ b/internal/graphquery/effective_access_test.go
@@ -100,6 +100,36 @@ func TestGetEffectiveAccessPathsUsesTypedFixtureAndPreservesLegacyShape(t *testi
 	}
 }
 
+type typedOnlyEffectiveAccessStore struct {
+	requests []ports.EffectiveAccessPathRequest
+	result   *ports.EffectiveAccessPathResult
+}
+
+func (s *typedOnlyEffectiveAccessStore) Ping(context.Context) error { return nil }
+
+func (s *typedOnlyEffectiveAccessStore) GetEntityNeighborhood(context.Context, string, int) (*ports.EntityNeighborhood, error) {
+	return nil, nil
+}
+
+func (s *typedOnlyEffectiveAccessStore) ListEffectiveAccessPaths(_ context.Context, request ports.EffectiveAccessPathRequest) (*ports.EffectiveAccessPathResult, error) {
+	s.requests = append(s.requests, request)
+	return s.result, nil
+}
+
+func TestGetEffectiveAccessPathsDoesNotRequireRawCypherCapability(t *testing.T) {
+	store := &typedOnlyEffectiveAccessStore{result: effectiveAccessTypedFixtureResult()}
+	result, err := New(store).GetEffectiveAccessPaths(context.Background(), EffectiveAccessPathRequest{
+		TenantID:      "writer",
+		IdentityQuery: "alice",
+	})
+	if err != nil {
+		t.Fatalf("GetEffectiveAccessPaths() error = %v", err)
+	}
+	if len(store.requests) != 1 || result == nil || len(result.Paths) != 1 {
+		t.Fatalf("typed requests = %d, result = %#v; want one typed request and path", len(store.requests), result)
+	}
+}
+
 func TestGetEffectiveAccessPathsRejectsInvalidTypedPath(t *testing.T) {
 	fixture := effectiveAccessTypedFixtureResult()
 	fixture.Paths[0].RelationChain = []string{"assigned_to"}


### PR DESCRIPTION
## Summary

- resolve the typed effective-access operation from the Rust neighborhood capability before the compatibility raw-query capability
- keep raw-only stores fail closed without executing Cypher
- add a typed-only regression fixture that proves the route works after raw-query capability removal

## Validation

- go test ./internal/graphquery -count=1
- go test ./internal/bootstrap -run '^TestGraphEffectiveAccessPathsEndpoint$' -count=1
- go test -race ./internal/graphquery -run '^TestGetEffectiveAccessPaths' -count=1
- make check-structural check-structural-test check-arch
- post-rebase focused effective-access test

The bounded DDESK retry remained in capacity reservation and did not reach compilation. Hosted checks are the full execution-environment receipt.