### PR TITLE
test: fail closed on audit-evidence finding rules

### DIFF
--- a/tools/rustcarve/README.md
+++ b/tools/rustcarve/README.md
@@ -60,6 +60,17 @@ The effective-access preset accepts exactly five identity arms and three access 
 
 `finding-rule/v1` accepts closed matcher predicates, typed missing-value behavior, a stable fingerprint contract, explicit lifecycle transitions, graph anchors, observed-at/TTL semantics, a public output contract, replay/counterexample references, authority requirements, and exact deletion symbols. The supplied request distills the existing Tailscale replay corpus without editing its evaluator. Rust scaffold and deletion eligibility remain false until exact replay parity is bound to the same IR, corpus, and tool revisions.
 
+The generated policy-event audit-evidence batch is a canonical unsupported input at `tools/rustcarve/testdata/policy-event-audit-evidence.request.json`. Run it with:
+
+```sh
+go run ./tools/rustcarve \
+  -root . \
+  -request tools/rustcarve/testdata/policy-event-audit-evidence.request.json \
+  -out tools/rustcarve/testdata/golden/policy-event-audit-evidence
+```
+
+The command is expected to fail closed and emit only `unsupported.json`, with `unsupported_graph_anchor` and `unsupported_lifecycle`. It emits no migration IR, Rust scaffold, parity test, or deletion manifest. The request records the active Go evaluator honestly; it does not weaken `finding-rule/v1` to treat an evaluate-only lifecycle or `AnchorNone` as durable Rust finding authority.
+
 ## Stable rejection codes
 
 The initial closed set includes:

--- a/tools/rustcarve/analyze.go
+++ b/tools/rustcarve/analyze.go
@@ -232,7 +232,7 @@ func validAuthorityState(kind behaviorKind, state string) bool {
 	case behaviorGraphQuery:
 		return stringSetOf("go_raw_query_active", "rust_only_fail_closed")[state]
 	case behaviorFindingRule:
-		return state == "rust_authoritative_no_go_writer"
+		return stringSetOf("go_evaluator_active", "rust_authoritative_no_go_writer")[state]
 	default:
 		return false
 	}

