### PR TITLE
refactor(sources): forward DigitalOcean Go projection retirement

### DIFF
--- a/internal/sourceprojection/digitalocean.go
+++ b/internal/sourceprojection/digitalocean.go
@@ -1,96 +1,22 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func digitaloceanDropletsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenant, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	dropletURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenant, "digitalocean_droplets", attributes["resource_id"]))
-	if dropletURN == "" {
-		return nil, nil, nil
-	}
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        dropletURN,
-		TenantID:   tenant,
-		SourceID:   event.GetSourceId(),
-		EntityType: "runtime.compute.droplet",
-		Label:      firstNonEmpty(attributes["resource_name"], attributes["resource_id"]),
-		Attributes: map[string]string{"resource_id": attributes["resource_id"], "resource_type": "droplet", "region": attributes["region"]},
-	})
-	if vpc := strings.TrimSpace(attributes["vpc_uuid"]); vpc != "" {
-		if vpcURN := projectionURN(tenant, "digitalocean_vpcs", vpc); vpcURN != "" {
-			addLink(links, projectedLink(tenant, event.GetSourceId(), dropletURN, vpcURN, relationBelongsTo, map[string]string{"event_id": event.GetId()}))
-		}
-	}
-	return identityProjectionResult(entities, links)
+var errDigitalOceanRustProjectionRequired = errors.New("digitalocean projection requires Rust authority")
+
+func digitaloceanDropletsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errDigitalOceanRustProjectionRequired
 }
 
-func digitaloceanVPCsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenant, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	vpcURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenant, "digitalocean_vpcs", attributes["resource_id"]))
-	if vpcURN == "" {
-		return nil, nil, nil
-	}
-	entities := map[string]*ports.ProjectedEntity{}
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        vpcURN,
-		TenantID:   tenant,
-		SourceID:   event.GetSourceId(),
-		EntityType: "runtime.network.vpc",
-		Label:      firstNonEmpty(attributes["resource_name"], attributes["resource_id"]),
-		Attributes: map[string]string{"resource_id": attributes["resource_id"], "resource_type": "vpc", "region": attributes["region"]},
-	})
-	return identityProjectionResult(entities, map[string]*ports.ProjectedLink{})
+func digitaloceanVPCsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errDigitalOceanRustProjectionRequired
 }
 
-func digitaloceanFirewallsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenant, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	firewallURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenant, "digitalocean_firewalls", attributes["resource_id"]))
-	if firewallURN == "" {
-		return nil, nil, nil
-	}
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	public := strings.EqualFold(strings.TrimSpace(attributes["public_ingress"]), "true")
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        firewallURN,
-		TenantID:   tenant,
-		SourceID:   event.GetSourceId(),
-		EntityType: "runtime.network.firewall",
-		Label:      firstNonEmpty(attributes["resource_name"], attributes["resource_id"]),
-		Attributes: map[string]string{"resource_id": attributes["resource_id"], "resource_type": "firewall", "public_ingress": attributes["public_ingress"]},
-	})
-	for _, raw := range strings.Split(attributes["droplet_ids"], ",") {
-		dropletID := strings.TrimSpace(raw)
-		if dropletID == "" {
-			continue
-		}
-		dropletURN := projectionURN(tenant, "digitalocean_droplets", dropletID)
-		if dropletURN == "" {
-			continue
-		}
-		addLink(links, projectedLink(tenant, event.GetSourceId(), firewallURN, dropletURN, relationAttachedTo, map[string]string{"event_id": event.GetId()}))
-		if public {
-			addLink(links, projectedLink(tenant, event.GetSourceId(), firewallURN, dropletURN, relationCanReach, map[string]string{"event_id": event.GetId(), "exposure": "public"}))
-		}
-	}
-	return identityProjectionResult(entities, links)
+func digitaloceanFirewallsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errDigitalOceanRustProjectionRequired
 }

