### PR TITLE
refactor(sources): retire Twilio Go projection writer

### DIFF
--- a/internal/sourceprojection/twilio.go
+++ b/internal/sourceprojection/twilio.go
@@ -1,39 +1,22 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func twilioAccountsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "twilio"})
+var errTwilioRustProjectionRequired = errors.New("twilio projection requires Rust authority")
+
+func twilioAccountsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errTwilioRustProjectionRequired
 }
 
-func twilioKeysProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return twilioSecretProjections(event)
+func twilioKeysProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errTwilioRustProjectionRequired
 }
 
-func twilioAuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "twilio"})
-}
-
-func twilioSecretProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	secretID := firstNonEmpty(attributes["secret_id"], event.GetId())
-	secretURN := projectionURN(tenantID, "secret", secretID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: secretURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "secret", Label: firstNonEmpty(attributes["secret_name"], secretID), Attributes: map[string]string{"secret_id": secretID, "secret_type": strings.TrimSpace(attributes["secret_type"]), "secret_status": strings.TrimSpace(attributes["secret_status"]), "secret_rotation_enabled": strings.TrimSpace(attributes["secret_rotation_enabled"]), "secret_last_rotated_at": strings.TrimSpace(attributes["secret_last_rotated_at"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), secretURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func twilioAuditEventsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errTwilioRustProjectionRequired
 }

--- a/internal/sourceprojection/twilio_test.go
+++ b/internal/sourceprojection/twilio_test.go
@@ -1,43 +1,27 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestTwilioSecretProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "twilio", Kind: "twilio.keys", Attributes: map[string]string{"secret_id": "secret-1", "secret_name": "DB Password", "secret_type": "password", "secret_status": "active", "evidence_id": "evidence-1"}}
-	entities, links, err := twilioKeysProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected secret")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestTwilioIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "twilio", Kind: "twilio.accounts", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := twilioAccountsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestTwilioAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "twilio", Kind: "twilio.audit_events", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := twilioAuditEventsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestTwilioGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{"twilio.accounts", "twilio.audit_events", "twilio.keys"} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "twilio",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errTwilioRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
Twilio's Rust source-catalog authority is complete on `main`: all three
compiled families (`accounts`, `keys`, `audit_events`) are both
collection- and projection-authoritative, and `twilio` already appears
in `retired_static_loader_sources_are_fully_rust_authoritative`
(crates/source-catalog/src/lib.rs) — landed via
writer/cerebro#2718 ("catalog(twilio): add provider_api proof for full
Rust authority", merged). With the Rust side proven, this PR retires
the now-redundant Go projection writer at
`internal/sourceprojection/twilio.go`, following the merged
`deepseek.go` / `deepseek_test.go` pattern:

- Every family projection function (`twilioAccountsProjections`,
  `twilioKeysProjections`, `twilioAuditEventsProjections`) keeps its
  name and signature but now returns `nil, nil,
  errTwilioRustProjectionRequired`.
- The now-unused helper `twilioSecretProjections` and the `strings`
  import are removed (grepped the rest of `internal/sourceprojection`
  first — `identityUserProjections`, `identityAuditProjections`,
  `identityProjectionResult`, `firstNonEmpty`, `projectionURN`,
  `addEntity`, `addLink`, `projectedLink`, `relationHasEvidence`, and
  `tenantID` are shared helpers used by hundreds of other provider
  files in `identity.go` and elsewhere, so they are untouched).
- `twilio_test.go` is rewritten as a table-driven fail-closed test over
  every event kind routed to this provider
  (`twilio.accounts`, `twilio.audit_events`, `twilio.keys`) via
  `ProjectEvent`, mirroring `deepseek_test.go`.

## Authority proof
This PR does not itself change catalog authority — it consumes the
authority already proven and merged in writer/cerebro#2718. For the
record, that PR verified all three Twilio families against Twilio's
documented API:

- `accounts` — `GET /2010-04-01/Accounts.json` — verified against
  https://www.twilio.com/docs/iam/api/account
- `keys` — `GET /2010-04-01/Accounts/${config.account_sid}/Keys.json` —
  verified against
  https://www.twilio.com/docs/iam/api-keys/key-resource-v2010
- `audit_events` — `GET /v1/Events` — verified against
  https://www.twilio.com/docs/usage/monitor-events

All three families appear in both `runtime_families` and
`provider_api.families` in `sources/twilio/catalog.yaml` with matching
method+path, and each has fixture coverage in `sources/twilio/testdata`
(`discover_*`, `read_*`, plus `provider_accounts.json` and
`source_worker_accounts_page.json`).

Re-verified in this session (this worktree, current `main`, before
making any Go changes):
- `cargo test -p cerebro-source-catalog --lib retired` — passes,
  confirming `twilio` has `CollectionAuthority::Authoritative` and
  every compiled family is both `is_authoritative()` and
  `is_projection_authoritative()`.

## Validation
Run from this worktree (`internal/sourceprojection` state after this
PR's changes):
- `gofmt -l internal/sourceprojection` — empty output
- `go build ./internal/sourceprojection` — clean
- `go vet ./internal/sourceprojection ./internal/sourceregistry` — clean
- `go test ./internal/sourceprojection -count=1` — ok
- `go test ./internal/sourceregistry -run TestBuiltinRetiresCoveredProviderGoLoaders -count=1` — PASS (twilio was already listed as a retired static loader from writer/cerebro#2541, on the fetch/loader side; this PR is the projection-writer counterpart)
- `cargo test -p cerebro-source-catalog --lib retired` — ok (twilio full Rust authority, pre-existing from #2718)

Note: this branch targets `main` directly rather than stacking on
`claude/twilio-rust-authority`, since that authority PR (#2718) was
already merged before this session started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)