### PR TITLE
Qdrant Cloud accounts and clusters Rust runtime evidence

### DIFF
--- a/crates/organizational-store/tests/qdrant_cloud_checkpoint_lease_evidence.rs
+++ b/crates/organizational-store/tests/qdrant_cloud_checkpoint_lease_evidence.rs
@@ -1,0 +1,181 @@
+use std::{collections::BTreeMap, env, error::Error};
+
+use cerebro_agent_context::AgentGraph;
+use cerebro_organizational_model::{SourceRuntimeId, TenantId};
+use cerebro_organizational_store::{
+    DurableGraphStore, Neo4jProjector, PostgresLedger, StoredSourceRuntime,
+};
+use cerebro_source_catalog::SourceCatalog;
+use cerebro_source_runtime_next::{
+    CatalogGraphMapper, CollectionRequest, HttpConnectorError, RuntimeError, SourceRuntime,
+};
+use tokio_postgres::NoTls;
+
+#[path = "support/qdrant_cloud/mod.rs"]
+mod support;
+
+use support::{qdrant_connector, repository_root, spawn_cluster_provider};
+
+#[tokio::test]
+#[ignore = "requires disposable PostgreSQL and Neo4j instances"]
+async fn clusters_resume_then_reject_a_stale_checkpoint_claim() -> Result<(), Box<dyn Error>> {
+    let postgres_dsn = env::var("CEREBRO_TEST_POSTGRES_DSN")?;
+    let (lease_client, lease_connection) = tokio_postgres::connect(&postgres_dsn, NoTls).await?;
+    tokio::spawn(async move {
+        lease_connection.await.expect("PostgreSQL lease connection");
+    });
+    let lease_ledger = PostgresLedger::from_client(lease_client);
+    lease_ledger.migrate().await?;
+    let (store_client, store_connection) = tokio_postgres::connect(&postgres_dsn, NoTls).await?;
+    tokio::spawn(async move {
+        store_connection.await.expect("PostgreSQL store connection");
+    });
+    let store_ledger = PostgresLedger::from_client(store_client);
+    store_ledger.migrate().await?;
+
+    let suffix = std::process::id();
+    let tenant = TenantId::parse(format!("tenant-qdrant-durable-{suffix}"))?;
+    let runtime_id = SourceRuntimeId::parse(format!("qdrant-durable-{suffix}"))?;
+    let stored_runtime = StoredSourceRuntime::new(
+        runtime_id.clone(),
+        tenant.clone(),
+        "qdrant_cloud".to_owned(),
+        BTreeMap::from([
+            ("family".to_owned(), "clusters".to_owned()),
+            (
+                "base_url".to_owned(),
+                "https://api.cloud.qdrant.io".to_owned(),
+            ),
+            ("account_id".to_owned(), "account-durable".to_owned()),
+        ]),
+        Some(serde_json::json!({
+            "watermark": "2026-08-26T00:00:00Z",
+            "cursor_opaque": "{\"token\":\"page-1\",\"resumable_checkpoint\":true}"
+        })),
+        Some(serde_json::json!({"opaque": "page-1"})),
+        None,
+    )?;
+    assert!(
+        lease_ledger
+            .put_source_runtime(&stored_runtime, None)
+            .await?
+    );
+    let fence = lease_ledger
+        .acquire_source_runtime_lease(&tenant, &runtime_id, "worker:qdrant-one", 60_000)
+        .await?
+        .expect("Qdrant lease");
+
+    let (base_url, provider) = spawn_cluster_provider().await;
+    let root = repository_root();
+    let source = SourceCatalog::load(
+        root.join("internal/connectorcatalog/catalog"),
+        root.join("sources"),
+    )?
+    .get("qdrant_cloud")
+    .expect("Qdrant catalog source")
+    .clone();
+    let mapper = || CatalogGraphMapper::new(source.clone(), "qdrant-durable-v1").unwrap();
+    let projector = Neo4jProjector::connect(
+        &env::var("CEREBRO_TEST_NEO4J_URI")?,
+        &env::var("CEREBRO_TEST_NEO4J_USERNAME")?,
+        &env::var("CEREBRO_TEST_NEO4J_PASSWORD")?,
+    )
+    .await?;
+    projector.migrate().await?;
+    let reader = projector.clone();
+    let store = DurableGraphStore::new(store_ledger, projector);
+    let request = |cursor: Option<String>| CollectionRequest {
+        tenant_id: tenant.clone(),
+        source_runtime_id: runtime_id.clone(),
+        cursor,
+    };
+
+    let mut interrupted = SourceRuntime::new(
+        qdrant_connector(
+            source.clone(),
+            &tenant,
+            &runtime_id,
+            &base_url,
+            fence.generation(),
+        ),
+        mapper(),
+        store,
+    );
+    let error = interrupted
+        .sync_fenced(request(Some("page-1".to_owned())), &fence)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        &error,
+        RuntimeError::Collect(HttpConnectorError::ProviderStatus(status))
+            if status.as_u16() == 429
+    ));
+    let after_interruption = lease_ledger.load_source_runtime(&runtime_id).await?;
+    assert_eq!(after_interruption.cursor(), Some("page-1"));
+    assert!(after_interruption.last_synced_at().is_none());
+
+    let mut resumed = SourceRuntime::new(
+        qdrant_connector(
+            source.clone(),
+            &tenant,
+            &runtime_id,
+            &base_url,
+            fence.generation(),
+        ),
+        mapper(),
+        interrupted.into_store(),
+    );
+    let receipt = resumed
+        .sync_fenced(request(Some("page-1".to_owned())), &fence)
+        .await?;
+    assert_eq!(receipt.entities_upserted, 2);
+    let committed = lease_ledger.load_source_runtime(&runtime_id).await?;
+    assert_eq!(committed.cursor(), None);
+    assert_eq!(committed.next_cursor(), None);
+    assert_eq!(
+        committed
+            .checkpoint()
+            .and_then(|value| value.get("cursor_opaque"))
+            .and_then(serde_json::Value::as_str),
+        Some("")
+    );
+    assert!(committed.last_synced_at().is_some());
+    assert_eq!(reader.revision(&tenant).await?, receipt.graph_revision);
+    let product_entities = reader.search(&tenant, "Durable cluster", &[], 10).await?;
+    assert_eq!(product_entities.len(), 2);
+
+    let store = resumed.into_store();
+    assert!(lease_ledger.release_source_runtime_lease(&fence).await?);
+    let successor = lease_ledger
+        .acquire_source_runtime_lease(&tenant, &runtime_id, "worker:qdrant-two", 60_000)
+        .await?
+        .expect("successor Qdrant lease");
+    assert!(successor.generation() > fence.generation());
+    let mut stale = SourceRuntime::new(
+        qdrant_connector(
+            source.clone(),
+            &tenant,
+            &runtime_id,
+            &base_url,
+            fence.generation(),
+        ),
+        mapper(),
+        store,
+    );
+    assert!(matches!(
+        stale.sync_fenced(request(None), &fence).await,
+        Err(RuntimeError::Store(_))
+    ));
+    let after_stale = lease_ledger.load_source_runtime(&runtime_id).await?;
+    assert_eq!(after_stale.next_cursor(), committed.next_cursor());
+    assert_eq!(after_stale.checkpoint(), committed.checkpoint());
+    assert_eq!(after_stale.last_synced_at(), committed.last_synced_at());
+    assert_eq!(reader.revision(&tenant).await?, receipt.graph_revision);
+    assert!(
+        lease_ledger
+            .release_source_runtime_lease(&successor)
+            .await?
+    );
+    provider.await?;
+    Ok(())
+}

