### PR TITLE
Source families: draft Rust promotion gate pending persisted receipt verification

### DIFF
--- a/crates/cerebro-platform/examples/organizational_graph_e2e.rs
+++ b/crates/cerebro-platform/examples/organizational_graph_e2e.rs
@@ -17,7 +17,7 @@ use cerebro_organizational_store::{
     CutoverPolicy, DurableGraphStore, Neo4jProjector, ParityReceipt, PostgresLedger,
     ProjectionAuthority, ProjectionPromotionRequest,
 };
-use cerebro_source_catalog::SourceCatalog;
+use cerebro_source_catalog::{AuthorityQualificationEvidence, SourceCatalog};
 use cerebro_source_runtime_next::{CollectedBatch, CollectedScope, GraphSink, SourceRecord};
 use hmac::{Hmac, KeyInit, Mac};
 use prost::Message;
@@ -737,6 +737,15 @@ fn promotion_request(
     family: &str,
     promoted_at: i64,
 ) -> Result<ProjectionPromotionRequest, Box<dyn Error>> {
+    let evidence_root = PathBuf::from(env::var("CEREBRO_AUTHORITY_EVIDENCE_DIR")?);
+    let evidence_path = evidence_root.join(source).join(format!("{family}.json"));
+    let qualification: AuthorityQualificationEvidence =
+        serde_json::from_slice(&fs::read(&evidence_path).map_err(|error| {
+            format!(
+                "read authority evidence {}: {error}",
+                evidence_path.to_string_lossy()
+            )
+        })?)?;
     Ok(ProjectionPromotionRequest::new(
         TENANT,
         source,
@@ -744,6 +753,7 @@ fn promotion_request(
         CutoverPolicy::new(3, 0)?,
         0,
         promoted_at,
+        qualification,
     )?)
 }
 

--- a/crates/cerebro-platform/src/cutover_command.rs
+++ b/crates/cerebro-platform/src/cutover_command.rs
@@ -1,20 +1,30 @@
 use std::{
     env,
     error::Error,
+    path::Path,
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use cerebro_organizational_store::{CutoverPolicy, PostgresLedger, ProjectionPromotionRequest};
+use cerebro_source_catalog::AuthorityQualificationEvidence;
 use cerebro_source_catalog::SourceCatalog;
 use serde::Serialize;
 
-use crate::{CatalogFamilyFilter, catalog_family_records, load_catalog, required_env};
+use crate::{
+    CatalogFamilyFilter, catalog_family_records,
+    cutover_evidence::{
+        authority_qualification_root, load_family_authority_qualification,
+        load_single_authority_qualification,
+    },
+    load_catalog, required_env,
+};
 
 fn promotion_request(
     tenant_id: String,
     source_id: String,
     family_id: String,
     promoted_at_unix_ms: i64,
+    qualification: AuthorityQualificationEvidence,
 ) -> Result<ProjectionPromotionRequest, Box<dyn Error>> {
     Ok(ProjectionPromotionRequest::new(
         tenant_id,
@@ -23,6 +33,7 @@ fn promotion_request(
         CutoverPolicy::new(3, 0)?,
         0,
         promoted_at_unix_ms,
+        qualification,
     )?)
 }
 
@@ -85,9 +96,16 @@ async fn ledger_and_request() -> Result<(PostgresLedger, ProjectionPromotionRequ
     ledger.migrate().await?;
     let evaluated_at_unix_ms =
         i64::try_from(SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis())?;
+    let qualification = load_single_authority_qualification()?;
     Ok((
         ledger,
-        promotion_request(tenant_id, source_id, family_id, evaluated_at_unix_ms)?,
+        promotion_request(
+            tenant_id,
+            source_id,
+            family_id,
+            evaluated_at_unix_ms,
+            qualification,
+        )?,
     ))
 }
 
@@ -217,6 +235,7 @@ async fn evaluate_one_family(
     family_id: &str,
     evaluated_at_unix_ms: i64,
     promote_ready: bool,
+    qualification_root: &Path,
 ) -> FamilyCutoverOutcome {
     let mut outcome = FamilyCutoverOutcome {
         source_id: source_id.to_owned(),
@@ -227,11 +246,20 @@ async fn evaluate_one_family(
         evidence_digest: None,
         error: None,
     };
+    let qualification =
+        match load_family_authority_qualification(qualification_root, source_id, family_id) {
+            Ok(qualification) => qualification,
+            Err(error) => {
+                outcome.error = Some(error.to_string());
+                return outcome;
+            }
+        };
     let request = match promotion_request(
         tenant_id.to_owned(),
         source_id.to_owned(),
         family_id.to_owned(),
         evaluated_at_unix_ms,
+        qualification,
     ) {
         Ok(request) => request,
         Err(error) => {
@@ -280,6 +308,7 @@ pub(crate) async fn evaluate_all_families() -> Result<(), Box<dyn Error>> {
     ledger.migrate().await?;
     let evaluated_at_unix_ms =
         i64::try_from(SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis())?;
+    let qualification_root = authority_qualification_root()?;
 
     let scopes = catalog_family_scopes(&catalog, &args.filter);
     let stdout = std::io::stdout();
@@ -294,6 +323,7 @@ pub(crate) async fn evaluate_all_families() -> Result<(), Box<dyn Error>> {
             &family_id,
             evaluated_at_unix_ms,
             args.promote_ready,
+            &qualification_root,
         )
         .await;
         summary.record(&outcome);
@@ -307,21 +337,6 @@ pub(crate) async fn evaluate_all_families() -> Result<(), Box<dyn Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn promotion_request_keeps_the_production_gate_strict() {
-        let request = promotion_request(
-            "tenant-a".to_owned(),
-            "box".to_owned(),
-            "users".to_owned(),
-            1,
-        )
-        .unwrap();
-        assert_eq!(request.tenant_id(), "tenant-a");
-        assert_eq!(request.source_id(), "box");
-        assert_eq!(request.family_id(), "users");
-        assert_eq!(request.projection_lag(), 0);
-    }
 
     #[test]
     fn family_scope_identifier_prefers_argument_then_environment() {

--- a/crates/cerebro-platform/src/cutover_evidence.rs
+++ b/crates/cerebro-platform/src/cutover_evidence.rs
@@ -1,0 +1,119 @@
+use std::{
+    error::Error,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use cerebro_source_catalog::AuthorityQualificationEvidence;
+
+use crate::required_env;
+
+pub(crate) fn load_single_authority_qualification()
+-> Result<AuthorityQualificationEvidence, Box<dyn Error>> {
+    let path = PathBuf::from(required_env("CEREBRO_AUTHORITY_EVIDENCE_PATH")?);
+    load_authority_qualification(&path)
+}
+
+pub(crate) fn authority_qualification_root() -> Result<PathBuf, Box<dyn Error>> {
+    Ok(PathBuf::from(required_env(
+        "CEREBRO_AUTHORITY_EVIDENCE_DIR",
+    )?))
+}
+
+pub(crate) fn load_family_authority_qualification(
+    root: &Path,
+    source_id: &str,
+    family_id: &str,
+) -> Result<AuthorityQualificationEvidence, Box<dyn Error>> {
+    load_authority_qualification(&root.join(source_id).join(format!("{family_id}.json")))
+}
+
+fn load_authority_qualification(
+    path: &Path,
+) -> Result<AuthorityQualificationEvidence, Box<dyn Error>> {
+    let bytes = fs::read(path).map_err(|error| {
+        format!(
+            "read authority evidence {}: {error}",
+            path.to_string_lossy()
+        )
+    })?;
+    decode_authority_qualification(&bytes).map_err(|error| {
+        format!(
+            "decode authority evidence {}: {error}",
+            path.to_string_lossy()
+        )
+        .into()
+    })
+}
+
+fn decode_authority_qualification(
+    bytes: &[u8],
+) -> Result<AuthorityQualificationEvidence, serde_json::Error> {
+    serde_json::from_slice(bytes)
+}
+
+#[cfg(test)]
+pub(crate) fn authority_qualification_fixture(
+    catalog: &cerebro_source_catalog::SourceCatalog,
+    source_id: &str,
+    family_id: &str,
+    corpus: &str,
+) -> AuthorityQualificationEvidence {
+    use cerebro_source_runtime_next::source_execution::{
+        SourceExecutionDispatcher, SourceExecutionSelectionRequestV1,
+    };
+
+    let plan_digest = catalog
+        .compiled_family_plan_digest(source_id, family_id)
+        .unwrap();
+    let runtime_plan_digest = SourceExecutionDispatcher
+        .compile_plan(&SourceExecutionSelectionRequestV1 {
+            source_id: source_id.to_owned(),
+            family_id: family_id.to_owned(),
+        })
+        .unwrap()
+        .plan_digest_sha256;
+    AuthorityQualificationEvidence {
+        plan_digest,
+        runtime_plan_digest,
+        fixture_corpus_revision: corpus.to_owned(),
+        supported_auth_modes: vec!["api_key".to_owned()],
+        supported_pagination_grammar: vec!["cursor".to_owned()],
+        supported_provider_errors: vec!["unauthorized".to_owned()],
+        egress_allowlist: vec!["https://provider.example.test".to_owned()],
+        response_limits: "body=1048576,decompression=4x".to_owned(),
+        credential_lease_mode: "one_operation".to_owned(),
+        projection_dependency: "rust_projection".to_owned(),
+        rollback_receipt: "receipt:rollback".to_owned(),
+        parity_status: "passed".to_owned(),
+        canonical_digest_vectors: vec!["plan".to_owned()],
+        config_safety_proof: "receipt:config".to_owned(),
+        cursor_checkpoint_proof: "receipt:checkpoint".to_owned(),
+        fencing_recovery_proof: "receipt:fencing".to_owned(),
+        worker_build_id: "source-runtime-next:test".to_owned(),
+        promotion_receipt: "sig:promotion:test".to_owned(),
+        authenticated_collection_receipt: "receipt:collection".to_owned(),
+        append_projection_checkpoint_receipt: "receipt:durable".to_owned(),
+        lease_restart_receipt: "receipt:restart".to_owned(),
+        product_read_receipt: "receipt:product-read".to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evidence_input_rejects_unknown_or_incomplete_json_shapes() {
+        assert!(decode_authority_qualification(br#"{"plan_digest":"abc"}"#).is_err());
+        let catalog = crate::load_catalog().unwrap();
+        let complete =
+            authority_qualification_fixture(&catalog, "asana", "users", "fixture-corpus:test");
+        let mut value = serde_json::to_value(complete).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("unexpected".to_owned(), true.into());
+        assert!(decode_authority_qualification(&serde_json::to_vec(&value).unwrap()).is_err());
+    }
+}

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -4,6 +4,7 @@ mod append_log_consumer;
 mod ask_queries;
 mod audit_events;
 mod cutover_command;
+mod cutover_evidence;
 mod graph_provenance;
 mod oidc;
 mod parity_command;
@@ -8239,7 +8240,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore = "requires disposable PostgreSQL and Neo4j instances"]
-    async fn promoted_box_family_projects_only_through_rust() {
+    async fn promoted_asana_family_projects_only_through_rust() {
         let postgres_dsn = env::var("CEREBRO_TEST_POSTGRES_DSN").unwrap();
         let authority = PostgresLedger::connect_tls(&postgres_dsn).await.unwrap();
         authority.migrate().await.unwrap();
@@ -8258,15 +8259,15 @@ mod tests {
             .unwrap()
             .as_nanos()
             .to_string();
-        let tenant_id = format!("platform-cutover-{suffix}");
+        let tenant_id = format!("platform-promotion-evidence-{suffix}");
         for index in 1..=3 {
             authority
                 .record_parity(
                     &cerebro_organizational_store::ParityReceipt::compare_scoped(
                         tenant_id.clone(),
-                        "box-runtime",
-                        "box",
-                        "content_assets",
+                        "asana-runtime",
+                        "asana",
+                        "users",
                         format!("corpus-{suffix}-{index}"),
                         "sha256:equal",
                         "sha256:equal",
@@ -8279,16 +8280,23 @@ mod tests {
                 .unwrap();
         }
         let catalog = load_catalog().unwrap();
+        let qualification = cutover_evidence::authority_qualification_fixture(
+            &catalog,
+            "asana",
+            "users",
+            &format!("corpus-{suffix}-3"),
+        );
         authority
             .evaluate_and_promote_projection_authority(
                 &catalog,
                 &cerebro_organizational_store::ProjectionPromotionRequest::new(
                     tenant_id.clone(),
-                    "box",
-                    "content_assets",
+                    "asana",
+                    "users",
                     cerebro_organizational_store::CutoverPolicy::new(3, 0).unwrap(),
                     0,
                     100,
+                    qualification,
                 )
                 .unwrap(),
             )
@@ -8299,30 +8307,27 @@ mod tests {
             authority,
             store: Mutex::new(DurableGraphStore::new(store_ledger, graph.clone())),
         });
-        let resource_urn = format!("urn:cerebro:{tenant_id}:runtime_file:asset-1");
         let response = runtime
             .project_committed_with_intent(
                 CommittedSourceEvent::from_input(
                     cerebro_source_runtime_next::CommittedSourceInput {
                         tenant_id: TenantId::parse(tenant_id.clone()).unwrap(),
-                        source_runtime_id: SourceRuntimeId::parse("box-runtime").unwrap(),
+                        source_runtime_id: SourceRuntimeId::parse("asana-runtime").unwrap(),
                         observation_id: ObservationId::parse("event-1").unwrap(),
-                        source_id: "box".to_owned(),
-                        family_id: "content_assets".to_owned(),
-                        event_kind: "box.content_assets".to_owned(),
-                        schema_ref: "box/content_assets/v1".to_owned(),
+                        source_id: "asana".to_owned(),
+                        family_id: "users".to_owned(),
+                        event_kind: "asana.users".to_owned(),
+                        schema_ref: "asana/users/v1".to_owned(),
                         observed_at_unix_ms: 100,
                         attributes: BTreeMap::from([
-                            ("resource_id".to_owned(), "asset-1".to_owned()),
-                            ("resource_name".to_owned(), "Architecture".to_owned()),
-                            ("resource_type".to_owned(), "file".to_owned()),
-                            ("resource_urn".to_owned(), resource_urn.clone()),
+                            ("tenant_id".to_owned(), tenant_id.clone()),
+                            ("source_event_id".to_owned(), "event-1".to_owned()),
+                            ("user_id".to_owned(), "user-1".to_owned()),
                         ]),
                         payload: serde_json::json!({
-                            "id": "asset-1",
-                            "name": "Architecture",
-                            "type": "file",
-                            "resource_urn": resource_urn.clone()
+                            "gid": "user-1",
+                            "name": "Person One",
+                            "email": "person@example.test"
                         }),
                     },
                 )
@@ -8333,9 +8338,23 @@ mod tests {
             .unwrap();
         assert!(response.projected);
         let tenant = TenantId::parse(tenant_id).unwrap();
-        let entity = graph.resolve(&tenant, &resource_urn).await.unwrap();
-        assert_eq!(entity.label, "Architecture");
-        assert_eq!(entity.properties.get("resource_urn"), Some(&resource_urn));
+        let provider = ProviderIdentity::new(
+            tenant.clone(),
+            SourceRuntimeId::parse("asana-runtime").unwrap(),
+            ProviderKind::parse("asana.identity_user").unwrap(),
+            "user-1",
+            "Person One",
+        )
+        .unwrap();
+        let entity = graph
+            .resolve(&tenant, provider.entity().id().as_str())
+            .await
+            .unwrap();
+        assert_eq!(entity.label, "Person One");
+        assert_eq!(
+            entity.properties.get("email").map(String::as_str),
+            Some("person@example.test")
+        );
     }
 
     #[test]

--- a/crates/organizational-store/src/cutover.rs
+++ b/crates/organizational-store/src/cutover.rs
@@ -1,10 +1,14 @@
 use std::{collections::BTreeMap, error::Error, fmt};
 
-use cerebro_source_catalog::SourceCatalog;
-use serde::Serialize;
+use cerebro_source_catalog::{
+    AuthorityQualificationEvidence, SourceCatalog, authority_qualification_digest,
+};
 use sha2::{Digest, Sha256};
 
-use crate::{ParityReceipt, ParityStatus};
+use crate::{
+    ParityReceipt, ParityStatus,
+    promotion::{CutoverDecision, promotion_evidence_reasons},
+};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CutoverPolicy {
@@ -24,121 +28,6 @@ impl CutoverPolicy {
             min_consecutive_matches,
             max_projection_lag,
         })
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ProjectionPromotionRequest {
-    tenant_id: String,
-    source_id: String,
-    family_id: String,
-    policy: CutoverPolicy,
-    projection_lag: u64,
-    promoted_at_unix_ms: i64,
-}
-
-impl ProjectionPromotionRequest {
-    pub fn new(
-        tenant_id: impl Into<String>,
-        source_id: impl Into<String>,
-        family_id: impl Into<String>,
-        policy: CutoverPolicy,
-        projection_lag: u64,
-        promoted_at_unix_ms: i64,
-    ) -> Result<Self, CutoverError> {
-        let tenant_id = checked_text(tenant_id.into(), "tenant_id")?;
-        let source_id = checked_text(source_id.into(), "source_id")?;
-        let family_id = checked_text(family_id.into(), "family_id")?;
-        if promoted_at_unix_ms <= 0 {
-            return Err(CutoverError::Invalid("promoted_at_unix_ms"));
-        }
-        Ok(Self {
-            tenant_id,
-            source_id,
-            family_id,
-            policy,
-            projection_lag,
-            promoted_at_unix_ms,
-        })
-    }
-
-    pub fn tenant_id(&self) -> &str {
-        &self.tenant_id
-    }
-
-    pub fn source_id(&self) -> &str {
-        &self.source_id
-    }
-
-    pub fn family_id(&self) -> &str {
-        &self.family_id
-    }
-
-    pub(crate) fn policy(&self) -> CutoverPolicy {
-        self.policy
-    }
-
-    pub fn projection_lag(&self) -> u64 {
-        self.projection_lag
-    }
-
-    pub(crate) fn promoted_at_unix_ms(&self) -> i64 {
-        self.promoted_at_unix_ms
-    }
-}
-
-fn checked_text(value: String, field: &'static str) -> Result<String, CutoverError> {
-    if value.is_empty() || value.trim() != value {
-        return Err(CutoverError::Invalid(field));
-    }
-    Ok(value)
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-pub struct CutoverDecision {
-    source_id: String,
-    family_id: String,
-    allowed: bool,
-    reasons: Vec<String>,
-    evidence_digest: String,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ProjectionAuthority {
-    Legacy,
-    Rust,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-pub struct ProjectionAuthorityRecord {
-    pub tenant_id: String,
-    pub source_id: String,
-    pub family_id: String,
-    pub authority: ProjectionAuthority,
-    pub evidence_digest: String,
-    pub promoted_at_unix_ms: Option<i64>,
-}
-
-impl CutoverDecision {
-    pub fn source_id(&self) -> &str {
-        &self.source_id
-    }
-
-    pub fn family_id(&self) -> &str {
-        &self.family_id
-    }
-
-    pub fn is_allowed(&self) -> bool {
-        self.allowed
-    }
-
-    pub fn reasons(&self) -> &[String] {
-        &self.reasons
-    }
-
-    pub fn evidence_digest(&self) -> &str {
-        &self.evidence_digest
     }
 }
 
@@ -177,19 +66,24 @@ impl CutoverGate {
     pub fn evaluate(
         &self,
         catalog: &SourceCatalog,
+        tenant_id: &str,
         source_id: &str,
         family_id: &str,
         receipts: &[ParityReceipt],
         projection_lag: u64,
+        qualification: &AuthorityQualificationEvidence,
     ) -> Result<CutoverDecision, CutoverError> {
         let source = catalog
             .get(source_id)
             .ok_or_else(|| CutoverError::UnknownSource(source_id.to_owned()))?;
-        let mut reasons = Vec::new();
+        let mut reasons = promotion_evidence_reasons(catalog, source_id, family_id, qualification)?;
         let family = source
             .families()
             .iter()
             .find(|family| family.id() == family_id)
+            .ok_or_else(|| CutoverError::UnknownSource(format!("{source_id}/{family_id}")))?;
+        let catalog_plan_digest = catalog
+            .compiled_family_plan_digest(source_id, family_id)
             .ok_or_else(|| CutoverError::UnknownSource(format!("{source_id}/{family_id}")))?;
         if !family.is_projection_authoritative() {
             reasons.push("provider method and path proof is incomplete".to_owned());
@@ -203,11 +97,24 @@ impl CutoverGate {
                 self.policy.max_projection_lag
             ));
         }
-        let source_receipts: Vec<_> = receipts
+        if receipts.iter().any(|receipt| {
+            receipt.source_id() == source_id
+                && receipt.family_id() == family_id
+                && receipt.tenant_id() != tenant_id
+        }) {
+            reasons.push("parity receipt tenant does not match promotion request".to_owned());
+        }
+        let mut source_receipts: Vec<_> = receipts
             .iter()
+            .filter(|receipt| receipt.tenant_id() == tenant_id)
             .filter(|receipt| receipt.source_id() == source_id)
             .filter(|receipt| receipt.family_id() == family_id)
             .collect();
+        source_receipts.sort_by(|left, right| {
+            left.compared_at_unix_ms()
+                .cmp(&right.compared_at_unix_ms())
+                .then_with(|| left.receipt_digest().cmp(right.receipt_digest()))
+        });
         let consecutive = source_receipts
             .iter()
             .rev()
@@ -220,8 +127,8 @@ impl CutoverGate {
             ));
         }
         let mut latest_by_corpus = BTreeMap::new();
-        for receipt in source_receipts {
-            latest_by_corpus.insert(receipt.collection_id(), receipt);
+        for receipt in &source_receipts {
+            latest_by_corpus.insert(receipt.collection_id(), *receipt);
         }
         if latest_by_corpus
             .values()
@@ -235,20 +142,36 @@ impl CutoverGate {
         {
             reasons.push("a latest parity receipt exceeds the projection lag policy".to_owned());
         }
+        if source_receipts
+            .last()
+            .is_some_and(|receipt| receipt.collection_id() != qualification.fixture_corpus_revision)
+        {
+            reasons
+                .push("qualification fixture corpus is not the latest parity receipt".to_owned());
+        }
+        let qualification_digest = authority_qualification_digest(qualification);
         let evidence_digest = digest(
-            &receipts
+            &source_receipts
                 .iter()
-                .filter(|receipt| receipt.source_id() == source_id)
-                .filter(|receipt| receipt.family_id() == family_id)
-                .map(ParityReceipt::receipt_digest)
+                .map(|receipt| receipt.receipt_digest())
+                .chain([
+                    tenant_id,
+                    source_id,
+                    family_id,
+                    qualification_digest.as_str(),
+                    catalog_plan_digest.as_str(),
+                    qualification.runtime_plan_digest.as_str(),
+                ])
                 .collect::<Vec<_>>(),
         );
         Ok(CutoverDecision {
+            tenant_id: tenant_id.to_owned(),
             source_id: source_id.to_owned(),
             family_id: family_id.to_owned(),
             allowed: reasons.is_empty(),
             reasons,
             evidence_digest,
+            qualification: qualification.clone(),
         })
     }
 }
@@ -272,6 +195,9 @@ fn digest(parts: &[&str]) -> String {
 mod tests {
     use super::*;
     use crate::SemanticSnapshot;
+    use cerebro_source_runtime_next::source_execution::{
+        SourceExecutionDispatcher, SourceExecutionError, SourceExecutionSelectionRequestV1,
+    };
     use std::path::{Path, PathBuf};
 
     fn repository_root() -> PathBuf {
@@ -281,8 +207,52 @@ mod tests {
             .unwrap()
     }
 
+    fn qualification(
+        catalog: &SourceCatalog,
+        source_id: &str,
+        family_id: &str,
+        corpus: &str,
+    ) -> AuthorityQualificationEvidence {
+        let plan_digest = catalog
+            .compiled_family_plan_digest(source_id, family_id)
+            .unwrap();
+        let selection = SourceExecutionSelectionRequestV1 {
+            source_id: source_id.to_owned(),
+            family_id: family_id.to_owned(),
+        };
+        let runtime_plan_digest = match SourceExecutionDispatcher.compile_plan(&selection) {
+            Ok(plan) => plan.plan_digest_sha256,
+            Err(SourceExecutionError::UnknownAdapter) => plan_digest.clone(),
+            Err(error) => panic!("compile runtime plan: {error}"),
+        };
+        AuthorityQualificationEvidence {
+            plan_digest,
+            runtime_plan_digest,
+            fixture_corpus_revision: corpus.to_owned(),
+            supported_auth_modes: vec!["api_key".to_owned()],
+            supported_pagination_grammar: vec!["cursor".to_owned()],
+            supported_provider_errors: vec!["unauthorized".to_owned()],
+            egress_allowlist: vec!["https://provider.example.test".to_owned()],
+            response_limits: "body=1048576,decompression=4x".to_owned(),
+            credential_lease_mode: "one_operation".to_owned(),
+            projection_dependency: "rust_projection".to_owned(),
+            rollback_receipt: "receipt:rollback".to_owned(),
+            parity_status: "passed".to_owned(),
+            canonical_digest_vectors: vec!["plan".to_owned()],
+            config_safety_proof: "receipt:config".to_owned(),
+            cursor_checkpoint_proof: "receipt:checkpoint".to_owned(),
+            fencing_recovery_proof: "receipt:fencing".to_owned(),
+            worker_build_id: "source-runtime-next:test".to_owned(),
+            promotion_receipt: "sig:promotion:test".to_owned(),
+            authenticated_collection_receipt: "receipt:collection".to_owned(),
+            append_projection_checkpoint_receipt: "receipt:durable".to_owned(),
+            lease_restart_receipt: "receipt:restart".to_owned(),
+            product_read_receipt: "receipt:product-read".to_owned(),
+        }
+    }
+
     #[test]
-    fn cutover_requires_proof_three_matches_and_zero_lag() {
+    fn promotion_gate_requires_complete_proof_three_matches_and_zero_lag() {
         let root = repository_root();
         let catalog = SourceCatalog::load(
             root.join("internal/connectorcatalog/catalog"),
@@ -291,8 +261,10 @@ mod tests {
         .unwrap();
         let receipts: Vec<_> = (1..=3)
             .map(|index| {
-                ParityReceipt::compare(
-                    "box",
+                ParityReceipt::compare_scoped(
+                    "tenant-a",
+                    "asana-runtime",
+                    "asana",
                     "users",
                     format!("corpus-{index}"),
                     "sha256:same",
@@ -304,62 +276,137 @@ mod tests {
             })
             .collect();
         let gate = CutoverGate::new(CutoverPolicy::new(3, 0).unwrap());
+        let qualification = qualification(&catalog, "asana", "users", "corpus-3");
+        let tenant_a = gate
+            .evaluate(
+                &catalog,
+                "tenant-a",
+                "asana",
+                "users",
+                &receipts,
+                0,
+                &qualification,
+            )
+            .unwrap();
+        assert!(tenant_a.is_allowed());
+        let tenant_b = gate
+            .evaluate(
+                &catalog,
+                "tenant-b",
+                "asana",
+                "users",
+                &receipts,
+                0,
+                &qualification,
+            )
+            .unwrap();
+        assert!(!tenant_b.is_allowed());
         assert!(
-            gate.evaluate(&catalog, "box", "users", &receipts, 0)
+            tenant_b.reasons().iter().any(|reason| {
+                reason == "parity receipt tenant does not match promotion request"
+            })
+        );
+        assert_ne!(tenant_a.evidence_digest(), tenant_b.evidence_digest());
+        let shuffled = vec![
+            receipts[2].clone(),
+            receipts[0].clone(),
+            receipts[1].clone(),
+        ];
+        let shuffled_decision = gate
+            .evaluate(
+                &catalog,
+                "tenant-a",
+                "asana",
+                "users",
+                &shuffled,
+                0,
+                &qualification,
+            )
+            .unwrap();
+        assert!(
+            shuffled_decision.is_allowed(),
+            "receipt order must not change the latest qualifying parity sequence"
+        );
+        assert_eq!(
+            shuffled_decision.evidence_digest(),
+            tenant_a.evidence_digest()
+        );
+        assert!(
+            !gate
+                .evaluate(
+                    &catalog,
+                    "tenant-a",
+                    "asana",
+                    "users",
+                    &receipts[..2],
+                    0,
+                    &qualification
+                )
                 .unwrap()
                 .is_allowed()
         );
         assert!(
             !gate
-                .evaluate(&catalog, "box", "users", &receipts[..2], 0)
-                .unwrap()
-                .is_allowed()
-        );
-        assert!(
-            !gate
-                .evaluate(&catalog, "agiloft", "users", &receipts, 0)
+                .evaluate(
+                    &catalog,
+                    "tenant-a",
+                    "agiloft",
+                    "users",
+                    &receipts,
+                    0,
+                    &qualification,
+                )
                 .unwrap()
                 .is_allowed()
         );
     }
 
     #[test]
-    fn promotion_request_and_decision_bind_the_exact_scope() {
-        let policy = CutoverPolicy::new(3, 2).unwrap();
-        let request =
-            ProjectionPromotionRequest::new("tenant-a", "box", "users", policy, 1, 100).unwrap();
-        assert_eq!(request.tenant_id(), "tenant-a");
-        assert_eq!(request.source_id(), "box");
-        assert_eq!(request.family_id(), "users");
-        assert_eq!(request.policy(), policy);
-        assert_eq!(request.projection_lag(), 1);
-        assert_eq!(request.promoted_at_unix_ms(), 100);
-
-        assert_eq!(CutoverPolicy::new(2, 0), Err(CutoverError::UnsafePolicy));
-        assert_eq!(
-            ProjectionPromotionRequest::new("", "box", "users", policy, 0, 1),
-            Err(CutoverError::Invalid("tenant_id"))
-        );
-        assert_eq!(
-            ProjectionPromotionRequest::new("tenant", " box", "users", policy, 0, 1),
-            Err(CutoverError::Invalid("source_id"))
-        );
-        assert_eq!(
-            ProjectionPromotionRequest::new("tenant", "box", "users", policy, 0, 0),
-            Err(CutoverError::Invalid("promoted_at_unix_ms"))
-        );
-        assert_eq!(
-            CutoverError::UnsafePolicy.to_string(),
-            "cutover requires at least three matching runs"
-        );
-        assert_eq!(
-            CutoverError::UnknownSource("missing".to_owned()).to_string(),
-            "source missing is not in the catalog"
+    fn catalog_only_family_cannot_pass_without_a_closed_runtime_adapter() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let receipts = (1..=3)
+            .map(|index| {
+                ParityReceipt::compare_scoped(
+                    "tenant-a",
+                    "box-runtime",
+                    "box",
+                    "content_assets",
+                    format!("corpus-{index}"),
+                    "sha256:same",
+                    "sha256:same",
+                    true,
+                    index,
+                )
+                .unwrap()
+            })
+            .collect::<Vec<_>>();
+        let qualification = qualification(&catalog, "box", "content_assets", "corpus-3");
+        let decision = CutoverGate::new(CutoverPolicy::new(3, 0).unwrap())
+            .evaluate(
+                &catalog,
+                "tenant-a",
+                "box",
+                "content_assets",
+                &receipts,
+                0,
+                &qualification,
+            )
+            .unwrap();
+        assert!(!decision.is_allowed());
+        assert!(
+            decision.reasons().iter().any(|reason| {
+                reason == "closed Rust source-execution adapter is not registered"
+            })
         );
     }
 
     #[test]
-    fn cutover_reports_each_failed_proof_instead_of_collapsing_them() {
+    fn promotion_gate_reports_each_failed_proof_instead_of_collapsing_them() {
         let root = repository_root();
         let catalog = SourceCatalog::load(
             root.join("internal/connectorcatalog/catalog"),
@@ -369,8 +416,8 @@ mod tests {
         let receipts = vec![
             ParityReceipt::compare_scoped(
                 "tenant-a",
-                "box-prod",
-                "box",
+                "asana-prod",
+                "asana",
                 "users",
                 "corpus-1",
                 "sha256:same",
@@ -381,8 +428,8 @@ mod tests {
             .unwrap(),
             ParityReceipt::compare_scoped(
                 "tenant-a",
-                "box-prod",
-                "box",
+                "asana-prod",
+                "asana",
                 "users",
                 "corpus-2",
                 "sha256:left",
@@ -393,8 +440,8 @@ mod tests {
             .unwrap(),
             ParityReceipt::compare_scoped(
                 "tenant-a",
-                "box-prod",
-                "box",
+                "asana-prod",
+                "asana",
                 "users",
                 "corpus-3",
                 "sha256:same",
@@ -405,10 +452,20 @@ mod tests {
             .unwrap(),
         ];
         let gate = CutoverGate::new(CutoverPolicy::new(3, 0).unwrap());
+        let qualification = qualification(&catalog, "asana", "users", "corpus-3");
         let decision = gate
-            .evaluate(&catalog, "box", "users", &receipts, 4)
+            .evaluate(
+                &catalog,
+                "tenant-a",
+                "asana",
+                "users",
+                &receipts,
+                4,
+                &qualification,
+            )
             .unwrap();
-        assert_eq!(decision.source_id(), "box");
+        assert_eq!(decision.tenant_id(), "tenant-a");
+        assert_eq!(decision.source_id(), "asana");
         assert_eq!(decision.family_id(), "users");
         assert!(!decision.is_allowed());
         assert!(
@@ -430,14 +487,36 @@ mod tests {
                 .any(|reason| reason == "latest corpus comparison is not a match")
         );
         assert!(decision.evidence_digest().starts_with("sha256:"));
+        let decision_json = serde_json::to_value(&decision).unwrap();
+        assert_eq!(decision_json["tenant_id"], "tenant-a");
+        assert_eq!(
+            decision_json["qualification"]["product_read_receipt"],
+            "receipt:product-read"
+        );
 
         assert_eq!(
-            gate.evaluate(&catalog, "missing", "users", &receipts, 0),
+            gate.evaluate(
+                &catalog,
+                "tenant-a",
+                "missing",
+                "users",
+                &receipts,
+                0,
+                &qualification,
+            ),
             Err(CutoverError::UnknownSource("missing".to_owned()))
         );
         assert_eq!(
-            gate.evaluate(&catalog, "box", "missing", &receipts, 0),
-            Err(CutoverError::UnknownSource("box/missing".to_owned()))
+            gate.evaluate(
+                &catalog,
+                "tenant-a",
+                "asana",
+                "missing",
+                &receipts,
+                0,
+                &qualification,
+            ),
+            Err(CutoverError::UnknownSource("asana/missing".to_owned()))
         );
     }
 
@@ -449,8 +528,10 @@ mod tests {
             root.join("sources"),
         )
         .unwrap();
-        let base = ParityReceipt::compare(
-            "box",
+        let base = ParityReceipt::compare_scoped(
+            "tenant-a",
+            "asana-runtime",
+            "asana",
             "users",
             "corpus-1",
             "sha256:same",
@@ -460,9 +541,9 @@ mod tests {
         )
         .unwrap();
         let legacy = SemanticSnapshot::from_facts(
-            "legacy-shadow",
-            "legacy-shadow",
-            "box",
+            "tenant-a",
+            "asana-runtime",
+            "asana",
             "users",
             "corpus-1",
             "legacy-shadow",
@@ -472,9 +553,9 @@ mod tests {
         )
         .unwrap();
         let rust = SemanticSnapshot::from_facts(
-            "legacy-shadow",
-            "legacy-shadow",
-            "box",
+            "tenant-a",
+            "asana-runtime",
+            "asana",
             "users",
             "corpus-1",
             "legacy-shadow",
@@ -486,8 +567,17 @@ mod tests {
         let lagged =
             ParityReceipt::compare_snapshots(&legacy, &rust, 3, 2, BTreeMap::new()).unwrap();
         let gate = CutoverGate::new(CutoverPolicy::new(3, 0).unwrap());
+        let qualification = qualification(&catalog, "asana", "users", "corpus-1");
         let decision = gate
-            .evaluate(&catalog, "box", "users", &[base.clone(), base, lagged], 0)
+            .evaluate(
+                &catalog,
+                "tenant-a",
+                "asana",
+                "users",
+                &[base.clone(), base, lagged],
+                0,
+                &qualification,
+            )
             .unwrap();
         assert!(!decision.is_allowed());
         assert!(decision

--- a/crates/organizational-store/src/lib.rs
+++ b/crates/organizational-store/src/lib.rs
@@ -30,11 +30,9 @@ mod neo4j;
 mod page_publication;
 mod parity;
 mod postgres;
+mod promotion;
 
-pub use cutover::{
-    CutoverDecision, CutoverGate, CutoverPolicy, ProjectionAuthority, ProjectionAuthorityRecord,
-    ProjectionPromotionRequest,
-};
+pub use cutover::{CutoverGate, CutoverPolicy};
 pub use neo4j::{
     CloudAttackPath, CloudAttackPathCounts, CloudAttackPathEdge, CloudAttackPathNode,
     CloudAttackPathOwnership, CloudAttackPathPage, ComplianceImpactDependency,
@@ -61,6 +59,9 @@ pub use postgres::{
     PostgresLedger, SourceCollectionReceipt, SourceEventReceipt,
     SourceRuntimeCollectionObservation, SourceRuntimeObservation, StoredAuditEvent,
     StoredAuditEventPage, StoredSourceRuntime,
+};
+pub use promotion::{
+    CutoverDecision, ProjectionAuthority, ProjectionAuthorityRecord, ProjectionPromotionRequest,
 };
 
 use std::{error::Error, fmt};

--- a/crates/organizational-store/src/postgres.rs
+++ b/crates/organizational-store/src/postgres.rs
@@ -2307,10 +2307,12 @@ LIMIT $3
         let decision = CutoverGate::new(request.policy())
             .evaluate(
                 catalog,
+                request.tenant_id(),
                 request.source_id(),
                 request.family_id(),
                 &receipts,
                 request.projection_lag(),
+                request.qualification(),
             )
             .map_err(|error| StoreError::Conflict(error.to_string()))?;
         Ok(decision)
@@ -2322,6 +2324,11 @@ LIMIT $3
         decision: &CutoverDecision,
         promoted_at_unix_ms: i64,
     ) -> Result<ProjectionAuthorityRecord, StoreError> {
+        if decision.tenant_id() != tenant_id {
+            return Err(StoreError::Conflict(
+                "projection promotion tenant does not match decision evidence".to_owned(),
+            ));
+        }
         if !decision.is_allowed() {
             return Err(StoreError::Conflict(format!(
                 "projection cutover is blocked: {}",

--- a/crates/organizational-store/src/promotion.rs
+++ b/crates/organizational-store/src/promotion.rs
@@ -1,0 +1,299 @@
+//! Promotion request validation, runtime-plan binding, and persisted decision types.
+
+use cerebro_source_catalog::{
+    AuthorityEvidenceError, AuthorityQualificationEvidence, SourceCatalog,
+    validate_authority_qualification_evidence,
+};
+use cerebro_source_runtime_next::source_execution::{
+    SourceExecutionDispatcher, SourceExecutionError, SourceExecutionSelectionRequestV1,
+};
+use serde::Serialize;
+
+use crate::cutover::{CutoverError, CutoverPolicy};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectionPromotionRequest {
+    tenant_id: String,
+    source_id: String,
+    family_id: String,
+    policy: CutoverPolicy,
+    projection_lag: u64,
+    promoted_at_unix_ms: i64,
+    qualification: AuthorityQualificationEvidence,
+}
+
+impl ProjectionPromotionRequest {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        tenant_id: impl Into<String>,
+        source_id: impl Into<String>,
+        family_id: impl Into<String>,
+        policy: CutoverPolicy,
+        projection_lag: u64,
+        promoted_at_unix_ms: i64,
+        qualification: AuthorityQualificationEvidence,
+    ) -> Result<Self, CutoverError> {
+        let tenant_id = checked_text(tenant_id.into(), "tenant_id")?;
+        let source_id = checked_text(source_id.into(), "source_id")?;
+        let family_id = checked_text(family_id.into(), "family_id")?;
+        if promoted_at_unix_ms <= 0 {
+            return Err(CutoverError::Invalid("promoted_at_unix_ms"));
+        }
+        validate_qualification(&qualification)?;
+        Ok(Self {
+            tenant_id,
+            source_id,
+            family_id,
+            policy,
+            projection_lag,
+            promoted_at_unix_ms,
+            qualification,
+        })
+    }
+
+    pub fn tenant_id(&self) -> &str {
+        &self.tenant_id
+    }
+
+    pub fn source_id(&self) -> &str {
+        &self.source_id
+    }
+
+    pub fn family_id(&self) -> &str {
+        &self.family_id
+    }
+
+    pub(crate) fn policy(&self) -> CutoverPolicy {
+        self.policy
+    }
+
+    pub fn projection_lag(&self) -> u64 {
+        self.projection_lag
+    }
+
+    pub(crate) fn promoted_at_unix_ms(&self) -> i64 {
+        self.promoted_at_unix_ms
+    }
+
+    pub fn qualification(&self) -> &AuthorityQualificationEvidence {
+        &self.qualification
+    }
+}
+
+fn checked_text(value: String, field: &'static str) -> Result<String, CutoverError> {
+    if value.is_empty() || value.trim() != value {
+        return Err(CutoverError::Invalid(field));
+    }
+    Ok(value)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CutoverDecision {
+    pub(crate) tenant_id: String,
+    pub(crate) source_id: String,
+    pub(crate) family_id: String,
+    pub(crate) allowed: bool,
+    pub(crate) reasons: Vec<String>,
+    pub(crate) evidence_digest: String,
+    pub(crate) qualification: AuthorityQualificationEvidence,
+}
+
+impl CutoverDecision {
+    pub fn tenant_id(&self) -> &str {
+        &self.tenant_id
+    }
+
+    pub fn source_id(&self) -> &str {
+        &self.source_id
+    }
+
+    pub fn family_id(&self) -> &str {
+        &self.family_id
+    }
+
+    pub fn is_allowed(&self) -> bool {
+        self.allowed
+    }
+
+    pub fn reasons(&self) -> &[String] {
+        &self.reasons
+    }
+
+    pub fn evidence_digest(&self) -> &str {
+        &self.evidence_digest
+    }
+
+    pub fn qualification(&self) -> &AuthorityQualificationEvidence {
+        &self.qualification
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectionAuthority {
+    Legacy,
+    Rust,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ProjectionAuthorityRecord {
+    pub tenant_id: String,
+    pub source_id: String,
+    pub family_id: String,
+    pub authority: ProjectionAuthority,
+    pub evidence_digest: String,
+    pub promoted_at_unix_ms: Option<i64>,
+}
+
+pub(crate) fn promotion_evidence_reasons(
+    catalog: &SourceCatalog,
+    source_id: &str,
+    family_id: &str,
+    qualification: &AuthorityQualificationEvidence,
+) -> Result<Vec<String>, CutoverError> {
+    validate_qualification(qualification)?;
+    let catalog_plan_digest = catalog
+        .compiled_family_plan_digest(source_id, family_id)
+        .ok_or_else(|| CutoverError::UnknownSource(format!("{source_id}/{family_id}")))?;
+    let mut reasons = Vec::new();
+    if qualification.plan_digest != catalog_plan_digest {
+        reasons.push("compiled catalog plan digest does not match qualification".to_owned());
+    }
+    let selection = SourceExecutionSelectionRequestV1 {
+        source_id: source_id.to_owned(),
+        family_id: family_id.to_owned(),
+    };
+    match SourceExecutionDispatcher.compile_plan(&selection) {
+        Ok(plan) if qualification.runtime_plan_digest != plan.plan_digest_sha256 => {
+            reasons.push("compiled runtime plan digest does not match qualification".to_owned());
+        }
+        Ok(_) => {}
+        Err(SourceExecutionError::UnknownAdapter) => {
+            reasons.push("closed Rust source-execution adapter is not registered".to_owned());
+        }
+        Err(error) => {
+            reasons.push(format!("closed Rust runtime plan failed: {}", error.code()));
+        }
+    }
+    Ok(reasons)
+}
+
+fn validate_qualification(
+    qualification: &AuthorityQualificationEvidence,
+) -> Result<(), CutoverError> {
+    validate_authority_qualification_evidence(qualification).map_err(|error| match error {
+        AuthorityEvidenceError::Invalid(field) => CutoverError::Invalid(field),
+        AuthorityEvidenceError::Immutable => CutoverError::Invalid("qualification_evidence"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::*;
+    use cerebro_source_runtime_next::source_execution::{
+        SourceExecutionDispatcher, SourceExecutionSelectionRequestV1,
+    };
+
+    fn repository_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()
+            .unwrap()
+    }
+
+    fn catalog() -> SourceCatalog {
+        let root = repository_root();
+        SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap()
+    }
+
+    fn qualification(catalog: &SourceCatalog) -> AuthorityQualificationEvidence {
+        let selection = SourceExecutionSelectionRequestV1 {
+            source_id: "asana".to_owned(),
+            family_id: "users".to_owned(),
+        };
+        AuthorityQualificationEvidence {
+            plan_digest: catalog
+                .compiled_family_plan_digest("asana", "users")
+                .unwrap(),
+            runtime_plan_digest: SourceExecutionDispatcher
+                .compile_plan(&selection)
+                .unwrap()
+                .plan_digest_sha256,
+            fixture_corpus_revision: "corpus-3".to_owned(),
+            supported_auth_modes: vec!["bearer".to_owned()],
+            supported_pagination_grammar: vec!["cursor".to_owned()],
+            supported_provider_errors: vec!["unauthorized".to_owned()],
+            egress_allowlist: vec!["https://app.asana.com".to_owned()],
+            response_limits: "body=1048576,decompression=4x".to_owned(),
+            credential_lease_mode: "one_operation".to_owned(),
+            projection_dependency: "rust_projection".to_owned(),
+            rollback_receipt: "receipt:recovery-readiness".to_owned(),
+            parity_status: "passed".to_owned(),
+            canonical_digest_vectors: vec!["plan".to_owned()],
+            config_safety_proof: "receipt:config".to_owned(),
+            cursor_checkpoint_proof: "receipt:checkpoint".to_owned(),
+            fencing_recovery_proof: "receipt:fencing".to_owned(),
+            worker_build_id: "source-runtime-next:test".to_owned(),
+            promotion_receipt: "sig:promotion:test".to_owned(),
+            authenticated_collection_receipt: "receipt:collection".to_owned(),
+            append_projection_checkpoint_receipt: "receipt:durable".to_owned(),
+            lease_restart_receipt: "receipt:restart".to_owned(),
+            product_read_receipt: "receipt:product-read".to_owned(),
+        }
+    }
+
+    #[test]
+    fn promotion_request_requires_complete_qualification_for_exact_scope() {
+        let catalog = catalog();
+        let request = ProjectionPromotionRequest::new(
+            "tenant-a",
+            "asana",
+            "users",
+            CutoverPolicy::new(3, 0).unwrap(),
+            0,
+            1,
+            qualification(&catalog),
+        )
+        .unwrap();
+        assert_eq!(request.tenant_id(), "tenant-a");
+        assert_eq!(request.source_id(), "asana");
+        assert_eq!(request.family_id(), "users");
+
+        let mut incomplete = qualification(&catalog);
+        incomplete.product_read_receipt.clear();
+        assert_eq!(
+            ProjectionPromotionRequest::new(
+                "tenant-a",
+                "asana",
+                "users",
+                CutoverPolicy::new(3, 0).unwrap(),
+                0,
+                1,
+                incomplete,
+            ),
+            Err(CutoverError::Invalid("product_read_receipt"))
+        );
+    }
+
+    #[test]
+    fn promotion_evidence_binds_catalog_and_runtime_plan_digests() {
+        let catalog = catalog();
+        let mut evidence = qualification(&catalog);
+        evidence.plan_digest = "a".repeat(64);
+        evidence.runtime_plan_digest = "b".repeat(64);
+        let reasons = promotion_evidence_reasons(&catalog, "asana", "users", &evidence).unwrap();
+        assert_eq!(
+            reasons,
+            vec![
+                "compiled catalog plan digest does not match qualification".to_owned(),
+                "compiled runtime plan digest does not match qualification".to_owned(),
+            ]
+        );
+    }
+}

--- a/crates/organizational-store/tests/live_cutover.rs
+++ b/crates/organizational-store/tests/live_cutover.rs
@@ -8,12 +8,57 @@ use std::{
 use cerebro_organizational_store::{
     CutoverPolicy, ParityReceipt, PostgresLedger, ProjectionAuthority, ProjectionPromotionRequest,
 };
-use cerebro_source_catalog::SourceCatalog;
+use cerebro_source_catalog::{AuthorityQualificationEvidence, SourceCatalog};
 use tokio_postgres::NoTls;
+
+fn qualification(
+    catalog: &SourceCatalog,
+    source_id: &str,
+    family_id: &str,
+    corpus: &str,
+) -> AuthorityQualificationEvidence {
+    let plan_digest = catalog
+        .compiled_family_plan_digest(source_id, family_id)
+        .unwrap();
+    let runtime_plan_digest =
+        cerebro_source_runtime_next::source_execution::SourceExecutionDispatcher
+            .compile_plan(
+                &cerebro_source_runtime_next::source_execution::SourceExecutionSelectionRequestV1 {
+                    source_id: source_id.to_owned(),
+                    family_id: family_id.to_owned(),
+                },
+            )
+            .unwrap()
+            .plan_digest_sha256;
+    AuthorityQualificationEvidence {
+        runtime_plan_digest,
+        plan_digest,
+        fixture_corpus_revision: corpus.to_owned(),
+        supported_auth_modes: vec!["api_key".to_owned()],
+        supported_pagination_grammar: vec!["cursor".to_owned()],
+        supported_provider_errors: vec!["unauthorized".to_owned()],
+        egress_allowlist: vec!["https://provider.example.test".to_owned()],
+        response_limits: "body=1048576,decompression=4x".to_owned(),
+        credential_lease_mode: "one_operation".to_owned(),
+        projection_dependency: "rust_projection".to_owned(),
+        rollback_receipt: "receipt:rollback".to_owned(),
+        parity_status: "passed".to_owned(),
+        canonical_digest_vectors: vec!["plan".to_owned()],
+        config_safety_proof: "receipt:config".to_owned(),
+        cursor_checkpoint_proof: "receipt:checkpoint".to_owned(),
+        fencing_recovery_proof: "receipt:fencing".to_owned(),
+        worker_build_id: "source-runtime-next:test".to_owned(),
+        promotion_receipt: "sig:promotion:test".to_owned(),
+        authenticated_collection_receipt: "receipt:collection".to_owned(),
+        append_projection_checkpoint_receipt: "receipt:durable".to_owned(),
+        lease_restart_receipt: "receipt:restart".to_owned(),
+        product_read_receipt: "receipt:product-read".to_owned(),
+    }
+}
 
 #[tokio::test]
 #[ignore = "requires disposable PostgreSQL"]
-async fn persisted_cutover_requires_three_matching_receipts_and_is_irreversible()
+async fn persisted_promotion_requires_complete_evidence_and_three_matching_receipts()
 -> Result<(), Box<dyn Error>> {
     let postgres_dsn = env::var("CEREBRO_TEST_POSTGRES_DSN")?;
     let (client, connection) = tokio_postgres::connect(&postgres_dsn, NoTls).await?;
@@ -26,15 +71,15 @@ async fn persisted_cutover_requires_three_matching_receipts_and_is_irreversible(
         .duration_since(UNIX_EPOCH)?
         .as_nanos()
         .to_string();
-    let tenant_id = format!("cutover-{suffix}");
+    let tenant_id = format!("promotion-evidence-{suffix}");
     for index in 1..=3 {
         ledger
             .record_parity(&ParityReceipt::compare_scoped(
                 tenant_id.clone(),
-                "box-runtime",
-                "box",
+                "asana-runtime",
+                "asana",
                 "users",
-                format!("cutover-{suffix}-{index}"),
+                format!("promotion-evidence-{suffix}-{index}"),
                 "sha256:equal",
                 "sha256:equal",
                 true,
@@ -49,11 +94,17 @@ async fn persisted_cutover_requires_three_matching_receipts_and_is_irreversible(
     )?;
     let request = ProjectionPromotionRequest::new(
         tenant_id.clone(),
-        "box",
+        "asana",
         "users",
         CutoverPolicy::new(3, 0)?,
         0,
         100,
+        qualification(
+            &catalog,
+            "asana",
+            "users",
+            &format!("promotion-evidence-{suffix}-3"),
+        ),
     )?;
     let decision = ledger
         .evaluate_projection_authority(&catalog, &request)
@@ -61,7 +112,7 @@ async fn persisted_cutover_requires_three_matching_receipts_and_is_irreversible(
     assert!(decision.is_allowed());
     assert_eq!(
         ledger
-            .projection_authority(&tenant_id, "box", "users")
+            .projection_authority(&tenant_id, "asana", "users")
             .await?
             .authority,
         ProjectionAuthority::Legacy,
@@ -71,9 +122,40 @@ async fn persisted_cutover_requires_three_matching_receipts_and_is_irreversible(
         .evaluate_and_promote_projection_authority(&catalog, &request)
         .await?;
     assert_eq!(authority.authority, ProjectionAuthority::Rust);
+
+    let (mut inspection, inspection_connection) =
+        tokio_postgres::connect(&postgres_dsn, NoTls).await?;
+    tokio::spawn(async move {
+        inspection_connection
+            .await
+            .expect("PostgreSQL inspection connection");
+    });
+    let inspection_transaction = inspection.transaction().await?;
+    inspection_transaction
+        .query_one(
+            "SELECT set_config('cerebro.tenant_id', $1, true)",
+            &[&tenant_id],
+        )
+        .await?;
+    let persisted_decision: serde_json::Value = inspection_transaction
+        .query_one(
+            "SELECT decision_json FROM organizational_projection_authority WHERE tenant_id = $1 AND source_id = 'asana' AND family_id = 'users'",
+            &[&tenant_id],
+        )
+        .await?
+        .get(0);
+    inspection_transaction.commit().await?;
+    assert_eq!(
+        persisted_decision["tenant_id"].as_str(),
+        Some(tenant_id.as_str())
+    );
+    assert_eq!(
+        persisted_decision["qualification"]["product_read_receipt"],
+        "receipt:product-read"
+    );
     assert_eq!(
         ledger
-            .projection_authority(&tenant_id, "box", "users")
+            .projection_authority(&tenant_id, "asana", "users")
             .await?
             .authority,
         ProjectionAuthority::Rust
@@ -82,10 +164,10 @@ async fn persisted_cutover_requires_three_matching_receipts_and_is_irreversible(
     ledger
         .record_parity(&ParityReceipt::compare_scoped(
             tenant_id.clone(),
-            "box-runtime",
-            "box",
+            "asana-runtime",
+            "asana",
             "users",
-            format!("cutover-{suffix}-4"),
+            format!("promotion-evidence-{suffix}-4"),
             "sha256:equal",
             "sha256:equal",
             true,
@@ -98,11 +180,17 @@ async fn persisted_cutover_requires_three_matching_receipts_and_is_irreversible(
                 &catalog,
                 &ProjectionPromotionRequest::new(
                     tenant_id.clone(),
-                    "box",
+                    "asana",
                     "users",
                     CutoverPolicy::new(3, 0)?,
                     0,
                     101,
+                    qualification(
+                        &catalog,
+                        "asana",
+                        "users",
+                        &format!("promotion-evidence-{suffix}-4"),
+                    ),
                 )?,
             )
             .await

--- a/crates/source-catalog/src/authority_evidence.rs
+++ b/crates/source-catalog/src/authority_evidence.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeSet;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 /// Source-family authority decision kinds recorded in the append-only evidence stream.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AuthorityDecisionKind {
     /// Promote one tenant/source/family to Rust authority.
@@ -17,8 +17,38 @@ pub enum AuthorityDecisionKind {
     CapabilityChanged,
 }
 
+/// Complete, non-secret proof bundle required for one source family to become
+/// Rust-authoritative. Compile-time catalog flags are necessary but cannot
+/// satisfy this runtime evidence contract by themselves.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthorityQualificationEvidence {
+    pub plan_digest: String,
+    pub runtime_plan_digest: String,
+    pub fixture_corpus_revision: String,
+    pub supported_auth_modes: Vec<String>,
+    pub supported_pagination_grammar: Vec<String>,
+    pub supported_provider_errors: Vec<String>,
+    pub egress_allowlist: Vec<String>,
+    pub response_limits: String,
+    pub credential_lease_mode: String,
+    pub projection_dependency: String,
+    pub rollback_receipt: String,
+    pub parity_status: String,
+    pub canonical_digest_vectors: Vec<String>,
+    pub config_safety_proof: String,
+    pub cursor_checkpoint_proof: String,
+    pub fencing_recovery_proof: String,
+    pub worker_build_id: String,
+    pub promotion_receipt: String,
+    pub authenticated_collection_receipt: String,
+    pub append_projection_checkpoint_receipt: String,
+    pub lease_restart_receipt: String,
+    pub product_read_receipt: String,
+}
+
 /// Immutable authority evidence for one tenant/source/family decision.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AuthorityEvidenceRecord {
     /// Tenant scope.
     pub tenant_id: String,
@@ -44,6 +74,11 @@ pub struct AuthorityEvidenceRecord {
     pub authenticated_receipt_id: String,
     /// Detached signature, when available.
     pub receipt_signature: String,
+    /// Prior decision in the exact tenant/source/family authority chain.
+    pub previous_decision_id: String,
+    /// Complete proof bundle for a promotion decision.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub qualification: Option<AuthorityQualificationEvidence>,
     /// Canonical record digest assigned at append time.
     pub record_digest_sha256: String,
 }
@@ -71,16 +106,58 @@ impl AuthorityEvidenceStream {
         mut record: AuthorityEvidenceRecord,
     ) -> Result<AuthorityEvidenceRecord, AuthorityEvidenceError> {
         validate_authority_evidence_record(&record)?;
+        self.validate_append_sequence(&record)?;
+        record.record_digest_sha256.clear();
+        record.record_digest_sha256 = digest_authority_evidence_record(&record);
+        self.insert_validated(record.clone())?;
+        Ok(record)
+    }
+
+    /// Hydrate one already-persisted record after verifying its digest and
+    /// monotonic family decision chain.
+    pub fn append_persisted(
+        &mut self,
+        record: AuthorityEvidenceRecord,
+    ) -> Result<(), AuthorityEvidenceError> {
+        validate_authority_evidence_record(&record)?;
+        if !is_sha256_hex(&record.record_digest_sha256)
+            || digest_authority_evidence_record(&record) != record.record_digest_sha256
+        {
+            return Err(AuthorityEvidenceError::Invalid("record_digest_sha256"));
+        }
+        self.validate_append_sequence(&record)?;
+        self.insert_validated(record)
+    }
+
+    fn insert_validated(
+        &mut self,
+        record: AuthorityEvidenceRecord,
+    ) -> Result<(), AuthorityEvidenceError> {
         if !self
             .decision_ids
             .insert(record.decision_id.trim().to_owned())
         {
             return Err(AuthorityEvidenceError::Immutable);
         }
-        record.record_digest_sha256.clear();
-        record.record_digest_sha256 = digest_authority_evidence_record(&record);
-        self.records.push(record.clone());
-        Ok(record)
+        self.records.push(record);
+        Ok(())
+    }
+
+    fn validate_append_sequence(
+        &self,
+        record: &AuthorityEvidenceRecord,
+    ) -> Result<(), AuthorityEvidenceError> {
+        let previous = self.latest(&record.tenant_id, &record.source_id, &record.family_id);
+        match previous {
+            Some(previous)
+                if record.authority_epoch == previous.authority_epoch + 1
+                    && record.previous_decision_id == previous.decision_id =>
+            {
+                Ok(())
+            }
+            None if record.previous_decision_id.trim().is_empty() => Ok(()),
+            _ => Err(AuthorityEvidenceError::Invalid("authority_sequence")),
+        }
     }
 
     /// Return ordered authority history for one tenant/source/family.
@@ -99,6 +176,20 @@ impl AuthorityEvidenceStream {
             })
             .cloned()
             .collect()
+    }
+
+    /// Return the latest verified record for one exact authority scope.
+    pub fn latest(
+        &self,
+        tenant_id: &str,
+        source_id: &str,
+        family_id: &str,
+    ) -> Option<&AuthorityEvidenceRecord> {
+        self.records.iter().rev().find(|record| {
+            record.tenant_id == tenant_id
+                && record.source_id == source_id
+                && record.family_id == family_id
+        })
     }
 
     /// Reject any post-append mutation to a stored record.
@@ -134,7 +225,7 @@ pub fn validate_authority_evidence_record(
     {
         return Err(AuthorityEvidenceError::Invalid("required_identity"));
     }
-    if record.authority_epoch == 0 {
+    if record.authority_epoch == 0 || record.timestamp_unix_ms <= 0 {
         return Err(AuthorityEvidenceError::Invalid("authority_epoch"));
     }
     if !is_sha256_hex(&record.input_evidence_digest_sha256) {
@@ -142,17 +233,139 @@ pub fn validate_authority_evidence_record(
             "input_evidence_digest_sha256",
         ));
     }
-    if record.decision_kind == AuthorityDecisionKind::Promotion
-        && record.authenticated_receipt_id.trim().is_empty()
-        && !record.receipt_signature.trim().starts_with("sig:")
-    {
+    if record.decision_kind == AuthorityDecisionKind::Promotion {
+        if record.authenticated_receipt_id.trim().is_empty()
+            && !record.receipt_signature.trim().starts_with("sig:")
+        {
+            return Err(AuthorityEvidenceError::Invalid("promotion_receipt"));
+        }
+        let qualification = record
+            .qualification
+            .as_ref()
+            .ok_or(AuthorityEvidenceError::Invalid("qualification_evidence"))?;
+        validate_authority_qualification_evidence(qualification)?;
+        if authority_qualification_digest(qualification)
+            != record
+                .input_evidence_digest_sha256
+                .trim()
+                .to_ascii_lowercase()
+        {
+            return Err(AuthorityEvidenceError::Invalid(
+                "input_evidence_digest_sha256",
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Validate every exact receipt required before a promotion record is valid.
+pub fn validate_authority_qualification_evidence(
+    evidence: &AuthorityQualificationEvidence,
+) -> Result<(), AuthorityEvidenceError> {
+    let missing = missing_authority_qualification_evidence(evidence);
+    if let Some(field) = missing.first() {
+        return Err(AuthorityEvidenceError::Invalid(*field));
+    }
+    if !is_sha256_hex(&evidence.plan_digest) {
+        return Err(AuthorityEvidenceError::Invalid("compiled_plan_digest"));
+    }
+    if !is_sha256_hex(&evidence.runtime_plan_digest) {
+        return Err(AuthorityEvidenceError::Invalid("runtime_plan_digest"));
+    }
+    if !matches!(evidence.parity_status.trim(), "passed" | "matched") {
+        return Err(AuthorityEvidenceError::Invalid("fixture_parity_status"));
+    }
+    let promotion = evidence.promotion_receipt.trim();
+    if !promotion.starts_with("sig:") && !promotion.starts_with("auth:") {
         return Err(AuthorityEvidenceError::Invalid("promotion_receipt"));
     }
     Ok(())
 }
 
+/// Return stable field names for every absent authority proof.
+pub fn missing_authority_qualification_evidence(
+    evidence: &AuthorityQualificationEvidence,
+) -> Vec<&'static str> {
+    let mut missing = Vec::new();
+    if evidence.plan_digest.trim().is_empty() {
+        missing.push("compiled_plan_digest");
+    }
+    if evidence.runtime_plan_digest.trim().is_empty() {
+        missing.push("runtime_plan_digest");
+    }
+    if evidence.fixture_corpus_revision.trim().is_empty() {
+        missing.push("fixture_corpus_revision");
+    }
+    for (field, values) in [
+        ("supported_auth_modes", &evidence.supported_auth_modes),
+        (
+            "supported_pagination_grammar",
+            &evidence.supported_pagination_grammar,
+        ),
+        (
+            "supported_provider_error_modes",
+            &evidence.supported_provider_errors,
+        ),
+        ("egress_allowlist", &evidence.egress_allowlist),
+        (
+            "canonical_digest_vectors",
+            &evidence.canonical_digest_vectors,
+        ),
+    ] {
+        if values.iter().all(|value| value.trim().is_empty()) {
+            missing.push(field);
+        }
+    }
+    for (field, value) in [
+        ("response_decompression_limits", &evidence.response_limits),
+        ("credential_lease_mode", &evidence.credential_lease_mode),
+        ("projection_dependency", &evidence.projection_dependency),
+        ("rollback_receipt", &evidence.rollback_receipt),
+        ("fixture_parity_status", &evidence.parity_status),
+        (
+            "credential_config_safety_proof",
+            &evidence.config_safety_proof,
+        ),
+        (
+            "cursor_checkpoint_rollback_proof",
+            &evidence.cursor_checkpoint_proof,
+        ),
+        (
+            "operational_fencing_recovery_proof",
+            &evidence.fencing_recovery_proof,
+        ),
+        ("worker_runtime_build_identity", &evidence.worker_build_id),
+        ("promotion_receipt", &evidence.promotion_receipt),
+        (
+            "authenticated_collection_receipt",
+            &evidence.authenticated_collection_receipt,
+        ),
+        (
+            "append_projection_checkpoint_receipt",
+            &evidence.append_projection_checkpoint_receipt,
+        ),
+        ("lease_restart_receipt", &evidence.lease_restart_receipt),
+        ("product_read_receipt", &evidence.product_read_receipt),
+    ] {
+        if value.trim().is_empty() {
+            missing.push(field);
+        }
+    }
+    missing.sort_unstable();
+    missing
+}
+
+/// Digest the canonical persisted proof bundle bound by a decision record.
+pub fn authority_qualification_digest(evidence: &AuthorityQualificationEvidence) -> String {
+    let bytes = serde_json::to_vec(evidence).expect("authority qualification serializes");
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
 fn digest_authority_evidence_record(record: &AuthorityEvidenceRecord) -> String {
-    let bytes = serde_json::to_vec(record).expect("authority evidence serializes");
+    let mut record = record.clone();
+    record.record_digest_sha256.clear();
+    let bytes = serde_json::to_vec(&record).expect("authority evidence serializes");
     let digest = Sha256::digest(bytes);
     digest.iter().map(|byte| format!("{byte:02x}")).collect()
 }
@@ -209,6 +422,15 @@ mod tests {
             Err(AuthorityEvidenceError::Immutable)
         );
 
+        let mut hydrated = AuthorityEvidenceStream::default();
+        hydrated.append_persisted(first.clone()).unwrap();
+        let mut tampered = second.clone();
+        tampered.reason_code = "tampered".to_owned();
+        assert_eq!(
+            hydrated.append_persisted(tampered),
+            Err(AuthorityEvidenceError::Invalid("record_digest_sha256"))
+        );
+
         let mut bad_digest =
             authority_record("decision-bad-digest", 4, AuthorityDecisionKind::Promotion);
         bad_digest.input_evidence_digest_sha256 = "not-a-sha".to_owned();
@@ -229,6 +451,13 @@ mod tests {
         let mut blocked = unsigned;
         blocked.decision_kind = AuthorityDecisionKind::ShadowOnlyBlocked;
         assert_eq!(validate_authority_evidence_record(&blocked), Ok(()));
+
+        let mut incomplete = qualification_evidence("a".repeat(64));
+        incomplete.product_read_receipt.clear();
+        assert_eq!(
+            validate_authority_qualification_evidence(&incomplete),
+            Err(AuthorityEvidenceError::Invalid("product_read_receipt"))
+        );
     }
 
     fn authority_record(
@@ -236,6 +465,11 @@ mod tests {
         authority_epoch: u64,
         decision_kind: AuthorityDecisionKind,
     ) -> AuthorityEvidenceRecord {
+        let qualification = (decision_kind == AuthorityDecisionKind::Promotion)
+            .then(|| qualification_evidence("a".repeat(64)));
+        let input_evidence_digest_sha256 = qualification
+            .as_ref()
+            .map_or_else(|| "a".repeat(64), authority_qualification_digest);
         AuthorityEvidenceRecord {
             tenant_id: "tenant-a".to_owned(),
             source_id: "custom_deposit".to_owned(),
@@ -243,13 +477,46 @@ mod tests {
             authority_epoch,
             decision_id: decision_id.to_owned(),
             decision_kind,
-            input_evidence_digest_sha256: "a".repeat(64),
+            input_evidence_digest_sha256,
             actor_id: "system:cutover".to_owned(),
             timestamp_unix_ms: 1_787_136_000_000,
             reason_code: "provider_proof_complete".to_owned(),
             authenticated_receipt_id: "receipt:promotion".to_owned(),
             receipt_signature: String::new(),
+            previous_decision_id: match authority_epoch {
+                1 => String::new(),
+                2 => "decision-promote".to_owned(),
+                _ => "decision-rollback".to_owned(),
+            },
+            qualification,
             record_digest_sha256: String::new(),
+        }
+    }
+
+    fn qualification_evidence(plan_digest: String) -> AuthorityQualificationEvidence {
+        AuthorityQualificationEvidence {
+            plan_digest,
+            runtime_plan_digest: "b".repeat(64),
+            fixture_corpus_revision: "fixture-corpus:v1".to_owned(),
+            supported_auth_modes: vec!["api_key".to_owned()],
+            supported_pagination_grammar: vec!["cursor".to_owned()],
+            supported_provider_errors: vec!["unauthorized".to_owned(), "rate_limited".to_owned()],
+            egress_allowlist: vec!["https://provider.example.test".to_owned()],
+            response_limits: "body=1048576,decompression=4x".to_owned(),
+            credential_lease_mode: "one_operation".to_owned(),
+            projection_dependency: "rust_projection".to_owned(),
+            rollback_receipt: "receipt:rollback".to_owned(),
+            parity_status: "passed".to_owned(),
+            canonical_digest_vectors: vec!["plan".to_owned(), "result".to_owned()],
+            config_safety_proof: "receipt:config-safety".to_owned(),
+            cursor_checkpoint_proof: "receipt:cursor-checkpoint".to_owned(),
+            fencing_recovery_proof: "receipt:fencing-recovery".to_owned(),
+            worker_build_id: "source-runtime-next:test".to_owned(),
+            promotion_receipt: "sig:promotion:test".to_owned(),
+            authenticated_collection_receipt: "receipt:collection".to_owned(),
+            append_projection_checkpoint_receipt: "receipt:durable-commit".to_owned(),
+            lease_restart_receipt: "receipt:lease-restart".to_owned(),
+            product_read_receipt: "receipt:product-read".to_owned(),
         }
     }
 }

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -18,7 +18,9 @@ use sha2::{Digest, Sha256};
 mod authority_evidence;
 pub use authority_evidence::{
     AuthorityDecisionKind, AuthorityEvidenceError, AuthorityEvidenceRecord,
-    AuthorityEvidenceStream, validate_authority_evidence_record,
+    AuthorityEvidenceStream, AuthorityQualificationEvidence, authority_qualification_digest,
+    missing_authority_qualification_evidence, validate_authority_evidence_record,
+    validate_authority_qualification_evidence,
 };
 
 const MAX_PAGE_SIZE: usize = 1_000;
@@ -820,58 +822,145 @@ impl SourceCatalog {
     }
 
     pub fn authority_readiness_report(&self) -> AuthorityReadinessReport {
+        self.authority_readiness_report_with_evidence("", &AuthorityEvidenceStream::default())
+    }
+
+    /// Return the exact compiled catalog plan digest for one source family.
+    pub fn compiled_family_plan_digest(&self, source_id: &str, family_id: &str) -> Option<String> {
+        let source = self.get(source_id.trim())?;
+        let family = source
+            .families()
+            .iter()
+            .find(|family| family.id() == family_id.trim())?;
+        Some(family_plan_digest(source, family))
+    }
+
+    /// Evaluate one tenant's persisted authority chain against the exact
+    /// compiled catalog and complete runtime proof bundle. A catalog compile
+    /// flag alone never selects Rust authority.
+    pub fn authority_readiness_report_with_evidence(
+        &self,
+        tenant_id: &str,
+        evidence: &AuthorityEvidenceStream,
+    ) -> AuthorityReadinessReport {
         let mut families = Vec::new();
+        let mut rust_authoritative_families = 0;
         for source in self.sources() {
             for family in source.families() {
                 let plan_digest = family_plan_digest(source, family);
-                let mut blocking_reasons = vec![
-                    "fixture_corpus_revision".to_owned(),
-                    "supported_auth_modes".to_owned(),
-                    "supported_pagination_grammar".to_owned(),
-                    "supported_provider_error_modes".to_owned(),
-                    "egress_allowlist".to_owned(),
-                    "response_decompression_limits".to_owned(),
-                    "credential_lease_mode".to_owned(),
-                    "rollback_receipt".to_owned(),
-                    "fixture_parity_status".to_owned(),
-                    "canonical_digest_vectors".to_owned(),
-                    "credential_config_safety_proof".to_owned(),
-                    "cursor_checkpoint_rollback_proof".to_owned(),
-                    "operational_fencing_recovery_proof".to_owned(),
-                    "worker_runtime_build_identity".to_owned(),
-                    "promotion_receipt".to_owned(),
-                ];
-                if !family.is_projection_authoritative() {
-                    blocking_reasons.push("projection_intent_readiness".to_owned());
+                let latest = (!tenant_id.trim().is_empty())
+                    .then(|| evidence.latest(tenant_id, source.id(), family.id()))
+                    .flatten();
+                let mut engine = "go_or_shadow_only".to_owned();
+                let mut authority_epoch = 0;
+                let mut proof_revision = "provider-proof:incomplete".to_owned();
+                let mut fixture_revision = String::new();
+                let mut parity_status = "missing".to_owned();
+                let mut rollback_status = "missing".to_owned();
+                let mut projection_status = if family.is_projection_authoritative() {
+                    "go_projection_dependency".to_owned()
+                } else {
+                    "missing".to_owned()
+                };
+                let mut promotion_decision_id = String::new();
+                let mut blocking_reasons = default_authority_blocking_reasons(family);
+
+                if let Some(record) = latest {
+                    authority_epoch = record.authority_epoch;
+                    promotion_decision_id = record.decision_id.clone();
+                    proof_revision = record.input_evidence_digest_sha256.clone();
+                    match record.decision_kind {
+                        AuthorityDecisionKind::Promotion => {
+                            let qualification = record
+                                .qualification
+                                .as_ref()
+                                .expect("verified promotion carries qualification evidence");
+                            fixture_revision = qualification.fixture_corpus_revision.clone();
+                            parity_status = qualification.parity_status.clone();
+                            rollback_status = qualification.rollback_receipt.clone();
+                            projection_status = qualification.projection_dependency.clone();
+                            blocking_reasons.clear();
+                            if !family.is_authoritative() {
+                                blocking_reasons.push("compiled_collection_authority".to_owned());
+                            }
+                            if !family.is_projection_authoritative() {
+                                blocking_reasons.push("projection_intent_readiness".to_owned());
+                            }
+                            if qualification.plan_digest != plan_digest {
+                                blocking_reasons.push("compiled_plan_digest".to_owned());
+                            }
+                            if blocking_reasons.is_empty() {
+                                engine = "rust_authoritative".to_owned();
+                                rust_authoritative_families += 1;
+                            }
+                        }
+                        AuthorityDecisionKind::Rollback => {
+                            blocking_reasons = vec!["authority_decision_rollback".to_owned()];
+                        }
+                        AuthorityDecisionKind::ShadowOnlyBlocked => {
+                            blocking_reasons =
+                                vec!["authority_decision_shadow_only_blocked".to_owned()];
+                        }
+                        AuthorityDecisionKind::CapabilityChanged => {
+                            blocking_reasons =
+                                vec!["authority_decision_capability_changed".to_owned()];
+                        }
+                    }
                 }
                 blocking_reasons.sort();
+                blocking_reasons.dedup();
                 families.push(AuthorityReadinessFamilyReport {
                     source_id: source.id().to_owned(),
                     family_id: family.id().to_owned(),
-                    engine: "go_or_shadow_only".to_owned(),
-                    authority_epoch: 0,
+                    engine,
+                    authority_epoch,
                     plan_digest,
-                    proof_revision: "provider-proof:incomplete".to_owned(),
-                    fixture_revision: String::new(),
-                    parity_status: "missing".to_owned(),
-                    rollback_status: "missing".to_owned(),
-                    projection_status: if family.is_projection_authoritative() {
-                        "go_projection_dependency".to_owned()
-                    } else {
-                        "missing".to_owned()
-                    },
-                    promotion_decision_id: String::new(),
+                    proof_revision,
+                    fixture_revision,
+                    parity_status,
+                    rollback_status,
+                    projection_status,
+                    promotion_decision_id,
                     blocking_reasons,
                 });
             }
         }
         AuthorityReadinessReport {
             total_families: families.len(),
-            rust_authoritative_families: 0,
-            shadow_or_go_families: families.len(),
+            rust_authoritative_families,
+            shadow_or_go_families: families.len() - rust_authoritative_families,
             families,
         }
     }
+}
+
+fn default_authority_blocking_reasons(family: &CompiledFamily) -> Vec<String> {
+    let mut blocking_reasons = vec![
+        "fixture_corpus_revision".to_owned(),
+        "supported_auth_modes".to_owned(),
+        "supported_pagination_grammar".to_owned(),
+        "supported_provider_error_modes".to_owned(),
+        "egress_allowlist".to_owned(),
+        "response_decompression_limits".to_owned(),
+        "credential_lease_mode".to_owned(),
+        "rollback_receipt".to_owned(),
+        "fixture_parity_status".to_owned(),
+        "canonical_digest_vectors".to_owned(),
+        "credential_config_safety_proof".to_owned(),
+        "cursor_checkpoint_rollback_proof".to_owned(),
+        "operational_fencing_recovery_proof".to_owned(),
+        "worker_runtime_build_identity".to_owned(),
+        "promotion_receipt".to_owned(),
+        "authenticated_collection_receipt".to_owned(),
+        "append_projection_checkpoint_receipt".to_owned(),
+        "lease_restart_receipt".to_owned(),
+        "product_read_receipt".to_owned(),
+    ];
+    if !family.is_projection_authoritative() {
+        blocking_reasons.push("projection_intent_readiness".to_owned());
+    }
+    blocking_reasons.sort();
+    blocking_reasons
 }
 
 fn reject_dual_mode_source_ids<'a>(
@@ -4097,6 +4186,85 @@ mod tests {
             report.shadow_or_go_families,
             aws_bedrock.plan_digest
         );
+
+        let (source, family) = catalog
+            .sources()
+            .find_map(|source| {
+                source
+                    .families()
+                    .iter()
+                    .find(|family| {
+                        family.is_authoritative() && family.is_projection_authoritative()
+                    })
+                    .map(|family| (source, family))
+            })
+            .expect("compile-qualified family");
+        let plan_digest = report
+            .families
+            .iter()
+            .find(|row| row.source_id == source.id() && row.family_id == family.id())
+            .expect("readiness row")
+            .plan_digest
+            .clone();
+        let qualification = complete_authority_qualification(plan_digest);
+        let mut stream = AuthorityEvidenceStream::default();
+        stream
+            .append(AuthorityEvidenceRecord {
+                tenant_id: "tenant-readiness".to_owned(),
+                source_id: source.id().to_owned(),
+                family_id: family.id().to_owned(),
+                authority_epoch: 1,
+                decision_id: "decision-promote-readiness".to_owned(),
+                decision_kind: AuthorityDecisionKind::Promotion,
+                input_evidence_digest_sha256: authority_qualification_digest(&qualification),
+                actor_id: "system:cutover".to_owned(),
+                timestamp_unix_ms: 1_787_136_000_000,
+                reason_code: "complete_runtime_evidence".to_owned(),
+                authenticated_receipt_id: "receipt:promotion".to_owned(),
+                receipt_signature: String::new(),
+                previous_decision_id: String::new(),
+                qualification: Some(qualification),
+                record_digest_sha256: String::new(),
+            })
+            .expect("verified promotion record");
+        let promoted =
+            catalog.authority_readiness_report_with_evidence("tenant-readiness", &stream);
+        assert_eq!(promoted.rust_authoritative_families, 1);
+        let promoted_family = promoted
+            .families
+            .iter()
+            .find(|row| row.source_id == source.id() && row.family_id == family.id())
+            .expect("promoted readiness row");
+        assert_eq!(promoted_family.engine, "rust_authoritative");
+        assert_eq!(promoted_family.authority_epoch, 1);
+        assert!(promoted_family.blocking_reasons.is_empty());
+    }
+
+    fn complete_authority_qualification(plan_digest: String) -> AuthorityQualificationEvidence {
+        AuthorityQualificationEvidence {
+            plan_digest,
+            runtime_plan_digest: "b".repeat(64),
+            fixture_corpus_revision: "fixture-corpus:v1".to_owned(),
+            supported_auth_modes: vec!["api_key".to_owned()],
+            supported_pagination_grammar: vec!["cursor".to_owned()],
+            supported_provider_errors: vec!["unauthorized".to_owned(), "rate_limited".to_owned()],
+            egress_allowlist: vec!["https://provider.example.test".to_owned()],
+            response_limits: "body=1048576,decompression=4x".to_owned(),
+            credential_lease_mode: "one_operation".to_owned(),
+            projection_dependency: "rust_projection".to_owned(),
+            rollback_receipt: "receipt:rollback".to_owned(),
+            parity_status: "passed".to_owned(),
+            canonical_digest_vectors: vec!["plan".to_owned(), "result".to_owned()],
+            config_safety_proof: "receipt:config-safety".to_owned(),
+            cursor_checkpoint_proof: "receipt:cursor-checkpoint".to_owned(),
+            fencing_recovery_proof: "receipt:fencing-recovery".to_owned(),
+            worker_build_id: "source-runtime-next:test".to_owned(),
+            promotion_receipt: "sig:promotion:test".to_owned(),
+            authenticated_collection_receipt: "receipt:collection".to_owned(),
+            append_projection_checkpoint_receipt: "receipt:durable-commit".to_owned(),
+            lease_restart_receipt: "receipt:lease-restart".to_owned(),
+            product_read_receipt: "receipt:product-read".to_owned(),
+        }
     }
 
     #[test]

--- a/crates/source-runtime-next/src/protocol.rs
+++ b/crates/source-runtime-next/src/protocol.rs
@@ -4,6 +4,8 @@ use serde::Serialize;
 use serde_json::json;
 use sha2::{Digest, Sha256};
 
+pub use cerebro_source_catalog::AuthorityQualificationEvidence as AuthorityEvidence;
+
 const PROTOCOL_REVISION: u16 = 1;
 
 /// Versioned source-runtime operations that a worker may execute.
@@ -110,45 +112,6 @@ pub struct SourceRuntimeErrorShape {
     pub diagnostics: BTreeMap<String, String>,
 }
 
-/// Complete evidence required before source-family Rust authority promotion.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct AuthorityEvidence {
-    /// Compiled execution plan digest.
-    pub plan_digest: String,
-    /// Fixture corpus revision.
-    pub fixture_corpus_revision: String,
-    /// Supported auth modes.
-    pub supported_auth_modes: Vec<String>,
-    /// Supported pagination grammar entries.
-    pub supported_pagination_grammar: Vec<String>,
-    /// Supported provider error modes.
-    pub supported_provider_errors: Vec<String>,
-    /// Bounded provider egress allowlist.
-    pub egress_allowlist: Vec<String>,
-    /// Response and decompression limits proof.
-    pub response_limits: String,
-    /// Credential lease mode proof.
-    pub credential_lease_mode: String,
-    /// Projection readiness or explicit Go dependency.
-    pub projection_dependency: String,
-    /// Rollback receipt.
-    pub rollback_receipt: String,
-    /// Fixture parity status.
-    pub parity_status: String,
-    /// Canonical digest vector names.
-    pub canonical_digest_vectors: Vec<String>,
-    /// Credential/config safety proof.
-    pub config_safety_proof: String,
-    /// Cursor/checkpoint rollback proof.
-    pub cursor_checkpoint_proof: String,
-    /// Fencing/recovery proof.
-    pub fencing_recovery_proof: String,
-    /// Worker/runtime build identity.
-    pub worker_build_id: String,
-    /// Signed or authenticated promotion receipt.
-    pub promotion_receipt: String,
-}
-
 /// Protocol validation failures.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ProtocolError {
@@ -237,19 +200,32 @@ pub fn validate_envelope_json(value: &serde_json::Value) -> Result<(), ProtocolE
 
 /// Validate complete provider proof before authority promotion.
 pub fn validate_authority_evidence(evidence: &AuthorityEvidence) -> Result<(), ProtocolError> {
-    let missing = missing_authority_evidence(evidence);
+    let missing = cerebro_source_catalog::missing_authority_qualification_evidence(evidence);
     if !missing.is_empty() {
         return Err(ProtocolError::MissingAuthorityEvidence(missing));
     }
-    if !is_sha256_hex(&evidence.plan_digest) {
-        return Err(ProtocolError::InvalidAuthorityDigest(
-            "compiled_plan_digest",
-        ));
+    match cerebro_source_catalog::validate_authority_qualification_evidence(evidence) {
+        Ok(()) => Ok(()),
+        Err(cerebro_source_catalog::AuthorityEvidenceError::Invalid("compiled_plan_digest")) => {
+            Err(ProtocolError::InvalidAuthorityDigest(
+                "compiled_plan_digest",
+            ))
+        }
+        Err(cerebro_source_catalog::AuthorityEvidenceError::Invalid("runtime_plan_digest")) => {
+            Err(ProtocolError::InvalidAuthorityDigest("runtime_plan_digest"))
+        }
+        Err(cerebro_source_catalog::AuthorityEvidenceError::Invalid("promotion_receipt")) => {
+            Err(ProtocolError::UnauthenticatedPromotionReceipt)
+        }
+        Err(cerebro_source_catalog::AuthorityEvidenceError::Invalid(field)) => {
+            Err(ProtocolError::MissingAuthorityEvidence(vec![field]))
+        }
+        Err(cerebro_source_catalog::AuthorityEvidenceError::Immutable) => {
+            Err(ProtocolError::MissingAuthorityEvidence(vec![
+                "authority_evidence_immutable",
+            ]))
+        }
     }
-    if !authenticated_promotion_receipt(&evidence.promotion_receipt) {
-        return Err(ProtocolError::UnauthenticatedPromotionReceipt);
-    }
-    Ok(())
 }
 
 /// Return canonical SHA-256 hex for a serializable JSON/protobuf-shaped value.
@@ -472,88 +448,6 @@ fn normalize_protocol_field_name(name: &str) -> String {
     normalized.trim_matches('_').to_owned()
 }
 
-fn missing_authority_evidence(evidence: &AuthorityEvidence) -> Vec<&'static str> {
-    let mut missing = Vec::new();
-    if evidence.plan_digest.trim().is_empty() {
-        missing.push("compiled_plan_digest");
-    }
-    if evidence.fixture_corpus_revision.trim().is_empty() {
-        missing.push("fixture_corpus_revision");
-    }
-    if evidence
-        .supported_auth_modes
-        .iter()
-        .all(|value| value.trim().is_empty())
-    {
-        missing.push("supported_auth_modes");
-    }
-    if evidence
-        .supported_pagination_grammar
-        .iter()
-        .all(|value| value.trim().is_empty())
-    {
-        missing.push("supported_pagination_grammar");
-    }
-    if evidence
-        .supported_provider_errors
-        .iter()
-        .all(|value| value.trim().is_empty())
-    {
-        missing.push("supported_provider_error_modes");
-    }
-    if evidence
-        .egress_allowlist
-        .iter()
-        .all(|value| value.trim().is_empty())
-    {
-        missing.push("egress_allowlist");
-    }
-    for (field, value) in [
-        ("response_decompression_limits", &evidence.response_limits),
-        ("credential_lease_mode", &evidence.credential_lease_mode),
-        ("projection_dependency", &evidence.projection_dependency),
-        ("rollback_receipt", &evidence.rollback_receipt),
-        ("fixture_parity_status", &evidence.parity_status),
-        (
-            "credential_config_safety_proof",
-            &evidence.config_safety_proof,
-        ),
-        (
-            "cursor_checkpoint_rollback_proof",
-            &evidence.cursor_checkpoint_proof,
-        ),
-        (
-            "operational_fencing_recovery_proof",
-            &evidence.fencing_recovery_proof,
-        ),
-        ("worker_runtime_build_identity", &evidence.worker_build_id),
-        ("promotion_receipt", &evidence.promotion_receipt),
-    ] {
-        if value.trim().is_empty() {
-            missing.push(field);
-        }
-    }
-    if evidence
-        .canonical_digest_vectors
-        .iter()
-        .all(|value| value.trim().is_empty())
-    {
-        missing.push("canonical_digest_vectors");
-    }
-    missing.sort_unstable();
-    missing
-}
-
-fn is_sha256_hex(value: &str) -> bool {
-    let value = value.trim();
-    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
-}
-
-fn authenticated_promotion_receipt(value: &str) -> bool {
-    let value = value.trim();
-    value.starts_with("sig:") || value.starts_with("auth:")
-}
-
 #[cfg(test)]
 pub(crate) fn fixture_envelope(operation: SourceRuntimeOperation) -> SourceRuntimeEnvelope {
     SourceRuntimeEnvelope {
@@ -773,6 +667,7 @@ mod tests {
     fn authority_readiness_requires_complete_evidence() {
         let complete = AuthorityEvidence {
             plan_digest: "a".repeat(64),
+            runtime_plan_digest: "b".repeat(64),
             fixture_corpus_revision: "fixture-corpus:v1".to_owned(),
             supported_auth_modes: vec!["api_key".to_owned()],
             supported_pagination_grammar: vec!["cursor".to_owned()],
@@ -793,6 +688,10 @@ mod tests {
             fencing_recovery_proof: "fence:rejected-stale".to_owned(),
             worker_build_id: "source-runtime-next:test".to_owned(),
             promotion_receipt: "sig:promotion:test".to_owned(),
+            authenticated_collection_receipt: "receipt:collection:test".to_owned(),
+            append_projection_checkpoint_receipt: "receipt:durable-commit:test".to_owned(),
+            lease_restart_receipt: "receipt:lease-restart:test".to_owned(),
+            product_read_receipt: "receipt:product-read:test".to_owned(),
         };
         validate_authority_evidence(&complete).unwrap();
 
@@ -812,6 +711,7 @@ mod tests {
     fn authority_evidence_rejects_malformed_digest_and_unsigned_promotion_receipt() {
         let complete = AuthorityEvidence {
             plan_digest: "a".repeat(64),
+            runtime_plan_digest: "b".repeat(64),
             fixture_corpus_revision: "fixture-corpus:v1".to_owned(),
             supported_auth_modes: vec!["api_key".to_owned()],
             supported_pagination_grammar: vec!["cursor".to_owned()],
@@ -832,6 +732,10 @@ mod tests {
             fencing_recovery_proof: "fence:rejected-stale".to_owned(),
             worker_build_id: "source-runtime-next:test".to_owned(),
             promotion_receipt: "sig:promotion:test".to_owned(),
+            authenticated_collection_receipt: "receipt:collection:test".to_owned(),
+            append_projection_checkpoint_receipt: "receipt:durable-commit:test".to_owned(),
+            lease_restart_receipt: "receipt:lease-restart:test".to_owned(),
+            product_read_receipt: "receipt:product-read:test".to_owned(),
         };
         let mut bad_digest = complete.clone();
         bad_digest.plan_digest = "not-a-sha256".to_owned();
@@ -840,6 +744,13 @@ mod tests {
             Err(ProtocolError::InvalidAuthorityDigest(
                 "compiled_plan_digest"
             ))
+        );
+
+        let mut bad_runtime_digest = complete.clone();
+        bad_runtime_digest.runtime_plan_digest = "not-a-sha256".to_owned();
+        assert_eq!(
+            validate_authority_evidence(&bad_runtime_digest),
+            Err(ProtocolError::InvalidAuthorityDigest("runtime_plan_digest"))
         );
 
         let mut unsigned = complete;

--- a/docs/engineering/rust-organizational-platform.md
+++ b/docs/engineering/rust-organizational-platform.md
@@ -268,7 +268,7 @@ The current checked-in pull catalog compiles to 798 sources and 3,925 families. 
 | Activity | 744 | audit and operational events |
 | Bespoke | 3 | retained for source coverage but barred from authority |
 
-Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 53 sources and 355 families are authoritative; the other 745 sources remain shadow-only. This preserves source coverage without converting catalog presence into a false production claim.
+Based on exact provider method-and-path proof, resolvable runtime path and query parameters, bounded fanout scopes, and auth support present in this Rust runtime, 53 sources and 355 families are technically eligible for qualification; they are not production-authoritative until the durable family authority record is promoted with complete evidence. The other 745 sources remain shadow-only. This preserves source coverage without converting catalog presence into a production-authority claim.
 
 ## Family cutover
 
@@ -293,7 +293,9 @@ Go projector                Rust mapper
                          Neo4j outbox apply
 ```
 
-`cerebro-platform evaluate-family` evaluates stored parity receipts without changing authority. `cerebro-platform promote-family` repeats that evaluation and records Rust authority. `cerebro-platform show-authority` reads the effective record. These commands use `CEREBRO_POSTGRES_DSN` plus `CEREBRO_TENANT_ID`, `CEREBRO_SOURCE_ID`, and `CEREBRO_SOURCE_FAMILY`.
+`cerebro-platform evaluate-family` evaluates stored parity receipts without changing authority. `cerebro-platform promote-family` repeats that evaluation and records Rust authority in `organizational_projection_authority`. `cerebro-platform show-authority` reads that same effective record. These commands use `CEREBRO_POSTGRES_DSN` plus `CEREBRO_TENANT_ID`, `CEREBRO_SOURCE_ID`, and `CEREBRO_SOURCE_FAMILY`. Evaluation and promotion also require `CEREBRO_AUTHORITY_EVIDENCE_PATH`, which must name one JSON-encoded `AuthorityQualificationEvidence` record. Batch evaluation uses `CEREBRO_AUTHORITY_EVIDENCE_DIR` and loads `<source>/<family>.json` beneath that directory.
+
+The qualification record binds the exact catalog and closed-runtime plan digests, fixture corpus and parity result, authentication and egress boundaries, response limits, credential lease behavior, canonical digest vectors, checkpoint and fencing proofs, worker build, authenticated promotion receipt, authenticated collection, append-projection-checkpoint ordering, lease/restart safety, and an applicable product read. Missing or malformed evidence fails before ledger mutation. An unregistered closed Rust execution adapter is a blocking result; the catalog plan digest is never substituted for a runtime plan digest.
 
 `cerebro-platform serve-neo4j-readonly` opens only the bounded Neo4j read plane. It does not connect to PostgreSQL, run store migrations, expose a projection runtime, or consume the append log. Use this process for the authority read endpoint. `serve-neo4j` adds the projection API, while `serve-neo4j-consumer` also starts append-log consumption.
 


### PR DESCRIPTION
## Current boundary

This draft introduces source-family promotion request types, catalog/runtime plan binding, parity evaluation, and decision persistence through the existing organizational_projection_authority row.

The current head is not safe to grant Rust authority. It validates operator-provided receipt labels and a prefix-shaped promotion value, but it does not yet verify those references against authoritative persisted collection, page publication, projection/checkpoint, lease/restart, product-read, or approval records. It also does not verify a detached signature.

Until that is repaired, evaluation must be treated as non-authoritative and no source family may be promoted from this head.

## Forward repair in progress

The next head must:

- replace opaque labels with typed tenant/source/family/runtime-revision-bound references
- verify each reference against its authoritative persisted owner
- reject fabricated, cross-tenant, cross-family, stale-revision, unprojected, uncheckpointed, lease-lost, and missing product-read evidence
- fail closed when a required verifier or persisted record is unavailable
- keep organizational_projection_authority as the sole dispatcher authority

## Module ownership

- source-catalog/authority_evidence.rs: evidence schema and canonical digest
- organizational-store/promotion.rs: request and decision types
- organizational-store/cutover.rs: parity and lag evaluation
- organizational-store/postgres.rs: existing authority row and persisted receipt lookup
- cerebro-platform/cutover_evidence.rs: strict evidence input decoding
- cerebro-platform/cutover_command.rs: command orchestration

## State

- Draft only; do not mark ready or merge.
- No source family is promoted.
- No Go writer is retired by this change.
- No deployment, provider collection, or authenticated product read is claimed.
- Managed execution validation remains unavailable; hosted checks on the current head do not resolve the persisted-verification defect.