### PR TITLE
Decouple wide-event writes from API requests

### DIFF
--- a/cmd/cerebro/main_test.go
+++ b/cmd/cerebro/main_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/writer/cerebro/internal/primitives"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceruntime"
+	"github.com/writer/cerebro/internal/telemetry"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -889,6 +890,11 @@ func captureCommandStderr(t *testing.T, fn func()) string {
 		os.Stderr = oldStderr
 	}()
 	fn()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := telemetry.FlushWideEvents(ctx); err != nil {
+		t.Fatalf("flush telemetry: %v", err)
+	}
 	if err := writer.Close(); err != nil {
 		t.Fatalf("close stderr writer: %v", err)
 	}

--- a/internal/appendlog/jetstream/jetstream_test.go
+++ b/internal/appendlog/jetstream/jetstream_test.go
@@ -147,6 +147,11 @@ func captureJetstreamTelemetry(t *testing.T, fn func()) string {
 		_ = reader.Close()
 	}()
 	fn()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := telemetry.FlushWideEvents(ctx); err != nil {
+		t.Fatalf("flush telemetry: %v", err)
+	}
 	if err := writer.Close(); err != nil {
 		t.Fatalf("close stderr pipe: %v", err)
 	}

--- a/internal/bootstrap/app_test.go
+++ b/internal/bootstrap/app_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourceops"
 	"github.com/writer/cerebro/internal/sourceruntime"
+	"github.com/writer/cerebro/internal/telemetry"
 	"github.com/writer/cerebro/internal/workflowevents"
 	"github.com/writer/cerebro/internal/workflowprojection"
 	sourcecatalogs "github.com/writer/cerebro/sources"
@@ -9164,6 +9165,11 @@ func captureBootstrapStderr(t *testing.T, fn func()) string {
 		os.Stderr = oldStderr
 	}()
 	fn()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := telemetry.FlushWideEvents(ctx); err != nil {
+		t.Fatalf("flush telemetry: %v", err)
+	}
 	if err := writer.Close(); err != nil {
 		t.Fatalf("close stderr writer: %v", err)
 	}

--- a/internal/findings/service_test.go
+++ b/internal/findings/service_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/writer/cerebro/internal/findingevidence"
 	"github.com/writer/cerebro/internal/ports"
 	"github.com/writer/cerebro/internal/securityevents"
+	"github.com/writer/cerebro/internal/telemetry"
 	"github.com/writer/cerebro/internal/workflowevents"
 )
 
@@ -6720,6 +6721,11 @@ func captureFindingStderr(t *testing.T, fn func()) string {
 		os.Stderr = oldStderr
 	}()
 	fn()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := telemetry.FlushWideEvents(ctx); err != nil {
+		t.Fatalf("flush telemetry: %v", err)
+	}
 	if err := writer.Close(); err != nil {
 		t.Fatalf("close stderr writer: %v", err)
 	}

--- a/internal/graphagent/llm_telemetry_test.go
+++ b/internal/graphagent/llm_telemetry_test.go
@@ -6,6 +6,9 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 func TestInstrumentedLLMClientDraftDoesNotEmitPromptOrCypherText(t *testing.T) {
@@ -57,6 +60,11 @@ func captureGraphAgentStderr(t *testing.T, fn func()) string {
 		os.Stderr = original
 	})
 	fn()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := telemetry.FlushWideEvents(ctx); err != nil {
+		t.Fatalf("flush telemetry: %v", err)
+	}
 	if err := writer.Close(); err != nil {
 		t.Fatalf("close stderr writer: %v", err)
 	}

