### PR TITLE
refactor(sources): retire Airtable Go projection writer

### DIFF
--- a/internal/sourceprojection/airtable.go
+++ b/internal/sourceprojection/airtable.go
@@ -1,40 +1,22 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func airtableUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "airtable"})
+var errAirtableRustProjectionRequired = errors.New("airtable projection requires Rust authority")
+
+func airtableUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirtableRustProjectionRequired
 }
 
-func airtableBasesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return airtableGenericAssetProjections(event)
+func airtableBasesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirtableRustProjectionRequired
 }
 
-func airtableAuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "airtable"})
-}
-
-func airtableGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func airtableAuditEventsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAirtableRustProjectionRequired
 }

--- a/internal/sourceprojection/airtable_test.go
+++ b/internal/sourceprojection/airtable_test.go
@@ -1,43 +1,31 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestAirtableAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "airtable", Kind: "airtable.bases", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "base", "resource_name": "base-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := airtableBasesProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAirtableIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "airtable", Kind: "airtable.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := airtableUsersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestAirtableAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "airtable", Kind: "airtable.audit_events", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := airtableAuditEventsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestAirtableGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"airtable.audit_events",
+		"airtable.bases",
+		"airtable.users",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "airtable",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAirtableRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Retires the Airtable Go projection writer in `internal/sourceprojection/airtable.go`, following the house pattern established by the DeepSeek retirement (#2658) and the 17 subsequent provider retirements (most recently Cloudflare, #2747).
- All three registry-dispatched functions (`airtableUsersProjections`, `airtableBasesProjections`, `airtableAuditEventsProjections`) now fail closed, returning `nil, nil, errAirtableRustProjectionRequired` instead of computing entities/links. Event params become `_`.
- `airtableUsersProjections` and `airtableAuditEventsProjections` previously called the shared, multi-provider `identityUserProjections` / `identityAuditProjections` helpers (still used by dozens of other providers) — those helpers are untouched; only the airtable-only wrapper functions were rewritten in place, so no `registry_builtins.go` repointing was needed (the registry already dispatched to the airtable-only wrappers, unlike the Cloudflare case which dispatched an entry directly to a shared helper).
- `airtableGenericAssetProjections`, the airtable-only helper backing `airtableBasesProjections`, is deleted along with its now-unused `strings` import — it was not referenced anywhere else in the package.
- `internal/sourceprojection/airtable_test.go` is rewritten as a single table-driven test, `TestAirtableGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering all three `airtable.*` kinds registered in `registry_builtins.go` (`airtable.audit_events`, `airtable.bases`, `airtable.users`), asserting `errors.Is` against the new sentinel and zero entities/links via `ProjectEvent`.

## Authority proof

Compiled Rust catalog marks every airtable family collection- and projection-authoritative (full-catalog census 2026-08-26). Go static loader: airtable has none.

## Cross-package check

`grep -rn "\"airtable\." --include='*.go' internal cmd | grep -v internal/sourceprojection` and `grep -rln "\"airtable\"" --include='*.go' internal cmd | grep -v internal/sourceprojection` both returned no matches — no other package (test corpora, fixtures, findings rules) projects or references `airtable.*` event kinds, so no cross-package changes were required.

## Validation

Run from the worktree root:

```
gofmt -l internal/sourceprojection            # empty
go build ./internal/sourceprojection          # ok
go test ./internal/sourceprojection -count=1  # ok
go test ./internal/sourceregistry -count=1    # ok
```

No cross-package consumers were identified, so no additional package tests were required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
