### PR TITLE
refactor(sources): retire JumpCloud Go projection writer

### DIFF
--- a/internal/sourceprojection/jumpcloud.go
+++ b/internal/sourceprojection/jumpcloud.go
@@ -1,34 +1,38 @@
 package sourceprojection
 
 import (
+	"errors"
+
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func jumpcloudUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "jumpcloud"})
+var errJumpCloudRustProjectionRequired = errors.New("jumpcloud projection requires Rust authority")
+
+func jumpcloudUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errJumpCloudRustProjectionRequired
 }
 
-func jumpcloudGroupsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityGroupProjections(event, identityProjectionProfile{Provider: "jumpcloud"})
+func jumpcloudGroupsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errJumpCloudRustProjectionRequired
 }
 
-func jumpcloudSystemsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return catalogRuntimeAssetProjections(event)
+func jumpcloudSystemsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errJumpCloudRustProjectionRequired
 }
 
-func jumpcloudApplicationsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityApplicationProjections(event, identityProjectionProfile{Provider: "jumpcloud"})
+func jumpcloudApplicationsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errJumpCloudRustProjectionRequired
 }
 
-func jumpcloudSystemGroupsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityGroupProjections(event, identityProjectionProfile{Provider: "jumpcloud"})
+func jumpcloudSystemGroupsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errJumpCloudRustProjectionRequired
 }
 
-func jumpcloudGroupMembersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityGroupMembershipProjections(event, identityProjectionProfile{Provider: "jumpcloud"})
+func jumpcloudGroupMembersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errJumpCloudRustProjectionRequired
 }
 
-func jumpcloudAuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "jumpcloud"})
+func jumpcloudAuditEventsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errJumpCloudRustProjectionRequired
 }

--- a/internal/sourceprojection/jumpcloud_test.go
+++ b/internal/sourceprojection/jumpcloud_test.go
@@ -1,84 +1,35 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestJumpcloudIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "jumpcloud", Kind: "jumpcloud.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := jumpcloudUsersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestJumpcloudIdentityGroupProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "jumpcloud", Kind: "jumpcloud.groups", Attributes: map[string]string{"group_id": "group-1", "group_email": "group@example.test", "group_name": "Group One"}}
-	entities, _, err := jumpcloudGroupsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity group")
-	}
-}
-
-func TestJumpcloudSystemProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "jumpcloud", Kind: "jumpcloud.systems", Attributes: map[string]string{"resource_id": "system-1", "resource_name": "Mac 1", "resource_type": "system", "system_id": "system-1"}}
-	entities, _, err := jumpcloudSystemsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected system asset")
-	}
-}
-
-func TestJumpcloudApplicationProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "jumpcloud", Kind: "jumpcloud.applications", Attributes: map[string]string{"app_id": "app-1", "app_name": "SAML App"}}
-	entities, _, err := jumpcloudApplicationsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected application")
-	}
-}
-
-func TestJumpcloudSystemGroupProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "jumpcloud", Kind: "jumpcloud.system_groups", Attributes: map[string]string{"group_id": "system-group-1", "group_name": "Mac laptops"}}
-	entities, _, err := jumpcloudSystemGroupsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected system group")
-	}
-}
-
-func TestJumpcloudGroupMembershipProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "jumpcloud", Kind: "jumpcloud.group_members", Attributes: map[string]string{"group_id": "group-1", "group_name": "Engineering", "member_user_id": "user-1", "member_type": "user"}}
-	entities, links, err := jumpcloudGroupMembersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want membership projection", len(entities), len(links))
-	}
-}
-
-func TestJumpcloudAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "jumpcloud", Kind: "jumpcloud.audit_events", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := jumpcloudAuditEventsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestJumpCloudGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"jumpcloud.users",
+		"jumpcloud.groups",
+		"jumpcloud.systems",
+		"jumpcloud.applications",
+		"jumpcloud.system_groups",
+		"jumpcloud.group_members",
+		"jumpcloud.audit_events",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "jumpcloud",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errJumpCloudRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

