### PR TITLE
refactor(sources): retire Cloudflare Go projection writer

### DIFF
--- a/internal/sourceprojection/cloudflare.go
+++ b/internal/sourceprojection/cloudflare.go
@@ -1,362 +1,60 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func cloudflareAccountURN(tenantID string, accountID string) string {
-	return projectionURN(tenantID, "cloudflare_account", strings.TrimSpace(accountID))
+var errCloudflareRustProjectionRequired = errors.New("cloudflare projection requires Rust authority")
+
+func cloudflareAccountProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCloudflareRustProjectionRequired
 }
 
-func cloudflareMemberURN(tenantID string, memberID string) string {
-	return projectionURN(tenantID, "cloudflare_member", strings.TrimSpace(memberID))
+func cloudflareMemberProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCloudflareRustProjectionRequired
 }
 
-func cloudflareRoleURN(tenantID string, roleID string) string {
-	return projectionURN(tenantID, "cloudflare_role", strings.TrimSpace(roleID))
+func cloudflareRoleProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCloudflareRustProjectionRequired
 }
 
-func cloudflareZoneURN(tenantID string, zoneID string) string {
-	return projectionURN(tenantID, "cloudflare_zone", strings.TrimSpace(zoneID))
+func cloudflareZoneProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCloudflareRustProjectionRequired
 }
 
-func cloudflareDNSRecordURN(tenantID string, recordID string) string {
-	return projectionURN(tenantID, "cloudflare_dns_record", strings.TrimSpace(recordID))
+func cloudflareDNSRecordProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCloudflareRustProjectionRequired
 }
 
-func cloudflareLoadBalancerPoolURN(tenantID string, poolID string) string {
-	return projectionURN(tenantID, "cloudflare_load_balancer_pool", strings.TrimSpace(poolID))
+func cloudflareAuditLogProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCloudflareRustProjectionRequired
 }
 
-func cloudflareEntity(event *cerebrov1.EventEnvelope, urn string, entityType string, label string, attrs map[string]string) *ports.ProjectedEntity {
-	return &ports.ProjectedEntity{
-		URN:        urn,
-		TenantID:   event.GetTenantId(),
-		SourceID:   event.GetSourceId(),
-		EntityType: entityType,
-		Label:      firstNonEmpty(label, urn),
-		Attributes: attrs,
-	}
+func cloudflareLoadBalancerProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCloudflareRustProjectionRequired
 }
 
-func cloudflareAttributes(in map[string]string) map[string]string {
-	out := map[string]string{}
-	for key, value := range in {
-		addProjectedAttribute(out, key, value)
-	}
-	return out
+func cloudflareAccountScopedInventoryProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCloudflareRustProjectionRequired
 }
 
-func cloudflareAccountProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attrs := event.GetAttributes()
-	accountID := strings.TrimSpace(attrs["account_id"])
-	if accountID == "" {
-		return nil, nil, nil
-	}
-	entities := map[string]*ports.ProjectedEntity{}
-	addEntity(entities, cloudflareEntity(event, cloudflareAccountURN(tenantID, accountID), "cloudflare.account", firstNonEmpty(attrs["name"], accountID), cloudflareAttributes(map[string]string{
-		"account_id": accountID,
-		"name":       attrs["name"],
-		"type":       attrs["type"],
-	})))
-	projectedEntities, _ := entitiesAndLinks(entities, map[string]*ports.ProjectedLink{})
-	return projectedEntities, nil, nil
+func cloudflareZoneScopedInventoryProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCloudflareRustProjectionRequired
 }
 