--- a/internal/graphingest/service_test.go
+++ b/internal/graphingest/service_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/writer/cerebro/internal/sourceconfig"
 	"github.com/writer/cerebro/internal/sourceops"
 	"github.com/writer/cerebro/internal/sourceruntime"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 type stubRunStore struct {
@@ -1920,6 +1921,11 @@ func captureGraphIngestStderr(t *testing.T, fn func()) string {
 		os.Stderr = oldStderr
 	}()
 	fn()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := telemetry.FlushWideEvents(ctx); err != nil {
+		t.Fatalf("flush telemetry: %v", err)
+	}
 	if err := writer.Close(); err != nil {
 		t.Fatalf("close stderr writer: %v", err)
 	}

--- a/internal/jobs/service_test.go
+++ b/internal/jobs/service_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 func TestCreateRejectsUnsupportedKind(t *testing.T) {
@@ -838,6 +839,11 @@ func captureJobServiceStderr(t *testing.T, fn func()) string {
 		os.Stderr = oldStderr
 	}()
 	fn()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := telemetry.FlushWideEvents(ctx); err != nil {
+		t.Fatalf("flush telemetry: %v", err)
+	}
 	if err := writer.Close(); err != nil {
 		t.Fatalf("close stderr writer: %v", err)
 	}

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
@@ -343,6 +344,11 @@ func captureObservabilityOutput(t *testing.T, fn func()) string {
 	}()
 
 	fn()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := telemetry.FlushWideEvents(ctx); err != nil {
+		t.Fatalf("flush telemetry: %v", err)
+	}
 	if err := stdoutWriter.Close(); err != nil {
 		t.Fatalf("close stdout writer: %v", err)
 	}

--- a/internal/sourcehttp/safe_test.go
+++ b/internal/sourcehttp/safe_test.go
@@ -253,6 +253,11 @@ func captureSourceHTTPStderr(t *testing.T, fn func()) (string, string) {
 	os.Stdout = stdoutWriter
 	os.Stderr = stderrWriter
 	fn()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := telemetry.FlushWideEvents(ctx); err != nil {
+		t.Fatalf("flush telemetry: %v", err)
+	}
 	_ = stdoutWriter.Close()
 	_ = stderrWriter.Close()
 	os.Stdout = oldStdout

--- a/internal/sourceops/service_test.go
+++ b/internal/sourceops/service_test.go
@@ -10,10 +10,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/sourcecdk"
 	"github.com/writer/cerebro/internal/sourceconfig"
+	"github.com/writer/cerebro/internal/telemetry"
 	sourcecatalogs "github.com/writer/cerebro/sources"
 	auth0source "github.com/writer/cerebro/sources/auth0"
 	githubsource "github.com/writer/cerebro/sources/github"
@@ -610,6 +612,11 @@ func captureSourceOpsStderr(t *testing.T, fn func()) string {
 		os.Stderr = oldStderr
 	}()
 	fn()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := telemetry.FlushWideEvents(ctx); err != nil {
+		t.Fatalf("flush telemetry: %v", err)
+	}
 	if err := writer.Close(); err != nil {
 		t.Fatalf("close stderr writer: %v", err)
 	}

--- a/internal/sourceprojection/projector_test.go
+++ b/internal/sourceprojection/projector_test.go
@@ -15,6 +15,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 type projectionRecorder struct {
@@ -7130,6 +7131,11 @@ func captureSourceProjectionStderr(t *testing.T, fn func()) string {
 		os.Stderr = oldStderr
 	}()
 	fn()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := telemetry.FlushWideEvents(ctx); err != nil {
+		t.Fatalf("flush telemetry: %v", err)
+	}
 	if err := writer.Close(); err != nil {
 		t.Fatalf("close stderr writer: %v", err)
 	}

--- a/internal/sourceruntime/lease_test.go
+++ b/internal/sourceruntime/lease_test.go
@@ -14,6 +14,7 @@ import (
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
+	"github.com/writer/cerebro/internal/telemetry"
 )
 
 type leaseEvent struct {
@@ -429,6 +430,11 @@ func captureSourceRuntimeStderr(t *testing.T, fn func()) string {
 		os.Stderr = oldStderr
 	}()
 	fn()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := telemetry.FlushWideEvents(ctx); err != nil {
+		t.Fatalf("flush telemetry: %v", err)
+	}
 	if err := writer.Close(); err != nil {
 		t.Fatalf("close stderr writer: %v", err)
 	}

--- a/internal/telemetry/otel.go
+++ b/internal/telemetry/otel.go
@@ -39,7 +39,7 @@ type ShutdownFunc func(context.Context) error
 
 func ConfigureOpenTelemetry(ctx context.Context, options OpenTelemetryOptions) (ShutdownFunc, error) {
 	if !options.Enabled {
-		return func(context.Context) error { return nil }, nil
+		return FlushWideEvents, nil
 	}
 	if options.Protocol == "" {
 		options.Protocol = defaultOTELProtocol
@@ -76,7 +76,7 @@ func ConfigureOpenTelemetry(ctx context.Context, options OpenTelemetryOptions) (
 	otel.SetMeterProvider(meterProvider)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 	return func(ctx context.Context) error {
-		return errors.Join(meterProvider.Shutdown(ctx), traceProvider.Shutdown(ctx))
+		return errors.Join(FlushWideEvents(ctx), meterProvider.Shutdown(ctx), traceProvider.Shutdown(ctx))
 	}, nil
 }
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -5,10 +5,8 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"runtime"
 	"strconv"
@@ -974,15 +972,7 @@ func emit(kind string, span *Span, attributes Attributes) {
 	for key, value := range attributes.values {
 		payload[key] = safeAttributeValue(key, value)
 	}
-	encoded, err := json.Marshal(payload)
-	if err != nil {
-		log.Printf("telemetry encode: %v", err)
-		return
-	}
-	encoded = append(encoded, '\n')
-	if _, err := os.Stderr.Write(encoded); err != nil {
-		log.Printf("telemetry write: %v", err)
-	}
+	wideEvents.enqueue(payload)
 }
 
 func safeAttributeValue(key string, value any) any {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -11,7 +12,9 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"go.opentelemetry.io/otel"
@@ -63,6 +66,129 @@ func TestQuietSpanStillExportsOpenTelemetryWithoutWideEvents(t *testing.T) {
 	}
 	if ended := recorder.Ended(); len(ended) != 1 || ended[0].Name() != "test.quiet" {
 		t.Fatalf("quiet span did not reach OTEL recorder: %#v", ended)
+	}
+}
+
+func TestWideEventSinkDoesNotBlockOnSlowOutput(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var output bytes.Buffer
+	var startOnce sync.Once
+	sink := newWideEventSink(1, func() io.Writer {
+		return writerFunc(func(payload []byte) (int, error) {
+			startOnce.Do(func() { close(started) })
+			<-release
+			return output.Write(payload)
+		})
+	})
+	if !sink.enqueue(map[string]any{"kind": "first"}) {
+		t.Fatal("first event was dropped")
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("telemetry worker did not reach slow output")
+	}
+	if !sink.enqueue(map[string]any{"kind": "second"}) {
+		t.Fatal("second event was dropped before the queue filled")
+	}
+	result := make(chan bool, 1)
+	go func() {
+		result <- sink.enqueue(map[string]any{"kind": "third"})
+	}()
+	select {
+	case accepted := <-result:
+		if accepted {
+			t.Fatal("third event was accepted into a full queue")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("request-side telemetry enqueue blocked on slow output")
+	}
+	close(release)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := sink.flush(ctx); err != nil {
+		t.Fatalf("flush() error = %v", err)
+	}
+	if !strings.Contains(output.String(), `"telemetry.wide_event.dropped":1`) {
+		t.Fatalf("telemetry output did not report the dropped event: %s", output.String())
+	}
+}
+
+func TestWideEventSinkSnapshotsScopeAndPreservesFIFO(t *testing.T) {
+	var output bytes.Buffer
+	sink := newWideEventSink(4, func() io.Writer { return &output })
+	first := map[string]any{
+		"kind":                     "event",
+		"name":                     "first",
+		"tenant_id":                "tenant-a",
+		"application_workspace_id": "workspace-a",
+	}
+	if !sink.enqueue(first) {
+		t.Fatal("first event was dropped")
+	}
+	first["tenant_id"] = "tenant-mutated"
+	first["application_workspace_id"] = "workspace-mutated"
+	if !sink.enqueue(map[string]any{
+		"kind":                     "event",
+		"name":                     "second",
+		"tenant_id":                "tenant-b",
+		"application_workspace_id": "workspace-b",
+	}) {
+		t.Fatal("second event was dropped")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := sink.flush(ctx); err != nil {
+		t.Fatalf("flush() error = %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("telemetry lines = %d, want 2: %s", len(lines), output.String())
+	}
+	var decoded [2]map[string]any
+	for index, line := range lines {
+		if err := json.Unmarshal([]byte(line), &decoded[index]); err != nil {
+			t.Fatalf("decode line %d: %v", index, err)
+		}
+	}
+	if decoded[0]["name"] != "first" || decoded[0]["tenant_id"] != "tenant-a" || decoded[0]["application_workspace_id"] != "workspace-a" {
+		t.Fatalf("first scope snapshot = %#v", decoded[0])
+	}
+	if decoded[1]["name"] != "second" || decoded[1]["tenant_id"] != "tenant-b" || decoded[1]["application_workspace_id"] != "workspace-b" {
+		t.Fatalf("second scope snapshot = %#v", decoded[1])
+	}
+}
+
+func TestWideEventSinkFlushHonorsContextDeadline(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startOnce sync.Once
+	sink := newWideEventSink(1, func() io.Writer {
+		return writerFunc(func(payload []byte) (int, error) {
+			startOnce.Do(func() { close(started) })
+			<-release
+			return len(payload), nil
+		})
+	})
+	if !sink.enqueue(map[string]any{"kind": "blocked"}) {
+		t.Fatal("event was dropped")
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("telemetry worker did not reach blocked output")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := sink.flush(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("flush() error = %v, want context deadline exceeded", err)
+	}
+	close(release)
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), time.Second)
+	defer drainCancel()
+	if err := sink.flush(drainCtx); err != nil {
+		t.Fatalf("drain flush() error = %v", err)
 	}
 }
 
@@ -584,6 +710,11 @@ func captureOutput(t *testing.T, fn func()) (string, string) {
 	}()
 
 	fn()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := FlushWideEvents(ctx); err != nil {
+		t.Fatalf("flush telemetry: %v", err)
+	}
 	if err := stdoutWriter.Close(); err != nil {
 		t.Fatalf("close stdout writer: %v", err)
 	}
@@ -599,4 +730,10 @@ func captureOutput(t *testing.T, fn func()) (string, string) {
 		t.Fatalf("read stderr: %v", err)
 	}
 	return string(stdout), string(stderr)
+}
+
+type writerFunc func([]byte) (int, error)
+
+func (write writerFunc) Write(payload []byte) (int, error) {
+	return write(payload)
 }

--- a/internal/telemetry/wide_event_writer.go
+++ b/internal/telemetry/wide_event_writer.go
@@ -1,0 +1,124 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"sync"
+	"sync/atomic"
+)
+
+const wideEventQueueCapacity = 1024
+
+type wideEventItem struct {
+	encoded []byte
+	writer  io.Writer
+	flushed chan struct{}
+}
+
+type wideEventSink struct {
+	queue   chan wideEventItem
+	start   sync.Once
+	dropped atomic.Uint64
+	failed  atomic.Uint64
+	output  func() io.Writer
+}
+
+var wideEvents = newWideEventSink(wideEventQueueCapacity, func() io.Writer { return os.Stderr })
+
+func newWideEventSink(capacity int, output func() io.Writer) *wideEventSink {
+	if capacity < 1 {
+		capacity = 1
+	}
+	if output == nil {
+		output = func() io.Writer { return io.Discard }
+	}
+	return &wideEventSink{
+		queue:  make(chan wideEventItem, capacity),
+		output: output,
+	}
+}
+
+func (s *wideEventSink) enqueue(payload map[string]any) bool {
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		s.failed.Add(1)
+		return false
+	}
+	encoded = append(encoded, '\n')
+	s.startWorker()
+	item := wideEventItem{encoded: encoded, writer: s.output()}
+	select {
+	case s.queue <- item:
+		return true
+	default:
+		s.dropped.Add(1)
+		return false
+	}
+}
+
+func (s *wideEventSink) flush(ctx context.Context) error {
+	s.startWorker()
+	flushed := make(chan struct{})
+	select {
+	case s.queue <- wideEventItem{writer: s.output(), flushed: flushed}:
+	case <-ctx.Done():
+		return fmt.Errorf("flush telemetry queue: %w", ctx.Err())
+	}
+	select {
+	case <-flushed:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("flush telemetry writer: %w", ctx.Err())
+	}
+}
+
+func (s *wideEventSink) startWorker() {
+	s.start.Do(func() {
+		go s.run()
+	})
+}
+
+func (s *wideEventSink) run() {
+	for item := range s.queue {
+		if item.flushed != nil {
+			s.writeDiagnostics(item.writer)
+			close(item.flushed)
+			continue
+		}
+		s.writeDiagnostics(item.writer)
+		if _, err := item.writer.Write(item.encoded); err != nil {
+			log.Printf("telemetry write: %v", err)
+		}
+	}
+}
+
+func (s *wideEventSink) writeDiagnostics(writer io.Writer) {
+	dropped := s.dropped.Swap(0)
+	failed := s.failed.Swap(0)
+	if dropped == 0 && failed == 0 {
+		return
+	}
+	payload, err := json.Marshal(map[string]any{
+		"kind":                               "telemetry_health",
+		"telemetry.wide_event.dropped":       dropped,
+		"telemetry.wide_event.encode_failed": failed,
+	})
+	if err != nil {
+		return
+	}
+	payload = append(payload, '\n')
+	if _, err := writer.Write(payload); err != nil {
+		log.Printf("telemetry diagnostic write: %v", err)
+	}
+}
+
+// FlushWideEvents waits for telemetry accepted by the bounded queue to reach
+// the configured output. Request paths never call this function; shutdown and
+// deterministic tests use it to preserve accepted wide events.
+func FlushWideEvents(ctx context.Context) error {
+	return wideEvents.flush(ctx)
+}


### PR DESCRIPTION
Summary
- send structured wide events through a bounded background writer so request handlers never wait on the log sink
- preserve redaction, per-event scope snapshots, FIFO delivery, OTEL export, and shutdown flushing
- emit bounded loss diagnostics when the queue cannot accept more events

Tests
- `make test`
- `go test -race ./internal/telemetry ./internal/observability ./internal/sourcehttp ./internal/appendlog/jetstream -count=1`
- `make lint-api-cmd lint-internal`
- `make check-structural check-structural-test check-arch`