### PR TITLE
test: align Cloudflare authority contract

### DIFF
--- a/crates/source-runtime-next/src/cloudflare/tests.rs
+++ b/crates/source-runtime-next/src/cloudflare/tests.rs
@@ -153,7 +153,7 @@ fn checked_in_catalog_compiles_the_closed_cloudflare_runtime() {
     .unwrap();
     let source = catalog.get("cloudflare").unwrap();
     assert_eq!(source.auth(), &AuthModel::BearerToken);
-    assert_eq!(source.authority(), CollectionAuthority::ShadowOnly);
+    assert_eq!(source.authority(), CollectionAuthority::Authoritative);
     let compiled = source
         .families()
         .iter()
@@ -165,7 +165,7 @@ fn checked_in_catalog_compiles_the_closed_cloudflare_runtime() {
         .collect::<std::collections::BTreeSet<_>>();
     assert_eq!(compiled, expected);
     for family in source.families() {
-        assert!(!family.is_authoritative(), "{} collection", family.id());
+        assert!(family.is_authoritative(), "{} collection", family.id());
         assert!(
             family.is_projection_authoritative(),
             "{} projection",


### PR DESCRIPTION
## Summary

- align the checked-in Cloudflare runtime test with the catalog's landed authoritative collection state
- require every compiled Cloudflare family to remain collection-authoritative and projection-authoritative

The preceding Cloudflare catalog transition removed the invalid configurable `tenant_id` binding because tenant identity is supplied by the authenticated runtime. The source catalog and Go contract already require all Cloudflare families to be Rust-authoritative; this updates the remaining stale Rust assertion without changing production authority.

## Validation

- `go test ./internal/connectorcatalog -run TestBuiltinCloudflareCatalogClosesTheProviderFamilyAndCredentialContracts -count=1`
- `make catalog-check`
- `git diff --check`

Local Rust execution is blocked before start by the managed Cargo capacity guard: the DDESK checkout has no registered disk and the shared cache is about 34.3 GB short. Hosted exact-head Rust checks are required before merge.