### PR TITLE
Align Cloudflare authority regression test

### DIFF
--- a/crates/source-runtime-next/src/cloudflare/tests.rs
+++ b/crates/source-runtime-next/src/cloudflare/tests.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, str::FromStr};
 
 use cerebro_source_catalog::{AuthModel, CollectionAuthority, Pagination, SourceCatalog};
 use serde::Deserialize;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 use super::*;
 
@@ -153,7 +153,7 @@ fn checked_in_catalog_compiles_the_closed_cloudflare_runtime() {
     .unwrap();
     let source = catalog.get("cloudflare").unwrap();
     assert_eq!(source.auth(), &AuthModel::BearerToken);
-    assert_eq!(source.authority(), CollectionAuthority::ShadowOnly);
+    assert_eq!(source.authority(), CollectionAuthority::Authoritative);
     let compiled = source
         .families()
         .iter()
@@ -165,7 +165,7 @@ fn checked_in_catalog_compiles_the_closed_cloudflare_runtime() {
         .collect::<std::collections::BTreeSet<_>>();
     assert_eq!(compiled, expected);
     for family in source.families() {
-        assert!(!family.is_authoritative(), "{} collection", family.id());
+        assert!(family.is_authoritative(), "{} collection", family.id());
         assert!(
             family.is_projection_authoritative(),
             "{} projection",


### PR DESCRIPTION
## Summary

- Align the Cloudflare catalog regression test with the authoritative collection state produced by the checked-in catalog.
- Preserve the per-family projection-authority assertions.

## Test plan

- `rustup run 1.93.1 rustfmt --check crates/source-runtime-next/src/cloudflare/tests.rs`
- Hosted CI validates the Rust catalog and graph-action suites.