### PR TITLE
test: wait for portable fixture process exit

### DIFF
--- a/apps/web/scripts/portable-web-fixture-e2e.test.mjs
+++ b/apps/web/scripts/portable-web-fixture-e2e.test.mjs
@@ -469,6 +469,7 @@ describe("portable web fixture E2E cleanup", () => {
       first = startFixture(0);
       const firstReady = await waitForReady(first);
       await stopProcessTree(first, { deadlineAt: Date.now() + 1_000, graceMs: 25 });
+      await waitForProcessExit(firstReady.pid);
       expect(processExists(firstReady.pid)).toBe(false);
 
       second = startFixture(firstReady.port);


### PR DESCRIPTION
## Summary

Wait for the owned portable fixture PID to leave the process table before asserting cleanup and reusing its port.

## Test Plan

- `npm test --workspace @writer/cerebro-web -- scripts/portable-web-fixture-e2e.test.mjs`
- 10 consecutive focused reruns: 33/33 tests passed each run
- `npm run check --workspace @writer/cerebro-web` under Node 22.23.2: 114 files and 733 tests passed
- ESLint on the changed test file

## Known Invariants

- Fixture cleanup remains bounded by the existing two-second process-exit waiter.
- The second fixture starts only after the first owned process has exited.

## Deterministic Review

The change is limited to the existing portable Web fixture cleanup test and does not alter production runtime behavior.