### PR TITLE
refactor(sources): retire Ada Support Go projection writer

### DIFF
--- a/internal/sourceprojection/ada_support.go
+++ b/internal/sourceprojection/ada_support.go
@@ -1,67 +1,30 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func adaSupportEndUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "ada_support"})
+var errAdaSupportRustProjectionRequired = errors.New("ada_support projection requires Rust authority")
+
+func adaSupportEndUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAdaSupportRustProjectionRequired
 }
 
-func adaSupportPlatformIntegrationsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return adaSupportGenericAssetProjections(event)
+func adaSupportPlatformIntegrationsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAdaSupportRustProjectionRequired
 }
 
-func adaSupportConversationsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return adaSupportGenericAssetProjections(event)
+func adaSupportConversationsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAdaSupportRustProjectionRequired
 }
 
-func adaSupportKnowledgeArticlesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return adaSupportGenericPolicyProjections(event)
+func adaSupportKnowledgeArticlesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAdaSupportRustProjectionRequired
 }
 
-func adaSupportAuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "ada_support"})
-}
-
-func adaSupportGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func adaSupportGenericPolicyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	policyID := firstNonEmpty(attributes["policy_id"], event.GetId())
-	policyURN := projectionURN(tenantID, "policy", policyID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: policyURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "policy", Label: firstNonEmpty(attributes["policy_name"], policyID), Attributes: map[string]string{"policy_id": policyID, "policy_type": strings.TrimSpace(attributes["policy_type"]), "policy_status": strings.TrimSpace(attributes["policy_status"]), "policy_severity": strings.TrimSpace(attributes["policy_severity"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), policyURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func adaSupportAuditEventsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAdaSupportRustProjectionRequired
 }

--- a/internal/sourceprojection/ada_support_test.go
+++ b/internal/sourceprojection/ada_support_test.go
@@ -1,71 +1,33 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestAdaSupportAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "ada_support", Kind: "ada_support.platform_integrations", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "platform_integration", "resource_name": "Knowledge Hub", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := adaSupportPlatformIntegrationsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAdaSupportConversationProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "ada_support", Kind: "ada_support.conversations", Attributes: map[string]string{"resource_id": "conversation-1", "resource_type": "conversation", "resource_name": "Billing question", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := adaSupportConversationsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected conversation")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAdaSupportPolicyProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "ada_support", Kind: "ada_support.knowledge_articles", Attributes: map[string]string{"policy_id": "policy-1", "policy_name": "Refund policy", "policy_type": "knowledge_article", "policy_status": "enabled", "evidence_id": "evidence-1"}}
-	entities, links, err := adaSupportKnowledgeArticlesProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected policy")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAdaSupportIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "ada_support", Kind: "ada_support.end_users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := adaSupportEndUsersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestAdaSupportAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "ada_support", Kind: "ada_support.audit_events", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := adaSupportAuditEventsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestAdaSupportGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"ada_support.audit_events",
+		"ada_support.conversations",
+		"ada_support.end_users",
+		"ada_support.knowledge_articles",
+		"ada_support.platform_integrations",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "ada_support",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAdaSupportRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Ada Support's Go projection writer (`internal/sourceprojection/ada_support.go`) is retired: every `ada_support.*` family projector now fails closed with `errAdaSupportRustProjectionRequired` instead of computing entities/links, following the deepseek.go pattern established across #2658 and 17 subsequent retirements (most recently Cloudflare, #2747).

- `adaSupportEndUsersProjections`, `adaSupportPlatformIntegrationsProjections`, `adaSupportConversationsProjections`, `adaSupportKnowledgeArticlesProjections`, and `adaSupportAuditEventsProjections` — the five functions `registry_builtins.go` dispatches all `ada_support.*` kinds to — keep their exact names/signatures but now return `nil, nil, errAdaSupportRustProjectionRequired`.
- `adaSupportEndUsersProjections` and `adaSupportAuditEventsProjections` previously called the shared `identityUserProjections`/`identityAuditProjections` helpers (also used by appgate, rivery, torii, tallyfy, and others); those shared helpers are untouched — only the ada_support wrapper functions changed.
- `adaSupportGenericAssetProjections` and `adaSupportGenericPolicyProjections` were ada_support-only helpers (confirmed by whole-package grep — no other provider called them) and are deleted along with the now-unused `strings` import.
- No `ada_support.*` dispatch entry in `registry_builtins.go` pointed directly at a shared multi-provider helper, so no Cloudflare-style repointing wrapper was needed — `registry_builtins.go` is unchanged.
- `ada_support_test.go` is rewritten as one table-driven test, `TestAdaSupportGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering all 5 `ada_support.*` kinds via `ProjectEvent`, asserting `errors.Is` against the sentinel and zero entities/links.

## Authority proof

Compiled Rust catalog marks every ada_support family collection- and projection-authoritative (full-catalog census 2026-08-26). Go static loader: ada_support has none.

## Cross-package blast radius

`grep -rn "\"ada_support\." --include='*.go' internal cmd | grep -v internal/sourceprojection` returned no matches — no other package projects `ada_support.*` events through `ProjectEvent` (no test corpora or fixtures reference it outside `internal/sourceprojection`), so no cross-package usage needed to move to a still-live provider.

## Validation

Run from the worktree root:

```
gofmt -l internal/sourceprojection
go build ./internal/sourceprojection
go test ./internal/sourceprojection -count=1
go test ./internal/sourceregistry -count=1
```

All pass. No other package touches `ada_support.*` projections, so no further consumer tests were required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
