### PR TITLE
authz: canonicalize role aliases

### DIFF
--- a/internal/authz/rbac.go
+++ b/internal/authz/rbac.go
@@ -69,34 +69,19 @@ var allScopes = []string{
 	ScopeUserPreferencesWrite,
 }
 
+var roleAliases = map[string]string{
+	"viewer":    RoleCerebroViewer,
+	"reader":    RoleCerebroViewer,
+	"read_only": RoleCerebroViewer,
+	"analyst":   RoleCerebroAnalyst,
+	"editor":    RoleCerebroAnalyst,
+	"admin":     RoleCerebroAdmin,
+	"owner":     RoleCerebroAdmin,
+}
+
 var roleScopes = map[string][]string{
 	RoleCerebroViewer: {ScopeCosmoSecurityRead, ScopeUserPreferencesWrite},
-	"viewer":          {ScopeCosmoSecurityRead, ScopeUserPreferencesWrite},
-	"reader":          {ScopeCosmoSecurityRead, ScopeUserPreferencesWrite},
-	"read_only":       {ScopeCosmoSecurityRead, ScopeUserPreferencesWrite},
 	RoleCerebroAnalyst: {
-		ScopeCosmoSecurityRead,
-		ScopeUserPreferencesWrite,
-		ScopeFindingCandidatePromote,
-		ScopeFindingLifecycleWrite,
-		ScopeGRCInventoryWrite,
-		ScopeGRCPolicyLifecycleWrite,
-		ScopeAskQueriesWrite,
-		ScopeDashboardsWrite,
-		ScopeRiskScoringWrite,
-	},
-	"analyst": {
-		ScopeCosmoSecurityRead,
-		ScopeUserPreferencesWrite,
-		ScopeFindingCandidatePromote,
-		ScopeFindingLifecycleWrite,
-		ScopeGRCInventoryWrite,
-		ScopeGRCPolicyLifecycleWrite,
-		ScopeAskQueriesWrite,
-		ScopeDashboardsWrite,
-		ScopeRiskScoringWrite,
-	},
-	"editor": {
 		ScopeCosmoSecurityRead,
 		ScopeUserPreferencesWrite,
 		ScopeFindingCandidatePromote,
@@ -127,14 +112,12 @@ var roleScopes = map[string][]string{
 	},
 	RoleCerebroJobManager: {ScopeCosmoSecurityRead, ScopeUserPreferencesWrite, ScopeJobsWrite},
 	RoleCerebroAdmin:      allScopes,
-	"admin":               allScopes,
-	"owner":               allScopes,
 }
 
 func ScopesForRoles(roles []string) []string {
 	var scopes []string
 	for _, role := range normalize(roles) {
-		scopes = append(scopes, roleScopes[role]...)
+		scopes = append(scopes, roleScopes[canonicalRole(role)]...)
 	}
 	return normalize(scopes)
 }
@@ -148,8 +131,19 @@ func HasRole(roles []string) bool {
 }
 
 func HasAdminRole(roles []string) bool {
-	roles = normalize(roles)
-	return contains(roles, RoleCerebroAdmin) || contains(roles, "admin") || contains(roles, "owner")
+	normalizedRoles := normalize(roles)
+	canonicalRoles := make([]string, 0, len(normalizedRoles))
+	for _, role := range normalizedRoles {
+		canonicalRoles = append(canonicalRoles, canonicalRole(role))
+	}
+	return contains(canonicalRoles, RoleCerebroAdmin)
+}
+
+func canonicalRole(role string) string {
+	if canonical, ok := roleAliases[role]; ok {
+		return canonical
+	}
+	return role
 }
 
 // PrincipalActorID returns the first stable identity field supplied by the

--- a/internal/authz/rbac_test.go
+++ b/internal/authz/rbac_test.go
@@ -1,6 +1,9 @@
 package authz
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestPrincipalActorIDUsesFirstConcreteAuthenticatedField(t *testing.T) {
 	if got := PrincipalActorID(" ", "client-1", "device-1", "credential-1"); got != "client-1" {
@@ -40,6 +43,42 @@ func TestUserPreferencesWriteScopeRoleExpansion(t *testing.T) {
 	} {
 		if !hasScope(ScopesForRoles([]string{role}), ScopeUserPreferencesWrite) {
 			t.Fatalf("role %q did not expand to %s", role, ScopeUserPreferencesWrite)
+		}
+	}
+}
+
+func TestRoleAliasesResolveToCanonicalScopes(t *testing.T) {
+	for alias, canonical := range roleAliases {
+		canonicalScopes, ok := roleScopes[canonical]
+		if !ok {
+			t.Errorf("role alias %q targets undefined canonical role %q", alias, canonical)
+			continue
+		}
+		if len(canonicalScopes) == 0 {
+			t.Errorf("canonical role %q has no scopes", canonical)
+		}
+		if _, ok := roleScopes[alias]; ok {
+			t.Errorf("role alias %q has its own scope definition", alias)
+		}
+
+		got := ScopesForRoles([]string{alias})
+		want := ScopesForRoles([]string{canonical})
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("role alias %q scopes = %#v, canonical role %q scopes = %#v", alias, got, canonical, want)
+		}
+	}
+}
+
+func TestAdminRoleAliasesPreserveAdminBehavior(t *testing.T) {
+	for _, role := range []string{RoleCerebroAdmin, "admin", "owner"} {
+		if !HasAdminRole([]string{role}) {
+			t.Errorf("role %q was not recognized as an admin role", role)
+		}
+	}
+
+	for _, role := range []string{RoleCerebroViewer, "viewer", "reader", "read_only", RoleCerebroAnalyst, "analyst", "editor"} {
+		if HasAdminRole([]string{role}) {
+			t.Errorf("role %q was unexpectedly recognized as an admin role", role)
 		}
 	}
 }


### PR DESCRIPTION
Closes #2686.

## Summary
- map supported role aliases to canonical roles before scope expansion
- keep one scope definition per canonical role
- verify every alias matches its canonical scope set and preserves admin detection

## Validation
- `go test ./internal/authz -count=1`
- `go test ./internal/authz -race -count=1`
- `git diff --check`