### PR TITLE
Fix Qdrant terminal cursor assertion after bounded pagination

### DIFF
--- a/crates/source-runtime-next/src/qdrant_cloud/pagination.rs
+++ b/crates/source-runtime-next/src/qdrant_cloud/pagination.rs
@@ -12,7 +12,7 @@ const PAGE_TWO: &str =
     r#"{"items":[{"id":"cluster-2","name":"Cluster two","status":"ready"}],"next_page_token":""}"#;
 
 #[tokio::test]
-async fn clusters_round_trip_two_pages_and_keep_cursor_on_the_declared_origin() {
+async fn clusters_collect_two_pages_and_bind_cursor_query_to_the_declared_origin() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
     let server = tokio::spawn(async move {
@@ -72,19 +72,10 @@ async fn clusters_round_trip_two_pages_and_keep_cursor_on_the_declared_origin() 
         .await
         .unwrap();
     assert!(matches!(&page_one.scope, CollectedScope::Complete(_)));
+    assert_eq!(page_one.records.len(), 2);
     assert_eq!(page_one.records[0].provider_id, "cluster-1");
-    assert_eq!(page_one.next_cursor.as_deref(), Some("page-2"));
-
-    let page_two = connector
-        .collect(CollectionRequest {
-            tenant_id: tenant.clone(),
-            source_runtime_id: runtime_id.clone(),
-            cursor: page_one.next_cursor,
-        })
-        .await
-        .unwrap();
-    assert_eq!(page_two.records[0].provider_id, "cluster-2");
-    assert!(page_two.next_cursor.is_none());
+    assert_eq!(page_one.records[1].provider_id, "cluster-2");
+    assert!(page_one.next_cursor.is_none());
 
     let origin_bound_page = connector
         .collect(CollectionRequest {


### PR DESCRIPTION
## Summary
- assert both Qdrant cluster records returned by the connector
- assert the cursor is terminal after the connector exhausts the second page
- keep the separate hostile cursor check bound to the declared provider origin

## Failure repaired
The landed #2773 exact-head `graph-actions` run 32979211334 failed the Qdrant pagination test because the connector collects both pages in one bounded call and returns `next_cursor: None`, while the test still expected `page-2` and attempted a redundant second collection.

## Validation
- `rustfmt --edition 2024 crates/source-runtime-next/src/qdrant_cloud/pagination.rs`
- `git diff --check`
- focused managed Cargo test attempted but blocked before execution: DDESK safe capacity short by 30,752,053,862 bytes
- exact-head hosted checks are the execution authority

## Evidence boundary
This repairs a Rust test contract only. It does not change collection behavior, projection authority, deployment, provider qualification, Go retirement, or authenticated product-read evidence.