### PR TITLE
Align Cloudflare Rust authority contract

### DIFF
--- a/crates/source-runtime-next/src/cloudflare/tests.rs
+++ b/crates/source-runtime-next/src/cloudflare/tests.rs
@@ -153,7 +153,7 @@ fn checked_in_catalog_compiles_the_closed_cloudflare_runtime() {
     .unwrap();
     let source = catalog.get("cloudflare").unwrap();
     assert_eq!(source.auth(), &AuthModel::BearerToken);
-    assert_eq!(source.authority(), CollectionAuthority::ShadowOnly);
+    assert_eq!(source.authority(), CollectionAuthority::Authoritative);
     let compiled = source
         .families()
         .iter()
@@ -165,7 +165,7 @@ fn checked_in_catalog_compiles_the_closed_cloudflare_runtime() {
         .collect::<std::collections::BTreeSet<_>>();
     assert_eq!(compiled, expected);
     for family in source.families() {
-        assert!(!family.is_authoritative(), "{} collection", family.id());
+        assert!(family.is_authoritative(), "{} collection", family.id());
         assert!(
             family.is_projection_authoritative(),
             "{} projection",


### PR DESCRIPTION
## Summary
- align the Cloudflare Rust catalog contract with its authoritative compiled source state
- require every compiled Cloudflare family to remain collection-authoritative

## Validation
- `rustfmt +1.93.1 --edition 2024 --check crates/source-runtime-next/src/cloudflare/tests.rs`
- `git diff --check`

The exact hosted Rust gate exposed the stale expectation. Local Cargo execution remains capacity-blocked before compilation, so hosted Rust tests are authoritative.