--- a/crates/organizational-store/tests/qdrant_cloud_cursor_bounds.rs
+++ b/crates/organizational-store/tests/qdrant_cloud_cursor_bounds.rs
@@ -1,0 +1,21 @@
+use std::{collections::BTreeMap, error::Error};
+
+use cerebro_organizational_model::{SourceRuntimeId, TenantId};
+use cerebro_organizational_store::StoredSourceRuntime;
+
+#[test]
+fn qdrant_runtime_rejects_oversized_durable_cursor() -> Result<(), Box<dyn Error>> {
+    assert!(matches!(
+        StoredSourceRuntime::new(
+            SourceRuntimeId::parse("qdrant-cursor-bound")?,
+            TenantId::parse("tenant-qdrant-cursor-bound")?,
+            "qdrant_cloud".to_owned(),
+            BTreeMap::from([("family".to_owned(), "clusters".to_owned())]),
+            None,
+            Some(serde_json::json!({"opaque": "x".repeat((64 * 1024) + 1)})),
+            None,
+        ),
+        Err(_)
+    ));
+    Ok(())
+}

--- a/crates/organizational-store/tests/support/qdrant_cloud/mod.rs
+++ b/crates/organizational-store/tests/support/qdrant_cloud/mod.rs
@@ -1,0 +1,5 @@
+mod network;
+mod request_setup;
+
+pub use network::spawn_cluster_provider;
+pub use request_setup::{qdrant_connector, repository_root};

