### PR TITLE
refactor(sources): retire Activecampaign Go projection writer

### DIFF
--- a/internal/sourceprojection/activecampaign.go
+++ b/internal/sourceprojection/activecampaign.go
@@ -1,48 +1,30 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func activecampaignUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "activecampaign"})
+var errActivecampaignRustProjectionRequired = errors.New("activecampaign projection requires Rust authority")
+
+func activecampaignUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errActivecampaignRustProjectionRequired
 }
 
-func activecampaignAccountsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return activecampaignGenericAssetProjections(event)
+func activecampaignAccountsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errActivecampaignRustProjectionRequired
 }
 
-func activecampaignContactsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return activecampaignGenericAssetProjections(event)
+func activecampaignContactsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errActivecampaignRustProjectionRequired
 }
 
-func activecampaignCampaignsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return activecampaignGenericAssetProjections(event)
+func activecampaignCampaignsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errActivecampaignRustProjectionRequired
 }
 
-func activecampaignAutomationsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return activecampaignGenericAssetProjections(event)
-}
-
-func activecampaignGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func activecampaignAutomationsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errActivecampaignRustProjectionRequired
 }

--- a/internal/sourceprojection/activecampaign_test.go
+++ b/internal/sourceprojection/activecampaign_test.go
@@ -1,74 +1,33 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestActivecampaignAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "activecampaign", Kind: "activecampaign.accounts", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := activecampaignAccountsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestActivecampaignCampaignProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "activecampaign", Kind: "activecampaign.campaigns", Attributes: map[string]string{"resource_id": "campaign-1", "resource_type": "activecampaign_campaign", "resource_name": "Welcome Campaign", "evidence_id": "evidence-1"}}
-	entities, links, err := activecampaignCampaignsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected campaign")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestActivecampaignContactProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "activecampaign", Kind: "activecampaign.contacts", Attributes: map[string]string{"resource_id": "contact-1", "resource_type": "activecampaign_contact", "resource_name": "contact@example.test"}}
-	entities, links, err := activecampaignContactsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected contact")
-	}
-	if len(links) != 0 {
-		t.Fatalf("links = %d, want no evidence link without evidence_id", len(links))
-	}
-}
-
-func TestActivecampaignIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "activecampaign", Kind: "activecampaign.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := activecampaignUsersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestActivecampaignAutomationProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "activecampaign", Kind: "activecampaign.automations", Attributes: map[string]string{"resource_id": "automation-1", "resource_type": "activecampaign_automation", "resource_name": "Subscription Automation"}}
-	entities, links, err := activecampaignAutomationsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected automation")
-	}
-	if len(links) != 0 {
-		t.Fatalf("links = %d, want no evidence link without evidence_id", len(links))
+func TestActivecampaignGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"activecampaign.accounts",
+		"activecampaign.automations",
+		"activecampaign.campaigns",
+		"activecampaign.contacts",
+		"activecampaign.users",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "activecampaign",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errActivecampaignRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Retires the Go projection writer for `activecampaign` in `internal/sourceprojection/activecampaign.go`, following the house pattern established by the DeepSeek retirement (#2658) and 17 more since (most recently the Cloudflare retirement, #2747). All five `activecampaign.*` family projectors dispatched from `registry_builtins.go` (`activecampaignAccountsProjections`, `activecampaignAutomationsProjections`, `activecampaignCampaignsProjections`, `activecampaignContactsProjections`, `activecampaignUsersProjections`) now fail closed with a single typed error, `errActivecampaignRustProjectionRequired`, instead of computing entities/links.

`activecampaignUsersProjections` previously delegated to the shared multi-provider `identityUserProjections` helper; since the registry already dispatches to the activecampaign-named wrapper (not directly to the shared helper), no shared code or other registry entries needed to change — only the wrapper's body. The activecampaign-only `activecampaignGenericAssetProjections` helper (used by the accounts/automations/campaigns/contacts family) is deleted along with the now-unused `strings` import, since nothing else in the package used it.

`internal/sourceprojection/activecampaign_test.go` is rewritten as one table-driven test, `TestActivecampaignGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering every `activecampaign.*` kind registered in `registry_builtins.go`, asserting `errors.Is` against the typed error and zero entities/links via `ProjectEvent`.

No changes to `registry_builtins.go` were needed — all five `activecampaign.*` entries already dispatched to activecampaign-named functions, not directly to a shared helper (unlike the Cloudflare case, which required a new wrapper).

## Authority proof

Compiled Rust catalog marks every activecampaign family collection- and projection-authoritative (full-catalog census 2026-08-26). Go static loader: activecampaign has none.

## Cross-package check

`grep -rn "\"activecampaign\." --include='*.go' internal cmd | grep -v internal/sourceprojection` returned no matches — no other package (test corpora, fixtures, findings rules) references `activecampaign.*` event kinds or activecampaign projection functions. No cross-package changes were required.

## Validation

```
gofmt -l internal/sourceprojection            # empty
go build ./internal/sourceprojection          # ok
go test ./internal/sourceprojection -count=1  # ok
go test ./internal/sourceregistry -count=1    # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
