### PR TITLE
Preserve custom dashboard workspace scope

### DIFF
--- a/apps/web/src/components/grc/CustomDashboardRenderer.tsx
+++ b/apps/web/src/components/grc/CustomDashboardRenderer.tsx
@@ -10,6 +10,7 @@ import type { CustomDashboard, CustomDashboardWidget } from "@/lib/custom-dashbo
 import {
   customDashboardFindingsPath,
   customDashboardFrameworksPath,
+  customDashboardScopedPath,
   customDashboardSummaryPath,
   customDashboardTrendPath,
 } from "@/lib/custom-dashboards";
@@ -109,7 +110,8 @@ function TrendWidget({ dashboard, widget }: { dashboard: CustomDashboard; widget
   const metricState = query.loading ? "loading" : "ready";
   const interval = String(widget.query?.params?.interval ?? dashboard.filters.interval ?? "week");
   const filterParams = {
-    tenant_id: stringValue(dashboard.filters.tenant_id),
+    tenant_id: stringValue(dashboard.tenant_id),
+    workspace_id: stringValue(dashboard.workspace_id),
     runtime_id: stringValue(dashboard.filters.runtime_id),
     source_id: stringValue(dashboard.filters.source_id),
     severity: stringValue(dashboard.filters.severity),
@@ -287,7 +289,7 @@ function FindingsTableWidget({ dashboard, widget }: { dashboard: CustomDashboard
             <tbody>
               {findings.map((finding) => (
                 <tr key={finding.id} className="border-t border-slate-100">
-                  <td className="px-3 py-2"><Link href={`/findings/${encodeURIComponent(finding.id)}`} className="font-medium text-indigo-600 hover:text-indigo-800">{finding.title}</Link></td>
+                  <td className="px-3 py-2"><Link href={customDashboardScopedPath(`/findings/${encodeURIComponent(finding.id)}`, dashboard)} className="font-medium text-indigo-600 hover:text-indigo-800">{finding.title}</Link></td>
                   <td className="px-3 py-2"><Badge value={finding.severity} tone="severity" /></td>
                   <td className="px-3 py-2 text-slate-700">{humanize(finding.status)}</td>
                   <td className="px-3 py-2 text-right"><RiskBadge score={finding.risk_score} level={finding.likelihood_level} /></td>
@@ -302,7 +304,7 @@ function FindingsTableWidget({ dashboard, widget }: { dashboard: CustomDashboard
 }
 
 function FrameworkProgressWidget({ dashboard, widget }: { dashboard: CustomDashboard; widget: CustomDashboardWidget }) {
-  const path = useMemo(() => customDashboardFrameworksPath(dashboard, widget), [dashboard, widget]);
+  const path = useMemo(() => customDashboardFrameworksPath(dashboard), [dashboard]);
   const query = useGRCQuery<GRCFrameworksResponse>(path);
   if (query.loading) return <LoadingBlock label={`Loading ${widget.title ?? "frameworks"}...`} />;
   if (query.error) return <ErrorBlock error={query.error} onRetry={() => void query.reload()} recoveryDetail="Frameworks will appear when the API is reachable." />;
@@ -324,7 +326,7 @@ function FrameworkProgressWidget({ dashboard, widget }: { dashboard: CustomDashb
                 percent={percent}
                 detail={`${mapped}/${total} controls mapped`}
                 total={`${framework.control_count} total`}
-                href={framework.id ? `/frameworks/${encodeURIComponent(framework.id)}` : undefined}
+                href={framework.id ? customDashboardScopedPath(`/frameworks/${encodeURIComponent(framework.id)}`, dashboard) : undefined}
               />
             );
           })}
@@ -338,7 +340,10 @@ function CatalogWidget({ dashboard, widget, catalog }: { dashboard: CustomDashbo
   const sourceID = catalogWidgetSourceID(widget);
   const source = findSource(catalog.sources, sourceID);
   const reportQuery = source ? buildWidgetReportQuery(source, dashboard.filters, widget) : null;
-  const result = useReportQuery(reportQuery);
+  const result = useReportQuery(reportQuery, {
+    tenantID: dashboard.tenant_id,
+    workspaceID: dashboard.workspace_id,
+  });
   const title = widget.title ?? source?.title ?? "Report";
 
   if (catalog.loading) return <LoadingBlock label={`Loading ${title}...`} />;

--- a/apps/web/src/lib/custom-dashboards.test.ts
+++ b/apps/web/src/lib/custom-dashboards.test.ts
@@ -5,6 +5,7 @@ import {
   customDashboardFindingsPath,
   customDashboardFrameworksPath,
   customDashboardSummaryPath,
+  customDashboardScopedPath,
   customDashboardTemplateWidgets,
   customDashboardTrendPath,
   sortCustomDashboards,
@@ -15,6 +16,7 @@ import {
 const dashboard = (id: string, updated_at: string): CustomDashboard => ({
   id,
   tenant_id: "tenant-a",
+  workspace_id: "workspace-a",
   name: id,
   visibility: "private",
   schema_version: 1,
@@ -58,6 +60,7 @@ describe("custom dashboard helpers", () => {
     });
     expect(path).toContain("/grc/trends?");
     expect(path).toContain("tenant_id=tenant-a");
+    expect(path).toContain("workspace_id=workspace-a");
     expect(path).toContain("severity=HIGH");
     expect(path).toContain("interval=month");
     expect(path).not.toContain("compare=");
@@ -68,12 +71,38 @@ describe("custom dashboard helpers", () => {
     const summary = customDashboardSummaryPath(dash, { id: "s", type: "summary_metrics" });
     expect(summary).toContain("/grc/dashboard?");
     expect(summary).toContain("view=summary");
+    expect(summary).toContain("tenant_id=tenant-a");
+    expect(summary).toContain("workspace_id=workspace-a");
     const findings = customDashboardFindingsPath(dash, { id: "f", type: "findings_table", query: { params: { limit: 5 } } });
     expect(findings).toContain("/grc/findings?");
     expect(findings).toContain("severity=HIGH");
+    expect(findings).toContain("tenant_id=tenant-a");
+    expect(findings).toContain("workspace_id=workspace-a");
     expect(findings).toContain("status=open");
     expect(findings).toContain("limit=5");
-    expect(customDashboardFrameworksPath(dash, { id: "fw", type: "framework_progress" })).toContain("/grc/frameworks?");
+    const frameworks = customDashboardFrameworksPath(dash);
+    expect(frameworks).toContain("/grc/frameworks?");
+    expect(frameworks).toContain("tenant_id=tenant-a");
+    expect(frameworks).toContain("workspace_id=workspace-a");
+  });
+
+  it("uses immutable dashboard scope instead of mutable widget filters", () => {
+    const dash = dashboard("dash", "2026-06-23T00:00:00Z");
+    dash.filters.tenant_id = "tenant-other";
+    const path = customDashboardFindingsPath(dash, {
+      id: "f",
+      type: "findings_table",
+      query: { params: { tenant_id: "tenant-widget" } },
+    });
+    expect(path).toContain("tenant_id=tenant-a");
+    expect(path).toContain("workspace_id=workspace-a");
+    expect(path).not.toContain("tenant-other");
+    expect(path).not.toContain("tenant-widget");
+  });
+
+  it("preserves dashboard scope on drilldown links", () => {
+    const path = customDashboardScopedPath("/findings/finding-a", dashboard("dash", "2026-06-23T00:00:00Z"));
+    expect(path).toBe("/findings/finding-a?tenant_id=tenant-a&workspace_id=workspace-a");
   });
 
   it("resolves template widget sets with known widget types", () => {

--- a/apps/web/src/lib/custom-dashboards.ts
+++ b/apps/web/src/lib/custom-dashboards.ts
@@ -83,6 +83,12 @@ export const customDashboardPath = (dashboardID: string) => `/grc/dashboards/${e
 
 export const customDashboardClonePath = (dashboardID: string) => `${customDashboardPath(dashboardID)}/clone`;
 
+export const customDashboardScopedPath = (path: string, dashboard: CustomDashboard) =>
+  grcPath(path, {
+    tenant_id: stringParam(dashboard.tenant_id),
+    workspace_id: stringParam(dashboard.workspace_id),
+  });
+
 export const customDashboardTrendPath = (dashboard: CustomDashboard, widget: CustomDashboardWidget) => {
   const params = {
     ...dashboard.filters,
@@ -91,7 +97,8 @@ export const customDashboardTrendPath = (dashboard: CustomDashboard, widget: Cus
   return grcPath("/grc/trends", {
     interval: stringParam(params.interval, "week"),
     days: numberParam(params.days, 90),
-    tenant_id: stringParam(params.tenant_id),
+    tenant_id: stringParam(dashboard.tenant_id),
+    workspace_id: stringParam(dashboard.workspace_id),
     runtime_id: stringParam(params.runtime_id),
     source_id: stringParam(params.source_id),
     severity: stringParam(params.severity),
@@ -111,7 +118,8 @@ const mergedWidgetParams = (dashboard: CustomDashboard, widget: CustomDashboardW
 export const customDashboardSummaryPath = (dashboard: CustomDashboard, widget: CustomDashboardWidget) => {
   const params = mergedWidgetParams(dashboard, widget);
   return grcDashboardPath({
-    tenant_id: stringParam(params.tenant_id),
+    tenant_id: stringParam(dashboard.tenant_id),
+    workspace_id: stringParam(dashboard.workspace_id),
     limit: numberParam(params.limit, 100),
   });
 };
@@ -119,7 +127,8 @@ export const customDashboardSummaryPath = (dashboard: CustomDashboard, widget: C
 export const customDashboardFindingsPath = (dashboard: CustomDashboard, widget: CustomDashboardWidget) => {
   const params = mergedWidgetParams(dashboard, widget);
   return grcPath("/grc/findings", {
-    tenant_id: stringParam(params.tenant_id),
+    tenant_id: stringParam(dashboard.tenant_id),
+    workspace_id: stringParam(dashboard.workspace_id),
     runtime_id: stringParam(params.runtime_id),
     source_id: stringParam(params.source_id),
     severity: stringParam(params.severity),
@@ -129,10 +138,10 @@ export const customDashboardFindingsPath = (dashboard: CustomDashboard, widget: 
   });
 };
 
-export const customDashboardFrameworksPath = (dashboard: CustomDashboard, widget: CustomDashboardWidget) => {
-  const params = mergedWidgetParams(dashboard, widget);
+export const customDashboardFrameworksPath = (dashboard: CustomDashboard) => {
   return grcPath("/grc/frameworks", {
-    tenant_id: stringParam(params.tenant_id),
+    tenant_id: stringParam(dashboard.tenant_id),
+    workspace_id: stringParam(dashboard.workspace_id),
   });
 };
 

--- a/apps/web/src/lib/grc-report-catalog.test.ts
+++ b/apps/web/src/lib/grc-report-catalog.test.ts
@@ -6,6 +6,8 @@ import {
   catalogWidgetSourceID,
   extractReportTable,
   findSource,
+  reportQueryCacheKey,
+  reportQueryPath,
   validateWidgetReportQuery,
   type ReportSource,
 } from "./grc-report-catalog";
@@ -100,6 +102,20 @@ describe("grc report catalog helpers", () => {
     const query = buildWidgetReportQuery(findingsSource, dashboard({ severity: "LOW" }).filters, widget);
     expect(query.params).toEqual({ severity: "CRITICAL" });
     expect(query.limit).toBeUndefined();
+  });
+
+  it("binds report paths and cache keys to tenant and workspace scope", () => {
+    const body = JSON.stringify({ source_id: "findings", limit: 25 });
+    const workspaceA = reportQueryPath({ tenantID: "tenant-a", workspaceID: "workspace-a" });
+    const workspaceB = reportQueryPath({ tenantID: "tenant-a", workspaceID: "workspace-b" });
+    expect(workspaceA).toBe("/grc/query?tenant_id=tenant-a&workspace_id=workspace-a");
+    expect(workspaceB).toBe("/grc/query?tenant_id=tenant-a&workspace_id=workspace-b");
+    expect(reportQueryCacheKey(workspaceA!, body, "key")).not.toBe(reportQueryCacheKey(workspaceB!, body, "key"));
+  });
+
+  it("does not build a report path without tenant scope", () => {
+    expect(reportQueryPath({})).toBeNull();
+    expect(reportQueryPath({ workspaceID: "workspace-a" })).toBeNull();
   });
 
   it("shapes a list-shaped envelope into a scalar-only table", () => {

--- a/apps/web/src/lib/grc-report-catalog.ts
+++ b/apps/web/src/lib/grc-report-catalog.ts
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useApiKey } from "@/components/providers";
 import { fetchCerebro } from "@/lib/cerebro-client";
 import type { CustomDashboard, CustomDashboardWidget } from "@/lib/custom-dashboards";
-import { grcResponseErrorMessage, useGRCQuery } from "@/lib/grc-client";
+import { grcPath, grcResponseErrorMessage, useGRCQuery } from "@/lib/grc-client";
 
 export const REPORT_CATALOG_PATH = "/grc/report-catalog";
 export const REPORT_QUERY_PATH = "/grc/query";
@@ -46,6 +46,21 @@ export type WidgetReportQuery = {
   source_id: string;
   params?: Record<string, string>;
   limit?: number;
+};
+
+export type ReportQueryScope = {
+  tenantID?: string;
+  workspaceID?: string;
+};
+
+export const reportQueryPath = (scope: ReportQueryScope): string | null => {
+  const tenantID = scope.tenantID?.trim() ?? "";
+  const workspaceID = scope.workspaceID?.trim() ?? "";
+  if (tenantID === "") return null;
+  return grcPath(REPORT_QUERY_PATH, {
+    tenant_id: tenantID,
+    workspace_id: workspaceID || undefined,
+  });
 };
 
 export type ReportQueryResponse = { source_id: string; generated_at: string; data: unknown };
@@ -187,10 +202,10 @@ type CachedReportQueryResponse = Awaited<ReturnType<typeof fetchCerebro<ReportQu
 const reportQueryCache = new Map<string, { expiresAt: number; response: CachedReportQueryResponse }>();
 const reportQueryInflight = new Map<string, Promise<CachedReportQueryResponse>>();
 
-const reportQueryCacheKey = (body: string, apiKey?: string) => `${apiKey ?? ""}\n${body}`;
+export const reportQueryCacheKey = (path: string, body: string, apiKey?: string) => `${apiKey ?? ""}\n${path}\n${body}`;
 
-const reportQueryCached = (body: string, apiKey?: string) => {
-  const cached = reportQueryCache.get(reportQueryCacheKey(body, apiKey));
+const reportQueryCached = (path: string, body: string, apiKey?: string) => {
+  const cached = reportQueryCache.get(reportQueryCacheKey(path, body, apiKey));
   return cached && cached.expiresAt > Date.now() ? cached.response : null;
 };
 
@@ -198,9 +213,9 @@ const reportQueryCached = (body: string, apiKey?: string) => {
 // successful responses are cached briefly and concurrent identical queries are
 // de-duplicated, so a dashboard with many report widgets (or remounts) does not
 // multiply backend traffic. force bypasses both the cache and in-flight entry.
-const fetchCachedReportQuery = (body: string, apiKey: string | undefined, force: boolean): Promise<CachedReportQueryResponse> => {
-  const cacheKey = reportQueryCacheKey(body, apiKey);
-  const cached = reportQueryCached(body, apiKey);
+const fetchCachedReportQuery = (path: string, body: string, apiKey: string | undefined, force: boolean): Promise<CachedReportQueryResponse> => {
+  const cacheKey = reportQueryCacheKey(path, body, apiKey);
+  const cached = reportQueryCached(path, body, apiKey);
   if (!force && cached) {
     return Promise.resolve(cached);
   }
@@ -208,7 +223,7 @@ const fetchCachedReportQuery = (body: string, apiKey: string | undefined, force:
   if (!force && inflight) {
     return inflight;
   }
-  const request = fetchCerebro<ReportQueryResponse>(REPORT_QUERY_PATH, apiKey, {
+  const request = fetchCerebro<ReportQueryResponse>(path, apiKey, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body,
@@ -233,45 +248,55 @@ const fetchCachedReportQuery = (body: string, apiKey: string | undefined, force:
 // useReportQuery runs one bounded report query through POST /grc/query. It
 // re-runs whenever the query body changes, shares the brief response cache
 // above, and ignores stale or post-unmount responses via a request counter.
-export const useReportQuery = (query: WidgetReportQuery | null) => {
+export const useReportQuery = (query: WidgetReportQuery | null, scope: ReportQueryScope) => {
   const { apiKey } = useApiKey();
   const [data, setData] = useState<ReportQueryResponse | null>(null);
+  const [dataKey, setDataKey] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [errorKey, setErrorKey] = useState("");
   const [loading, setLoading] = useState(false);
   const requestID = useRef(0);
+  const path = reportQueryPath(scope);
   const key = query ? JSON.stringify(query) : "";
+  const requestKey = path && key ? `${path}\n${key}` : "";
 
   const load = useCallback(
     async (force = false) => {
-      if (key === "") {
+      if (key === "" || path === null) {
         setData(null);
-        setError(null);
+        setDataKey("");
+        setError(key === "" ? null : "Report query requires tenant scope.");
+        setErrorKey("");
         setLoading(false);
         return;
       }
       const currentRequestID = requestID.current + 1;
       requestID.current = currentRequestID;
-      setLoading(!(!force && reportQueryCached(key, apiKey)));
+      setLoading(!(!force && reportQueryCached(path, key, apiKey)));
       setError(null);
+      setErrorKey("");
       let response;
       try {
-        response = await fetchCachedReportQuery(key, apiKey, force);
+        response = await fetchCachedReportQuery(path, key, apiKey, force);
       } catch (err) {
         if (currentRequestID !== requestID.current) return;
-        setError(err instanceof Error ? err.message : grcResponseErrorMessage(REPORT_QUERY_PATH, 0, null));
+        setError(err instanceof Error ? err.message : grcResponseErrorMessage(path, 0, null));
+        setErrorKey(requestKey);
         setLoading(false);
         return;
       }
       if (currentRequestID !== requestID.current) return;
       if (!response.ok) {
-        setError(grcResponseErrorMessage(REPORT_QUERY_PATH, response.status, response.data));
+        setError(grcResponseErrorMessage(path, response.status, response.data));
+        setErrorKey(requestKey);
         setLoading(false);
         return;
       }
       setData(response.data);
+      setDataKey(requestKey);
       setLoading(false);
     },
-    [apiKey, key],
+    [apiKey, key, path, requestKey],
   );
 
   useEffect(() => {
@@ -283,5 +308,11 @@ export const useReportQuery = (query: WidgetReportQuery | null) => {
   }, [load]);
 
   const reload = useCallback(() => load(true), [load]);
-  return { data, error, loading, reload };
+  const visibleError = path === null && key !== "" ? "Report query requires tenant scope." : errorKey === requestKey ? error : null;
+  return {
+    data: dataKey === requestKey ? data : null,
+    error: visibleError,
+    loading: path !== null && key !== "" && dataKey !== requestKey ? true : loading,
+    reload,
+  };
 };


### PR DESCRIPTION
## Summary

- derive custom-dashboard report and legacy widget requests from the dashboard tenant and workspace
- include tenant and workspace in report URLs, cache keys, and in-flight request identity
- discard prior-scope report state while a new tenant or workspace request is pending
- preserve tenant and workspace on trend, finding, and framework drilldowns

## Isolation behavior

- a missing tenant, including an orphan workspace, produces no report request path and no fetch
- existing proxy route tests prove orphan workspaces and selector mismatches return 400 before fixture or upstream reads
- existing authorization tests prove a 403 is returned after one scoped upstream call with no unscoped retry

## Validation

- npm workspace @writer/cerebro-web focused tests: 4 files, 75 tests passed
- changed-file ESLint: passed
- TypeScript no-emit check: passed
- focused internal/bootstrap GRC scope and query tests: passed
- make check-structural check-structural-test check-arch: passed
- git diff --check: passed
