### PR TITLE
refactor(sources): retire Asana users Go projection

### DIFF
--- a/internal/sourceprojection/asana.go
+++ b/internal/sourceprojection/asana.go
@@ -1,14 +1,17 @@
 package sourceprojection
 
 import (
+	"errors"
 	"strings"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func asanaUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "asana"})
+var errAsanaUsersRustProjectionRequired = errors.New("asana users projection requires Rust authority")
+
+func asanaUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAsanaUsersRustProjectionRequired
 }
 
 func asanaProjectsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {

--- a/internal/sourceprojection/asana_test.go
+++ b/internal/sourceprojection/asana_test.go
@@ -1,6 +1,7 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
@@ -20,14 +21,18 @@ func TestAsanaAssetProjection(t *testing.T) {
 	}
 }
 
-func TestAsanaIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "asana", Kind: "asana.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := asanaUsersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
+func TestAsanaUsersGoProjectionFailsClosedForRustAuthoritativeFamily(t *testing.T) {
+	entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+		Id:       "event-1",
+		TenantId: "tenant",
+		SourceId: "asana",
+		Kind:     "asana.users",
+	})
+	if !errors.Is(err, errAsanaUsersRustProjectionRequired) {
+		t.Fatalf("ProjectEvent() error = %v", err)
 	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
+	if len(entities) != 0 || len(links) != 0 {
+		t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
 	}
 }
 


### PR DESCRIPTION
## Summary

- fail closed when the Go projector receives Asana user events
- preserve the existing Asana project and audit-event projection paths
- add a regression test proving the retired family cannot produce Go graph writes

## Validation

- go test ./internal/sourceprojection -count=1
- go test ./internal/sourceruntime ./internal/sourceruntime/sourceworker -count=1
- make check-structural check-arch
- make source-fixture-check
- make catalog-check

Rust formatting and test execution remain delegated to hosted checks because the managed local Cargo cache rejected the build before execution on its safe-capacity guard.