### PR TITLE
chore(rust): format combined platform modules

### DIFF
--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -1,8 +1,8 @@
 #![forbid(unsafe_code)]
 
 mod append_log_consumer;
-mod audit_events;
 mod ask_queries;
+mod audit_events;
 mod cutover_command;
 mod graph_provenance;
 mod oidc;


### PR DESCRIPTION
## State

Forward-only repair for the #2749 merge race. The audit-events PR merged before its formatting-only follow-up commit reached the branch, leaving `cargo fmt --all -- --check` with a one-line module-order diff.

## Change

- keep both `ask_queries` and `audit_events` modules
- order the declarations exactly as rustfmt requires

## Validation

- `rustfmt --edition 2024 --check crates/cerebro-platform/src/main.rs`
- `git diff --check`

No routes, handlers, contracts, or runtime behavior change.