--- a/tools/rustcarve/audit_evidence_test.go
+++ b/tools/rustcarve/audit_evidence_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestPolicyEventAuditEvidenceBatchFailsClosedWithCanonicalReasons(t *testing.T) {
+	request, err := loadCarveRequest("testdata/policy-event-audit-evidence.request.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.Subject.AuthorityState != "go_evaluator_active" {
+		t.Fatalf("authority state = %q, want active Go evaluator", request.Subject.AuthorityState)
+	}
+	result, err := distill(repositoryRoot(t), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Unsupported == nil {
+		t.Fatal("audit-evidence batch produced migration artifacts")
+	}
+	wantReasons := []reasonCode{reasonUnsupportedGraphAnchor, reasonUnsupportedLifecycle}
+	if !reflect.DeepEqual(result.Unsupported.ReasonCodes, wantReasons) {
+		t.Fatalf("unsupported reasons = %v, want %v", result.Unsupported.ReasonCodes, wantReasons)
+	}
+	if len(result.Artifacts) != 0 || result.Manifest.Eligible {
+		t.Fatalf("unsupported batch emitted artifacts or deletion eligibility: %#v", result)
+	}
+
+	payload, err := os.ReadFile("testdata/golden/policy-event-audit-evidence/unsupported.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var golden unsupportedReport
+	if err := json.Unmarshal(payload, &golden); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(*result.Unsupported, golden) {
+		t.Fatalf("unsupported result differs from golden: got %#v want %#v", *result.Unsupported, golden)
+	}
+}

--- a/tools/rustcarve/testdata/golden/policy-event-audit-evidence/unsupported.json
+++ b/tools/rustcarve/testdata/golden/policy-event-audit-evidence/unsupported.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "cerebro.rustcarve.unsupported/v1",
+  "behavior_kind": "finding_rule",
+  "subject_id": "policy-event-audit-evidence-catalog",
+  "reason_codes": [
+    "unsupported_graph_anchor",
+    "unsupported_lifecycle"
+  ],
+  "details": [
+    "finding rule failed closed validation"
+  ]
+}

--- a/tools/rustcarve/testdata/policy-event-audit-evidence.request.json
+++ b/tools/rustcarve/testdata/policy-event-audit-evidence.request.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": "cerebro.rustcarve.request/v2",
+  "behavior_kind": "finding_rule",
+  "subject": {
+    "id": "policy-event-audit-evidence-catalog",
+    "package_dir": "internal/findings",
+    "catalog_path": "",
+    "go_files": ["internal/findings/policy_rule.go"],
+    "owner_symbols": ["newPolicyCatalogRules", "newPolicyCatalogRule", "normalizePolicyRuleConfig", "policyRuleEventMatchesDefinition", "policyRuleEventFailed"],
+    "rust_implementation_revision": "9a0d21b5b87996019ac78aec5a426129e6114558",
+    "authority_state": "go_evaluator_active"
+  },
+  "scope": {
+    "tenant": {"name": "tenant_id", "type": "tenant_id", "required": true},
+    "workspace_policy": "required",
+    "workspace": {"name": "workspace_id", "type": "workspace_id", "required": true}
+  },
+  "fixture_corpus": [
+    {"path": "internal/findings/policy_rule_catalog_gen.go", "role": "generated_rule_catalog"},
+    {"path": "internal/findings/policy_rule_test.go", "role": "go_evaluator_oracle"},
+    {"path": "internal/findings/rulepack_audit_test.go", "role": "lifecycle_replay_contract"}
+  ],
+  "port_traces": [
+    {"path": "crates/finding-rule-kernel/src/evaluation.rs", "role": "rust_authority_contract"}
+  ],
+  "differential_receipts": [],
+  "deletion": {
+    "paths": [],
+    "imports": [],
+    "symbols": []
+  },
+  "finding_rule": {
+    "ir_version": "finding-rule/v1",
+    "rule": {
+      "rule_id": "policy-event-audit-evidence-catalog",
+      "family": "policy.event",
+      "catalog_revision": "sha256:32fe570ac78bccfd99fc71de3eb4ca6a1bb5892778bde700772dee5a9ba0b7b7"
+    },
+    "scope": {
+      "tenant": {"name": "tenant_id", "type": "tenant_id", "required": true},
+      "workspace_policy": "required",
+      "workspace": {"name": "workspace_id", "type": "workspace_id", "required": true}
+    },
+    "matcher": {
+      "input_fields": [
+        {"name": "runtime_tenant_id", "type": "tenant_id"},
+        {"name": "runtime_workspace_id", "type": "workspace_id"},
+        {"name": "event_tenant_id", "type": "tenant_id"},
+        {"name": "event_workspace_id", "type": "workspace_id"},
+        {"name": "event_source_id", "type": "string"},
+        {"name": "event_kind", "type": "string"},
+        {"name": "event_id", "type": "string"},
+        {"name": "occurred_at", "type": "timestamp"},
+        {"name": "policy_id", "type": "string"},
+        {"name": "result", "type": "string"},
+        {"name": "runtime_id", "type": "string"},
+        {"name": "resource_or_event_id", "type": "string"}
+      ],
+      "predicates": [
+        {"kind": "equals", "target": "runtime_tenant_id", "input": "event_tenant_id"},
+        {"kind": "equals", "target": "runtime_workspace_id", "input": "event_workspace_id"},
+        {"kind": "equals", "target": "event_source_id", "input": "policy"},
+        {"kind": "in_set", "target": "event_kind", "input": "policy.evidence|policy.result"},
+        {"kind": "equals", "target": "policy_id", "input": "catalog_rule_id"},
+        {"kind": "in_set", "target": "result", "input": "failed|error|noncompliant"}
+      ],
+      "required_attributes": [
+        {"name": "policy_id", "type": "string", "missing_behavior": "no_match"},
+        {"name": "result", "type": "string", "missing_behavior": "no_match"}
+      ]
+    },
+    "fingerprint": {
+      "domain_separator": "policy-event-audit-evidence-catalog\\u0000",
+      "fields": ["rule_id", "tenant_id", "runtime_id", "resource_or_event_id"],
+      "normalization": "utf8_trim",
+      "hash": "sha256"
+    },
+    "lifecycle": {
+      "states": ["open"],
+      "transitions": [],
+      "close_condition": "",
+      "observed_at_source": "event.occurred_at"
+    },
+    "graph_anchors": [],
+    "expiry": {
+      "mode": "none",
+      "ttl_seconds": 0,
+      "clock": "observed_at",
+      "expiry_source": ""
+    },
+    "output": {
+      "schema_version": "cerebro.public-finding/v1",
+      "fields": [
+        {"name": "id", "type": "string"},
+        {"name": "fingerprint", "type": "string"},
+        {"name": "tenant_id", "type": "tenant_id"},
+        {"name": "runtime_id", "type": "string"},
+        {"name": "rule_id", "type": "string"},
+        {"name": "title", "type": "string"},
+        {"name": "severity", "type": "string"},
+        {"name": "status", "type": "string"},
+        {"name": "summary", "type": "string"},
+        {"name": "resource_urns", "type": "array<urn>"},
+        {"name": "event_ids", "type": "array<string>"},
+        {"name": "observed_policy_ids", "type": "array<string>"},
+        {"name": "policy_id", "type": "string"},
+        {"name": "policy_name", "type": "string"},
+        {"name": "check_id", "type": "string"},
+        {"name": "check_name", "type": "string"},
+        {"name": "control_refs", "type": "array<finding_control_ref>"},
+        {"name": "attributes", "type": "map<string,string>"},
+        {"name": "first_observed_at", "type": "timestamp"},
+        {"name": "last_observed_at", "type": "timestamp"}
+      ]
+    },
+    "replay_corpus": [
+      {"path": "internal/findings/policy_rule_catalog_gen.go", "role": "generated_rule_catalog"},
+      {"path": "internal/findings/policy_rule_test.go", "role": "go_evaluator_oracle"},
+      {"path": "internal/findings/rulepack_audit_test.go", "role": "lifecycle_replay_contract"}
+    ],
+    "counterexamples": [
+      {"path": "internal/findings/policy_rule_test.go", "role": "scope_match_and_no_match_cases"}
+    ],
+    "authority": {
+      "required_authority": "rust_finding_rule_kernel",
+      "fail_closed": true,
+      "replay_parity": "exact"
+    },
+    "deletion": {
+      "paths": [],
+      "imports": [],
+      "symbols": []
+    }
+  },
+  "options": {
+    "expected_registration_shape": "",
+    "max_input_bytes": 4194304
+  }
+}


