### PR TITLE
Fix Rust graph qualification route ownership

### DIFF
--- a/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
+++ b/crates/cerebro-platform/tests/rust_only_runtime_contract.rs
@@ -1,5 +1,7 @@
 #![forbid(unsafe_code)]
 
+use std::process::Command;
+
 const DOCKERFILE: &str = include_str!("../../../Dockerfile.rust");
 const WORKFLOW: &str = include_str!("../../../.github/workflows/rust-only-candidate.yml");
 const REPLACEMENT_WORKFLOW: &str =
@@ -11,6 +13,7 @@ const WORKSPACE_LOCK: &str = include_str!("../../../Cargo.lock");
 const MAKEFILE: &str = include_str!("../../../Makefile");
 const RUST_CODEGEN: &str = include_str!("../../../buf.gen.rust.yaml");
 const QUALIFICATION_SCRIPT: &str = include_str!("../../../scripts/qualify-rust-graph.sh");
+const TENANT_AUTH_HELPER: &str = include_str!("../../../scripts/lib/rust-tenant-auth.sh");
 const CONNECTRPC_REVISION: &str = "8b3c3b05d3b54af547477a9e3b3a77d62f68e229";
 const BUFFA_VERSION: &str = "0.9.1";
 
@@ -124,8 +127,14 @@ fn rust_candidate_build_never_invokes_go_or_emulation() {
 fn graph_qualification_stays_on_retired_rust_authority_path() {
     for required in [
         "export CEREBRO_RUST_READ_MODE=authority",
+        "graph_url=\"${rust_graph_base}/platform/graph/neighborhood",
+        "assert_status 404 retired-go-graph-before",
         "cmp \"${output_dir}/authority-graph-response-after-restart.canonical.json\"",
-        "assert_status 503 graph-authority-without-rust",
+        "assert_status 503 readiness-authority-without-rust",
+        "assert_status 000 rust-graph-authority-without-rust",
+        "assert_status 404 retired-go-graph-without-rust",
+        "\"${graph_bearer}\" \"${graph_tenant}\"",
+        "--header \"X-Cerebro-Tenant: ${graph_tenant}\"",
     ] {
         assert!(
             QUALIFICATION_SCRIPT.contains(required),
@@ -144,12 +153,71 @@ fn graph_qualification_stays_on_retired_rust_authority_path() {
         "verified_canary_restart",
         "canary_legacy_isolation",
         "canary_rust_fail_closed",
+        "graph_url=\"http://127.0.0.1:8080",
+        "assert_status 503 graph-authority-without-rust",
     ] {
         assert!(
             !QUALIFICATION_SCRIPT.contains(forbidden),
             "Rust graph qualification retained removed Go canary setup {forbidden:?}"
         );
     }
+}
+
+#[test]
+fn graph_qualification_tenant_auth_matches_the_rust_contract() {
+    for required in [
+        "cerebro-organizational-graph/tenant/v1\\0",
+        "printf -v tenant_length_hex '%016x'",
+        "openssl dgst -sha256 -hmac",
+        "Rust graph shared secret must be at least 32 bytes",
+    ] {
+        assert!(
+            TENANT_AUTH_HELPER.contains(required),
+            "Rust graph qualification tenant auth is missing {required:?}"
+        );
+    }
+
+    let helper = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../scripts/lib/rust-tenant-auth.sh"
+    );
+    let valid = Command::new("bash")
+        .args([
+            "-c",
+            "source \"$1\"; cerebro_rust_tenant_bearer \"$2\" \"$3\"",
+            "tenant-auth-test",
+            helper,
+            "test-organizational-graph-secret-32-bytes",
+            "tenant-a",
+        ])
+        .output()
+        .expect("run Rust graph tenant auth helper");
+    assert!(
+        valid.status.success(),
+        "tenant auth helper failed: {}",
+        String::from_utf8_lossy(&valid.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(valid.stdout).unwrap().trim(),
+        "34b1625abbaa7a28cbca5f0a4803c1ba5360a998e5cc2f5b28d37bd32ba131d6"
+    );
+
+    let short_secret = Command::new("bash")
+        .args([
+            "-c",
+            "source \"$1\"; cerebro_rust_tenant_bearer \"$2\" \"$3\"",
+            "tenant-auth-test",
+            helper,
+            "too-short",
+            "tenant-a",
+        ])
+        .output()
+        .expect("run Rust graph tenant auth helper with short secret");
+    assert!(!short_secret.status.success());
+    assert_eq!(
+        String::from_utf8(short_secret.stderr).unwrap().trim(),
+        "Rust graph shared secret must be at least 32 bytes"
+    );
 }
 
 #[test]

--- a/crates/source-runtime-next/src/cloudflare/tests.rs
+++ b/crates/source-runtime-next/src/cloudflare/tests.rs
@@ -153,7 +153,7 @@ fn checked_in_catalog_compiles_the_closed_cloudflare_runtime() {
     .unwrap();
     let source = catalog.get("cloudflare").unwrap();
     assert_eq!(source.auth(), &AuthModel::BearerToken);
-    assert_eq!(source.authority(), CollectionAuthority::ShadowOnly);
+    assert_eq!(source.authority(), CollectionAuthority::Authoritative);
     let compiled = source
         .families()
         .iter()
@@ -165,7 +165,7 @@ fn checked_in_catalog_compiles_the_closed_cloudflare_runtime() {
         .collect::<std::collections::BTreeSet<_>>();
     assert_eq!(compiled, expected);
     for family in source.families() {
-        assert!(!family.is_authoritative(), "{} collection", family.id());
+        assert!(family.is_authoritative(), "{} collection", family.id());
         assert!(
             family.is_projection_authoritative(),
             "{} projection",

--- a/scripts/lib/rust-tenant-auth.sh
+++ b/scripts/lib/rust-tenant-auth.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Shared tenant authentication for direct Rust platform qualification probes.
+# The message framing must stay byte-for-byte compatible with TenantRequestAuth.
+cerebro_rust_tenant_bearer() {
+  local secret="${1:?shared secret is required}"
+  local tenant="${2:?tenant ID is required}"
+  local secret_bytes
+  local tenant_bytes
+  local tenant_length_hex
+  local tenant_length_escapes=""
+  local offset
+  local digest
+
+  secret_bytes="$(printf '%s' "${secret}" | LC_ALL=C wc -c | tr -d '[:space:]')"
+  if ((secret_bytes < 32)); then
+    echo "Rust graph shared secret must be at least 32 bytes" >&2
+    return 1
+  fi
+
+  tenant_bytes="$(printf '%s' "${tenant}" | LC_ALL=C wc -c | tr -d '[:space:]')"
+  printf -v tenant_length_hex '%016x' "${tenant_bytes}"
+  for ((offset = 0; offset < 16; offset += 2)); do
+    tenant_length_escapes+="\\x${tenant_length_hex:offset:2}"
+  done
+
+  digest="$({
+    printf 'cerebro-organizational-graph/tenant/v1\0'
+    printf '%b' "${tenant_length_escapes}"
+    printf '%s' "${tenant}"
+  } | openssl dgst -sha256 -hmac "${secret}" -r)"
+  digest="${digest%% *}"
+  if ! [[ "${digest}" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "Unable to derive Rust graph tenant authentication" >&2
+    return 1
+  fi
+  printf '%s\n' "${digest}"
+}

--- a/scripts/qualify-rust-graph.sh
+++ b/scripts/qualify-rust-graph.sh
@@ -10,6 +10,10 @@ readonly repository_root="${CEREBRO_REPOSITORY_ROOT:-$(pwd)}"
 readonly output_dir="${CEREBRO_QUALIFICATION_OUTPUT:-${repository_root}/.dist/pr-rust-graph}"
 readonly compose_project="${COMPOSE_PROJECT_NAME:-cerebro-rust-graph-${RANDOM}}"
 readonly soak_seconds="${SOAK_SECONDS:-60}"
+readonly rust_graph_port="${CEREBRO_RUST_PORT:-18081}"
+readonly rust_graph_base="http://127.0.0.1:${rust_graph_port}"
+readonly go_api_base="http://127.0.0.1:8080"
+readonly graph_tenant="rust-e2e"
 graph_secret="$(openssl rand -hex 32)"
 readonly graph_secret
 readonly auth_header_name="Authorization"
@@ -20,6 +24,10 @@ readonly qualification_receipt="${output_dir}/receipt.json"
 readonly service_logs="${output_dir}/service-logs.txt"
 readonly compose_files=(-f "${repository_root}/docker-compose.yml" -f "${repository_root}/docker-compose.rust.yml")
 
+source "${repository_root}/scripts/lib/rust-tenant-auth.sh"
+graph_bearer="$(cerebro_rust_tenant_bearer "${graph_secret}" "${graph_tenant}")"
+readonly graph_bearer
+
 if ! [[ "${CEREBRO_QUALIFICATION_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
   echo "CEREBRO_QUALIFICATION_SHA must be an exact 40-character commit" >&2
   exit 1
@@ -28,12 +36,18 @@ if ! [[ "${soak_seconds}" =~ ^[0-9]+$ ]] || ((soak_seconds < 60 || soak_seconds 
   echo "SOAK_SECONDS must be between 60 and 1800" >&2
   exit 1
 fi
+if ! [[ "${rust_graph_port}" =~ ^[0-9]+$ ]] ||
+  ((rust_graph_port < 1 || rust_graph_port > 65535)); then
+  echo "CEREBRO_RUST_PORT must be a valid TCP port" >&2
+  exit 1
+fi
 
 mkdir -p "${output_dir}"
 export COMPOSE_PROJECT_NAME="${compose_project}"
 export CEREBRO_RUST_COMMAND=serve-neo4j-consumer
 export CEREBRO_RUST_READ_MODE=authority
 export CEREBRO_RUST_GRAPH_SECRET="${graph_secret}"
+export CEREBRO_RUST_PORT="${rust_graph_port}"
 
 cleanup() {
   local exit_code=$?
@@ -59,7 +73,7 @@ run_harness() {
   CEREBRO_TEST_NEO4J_USERNAME=neo4j \
   CEREBRO_TEST_NEO4J_PASSWORD=local-password \
   CEREBRO_TEST_NATS_URL='nats://127.0.0.1:4222' \
-  CEREBRO_TEST_GRAPH_URL='http://127.0.0.1:18081' \
+  CEREBRO_TEST_GRAPH_URL="${rust_graph_base}" \
   CEREBRO_ORGANIZATIONAL_GRAPH_SHARED_SECRET="${graph_secret}" \
   CEREBRO_TEST_COMMIT="${CEREBRO_QUALIFICATION_SHA}" \
   CEREBRO_TEST_IMAGE="${CEREBRO_RUST_IMAGE}" \
@@ -93,7 +107,8 @@ validate_entity_id canonical_identity_id "${canonical_id}"
 root_urn="urn:cerebro:rust-e2e:organizational_entity:${root_id}"
 canonical_urn="urn:cerebro:rust-e2e:organizational_entity:${canonical_id}"
 encoded_root="$(jq -rn --arg value "${root_urn}" '$value|@uri')"
-graph_url="http://127.0.0.1:8080/platform/graph/neighborhood?root_urn=${encoded_root}&limit=10"
+graph_url="${rust_graph_base}/platform/graph/neighborhood?root_urn=${encoded_root}&limit=10"
+retired_go_graph_url="${go_api_base}/platform/graph/neighborhood?root_urn=${encoded_root}&limit=10"
 
 neo4j_container="$(docker compose "${compose_files[@]}" ps -q neo4j)"
 test -n "${neo4j_container}"
@@ -116,9 +131,15 @@ request_status() {
   local output="$1"
   local url="$2"
   local api_key="${3:-local-dev-key}"
+  local tenant="${4:-}"
+  local headers=(--header "${auth_header_name}: ${auth_scheme} ${api_key}")
+  if [[ -n "${tenant}" ]]; then
+    headers+=(--header "X-Cerebro-Tenant: ${tenant}")
+  fi
+  : >"${output}"
   curl --max-time 10 --silent --show-error --output "${output}" \
     --write-out '%{http_code} %{time_total}' \
-    --header "${auth_header_name}: ${auth_scheme} ${api_key}" \
+    "${headers[@]}" \
     "${url}"
 }
 
@@ -128,8 +149,9 @@ assert_status() {
   local output="$3"
   local url="$4"
   local api_key="${5:-local-dev-key}"
+  local tenant="${6:-}"
   local observed
-  observed="$(request_status "${output}" "${url}" "${api_key}" || true)"
+  observed="$(request_status "${output}" "${url}" "${api_key}" "${tenant}" || true)"
   echo "${label}: ${observed}"
   if [[ "${observed%% *}" != "${expected}" ]]; then
     cat "${output}" >&2 || true
@@ -137,8 +159,11 @@ assert_status() {
   fi
 }
 
-assert_status 200 readiness-before "${output_dir}/readiness.json" http://127.0.0.1:8080/health
-assert_status 200 graph-before "${output_dir}/graph-response.json" "${graph_url}"
+assert_status 200 readiness-before "${output_dir}/readiness.json" "${go_api_base}/health"
+assert_status 404 retired-go-graph-before "${output_dir}/retired-go-graph-response.txt" \
+  "${retired_go_graph_url}"
+assert_status 200 graph-before "${output_dir}/graph-response.json" "${graph_url}" \
+  "${graph_bearer}" "${graph_tenant}"
 jq -e --arg root "${root_urn}" '
   .root.urn == $root
   and ([.relations[] | select(.relation == "represents")] | length) >= 1
@@ -155,7 +180,8 @@ while ((SECONDS < deadline)); do
     --show-error \
     --output /dev/null \
     --write-out '%{http_code}\n' \
-    --header "${auth_header_name}: ${auth_scheme} local-dev-key" \
+    --header "${auth_header_name}: ${auth_scheme} ${graph_bearer}" \
+    --header "X-Cerebro-Tenant: ${graph_tenant}" \
     "${graph_url}" >>"${output_dir}/authority-statuses.txt" || true
   request_count=$((request_count + 2))
   sleep 1
@@ -175,8 +201,10 @@ for attempt in $(seq 1 36); do
   test "${attempt}" -lt 36
   sleep 5
 done
-assert_status 200 readiness-after-restart "${output_dir}/readiness.json" http://127.0.0.1:8080/health
-assert_status 200 graph-after-restart "${output_dir}/authority-graph-response-after-restart.json" "${graph_url}"
+assert_status 200 readiness-after-restart "${output_dir}/readiness.json" "${go_api_base}/health"
+assert_status 200 graph-after-restart \
+  "${output_dir}/authority-graph-response-after-restart.json" "${graph_url}" \
+  "${graph_bearer}" "${graph_tenant}"
 jq -S . "${output_dir}/authority-graph-response-after-restart.json" \
   >"${output_dir}/authority-graph-response-after-restart.canonical.json"
 cmp "${output_dir}/authority-graph-response.json" \
@@ -190,8 +218,9 @@ test "$(jq '[.checks[] | select(.status == "passed")] | length' "${organizationa
 
 export CEREBRO_RUST_READ_MODE=authority
 docker compose "${compose_files[@]}" up -d --force-recreate --wait cerebro
-assert_status 200 readiness-authority "${output_dir}/readiness.json" http://127.0.0.1:8080/health
-assert_status 200 graph-authority "${output_dir}/authority-graph-response.json" "${graph_url}"
+assert_status 200 readiness-authority "${output_dir}/readiness.json" "${go_api_base}/health"
+assert_status 200 graph-authority "${output_dir}/authority-graph-response.json" "${graph_url}" \
+  "${graph_bearer}" "${graph_tenant}"
 jq -S . "${output_dir}/authority-graph-response.json" \
   >"${output_dir}/authority-graph-response.canonical.json"
 cmp "${output_dir}/authority-graph-response-after-restart.canonical.json" \
@@ -201,9 +230,11 @@ rust_container="$(docker compose "${compose_files[@]}" ps -q rust-platform)"
 test -n "${rust_container}"
 docker stop "${rust_container}" >/dev/null
 assert_status 503 readiness-authority-without-rust \
-  "${output_dir}/readiness.json" http://127.0.0.1:8080/health
-assert_status 503 graph-authority-without-rust \
-  "${output_dir}/graph-response.json" "${graph_url}"
+  "${output_dir}/readiness.json" "${go_api_base}/health"
+assert_status 000 rust-graph-authority-without-rust \
+  "${output_dir}/graph-response.json" "${graph_url}" "${graph_bearer}" "${graph_tenant}"
+assert_status 404 retired-go-graph-without-rust \
+  "${output_dir}/retired-go-graph-response.txt" "${retired_go_graph_url}"
 
 jq \
   --arg schema_version "cerebro.pr-rust-graph/v1" \
@@ -214,17 +245,17 @@ jq \
        {
          name: "rust_authority_soak",
          status: "passed",
-         evidence: (($authority_requests | tostring) + " Rust-authority product graph reads returned 200")
+         evidence: (($authority_requests | tostring) + " direct Rust-authority product graph reads returned 200")
        },
        {
          name: "rust_authority_restart",
          status: "passed",
-         evidence: "the Rust-authority product response remained identical after a Rust process restart"
+         evidence: "the direct Rust product response remained identical after a Rust process restart"
        },
        {
          name: "authority_fail_closed",
          status: "passed",
-         evidence: "API readiness and product graph reads returned 503 when Rust authority was stopped"
+         evidence: "Go readiness returned 503, the Rust product listener was unavailable, and the retired Go graph route remained 404 when Rust authority was stopped"
        }
      ]' "${organizational_receipt}" >"${qualification_receipt}"
 


### PR DESCRIPTION
## Summary
- send graph qualification reads to the Rust product listener with tenant-bound authentication
- keep Go readiness checks and assert the retired Go graph route remains absent
- prove restart stability and fail-closed behavior against the runtime that owns each surface
- add focused shell authentication and route-ownership contracts

## Local validation
- `shellcheck scripts/qualify-rust-graph.sh scripts/lib/rust-tenant-auth.sh`
- `bash -n scripts/qualify-rust-graph.sh scripts/lib/rust-tenant-auth.sh`
- exact tenant-auth compatibility vector and short-secret rejection
- `rustfmt +1.93.1 --edition 2024 --check crates/cerebro-platform/tests/rust_only_runtime_contract.rs`
- `git diff HEAD^ --check`

Local Cargo execution was capacity-blocked before compilation; exact-head hosted Rust and Ephemeral Cerebro checks are authoritative.