--- a/crates/organizational-store/tests/support/qdrant_cloud/network.rs
+++ b/crates/organizational-store/tests/support/qdrant_cloud/network.rs
@@ -1,0 +1,52 @@
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    task::JoinHandle,
+};
+
+pub async fn spawn_cluster_provider() -> (String, JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let provider = tokio::spawn(async move {
+        for request_index in 0..6 {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4_096];
+            let read = socket.read(&mut request).await.unwrap();
+            let request = String::from_utf8_lossy(&request[..read]);
+            assert!(request.starts_with("GET /api/cluster/v1/accounts/account-durable/clusters?"));
+            assert!(request.contains("page_size=250"));
+            assert!(
+                request
+                    .to_ascii_lowercase()
+                    .contains("authorization: apikey fixture-management-key")
+            );
+            let second_page = matches!(request_index, 1 | 3 | 5);
+            if second_page {
+                assert!(request.contains("page_token=page-2"));
+            } else if request_index == 0 || request_index == 2 {
+                assert!(request.contains("page_token=page-1"));
+            } else {
+                assert!(!request.contains("page_token="));
+            }
+            if request_index == 1 {
+                socket
+                    .write_all(
+                        b"HTTP/1.1 429 Too Many Requests\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+                    )
+                    .await
+                    .unwrap();
+                continue;
+            }
+            let body = if second_page {
+                r#"{"items":[{"id":"cluster-2","name":"Durable cluster two","status":"ready"}],"next_page_token":""}"#
+            } else {
+                r#"{"items":[{"id":"cluster-1","name":"Durable cluster one","status":"ready"}],"next_page_token":"page-2"}"#
+            };
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        }
+    });
+    (format!("http://{address}"), provider)
+}

--- a/crates/organizational-store/tests/support/qdrant_cloud/request_setup.rs
+++ b/crates/organizational-store/tests/support/qdrant_cloud/request_setup.rs
@@ -1,0 +1,69 @@
+use std::{collections::BTreeMap, path::Path};
+
+use cerebro_organizational_model::{SourceRuntimeId, TenantId};
+use cerebro_source_catalog::CompiledSource;
+use cerebro_source_runtime_next::{
+    CredentialLeaseReference, EgressPolicy, EgressRequestContext, HttpProviderAccess,
+    HttpSourceConnector, OperationScopedCredentialLease, ResolvedAuth, SourceRuntimeOperation,
+};
+
+pub fn repository_root() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .unwrap()
+}
+
+pub fn qdrant_connector(
+    source: CompiledSource,
+    tenant: &TenantId,
+    runtime_id: &SourceRuntimeId,
+    base_url: &str,
+    generation: u64,
+) -> HttpSourceConnector {
+    let request_intent_digest = "b".repeat(64);
+    let context = EgressRequestContext {
+        tenant_id: tenant.as_str().to_owned(),
+        runtime_id: runtime_id.as_str().to_owned(),
+        source_id: "qdrant_cloud".to_owned(),
+        family_id: "clusters".to_owned(),
+        operation: SourceRuntimeOperation::ReadPage,
+        request_intent_digest: request_intent_digest.clone(),
+        logical_page_id: format!("qdrant-clusters-{generation}"),
+        source_generation: generation,
+        authority_epoch: 1,
+    };
+    let credential_lease = OperationScopedCredentialLease::new(
+        CredentialLeaseReference::new(
+            format!("qdrant-clusters-lease-{generation}"),
+            context.lease_scope().unwrap(),
+            1_000,
+            1_000,
+        )
+        .unwrap(),
+    );
+    let policy = EgressPolicy::live(
+        tenant.as_str(),
+        "clusters",
+        &request_intent_digest,
+        [base_url],
+    )
+    .unwrap();
+    HttpSourceConnector::new(
+        source,
+        "clusters",
+        base_url,
+        BTreeMap::from([("account_id".to_owned(), "account-durable".to_owned())]),
+        ResolvedAuth::Header {
+            name: "Authorization".to_owned(),
+            value: "apikey fixture-management-key".to_owned(),
+        },
+    )
+    .unwrap()
+    .with_provider_access(HttpProviderAccess::new_with_clock(
+        context,
+        policy,
+        credential_lease,
+        1_500,
+    ))
+}

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -57,7 +57,8 @@ mod portable_ai;
 mod protocol;
 mod provider_failure;
 #[cfg(test)]
-mod qdrant_cloud_vertical_slice;
+#[cfg(test)]
+mod qdrant_cloud;
 mod runtime_config;
 mod runtime_health;
 mod sdk;

--- a/crates/source-runtime-next/src/qdrant_cloud.rs
+++ b/crates/source-runtime-next/src/qdrant_cloud.rs
@@ -1,0 +1,6 @@
+mod accounts;
+mod failures;
+mod fixture_server;
+mod pagination;
+mod request_setup;
+mod restart;

