### PR TITLE
refactor(sources): retire Airbrake Go projection writer

### DIFF
--- a/internal/sourceprojection/airbrake.go
+++ b/internal/sourceprojection/airbrake.go
@@ -1,70 +1,30 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func airbrakeProjectsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return airbrakeGenericAssetProjections(event)
+var errAirbrakeRustProjectionRequired = errors.New("airbrake projection requires Rust authority")
+
+func airbrakeProjectsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirbrakeRustProjectionRequired
 }
 
-func airbrakeGroupsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return airbrakeGenericFindingProjections(event)
+func airbrakeGroupsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirbrakeRustProjectionRequired
 }
 
-func airbrakeDeploysProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return airbrakeGenericAssetProjections(event)
+func airbrakeDeploysProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirbrakeRustProjectionRequired
 }
 
-func airbrakeSourceMapsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return airbrakeGenericAssetProjections(event)
+func airbrakeSourceMapsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirbrakeRustProjectionRequired
 }
 
-func airbrakeProjectActivitiesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "airbrake"})
-}
-
-func airbrakeGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func airbrakeGenericFindingProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	findingID := firstNonEmpty(attributes["finding_id"], event.GetId())
-	findingURN := projectionURN(tenantID, "finding", findingID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: findingURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "finding", Label: firstNonEmpty(attributes["title"], findingID), Attributes: map[string]string{"finding_id": findingID, "severity": strings.TrimSpace(attributes["severity"]), "status": strings.TrimSpace(attributes["status"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if resourceURN := strings.TrimSpace(attributes["resource_urn"]); resourceURN != "" {
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), findingURN, resourceURN, relationAffects, map[string]string{"event_id": event.GetId()}))
-	}
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), evidenceURN, findingURN, relationSupports, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func airbrakeProjectActivitiesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirbrakeRustProjectionRequired
 }

--- a/internal/sourceprojection/airbrake_test.go
+++ b/internal/sourceprojection/airbrake_test.go
@@ -1,71 +1,33 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestAirbrakeProjectsProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "airbrake", Kind: "airbrake.projects", Attributes: map[string]string{"resource_id": "project-1", "resource_type": "airbrake_project", "resource_name": "Checkout", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := airbrakeProjectsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected project")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAirbrakeGroupsProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "airbrake", Kind: "airbrake.groups", Attributes: map[string]string{"finding_id": "group-1", "title": "RuntimeError", "severity": "error", "status": "open", "resource_urn": "urn:cerebro:tenant:runtime_asset:project-1", "evidence_id": "evidence-1"}}
-	entities, links, err := airbrakeGroupsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected finding")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected finding links")
-	}
-	if !hasProjectedEntityType(entities, "runtime_evidence") {
-		t.Fatal("expected projected runtime evidence entity")
-	}
-}
-
-func TestAirbrakeDeploysProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "airbrake", Kind: "airbrake.deploys", Attributes: map[string]string{"resource_id": "deploy-1", "resource_type": "airbrake_deploy", "resource_name": "v1.2.3"}}
-	entities, _, err := airbrakeDeploysProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected deploy")
-	}
-}
-
-func TestAirbrakeSourceMapsProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "airbrake", Kind: "airbrake.source_maps", Attributes: map[string]string{"resource_id": "map-1", "resource_type": "airbrake_source_map", "resource_name": "app.min.js.map"}}
-	entities, _, err := airbrakeSourceMapsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected source map")
-	}
-}
-
-func TestAirbrakeProjectActivitiesProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "airbrake", Kind: "airbrake.project_activities", Attributes: map[string]string{"event_type": "group.resolved", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "group-1", "resource_type": "Group"}}
-	entities, links, err := airbrakeProjectActivitiesProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestAirbrakeGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"airbrake.deploys",
+		"airbrake.groups",
+		"airbrake.project_activities",
+		"airbrake.projects",
+		"airbrake.source_maps",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "airbrake",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAirbrakeRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Retires the Go projection writer for the `airbrake` provider, following the standard fail-closed retirement pattern (deepseek #2658 and 17 more since).
- `internal/sourceprojection/airbrake.go`: all 5 registry-dispatched functions (`airbrakeProjectsProjections`, `airbrakeGroupsProjections`, `airbrakeDeploysProjections`, `airbrakeSourceMapsProjections`, `airbrakeProjectActivitiesProjections`) now return `nil, nil, errAirbrakeRustProjectionRequired` and take an unused `_ *cerebrov1.EventEnvelope` parameter. `registry_builtins.go` entries are unchanged (same function names, same signatures).
- Deleted the two airbrake-only helpers that became unused: `airbrakeGenericAssetProjections` and `airbrakeGenericFindingProjections`. `identityAuditProjections` (used by `airbrakeProjectActivitiesProjections`) is a shared multi-provider helper used by many other providers and was left untouched.
- Rewrote `internal/sourceprojection/airbrake_test.go` as a single table-driven test, `TestAirbrakeGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering all 5 `airbrake.*` kinds dispatched in `registry_builtins.go`, asserting `errors.Is(err, errAirbrakeRustProjectionRequired)` and zero entities/links via `ProjectEvent`.

## Authority proof

Compiled Rust catalog marks every airbrake family collection- and projection-authoritative (full-catalog census 2026-08-26). Go static loader: airbrake has none.

## Cross-package blast radius

`grep -rn "\"airbrake\." --include='*.go' internal cmd | grep -v internal/sourceprojection` returned no matches — no other package (test corpora, fixtures, findings rules) references `airbrake.*` event kinds or airbrake projection functions. No oracle/parity/corpus tests reference airbrake functions by name. No cross-package changes were needed.

## Validation

Run from the worktree root:

```
gofmt -l internal/sourceprojection          # empty
go build ./internal/sourceprojection        # ok
go test ./internal/sourceprojection -count=1  # ok
go test ./internal/sourceregistry -count=1    # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
