### PR TITLE
refactor(sources): retire Increase Go projection writer

### DIFF
--- a/internal/sourceprojection/increase.go
+++ b/internal/sourceprojection/increase.go
@@ -1,114 +1,58 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func increaseEventProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "increase"})
+var errIncreaseRustProjectionRequired = errors.New("increase projection requires Rust authority")
+
+func increaseEventProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errIncreaseRustProjectionRequired
 }
 
-func increaseAccountProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "increase"})
+func increaseAccountProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errIncreaseRustProjectionRequired
 }
 
-func increaseDigitalWalletTokenProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return increaseGenericSecretProjections(event)
+func increaseDigitalWalletTokenProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errIncreaseRustProjectionRequired
 }
 
-func increaseAchPrenotificationProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return increaseGenericAlertProjections(event)
+func increaseAchPrenotificationProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errIncreaseRustProjectionRequired
 }
 
-func increaseOauthConnectionProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return increaseGenericAssetProjections(event)
+func increaseOauthConnectionProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errIncreaseRustProjectionRequired
 }
 
-func increaseEventSubscriptionProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "increase"})
+func increaseEventSubscriptionProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errIncreaseRustProjectionRequired
 }
 
-func increaseAccountNumberProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "increase"})
+func increaseAccountNumberProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errIncreaseRustProjectionRequired
 }
 
-func increaseAccountStatementProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "increase"})
+func increaseAccountStatementProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errIncreaseRustProjectionRequired
 }
 
-func increaseAccountTransferProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "increase"})
+func increaseAccountTransferProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errIncreaseRustProjectionRequired
 }
 
-func increaseExternalAccountProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "increase"})
+func increaseExternalAccountProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errIncreaseRustProjectionRequired
 }
 
-func increaseAchTransferProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return increaseGenericAssetProjections(event)
+func increaseAchTransferProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errIncreaseRustProjectionRequired
 }
 