--- a/crates/source-runtime-next/src/qdrant_cloud/accounts.rs
+++ b/crates/source-runtime-next/src/qdrant_cloud/accounts.rs
@@ -1,83 +1,14 @@
-use std::{
-    collections::BTreeMap,
-    path::{Path, PathBuf},
-};
-
 use cerebro_organizational_graph::{GraphRead, OrganizationalGraph};
 use cerebro_organizational_model::{SourceRuntimeId, TenantId};
-use cerebro_source_catalog::{CollectionAuthority, CompiledSource, HttpMethod, SourceCatalog};
+use cerebro_source_catalog::{CollectionAuthority, HttpMethod};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-use crate::{
-    CatalogGraphMapper, CollectionRequest, CredentialLeaseReference, EgressPolicy,
-    EgressRequestContext, HttpProviderAccess, HttpSourceConnector, OperationScopedCredentialLease,
-    ResolvedAuth, SourceRuntime, SourceRuntimeOperation,
-};
+use crate::CollectionRequest;
 
-fn repository_root() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../..")
-        .canonicalize()
-        .unwrap()
-}
-
-fn qdrant_runtime(
-    source: &CompiledSource,
-    tenant_id: &str,
-    runtime_id: &str,
-    base_url: &str,
-    generation: u64,
-    store: OrganizationalGraph,
-) -> SourceRuntime<HttpSourceConnector, CatalogGraphMapper, OrganizationalGraph> {
-    let request_intent_digest = "a".repeat(64);
-    let context = EgressRequestContext {
-        tenant_id: tenant_id.to_owned(),
-        runtime_id: runtime_id.to_owned(),
-        source_id: "qdrant_cloud".to_owned(),
-        family_id: "accounts".to_owned(),
-        operation: SourceRuntimeOperation::ReadPage,
-        request_intent_digest: request_intent_digest.clone(),
-        logical_page_id: format!("accounts-page-{generation}"),
-        source_generation: generation,
-        authority_epoch: 1,
-    };
-    let lease_scope = context.lease_scope().unwrap();
-    let credential_lease = OperationScopedCredentialLease::new(
-        CredentialLeaseReference::new(
-            format!("qdrant-accounts-lease-{generation}"),
-            lease_scope,
-            1_000,
-            1_000,
-        )
-        .unwrap(),
-    );
-    let egress_policy =
-        EgressPolicy::live(tenant_id, "accounts", &request_intent_digest, [base_url]).unwrap();
-    let auth = ResolvedAuth::Header {
-        name: "Authorization".to_owned(),
-        value: "apikey fixture-management-key".to_owned(),
-    };
-    assert!(!format!("{auth:?}").contains("fixture-management-key"));
-    let connector = HttpSourceConnector::new(
-        source.clone(),
-        "accounts",
-        base_url,
-        BTreeMap::from([("account_id".to_owned(), "account-fixture".to_owned())]),
-        auth,
-    )
-    .unwrap()
-    .with_provider_access(HttpProviderAccess::new_with_clock(
-        context,
-        egress_policy,
-        credential_lease,
-        1_500,
-    ));
-    let mapper = CatalogGraphMapper::new(source.clone(), "qdrant-accounts-v1").unwrap();
-    SourceRuntime::new(connector, mapper, store)
-}
+use super::request_setup::{qdrant_runtime, qdrant_source};
 
 #[tokio::test]
-async fn qdrant_accounts_collects_projects_restarts_and_reads_with_tenant_identity() {
+async fn accounts_collect_project_restart_and_preserve_tenant_identity() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
     let server = tokio::spawn(async move {
@@ -101,15 +32,7 @@ async fn qdrant_accounts_collects_projects_restarts_and_reads_with_tenant_identi
         }
     });
 
-    let root = repository_root();
-    let source = SourceCatalog::load(
-        root.join("internal/connectorcatalog/catalog"),
-        root.join("sources"),
-    )
-    .unwrap()
-    .get("qdrant_cloud")
-    .unwrap()
-    .clone();
+    let source = qdrant_source();
     // This closes the technical catalog contract only. Persisted authority
     // evidence is a separate promotion gate owned by the runtime ledger.
     assert_eq!(source.authority(), CollectionAuthority::Authoritative);
