### PR TITLE
fix(web): scope browser GRC client state by identity

### DIFF
--- a/apps/web/src/app/connectors/page.tsx
+++ b/apps/web/src/app/connectors/page.tsx
@@ -704,6 +704,7 @@ export default function ConnectorsPage() {
   const libraryQuery = useConnectorLibraryQuery({ tenantID: debouncedTenantID, view: "summary" });
   const runtimeHealthQuery = useGRCQuery<ConnectorRuntimeHealthResponse>(withQuery("/v1/source-runtimes/health", {
     limit: CONNECTOR_RUNTIME_LIMIT,
+    tenant_id: debouncedTenantID,
   }));
   const definitionsQuery = useGRCQuery<ConnectorDefinitionListResponse>(withQuery("/connector-definitions", { tenant_id: debouncedTenantID }));
 

--- a/apps/web/src/app/explore/page.tsx
+++ b/apps/web/src/app/explore/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import AskAboutLink from "@/components/ask/AskAboutLink";
 import GraphViewer from "@/components/grc/LazyGraphViewer";
@@ -67,7 +67,7 @@ export default function ExplorePage() {
   }), [actor, normalizedTenantID, normalizedWorkspaceID]);
   const activeScopeKey = useMemo(() => grcClientScopeKey(scope, apiKey), [apiKey, scope]);
   const activeScopeKeyRef = useRef(activeScopeKey);
