### PR TITLE
refactor(sources): retire Activtrak Go projection writer

### DIFF
--- a/internal/sourceprojection/activtrak.go
+++ b/internal/sourceprojection/activtrak.go
@@ -1,48 +1,30 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func activtrakUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "activtrak"})
+var errActivtrakRustProjectionRequired = errors.New("activtrak projection requires Rust authority")
+
+func activtrakUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errActivtrakRustProjectionRequired
 }
 
-func activtrakGroupsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return activtrakGenericAssetProjections(event)
+func activtrakGroupsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errActivtrakRustProjectionRequired
 }
 
-func activtrakClientsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return activtrakGenericAssetProjections(event)
+func activtrakClientsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errActivtrakRustProjectionRequired
 }
 
-func activtrakConsumersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "activtrak"})
+func activtrakConsumersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errActivtrakRustProjectionRequired
 }
 
-func activtrakActivityLogProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "activtrak"})
-}
-
-func activtrakGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func activtrakActivityLogProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errActivtrakRustProjectionRequired
 }

--- a/internal/sourceprojection/activtrak_test.go
+++ b/internal/sourceprojection/activtrak_test.go
@@ -1,68 +1,27 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestActivtrakAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "activtrak", Kind: "activtrak.groups", Attributes: map[string]string{"resource_id": "group-1", "resource_type": "activtrak_group", "resource_name": "Engineering", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := activtrakGroupsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestActivtrakClientProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "activtrak", Kind: "activtrak.clients", Attributes: map[string]string{"resource_id": "client-1", "resource_type": "activtrak_client", "resource_name": "Client One", "evidence_id": "evidence-1"}}
-	entities, links, err := activtrakClientsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected client asset")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestActivtrakIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "activtrak", Kind: "activtrak.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := activtrakUsersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestActivtrakConsumerProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "activtrak", Kind: "activtrak.consumers", Attributes: map[string]string{"user_id": "consumer-1", "email": "consumer@example.test", "display_name": "Consumer One"}}
-	entities, _, err := activtrakConsumersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected consumer identity")
-	}
-}
-
-func TestActivtrakAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "activtrak", Kind: "activtrak.activity_log", Attributes: map[string]string{"event_type": "application.use", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := activtrakActivityLogProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestActivtrakGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{"activtrak.activity_log", "activtrak.clients", "activtrak.consumers", "activtrak.groups", "activtrak.users"} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "activtrak",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errActivtrakRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Retires the Activtrak Go projection writer in `internal/sourceprojection/activtrak.go`, following the deepseek/Cloudflare/JumpCloud/etc. retirement pattern (deepseek #2658 and 17 more since, most recently Cloudflare #2747).
- All five registry-dispatched functions (`activtrak.activity_log`, `activtrak.clients`, `activtrak.consumers`, `activtrak.groups`, `activtrak.users`) now return `nil, nil, errActivtrakRustProjectionRequired` instead of computing entities/links.
- Two of these functions (`activtrakUsersProjections`, `activtrakConsumersProjections` via `identityUserProjections`, and `activtrakActivityLogProjections` via `identityAuditProjections`) previously called shared multi-provider identity helpers in `identity.go`. Those shared helpers are untouched — only the activtrak-only wrapper functions in `activtrak.go` (the ones `registry_builtins.go` actually dispatches to) were changed, so every other provider still using `identityUserProjections`/`identityAuditProjections` is unaffected.
- `activtrakGenericAssetProjections`, an activtrak-only helper (confirmed via package-wide grep to have no other callers), is deleted along with its now-unused `strings` import, since both `activtrakClientsProjections` and `activtrakGroupsProjections` — its only callers — now fail closed directly.
- `registry_builtins.go` is untouched: it still dispatches all five `activtrak.*` kinds to the same function names/signatures, which now uniformly fail closed.
- `internal/sourceprojection/activtrak_test.go` is rewritten as one table-driven test, `TestActivtrakGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering all five `activtrak.*` kinds via `ProjectEvent`, asserting `errors.Is` against the new sentinel and zero entities/links.

## Authority proof

Compiled Rust catalog marks every activtrak family collection- and projection-authoritative (full-catalog census 2026-08-26). Go static loader: activtrak has none.

## Cross-package check

`grep -rn "\"activtrak\." --include='*.go' internal cmd | grep -v internal/sourceprojection` and a broader `grep -rl "activtrak"` across `internal`/`cmd` outside `internal/sourceprojection` both return no matches — no other package (test corpora, fixtures, findings rules, action constants) references activtrak, so there is no cross-package blast radius to remediate.

## Validation

Run from the worktree root:

```
gofmt -l internal/sourceprojection
go build ./internal/sourceprojection
go test ./internal/sourceprojection -count=1
go test ./internal/sourceregistry -count=1
```

All four pass clean; no cross-package consumers exist to test beyond these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
