### PR TITLE
refactor(sources): retire Aha Go projection writer

### DIFF
--- a/internal/sourceprojection/aha.go
+++ b/internal/sourceprojection/aha.go
@@ -1,48 +1,30 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func ahaUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "aha"})
+var errAhaRustProjectionRequired = errors.New("aha projection requires Rust authority")
+
+func ahaUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAhaRustProjectionRequired
 }
 
-func ahaProductsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return ahaGenericAssetProjections(event)
+func ahaProductsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAhaRustProjectionRequired
 }
 
-func ahaFeaturesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return ahaGenericAssetProjections(event)
+func ahaFeaturesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAhaRustProjectionRequired
 }
 
-func ahaReleasesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return ahaGenericAssetProjections(event)
+func ahaReleasesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAhaRustProjectionRequired
 }
 
-func ahaAuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "aha"})
-}
-
-func ahaGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func ahaAuditEventsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAhaRustProjectionRequired
 }

--- a/internal/sourceprojection/aha_test.go
+++ b/internal/sourceprojection/aha_test.go
@@ -1,71 +1,33 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestAhaIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "aha", Kind: "aha.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := ahaUsersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestAhaAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "aha", Kind: "aha.products", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := ahaProductsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAhaFeaturesProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "aha", Kind: "aha.features", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := ahaFeaturesProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAhaReleasesProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "aha", Kind: "aha.releases", Attributes: map[string]string{"resource_id": "release-1", "resource_type": "release", "resource_name": "Q3 Launch", "evidence_id": "evidence-1"}}
-	entities, links, err := ahaReleasesProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected release")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAhaAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "aha", Kind: "aha.audit_events", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := ahaAuditEventsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestAhaGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"aha.audit_events",
+		"aha.features",
+		"aha.products",
+		"aha.releases",
+		"aha.users",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "aha",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAhaRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Aha is fully Rust-authoritative for collection and projection across all families, so the Go projection writer in `internal/sourceprojection/aha.go` is retired following the standard pattern (deepseek #2658, and 17 more since, most recently Cloudflare #2747).

- Every dispatched `aha.*` kind (`aha.audit_events`, `aha.features`, `aha.products`, `aha.releases`, `aha.users`) now fails closed through one typed error, `errAhaRustProjectionRequired`, instead of computing entities/links.
- `ahaUsersProjections` and `ahaAuditEventsProjections` previously called the shared multi-provider helpers `identityUserProjections` / `identityAuditProjections` (still used by many other providers — abnormal_security, activtrak, ada_support, addigy, agiloft, adp_workforce_now, etc.). Those shared helpers are untouched; only the aha-specific wrapper bodies were changed, matching the Cloudflare precedent (#2747) of never editing a shared helper.
- `ahaGenericAssetProjections` was an aha-only helper (used by `ahaProductsProjections`, `ahaFeaturesProjections`, `ahaReleasesProjections`) and is deleted along with its now-unused imports (`strings`), since nothing else in the package referenced it.
- `internal/sourceprojection/aha_test.go` is rewritten as one table-driven test, `TestAhaGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering every `aha.*` kind in `registry_builtins.go`, asserting `errors.Is(err, errAhaRustProjectionRequired)` and zero entities/links via `ProjectEvent`.
- `registry_builtins.go` is unchanged — all five `aha.*` kinds already dispatched to aha-specific function names (not directly to a shared helper), so no dispatch-table repointing was needed.
- No oracle/parity/corpus tests elsewhere in the package reference aha functions, and `grep -rn '"aha\.' --include='*.go' internal cmd` outside `internal/sourceprojection` returns no matches — no cross-package blast radius.

## Authority proof

Compiled Rust catalog marks every aha family collection- and projection-authoritative (full-catalog census 2026-08-26); Go static loader: aha has none.

## Validation

```
gofmt -l internal/sourceprojection            # empty
go build ./internal/sourceprojection          # ok
go test ./internal/sourceprojection -count=1  # ok
go test ./internal/sourceregistry -count=1    # ok
```

No cross-package consumers of `aha.*` events were found (grep for `"aha.` outside `internal/sourceprojection` came back empty), so no additional package tests were required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