### PR DESCRIPTION
## State

Code complete at `89c5fb4e6ed08a08816981f7a1b2cf76dcfc4689`, based on `337d5554b8a10ca28fda24bdfea635d1c5c997e3`.

## Converter response

This PR records the existing generated policy-event audit-evidence batch as a canonical unsupported `finding-rule/v1` input. It does not weaken the durable lifecycle or graph-anchor contract.

- Request: `tools/rustcarve/testdata/policy-event-audit-evidence.request.json`
- Closed schema entrypoint: `tools/rustcarve/schema.go` (`cerebro.rustcarve.closed-schema/v2`, `finding-rule/v1`)
- Canonical output: `tools/rustcarve/testdata/golden/policy-event-audit-evidence/unsupported.json`
- Invocation: `go run ./tools/rustcarve -root . -request tools/rustcarve/testdata/policy-event-audit-evidence.request.json -out tools/rustcarve/testdata/golden/policy-event-audit-evidence`

The command exits fail-closed and emits only:

- `unsupported_graph_anchor`
- `unsupported_lifecycle`

It emits no migration IR, Rust scaffold, parity test, or deletion manifest. The request binds required tenant/workspace inputs, deterministic matcher and fingerprint fields, the public finding shape, no TTL, the existing Go oracle/replay contract, and the general Rust kernel revision. `go_evaluator_active` is accepted only as an honest migration-input authority state; it does not grant Rust authority or deletion eligibility.

## Local validation

- `go test -race ./tools/rustcarve`
- supported `finding-rule.request.json` deterministic `-check`
- audit-evidence request deterministic fail-closed `-check`
- `make check-arch check-structural check-structural-test`
- staged and range tenant-data leak checks
- scoped Gitleaks 8.30.1, zero results

No `internal/findings`, Rust kernel, generated policy catalog, provider, graph-query, or source-registry runtime file is changed.

## Hosted validation boundary

At exact head `89c5fb4e6ed08a08816981f7a1b2cf76dcfc4689`, 75 hosted checks passed, including the replacement deterministic review, CodeQL, Semgrep, Gitleaks, build, lint, tests, races, and structural checks. The initial deterministic-review aggregate failure was produced by the cancelled draft run; its replacement run passed.

The remaining failures are inherited from current `main`, outside this converter diff:

- `graph-actions` and `codegen`: stale Cloudflare authority assertion; repair is independently owned by #2732.
- `Seeded Go and Rust graph`: qualification requests the retired Go listener and receives 404; repair is independently owned by #2726.
- `verify`: aggregate of the failed core leaves above.

Normal merge remains blocked by those base repairs and the repository-required approval. No reviewer is assigned or requested.