### PR TITLE
Fix Qdrant runtime evidence Clippy and collection-scope checks

### DIFF
--- a/crates/organizational-store/tests/qdrant_cloud_cursor_bounds.rs
+++ b/crates/organizational-store/tests/qdrant_cloud_cursor_bounds.rs
@@ -5,7 +5,7 @@ use cerebro_organizational_store::StoredSourceRuntime;
 
 #[test]
 fn qdrant_runtime_rejects_oversized_durable_cursor() -> Result<(), Box<dyn Error>> {
-    assert!(matches!(
+    assert!(
         StoredSourceRuntime::new(
             SourceRuntimeId::parse("qdrant-cursor-bound")?,
             TenantId::parse("tenant-qdrant-cursor-bound")?,
@@ -14,8 +14,8 @@ fn qdrant_runtime_rejects_oversized_durable_cursor() -> Result<(), Box<dyn Error
             None,
             Some(serde_json::json!({"opaque": "x".repeat((64 * 1024) + 1)})),
             None,
-        ),
-        Err(_)
-    ));
+        )
+        .is_err()
+    );
     Ok(())
 }

--- a/crates/source-runtime-next/src/lib.rs
+++ b/crates/source-runtime-next/src/lib.rs
@@ -59,7 +59,6 @@ mod portable_ai;
 mod protocol;
 mod provider_failure;
 #[cfg(test)]
-#[cfg(test)]
 mod qdrant_cloud;
 mod runtime_config;
 mod runtime_health;

--- a/crates/source-runtime-next/src/qdrant_cloud/pagination.rs
+++ b/crates/source-runtime-next/src/qdrant_cloud/pagination.rs
@@ -71,10 +71,7 @@ async fn clusters_round_trip_two_pages_and_keep_cursor_on_the_declared_origin() 
         })
         .await
         .unwrap();
-    assert!(matches!(
-        &page_one.scope,
-        CollectedScope::NonAuthoritative(_)
-    ));
+    assert!(matches!(&page_one.scope, CollectedScope::Complete(_)));
     assert_eq!(page_one.records[0].provider_id, "cluster-1");
     assert_eq!(page_one.next_cursor.as_deref(), Some("page-2"));
 


### PR DESCRIPTION
## Summary

- remove the duplicated test-only cfg attribute that fails Clippy
- use the direct error assertion required by Clippy for the durable cursor bound
- assert the catalog-correct Complete collection scope in the cluster pagination test

Complete collection scope records pagination completeness and enables collection semantics such as missing-record handling. It is not the persisted source-family projection-authority record.

## Validation

- direct Rust 2024 formatting check for all three changed Rust files
- git diff --check
- exact-head hosted checks are running

Managed local Cargo execution remains unavailable because the required build environment is capacity-blocked. The previous exact head proved both Clippy diagnostics were fixed, then exposed the incorrect collection-scope assertion; this new head includes that forward test correction.

## Evidence boundary

This repair does not promote qdrant_cloud, change the organizational_projection_authority row, retire a Go writer, deploy a runtime, or prove a provider or product request. Keep the pull request draft until exact-head hosted checks are terminal and normal repository protection is satisfied.