### PR TITLE
refactor(contracts): move the Rust authority route list to a data ledger

### DIFF
--- a/docs/contracts/rust-authority-routes.json
+++ b/docs/contracts/rust-authority-routes.json
@@ -1,0 +1,17 @@
+[
+  {
+    "method": "GET",
+    "path": "/platform/graph/neighborhood",
+    "marker": "get(product_neighborhood_route)"
+  },
+  {
+    "method": "GET",
+    "path": "/platform/graph/provenance",
+    "marker": "get(graph_provenance_route)"
+  },
+  {
+    "method": "GET",
+    "path": "/v1/security/lifecycle",
+    "marker": "get(security_lifecycle)"
+  }
+]

--- a/internal/bootstrap/public_contract_inventory_test.go
+++ b/internal/bootstrap/public_contract_inventory_test.go
@@ -327,32 +327,39 @@ func rustAuthorityHTTPContractEntries(t *testing.T, root string, openAPI map[str
 	if err != nil {
 		t.Fatalf("read Rust platform router: %v", err)
 	}
-	routes := []struct {
-		method string
-		path   string
-		marker string
-	}{
-		{method: http.MethodGet, path: "/platform/graph/neighborhood", marker: "get(product_neighborhood_route)"},
-		{method: http.MethodGet, path: "/platform/graph/provenance", marker: "get(graph_provenance_route)"},
-		{method: http.MethodGet, path: "/v1/security/lifecycle", marker: "get(security_lifecycle)"},
+	// #nosec G304 -- fixed repo-relative guardrail path derived from runtime.Caller.
+	ledgerPayload, err := os.ReadFile(filepath.Join(root, "docs", "contracts", "rust-authority-routes.json"))
+	if err != nil {
+		t.Fatalf("read rust authority route ledger: %v", err)
+	}
+	var routes []struct {
+		Method string `json:"method"`
+		Path   string `json:"path"`
+		Marker string `json:"marker"`
+	}
+	if err := json.Unmarshal(ledgerPayload, &routes); err != nil {
+		t.Fatalf("parse rust authority route ledger: %v", err)
+	}
+	if len(routes) == 0 {
+		t.Fatal("rust authority route ledger is empty")
 	}
 	entries := make([]platformContractEntry, 0, len(routes))
 	for _, route := range routes {
-		if !strings.Contains(string(body), `"`+route.path+`"`) || !strings.Contains(string(body), route.marker) {
-			t.Fatalf("Rust platform router is missing %s %s", route.method, route.path)
+		if !strings.Contains(string(body), `"`+route.Path+`"`) || !strings.Contains(string(body), route.Marker) {
+			t.Fatalf("Rust platform router is missing %s %s", route.Method, route.Path)
 		}
-		methods := openAPI[route.path]
-		if _, ok := methods[strings.ToLower(route.method)]; !ok {
-			t.Fatalf("Rust authority route %s %s is missing from OpenAPI", route.method, route.path)
+		methods := openAPI[route.Path]
+		if _, ok := methods[strings.ToLower(route.Method)]; !ok {
+			t.Fatalf("Rust authority route %s %s is missing from OpenAPI", route.Method, route.Path)
 		}
 		entries = append(entries, platformContractEntry{
-			Identity:        route.method + " " + route.path,
+			Identity:        route.Method + " " + route.Path,
 			Kind:            "http",
-			Method:          route.method,
-			Path:            route.path,
+			Method:          route.Method,
+			Path:            route.Path,
 			Surface:         "rust-authority",
 			AuthorityOwner:  "rust-authority",
-			Owner:           contractOwnerForPath(route.path),
+			Owner:           contractOwnerForPath(route.Path),
 			AuthClass:       "api-key-or-bearer",
 			TenantScopeRule: "tenant-id-required",
 			ContractSource:  "OpenAPI",

--- a/scripts/openapi_route_parity.go
+++ b/scripts/openapi_route_parity.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -18,7 +19,10 @@ var (
 	componentsLine = []byte("\ncomponents:\n")
 )
 
-const openAPIPath = "api/openapi.yaml"
+const (
+	openAPIPath             = "api/openapi.yaml"
+	rustAuthorityLedgerPath = "docs/contracts/rust-authority-routes.json"
+)
 
 type route struct {
 	Method string
@@ -33,7 +37,7 @@ func main() {
 	if err != nil {
 		fail(err)
 	}
-	rustRoutes, err := registeredRustAuthorityRoutes("crates/cerebro-platform/src/main.rs")
+	rustRoutes, err := registeredRustAuthorityRoutes("crates/cerebro-platform/src/main.rs", rustAuthorityLedgerPath)
 	if err != nil {
 		fail(err)
 	}
@@ -66,25 +70,44 @@ func main() {
 	os.Exit(1)
 }
 
-func registeredRustAuthorityRoutes(path string) ([]route, error) {
+type rustAuthorityLedgerEntry struct {
+	Method string `json:"method"`
+	Path   string `json:"path"`
+	Marker string `json:"marker"`
+}
+
+func rustAuthorityLedger(path string) ([]rustAuthorityLedgerEntry, error) {
 	payload, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	routes := []struct {
-		route  route
-		marker string
-	}{
-		{route: route{Method: "get", Path: "/platform/graph/neighborhood"}, marker: "get(product_neighborhood_route)"},
-		{route: route{Method: "get", Path: "/platform/graph/provenance"}, marker: "get(graph_provenance_route)"},
-		{route: route{Method: "get", Path: "/v1/security/lifecycle"}, marker: "get(security_lifecycle)"},
+	var entries []rustAuthorityLedgerEntry
+	if err := json.Unmarshal(payload, &entries); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}
-	registered := make([]route, 0, len(routes))
-	for _, candidate := range routes {
-		if !bytes.Contains(payload, []byte(`"`+candidate.route.Path+`"`)) || !bytes.Contains(payload, []byte(candidate.marker)) {
-			return nil, fmt.Errorf("Rust authority route is not registered: %s %s", strings.ToUpper(candidate.route.Method), candidate.route.Path)
+	for _, entry := range entries {
+		if entry.Method == "" || entry.Path == "" || entry.Marker == "" {
+			return nil, fmt.Errorf("%s: every entry requires method, path, and marker", path)
 		}
-		registered = append(registered, candidate.route)
+	}
+	return entries, nil
+}
+
+func registeredRustAuthorityRoutes(path string, ledgerPath string) ([]route, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := rustAuthorityLedger(ledgerPath)
+	if err != nil {
+		return nil, err
+	}
+	registered := make([]route, 0, len(entries))
+	for _, entry := range entries {
+		if !bytes.Contains(payload, []byte(`"`+entry.Path+`"`)) || !bytes.Contains(payload, []byte(entry.Marker)) {
+			return nil, fmt.Errorf("Rust authority route is not registered: %s %s", strings.ToUpper(entry.Method), entry.Path)
+		}
+		registered = append(registered, route{Method: strings.ToLower(entry.Method), Path: entry.Path})
 	}
 	return registered, nil
 }

--- a/scripts/openapi_route_parity_test.go
+++ b/scripts/openapi_route_parity_test.go
@@ -126,44 +126,56 @@ func TestRouteParityIsBidirectional(t *testing.T) {
 }
 
 func TestRegisteredRustAuthorityRoutesRequiresTheNativeHandler(t *testing.T) {
-	sourcePath := filepath.Join(t.TempDir(), "main.rs")
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "main.rs")
+	ledgerPath := filepath.Join(dir, "rust-authority-routes.json")
 	if err := os.WriteFile(sourcePath, []byte(`
 Router::new().route(
-    "/platform/graph/neighborhood",
-    get(product_neighborhood_route),
-).route(
-    "/platform/graph/provenance",
-    get(graph_provenance_route),
-).route(
-    "/v1/security/lifecycle",
-    get(security_lifecycle),
+    "/v1/example",
+    get(example_route),
 )
 `), 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
+	if err := os.WriteFile(ledgerPath, []byte(`[
+  {"method": "GET", "path": "/v1/example", "marker": "get(example_route)"}
+]`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
 
-	routes, err := registeredRustAuthorityRoutes(sourcePath)
+	routes, err := registeredRustAuthorityRoutes(sourcePath, ledgerPath)
 	if err != nil {
 		t.Fatalf("registeredRustAuthorityRoutes() error = %v", err)
 	}
-	want := []route{
-		{Method: "get", Path: "/platform/graph/neighborhood"},
-		{Method: "get", Path: "/platform/graph/provenance"},
-		{Method: "get", Path: "/v1/security/lifecycle"},
-	}
-	if len(routes) != len(want) {
+	want := []route{{Method: "get", Path: "/v1/example"}}
+	if len(routes) != len(want) || routes[0] != want[0] {
 		t.Fatalf("registeredRustAuthorityRoutes() = %#v, want %#v", routes, want)
-	}
-	for index := range want {
-		if routes[index] != want[index] {
-			t.Fatalf("registeredRustAuthorityRoutes()[%d] = %#v, want %#v", index, routes[index], want[index])
-		}
 	}
 
 	if err := os.WriteFile(sourcePath, []byte(`Router::new()`), 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
-	if _, err := registeredRustAuthorityRoutes(sourcePath); err == nil {
+	if _, err := registeredRustAuthorityRoutes(sourcePath, ledgerPath); err == nil {
 		t.Fatal("registeredRustAuthorityRoutes() error = nil, want missing handler error")
+	}
+
+	if err := os.WriteFile(ledgerPath, []byte(`[{"method": "GET", "path": "/v1/example"}]`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if _, err := registeredRustAuthorityRoutes(sourcePath, ledgerPath); err == nil {
+		t.Fatal("registeredRustAuthorityRoutes() error = nil, want incomplete ledger entry error")
+	}
+}
+
+func TestRustAuthorityLedgerMatchesCheckedInRouter(t *testing.T) {
+	routes, err := registeredRustAuthorityRoutes(
+		filepath.Join("..", "crates", "cerebro-platform", "src", "main.rs"),
+		filepath.Join("..", rustAuthorityLedgerPath),
+	)
+	if err != nil {
+		t.Fatalf("registeredRustAuthorityRoutes() error = %v", err)
+	}
+	if len(routes) == 0 {
+		t.Fatal("rust authority ledger is empty")
 	}
 }


### PR DESCRIPTION
## Summary

Pre-work PR from the migration campaign map — the single highest-leverage change for route-transfer parallelism:

- register Rust-authority routes once in `docs/contracts/rust-authority-routes.json` (method, path, native-handler marker)
- `scripts/openapi_route_parity.go` and the public contract inventory generator both read the ledger instead of carrying hardcoded lists
- the parity unit test now uses a synthetic ledger fixture, and a new `TestRustAuthorityLedgerMatchesCheckedInRouter` pins the checked-in ledger against the real Rust router

Every future transfer PR (there will be many — #2748 and #2750 already collided on exactly these lines) now touches only the ledger plus its own code.

## Validation

- go build ./... ; go run ./scripts/openapi_route_parity.go (clean)
- go test ./internal/bootstrap ./tools/archtests/... ./scripts/... -count=1 (ok; inventory golden unchanged — same entries, new source of truth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)