### PR TITLE
fix(web): bind shared caches to authenticated actor

### DIFF
--- a/apps/web/src/lib/grc-report-catalog.test.ts
+++ b/apps/web/src/lib/grc-report-catalog.test.ts
@@ -104,13 +104,18 @@ describe("grc report catalog helpers", () => {
     expect(query.limit).toBeUndefined();
   });
 
-  it("binds report paths and cache keys to tenant and workspace scope", () => {
+  it("binds report paths and cache keys to actor, tenant, and workspace scope", () => {
     const body = JSON.stringify({ source_id: "findings", limit: 25 });
     const workspaceA = reportQueryPath({ tenantID: "tenant-a", workspaceID: "workspace-a" });
     const workspaceB = reportQueryPath({ tenantID: "tenant-a", workspaceID: "workspace-b" });
     expect(workspaceA).toBe("/grc/query?tenant_id=tenant-a&workspace_id=workspace-a");
     expect(workspaceB).toBe("/grc/query?tenant_id=tenant-a&workspace_id=workspace-b");
-    expect(reportQueryCacheKey(workspaceA!, body, "key")).not.toBe(reportQueryCacheKey(workspaceB!, body, "key"));
+    expect(reportQueryCacheKey(workspaceA!, body, "key", "actor-a")).not.toBe(
+      reportQueryCacheKey(workspaceB!, body, "key", "actor-a"),
+    );
+    expect(reportQueryCacheKey(workspaceA!, body, "key", "actor-a")).not.toBe(
+      reportQueryCacheKey(workspaceA!, body, "key", "actor-b"),
+    );
   });
 
   it("does not build a report path without tenant scope", () => {

--- a/apps/web/src/lib/grc-report-catalog.ts
+++ b/apps/web/src/lib/grc-report-catalog.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { useApiKey } from "@/components/providers";
+import { useApiKey, useCurrentUser } from "@/components/providers";
 import { fetchCerebro } from "@/lib/cerebro-client";
 import type { CustomDashboard, CustomDashboardWidget } from "@/lib/custom-dashboards";
 import { grcPath, grcResponseErrorMessage, useGRCQuery } from "@/lib/grc-client";
@@ -202,10 +202,11 @@ type CachedReportQueryResponse = Awaited<ReturnType<typeof fetchCerebro<ReportQu
 const reportQueryCache = new Map<string, { expiresAt: number; response: CachedReportQueryResponse }>();
 const reportQueryInflight = new Map<string, Promise<CachedReportQueryResponse>>();
 
-export const reportQueryCacheKey = (path: string, body: string, apiKey?: string) => `${apiKey ?? ""}\n${path}\n${body}`;
+export const reportQueryCacheKey = (path: string, body: string, apiKey: string | undefined, actor: string) =>
+  `${apiKey ?? ""}\n${actor.trim()}\n${path}\n${body}`;
 
-const reportQueryCached = (path: string, body: string, apiKey?: string) => {
-  const cached = reportQueryCache.get(reportQueryCacheKey(path, body, apiKey));
+const reportQueryCached = (path: string, body: string, apiKey: string | undefined, actor: string) => {
+  const cached = reportQueryCache.get(reportQueryCacheKey(path, body, apiKey, actor));
   return cached && cached.expiresAt > Date.now() ? cached.response : null;
 };
 
@@ -213,9 +214,9 @@ const reportQueryCached = (path: string, body: string, apiKey?: string) => {
 // successful responses are cached briefly and concurrent identical queries are
 // de-duplicated, so a dashboard with many report widgets (or remounts) does not
 // multiply backend traffic. force bypasses both the cache and in-flight entry.
-const fetchCachedReportQuery = (path: string, body: string, apiKey: string | undefined, force: boolean): Promise<CachedReportQueryResponse> => {
-  const cacheKey = reportQueryCacheKey(path, body, apiKey);
-  const cached = reportQueryCached(path, body, apiKey);
+const fetchCachedReportQuery = (path: string, body: string, apiKey: string | undefined, actor: string, force: boolean): Promise<CachedReportQueryResponse> => {
+  const cacheKey = reportQueryCacheKey(path, body, apiKey, actor);
+  const cached = reportQueryCached(path, body, apiKey, actor);
   if (!force && cached) {
     return Promise.resolve(cached);
   }
@@ -250,6 +251,7 @@ const fetchCachedReportQuery = (path: string, body: string, apiKey: string | und
 // above, and ignores stale or post-unmount responses via a request counter.
 export const useReportQuery = (query: WidgetReportQuery | null, scope: ReportQueryScope) => {
   const { apiKey } = useApiKey();
+  const { actor, loading: currentUserLoading } = useCurrentUser();
   const [data, setData] = useState<ReportQueryResponse | null>(null);
   const [dataKey, setDataKey] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -258,26 +260,31 @@ export const useReportQuery = (query: WidgetReportQuery | null, scope: ReportQue
   const requestID = useRef(0);
   const path = reportQueryPath(scope);
   const key = query ? JSON.stringify(query) : "";
-  const requestKey = path && key ? `${path}\n${key}` : "";
+  const normalizedActor = actor.trim();
+  const requestKey = path && key && normalizedActor ? `${normalizedActor}\n${path}\n${key}` : "";
 
   const load = useCallback(
     async (force = false) => {
-      if (key === "" || path === null) {
+      if (key === "" || path === null || currentUserLoading || normalizedActor === "") {
         setData(null);
         setDataKey("");
-        setError(key === "" ? null : "Report query requires tenant scope.");
+        setError(key === "" || currentUserLoading
+          ? null
+          : path === null
+            ? "Report query requires tenant scope."
+            : "Report query requires an authenticated actor.");
         setErrorKey("");
         setLoading(false);
         return;
       }
       const currentRequestID = requestID.current + 1;
       requestID.current = currentRequestID;
-      setLoading(!(!force && reportQueryCached(path, key, apiKey)));
+      setLoading(!(!force && reportQueryCached(path, key, apiKey, normalizedActor)));
       setError(null);
       setErrorKey("");
       let response;
       try {
-        response = await fetchCachedReportQuery(path, key, apiKey, force);
+        response = await fetchCachedReportQuery(path, key, apiKey, normalizedActor, force);
       } catch (err) {
         if (currentRequestID !== requestID.current) return;
         setError(err instanceof Error ? err.message : grcResponseErrorMessage(path, 0, null));
@@ -296,7 +303,7 @@ export const useReportQuery = (query: WidgetReportQuery | null, scope: ReportQue
       setDataKey(requestKey);
       setLoading(false);
     },
-    [apiKey, key, path, requestKey],
+    [apiKey, currentUserLoading, key, normalizedActor, path, requestKey],
   );
 
   useEffect(() => {
@@ -308,11 +315,15 @@ export const useReportQuery = (query: WidgetReportQuery | null, scope: ReportQue
   }, [load]);
 
   const reload = useCallback(() => load(true), [load]);
-  const visibleError = path === null && key !== "" ? "Report query requires tenant scope." : errorKey === requestKey ? error : null;
+  const visibleError = path === null && key !== ""
+    ? "Report query requires tenant scope."
+    : !currentUserLoading && normalizedActor === "" && key !== ""
+      ? "Report query requires an authenticated actor."
+      : errorKey === requestKey ? error : null;
   return {
     data: dataKey === requestKey ? data : null,
     error: visibleError,
-    loading: path !== null && key !== "" && dataKey !== requestKey ? true : loading,
+    loading: currentUserLoading || (path !== null && key !== "" && normalizedActor !== "" && dataKey !== requestKey ? true : loading),
     reload,
   };
 };

--- a/apps/web/src/lib/live-search.test.ts
+++ b/apps/web/src/lib/live-search.test.ts
@@ -6,7 +6,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { NuqsTestingAdapter } from "nuqs/adapters/testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ApiKeyProvider } from "@/components/providers";
+import { ApiKeyProvider, CurrentUserProvider } from "@/components/providers";
 
 import {
   LIVE_SEARCH_TIMEOUT_MS,
@@ -43,13 +43,14 @@ describe("live search scope", () => {
   it("partitions shared state by API key, tenant, and workspace", () => {
     const scope = { tenantID: "tenant-a", workspaceID: "workspace-a" };
     const keys = new Set([
-      liveSearchScopeKey("key-a", scope),
-      liveSearchScopeKey("key-a", { ...scope, workspaceID: "workspace-b" }),
-      liveSearchScopeKey("key-a", { ...scope, tenantID: "tenant-b" }),
-      liveSearchScopeKey("key-b", scope),
+      liveSearchScopeKey("key-a", "actor-a", scope),
+      liveSearchScopeKey("key-a", "actor-a", { ...scope, workspaceID: "workspace-b" }),
+      liveSearchScopeKey("key-a", "actor-a", { ...scope, tenantID: "tenant-b" }),
+      liveSearchScopeKey("key-b", "actor-a", scope),
+      liveSearchScopeKey("key-a", "actor-b", scope),
     ]);
 
-    expect(keys).toHaveLength(4);
+    expect(keys).toHaveLength(5);
   });
 
   it("does not permit a workspace selector without an explicit tenant", () => {
@@ -68,10 +69,28 @@ describe("live search scope requests", () => {
     reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage.setItem("cerebro.apiKey", "live-search-test-key");
     window.__cerebroLiveSearchDashboard = undefined;
-    fetchMock = vi.fn(async () => new Response("{}", {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    }));
+    fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input) === "/api/me") {
+        return new Response(JSON.stringify({
+          authenticated: true,
+          user: {
+            actorId: "actor-a",
+            actorLabel: "Actor A",
+            confidence: "trusted-proxy",
+            displayName: "Actor A",
+            initials: "AA",
+            source: "headers",
+          },
+        }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
     vi.stubGlobal("fetch", fetchMock);
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -95,26 +114,34 @@ describe("live search scope requests", () => {
             hasMemory: true,
             searchParams,
           } as ComponentProps<typeof NuqsTestingAdapter>,
-          createElement(ApiKeyProvider, null, createElement(LiveSearchHarness)),
+          createElement(
+            ApiKeyProvider,
+            null,
+            createElement(CurrentUserProvider, null, createElement(LiveSearchHarness)),
+          ),
         ),
       );
     });
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
     });
   };
 
   it("does not issue a read for an orphan workspace", async () => {
     await renderSearch("?workspace_id=workspace-a");
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchMock.mock.calls.filter(([input]) => String(input).includes("/grc/dashboard"))).toHaveLength(0);
   });
 
   it("issues the scoped dashboard read for a tenant and workspace", async () => {
     await renderSearch("?tenant_id=tenant-a&workspace_id=workspace-a");
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+    const dashboardCalls = fetchMock.mock.calls.filter(([input]) => String(input).includes("/grc/dashboard"));
+    expect(dashboardCalls).toHaveLength(1);
+    expect(dashboardCalls[0]?.[0]).toBe(
       "/api/cerebro/grc/dashboard?limit=100&tenant_id=tenant-a&workspace_id=workspace-a&view=summary",
     );
   });

--- a/apps/web/src/lib/live-search.ts
+++ b/apps/web/src/lib/live-search.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 
-import { useApiKey } from "@/components/providers";
+import { useApiKey, useCurrentUser } from "@/components/providers";
 import { fetchCachedGRC, grcDashboardPath, grcTimeoutMessage } from "@/lib/grc-client";
 import { grcScopeQuery, type GRCScope, useGRCScopeQueryState } from "@/lib/grc-scope";
 import {
@@ -82,8 +82,8 @@ export const LIVE_SEARCH_UNAVAILABLE_COPY = "Page actions are ready. Live search
 export const liveSearchDashboardPath = (scope: GRCScope) =>
   grcDashboardPath({ limit: 100, ...grcScopeQuery(scope) });
 
-export const liveSearchScopeKey = (apiKey: string | undefined, scope: GRCScope) =>
-  JSON.stringify([apiKey ?? "", scope.tenantID.trim(), scope.workspaceID.trim()]);
+export const liveSearchScopeKey = (apiKey: string | undefined, actor: string, scope: GRCScope) =>
+  JSON.stringify([apiKey ?? "", actor.trim(), scope.tenantID.trim(), scope.workspaceID.trim()]);
 
 export const liveSearchScopeIsReady = (scope: GRCScope) =>
   !scope.workspaceID.trim() || Boolean(scope.tenantID.trim());
@@ -312,12 +312,17 @@ const errorMessage = (data: unknown, status: number) =>
 
 export function useLiveSearchCommands(query: string, isOpen: boolean) {
   const { apiKey } = useApiKey();
+  const { actor, loading: currentUserLoading } = useCurrentUser();
   const { tenantID, workspaceID } = useGRCScopeQueryState();
   const scope = useMemo(() => ({ tenantID: tenantID.trim(), workspaceID: workspaceID.trim() }), [tenantID, workspaceID]);
-  const scopeKey = useMemo(() => liveSearchScopeKey(apiKey, scope), [apiKey, scope]);
+  const scopeKey = useMemo(() => liveSearchScopeKey(apiKey, actor, scope), [actor, apiKey, scope]);
   const dashboardPath = useMemo(() => liveSearchDashboardPath(scope), [scope]);
   const trimmedQuery = query.trim();
-  const shouldSearch = isOpen && trimmedQuery.length >= 2 && liveSearchScopeIsReady(scope);
+  const shouldSearch = isOpen
+    && trimmedQuery.length >= 2
+    && !currentUserLoading
+    && Boolean(actor.trim())
+    && liveSearchScopeIsReady(scope);
   const [loadState, setLoadState] = useState<LiveSearchLoadState>(emptyLoadState);
 
   useEffect(() => {


### PR DESCRIPTION
Summary:
- partition live-search shared dashboard state by authenticated actor, API key, tenant, and workspace
- partition custom-dashboard report query cache and in-flight requests by the same actor boundary
- wait for identity resolution and fail closed when no authenticated actor is available

Validation:
- npm --workspace @writer/cerebro-web exec eslint -- src/lib/live-search.ts src/lib/live-search.test.ts src/lib/grc-report-catalog.ts src/lib/grc-report-catalog.test.ts
- npm --workspace @writer/cerebro-web test (116 files, 750 tests)
- git diff --check origin/main...HEAD
- Practice Registry final gate 3089: passed, no findings

Environment boundary:
- local Mac recovery validation only because the dedicated DDESK project workspace is blocked on an unregistered project disk; exact-head hosted checks remain merge authority.