--- a/internal/sourceprojection/digitalocean_test.go
+++ b/internal/sourceprojection/digitalocean_test.go
@@ -1,62 +1,27 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestDigitaloceanDropletProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{
-		Id: "event-1", TenantId: "tenant", SourceId: "digitalocean", Kind: "digitalocean.droplets",
-		Attributes: map[string]string{"resource_id": "3164444", "resource_type": "droplet", "resource_name": "web-01", "vpc_uuid": "vpc-1111", "region": "nyc3"},
-	}
-	entities, links, err := digitaloceanDropletsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected droplet entity")
-	}
-	dropletURN := projectionURN("tenant", "digitalocean_droplets", "3164444")
-	vpcURN := projectionURN("tenant", "digitalocean_vpcs", "vpc-1111")
-	if !projectedLinksContain(links, dropletURN, relationBelongsTo, vpcURN) {
-		t.Fatalf("expected droplet %q belongs_to vpc %q, got %+v", dropletURN, vpcURN, links)
-	}
-}
-
-func TestDigitaloceanVPCProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{
-		Id: "event-1", TenantId: "tenant", SourceId: "digitalocean", Kind: "digitalocean.vpcs",
-		Attributes: map[string]string{"resource_id": "vpc-1111", "resource_type": "vpc", "resource_name": "default-nyc3", "region": "nyc3"},
-	}
-	entities, _, err := digitaloceanVPCsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected vpc entity")
-	}
-}
-
-func TestDigitaloceanFirewallProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{
-		Id: "event-1", TenantId: "tenant", SourceId: "digitalocean", Kind: "digitalocean.firewalls",
-		Attributes: map[string]string{"resource_id": "fw-2222", "resource_type": "firewall", "resource_name": "web-fw", "droplet_ids": "3164444,3164445", "public_ingress": "true"},
-	}
-	entities, links, err := digitaloceanFirewallsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected firewall entity")
-	}
-	firewallURN := projectionURN("tenant", "digitalocean_firewalls", "fw-2222")
-	dropletURN := projectionURN("tenant", "digitalocean_droplets", "3164444")
-	if !projectedLinksContain(links, firewallURN, relationCanReach, dropletURN) {
-		t.Fatalf("expected firewall %q can_reach droplet %q, got %+v", firewallURN, dropletURN, links)
-	}
-	if !projectedLinksContain(links, firewallURN, relationAttachedTo, dropletURN) {
-		t.Fatalf("expected firewall %q attached_to droplet %q", firewallURN, dropletURN)
+func TestDigitalOceanGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{"digitalocean.droplets", "digitalocean.vpcs", "digitalocean.firewalls"} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "digitalocean",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errDigitalOceanRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Removes the production Go projection implementations for DigitalOcean droplets, VPCs, and firewalls.
- Keeps the generated registry entry points but makes each Go path fail closed with errDigitalOceanRustProjectionRequired.
- Preserves the projection oracle as a fail-closed test and does not change shared registries, generators, source catalogs, or other providers.
- Net diff: 26 additions and 135 deletions; production Go is 9 additions and 83 deletions.

## Forward receipt

PR #2721 head a1e6896a5653ff36f214575e6bc0f2ad80149ef2 was merged as 70b60990ae34a83bc71eb1845673dace28c2bb07 into claude/digitalocean-rust-authority rather than main. At refreshed main fefda4b24c3785ce27f8b308229eb53c17a07cec, git merge-base --is-ancestor returned 1. This pull request carries the exact two-file deletion diff forward from current main; it does not revert or alter the merged feature branch.

## Authority boundary

DigitalOcean droplets, VPCs, and firewalls are already collection- and projection-authoritative in the Rust source catalog from #2716. The Go registry symbols remain for public/generated compatibility only and cannot write when invoked.

## Validation

Mac recovery environment after two DDESK workspace reservations did not produce a usable terminal; DDESK status and doctor were otherwise green.

- go test ./internal/sourceprojection -run TestDigitalOceanGoProjectionFailsClosedForRustAuthoritativeFamilies -count=1 -v
- go test -race ./internal/sourceprojection -run TestDigitalOceanGoProjectionFailsClosedForRustAuthoritativeFamilies -count=1 -v
- go test ./internal/sourceregistry -run TestBuiltinRetiresCoveredProviderGoLoaders -count=1 -v

All three passed. Broader validation and hosted exact-head checks will continue on this draft.