-  useEffect(() => {
+  useLayoutEffect(() => {
     activeScopeKeyRef.current = activeScopeKey;
   }, [activeScopeKey]);
   const [rootURN, setRootURN] = useQueryParamState("root_urn");
@@ -115,6 +115,8 @@ export default function ExplorePage() {
 
   const clearSeed = useCallback(() => {
     setState(null);
+    setSeedLoading(false);
+    setExpandingURN(null);
     setLoadedScopeKey("");
     setError(null);
     setExpandNotice(null);

--- a/apps/web/src/app/explore/page.tsx
+++ b/apps/web/src/app/explore/page.tsx
@@ -66,6 +66,10 @@ export default function ExplorePage() {
     workspaceID: normalizedWorkspaceID,
   }), [actor, normalizedTenantID, normalizedWorkspaceID]);
   const activeScopeKey = useMemo(() => grcClientScopeKey(scope, apiKey), [apiKey, scope]);
+  const activeScopeKeyRef = useRef(activeScopeKey);
+  useEffect(() => {
+    activeScopeKeyRef.current = activeScopeKey;
+  }, [activeScopeKey]);
   const [rootURN, setRootURN] = useQueryParamState("root_urn");
   const debouncedRootURN = useDebouncedValue(rootURN.trim());
   const needsFallbackRoot = debouncedRootURN === "";
@@ -197,6 +201,7 @@ export default function ExplorePage() {
     const target = urn.trim();
     if (target === "") return;
     if (scopedState && isExploreNodeExpanded(scopedState, target)) return;
+    const requestScopeKey = activeScopeKey;
     setExpandingURN(target);
     setError(null);
     setExpandNotice(null);
@@ -204,6 +209,7 @@ export default function ExplorePage() {
     const controller = new AbortController();
     try {
       const response = await fetchNeighborhood(path, false, controller.signal);
+      if (activeScopeKeyRef.current !== requestScopeKey) return;
       if (!response.ok) {
         setError(grcResponseErrorMessage(path, response.status, response.data));
         return;
@@ -225,11 +231,14 @@ export default function ExplorePage() {
           : `Expanded ${shortEntity(target)}: no new neighbors found.`,
       });
     } catch (err) {
+      if (activeScopeKeyRef.current !== requestScopeKey) return;
       setError(err instanceof Error ? err.message : "Unable to expand node.");
     } finally {
-      setExpandingURN(null);
+      if (activeScopeKeyRef.current === requestScopeKey) {
+        setExpandingURN(null);
+      }
     }
-  }, [fetchNeighborhood, normalizedTenantID, normalizedWorkspaceID, scopedState]);
+  }, [activeScopeKey, fetchNeighborhood, normalizedTenantID, normalizedWorkspaceID, scopedState]);
 
   const removeNode = useCallback((urn: string) => {
     setState((current) => (current ? removeExploreNode(current, urn) : current));

--- a/apps/web/src/app/explore/page.tsx
+++ b/apps/web/src/app/explore/page.tsx
@@ -30,6 +30,7 @@ import {
   removeExploreNode,
   toGRCGraph,
 } from "@/lib/graph-explore";
+import { grcScopeQuery, useGRCScopeQueryState } from "@/lib/grc-scope";
 import { useQueryParamState } from "@/lib/query-params";
 import { metricValueForState, runtimeStateForError, type RuntimeState } from "@/lib/runtime-state";
 
@@ -41,8 +42,11 @@ const EXPLORE_NODE_LIMIT = 200;
 const inputClass = "mt-1 w-full rounded-md border border-slate-200 bg-white px-3 py-1.5 text-[13px] text-slate-900 placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-1 focus:ring-indigo-400/30";
 const labelClass = "text-[11px] font-medium uppercase tracking-wider text-slate-500";
 
-const neighborhoodPath = (urn: string) =>
-  organizationalGraphNeighborhoodPath(urn, { limit: NEIGHBORS_PER_EXPAND });
+const neighborhoodPath = (urn: string, tenantID = "", workspaceID = "") =>
+  organizationalGraphNeighborhoodPath(urn, {
+    ...grcScopeQuery({ tenantID, workspaceID }),
+    limit: NEIGHBORS_PER_EXPAND,
+  });
 
 const isLikelyEntityURN = (value: string) => /^urn:[^\s:]+:.+/.test(value.trim());
 
@@ -52,14 +56,28 @@ const graphNodeURNs = (graph: GRCGraph | undefined) =>
 export default function ExplorePage() {
   const { apiKey } = useApiKey();
   const { actor, loading: userLoading } = useCurrentUser();
-  const scope = useMemo<GRCQueryScope>(() => ({ actor }), [actor]);
+  const { tenantID, workspaceID } = useGRCScopeQueryState();
+  const normalizedTenantID = tenantID.trim();
+  const normalizedWorkspaceID = workspaceID.trim();
+  const invalidWorkspaceScope = Boolean(normalizedWorkspaceID && !normalizedTenantID);
+  const scope = useMemo<GRCQueryScope>(() => ({
+    actor,
+    tenantID: normalizedTenantID,
+    workspaceID: normalizedWorkspaceID,
+  }), [actor, normalizedTenantID, normalizedWorkspaceID]);
   const activeScopeKey = useMemo(() => grcClientScopeKey(scope, apiKey), [apiKey, scope]);
   const [rootURN, setRootURN] = useQueryParamState("root_urn");
   const debouncedRootURN = useDebouncedValue(rootURN.trim());
   const needsFallbackRoot = debouncedRootURN === "";
 
   const fallbackFindings = useGRCQuery<FindingsResponse>(
-    needsFallbackRoot ? grcPath("/grc/findings", { status: "open", limit: 10 }) : null,
+    needsFallbackRoot && !invalidWorkspaceScope
+      ? grcPath("/grc/findings", {
+        ...grcScopeQuery({ tenantID: normalizedTenantID, workspaceID: normalizedWorkspaceID }),
+        status: "open",
+        limit: 10,
+      })
+      : null,
   );
   const fallbackRoot = fallbackFindings.data?.findings?.find((finding) => finding.entity || finding.resource_urns?.[0])?.entity ?? fallbackFindings.data?.findings?.find((finding) => finding.resource_urns?.[0])?.resource_urns?.[0] ?? "";
   const seedValidation = debouncedRootURN && !isLikelyEntityURN(debouncedRootURN) ? "Use a full entity URN, for example urn:cerebro:tenant:asset:id." : "";
@@ -122,7 +140,7 @@ export default function ExplorePage() {
       setSeedLoading(true);
       setError(null);
       setExpandNotice(null);
-      const path = neighborhoodPath(seed);
+      const path = neighborhoodPath(seed, normalizedTenantID, normalizedWorkspaceID);
       try {
         const response = await fetchNeighborhood(path, force, signal);
         if (isCancelled()) return;
@@ -143,7 +161,7 @@ export default function ExplorePage() {
         if (!isCancelled()) setSeedLoading(false);
       }
     },
-    [activeScopeKey, fetchNeighborhood],
+    [activeScopeKey, fetchNeighborhood, normalizedTenantID, normalizedWorkspaceID],
   );
 
   useEffect(() => {
@@ -151,7 +169,7 @@ export default function ExplorePage() {
     const controller = new AbortController();
     const timer = window.setTimeout(() => {
       if (cancelled) return;
-      if (userLoading || !actor.trim()) {
+      if (userLoading || !actor.trim() || invalidWorkspaceScope) {
         loadKeyRef.current = "";
         clearSeed();
         return;
@@ -171,7 +189,7 @@ export default function ExplorePage() {
       controller.abort();
       window.clearTimeout(timer);
     };
-  }, [activeScopeKey, actor, clearSeed, loadSeed, reloadToken, selectedSeed, userLoading]);
+  }, [activeScopeKey, actor, clearSeed, invalidWorkspaceScope, loadSeed, reloadToken, selectedSeed, userLoading]);
 
   const scopedState = loadedScopeKey !== "" && loadedScopeKey === activeScopeKey ? state : null;
 
@@ -182,7 +200,7 @@ export default function ExplorePage() {
     setExpandingURN(target);
     setError(null);
     setExpandNotice(null);
-    const path = neighborhoodPath(target);
+    const path = neighborhoodPath(target, normalizedTenantID, normalizedWorkspaceID);
     const controller = new AbortController();
     try {
       const response = await fetchNeighborhood(path, false, controller.signal);
@@ -211,7 +229,7 @@ export default function ExplorePage() {
     } finally {
       setExpandingURN(null);
     }
-  }, [fetchNeighborhood, scopedState]);
+  }, [fetchNeighborhood, normalizedTenantID, normalizedWorkspaceID, scopedState]);
 
   const removeNode = useCallback((urn: string) => {
     setState((current) => (current ? removeExploreNode(current, urn) : current));
@@ -228,10 +246,10 @@ export default function ExplorePage() {
 
   const retryExplore = useCallback(() => {
     resetExploration();
-    if (!selectedSeed) {
+    if (!selectedSeed && !invalidWorkspaceScope && !userLoading && actor.trim()) {
       void fallbackFindings.reload();
     }
-  }, [fallbackFindings, resetExploration, selectedSeed]);
+  }, [actor, fallbackFindings, invalidWorkspaceScope, resetExploration, selectedSeed, userLoading]);
 
   const graph = useMemo(() => (scopedState ? toGRCGraph(scopedState) : undefined), [scopedState]);
   const expandedURNs = useMemo(() => new Set(scopedState ? Object.keys(scopedState.expanded) : []), [scopedState]);

--- a/apps/web/src/app/explore/page.tsx
+++ b/apps/web/src/app/explore/page.tsx
@@ -5,9 +5,20 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import AskAboutLink from "@/components/ask/AskAboutLink";
 import GraphViewer from "@/components/grc/LazyGraphViewer";
 import { DataStateBanner, EmptyBlock, MetricCard, PageHeader, Panel } from "@/components/grc/Primitives";
-import { useApiKey } from "@/components/providers";
+import { useApiKey, useCurrentUser } from "@/components/providers";
 import { GRCFinding, GRCGraph, shortEntity } from "@/lib/grc";
-import { fetchCachedGRC, grcPath, grcResponseErrorMessage, grcTimeoutMessage, GRC_QUERY_TIMEOUT_MS, organizationalGraphNeighborhoodPath, useDebouncedValue, useGRCQuery } from "@/lib/grc-client";
+import {
+  fetchCachedGRC,
+  grcClientScopeKey,
+  grcPath,
+  grcResponseErrorMessage,
+  grcTimeoutMessage,
+  GRC_QUERY_TIMEOUT_MS,
+  organizationalGraphNeighborhoodPath,
+  useDebouncedValue,
+  useGRCQuery,
+  type GRCQueryScope,
+} from "@/lib/grc-client";
 import {
   ExploreGraphState,
   emptyExploreState,
@@ -40,6 +51,9 @@ const graphNodeURNs = (graph: GRCGraph | undefined) =>
 
 export default function ExplorePage() {
   const { apiKey } = useApiKey();
+  const { actor, loading: userLoading } = useCurrentUser();
+  const scope = useMemo<GRCQueryScope>(() => ({ actor }), [actor]);
+  const activeScopeKey = useMemo(() => grcClientScopeKey(scope, apiKey), [apiKey, scope]);
   const [rootURN, setRootURN] = useQueryParamState("root_urn");
   const debouncedRootURN = useDebouncedValue(rootURN.trim());
   const needsFallbackRoot = debouncedRootURN === "";
@@ -59,6 +73,7 @@ export default function ExplorePage() {
   const [recentlyDiscoveredURNs, setRecentlyDiscoveredURNs] = useState<Set<string>>(new Set());
   const [reloadToken, setReloadToken] = useState(0);
   const [lastGraphLoadedAt, setLastGraphLoadedAt] = useState<number | null>(null);
+  const [loadedScopeKey, setLoadedScopeKey] = useState("");
   const loadKeyRef = useRef("");
 
   const seedSuggestions = useMemo(() => {
@@ -78,6 +93,7 @@ export default function ExplorePage() {
 
   const clearSeed = useCallback(() => {
     setState(null);
+    setLoadedScopeKey("");
     setError(null);
     setExpandNotice(null);
     setRecentlyDiscoveredURNs(new Set());
@@ -89,7 +105,7 @@ export default function ExplorePage() {
     signal?.addEventListener("abort", abort, { once: true });
     const timer = window.setTimeout(() => controller.abort(), GRC_QUERY_TIMEOUT_MS);
     try {
-      return await fetchCachedGRC<GRCGraph>(path, apiKey, force, { signal: controller.signal });
+      return await fetchCachedGRC<GRCGraph>(path, apiKey, force, { signal: controller.signal }, scope);
     } catch (err) {
       if (controller.signal.aborted && !signal?.aborted) {
         throw new Error(grcTimeoutMessage(path, GRC_QUERY_TIMEOUT_MS));
@@ -99,7 +115,7 @@ export default function ExplorePage() {
       signal?.removeEventListener("abort", abort);
       window.clearTimeout(timer);
     }
-  }, [apiKey]);
+  }, [apiKey, scope]);
 
   const loadSeed = useCallback(
     async (seed: string, force: boolean, signal: AbortSignal, isCancelled: () => boolean) => {
@@ -116,6 +132,7 @@ export default function ExplorePage() {
           return;
         }
         setState(mergeNeighborhood(emptyExploreState(seed), seed, response.data));
+        setLoadedScopeKey(activeScopeKey);
         setLastGraphLoadedAt(Date.now());
         setRecentlyDiscoveredURNs(new Set(graphNodeURNs(response.data)));
       } catch (err) {
@@ -126,7 +143,7 @@ export default function ExplorePage() {
         if (!isCancelled()) setSeedLoading(false);
       }
     },
-    [fetchNeighborhood],
+    [activeScopeKey, fetchNeighborhood],
   );
 
   useEffect(() => {
@@ -134,12 +151,17 @@ export default function ExplorePage() {
     const controller = new AbortController();
     const timer = window.setTimeout(() => {
       if (cancelled) return;
+      if (userLoading || !actor.trim()) {
+        loadKeyRef.current = "";
+        clearSeed();
+        return;
+      }
       if (selectedSeed === "") {
         loadKeyRef.current = "";
         clearSeed();
         return;
       }
-      const loadKey = `${selectedSeed}|${reloadToken}`;
+      const loadKey = `${activeScopeKey}|${selectedSeed}|${reloadToken}`;
       if (loadKey === loadKeyRef.current) return;
       loadKeyRef.current = loadKey;
       void loadSeed(selectedSeed, reloadToken > 0, controller.signal, () => cancelled);
@@ -149,12 +171,14 @@ export default function ExplorePage() {
       controller.abort();
       window.clearTimeout(timer);
     };
-  }, [clearSeed, loadSeed, reloadToken, selectedSeed]);
+  }, [activeScopeKey, actor, clearSeed, loadSeed, reloadToken, selectedSeed, userLoading]);
+
+  const scopedState = loadedScopeKey !== "" && loadedScopeKey === activeScopeKey ? state : null;
 
   const expand = useCallback(async (urn: string) => {
     const target = urn.trim();
     if (target === "") return;
-    if (state && isExploreNodeExpanded(state, target)) return;
+    if (scopedState && isExploreNodeExpanded(scopedState, target)) return;
     setExpandingURN(target);
     setError(null);
     setExpandNotice(null);
@@ -166,10 +190,10 @@ export default function ExplorePage() {
         setError(grcResponseErrorMessage(path, response.status, response.data));
         return;
       }
-      if (!state) return;
-      const beforeNodes = exploreNodeCount(state);
-      const beforeRelations = exploreRelationCount(state);
-      const next = mergeNeighborhood(state, target, response.data);
+      if (!scopedState) return;
+      const beforeNodes = exploreNodeCount(scopedState);
+      const beforeRelations = exploreRelationCount(scopedState);
+      const next = mergeNeighborhood(scopedState, target, response.data);
       const addedNodes = Math.max(0, exploreNodeCount(next) - beforeNodes);
       const addedRelations = Math.max(0, exploreRelationCount(next) - beforeRelations);
       const discovered = new Set([target, ...graphNodeURNs(response.data)]);
@@ -187,7 +211,7 @@ export default function ExplorePage() {
     } finally {
       setExpandingURN(null);
     }
-  }, [fetchNeighborhood, state]);
+  }, [fetchNeighborhood, scopedState]);
 
   const removeNode = useCallback((urn: string) => {
     setState((current) => (current ? removeExploreNode(current, urn) : current));
@@ -209,17 +233,17 @@ export default function ExplorePage() {
     }
   }, [fallbackFindings, resetExploration, selectedSeed]);
 
-  const graph = useMemo(() => (state ? toGRCGraph(state) : undefined), [state]);
-  const expandedURNs = useMemo(() => new Set(state ? Object.keys(state.expanded) : []), [state]);
+  const graph = useMemo(() => (scopedState ? toGRCGraph(scopedState) : undefined), [scopedState]);
+  const expandedURNs = useMemo(() => new Set(scopedState ? Object.keys(scopedState.expanded) : []), [scopedState]);
   const pinnedURNs = useMemo(() => {
     const next = new Set(expandedURNs);
     recentlyDiscoveredURNs.forEach((urn) => next.add(urn));
     if (selectedSeed) next.add(selectedSeed);
     return next;
   }, [expandedURNs, recentlyDiscoveredURNs, selectedSeed]);
-  const nodeCount = state ? exploreNodeCount(state) : 0;
-  const relationCount = state ? exploreRelationCount(state) : 0;
-  const expandedCount = state ? exploreExpandedCount(state) : 0;
+  const nodeCount = scopedState ? exploreNodeCount(scopedState) : 0;
+  const relationCount = scopedState ? exploreRelationCount(scopedState) : 0;
+  const expandedCount = scopedState ? exploreExpandedCount(scopedState) : 0;
   const visibleNodeCount = Math.min(nodeCount, EXPLORE_NODE_LIMIT);
   const hiddenNodeCount = Math.max(0, nodeCount - visibleNodeCount);
 

--- a/apps/web/src/app/explore/page.tsx
+++ b/apps/web/src/app/explore/page.tsx
@@ -144,6 +144,7 @@ export default function ExplorePage() {
   const loadSeed = useCallback(
     async (seed: string, force: boolean, signal: AbortSignal, isCancelled: () => boolean) => {
       setSeedLoading(true);
+      setExpandingURN(null);
       setError(null);
       setExpandNotice(null);
       const path = neighborhoodPath(seed, normalizedTenantID, normalizedWorkspaceID);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -51,7 +51,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                               <div className="flex h-screen max-w-full overflow-hidden bg-[var(--app-bg)]">
                                 <Sidebar />
                                 <div className="flex min-w-0 flex-1 flex-col overflow-x-hidden">
-                                  <Topbar />
+                                  <Suspense fallback={null}>
+                                    <Topbar />
+                                  </Suspense>
                                   <main className="min-w-0 flex-1 overflow-x-hidden overflow-y-auto bg-[var(--app-bg)] px-8 py-6 max-md:px-4">
                                     <Suspense fallback={null}>{children}</Suspense>
                                   </main>

--- a/apps/web/src/components/Topbar.tsx
+++ b/apps/web/src/components/Topbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { Check, Settings2, Share2, UsersRound } from "lucide-react";
 
@@ -11,7 +12,7 @@ import type { GRCDashboard } from "@/lib/grc";
 import { DASHBOARD_FINDING_LIMIT, grcDashboardPath, grcPath, useGRCQuery } from "@/lib/grc-client";
 import { currentUserConfidenceLabel, identityPosture } from "@/lib/identity";
 import { currentUserWriteFieldForPath } from "@/lib/identity-write-stamp";
-import { buildNotifications, notificationSignatures, reportRunNotifications, unreadNotifications, type NotificationIntent } from "@/lib/notifications";
+import { buildNotifications, notificationReadStorageKey, notificationSignatures, reportRunNotifications, unreadNotifications, type NotificationIntent } from "@/lib/notifications";
 import { authorizationRoleLabelsForUser, effectiveAuthorizationPermissionsForUser } from "@/lib/rbac";
 import type { ReportRunListResponse } from "@/lib/report-schedules";
 import { usePopoverDismissal } from "@/lib/use-popover-dismissal";
@@ -19,7 +20,6 @@ import { HOME_SECTION_IDS, HOME_SECTION_LABELS, userPreferencesShareURL, type Di
 
 const displayValues = (values: string[] | undefined) => values?.filter(Boolean).join(", ") || "—";
 
-const NOTIFICATIONS_READ_KEY = "cerebro.notifications.read";
 const NOTIFICATIONS_READ_EVENT = "cerebro-notifications-read";
 
 const subscribeReadSignatures = (callback: () => void) => {
@@ -31,11 +31,10 @@ const subscribeReadSignatures = (callback: () => void) => {
   };
 };
 
-const getReadSignaturesSnapshot = () => window.localStorage.getItem(NOTIFICATIONS_READ_KEY) ?? "[]";
 const getReadSignaturesServerSnapshot = () => "[]";
 
-const persistReadSignatures = (signatures: string[]) => {
-  window.localStorage.setItem(NOTIFICATIONS_READ_KEY, JSON.stringify(signatures));
+const persistReadSignatures = (storageKey: string, signatures: string[]) => {
+  window.localStorage.setItem(storageKey, JSON.stringify(signatures));
   window.dispatchEvent(new Event(NOTIFICATIONS_READ_EVENT));
 };
 
@@ -48,7 +47,8 @@ export default function Topbar() {
   const topbarRef = useRef<HTMLElement>(null);
   const { apiKey, setApiKey } = useApiKey();
   const { openCommandPalette } = useCommandPalette();
-  const { error: userError, loading: userLoading, user } = useCurrentUser();
+  const { actor, error: userError, loading: userLoading, user } = useCurrentUser();
+  const searchParams = useSearchParams();
   const { theme, setTheme, toggleTheme } = useTheme();
   const {
     error: preferencesError,
@@ -156,6 +156,19 @@ export default function Topbar() {
   const reportRunsQuery = useGRCQuery<ReportRunListResponse>(
     notificationsRequested ? grcPath("/report-runs", { limit: 5 }) : null,
   );
+  const notificationStorageKey = useMemo(
+    () => notificationReadStorageKey({
+      actor,
+      apiKey,
+      tenantID: searchParams.get("tenant_id") ?? "",
+      workspaceID: searchParams.get("workspace_id") ?? "",
+    }),
+    [actor, apiKey, searchParams],
+  );
+  const getReadSignaturesSnapshot = useCallback(
+    () => window.localStorage.getItem(notificationStorageKey) ?? "[]",
+    [notificationStorageKey],
+  );
   const notificationsLoading = notificationsQuery.loading || reportRunsQuery.loading;
   const notifications = useMemo(
     () => [...buildNotifications(notificationsQuery.data), ...reportRunNotifications(reportRunsQuery.data?.runs)],
@@ -177,7 +190,7 @@ export default function Topbar() {
   const unread = useMemo(() => unreadNotifications(notifications, readSignatures), [notifications, readSignatures]);
   const unreadCount = unread.length;
   const hasDangerUnread = unread.some((notification) => notification.intent === "danger");
-  const markAllNotificationsRead = () => persistReadSignatures(notificationSignatures(notifications));
+  const markAllNotificationsRead = () => persistReadSignatures(notificationStorageKey, notificationSignatures(notifications));
   const popoverOpen = showConnection || showIdentity || showNotifications;
   const closePopovers = useCallback(() => {
     setShowConnection(false);

--- a/apps/web/src/components/Topbar.tsx
+++ b/apps/web/src/components/Topbar.tsx
@@ -49,6 +49,9 @@ export default function Topbar() {
   const { openCommandPalette } = useCommandPalette();
   const { actor, error: userError, loading: userLoading, user } = useCurrentUser();
   const searchParams = useSearchParams();
+  const notificationTenantID = searchParams.get("tenant_id")?.trim() ?? "";
+  const notificationWorkspaceID = searchParams.get("workspace_id")?.trim() ?? "";
+  const invalidNotificationScope = Boolean(notificationWorkspaceID && !notificationTenantID);
   const { theme, setTheme, toggleTheme } = useTheme();
   const {
     error: preferencesError,
@@ -151,20 +154,29 @@ export default function Topbar() {
   }, [shareStatus, shareURL]);
 
   const notificationsQuery = useGRCQuery<GRCDashboard>(
-    notificationsRequested ? grcDashboardPath({ limit: DASHBOARD_FINDING_LIMIT }) : null,
+    notificationsRequested && !invalidNotificationScope
+      ? grcDashboardPath({
+        limit: DASHBOARD_FINDING_LIMIT,
+        tenant_id: notificationTenantID || undefined,
+        workspace_id: notificationWorkspaceID || undefined,
+      })
+      : null,
   );
   const reportRunsQuery = useGRCQuery<ReportRunListResponse>(
-    notificationsRequested ? grcPath("/report-runs", { limit: 5 }) : null,
+    notificationsRequested && !invalidNotificationScope
+      ? grcPath("/report-runs", {
+        limit: 5,
+        tenant_id: notificationTenantID || undefined,
+        workspace_id: notificationWorkspaceID || undefined,
+      })
+      : null,
   );
-  const notificationStorageKey = useMemo(
-    () => notificationReadStorageKey({
-      actor,
-      apiKey,
-      tenantID: searchParams.get("tenant_id") ?? "",
-      workspaceID: searchParams.get("workspace_id") ?? "",
-    }),
-    [actor, apiKey, searchParams],
-  );
+  const notificationStorageKey = notificationReadStorageKey({
+    actor,
+    apiKey,
+    tenantID: notificationTenantID,
+    workspaceID: notificationWorkspaceID,
+  });
   const getReadSignaturesSnapshot = useCallback(
     () => window.localStorage.getItem(notificationStorageKey) ?? "[]",
     [notificationStorageKey],
@@ -196,7 +208,7 @@ export default function Topbar() {
     setShowConnection(false);
     setShowIdentity(false);
     setShowNotifications(false);
-  }, []);
+  }, [setShowConnection, setShowIdentity, setShowNotifications]);
   usePopoverDismissal({ containerRef: topbarRef, enabled: popoverOpen, onDismiss: closePopovers });
 
   return (

--- a/apps/web/src/lib/connector-library-query.scope.test.tsx
+++ b/apps/web/src/lib/connector-library-query.scope.test.tsx
@@ -77,7 +77,7 @@ describe("connector library scope transitions", () => {
     await act(async () => {
       root.render(<ConnectorLibraryHarness tenantID="tenant-b" />);
     });
-    expect(container.querySelector("#connector-state")?.textContent).toBe("empty");
+    expect(container.querySelector("#connector-state")?.textContent).not.toBe("connector-a");
 
     await act(async () => {
       await flushReactUpdates();

--- a/apps/web/src/lib/connector-library-query.scope.test.tsx
+++ b/apps/web/src/lib/connector-library-query.scope.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const currentScope = vi.hoisted(() => ({ actor: "actor-a", apiKey: "key-a" }));
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+vi.mock("@/components/providers", () => ({
+  useApiKey: () => ({ apiKey: currentScope.apiKey }),
+  useCurrentUser: () => ({ actor: currentScope.actor, loading: false }),
+}));
+
+import { useConnectorLibraryQuery } from "./connector-library-query";
+
+const flushReactUpdates = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  await new Promise((resolve) => setTimeout(resolve, 10));
+};
+
+function ConnectorLibraryHarness({ tenantID }: { tenantID: string }) {
+  const query = useConnectorLibraryQuery({ tenantID });
+  return <output id="connector-state">{query.loading ? "loading" : query.data?.connectors?.[0]?.source_id ?? "empty"}</output>;
+}
+
+const connectorResponse = (tenantID: string, sourceID: string) => new Response(JSON.stringify({
+  tenant_id: tenantID,
+  connectors: [{ source_id: sourceID, name: sourceID }],
+  page: { total: 1, returned: 1, limit: 200, has_more: false },
+}), {
+  headers: { "content-type": "application/json" },
+  status: 200,
+});
+
+describe("connector library scope transitions", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let pending: Array<(response: Response) => void>;
+
+  beforeEach(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    currentScope.actor = "actor-a";
+    currentScope.apiKey = "key-a";
+    pending = [];
+    vi.stubGlobal("fetch", vi.fn(() => new Promise<Response>((resolve) => pending.push(resolve))));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("does not render the prior tenant while the replacement page is loading", async () => {
+    await act(() => {
+      root.render(<ConnectorLibraryHarness tenantID="tenant-a" />);
+    });
+    await act(async () => {
+      await flushReactUpdates();
+    });
+    expect(pending).toHaveLength(1);
+
+    await act(async () => {
+      pending.shift()?.(connectorResponse("tenant-a", "connector-a"));
+      await flushReactUpdates();
+    });
+    expect(container.querySelector("#connector-state")?.textContent).toBe("connector-a");
+
+    await act(async () => {
+      root.render(<ConnectorLibraryHarness tenantID="tenant-b" />);
+    });
+    expect(container.querySelector("#connector-state")?.textContent).toBe("empty");
+
+    await act(async () => {
+      await flushReactUpdates();
+    });
+    expect(pending).toHaveLength(1);
+    await act(async () => {
+      pending.shift()?.(connectorResponse("tenant-b", "connector-b"));
+      await flushReactUpdates();
+    });
+    expect(container.querySelector("#connector-state")?.textContent).toBe("connector-b");
+  });
+});

--- a/apps/web/src/lib/connector-library-query.ts
+++ b/apps/web/src/lib/connector-library-query.ts
@@ -2,10 +2,17 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { useApiKey } from "@/components/providers";
+import { useApiKey, useCurrentUser } from "@/components/providers";
 import { withQuery } from "@/lib/cerebro-data";
 import type { ConnectorLibraryResponse } from "@/lib/connectors";
-import { fetchCachedGRC, GRC_QUERY_TIMEOUT_MS, grcResponseErrorMessage, grcTimeoutMessage } from "@/lib/grc-client";
+import {
+  fetchCachedGRC,
+  GRC_QUERY_TIMEOUT_MS,
+  grcClientScopeKey,
+  grcResponseErrorMessage,
+  grcTimeoutMessage,
+  type GRCQueryScope,
+} from "@/lib/grc-client";
 
 export const CONNECTOR_LIBRARY_PAGE_LIMIT = 200;
 const CONNECTOR_LIBRARY_MAX_PAGES = 50;
@@ -76,15 +83,20 @@ export function useConnectorLibraryQuery({
   enabled = true,
 }: ConnectorLibraryQueryOptions = {}) {
   const { apiKey } = useApiKey();
+  const { actor, loading: userLoading } = useCurrentUser();
   const [data, setData] = useState<ConnectorLibraryResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [durationMs, setDurationMs] = useState<number | null>(null);
+  const [loadedScopeKey, setLoadedScopeKey] = useState("");
   const requestID = useRef(0);
   const pageLimit = useMemo(() => connectorLibraryLimit(limit), [limit]);
+  const scope = useMemo<GRCQueryScope>(() => ({ actor, tenantID: tenantID.trim() }), [actor, tenantID]);
+  const requestScopeKey = useMemo(() => grcClientScopeKey(scope, apiKey), [apiKey, scope]);
+  const requestEnabled = enabled && !userLoading && Boolean(actor.trim());
   const firstPagePath = useMemo(
-    () => enabled ? connectorLibraryPagePath({ tenantID, view, limit: pageLimit }) : null,
-    [enabled, pageLimit, tenantID, view],
+    () => requestEnabled ? connectorLibraryPagePath({ tenantID, view, limit: pageLimit }) : null,
+    [pageLimit, requestEnabled, tenantID, view],
   );
 
   const load = useCallback(async (signal?: AbortSignal, force = false) => {
@@ -93,6 +105,7 @@ export function useConnectorLibraryQuery({
       setError(null);
       setLoading(false);
       setDurationMs(null);
+      setLoadedScopeKey("");
       return;
     }
 
@@ -120,7 +133,7 @@ export function useConnectorLibraryQuery({
         const path = index === 0
           ? firstPagePath
           : connectorLibraryPagePath({ tenantID, view, limit: pageLimit, cursor });
-        const response = await fetchCachedGRC<ConnectorLibraryResponse>(path, apiKey, force, { signal: controller.signal });
+        const response = await fetchCachedGRC<ConnectorLibraryResponse>(path, apiKey, force, { signal: controller.signal }, scope);
 
         if (!response.ok) {
           throw new Error(grcResponseErrorMessage(path, response.status, response.data, Math.round(performance.now() - startedAt)));
@@ -145,8 +158,9 @@ export function useConnectorLibraryQuery({
       if (cursor) {
         throw new Error("Connector catalog pagination exceeded the client page limit.");
       }
-      if (currentRequestID !== requestID.current) return;
+      if (signal?.aborted || currentRequestID !== requestID.current) return;
       setData(mergeConnectorLibraryPages(pages) ?? { connectors: [] });
+      setLoadedScopeKey(requestScopeKey);
       setDurationMs(Math.round(performance.now() - startedAt));
       setLoading(false);
     } catch (err) {
@@ -161,7 +175,7 @@ export function useConnectorLibraryQuery({
       window.clearTimeout(timeout);
       signal?.removeEventListener("abort", abortFromCaller);
     }
-  }, [apiKey, firstPagePath, pageLimit, tenantID, view]);
+  }, [apiKey, firstPagePath, pageLimit, requestScopeKey, scope, tenantID, view]);
 
   const reload = useCallback(() => load(undefined, true), [load]);
 
@@ -174,5 +188,6 @@ export function useConnectorLibraryQuery({
     };
   }, [load]);
 
-  return { data, error, loading, durationMs, reload };
+  const visibleData = loadedScopeKey !== "" && loadedScopeKey === requestScopeKey ? data : null;
+  return { data: visibleData, error, loading, durationMs, reload };
 }

--- a/apps/web/src/lib/grc-client.test.tsx
+++ b/apps/web/src/lib/grc-client.test.tsx
@@ -20,6 +20,7 @@ import {
   GRC_QUERY_TIMEOUT_MS,
   grcResponseErrorMessage,
   grcTimeoutMessage,
+  isValidGRCQueryScope,
   organizationalGraphNeighborhoodPath,
   readCachedGRC,
   useGRCMutation,
@@ -95,6 +96,12 @@ describe("grc client paths", () => {
 
 describe("grc query keys", () => {
   const scopeA: GRCQueryScope = { actor: "actor-a", tenantID: "tenant-a", workspaceID: "workspace-a" };
+
+  it("rejects orphan workspace scopes before a query can run", () => {
+    expect(isValidGRCQueryScope({ actor: "actor-a", workspaceID: "workspace-a" })).toBe(false);
+    expect(isValidGRCQueryScope({ actor: "actor-a", tenantID: "tenant-a" })).toBe(true);
+    expect(isValidGRCQueryScope(scopeA)).toBe(true);
+  });
 
   it("scopes TanStack Query cache entries by API key, actor, path, tenant, and workspace", () => {
     const path = "/grc/dashboard?limit=10";

--- a/apps/web/src/lib/grc-client.test.tsx
+++ b/apps/web/src/lib/grc-client.test.tsx
@@ -8,7 +8,23 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApiKeyProvider } from "@/components/providers";
 
-import { downloadGRCExport, grcDashboardPath, grcEntityImpactPath, grcExportFilename, grcPath, grcProgramReadinessPath, grcQueryKey, GRC_QUERY_TIMEOUT_MS, grcResponseErrorMessage, grcTimeoutMessage, organizationalGraphNeighborhoodPath, useGRCMutation } from "./grc-client";
+import {
+  downloadGRCExport,
+  fetchCachedGRC,
+  grcDashboardPath,
+  grcEntityImpactPath,
+  grcExportFilename,
+  grcPath,
+  grcProgramReadinessPath,
+  grcQueryKey,
+  GRC_QUERY_TIMEOUT_MS,
+  grcResponseErrorMessage,
+  grcTimeoutMessage,
+  organizationalGraphNeighborhoodPath,
+  readCachedGRC,
+  useGRCMutation,
+  type GRCQueryScope,
+} from "./grc-client";
 
 describe("grc client error copy", () => {
   it("includes status, endpoint, elapsed time, and upstream text", () => {
@@ -78,13 +94,63 @@ describe("grc client paths", () => {
 });
 
 describe("grc query keys", () => {
-  it("scopes TanStack Query cache entries by API key and path", () => {
-    expect(grcQueryKey("/grc/dashboard?limit=10", "key-a")).toEqual(["grc", "key-a", "/grc/dashboard?limit=10"]);
-    expect(grcQueryKey("/grc/dashboard?limit=10", "key-b")).not.toEqual(grcQueryKey("/grc/dashboard?limit=10", "key-a"));
+  const scopeA: GRCQueryScope = { actor: "actor-a", tenantID: "tenant-a", workspaceID: "workspace-a" };
+
+  it("scopes TanStack Query cache entries by API key, actor, path, tenant, and workspace", () => {
+    const path = "/grc/dashboard?limit=10";
+    expect(grcQueryKey(path, "key-a", scopeA)).toEqual(["grc", "key-a", path, "actor-a", "tenant-a", "workspace-a"]);
+    expect(grcQueryKey(path, "key-b", scopeA)).not.toEqual(grcQueryKey(path, "key-a", scopeA));
+    expect(grcQueryKey(path, "key-a", { ...scopeA, actor: "actor-b" })).not.toEqual(grcQueryKey(path, "key-a", scopeA));
+    expect(grcQueryKey(path, "key-a", { ...scopeA, tenantID: "tenant-b" })).not.toEqual(grcQueryKey(path, "key-a", scopeA));
+    expect(grcQueryKey(path, "key-a", { ...scopeA, workspaceID: "workspace-b" })).not.toEqual(grcQueryKey(path, "key-a", scopeA));
   });
 
   it("uses a stable disabled key for inactive queries", () => {
-    expect(grcQueryKey(null)).toEqual(["grc", "", "disabled"]);
+    expect(grcQueryKey(null)).toEqual(["grc", "", "disabled", "", "", ""]);
+  });
+});
+
+describe("scoped GRC response cache", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("does not reuse a response when actor, API key, tenant, or workspace changes", async () => {
+    const path = "/grc/dashboard?tenant_id=tenant-a&workspace_id=workspace-a&cache_test=scope-transition";
+    const scopeA: GRCQueryScope = { actor: "actor-a", tenantID: "tenant-a", workspaceID: "workspace-a" };
+    const scopeB: GRCQueryScope = { actor: "actor-b", tenantID: "tenant-b", workspaceID: "workspace-b" };
+    let responseNumber = 0;
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ value: `response-${++responseNumber}` }), {
+      headers: { "content-type": "application/json" },
+      status: 200,
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchCachedGRC(path, "key-a", false, {}, scopeA);
+    await fetchCachedGRC(path, "key-a", false, {}, scopeA);
+    await fetchCachedGRC(path, "key-b", false, {}, scopeA);
+    await fetchCachedGRC(path, "key-a", false, {}, scopeB);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect((readCachedGRC<{ value: string }>(path, "key-a", scopeA))?.data).toEqual({ value: "response-1" });
+    expect((readCachedGRC<{ value: string }>(path, "key-b", scopeA))?.data).toEqual({ value: "response-2" });
+    expect((readCachedGRC<{ value: string }>(path, "key-a", scopeB))?.data).toEqual({ value: "response-3" });
+  });
+
+  it("does not cache or deduplicate a read while actor scope is unresolved", async () => {
+    const path = "/grc/dashboard?cache_test=unresolved-actor";
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ value: "uncached" }), {
+      headers: { "content-type": "application/json" },
+      status: 200,
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchCachedGRC(path, "key-a");
+    await fetchCachedGRC(path, "key-a");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(readCachedGRC(path, "key-a")).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/grc-client.ts
+++ b/apps/web/src/lib/grc-client.ts
@@ -40,6 +40,11 @@ const grcQueryInflight = new Map<string, Promise<Awaited<ReturnType<typeof fetch
 const normalizedScopeValue = (value: string | undefined) => value?.trim() ?? "";
 
 const hasActorScope = (scope: GRCQueryScope | undefined) => Boolean(scope?.actor.trim());
+export const isValidGRCQueryScope = (scope: GRCQueryScope | undefined) => {
+  const tenantID = normalizedScopeValue(scope?.tenantID);
+  const workspaceID = normalizedScopeValue(scope?.workspaceID);
+  return !workspaceID || Boolean(tenantID);
+};
 
 export const grcClientScopeKey = (scope: GRCQueryScope | undefined, apiKey?: string) => [
   apiKey ?? "",
@@ -402,7 +407,7 @@ export function useGRCQuery<T>(path: string | null) {
   const { apiKey } = useApiKey();
   const { actor, loading: currentUserLoading } = useCurrentUser();
   const scope = scopeForPath(path, actor);
-  const enabled = Boolean(path && !currentUserLoading && hasActorScope(scope));
+  const enabled = Boolean(path && !currentUserLoading && hasActorScope(scope) && isValidGRCQueryScope(scope));
   const query = useQuery<GRCQueryPayload<T>, Error>({
     enabled,
     queryFn: ({ signal }) => fetchGRCQueryPayload<T>(path ?? "", apiKey, signal, scope),
@@ -416,8 +421,9 @@ export function useGRCQuery<T>(path: string | null) {
   const lastSuccessfulAt = enabled && path ? query.data?.successfulAt ?? null : null;
   const { refetch } = query;
   const reload = useCallback(async () => {
+    if (!enabled) return;
     await refetch({ cancelRefetch: true });
-  }, [refetch]);
+  }, [enabled, refetch]);
 
   const state = runtimeStateForQuery({
     data,

--- a/apps/web/src/lib/grc-client.ts
+++ b/apps/web/src/lib/grc-client.ts
@@ -3,9 +3,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { useApiKey } from "@/components/providers";
+import { useApiKey, useCurrentUser } from "@/components/providers";
 import { fetchCerebro } from "@/lib/cerebro-client";
-import { cacheGRCMetadata } from "@/lib/grc-metadata-cache";
+import { cacheGRCMetadata, type GRCMetadataScope } from "@/lib/grc-metadata-cache";
 import { runtimeStateForQuery } from "@/lib/runtime-state";
 
 export const GRC_QUERY_CACHE_TTL_MS = 30_000;
@@ -28,16 +28,63 @@ type CachedGRCResponse = {
   response: Awaited<ReturnType<typeof fetchCerebro>>;
 };
 
+export type GRCQueryScope = {
+  actor: string;
+  tenantID?: string;
+  workspaceID?: string;
+};
+
 const grcQueryCache = new Map<string, CachedGRCResponse>();
 const grcQueryInflight = new Map<string, Promise<Awaited<ReturnType<typeof fetchCerebro>>>>();
 
-const grcQueryCacheKey = (path: string, apiKey?: string) => `${apiKey ?? ""}\n${path}`;
+const normalizedScopeValue = (value: string | undefined) => value?.trim() ?? "";
 
-export const grcQueryKey = (path: string | null, apiKey?: string) =>
-  ["grc", apiKey ?? "", path ?? "disabled"] as const;
+const hasActorScope = (scope: GRCQueryScope | undefined) => Boolean(scope?.actor.trim());
 
-export const readCachedGRC = <T,>(path: string, apiKey?: string) => {
-  const cached = grcQueryCache.get(grcQueryCacheKey(path, apiKey));
+export const grcClientScopeKey = (scope: GRCQueryScope | undefined, apiKey?: string) => [
+  apiKey ?? "",
+  normalizedScopeValue(scope?.actor),
+  normalizedScopeValue(scope?.tenantID),
+  normalizedScopeValue(scope?.workspaceID),
+].join("\n");
+
+const grcQueryCacheKey = (path: string, apiKey?: string, scope?: GRCQueryScope) =>
+  `${grcClientScopeKey(scope, apiKey)}\n${path}`;
+
+const scopeForPath = (path: string | null, actor: string): GRCQueryScope => {
+  if (!path) return { actor };
+  try {
+    const query = new URL(path, "http://cerebro.local").searchParams;
+    return {
+      actor,
+      tenantID: query.get("tenant_id") ?? "",
+      workspaceID: query.get("workspace_id") ?? "",
+    };
+  } catch {
+    return { actor };
+  }
+};
+
+const metadataScopeFor = (scope: GRCQueryScope, apiKey?: string): GRCMetadataScope => ({
+  actor: scope.actor,
+  apiKey,
+  tenantID: scope.tenantID,
+  workspaceID: scope.workspaceID,
+});
+
+export const grcQueryKey = (path: string | null, apiKey?: string, scope?: GRCQueryScope) =>
+  [
+    "grc",
+    apiKey ?? "",
+    path ?? "disabled",
+    normalizedScopeValue(scope?.actor),
+    normalizedScopeValue(scope?.tenantID),
+    normalizedScopeValue(scope?.workspaceID),
+  ] as const;
+
+export const readCachedGRC = <T,>(path: string, apiKey?: string, scope?: GRCQueryScope) => {
+  if (!hasActorScope(scope)) return null;
+  const cached = grcQueryCache.get(grcQueryCacheKey(path, apiKey, scope));
   if (cached && cached.expiresAt > Date.now()) {
     return cached.response as Awaited<ReturnType<typeof fetchCerebro<T>>>;
   }
@@ -132,14 +179,16 @@ export const fetchCachedGRC = async <T,>(
   apiKey: string | undefined,
   force = false,
   init: RequestInit = {},
+  scope: GRCQueryScope = { actor: "" },
 ) => {
-  const key = grcQueryCacheKey(path, apiKey);
-  const cached = readCachedGRC<T>(path, apiKey);
+  const scoped = hasActorScope(scope);
+  const key = grcQueryCacheKey(path, apiKey, scope);
+  const cached = scoped ? readCachedGRC<T>(path, apiKey, scope) : null;
   if (!force && cached) {
     return cached;
   }
 
-  const inflight = grcQueryInflight.get(key);
+  const inflight = scoped ? grcQueryInflight.get(key) : undefined;
   if (!force && inflight) {
     return inflight as Promise<Awaited<ReturnType<typeof fetchCerebro<T>>>>;
   }
@@ -147,16 +196,16 @@ export const fetchCachedGRC = async <T,>(
   const requestInit = force ? withFreshCacheHeaders(init) : init.signal ? init : withoutAbortSignal(init);
   const request = fetchCerebro<T>(path, apiKey, requestInit).then((response) => {
     if (response.ok) {
-      writeGRCQueryCache(key, response);
-      cacheGRCMetadata(response.data);
+      if (scoped) writeGRCQueryCache(key, response);
+      cacheGRCMetadata(response.data, metadataScopeFor(scope, apiKey));
     }
     return response;
   }).finally(() => {
-    if (grcQueryInflight.get(key) === request) {
+    if (scoped && grcQueryInflight.get(key) === request) {
       grcQueryInflight.delete(key);
     }
   });
-  if (!force && !init.signal) {
+  if (scoped && !force && !init.signal) {
     grcQueryInflight.set(key, request);
   }
   return request;
@@ -172,6 +221,7 @@ const fetchGRCQueryPayload = async <T,>(
   path: string,
   apiKey: string | undefined,
   signal: AbortSignal | undefined,
+  scope: GRCQueryScope,
 ): Promise<GRCQueryPayload<T>> => {
   const startedAt = performance.now();
   const request = timedAbortSignal(signal, GRC_QUERY_TIMEOUT_MS);
@@ -181,7 +231,7 @@ const fetchGRCQueryPayload = async <T,>(
     if (!response.ok) {
       throw new Error(grcResponseErrorMessage(path, response.status, response.data, durationMs));
     }
-    cacheGRCMetadata(response.data);
+    cacheGRCMetadata(response.data, metadataScopeFor(scope, apiKey));
     return {
       data: response.data,
       durationMs,
@@ -350,17 +400,20 @@ export function useGRCFormMutation<T = unknown>({ timeoutMs = GRC_FORM_MUTATION_
 
 export function useGRCQuery<T>(path: string | null) {
   const { apiKey } = useApiKey();
+  const { actor, loading: currentUserLoading } = useCurrentUser();
+  const scope = scopeForPath(path, actor);
+  const enabled = Boolean(path && !currentUserLoading && hasActorScope(scope));
   const query = useQuery<GRCQueryPayload<T>, Error>({
-    enabled: Boolean(path),
-    queryFn: ({ signal }) => fetchGRCQueryPayload<T>(path ?? "", apiKey, signal),
-    queryKey: grcQueryKey(path, apiKey),
+    enabled,
+    queryFn: ({ signal }) => fetchGRCQueryPayload<T>(path ?? "", apiKey, signal, scope),
+    queryKey: grcQueryKey(path, apiKey, scope),
     staleTime: GRC_QUERY_CACHE_TTL_MS,
   });
-  const data = path ? query.data?.data ?? null : null;
-  const error = path && query.error ? query.error.message : null;
-  const loading = Boolean(path) && (query.isPending || query.isFetching);
-  const durationMs = path ? query.data?.durationMs ?? null : null;
-  const lastSuccessfulAt = path ? query.data?.successfulAt ?? null : null;
+  const data = enabled && path ? query.data?.data ?? null : null;
+  const error = enabled && path && query.error ? query.error.message : null;
+  const loading = enabled && (query.isPending || query.isFetching);
+  const durationMs = enabled && path ? query.data?.durationMs ?? null : null;
+  const lastSuccessfulAt = enabled && path ? query.data?.successfulAt ?? null : null;
   const { refetch } = query;
   const reload = useCallback(async () => {
     await refetch({ cancelRefetch: true });
@@ -368,7 +421,7 @@ export function useGRCQuery<T>(path: string | null) {
 
   const state = runtimeStateForQuery({
     data,
-    enabled: Boolean(path),
+    enabled,
     error,
     loading,
   });

--- a/apps/web/src/lib/grc-metadata-cache.test.ts
+++ b/apps/web/src/lib/grc-metadata-cache.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { cacheGRCMetadata, readGRCMetadata, type GRCMetadataScope } from "./grc-metadata-cache";
+
+const scopeA: GRCMetadataScope = {
+  actor: "actor-a",
+  apiKey: "key-a",
+  tenantID: "tenant-a",
+  workspaceID: "workspace-a",
+};
+
+const dashboardFor = (policyName: string) => ({
+  controls: [{ framework_name: "SOC 2", control_id: "CC1" }],
+  connectors: [{ runtime_id: "runtime-1", source_id: "github" }],
+  findings: [{ rule_id: "rule-1", policy_id: "policy-1", policy_name: policyName }],
+});
+
+describe("GRC metadata cache scope", () => {
+  it("keeps metadata isolated across actor, API key, tenant, and workspace changes", () => {
+    cacheGRCMetadata(dashboardFor("Tenant A policy"), scopeA);
+
+    expect(readGRCMetadata("policy:policy-1", scopeA)).toBe("Tenant A policy");
+    for (const changedScope of [
+      { ...scopeA, actor: "actor-b" },
+      { ...scopeA, apiKey: "key-b" },
+      { ...scopeA, tenantID: "tenant-b" },
+      { ...scopeA, workspaceID: "workspace-b" },
+    ]) {
+      expect(readGRCMetadata("policy:policy-1", changedScope)).toBeNull();
+    }
+
+    cacheGRCMetadata(dashboardFor("Tenant B policy"), { ...scopeA, tenantID: "tenant-b" });
+    expect(readGRCMetadata("policy:policy-1", scopeA)).toBe("Tenant A policy");
+    expect(readGRCMetadata("policy:policy-1", { ...scopeA, tenantID: "tenant-b" })).toBe("Tenant B policy");
+  });
+
+  it("does not read or write metadata without an authenticated actor", () => {
+    const unresolvedScope = { ...scopeA, actor: " " };
+    cacheGRCMetadata(dashboardFor("unresolved policy"), unresolvedScope);
+
+    expect(readGRCMetadata("policy:policy-1", unresolvedScope)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/grc-metadata-cache.ts
+++ b/apps/web/src/lib/grc-metadata-cache.ts
@@ -3,33 +3,61 @@ import type { GRCDashboard } from "@/lib/grc";
 const GRC_METADATA_CACHE_TTL_MS = 5 * 60_000;
 const grcMetadata = new Map<string, { value: string; expiresAt: number }>();
 
-const writeMetadata = (key: string, value: unknown, now: number) => {
+export type GRCMetadataScope = {
+  actor: string;
+  apiKey?: string;
+  tenantID?: string;
+  workspaceID?: string;
+};
+
+const metadataCacheKey = (key: string, scope: GRCMetadataScope) => {
+  const actor = scope.actor.trim();
+  if (!actor) return null;
+  return [
+    scope.apiKey?.trim() ?? "",
+    actor,
+    scope.tenantID?.trim() ?? "",
+    scope.workspaceID?.trim() ?? "",
+    key,
+  ].join("\n");
+};
+
+const writeMetadata = (key: string, value: unknown, now: number, scope: GRCMetadataScope) => {
   const normalized = String(value ?? "").trim();
   if (!normalized) return;
-  grcMetadata.set(key, { value: normalized, expiresAt: now + GRC_METADATA_CACHE_TTL_MS });
+  const scopedKey = metadataCacheKey(key, scope);
+  if (!scopedKey) return;
+  grcMetadata.set(scopedKey, { value: normalized, expiresAt: now + GRC_METADATA_CACHE_TTL_MS });
 };
 
-export const cacheGRCMetadata = (payload: unknown) => {
+export const cacheGRCMetadata = (payload: unknown, scope: GRCMetadataScope) => {
   const dashboard = payload as Partial<GRCDashboard> | null;
-  if (!dashboard || typeof dashboard !== "object") return;
+  if (!dashboard || typeof dashboard !== "object" || !scope.actor.trim()) return;
   const now = Date.now();
   dashboard.controls?.forEach((control) => {
-    writeMetadata(`control:${control.framework_name}:${control.control_id}`, `${control.framework_name} ${control.control_id}`, now);
+    writeMetadata(
+      `control:${control.framework_name}:${control.control_id}`,
+      `${control.framework_name} ${control.control_id}`,
+      now,
+      scope,
+    );
   });
   dashboard.connectors?.forEach((connector) => {
-    writeMetadata(`runtime:${connector.runtime_id}`, connector.source_id || connector.runtime_id, now);
+    writeMetadata(`runtime:${connector.runtime_id}`, connector.source_id || connector.runtime_id, now, scope);
   });
   dashboard.findings?.forEach((finding) => {
-    writeMetadata(`rule:${finding.rule_id}`, finding.rule_id, now);
-    writeMetadata(`policy:${finding.policy_id}`, finding.policy_name || finding.policy_id, now);
+    writeMetadata(`rule:${finding.rule_id}`, finding.rule_id, now, scope);
+    writeMetadata(`policy:${finding.policy_id}`, finding.policy_name || finding.policy_id, now, scope);
   });
 };
 
-export const readGRCMetadata = (key: string) => {
-  const cached = grcMetadata.get(key);
+export const readGRCMetadata = (key: string, scope: GRCMetadataScope) => {
+  const scopedKey = metadataCacheKey(key, scope);
+  if (!scopedKey) return null;
+  const cached = grcMetadata.get(scopedKey);
   if (!cached) return null;
   if (cached.expiresAt <= Date.now()) {
-    grcMetadata.delete(key);
+    grcMetadata.delete(scopedKey);
     return null;
   }
   return cached.value;

--- a/apps/web/src/lib/notifications.test.ts
+++ b/apps/web/src/lib/notifications.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildNotifications, notificationSignatures, reportRunNotifications, unreadNotifications } from "@/lib/notifications";
+import { buildNotifications, notificationReadStorageKey, notificationSignatures, reportRunNotifications, unreadNotifications } from "@/lib/notifications";
 import type { GRCDashboard, GRCFinding, GRCSummary } from "@/lib/grc";
 import type { ReportDefinition, ReportRun } from "@/lib/report-schedules";
 
@@ -189,5 +189,18 @@ describe("notificationSignatures", () => {
       makeDashboard({ findings: [makeFinding({ id: "a", severity: "CRITICAL" })], summary: makeSummary({ stale_connectors: 1 }) }),
     );
     expect(notificationSignatures(items)).toEqual(items.map((item) => item.signature));
+  });
+});
+
+describe("notificationReadStorageKey", () => {
+  const scope = { actor: "actor-a", apiKey: "key-a", tenantID: "tenant-a", workspaceID: "workspace-a" };
+
+  it("partitions read state across actor, API key, tenant, and workspace", () => {
+    const base = notificationReadStorageKey(scope);
+    expect(notificationReadStorageKey({ ...scope, actor: "actor-b" })).not.toBe(base);
+    expect(notificationReadStorageKey({ ...scope, apiKey: "key-b" })).not.toBe(base);
+    expect(notificationReadStorageKey({ ...scope, tenantID: "tenant-b" })).not.toBe(base);
+    expect(notificationReadStorageKey({ ...scope, workspaceID: "workspace-b" })).not.toBe(base);
+    expect(base).toMatch(/^cerebro\.notifications\.read\.[0-9a-f]{16}$/);
   });
 });

--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -13,6 +13,33 @@ export type AppNotification = {
   href: string;
 };
 
+export type NotificationScope = {
+  actor: string;
+  apiKey?: string;
+  tenantID?: string;
+  workspaceID?: string;
+};
+
+const notificationScopeHash = (seed: number, value: string) => {
+  let hash = seed >>> 0;
+  for (const character of value) {
+    hash = Math.imul(hash ^ (character.codePointAt(0) ?? 0), 16777619);
+  }
+  return hash >>> 0;
+};
+
+export const notificationReadStorageKey = (scope: NotificationScope) => {
+  const serialized = JSON.stringify([
+    scope.actor.trim(),
+    scope.apiKey?.trim() ?? "",
+    scope.tenantID?.trim() ?? "",
+    scope.workspaceID?.trim() ?? "",
+  ]);
+  const primary = notificationScopeHash(2166136261, serialized);
+  const secondary = notificationScopeHash(2654435761, serialized);
+  return `cerebro.notifications.read.${primary.toString(16).padStart(8, "0")}${secondary.toString(16).padStart(8, "0")}`;
+};
+
 const MAX_FINDING_NOTIFICATIONS = 8;
 
 const isOverdue = (finding: GRCFinding) => (finding.sla_status ?? "").toLowerCase() === "overdue";

--- a/apps/web/src/lib/ui-contract.test.ts
+++ b/apps/web/src/lib/ui-contract.test.ts
@@ -215,6 +215,7 @@ describe("product UI contract", () => {
     expect(page).toContain("const requestScopeKey = activeScopeKey");
     expect(page).toContain("activeScopeKeyRef.current !== requestScopeKey");
     expect(page).toContain("activeScopeKeyRef.current === requestScopeKey");
+    expect(page).toContain("setExpandingURN(null);");
   });
 
   it("keeps vendor decisions ahead of source diagnostics without a duplicate queue", () => {

--- a/apps/web/src/lib/ui-contract.test.ts
+++ b/apps/web/src/lib/ui-contract.test.ts
@@ -70,8 +70,9 @@ describe("product UI contract", () => {
     const statusSource = readProjectFile("src/components/StatusPanel.tsx");
     const topbarSource = readProjectFile("src/components/Topbar.tsx");
 
-    expect(topbarSource).toContain("notificationsRequested ? grcDashboardPath");
-    expect(topbarSource).toContain("notificationsRequested ? grcPath");
+    expect(topbarSource).toContain("notificationsRequested && !invalidNotificationScope");
+    expect(topbarSource).toContain("grcDashboardPath({");
+    expect(topbarSource).toContain('grcPath("/report-runs"');
     expect(topbarSource).toContain("onFocus={() => setNotificationsRequested(true)}");
     expect(topbarSource).toContain("onMouseEnter={() => setNotificationsRequested(true)}");
     expect(topbarSource).not.toContain("showNotifications ? grcDashboardPath");

--- a/apps/web/src/lib/ui-contract.test.ts
+++ b/apps/web/src/lib/ui-contract.test.ts
@@ -201,11 +201,20 @@ describe("product UI contract", () => {
     const runtime = readProjectFile("src/lib/connector-runtime.ts");
 
     expect(page).toContain('withQuery("/v1/source-runtimes/health"');
+    expect(page).toContain("tenant_id: debouncedTenantID");
     expect(page).toContain("normalizeSourceRuntimeSummary");
     expect(page).not.toContain("sourceHealthBreakdown");
     expect(runtime).toContain('stringField(runtime, ["readiness"])');
     expect(runtime).toContain('stringField(summary, ["readiness"])');
     expect(runtime).not.toContain("const sourceReadiness =");
+  });
+
+  it("guards Explore expansion responses against a changed scope", () => {
+    const page = readProjectFile("src/app/explore/page.tsx");
+
+    expect(page).toContain("const requestScopeKey = activeScopeKey");
+    expect(page).toContain("activeScopeKeyRef.current !== requestScopeKey");
+    expect(page).toContain("activeScopeKeyRef.current === requestScopeKey");
   });
 
   it("keeps vendor decisions ahead of source diagnostics without a duplicate queue", () => {


### PR DESCRIPTION
## Scope

- Partition browser GRC response, in-flight, TanStack Query, and metadata caches by actor, API key, tenant, and workspace.
- Require a resolved actor before caching or deduplicating browser GRC reads.
- Hide prior connector and graph state while a new scope loads.
- Partition notification read markers by actor, API key, tenant, and workspace without persisting raw scope values.
- Include tenant and workspace selectors on Topbar notification dashboard/report-run requests.
- Include tenant and workspace selectors on Explore graph and fallback-finding requests.
- Synchronize the active Explore scope before response handling; ignore late expansion responses, errors, and cleanup from an earlier scope generation.
- Clear seed and expansion loading state at every new seed/scope load boundary.
- Include the selected tenant on connector runtime-health reads so health summaries and query identity change with tenant selection.
- Disable reads and clear prior Explore state for an orphan workspace selector; disabled query reloads are no-ops.
- Keep backend mismatch handling fail-closed; no unscoped fallback is introduced.

## Validation

- DDESK: browser-build desk, unique workspace cbcache826.
- Focused Web: 9 files, 78 tests passed.
- Proxy and page fail-closed suite: 6 files, 82 tests passed.
- Changed-file ESLint passed.
- Web TypeScript check passed.
- Production Web build passed: 49 routes generated and standalone assets packaged.
- Structural, structural-test, and architecture checks passed.
- Practice Registry final gate passed.
- No human reviewer assigned; no protection bypass used.

## Boundaries

- Browser-only change; live deployment and authenticated live-user-path proof are not claimed.
- No credential values or private infrastructure details are included.
- The Ask/live-search and release lanes are outside this change.