-func increaseCardProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return increaseGenericAssetProjections(event)
-}
-
-func increaseGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func increaseGenericSecretProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	secretID := firstNonEmpty(attributes["secret_id"], event.GetId())
-	secretURN := projectionURN(tenantID, "secret", secretID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: secretURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "secret", Label: firstNonEmpty(attributes["secret_name"], secretID), Attributes: map[string]string{"secret_id": secretID, "secret_type": strings.TrimSpace(attributes["secret_type"]), "secret_status": strings.TrimSpace(attributes["secret_status"]), "secret_rotation_enabled": strings.TrimSpace(attributes["secret_rotation_enabled"]), "secret_last_rotated_at": strings.TrimSpace(attributes["secret_last_rotated_at"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), secretURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func increaseGenericAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	alertID := firstNonEmpty(attributes["alert_id"], event.GetId())
-	alertURN := projectionURN(tenantID, "alert", alertID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: alertURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "alert", Label: firstNonEmpty(attributes["alert_name"], alertID), Attributes: map[string]string{"alert_id": alertID, "alert_severity": strings.TrimSpace(attributes["alert_severity"]), "alert_status": strings.TrimSpace(attributes["alert_status"]), "alert_type": strings.TrimSpace(attributes["alert_type"]), "alert_source": strings.TrimSpace(attributes["alert_source"]), "alert_fired_at": strings.TrimSpace(attributes["alert_fired_at"]), "alert_resolved_at": strings.TrimSpace(attributes["alert_resolved_at"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func increaseCardProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errIncreaseRustProjectionRequired
 }

--- a/internal/sourceprojection/increase_test.go
+++ b/internal/sourceprojection/increase_test.go
@@ -1,154 +1,40 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestIncreaseAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "increase", Kind: "increase.event", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := increaseEventProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
-	}
-}
-
-func TestIncreaseIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "increase", Kind: "increase.account", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := increaseAccountProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestIncreaseSecretProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "increase", Kind: "increase.digital_wallet_token", Attributes: map[string]string{"secret_id": "secret-1", "secret_name": "DB Password", "secret_type": "password", "secret_status": "active", "evidence_id": "evidence-1"}}
-	entities, links, err := increaseDigitalWalletTokenProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected secret")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestIncreaseAlertProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "increase", Kind: "increase.ach_prenotification", Attributes: map[string]string{"alert_id": "alert-1", "alert_name": "High Error Rate", "alert_severity": "critical", "alert_status": "open", "evidence_id": "evidence-1"}}
-	entities, links, err := increaseAchPrenotificationProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected alert")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestIncreaseAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "increase", Kind: "increase.oauth_connection", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := increaseOauthConnectionProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestIncreaseEventSubscriptionProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "increase", Kind: "increase.event_subscription", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := increaseEventSubscriptionProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
-	}
-}
-
-func TestIncreaseAccountNumberProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "increase", Kind: "increase.account_number", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := increaseAccountNumberProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestIncreaseAccountStatementProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "increase", Kind: "increase.account_statement", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := increaseAccountStatementProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestIncreaseAccountTransferProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "increase", Kind: "increase.account_transfer", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := increaseAccountTransferProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestIncreaseExternalAccountProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "increase", Kind: "increase.external_account", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := increaseExternalAccountProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestIncreaseAchTransferProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "increase", Kind: "increase.ach_transfer", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := increaseAchTransferProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestIncreaseCardProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "increase", Kind: "increase.card", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := increaseCardProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
+func TestIncreaseGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"increase.account",
+		"increase.account_number",
+		"increase.account_statement",
+		"increase.account_transfer",
+		"increase.ach_prenotification",
+		"increase.ach_transfer",
+		"increase.card",
+		"increase.digital_wallet_token",
+		"increase.event",
+		"increase.event_subscription",
+		"increase.external_account",
+		"increase.oauth_connection",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "increase",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errIncreaseRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Retires `internal/sourceprojection/increase.go` as a real projection writer: every `increaseXProjections` function keeps its existing name and signature but now returns `nil, nil, errIncreaseRustProjectionRequired`, mirroring the merged `deepseek.go` pattern.
- Removes the Increase-only generic helpers (`increaseGenericAssetProjections`, `increaseGenericSecretProjections`, `increaseGenericAlertProjections`) along with the now-unused `strings` import — grepped the rest of `internal/sourceprojection` first and confirmed no other file calls them.
- Rewrites `increase_test.go` as a table-driven fail-closed test (`TestIncreaseGoProjectionFailsClosedForRustAuthoritativeFamilies`) over all 12 `increase.*` event kinds, routed through `ProjectEvent`, mirroring `deepseek_test.go`.
- No changes to `internal/sourceprojection/registry_builtins.go` — the routing table entries stay pointed at the same function names, which now fail closed.

## Authority proof

This PR does not add authority — it retires the Go writer now that Increase authority is already fully proven and merged into `main` via #2719 (`catalog(increase): promote provider_api basis to declared for full Rust authority`). That PR:

- Switched `sources/increase/catalog.yaml`'s `provider_api.basis` from `discovered` to `declared`, sourced against Increase's first-party OpenAPI spec at `https://increase.com/openapi.json` (apis.guru mirror kept as a secondary reference), confirming GET method+path for all 12 families.
- Added `increase` to `retired_static_loader_sources_are_fully_rust_authoritative` in `crates/source-catalog/src/lib.rs`.

I re-verified this is still true on current `main` before starting this PR, using a throwaway probe test (`crates/source-catalog/tests/wave2_probe.rs`, deleted before commit) that loads the catalog and prints `is_authoritative()` / `is_projection_authoritative()` / `unsupported_reasons()` for every Increase family:

```
increase/event authoritative=true projection_authoritative=true unsupported_reasons=[]
increase/account authoritative=true projection_authoritative=true unsupported_reasons=[]
increase/digital_wallet_token authoritative=true projection_authoritative=true unsupported_reasons=[]
increase/ach_prenotification authoritative=true projection_authoritative=true unsupported_reasons=[]
increase/oauth_connection authoritative=true projection_authoritative=true unsupported_reasons=[]
increase/event_subscription authoritative=true projection_authoritative=true unsupported_reasons=[]
increase/account_number authoritative=true projection_authoritative=true unsupported_reasons=[]
increase/account_statement authoritative=true projection_authoritative=true unsupported_reasons=[]
increase/account_transfer authoritative=true projection_authoritative=true unsupported_reasons=[]
increase/external_account authoritative=true projection_authoritative=true unsupported_reasons=[]
increase/ach_transfer authoritative=true projection_authoritative=true unsupported_reasons=[]
increase/card authoritative=true projection_authoritative=true unsupported_reasons=[]
```

All 12 compiled families: `authoritative=true`, `projection_authoritative=true`, no unsupported reasons.

Note: this branches directly off `main` (not stacked) because the authority PR (#2719) was already merged before this session started — there was no unmerged authority branch left to stack on.

## Validation

- `gofmt -l internal/sourceprojection` — empty
- `go vet ./internal/sourceprojection/...` — clean
- `go build ./internal/sourceprojection` — clean
- `go test ./internal/sourceprojection -count=1` — ok
- `go test ./internal/sourceregistry -run TestBuiltinRetiresCoveredProviderGoLoaders -count=1` — PASS (confirms Increase has no static Go source loader and is registered through its current runtime)
- `cargo test -p cerebro-source-catalog --lib retired` — PASS (`retired_static_loader_sources_are_fully_rust_authoritative`, includes `increase`)
- Throwaway probe (`cargo test -p cerebro-source-catalog --test wave2_probe -- --nocapture`), deleted before commit — all 12 families authoritative

🤖 Generated with [Claude Code](https://claude.com/claude-code)