All jumpcloud compiled families (`users`, `groups`, `systems`, `applications`, `system_groups`, `group_members`, `audit_events`) are collection- and projection-authoritative in the Rust `source-catalog` on `main` as of PR #2720 (merged), which bound `audit_events` to its verified Directory Insights origin and closed the last `MissingProviderProof` gap. With full Rust authority established, this PR retires the Go projection writer for JumpCloud, following the merged `deepseek` pattern (#see `internal/sourceprojection/deepseek.go`):

- Every `jumpcloud*Projections` function keeps its name and signature but now returns `nil, nil, errJumpCloudRustProjectionRequired`, a typed sentinel error.
- `jumpcloud_test.go` is rewritten as a table-driven, fail-closed test over every event kind routed to this provider (`jumpcloud.users`, `.groups`, `.systems`, `.applications`, `.system_groups`, `.group_members`, `.audit_events`), calling `ProjectEvent` end-to-end.
- The previously used shared helpers (`identityUserProjections`, `identityGroupProjections`, `catalogRuntimeAssetProjections`, `identityApplicationProjections`, `identityGroupMembershipProjections`, `identityAuditProjections`) are still used by many other providers, so nothing shared was removed — only the JumpCloud-specific call sites changed. No imports became unused.
- `internal/sourceprojection/registry_builtins.go` routing (kind -> function) is untouched since function names/signatures are unchanged.

## Authority proof

Full Rust authority for jumpcloud was established on `main` in **#2720** (`catalog(jumpcloud): bind audit_events to its verified Directory Insights origin for full Rust authority`, already merged), which:
- Added `config.base_url: https://api.jumpcloud.com/insights/directory/v1` to the compiled `audit_events` family in `internal/connectorcatalog/catalog/identity-access-secrets/jumpcloud.yaml`, so the compiled family's resolved locator matches the `provider_api` proof already declared in `sources/jumpcloud/catalog.yaml` for `POST https://api.jumpcloud.com/insights/directory/v1/events` (verified against `jumpcloud.com/support/directory-insights-api`, matching the origin the bespoke Rust runtime validates in `crates/source-runtime-next/src/jumpcloud/origin.rs`).
- Added `"jumpcloud"` to the `retired_static_loader_sources_are_fully_rust_authoritative` list in `crates/source-catalog/src/lib.rs`.

Re-verified from this branch (built on current `main`, which already contains #2720) with a throwaway probe (`crates/source-catalog/tests/wave2_probe.rs`, loaded via `SourceCatalog::load` and deleted before this commit) printing `is_authoritative()` / `is_projection_authoritative()` / `unsupported_reasons()` for every jumpcloud family:

```
family=users            collection_authoritative=true projection_authoritative=true reasons=[]
family=groups           collection_authoritative=true projection_authoritative=true reasons=[]
family=systems          collection_authoritative=true projection_authoritative=true reasons=[]
family=applications     collection_authoritative=true projection_authoritative=true reasons=[]
family=system_groups    collection_authoritative=true projection_authoritative=true reasons=[]
family=group_members    collection_authoritative=true projection_authoritative=true reasons=[]
family=audit_events     collection_authoritative=true projection_authoritative=true reasons=[]
```

All 7 families are fully authoritative, so retiring the Go projection writer is safe.

## Validation

- `gofmt -l internal/sourceprojection` — empty
- `go build ./internal/sourceprojection` — clean
- `go test ./internal/sourceprojection -count=1` — ok
- `go test ./internal/sourceregistry -run TestBuiltinRetiresCoveredProviderGoLoaders -count=1` — PASS
- `cargo test -p cerebro-source-catalog --lib retired` — PASS (`retired_static_loader_sources_are_fully_rust_authoritative`)
- Probe test (`wave2_probe.rs`, deleted before commit): all jumpcloud families `collection_authoritative=true`, `projection_authoritative=true`, `reasons=[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)