### PR TITLE
catalog(asana): fix users path prefix for full Rust authority

### DIFF
--- a/internal/connectorcatalog/catalog/collaboration-productivity/asana.yaml
+++ b/internal/connectorcatalog/catalog/collaboration-productivity/asana.yaml
@@ -54,7 +54,7 @@ entries:
             page_size: 100
             page_size_param: limit
             type: cursor
-          path: /v1/users
+          path: /users
           projection:
             fields:
               display_name: name


### PR DESCRIPTION
## Summary

Closes part of the Rust source-catalog authority gap for the Asana provider. `sources/asana/catalog.yaml`'s `provider_api` proof was already correct (paths match Asana's real, documented REST API and the bespoke Rust runtime in `crates/source-runtime-next/src/asana/`). The actual gap was in the *compiled* family definitions in `internal/connectorcatalog/catalog/collaboration-productivity/asana.yaml`, which is the other input to `verified_families()` / `provider_contract_verified` in `crates/source-catalog/src/lib.rs`.

The compiled `users` family declared `path: /v1/users` against the entry's templated `${config.base_url}`. Asana's real API has no `/v1` segment — every real family lives directly under the fixed base `https://app.asana.com/api/1.0` (e.g. `GET /users`). That `/v1` prefix meant the compiled locator (`/v1/users`) could never match the already-correct provider proof (`/users`), so `users` failed with `MissingProviderProof` even though every other authority check for it already passed. This PR drops the spurious `/v1` prefix, which is the only change needed.

I did **not** touch `sources/asana/catalog.yaml` — it needed no changes for the family this PR closes.

## Authority proof

**Compiled families** (from `internal/connectorcatalog/catalog/collaboration-productivity/asana.yaml`): `users`, `groups`, `workspaces`, `documents`, `audit_events`.

| Family | Verdict | Evidence |
|---|---|---|
| `users` | **Now authoritative** | `GET /users` confirmed live against [developers.asana.com/reference/getusers](https://developers.asana.com/reference/getusers) and the OpenAPI spec at [github.com/Asana/openapi](https://github.com/Asana/openapi/blob/master/defs/asana_oas.yaml). Matches `sources/asana/catalog.yaml` `provider_api.families` (unchanged) and the literal request path the bespoke Rust runtime builds in `crates/source-runtime-next/src/asana/request.rs`. Fixture coverage exists: `sources/asana/testdata/{discover,read}_users.json`. |
| `groups` | Left unproven | No "Groups" resource exists anywhere in Asana's documented API — confirmed against the full resource index at [developers.asana.com/llms.txt](https://developers.asana.com/llms.txt), which lists every Asana object (Users, Workspaces, Teams, Projects, Audit Log Events, etc.) and includes no Groups endpoint. Asana's only "group" concept is a separate SCIM 2.0 provisioning endpoint under `/scim`, not this REST family. Nothing to add. |
| `documents` | Left unproven | Same check — no "Documents" resource exists in Asana's API (confirmed against the same `llms.txt` index). Nothing to add. |
| `workspaces` | Left unproven | `GET /workspaces` is a real, documented endpoint (confirmed against [developers.asana.com/reference/getworkspaces](https://developers.asana.com/reference/getworkspaces)), but the bespoke Rust runtime (`crates/source-runtime-next/src/asana/family.rs`) has no `AsanaFamily::Workspaces` variant, no `asana.workspaces` emitted kind, and no `sources/asana/testdata` fixture — the Rust runtime only uses `workspace_gid` as a scoping parameter, never fetches a workspace collection. Adding `workspaces` to `runtime_families` would be a false claim of runtime coverage per the task's fixture-coverage rule, so it stays out regardless of the compiled path being fixable. |
| `audit_events` | Left unproven | Real and Rust-implemented (`GET /workspaces/{workspace_gid}/audit_log_events`, confirmed against [developers.asana.com/reference/getauditlogevents](https://developers.asana.com/reference/getauditlogevents)), with fixtures in `sources/asana/testdata`. But the compiled family models it as a flat `/v1/audit_events` path with no `workspace_gid` path parameter or config field, unlike the true nested shape. Fixing this needs adding new required config surface (a `workspace_gid` config field plus `read.path_params` wiring) to the compiled catalog entry, not just a path-string correction — a materially bigger, unprecedented change I did not make in this pass so as not to fabricate or overreach past what's already verified. |

**Note on family-id mismatch:** `sources/asana/catalog.yaml`'s `runtime_families`/`provider_api.families` include `projects` (a real, Rust-implemented, fixture-backed family — `GET /projects`, confirmed against [developers.asana.com/reference/getprojects](https://developers.asana.com/reference/getprojects)), but the compiled catalog has no `projects` resource family at all. This is an omission in the compiled (Go) catalog, not an error in `sources/asana/catalog.yaml`, so I left `projects` as declared — it will simply have no effect on authority until/unless a compiled `projects` family is added.

**Probe results** (throwaway `crates/source-catalog/tests/wave2_probe.rs`, deleted before commit), before → after this change:

```
family=users        authoritative=false -> true   projection_authoritative=false -> true   reasons=[] (was [MissingProviderProof, IncompleteRuntimeFamilyProof])
family=groups       authoritative=false            reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]  (unchanged)
family=workspaces   authoritative=false            reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]  (unchanged)
family=documents    authoritative=false            reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]  (unchanged)
family=audit_events authoritative=false            reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]  (unchanged)
```

Since not all five compiled families are authoritative, `asana.authority()` remains `ShadowOnly` overall, so it does not qualify for the `retired_static_loader_sources_are_fully_rust_authoritative` list, and the stacked Go-projection-retirement PR is skipped for this pass.

## Validation

- `cargo test -p cerebro-source-catalog --test wave2_probe -- --nocapture` (probe run to confirm authority flip, then file deleted)
- `cargo test -p cerebro-source-catalog --lib` (27 passed, including `compiles_the_complete_checked_in_catalog` and `retired_static_loader_sources_are_fully_rust_authoritative`)
- `go build ./...`
- `go test ./internal/... ./tools/catalogcheck/... ./tools/connectorcatalogfidelity/... -count=1` (all pass, no `FAIL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)