@@ -135,6 +58,7 @@ async fn qdrant_accounts_collects_projects_restarts_and_reads_with_tenant_identi
 
     let mut first = qdrant_runtime(
         &source,
+        "accounts",
         tenant_a.as_str(),
         runtime_id.as_str(),
         &base_url,
@@ -164,6 +88,7 @@ async fn qdrant_accounts_collects_projects_restarts_and_reads_with_tenant_identi
 
     let mut restarted = qdrant_runtime(
         &source,
+        "accounts",
         tenant_a.as_str(),
         runtime_id.as_str(),
         &base_url,
@@ -179,6 +104,7 @@ async fn qdrant_accounts_collects_projects_restarts_and_reads_with_tenant_identi
     let tenant_b = TenantId::parse("tenant-b").unwrap();
     let mut second_tenant = qdrant_runtime(
         &source,
+        "accounts",
         tenant_b.as_str(),
         runtime_id.as_str(),
         &base_url,

--- a/crates/source-runtime-next/src/qdrant_cloud/failures.rs
+++ b/crates/source-runtime-next/src/qdrant_cloud/failures.rs
@@ -1,0 +1,96 @@
+use std::collections::BTreeMap;
+
+use crate::{
+    CollectionRequest, HttpSourceConnector, ProviderFailureKind, ResolvedAuth, RuntimeError,
+};
+use cerebro_organizational_graph::{GraphRead, OrganizationalGraph};
+use cerebro_organizational_model::{SourceRuntimeId, TenantId};
+
+use super::{
+    fixture_server::{accept_request, write_json},
+    request_setup::{qdrant_runtime, qdrant_source},
+};
+
+#[tokio::test]
+async fn clusters_reject_wrong_auth_malformed_and_oversized_provider_data() {
+    let source = qdrant_source();
+    assert!(matches!(
+        HttpSourceConnector::new(
+            source.clone(),
+            "clusters",
+            "https://api.cloud.qdrant.io",
+            BTreeMap::from([("account_id".to_owned(), "account-fixture".to_owned())]),
+            ResolvedAuth::Bearer {
+                token: "wrong-auth-shape".to_owned(),
+            },
+        ),
+        Err(crate::HttpConnectorError::InvalidConfiguration(_))
+    ));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let bodies = [
+            "not-json".to_owned(),
+            serde_json::json!({
+                "items": [{"id": "x".repeat(1_025), "name": "Oversized identity"}],
+                "next_page_token": ""
+            })
+            .to_string(),
+            serde_json::json!({
+                "items": [{"id": "cluster-oversized", "name": "x".repeat((16 << 20) + 1)}],
+                "next_page_token": ""
+            })
+            .to_string(),
+        ];
+        for body in bodies {
+            let (socket, _) = accept_request(&listener).await;
+            write_json(socket, &body).await;
+        }
+    });
+
+    let base_url = format!("http://{address}");
+    for (generation, expected_kind) in [
+        (1, Some(ProviderFailureKind::PartialPageResponse)),
+        (2, None),
+        (3, Some(ProviderFailureKind::ResponseSizeLimit)),
+    ] {
+        let mut runtime = qdrant_runtime(
+            &source,
+            "clusters",
+            "tenant-failures",
+            "qdrant-clusters-failures",
+            &base_url,
+            generation,
+            OrganizationalGraph::new(),
+        );
+        let error = runtime
+            .sync(CollectionRequest {
+                tenant_id: TenantId::parse("tenant-failures").unwrap(),
+                source_runtime_id: SourceRuntimeId::parse("qdrant-clusters-failures").unwrap(),
+                cursor: None,
+            })
+            .await
+            .unwrap_err();
+        match (expected_kind, error) {
+            (Some(expected_kind), RuntimeError::Collect(error)) => {
+                assert!(matches!(
+                    &error,
+                    crate::HttpConnectorError::InvalidResponse(_)
+                ));
+                let classification = error.provider_failure_classification().unwrap();
+                assert_eq!(classification.kind, expected_kind);
+                assert!(!classification.advances_progress);
+            }
+            (None, RuntimeError::Map(_)) => {}
+            (_, error) => panic!("provider rejection crossed the expected boundary: {error:?}"),
+        }
+        assert_eq!(
+            runtime
+                .into_store()
+                .graph_revision(&TenantId::parse("tenant-failures").unwrap()),
+            0
+        );
+    }
+    server.await.unwrap();
+}

--- a/crates/source-runtime-next/src/qdrant_cloud/fixture_server.rs
+++ b/crates/source-runtime-next/src/qdrant_cloud/fixture_server.rs
@@ -1,0 +1,45 @@
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+};
+
+pub(super) async fn accept_request(listener: &TcpListener) -> (TcpStream, String) {
+    let (mut socket, _) = listener.accept().await.unwrap();
+    let mut request = vec![0; 4_096];
+    let read = socket.read(&mut request).await.unwrap();
+    (
+        socket,
+        String::from_utf8_lossy(&request[..read]).into_owned(),
+    )
+}
+
+pub(super) fn assert_cluster_request(request: &str, account_id: &str) {
+    assert!(request.starts_with(&format!(
+        "GET /api/cluster/v1/accounts/{account_id}/clusters?"
+    )));
+    assert!(request.contains("page_size=250"));
+    assert!(
+        request
+            .to_ascii_lowercase()
+            .contains("authorization: apikey fixture-management-key")
+    );
+}
+
+pub(super) async fn write_json(mut socket: TcpStream, body: &str) {
+    let response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    // Oversized-response coverage may close the client before the fixture has
+    // finished writing. The client-side bound is the assertion under test.
+    let _ = socket.write_all(response.as_bytes()).await;
+}
+
+pub(super) async fn write_rate_limit(mut socket: TcpStream) {
+    socket
+        .write_all(
+            b"HTTP/1.1 429 Too Many Requests\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+        )
+        .await
+        .unwrap();
+}

--- a/crates/source-runtime-next/src/qdrant_cloud/pagination.rs
+++ b/crates/source-runtime-next/src/qdrant_cloud/pagination.rs
@@ -1,0 +1,102 @@
+use cerebro_organizational_model::{SourceRuntimeId, TenantId};
+
+use crate::{CollectedScope, CollectionRequest, SourceConnector};
+
+use super::{
+    fixture_server::{accept_request, assert_cluster_request, write_json},
+    request_setup::{qdrant_connector, qdrant_source},
+};
+
+const PAGE_ONE: &str = r#"{"items":[{"id":"cluster-1","name":"Cluster one","status":"ready"}],"next_page_token":"page-2"}"#;
+const PAGE_TWO: &str =
+    r#"{"items":[{"id":"cluster-2","name":"Cluster two","status":"ready"}],"next_page_token":""}"#;
+
+#[tokio::test]
+async fn clusters_round_trip_two_pages_and_keep_cursor_on_the_declared_origin() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        for request_index in 0..3 {
+            let (socket, request) = accept_request(&listener).await;
+            assert_cluster_request(&request, "account-fixture");
+            match request_index {
+                0 => {
+                    assert!(!request.contains("page_token="));
+                    write_json(socket, PAGE_ONE).await;
+                }
+                1 => {
+                    assert!(request.contains("page_token=page-2"));
+                    write_json(socket, PAGE_TWO).await;
+                }
+                2 => {
+                    assert!(
+                        request
+                            .contains("page_token=https%3A%2F%2Fattacker.invalid%2Fescape%3Fx%3D1")
+                    );
+                    write_json(socket, PAGE_TWO).await;
+                }
+                _ => unreachable!(),
+            }
+        }
+    });
+
+    let source = qdrant_source();
+    let clusters = source
+        .families()
+        .iter()
+        .find(|family| family.id() == "clusters")
+        .unwrap();
+    assert_eq!(
+        clusters.path(),
+        "/api/cluster/v1/accounts/${config.account_id}/clusters"
+    );
+    assert_eq!(clusters.projection().template(), "deployment");
+
+    let base_url = format!("http://{address}");
+    let tenant = TenantId::parse("tenant-clusters-pagination").unwrap();
+    let runtime_id = SourceRuntimeId::parse("qdrant-clusters-pagination").unwrap();
+    let mut connector = qdrant_connector(
+        &source,
+        "clusters",
+        tenant.as_str(),
+        runtime_id.as_str(),
+        &base_url,
+        1,
+    );
+    let page_one = connector
+        .collect(CollectionRequest {
+            tenant_id: tenant.clone(),
+            source_runtime_id: runtime_id.clone(),
+            cursor: None,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(
+        &page_one.scope,
+        CollectedScope::NonAuthoritative(_)
+    ));
+    assert_eq!(page_one.records[0].provider_id, "cluster-1");
+    assert_eq!(page_one.next_cursor.as_deref(), Some("page-2"));
+
+    let page_two = connector
+        .collect(CollectionRequest {
+            tenant_id: tenant.clone(),
+            source_runtime_id: runtime_id.clone(),
+            cursor: page_one.next_cursor,
+        })
+        .await
+        .unwrap();
+    assert_eq!(page_two.records[0].provider_id, "cluster-2");
+    assert!(page_two.next_cursor.is_none());
+
+    let origin_bound_page = connector
+        .collect(CollectionRequest {
+            tenant_id: tenant,
+            source_runtime_id: runtime_id,
+            cursor: Some("https://attacker.invalid/escape?x=1".to_owned()),
+        })
+        .await
+        .unwrap();
+    assert_eq!(origin_bound_page.records[0].provider_id, "cluster-2");
+    server.await.unwrap();
+}

