### PR TITLE
Fix compliance impact lint regressions

### DIFF
--- a/internal/complianceimpact/analyzer.go
+++ b/internal/complianceimpact/analyzer.go
@@ -219,7 +219,7 @@ func (a *Analyzer) listDependents(ctx context.Context, tenantID string, current 
 
 func impactGraphError(err error) error {
 	if errors.Is(err, ports.ErrComplianceImpactInvalidProjection) {
-		return fmt.Errorf("%w: %v", ErrInvalidGraph, err)
+		return fmt.Errorf("%w: %s", ErrInvalidGraph, err.Error())
 	}
 	return err
 }

--- a/internal/sourcehttp/organizationalgraph/query.go
+++ b/internal/sourcehttp/organizationalgraph/query.go
@@ -1083,7 +1083,7 @@ func (s *QueryStore) GetComplianceImpactFact(ctx context.Context, tenantID strin
 			return ports.ComplianceImpactDomainFact{}, ports.ErrComplianceImpactRevisionNotFound
 		}
 		if connect.CodeOf(err) == connect.CodeFailedPrecondition {
-			return ports.ComplianceImpactDomainFact{}, fmt.Errorf("%w: %v", ports.ErrComplianceImpactInvalidProjection, err)
+			return ports.ComplianceImpactDomainFact{}, fmt.Errorf("%w: %s", ports.ErrComplianceImpactInvalidProjection, err.Error())
 		}
 		return ports.ComplianceImpactDomainFact{}, graphRPCError("get compliance impact fact", err)
 	}
@@ -1142,7 +1142,7 @@ func (s *QueryStore) ListComplianceImpactDependents(ctx context.Context, request
 	response, err := s.graph.ListComplianceImpactDependents(ctx, message)
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodeFailedPrecondition {
-			return ports.ComplianceImpactDependentPage{}, fmt.Errorf("%w: %v", ports.ErrComplianceImpactInvalidProjection, err)
+			return ports.ComplianceImpactDependentPage{}, fmt.Errorf("%w: %s", ports.ErrComplianceImpactInvalidProjection, err.Error())
 		}
 		return ports.ComplianceImpactDependentPage{}, graphRPCError("list compliance impact dependents", err)
 	}

--- a/internal/sourcehttp/organizationalgraph/query_test.go
+++ b/internal/sourcehttp/organizationalgraph/query_test.go
@@ -434,7 +434,7 @@ func TestComplianceImpactTypedReadsPreserveExactOrderedDependencyRelations(t *te
 	})
 	store := newComplianceImpactQueryStore(t, graphServiceStub{impactFact: func(context.Context, *connect.Request[cerebrographv1.GetComplianceImpactFactRequest]) (*connect.Response[cerebrographv1.GetComplianceImpactFactResponse], error) {
 		return connect.NewResponse(&cerebrographv1.GetComplianceImpactFactResponse{
-			TenantId: "tenant-a", Fact: complianceImpactEntity(t, root), DependencyCount: uint32(len(fixtures)),
+			TenantId: "tenant-a", Fact: complianceImpactEntity(t, root), DependencyCount: 2,
 			Dependencies: []*cerebrographv1.ComplianceImpactDependency{
 				{Entity: complianceImpactEntity(t, fixtures[0].revision), Relation: fixtures[0].relation},
 				{Entity: complianceImpactEntity(t, fixtures[1].revision), Relation: fixtures[1].relation},
@@ -480,7 +480,7 @@ func TestComplianceImpactTypedReadsRejectDuplicateDirectDependencies(t *testing.
 func TestComplianceImpactTypedReadsRejectMalformedDependentCursors(t *testing.T) {
 	dependency := canonicalComplianceRevision(t, "tenant-a", complianceintegration.FactPolicy, "policy-1", "policy-1-revision", 1, "a", time.Date(2026, time.August, 25, 12, 0, 0, 0, time.UTC))
 	first := canonicalComplianceRevision(t, "tenant-a", complianceintegration.FactAssessmentPlan, "plan-a", "plan-a-revision", 1, "b", time.Date(2026, time.August, 25, 12, 1, 0, 0, time.UTC))
-	second := canonicalComplianceRevision(t, "tenant-a", complianceintegration.FactAssessmentPlan, "plan-b", "plan-b-revision", 1, "c", time.Date(2026, time.August, 25, 12, 2, 0, 0, time.UTC))
+	second := canonicalComplianceRevision(t, "tenant-a", complianceintegration.FactAssessmentPlan, "plan-b", "plan-b-revision", 2, "c", time.Date(2026, time.August, 25, 12, 2, 0, 0, time.UTC))
 	firstKey := complianceImpactKey(t, first)
 	secondKey := complianceImpactKey(t, second)
 	if secondKey < firstKey {


### PR DESCRIPTION
## Summary
- preserve compliance-impact error classification while satisfying error-wrapping lint rules
- remove unsafe test-only integer conversion
- exercise non-constant revision versions in the canonical fixture helper

## Validation
- `go test ./internal/sourcehttp/organizationalgraph ./internal/complianceimpact -count=1`
- `go test -race ./internal/sourcehttp/organizationalgraph ./internal/complianceimpact -count=1`
- `golangci-lint run --allow-parallel-runners --timeout 5m ./internal/sourcehttp/organizationalgraph ./internal/complianceimpact`
- `make lint-shard LINT_PACKAGES="./internal/..." LINT_SHARD_TOTAL=4 LINT_SHARD_INDEX=1`
- `make lint-shard LINT_PACKAGES="./internal/..." LINT_SHARD_TOTAL=4 LINT_SHARD_INDEX=3`

No runtime authority or fallback behavior changes.