### PR TITLE
refactor(sources): retire Adp Workforce Now Go projection writer

### DIFF
--- a/internal/sourceprojection/adp_workforce_now.go
+++ b/internal/sourceprojection/adp_workforce_now.go
@@ -1,14 +1,18 @@
 package sourceprojection
 
 import (
+	"errors"
+
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func adpWorkforceNowUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "adp_workforce_now"})
+var errAdpWorkforceNowRustProjectionRequired = errors.New("adp_workforce_now projection requires Rust authority")
+
+func adpWorkforceNowUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAdpWorkforceNowRustProjectionRequired
 }
 
-func adpWorkforceNowEventNotificationsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "adp_workforce_now"})
+func adpWorkforceNowEventNotificationsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAdpWorkforceNowRustProjectionRequired
 }

--- a/internal/sourceprojection/adp_workforce_now_test.go
+++ b/internal/sourceprojection/adp_workforce_now_test.go
@@ -1,29 +1,30 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestAdpWorkforceNowIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "adp_workforce_now", Kind: "adp_workforce_now.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := adpWorkforceNowUsersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestAdpWorkforceNowEventNotificationsProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "adp_workforce_now", Kind: "adp_workforce_now.event_notifications", Attributes: map[string]string{"event_type": "worker.hire", "actor_id": "user-1", "resource_id": "worker-1", "resource_type": "worker"}}
-	entities, links, err := adpWorkforceNowEventNotificationsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want event notification projection", len(entities), len(links))
+func TestAdpWorkforceNowGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"adp_workforce_now.event_notifications",
+		"adp_workforce_now.users",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "adp_workforce_now",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAdpWorkforceNowRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Retires the Go projection writer for `adp_workforce_now`, following the standard retirement pattern (deepseek #2658 and 17 more since).
- `adpWorkforceNowUsersProjections` and `adpWorkforceNowEventNotificationsProjections` — the only two functions `registry_builtins.go` dispatches `adp_workforce_now.*` kinds to — now return `nil, nil, errAdpWorkforceNowRustProjectionRequired` unconditionally instead of delegating to the shared `identityUserProjections` / `identityAuditProjections` helpers. Those shared helpers are used by many other still-live providers (appgate, postmark, tallyfy, torii, rivery, thoropass, vidyard, fathom_video, burp_suite_enterprise, gsmtasks, elmah, robin, and more) and are untouched.
- Names and signatures of both functions are unchanged, so `registry_builtins.go` needs no edits.
- Rewrote `adp_workforce_now_test.go` as a single table-driven test, `TestAdpWorkforceNowGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering both `adp_workforce_now.*` kinds registered in `registry_builtins.go`, asserting `errors.Is` against the new typed error and zero entities/links via `ProjectEvent`.

## Authority proof
Compiled Rust catalog marks every `adp_workforce_now` family collection- and projection-authoritative (full-catalog census 2026-08-26); Go static loader: adp_workforce_now has none.

## Validation
Run from the worktree root:
```
gofmt -l internal/sourceprojection          # empty
go build ./internal/sourceprojection        # ok
go test ./internal/sourceprojection -count=1   # ok
go test ./internal/sourceregistry -count=1     # ok
```
Cross-package check: `grep -rn "\"adp_workforce_now\." --include='*.go' internal cmd | grep -v internal/sourceprojection` returned no matches — no other package projects `adp_workforce_now.*` events through `ProjectEvent`, and no test corpora/fixtures reference the retired functions, so no cross-package changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)