### PR TITLE
refactor(sources): retire Airbyte Cloud Go projection writer

### DIFF
--- a/internal/sourceprojection/airbyte_cloud.go
+++ b/internal/sourceprojection/airbyte_cloud.go
@@ -1,67 +1,30 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func airbyteCloudUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "airbyte_cloud"})
+var errAirbyteCloudRustProjectionRequired = errors.New("airbyte_cloud projection requires Rust authority")
+
+func airbyteCloudUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirbyteCloudRustProjectionRequired
 }
 
-func airbyteCloudOrganizationsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return airbyteCloudGenericAssetProjections(event)
+func airbyteCloudOrganizationsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirbyteCloudRustProjectionRequired
 }
 
-func airbyteCloudSourcesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return airbyteCloudGenericAssetProjections(event)
+func airbyteCloudSourcesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirbyteCloudRustProjectionRequired
 }
 
-func airbyteCloudPermissionsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return airbyteCloudGenericPolicyProjections(event)
+func airbyteCloudPermissionsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirbyteCloudRustProjectionRequired
 }
 
-func airbyteCloudConnectionsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return airbyteCloudGenericAssetProjections(event)
-}
-
-func airbyteCloudGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func airbyteCloudGenericPolicyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	policyID := firstNonEmpty(attributes["policy_id"], event.GetId())
-	policyURN := projectionURN(tenantID, "policy", policyID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: policyURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "policy", Label: firstNonEmpty(attributes["policy_name"], policyID), Attributes: map[string]string{"policy_id": policyID, "policy_type": strings.TrimSpace(attributes["policy_type"]), "policy_status": strings.TrimSpace(attributes["policy_status"]), "policy_severity": strings.TrimSpace(attributes["policy_severity"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), policyURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func airbyteCloudConnectionsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirbyteCloudRustProjectionRequired
 }

--- a/internal/sourceprojection/airbyte_cloud_test.go
+++ b/internal/sourceprojection/airbyte_cloud_test.go
@@ -1,59 +1,33 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestAirbyteCloudAssetProjection(t *testing.T) {
-	cases := []struct {
-		name    string
-		kind    string
-		project ProjectFunc
-	}{
-		{name: "organizations", kind: "airbyte_cloud.organizations", project: airbyteCloudOrganizationsProjections},
-		{name: "sources", kind: "airbyte_cloud.sources", project: airbyteCloudSourcesProjections},
-		{name: "connections", kind: "airbyte_cloud.connections", project: airbyteCloudConnectionsProjections},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "airbyte_cloud", Kind: tc.kind, Attributes: map[string]string{"resource_id": tc.name + "-1", "resource_type": "airbyte_" + tc.name, "resource_name": tc.name + "-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-			entities, links, err := tc.project(event)
-			if err != nil {
-				t.Fatalf("projection error = %v", err)
+func TestAirbyteCloudGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"airbyte_cloud.connections",
+		"airbyte_cloud.organizations",
+		"airbyte_cloud.permissions",
+		"airbyte_cloud.sources",
+		"airbyte_cloud.users",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "airbyte_cloud",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAirbyteCloudRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
 			}
-			if len(entities) == 0 {
-				t.Fatal("expected projected entities")
-			}
-			if len(links) == 0 {
-				t.Fatal("expected projected evidence links")
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
 			}
 		})
-	}
-}
-
-func TestAirbyteCloudPolicyProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "airbyte_cloud", Kind: "airbyte_cloud.permissions", Attributes: map[string]string{"policy_id": "permission-1", "policy_name": "workspace_admin", "policy_type": "airbyte_permission", "policy_status": "active", "evidence_id": "evidence-1"}}
-	entities, links, err := airbyteCloudPermissionsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected policy")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAirbyteCloudIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "airbyte_cloud", Kind: "airbyte_cloud.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := airbyteCloudUsersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
 	}
 }


### PR DESCRIPTION
## Summary
- Retires the Go-side projection writer for `airbyte_cloud`, following the deepseek (#2658) pattern now applied to 17+ other providers (most recently Cloudflare, #2747).
- Every `airbyte_cloud.*` kind dispatched from `registry_builtins.go` (`connections`, `organizations`, `permissions`, `sources`, `users`) keeps its exact function name/signature but now returns `nil, nil, errAirbyteCloudRustProjectionRequired` instead of computing entities/links.
- `airbyte_cloud.users` dispatches through the airbyte_cloud-only wrapper `airbyteCloudUsersProjections`, which previously called the shared multi-provider helper `identityUserProjections`. That shared helper is untouched — only the airbyte_cloud-only wrapper's body changed to fail closed, so no `registry_builtins.go` repoint was needed for this kind (unlike the Cloudflare case, where the registry entry pointed directly at a shared helper).
- Deleted the now-unused airbyte_cloud-only helpers `airbyteCloudGenericAssetProjections` and `airbyteCloudGenericPolicyProjections` (grepped the whole package first — nothing else referenced them).
- Rewrote `airbyte_cloud_test.go` as one table-driven test, `TestAirbyteCloudGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering all five `airbyte_cloud.*` kinds in `registry_builtins.go`, asserting `errors.Is(err, errAirbyteCloudRustProjectionRequired)` and zero entities/links via `ProjectEvent`.
- No oracle/parity/corpus tests elsewhere in the package referenced airbyte_cloud-specific functions, and no other package (`internal`, `cmd`) projects `airbyte_cloud.*` events or references airbyte_cloud projection functions at all — confirmed by grep, so there was no cross-package blast radius to migrate.

## Authority proof
Compiled Rust catalog marks every airbyte_cloud family collection- and projection-authoritative (full-catalog census 2026-08-26). Go static loader: airbyte_cloud has none.

## Validation
```
gofmt -l internal/sourceprojection
go build ./internal/sourceprojection
go test ./internal/sourceprojection -count=1
go test ./internal/sourceregistry -count=1
```
All four passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