-func cloudflareMemberProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attrs := event.GetAttributes()
-	memberID := strings.TrimSpace(attrs["member_id"])
-	if memberID == "" {
-		return nil, nil, nil
-	}
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	memberURN := cloudflareMemberURN(tenantID, memberID)
-	addEntity(entities, cloudflareEntity(event, memberURN, "cloudflare.member", firstNonEmpty(attrs["email"], memberID), cloudflareAttributes(map[string]string{
-		"member_id":  memberID,
-		"account_id": attrs["account_id"],
-		"email":      attrs["email"],
-		"status":     attrs["status"],
-	})))
-	if email := strings.TrimSpace(attrs["email"]); email != "" {
-		addIdentifierLink(entities, links, tenantID, event.GetSourceId(), event.GetId(), memberURN, email, event.GetOccurredAt())
-	}
-	if accountID := strings.TrimSpace(attrs["account_id"]); accountID != "" {
-		accountURN := cloudflareAccountURN(tenantID, accountID)
-		addEntity(entities, cloudflareEntity(event, accountURN, "cloudflare.account", "", map[string]string{"account_id": accountID}))
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), memberURN, accountURN, relationBelongsTo, map[string]string{
-			"event_id":   event.GetId(),
-			"at":         eventObservedAt(event),
-			"match_type": "cloudflare_member_account",
-		}))
-	}
-	for _, role := range cloudflareMemberRoleRefs(event) {
-		roleURN := cloudflareRoleURN(tenantID, role.id)
-		if roleURN == "" {
-			continue
-		}
-		addEntity(entities, cloudflareEntity(event, roleURN, "cloudflare.role", firstNonEmpty(role.name, role.id), map[string]string{
-			"role_id": role.id,
-			"name":    role.name,
-		}))
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), memberURN, roleURN, relationAssignedTo, map[string]string{
-			"event_id":   event.GetId(),
-			"at":         eventObservedAt(event),
-			"match_type": "cloudflare_member_role",
-			"role_id":    role.id,
-		}))
-	}
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
-}
-
-func cloudflareRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attrs := event.GetAttributes()
-	roleID := strings.TrimSpace(attrs["role_id"])
-	if roleID == "" {
-		return nil, nil, nil
-	}
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	roleURN := cloudflareRoleURN(tenantID, roleID)
-	addEntity(entities, cloudflareEntity(event, roleURN, "cloudflare.role", firstNonEmpty(attrs["name"], roleID), cloudflareAttributes(map[string]string{
-		"role_id":     roleID,
-		"account_id":  attrs["account_id"],
-		"name":        attrs["name"],
-		"description": attrs["description"],
-		"permissions": attrs["permissions"],
-	})))
-	if accountID := strings.TrimSpace(attrs["account_id"]); accountID != "" {
-		accountURN := cloudflareAccountURN(tenantID, accountID)
-		addEntity(entities, cloudflareEntity(event, accountURN, "cloudflare.account", "", map[string]string{"account_id": accountID}))
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), roleURN, accountURN, relationBelongsTo, map[string]string{
-			"event_id":   event.GetId(),
-			"at":         eventObservedAt(event),
-			"match_type": "cloudflare_role_account",
-		}))
-	}
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
-}
-
-func cloudflareZoneProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attrs := event.GetAttributes()
-	zoneID := strings.TrimSpace(attrs["zone_id"])
-	if zoneID == "" {
-		return nil, nil, nil
-	}
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	zoneURN := cloudflareZoneURN(tenantID, zoneID)
-	addEntity(entities, cloudflareEntity(event, zoneURN, "cloudflare.zone", firstNonEmpty(attrs["name"], zoneID), cloudflareAttributes(map[string]string{
-		"zone_id":    zoneID,
-		"account_id": attrs["account_id"],
-		"name":       attrs["name"],
-		"status":     attrs["status"],
-		"type":       attrs["type"],
-		"paused":     attrs["paused"],
-	})))
-	if accountID := strings.TrimSpace(attrs["account_id"]); accountID != "" {
-		accountURN := cloudflareAccountURN(tenantID, accountID)
-		addEntity(entities, cloudflareEntity(event, accountURN, "cloudflare.account", "", map[string]string{"account_id": accountID}))
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), zoneURN, accountURN, relationBelongsTo, map[string]string{
-			"event_id":   event.GetId(),
-			"at":         eventObservedAt(event),
-			"match_type": "cloudflare_zone_account",
-		}))
-	}
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
-}
-
-func cloudflareDNSRecordProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attrs := event.GetAttributes()
-	recordID := strings.TrimSpace(attrs["record_id"])
-	zoneID := strings.TrimSpace(attrs["zone_id"])
-	if recordID == "" || zoneID == "" {
-		return nil, nil, nil
-	}
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	recordURN := cloudflareDNSRecordURN(tenantID, recordID)
-	addEntity(entities, cloudflareEntity(event, recordURN, "cloudflare.dns_record", firstNonEmpty(attrs["name"], recordID), cloudflareAttributes(map[string]string{
-		"record_id": recordID,
-		"zone_id":   zoneID,
-		"name":      attrs["name"],
-		"type":      attrs["type"],
-		"content":   attrs["content"],
-		"proxied":   attrs["proxied"],
-	})))
-	zoneURN := cloudflareZoneURN(tenantID, zoneID)
-	addEntity(entities, cloudflareEntity(event, zoneURN, "cloudflare.zone", "", map[string]string{"zone_id": zoneID}))
-	linkAttrs := map[string]string{
-		"event_id":   event.GetId(),
-		"at":         eventObservedAt(event),
-		"match_type": "cloudflare_dns_record_zone",
-	}
-	addLink(links, projectedLink(tenantID, event.GetSourceId(), recordURN, zoneURN, relationBelongsTo, linkAttrs))
-	addLink(links, projectedLink(tenantID, event.GetSourceId(), zoneURN, recordURN, relationHasDNSRecord, linkAttrs))
-	projectedEntities, projectedLinks := entitiesAndLinks(entities, links)
-	return projectedEntities, projectedLinks, nil
-}
-
-type cloudflareScopeURNFunc func(string, string) string
-
-func cloudflareAccountScopedInventoryProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return cloudflareScopedInventoryProjections(event, "account_id", "cloudflare.account", "cloudflare_account_scope", cloudflareAccountURN)
-}
-
-func cloudflareZoneScopedInventoryProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return cloudflareScopedInventoryProjections(event, "zone_id", "cloudflare.zone", "cloudflare_zone_scope", cloudflareZoneURN)
-}
-
-func cloudflareLoadBalancerProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	entities, links, err := cloudflareZoneScopedInventoryProjections(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	if len(entities) == 0 {
-		return entities, links, nil
-	}
-	primary := entities[0]
-	tenant := primary.TenantID
-	if tenant == "" {
-		return entities, links, nil
-	}
-	seen := map[string]struct{}{}
-	addPool := func(poolID string) {
-		poolID = strings.TrimSpace(poolID)
-		if poolID == "" {
-			return
-		}
-		if _, ok := seen[poolID]; ok {
-			return
-		}
-		seen[poolID] = struct{}{}
-		poolURN := cloudflareLoadBalancerPoolURN(tenant, poolID)
-		entities = append(entities, cloudflareEntity(event, poolURN, "cloudflare.load_balancer_pool", poolID, map[string]string{"pool_id": poolID}))
-		links = append(links, projectedLink(tenant, event.GetSourceId(), primary.URN, poolURN, relationDependsOn, map[string]string{
-			"event_id":   event.GetId(),
-			"at":         eventObservedAt(event),
-			"match_type": "cloudflare_load_balancer_pool",
-		}))
-	}
-	attrs := event.GetAttributes()
-	addPool(attrs["fallback_pool"])
-	for _, poolID := range splitCSV(attrs["default_pools"]) {
-		addPool(poolID)
-	}
-	return entities, links, nil
-}
-
-func cloudflareScopedInventoryProjections(event *cerebrov1.EventEnvelope, scopeAttr string, scopeEntityType string, matchType string, scopeURN cloudflareScopeURNFunc) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	entities, links, err := genericInventoryProjections(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	if len(entities) == 0 {
-		return entities, links, nil
-	}
-	primary := entities[0]
-	tenant := primary.TenantID
-	scopeID := strings.TrimSpace(event.GetAttributes()[scopeAttr])
-	if tenant == "" || scopeID == "" {
-		return entities, links, nil
-	}
-	targetURN := scopeURN(tenant, scopeID)
-	entities = append(entities, cloudflareEntity(event, targetURN, scopeEntityType, scopeID, map[string]string{scopeAttr: scopeID}))
-	links = append(links, projectedLink(tenant, event.GetSourceId(), primary.URN, targetURN, relationBelongsTo, map[string]string{
-		"event_id":   event.GetId(),
-		"at":         eventObservedAt(event),
-		"match_type": matchType,
-	}))
-	return entities, links, nil
-}
-
-// cloudflareDNSRecordRetractions removes obsolete dns_record-to-zone links when a
-// DNS record is observed as reassigned to a different zone, so the record no
-// longer appears under a zone where it is no longer present.
-func cloudflareDNSRecordRetractions(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedLink, error) {
-	if event.GetKind() != "cloudflare.dns_record" {
-		return nil, nil
-	}
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, err
-	}
-	attrs := event.GetAttributes()
-	recordID := strings.TrimSpace(attrs["record_id"])
-	previousZoneID := strings.TrimSpace(attrs["previous_zone_id"])
-	currentZoneID := strings.TrimSpace(attrs["zone_id"])
-	if recordID == "" || previousZoneID == "" || previousZoneID == currentZoneID {
-		return nil, nil
-	}
-	recordURN := cloudflareDNSRecordURN(tenantID, recordID)
-	previousZoneURN := cloudflareZoneURN(tenantID, previousZoneID)
-	links := map[string]*ports.ProjectedLink{}
-	retractionAttrs := map[string]string{
-		"event_id":   event.GetId(),
-		"retraction": "cloudflare_dns_record_zone_reassigned",
-	}
-	addLink(links, projectedLink(tenantID, event.GetSourceId(), recordURN, previousZoneURN, relationBelongsTo, retractionAttrs))
-	addLink(links, projectedLink(tenantID, event.GetSourceId(), previousZoneURN, recordURN, relationHasDNSRecord, retractionAttrs))
-	_, projectedLinks := entitiesAndLinks(nil, links)
-	return projectedLinks, nil
-}
-
-type cloudflareRoleRef struct {
-	id   string
-	name string
-}
-
-func cloudflareMemberRoleRefs(event *cerebrov1.EventEnvelope) []cloudflareRoleRef {
-	payload := payloadMap(event)
-	rawRoles, ok := payload["roles"].([]any)
-	if !ok {
-		return nil
-	}
-	refs := make([]cloudflareRoleRef, 0, len(rawRoles))
-	seen := map[string]struct{}{}
-	for _, raw := range rawRoles {
-		ref := cloudflareRoleRef{}
-		switch typed := raw.(type) {
-		case map[string]any:
-			ref.id = strings.TrimSpace(stringValue(typed, "id"))
-			ref.name = strings.TrimSpace(stringValue(typed, "name"))
-		case string:
-			ref.id = strings.TrimSpace(typed)
-		}
-		if ref.id == "" {
-			continue
-		}
-		if _, dup := seen[ref.id]; dup {
-			continue
-		}
-		seen[ref.id] = struct{}{}
-		refs = append(refs, ref)
-	}
-	return refs
+// cloudflareDNSRecordRetractions previously removed obsolete dns_record-to-zone
+// links when a DNS record was observed as reassigned to a different zone. DNS
+// record projection (entities and links alike) is now Rust-authoritative, and
+// (*Service).ProjectRecordsContext already fails closed on cloudflare.dns_record
+// before (*Service).ProjectRetractions can run in the production dispatch path
+// (see ProjectWithDelta), so this hook is unreachable there. It is called
+// unconditionally for every event kind regardless of registry, though, so it
+// stays registered as a permanent no-op rather than erroring, to avoid
+// tripping up unrelated registries (e.g. catalog-runtime template tests) that
+// still route cloudflare.dns_record through a generic projector.
+func cloudflareDNSRecordRetractions(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedLink, error) {
+	return nil, nil
 }

--- a/internal/sourceprojection/cloudflare_test.go
+++ b/internal/sourceprojection/cloudflare_test.go
@@ -1,425 +1,70 @@
 package sourceprojection
 
 import (
-	"context"
-	"fmt"
-	"strings"
+	"errors"
 	"testing"
-	"time"
-
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func cloudflareTestEvent(id string, kind string, attrs map[string]string, payload string) *cerebrov1.EventEnvelope {
-	return &cerebrov1.EventEnvelope{
-		Id:         id,
-		TenantId:   "writer",
-		SourceId:   "cloudflare",
-		Kind:       kind,
-		OccurredAt: timestamppb.New(time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)),
-		Attributes: attrs,
-		Payload:    []byte(payload),
-	}
-}
-
-func TestProjectCloudflareInventoryEntitiesAndLinks(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-	ctx := context.Background()
-
-	// The in-memory test recorder replaces entities on upsert (the production
-	// store merges), so events that emit stub endpoints are projected before the
-	// rich event for the same entity to keep this assertion deterministic.
-	events := []*cerebrov1.EventEnvelope{
-		cloudflareTestEvent("cf-dns-1", "cloudflare.dns_record", map[string]string{
-			"record_id": "dns-1", "zone_id": "zone-1", "name": "www.example.com", "type": "A", "content": "203.0.113.10", "proxied": "true",
-		}, `{"id":"dns-1","name":"www.example.com"}`),
-		cloudflareTestEvent("cf-member-1", "cloudflare.member", map[string]string{
-			"member_id": "member-1", "account_id": "acct-1", "email": "alice@example.com", "status": "accepted",
-		}, `{"id":"member-1","roles":[{"id":"role-1","name":"Administrator"}]}`),
-		cloudflareTestEvent("cf-zone-1", "cloudflare.zone", map[string]string{
-			"zone_id": "zone-1", "account_id": "acct-1", "name": "example.com", "status": "active", "paused": "false",
-		}, `{"id":"zone-1","name":"example.com"}`),
-		cloudflareTestEvent("cf-role-1", "cloudflare.role", map[string]string{
-			"role_id": "role-1", "account_id": "acct-1", "name": "Administrator",
-		}, `{"id":"role-1","name":"Administrator"}`),
-		cloudflareTestEvent("cf-account-1", "cloudflare.account", map[string]string{
-			"account_id": "acct-1", "name": "Writer", "type": "enterprise",
-		}, `{"id":"acct-1","name":"Writer"}`),
-	}
-	for _, event := range events {
-		if _, err := service.Project(ctx, event); err != nil {
-			t.Fatalf("Project(%s) error = %v", event.GetKind(), err)
-		}
-	}
-
-	accountURN := "urn:cerebro:writer:cloudflare_account:acct-1"
-	emailURN := "urn:cerebro:writer:identifier:email:alice@example.com"
-	identityURN := "urn:cerebro:writer:identity:email:alice@example.com"
-	roleURN := "urn:cerebro:writer:cloudflare_role:role-1"
-	memberURN := "urn:cerebro:writer:cloudflare_member:member-1"
-	zoneURN := "urn:cerebro:writer:cloudflare_zone:zone-1"
-	recordURN := "urn:cerebro:writer:cloudflare_dns_record:dns-1"
-
-	if entity := state.entities[accountURN]; entity == nil || entity.EntityType != "cloudflare.account" {
-		t.Fatalf("cloudflare.account entity missing or wrong: %#v", entity)
-	}
-	member := state.entities[memberURN]
-	if member == nil || member.EntityType != "cloudflare.member" {
-		t.Fatalf("cloudflare.member entity missing or wrong: %#v", member)
-	}
-	if got := member.Attributes["email"]; got != "alice@example.com" {
-		t.Fatalf("member email attribute = %q", got)
-	}
-	if entity := state.entities[zoneURN]; entity == nil || entity.Attributes["paused"] != "false" {
-		t.Fatalf("cloudflare.zone entity missing or paused attr wrong: %#v", entity)
-	}
-	record := state.entities[recordURN]
-	if record == nil || record.Attributes["proxied"] != "true" {
-		t.Fatalf("cloudflare.dns_record entity missing or proxied attr wrong: %#v", record)
-	}
-
-	assertProjectedLink(t, state, memberURN, relationBelongsTo, accountURN)
-	assertProjectedLink(t, state, memberURN, relationAssignedTo, roleURN)
-	assertProjectedLink(t, state, memberURN, relationHasIdentifier, emailURN)
-	assertProjectedLink(t, state, memberURN, relationRepresentsIdentity, identityURN)
-	assertProjectedLink(t, state, roleURN, relationBelongsTo, accountURN)
-	assertProjectedLink(t, state, zoneURN, relationBelongsTo, accountURN)
-	assertProjectedLink(t, state, recordURN, relationBelongsTo, zoneURN)
-	assertProjectedLink(t, state, zoneURN, relationHasDNSRecord, recordURN)
-}
-
-func TestRegistryRoutesCloudflareCoreKinds(t *testing.T) {
-	events := []*cerebrov1.EventEnvelope{
-		{Id: "cf-access-application", TenantId: "writer", SourceId: "cloudflare", Kind: "cloudflare.access_application", Attributes: map[string]string{"application_id": "app-1", "account_id": "acct-1", "name": "Admin App"}, Payload: []byte(`{"id":"app-1"}`)},
-		{Id: "cf-access-group", TenantId: "writer", SourceId: "cloudflare", Kind: "cloudflare.access_group", Attributes: map[string]string{"group_id": "group-1", "account_id": "acct-1", "name": "Employees"}, Payload: []byte(`{"id":"group-1"}`)},
-		{Id: "cf-account", TenantId: "writer", SourceId: "cloudflare", Kind: "cloudflare.account", Attributes: map[string]string{"account_id": "acct-1", "name": "Writer"}, Payload: []byte(`{"id":"acct-1"}`)},
-		{Id: "cf-account-ruleset", TenantId: "writer", SourceId: "cloudflare", Kind: "cloudflare.account_ruleset", Attributes: map[string]string{"ruleset_id": "ruleset-1", "account_id": "acct-1", "name": "Account WAF"}, Payload: []byte(`{"id":"ruleset-1"}`)},
-		{Id: "cf-audit-log", TenantId: "writer", SourceId: "cloudflare", Kind: "cloudflare.audit_log", Attributes: map[string]string{"audit_id": "audit-1", "account_id": "acct-1", "actor_email": "admin@example.com"}, Payload: []byte(`{"id":"audit-1"}`)},
-		{Id: "cf-member", TenantId: "writer", SourceId: "cloudflare", Kind: "cloudflare.member", Attributes: map[string]string{"member_id": "member-1", "account_id": "acct-1", "email": "alice@example.com"}, Payload: []byte(`{"id":"member-1"}`)},
-		{Id: "cf-gateway-rule", TenantId: "writer", SourceId: "cloudflare", Kind: "cloudflare.gateway_rule", Attributes: map[string]string{"rule_id": "rule-1", "account_id": "acct-1", "name": "Block Malware"}, Payload: []byte(`{"id":"rule-1"}`)},
-		{Id: "cf-load-balancer", TenantId: "writer", SourceId: "cloudflare", Kind: "cloudflare.load_balancer", Attributes: map[string]string{"load_balancer_id": "lb-1", "zone_id": "zone-1", "name": "www.example.com"}, Payload: []byte(`{"id":"lb-1"}`)},
-		{Id: "cf-load-balancer-pool", TenantId: "writer", SourceId: "cloudflare", Kind: "cloudflare.load_balancer_pool", Attributes: map[string]string{"pool_id": "pool-1", "account_id": "acct-1", "name": "Primary Pool"}, Payload: []byte(`{"id":"pool-1"}`)},
-		{Id: "cf-role", TenantId: "writer", SourceId: "cloudflare", Kind: "cloudflare.role", Attributes: map[string]string{"role_id": "role-1", "account_id": "acct-1", "name": "Administrator"}, Payload: []byte(`{"id":"role-1"}`)},
-		{Id: "cf-worker-script", TenantId: "writer", SourceId: "cloudflare", Kind: "cloudflare.worker_script", Attributes: map[string]string{"script_id": "api", "account_id": "acct-1", "name": "api"}, Payload: []byte(`{"id":"api"}`)},
-		{Id: "cf-zone", TenantId: "writer", SourceId: "cloudflare", Kind: "cloudflare.zone", Attributes: map[string]string{"zone_id": "zone-1", "account_id": "acct-1", "name": "example.com"}, Payload: []byte(`{"id":"zone-1"}`)},
-		{Id: "cf-zone-access-application", TenantId: "writer", SourceId: "cloudflare", Kind: "cloudflare.zone_access_application", Attributes: map[string]string{"application_id": "app-1", "zone_id": "zone-1", "name": "Zone Admin"}, Payload: []byte(`{"id":"app-1"}`)},
-		{Id: "cf-zone-access-group", TenantId: "writer", SourceId: "cloudflare", Kind: "cloudflare.zone_access_group", Attributes: map[string]string{"group_id": "group-1", "zone_id": "zone-1", "name": "Zone Employees"}, Payload: []byte(`{"id":"group-1"}`)},
-		{Id: "cf-zone-ruleset", TenantId: "writer", SourceId: "cloudflare", Kind: "cloudflare.zone_ruleset", Attributes: map[string]string{"ruleset_id": "zone-ruleset-1", "zone_id": "zone-1", "name": "Zone WAF"}, Payload: []byte(`{"id":"zone-ruleset-1"}`)},
-		{Id: "cf-dns-record", TenantId: "writer", SourceId: "cloudflare", Kind: "cloudflare.dns_record", Attributes: map[string]string{"record_id": "dns-1", "zone_id": "zone-1", "name": "www.example.com"}, Payload: []byte(`{"id":"dns-1"}`)},
-	}
-	for _, event := range events {
-		t.Run(event.GetKind(), func(t *testing.T) {
-			entities, _, err := BuiltinRegistry().Project(event)
-			if err != nil {
-				t.Fatalf("Project(%s) error = %v", event.GetKind(), err)
+func TestCloudflareGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"cloudflare.access_application",
+		"cloudflare.access_group",
+		"cloudflare.account",
+		"cloudflare.account_ruleset",
+		"cloudflare.audit_log",
+		"cloudflare.dns_record",
+		"cloudflare.gateway_rule",
+		"cloudflare.load_balancer",
+		"cloudflare.load_balancer_pool",
+		"cloudflare.member",
+		"cloudflare.role",
+		"cloudflare.worker_script",
+		"cloudflare.zone",
+		"cloudflare.zone_access_application",
+		"cloudflare.zone_access_group",
+		"cloudflare.zone_ruleset",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "cloudflare",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errCloudflareRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
 			}
-			found := false
-			for _, entity := range entities {
-				if entity.EntityType == event.GetKind() {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Fatalf("kind %q did not route to projector; entities=%#v", event.GetKind(), entities)
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
 			}
 		})
 	}
 }
 
-func TestProjectCloudflareScopedInventoryLinks(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-	ctx := context.Background()
-
-	events := []*cerebrov1.EventEnvelope{
-		cloudflareTestEvent("cf-access-app", "cloudflare.access_application", map[string]string{
-			"application_id": "app-1", "account_id": "acct-1", "name": "Admin App",
-		}, `{"id":"app-1"}`),
-		cloudflareTestEvent("cf-account-ruleset", "cloudflare.account_ruleset", map[string]string{
-			"ruleset_id": "ruleset-1", "account_id": "acct-1", "name": "Account WAF",
-		}, `{"id":"ruleset-1"}`),
-		cloudflareTestEvent("cf-worker-script", "cloudflare.worker_script", map[string]string{
-			"script_id": "api", "account_id": "acct-1", "name": "api",
-		}, `{"id":"api"}`),
-		cloudflareTestEvent("cf-pool", "cloudflare.load_balancer_pool", map[string]string{
-			"pool_id": "pool-1", "account_id": "acct-1", "name": "Primary Pool",
-		}, `{"id":"pool-1"}`),
-		cloudflareTestEvent("cf-zone-access-group", "cloudflare.zone_access_group", map[string]string{
-			"group_id": "group-1", "zone_id": "zone-1", "name": "Employees",
-		}, `{"id":"group-1"}`),
-		cloudflareTestEvent("cf-zone-ruleset", "cloudflare.zone_ruleset", map[string]string{
-			"ruleset_id": "zone-ruleset-1", "zone_id": "zone-1", "name": "Zone WAF",
-		}, `{"id":"zone-ruleset-1"}`),
-		cloudflareTestEvent("cf-lb", "cloudflare.load_balancer", map[string]string{
-			"load_balancer_id": "lb-1", "zone_id": "zone-1", "name": "www.example.com", "fallback_pool": "pool-1", "default_pools": "pool-2,pool-1",
-		}, `{"id":"lb-1"}`),
-		cloudflareTestEvent("cf-audit", "cloudflare.audit_log", map[string]string{
-			"audit_id": "audit-1", "account_id": "acct-1", "zone_id": "zone-1", "actor_email": "admin@example.com",
-		}, `{"id":"audit-1"}`),
-	}
-	for _, event := range events {
-		if _, err := service.Project(ctx, event); err != nil {
-			t.Fatalf("Project(%s) error = %v", event.GetKind(), err)
-		}
-	}
-
-	accountURN := "urn:cerebro:writer:cloudflare_account:acct-1"
-	zoneURN := "urn:cerebro:writer:cloudflare_zone:zone-1"
-	accessAppURN := "urn:cerebro:writer:cloudflare_access_application:acct-1%7Capp-1"
-	accountRulesetURN := "urn:cerebro:writer:cloudflare_account_ruleset:acct-1%7Cruleset-1"
-	workerScriptURN := "urn:cerebro:writer:cloudflare_worker_script:acct-1%7Capi"
-	poolURN := "urn:cerebro:writer:cloudflare_load_balancer_pool:pool-1"
-	defaultPoolURN := "urn:cerebro:writer:cloudflare_load_balancer_pool:pool-2"
-	zoneAccessGroupURN := "urn:cerebro:writer:cloudflare_zone_access_group:zone-1%7Cgroup-1"
-	zoneRulesetURN := "urn:cerebro:writer:cloudflare_zone_ruleset:zone-1%7Czone-ruleset-1"
-	loadBalancerURN := "urn:cerebro:writer:cloudflare_load_balancer:zone-1%7Clb-1"
-	auditURN := "urn:cerebro:writer:cloudflare_audit_log:audit-1"
-
-	for _, urn := range []string{accessAppURN, accountRulesetURN, workerScriptURN, poolURN, zoneAccessGroupURN, zoneRulesetURN, loadBalancerURN, auditURN} {
-		if entity := state.entities[urn]; entity == nil {
-			t.Fatalf("expected entity %s; entities=%#v", urn, state.entities)
-		}
-	}
-	assertProjectedLink(t, state, accessAppURN, relationBelongsTo, accountURN)
-	assertProjectedLink(t, state, accountRulesetURN, relationBelongsTo, accountURN)
-	assertProjectedLink(t, state, workerScriptURN, relationBelongsTo, accountURN)
-	assertProjectedLink(t, state, poolURN, relationBelongsTo, accountURN)
-	assertProjectedLink(t, state, zoneAccessGroupURN, relationBelongsTo, zoneURN)
-	assertProjectedLink(t, state, zoneRulesetURN, relationBelongsTo, zoneURN)
-	assertProjectedLink(t, state, loadBalancerURN, relationBelongsTo, zoneURN)
-	assertProjectedLink(t, state, loadBalancerURN, relationDependsOn, poolURN)
-	assertProjectedLink(t, state, loadBalancerURN, relationDependsOn, defaultPoolURN)
-}
-
-func TestProjectCloudflareWorkerScriptRequiresAccountScopedIdentity(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-
-	event := cloudflareTestEvent("cf-worker-missing-account", "cloudflare.worker_script", map[string]string{
-		"script_id": "api",
-		"name":      "api",
-	}, `{"id":"api"}`)
-	if _, err := service.Project(context.Background(), event); err != nil {
-		t.Fatalf("Project() error = %v", err)
-	}
-
-	nameOnlyURN := "urn:cerebro:writer:cloudflare_worker_script:api"
-	if entity := state.entities[nameOnlyURN]; entity != nil {
-		t.Fatalf("worker script without account must not use script name alone: %#v", entity)
-	}
-	eventURN := "urn:cerebro:writer:cloudflare_worker_script:cf-worker-missing-account"
-	if entity := state.entities[eventURN]; entity == nil || entity.EntityType != "cloudflare.worker_script" {
-		t.Fatalf("worker script fallback entity missing or wrong: %#v", entity)
-	}
-}
-
-func TestProjectCloudflareLoadBalancerDoesNotUseZoneAsIdentity(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-
-	event := cloudflareTestEvent("cf-lb-missing-id", "cloudflare.load_balancer", map[string]string{
-		"zone_id": "zone-1",
-		"name":    "www.example.com",
-	}, `{"name":"www.example.com"}`)
-	if _, err := service.Project(context.Background(), event); err != nil {
-		t.Fatalf("Project() error = %v", err)
-	}
-
-	zoneDerivedURN := "urn:cerebro:writer:cloudflare_load_balancer:zone-1"
-	if entity := state.entities[zoneDerivedURN]; entity != nil {
-		t.Fatalf("load balancer without id must not use zone as identity: %#v", entity)
-	}
-	eventURN := "urn:cerebro:writer:cloudflare_load_balancer:cf-lb-missing-id"
-	if entity := state.entities[eventURN]; entity == nil || entity.EntityType != "cloudflare.load_balancer" {
-		t.Fatalf("load balancer fallback entity missing or wrong: %#v", entity)
-	}
-}
-
-func TestProjectCloudflareScopedResourcesRequireScopeKey(t *testing.T) {
-	tests := []struct {
-		name     string
-		eventID  string
-		kind     string
-		attrs    map[string]string
-		entityID string
-	}{
-		{
-			name:     "access_application without account_id",
-			eventID:  "cf-app-no-account",
-			kind:     "cloudflare.access_application",
-			attrs:    map[string]string{"application_id": "app-1", "name": "Admin App"},
-			entityID: "app-1",
-		},
-		{
-			name:     "zone_access_group without zone_id",
-			eventID:  "cf-group-no-zone",
-			kind:     "cloudflare.zone_access_group",
-			attrs:    map[string]string{"group_id": "group-1", "name": "Employees"},
-			entityID: "group-1",
-		},
-		{
-			name:     "account_ruleset without account_id",
-			eventID:  "cf-ruleset-no-account",
-			kind:     "cloudflare.account_ruleset",
-			attrs:    map[string]string{"ruleset_id": "ruleset-1", "name": "WAF"},
-			entityID: "ruleset-1",
-		},
-		{
-			name:     "gateway_rule without account_id",
-			eventID:  "cf-gw-rule-no-account",
-			kind:     "cloudflare.gateway_rule",
-			attrs:    map[string]string{"rule_id": "rule-1", "name": "Block bad traffic"},
-			entityID: "rule-1",
+// TestCloudflareDNSRecordRetractionsIsNoOp covers the DNS-record zone
+// reassignment retraction hook, which is wired independently of the family
+// dispatch table above (see (*Service).ProjectRetractions) and is called
+// unconditionally for every event regardless of registry. Now that DNS record
+// projection is Rust-authoritative, it must never compute retractions itself.
+func TestCloudflareDNSRecordRetractionsIsNoOp(t *testing.T) {
+	event := &cerebrov1.EventEnvelope{
+		Id:       "event-1",
+		TenantId: "tenant",
+		SourceId: "cloudflare",
+		Kind:     "cloudflare.dns_record",
+		Attributes: map[string]string{
+			"record_id":        "dns-1",
+			"zone_id":          "zone-2",
+			"previous_zone_id": "zone-1",
 		},
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			state := &projectionRecorder{}
-			service := New(state, nil)
-
-			event := cloudflareTestEvent(tc.eventID, tc.kind, tc.attrs, `{"id":"`+tc.entityID+`"}`)
-			if _, err := service.Project(context.Background(), event); err != nil {
-				t.Fatalf("Project() error = %v", err)
-			}
-
-			family := strings.ReplaceAll(tc.kind, ".", "_")
-			unscopedURN := fmt.Sprintf("urn:cerebro:writer:%s:%s", family, tc.entityID)
-			if entity := state.entities[unscopedURN]; entity != nil {
-				t.Fatalf("unscoped entity %s must not exist: %#v", unscopedURN, entity)
-			}
-			eventURN := fmt.Sprintf("urn:cerebro:writer:%s:%s", family, tc.eventID)
-			if entity := state.entities[eventURN]; entity == nil || entity.EntityType != tc.kind {
-				t.Fatalf("fallback entity %s missing or wrong: %#v", eventURN, entity)
-			}
-		})
-	}
-}
-
-func TestProjectCloudflareScopedResourcesStayDistinctAcrossScopes(t *testing.T) {
-	tests := []struct {
-		name     string
-		kind     string
-		idKey    string
-		idValue  string
-		scopeKey string
-		scopeA   string
-		scopeB   string
-	}{
-		{
-			name:     "access_application across accounts",
-			kind:     "cloudflare.access_application",
-			idKey:    "application_id",
-			idValue:  "app-1",
-			scopeKey: "account_id",
-			scopeA:   "acct-1",
-			scopeB:   "acct-2",
-		},
-		{
-			name:     "zone_access_group across zones",
-			kind:     "cloudflare.zone_access_group",
-			idKey:    "group_id",
-			idValue:  "group-1",
-			scopeKey: "zone_id",
-			scopeA:   "zone-1",
-			scopeB:   "zone-2",
-		},
-		{
-			name:     "load_balancer across zones",
-			kind:     "cloudflare.load_balancer",
-			idKey:    "load_balancer_id",
-			idValue:  "lb-1",
-			scopeKey: "zone_id",
-			scopeA:   "zone-1",
-			scopeB:   "zone-2",
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			state := &projectionRecorder{}
-			service := New(state, nil)
-
-			for i, scope := range []string{tc.scopeA, tc.scopeB} {
-				event := cloudflareTestEvent(
-					fmt.Sprintf("cf-%s-%d", tc.idValue, i),
-					tc.kind,
-					map[string]string{tc.idKey: tc.idValue, tc.scopeKey: scope, "name": "test"},
-					`{"id":"`+tc.idValue+`"}`,
-				)
-				if _, err := service.Project(context.Background(), event); err != nil {
-					t.Fatalf("Project() error = %v", err)
-				}
-			}
-
-			family := strings.ReplaceAll(tc.kind, ".", "_")
-			urnA := fmt.Sprintf("urn:cerebro:writer:%s:%s%%7C%s", family, tc.scopeA, tc.idValue)
-			urnB := fmt.Sprintf("urn:cerebro:writer:%s:%s%%7C%s", family, tc.scopeB, tc.idValue)
-			if urnA == urnB {
-				t.Fatalf("URNs must differ across scopes: %s", urnA)
-			}
-			for _, urn := range []string{urnA, urnB} {
-				if entity := state.entities[urn]; entity == nil {
-					t.Fatalf("expected entity %s; entities=%#v", urn, state.entities)
-				}
-			}
-		})
-	}
-}
-
-func TestProjectCloudflareDNSRecordZoneReassignmentRetraction(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-
-	event := cloudflareTestEvent("cf-dns-reassigned", "cloudflare.dns_record", map[string]string{
-		"record_id":        "dns-1",
-		"zone_id":          "zone-2",
-		"previous_zone_id": "zone-1",
-		"name":             "www.example.com",
-	}, `{"id":"dns-1"}`)
-
-	links, err := service.ProjectRetractions(event)
+	links, err := cloudflareDNSRecordRetractions(event)
 	if err != nil {
-		t.Fatalf("ProjectRetractions() error = %v", err)
-	}
-	recordURN := "urn:cerebro:writer:cloudflare_dns_record:dns-1"
-	previousZoneURN := "urn:cerebro:writer:cloudflare_zone:zone-1"
-	currentZoneURN := "urn:cerebro:writer:cloudflare_zone:zone-2"
-
-	belongsRetracted := false
-	hasRecordRetracted := false
-	for _, link := range links {
-		if link.FromURN == currentZoneURN || link.ToURN == currentZoneURN {
-			t.Fatalf("retraction unexpectedly targeted current zone: %#v", link)
-		}
-		if link.FromURN == recordURN && link.ToURN == previousZoneURN && link.Relation == relationBelongsTo {
-			belongsRetracted = true
-		}
-		if link.FromURN == previousZoneURN && link.ToURN == recordURN && link.Relation == relationHasDNSRecord {
-			hasRecordRetracted = true
-		}
-	}
-	if !belongsRetracted || !hasRecordRetracted {
-		t.Fatalf("expected record<->previous-zone links retracted; links=%#v", links)
-	}
-}
-
-func TestProjectCloudflareDNSRecordNoRetractionWithoutReassignment(t *testing.T) {
-	state := &projectionRecorder{}
-	service := New(state, nil)
-
-	event := cloudflareTestEvent("cf-dns-stable", "cloudflare.dns_record", map[string]string{
-		"record_id": "dns-1",
-		"zone_id":   "zone-1",
-	}, `{"id":"dns-1"}`)
-
-	links, err := service.ProjectRetractions(event)
-	if err != nil {
-		t.Fatalf("ProjectRetractions() error = %v", err)
+		t.Fatalf("cloudflareDNSRecordRetractions() error = %v", err)
 	}
 	if len(links) != 0 {
-		t.Fatalf("expected no retractions without zone reassignment; got %#v", links)
+		t.Fatalf("Go retraction produced links=%d, want none", len(links))
 	}
 }

--- a/internal/sourceprojection/registry_builtins.go
+++ b/internal/sourceprojection/registry_builtins.go
@@ -506,7 +506,7 @@ var builtinRegistry = &Registry{projectors: map[string]ProjectFunc{
 	"cloudflare.access_group":                       cloudflareAccountScopedInventoryProjections,
 	"cloudflare.account":                            cloudflareAccountProjections,
 	"cloudflare.account_ruleset":                    cloudflareAccountScopedInventoryProjections,
-	"cloudflare.audit_log":                          genericInventoryProjections,
+	"cloudflare.audit_log":                          cloudflareAuditLogProjections,
 	"cloudflare.dns_record":                         cloudflareDNSRecordProjections,
 	"cloudflare.gateway_rule":                       cloudflareAccountScopedInventoryProjections,
 	"cloudflare.load_balancer":                      cloudflareLoadBalancerProjections,


### PR DESCRIPTION
## Summary

Cloudflare's collection- and projection-authority gap was closed and merged
in #2715 (`catalog(cloudflare): close collection authority gap (unbind
spurious tenant_id)`), which added `cloudflare` to the
`retired_static_loader_sources_are_fully_rust_authoritative` test in
`crates/source-catalog/src/lib.rs`. With authority fully proven, this PR
retires the now-redundant Go projection writer at
`internal/sourceprojection/cloudflare.go`, following the merged pattern in
`deepseek.go`/`deepseek_test.go`:

- Every one of the 16 family projector functions
  (`cloudflareAccountProjections`, `cloudflareMemberProjections`,
  `cloudflareRoleProjections`, `cloudflareZoneProjections`,
  `cloudflareDNSRecordProjections`, `cloudflareLoadBalancerProjections`,
  `cloudflareAccountScopedInventoryProjections`,
  `cloudflareZoneScopedInventoryProjections`) keeps its name and signature
  but now returns `nil, nil, errCloudflareRustProjectionRequired` instead of
  computing entities/links.
- `cloudflare.audit_log` previously dispatched straight to the shared
  `genericInventoryProjections` helper (also used by `langchain`, `datadog`,
  `kubernetes`, `writer`, `pagerduty`, etc.). Rather than touch that shared
  helper, it now gets its own `cloudflareAuditLogProjections` wrapper
  function that fails closed, and `registry_builtins.go` routes
  `cloudflare.audit_log` to it instead.
- `cloudflareDNSRecordRetractions` is invoked unconditionally by
  `(*Service).ProjectRetractions` for every event regardless of which
  registry the `Service` was built with (it is not part of the per-kind
  dispatch table). In the real production path,
  `(*Service).ProjectRecordsContext` already fails closed on
  `cloudflare.dns_record` before `ProjectRetractions` is ever reached (see
  `ProjectWithDelta`), so this hook is unreachable there — but making it
  error too broke an unrelated catalog-runtime template test
  (`TestGeneratedCatalogFamiliesProjectIntoGraph`) that exercises ~750
  generateable/catalog-ready connectorcatalog sources through synthetic
  projectors sharing this same hook. It is now a permanent no-op instead.
- Removed the cloudflare-only helpers that became dead code (`cloudflareEntity`,
  `cloudflareAttributes`, `cloudflareScopedInventoryProjections`,
  `cloudflareMemberRoleRefs`, `cloudflareRoleRef`, the `cloudflareScopeURNFunc`
  type, and the six `cloudflare*URN` builders). Shared helpers
  (`genericInventoryProjections`, `assertProjectedLink`, `relationBelongsTo`,
  `relationHasDNSRecord`, `relationDependsOn`, etc.) were grepped for other
  callers first and left untouched — they're still used by `langchain`,
  `kubernetes`, `pagerduty`, `auth0`, `okta`, and others.
- Rewrote `cloudflare_test.go` as a table-driven fail-closed test over all
  16 event kinds routed to this provider (via `ProjectEvent`), mirroring
  `deepseek_test.go`, plus one test confirming the DNS-record retraction
  hook is now a no-op.

## Authority proof

Stacked on / built on top of #2715, which is merged into `main`. That PR's
probe (throwaway `crates/source-catalog/tests/wave2_probe.rs`, deleted
before commit) showed all 16 Cloudflare families both collection- and
projection-authoritative with zero unsupported reasons, verified against
`sources/cloudflare/catalog.yaml`'s `provider_api` block (`status: verified`,
`basis: declared`, spec at
https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json,
reference: https://github.com/cloudflare/api-schemas/blob/main/openapi.json).
`crates/source-catalog/src/lib.rs`'s
`retired_static_loader_sources_are_fully_rust_authoritative` test already
includes `cloudflare` on `main` as of that merge, and this branch is built
directly on current `main` so that assertion is already in effect here too
(no further Rust changes needed in this PR).

## Validation

- `gofmt -l internal/sourceprojection` — empty
- `go build ./internal/sourceprojection` and `go build ./...` — clean
- `go test ./internal/sourceprojection -count=1` — all tests pass, including
  the new `TestCloudflareGoProjectionFailsClosedForRustAuthoritativeFamilies`
  (all 16 kinds) and `TestCloudflareDNSRecordRetractionsIsNoOp`
- `go test ./internal/sourceregistry -run TestBuiltinRetiresCoveredProviderGoLoaders -count=1` — passes (`cloudflare` already listed as retired there)
- `go test ./internal/sourceregistry ./internal/graphingest ./internal/connectorcatalog -count=1` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)