### PR TITLE
refactor(sources): retire Anchore Go projection writer

### DIFF
--- a/internal/sourceprojection/anchore.go
+++ b/internal/sourceprojection/anchore.go
@@ -1,62 +1,22 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func anchoreAssetsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return anchoreGenericAssetProjections(event)
+var errAnchoreRustProjectionRequired = errors.New("anchore projection requires Rust authority")
+
+func anchoreAssetsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAnchoreRustProjectionRequired
 }
 
-func anchoreFindingsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return anchoreGenericFindingProjections(event)
+func anchoreFindingsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAnchoreRustProjectionRequired
 }
 
-func anchoreVulnerabilitiesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return anchoreGenericFindingProjections(event)
-}
-
-func anchoreGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func anchoreGenericFindingProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	findingID := firstNonEmpty(attributes["finding_id"], event.GetId())
-	findingURN := projectionURN(tenantID, "finding", findingID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: findingURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "finding", Label: firstNonEmpty(attributes["title"], findingID), Attributes: map[string]string{"finding_id": findingID, "severity": strings.TrimSpace(attributes["severity"]), "status": strings.TrimSpace(attributes["status"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if resourceURN := strings.TrimSpace(attributes["resource_urn"]); resourceURN != "" {
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), findingURN, resourceURN, relationAffects, map[string]string{"event_id": event.GetId()}))
-	}
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), evidenceURN, findingURN, relationSupports, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func anchoreVulnerabilitiesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAnchoreRustProjectionRequired
 }

--- a/internal/sourceprojection/anchore_test.go
+++ b/internal/sourceprojection/anchore_test.go
@@ -1,55 +1,27 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestAnchoreAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "anchore", Kind: "anchore.assets", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := anchoreAssetsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAnchoreFindingProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "anchore", Kind: "anchore.findings", Attributes: map[string]string{"finding_id": "finding-1", "title": "Finding One", "severity": "high", "status": "open", "resource_urn": "urn:cerebro:tenant:runtime_asset:asset-1", "evidence_id": "evidence-1"}}
-	entities, links, err := anchoreFindingsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected finding")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected finding links")
-	}
-	if !hasProjectedEntityType(entities, "runtime_evidence") {
-		t.Fatal("expected projected runtime evidence entity")
-	}
-}
-
-func TestAnchoreVulnerabilitiesProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "anchore", Kind: "anchore.vulnerabilities", Attributes: map[string]string{"finding_id": "finding-1", "title": "Finding One", "severity": "high", "status": "open", "resource_urn": "urn:cerebro:tenant:runtime_asset:asset-1", "evidence_id": "evidence-1"}}
-	entities, links, err := anchoreVulnerabilitiesProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected finding")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected finding links")
-	}
-	if !hasProjectedEntityType(entities, "runtime_evidence") {
-		t.Fatal("expected projected runtime evidence entity")
+func TestAnchoreGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{"anchore.assets", "anchore.findings", "anchore.vulnerabilities"} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "anchore",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAnchoreRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Retires the Anchore Go projection writer in `internal/sourceprojection`, following the standard fail-closed retirement pattern (deepseek #2658 and the 17+ subsequent retirements).
- `anchoreAssetsProjections`, `anchoreFindingsProjections`, and `anchoreVulnerabilitiesProjections` keep their exact names and signatures (still dispatched from `registry_builtins.go` for `anchore.assets` / `anchore.findings` / `anchore.vulnerabilities`) but now return `nil, nil, errAnchoreRustProjectionRequired` unconditionally.
- Deleted the two Anchore-only helper functions (`anchoreGenericAssetProjections`, `anchoreGenericFindingProjections`) that became unused — confirmed via a package-wide grep that nothing else in `internal/sourceprojection` referenced them, so no shared-helper wrapper (Cloudflare #2747 style) was needed here.
- Rewrote `anchore_test.go` as a single table-driven test, `TestAnchoreGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering all three `anchore.*` kinds registered in `registry_builtins.go`, calling `ProjectEvent` with a minimal `EventEnvelope` and asserting `errors.Is` against the new sentinel plus zero entities/links.

## Authority proof
Compiled Rust catalog marks every Anchore family collection- and projection-authoritative (full-catalog census 2026-08-26); Go static loader: anchore has none.

## Validation
Cross-package check: `grep -rn "\"anchore\." --include='*.go' internal cmd | grep -v internal/sourceprojection` and a whole-word case-insensitive sweep (`grep -rlwi "anchore" --include='*.go' internal cmd`) outside `internal/sourceprojection` turned up no matches — the only other case-insensitive hits were false positives on `Anchor`/`AnchorGraphAnchored` (graph anchoring, unrelated to the Anchore provider) in `internal/findings` and `internal/grccatalog`. No cross-package consumer needed changes.

Commands run from the worktree root, all passing:
```
gofmt -l internal/sourceprojection          # empty output
go build ./internal/sourceprojection
go test ./internal/sourceprojection -count=1
go test ./internal/sourceregistry -count=1
go vet ./internal/sourceprojection ./internal/sourceregistry
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
