### PR TITLE
refactor(sources): retire Abuseipdb Go projection writer

### DIFF
--- a/internal/sourceprojection/abuseipdb.go
+++ b/internal/sourceprojection/abuseipdb.go
@@ -1,58 +1,18 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func abuseipdbReportsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return abuseipdbGenericFindingProjections(event)
+var errAbuseipdbRustProjectionRequired = errors.New("abuseipdb projection requires Rust authority")
+
+func abuseipdbReportsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAbuseipdbRustProjectionRequired
 }
 
-func abuseipdbIpAddressesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return abuseipdbGenericAssetProjections(event)
-}
-
-func abuseipdbGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func abuseipdbGenericFindingProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	findingID := firstNonEmpty(attributes["finding_id"], event.GetId())
-	findingURN := projectionURN(tenantID, "finding", findingID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: findingURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "finding", Label: firstNonEmpty(attributes["title"], findingID), Attributes: map[string]string{"finding_id": findingID, "severity": strings.TrimSpace(attributes["severity"]), "status": strings.TrimSpace(attributes["status"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if resourceURN := strings.TrimSpace(attributes["resource_urn"]); resourceURN != "" {
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), findingURN, resourceURN, relationAffects, map[string]string{"event_id": event.GetId()}))
-	}
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), evidenceURN, findingURN, relationSupports, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func abuseipdbIpAddressesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAbuseipdbRustProjectionRequired
 }

--- a/internal/sourceprojection/abuseipdb_test.go
+++ b/internal/sourceprojection/abuseipdb_test.go
@@ -1,38 +1,27 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestAbuseipdbFindingProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "abuseipdb", Kind: "abuseipdb.reports", Attributes: map[string]string{"finding_id": "finding-1", "title": "Finding One", "severity": "high", "status": "open", "resource_urn": "urn:cerebro:tenant:runtime_asset:asset-1", "evidence_id": "evidence-1"}}
-	entities, links, err := abuseipdbReportsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected finding")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected finding links")
-	}
-	if !hasProjectedEntityType(entities, "runtime_evidence") {
-		t.Fatal("expected projected runtime evidence entity")
-	}
-}
-
-func TestAbuseipdbAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "abuseipdb", Kind: "abuseipdb.ip_addresses", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := abuseipdbIpAddressesProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
+func TestAbuseipdbGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{"abuseipdb.ip_addresses", "abuseipdb.reports"} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "abuseipdb",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAbuseipdbRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Retire the Go projection writer for the `abuseipdb` source, following the standard fail-closed retirement pattern (deepseek #2658 and 17+ since).
- `abuseipdbReportsProjections` and `abuseipdbIpAddressesProjections` — the two registry-dispatched entry points for `abuseipdb.reports` and `abuseipdb.ip_addresses` — now return `nil, nil, errAbuseipdbRustProjectionRequired` instead of building entities/links in Go.
- Removed the abuseipdb-only helpers `abuseipdbGenericAssetProjections` and `abuseipdbGenericFindingProjections` (confirmed unused by any other provider) along with their now-unused imports (`strings`).
- Rewrote `abuseipdb_test.go` as one table-driven test, `TestAbuseipdbGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering both `abuseipdb.*` kinds registered in `registry_builtins.go`, asserting `errors.Is` against the typed error and zero entities/links via `ProjectEvent`.

## Authority proof
Compiled Rust catalog marks every abuseipdb family collection- and projection-authoritative (full-catalog census 2026-08-26); Go static loader: abuseipdb has none.

## Validation
- `gofmt -l internal/sourceprojection` (empty)
- `go build ./internal/sourceprojection`
- `go test ./internal/sourceprojection -count=1`
- `go test ./internal/sourceregistry -count=1`

### Cross-package blast radius
`grep -rn "\"abuseipdb\." --include='*.go' internal cmd | grep -v internal/sourceprojection` returned no matches — no other package (test corpora, fixtures, findings rules) projects `abuseipdb.*` events or references abuseipdb projection functions. The only other `abuseipdb` reference in the tree is `internal/connectorcatalog/catalog_test.go`, which exercises the connector's auth definition (API key header), not projection, and needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)