--- a/crates/source-runtime-next/src/qdrant_cloud/request_setup.rs
+++ b/crates/source-runtime-next/src/qdrant_cloud/request_setup.rs
@@ -1,0 +1,97 @@
+use std::{collections::BTreeMap, path::PathBuf};
+
+use cerebro_organizational_graph::OrganizationalGraph;
+use cerebro_source_catalog::{CompiledSource, SourceCatalog};
+
+use crate::{
+    CatalogGraphMapper, CredentialLeaseReference, EgressPolicy, EgressRequestContext,
+    HttpProviderAccess, HttpSourceConnector, OperationScopedCredentialLease, ResolvedAuth,
+    SourceRuntime, SourceRuntimeOperation,
+};
+
+fn repository_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .unwrap()
+}
+
+pub(super) fn qdrant_source() -> CompiledSource {
+    let root = repository_root();
+    SourceCatalog::load(
+        root.join("internal/connectorcatalog/catalog"),
+        root.join("sources"),
+    )
+    .unwrap()
+    .get("qdrant_cloud")
+    .unwrap()
+    .clone()
+}
+
+pub(super) fn qdrant_connector(
+    source: &CompiledSource,
+    family_id: &str,
+    tenant_id: &str,
+    runtime_id: &str,
+    base_url: &str,
+    generation: u64,
+) -> HttpSourceConnector {
+    let request_intent_digest = "a".repeat(64);
+    let context = EgressRequestContext {
+        tenant_id: tenant_id.to_owned(),
+        runtime_id: runtime_id.to_owned(),
+        source_id: "qdrant_cloud".to_owned(),
+        family_id: family_id.to_owned(),
+        operation: SourceRuntimeOperation::ReadPage,
+        request_intent_digest: request_intent_digest.clone(),
+        logical_page_id: format!("{family_id}-page-{generation}"),
+        source_generation: generation,
+        authority_epoch: 1,
+    };
+    let credential_lease = OperationScopedCredentialLease::new(
+        CredentialLeaseReference::new(
+            format!("qdrant-{family_id}-lease-{generation}"),
+            context.lease_scope().unwrap(),
+            1_000,
+            1_000,
+        )
+        .unwrap(),
+    );
+    let egress_policy =
+        EgressPolicy::live(tenant_id, family_id, &request_intent_digest, [base_url]).unwrap();
+    let auth = ResolvedAuth::Header {
+        name: "Authorization".to_owned(),
+        value: "apikey fixture-management-key".to_owned(),
+    };
+    assert!(!format!("{auth:?}").contains("fixture-management-key"));
+    HttpSourceConnector::new(
+        source.clone(),
+        family_id,
+        base_url,
+        BTreeMap::from([("account_id".to_owned(), "account-fixture".to_owned())]),
+        auth,
+    )
+    .unwrap()
+    .with_provider_access(HttpProviderAccess::new_with_clock(
+        context,
+        egress_policy,
+        credential_lease,
+        1_500,
+    ))
+}
+
+pub(super) fn qdrant_runtime(
+    source: &CompiledSource,
+    family_id: &str,
+    tenant_id: &str,
+    runtime_id: &str,
+    base_url: &str,
+    generation: u64,
+    store: OrganizationalGraph,
+) -> SourceRuntime<HttpSourceConnector, CatalogGraphMapper, OrganizationalGraph> {
+    let connector = qdrant_connector(
+        source, family_id, tenant_id, runtime_id, base_url, generation,
+    );
+    let mapper = CatalogGraphMapper::new(source.clone(), "qdrant-cloud-v1").unwrap();
+    SourceRuntime::new(connector, mapper, store)
+}

