### PR TITLE
refactor(sources): retire Abnormal Security Go projection writer

### DIFF
--- a/internal/sourceprojection/abnormal_security.go
+++ b/internal/sourceprojection/abnormal_security.go
@@ -1,88 +1,34 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func abnormalSecurityResourcesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return abnormalSecurityGenericAssetProjections(event)
+var errAbnormalSecurityRustProjectionRequired = errors.New("abnormal_security projection requires Rust authority")
+
+func abnormalSecurityResourcesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAbnormalSecurityRustProjectionRequired
 }
 
-func abnormalSecurityThreatsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return abnormalSecurityGenericFindingProjections(event)
+func abnormalSecurityThreatsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAbnormalSecurityRustProjectionRequired
 }
 
-func abnormalSecurityCasesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return abnormalSecurityGenericFindingProjections(event)
+func abnormalSecurityCasesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAbnormalSecurityRustProjectionRequired
 }
 
-func abnormalSecurityPostureCatalogProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return abnormalSecurityGenericPolicyProjections(event)
+func abnormalSecurityPostureCatalogProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAbnormalSecurityRustProjectionRequired
 }
 
-func abnormalSecurityAuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "abnormal_security"})
-}
-
-func abnormalSecurityGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func abnormalSecurityGenericFindingProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	findingID := firstNonEmpty(attributes["finding_id"], event.GetId())
-	findingURN := projectionURN(tenantID, "finding", findingID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: findingURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "finding", Label: firstNonEmpty(attributes["title"], findingID), Attributes: map[string]string{"finding_id": findingID, "severity": strings.TrimSpace(attributes["severity"]), "status": strings.TrimSpace(attributes["status"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if resourceURN := strings.TrimSpace(attributes["resource_urn"]); resourceURN != "" {
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), findingURN, resourceURN, relationAffects, map[string]string{"event_id": event.GetId()}))
-	}
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), evidenceURN, findingURN, relationSupports, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-func abnormalSecurityGenericPolicyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	policyID := firstNonEmpty(attributes["policy_id"], event.GetId())
-	policyURN := projectionURN(tenantID, "policy", policyID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: policyURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "policy", Label: firstNonEmpty(attributes["policy_name"], policyID), Attributes: map[string]string{"policy_id": policyID, "policy_type": strings.TrimSpace(attributes["policy_type"]), "policy_status": strings.TrimSpace(attributes["policy_status"]), "policy_severity": strings.TrimSpace(attributes["policy_severity"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), policyURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+// abnormalSecurityAuditEventsProjections previously dispatched straight to the
+// shared identityAuditProjections helper. It now fails closed on its own so
+// that shared helper (still used by other identity-audit providers) is left
+// untouched.
+func abnormalSecurityAuditEventsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAbnormalSecurityRustProjectionRequired
 }

--- a/internal/sourceprojection/abnormal_security_test.go
+++ b/internal/sourceprojection/abnormal_security_test.go
@@ -1,77 +1,33 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestAbnormalSecurityAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "abnormal_security", Kind: "abnormal_security.resources", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := abnormalSecurityResourcesProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAbnormalSecurityFindingProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "abnormal_security", Kind: "abnormal_security.threats", Attributes: map[string]string{"finding_id": "finding-1", "title": "Finding One", "severity": "high", "status": "open", "resource_urn": "urn:cerebro:tenant:runtime_asset:asset-1", "evidence_id": "evidence-1"}}
-	entities, links, err := abnormalSecurityThreatsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected finding")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected finding links")
-	}
-	if !hasProjectedEntityType(entities, "runtime_evidence") {
-		t.Fatal("expected projected runtime evidence entity")
-	}
-}
-
-func TestAbnormalSecurityPolicyProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "abnormal_security", Kind: "abnormal_security.posture_catalog", Attributes: map[string]string{"policy_id": "policy-1", "policy_name": "Require MFA", "policy_type": "posture_catalog", "policy_status": "enabled", "evidence_id": "evidence-1"}}
-	entities, links, err := abnormalSecurityPostureCatalogProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected policy")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAbnormalSecurityCaseProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "abnormal_security", Kind: "abnormal_security.cases", Attributes: map[string]string{"finding_id": "case-1", "title": "Case One", "severity": "medium", "status": "open", "resource_urn": "urn:cerebro:tenant:identity:employee@example.com", "evidence_id": "evidence-1"}}
-	entities, links, err := abnormalSecurityCasesProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected case")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected case links")
-	}
-}
-
-func TestAbnormalSecurityAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "abnormal_security", Kind: "abnormal_security.audit_events", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := abnormalSecurityAuditEventsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestAbnormalSecurityGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"abnormal_security.resources",
+		"abnormal_security.audit_events",
+		"abnormal_security.cases",
+		"abnormal_security.posture_catalog",
+		"abnormal_security.threats",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "abnormal_security",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAbnormalSecurityRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Abnormal Security is fully Rust-authoritative for collection and projection across all families (full-catalog census, 2026-08-26). This retires the Go projection writer in `internal/sourceprojection/abnormal_security.go`, following the deepseek (#2658) / Cloudflare (#2747) precedent: every `abnormal_security.*` family projector now fails closed with `errAbnormalSecurityRustProjectionRequired` instead of computing entities/links.
- `abnormalSecurityAuditEventsProjections` previously dispatched straight to the shared `identityAuditProjections` helper (used by many other identity-audit providers); it now fails closed on its own so that shared helper is left untouched.
- Deleted the now-unused abnormal_security-only helpers (`abnormalSecurityGenericAssetProjections`, `abnormalSecurityGenericFindingProjections`, `abnormalSecurityGenericPolicyProjections`) and their now-unused `strings` import — grepped the whole package first to confirm nothing else references them.
- Rewrote `abnormal_security_test.go` as one table-driven test, `TestAbnormalSecurityGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering every `abnormal_security.*` kind dispatched in `registry_builtins.go` (`resources`, `audit_events`, `cases`, `posture_catalog`, `threats`), asserting `errors.Is` against the sentinel error and zero entities/links via `ProjectEvent`.
- No `registry_builtins.go` change was needed: all five `abnormal_security.*` entries already dispatched to dedicated per-kind wrapper functions (not directly to the shared helper), so the dispatch table is untouched.
- Cross-package blast radius: `grep -rn "\"abnormal_security\." --include='*.go' internal cmd` (excluding `internal/sourceprojection`) found no other package projecting `abnormal_security.*` events through `ProjectEvent` — no test corpora or fixtures to migrate. The only other repo hit for `abnormal_security` outside this package is `internal/connectorcatalog/catalog/security-posture-vulnerability/abnormal_security.yaml`, which is connector-catalog metadata (auth/config schema), not a Go projection consumer — no change needed.

## Authority proof
Compiled Rust catalog marks every abnormal_security family collection- and projection-authoritative (full-catalog census 2026-08-26). Go static loader: abnormal_security has none.

## Validation
Run from the worktree root:
```
gofmt -l internal/sourceprojection
go build ./internal/sourceprojection
go test ./internal/sourceprojection -count=1
go test ./internal/sourceregistry -count=1
```
All pass. No other cross-package consumers were identified that required test changes or a re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