--- a/crates/source-runtime-next/src/qdrant_cloud/restart.rs
+++ b/crates/source-runtime-next/src/qdrant_cloud/restart.rs
@@ -1,0 +1,104 @@
+use cerebro_organizational_graph::{GraphRead, OrganizationalGraph};
+use cerebro_organizational_model::{SourceRuntimeId, TenantId};
+
+use crate::{CollectionRequest, ProviderFailureKind, RuntimeError};
+
+use super::{
+    fixture_server::{accept_request, assert_cluster_request, write_json, write_rate_limit},
+    request_setup::{qdrant_runtime, qdrant_source},
+};
+
+const PAGE_ONE: &str = r#"{"items":[{"id":"cluster-1","name":"Cluster one","status":"ready"}],"next_page_token":"page-2"}"#;
+const PAGE_TWO: &str =
+    r#"{"items":[{"id":"cluster-2","name":"Cluster two","status":"ready"}],"next_page_token":""}"#;
+
+#[tokio::test]
+async fn clusters_retry_and_restart_without_duplicate_identities() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        for request_index in 0..6 {
+            let (socket, request) = accept_request(&listener).await;
+            assert_cluster_request(&request, "account-fixture");
+            let second_page = request_index % 2 == 1;
+            if second_page {
+                assert!(request.contains("page_token=page-2"));
+            } else {
+                assert!(!request.contains("page_token="));
+            }
+            if request_index == 1 {
+                write_rate_limit(socket).await;
+            } else {
+                write_json(socket, if second_page { PAGE_TWO } else { PAGE_ONE }).await;
+            }
+        }
+    });
+
+    let source = qdrant_source();
+    let base_url = format!("http://{address}");
+    let tenant = TenantId::parse("tenant-clusters-restart").unwrap();
+    let runtime_id = SourceRuntimeId::parse("qdrant-clusters-restart").unwrap();
+    let request = || CollectionRequest {
+        tenant_id: tenant.clone(),
+        source_runtime_id: runtime_id.clone(),
+        cursor: None,
+    };
+
+    let mut interrupted = qdrant_runtime(
+        &source,
+        "clusters",
+        tenant.as_str(),
+        runtime_id.as_str(),
+        &base_url,
+        1,
+        OrganizationalGraph::new(),
+    );
+    let error = interrupted.sync(request()).await.unwrap_err();
+    let RuntimeError::Collect(error) = error else {
+        panic!("interrupted collection failed outside the provider boundary");
+    };
+    let classification = error.provider_failure_classification().unwrap();
+    assert_eq!(classification.kind, ProviderFailureKind::RetryAfter);
+    assert!(classification.retryable);
+    assert!(!classification.advances_progress);
+    let graph = interrupted.into_store();
+    assert!(graph.entities(&tenant).is_empty());
+    assert_eq!(graph.graph_revision(&tenant), 0);
+
+    let mut resumed = qdrant_runtime(
+        &source,
+        "clusters",
+        tenant.as_str(),
+        runtime_id.as_str(),
+        &base_url,
+        2,
+        graph,
+    );
+    assert_eq!(resumed.sync(request()).await.unwrap().entities_upserted, 2);
+    let graph = resumed.into_store();
+    let first_ids = graph
+        .entities(&tenant)
+        .into_iter()
+        .map(|entity| entity.id().clone())
+        .collect::<Vec<_>>();
+    assert_eq!(first_ids.len(), 2);
+
+    let mut restarted = qdrant_runtime(
+        &source,
+        "clusters",
+        tenant.as_str(),
+        runtime_id.as_str(),
+        &base_url,
+        3,
+        graph,
+    );
+    restarted.sync(request()).await.unwrap();
+    let restarted_ids = restarted
+        .into_store()
+        .entities(&tenant)
+        .into_iter()
+        .map(|entity| entity.id().clone())
+        .collect::<Vec<_>>();
+    assert_eq!(restarted_ids, first_ids);
+    server.await.unwrap();
+}


### PR DESCRIPTION
## Scope

- Forward follow-up to merged #2768; no rollback and no changes to its branch.
- Rename the inherited Qdrant test module and split it into a small facade with focused accounts, pagination, restart, typed-failure, fixture-network, and credential-origin setup modules.
- Exercise two provider-shaped Qdrant Cloud cluster pages, round-trippable cursors, cursor-as-data origin restriction, rate-limit interruption and resume, restart identity stability, auth-shape rejection, malformed responses, record bounds, response bounds, and cursor bounds.
- Add an environment-gated Postgres and Neo4j test for checkpoint preservation, successful resume, lease-generation fencing, and the existing graph read interface.
- Keep the Go projector unchanged.

## Module map

- qdrant_cloud.rs: small test-support facade
- qdrant_cloud/accounts.rs: accounts normalization, tenant identity, graph projection, and restart stability
- qdrant_cloud/pagination.rs: two cluster pages, cursor round-trip, and origin restriction
- qdrant_cloud/restart.rs: rate-limit interruption, retry, restart, and duplicate prevention
- qdrant_cloud/failures.rs: auth shape, malformed response, record, response, and cursor bounds
- fixture_server.rs and request_setup.rs: loopback provider, credential redaction, origin policy, and lease scope
- organizational-store focused tests: cursor bounds, checkpoint resume, lease fencing, and graph read

## Local recovery evidence

- Rust formatting on every changed file: passed.
- Git diff whitespace validation: passed.
- Factual-name source-tree audit: passed.
- Focused Qdrant Cloud Go projection tests: passed.
- Managed Cargo did not start a build: the DDESK checkout is waiting-for-disk, sync/bootstrap are blocked, and safe build capacity is short by 14,125,107,814 bytes. No new disk was provisioned. Hosted exact-head checks are the Rust compile authority.

## Evidence boundary

- Draft only; do not mark ready or merge.
- This does not create or prove an effective persisted Rust authority record.
- The Postgres and Neo4j test is ignored unless disposable service endpoints are supplied; its presence is not execution evidence.
- No deployment, live provider collection, authenticated product qualification, or Go writer retirement is claimed.