### PR TITLE
Verify persisted source-family receipts before Rust authority

### DIFF
--- a/crates/cerebro-platform/examples/organizational_graph_e2e.rs
+++ b/crates/cerebro-platform/examples/organizational_graph_e2e.rs
@@ -17,7 +17,7 @@ use cerebro_organizational_store::{
     CutoverPolicy, DurableGraphStore, Neo4jProjector, ParityReceipt, PostgresLedger,
     ProjectionAuthority, ProjectionPromotionRequest,
 };
-use cerebro_source_catalog::SourceCatalog;
+use cerebro_source_catalog::{AuthorityQualificationEvidence, SourceCatalog};
 use cerebro_source_runtime_next::{CollectedBatch, CollectedScope, GraphSink, SourceRecord};
 use hmac::{Hmac, KeyInit, Mac};
 use prost::Message;
@@ -737,6 +737,15 @@ fn promotion_request(
     family: &str,
     promoted_at: i64,
 ) -> Result<ProjectionPromotionRequest, Box<dyn Error>> {
+    let evidence_root = PathBuf::from(env::var("CEREBRO_AUTHORITY_EVIDENCE_DIR")?);
+    let evidence_path = evidence_root.join(source).join(format!("{family}.json"));
+    let qualification: AuthorityQualificationEvidence =
+        serde_json::from_slice(&fs::read(&evidence_path).map_err(|error| {
+            format!(
+                "read authority evidence {}: {error}",
+                evidence_path.to_string_lossy()
+            )
+        })?)?;
     Ok(ProjectionPromotionRequest::new(
         TENANT,
         source,
@@ -744,6 +753,7 @@ fn promotion_request(
         CutoverPolicy::new(3, 0)?,
         0,
         promoted_at,
+        qualification,
     )?)
 }
 

--- a/crates/cerebro-platform/src/cutover_command.rs
+++ b/crates/cerebro-platform/src/cutover_command.rs
@@ -1,20 +1,30 @@
 use std::{
     env,
     error::Error,
+    path::Path,
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use cerebro_organizational_store::{CutoverPolicy, PostgresLedger, ProjectionPromotionRequest};
+use cerebro_source_catalog::AuthorityQualificationEvidence;
 use cerebro_source_catalog::SourceCatalog;
 use serde::Serialize;
 
-use crate::{CatalogFamilyFilter, catalog_family_records, load_catalog, required_env};
+use crate::{
+    CatalogFamilyFilter, catalog_family_records,
+    cutover_evidence::{
+        authority_qualification_root, load_family_authority_qualification,
+        load_single_authority_qualification,
+    },
+    load_catalog, required_env,
+};
 
 fn promotion_request(
     tenant_id: String,
     source_id: String,
     family_id: String,
     promoted_at_unix_ms: i64,
+    qualification: AuthorityQualificationEvidence,
 ) -> Result<ProjectionPromotionRequest, Box<dyn Error>> {
     Ok(ProjectionPromotionRequest::new(
         tenant_id,
@@ -23,6 +33,7 @@ fn promotion_request(
         CutoverPolicy::new(3, 0)?,
         0,
         promoted_at_unix_ms,
+        qualification,
     )?)
 }
 
@@ -85,9 +96,16 @@ async fn ledger_and_request() -> Result<(PostgresLedger, ProjectionPromotionRequ
     ledger.migrate().await?;
     let evaluated_at_unix_ms =
         i64::try_from(SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis())?;
+    let qualification = load_single_authority_qualification()?;
     Ok((
         ledger,
-        promotion_request(tenant_id, source_id, family_id, evaluated_at_unix_ms)?,
+        promotion_request(
+            tenant_id,
+            source_id,
+            family_id,
+            evaluated_at_unix_ms,
+            qualification,
+        )?,
     ))
 }
 
@@ -217,6 +235,7 @@ async fn evaluate_one_family(
     family_id: &str,
     evaluated_at_unix_ms: i64,
     promote_ready: bool,
+    qualification_root: &Path,
 ) -> FamilyCutoverOutcome {
     let mut outcome = FamilyCutoverOutcome {
         source_id: source_id.to_owned(),
@@ -227,11 +246,20 @@ async fn evaluate_one_family(
         evidence_digest: None,
         error: None,
     };
+    let qualification =
+        match load_family_authority_qualification(qualification_root, source_id, family_id) {
+            Ok(qualification) => qualification,
+            Err(error) => {
+                outcome.error = Some(error.to_string());
+                return outcome;
+            }
+        };
     let request = match promotion_request(
         tenant_id.to_owned(),
         source_id.to_owned(),
         family_id.to_owned(),
         evaluated_at_unix_ms,
+        qualification,
     ) {
         Ok(request) => request,
         Err(error) => {
@@ -280,6 +308,7 @@ pub(crate) async fn evaluate_all_families() -> Result<(), Box<dyn Error>> {
     ledger.migrate().await?;
     let evaluated_at_unix_ms =
         i64::try_from(SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis())?;
+    let qualification_root = authority_qualification_root()?;
 
     let scopes = catalog_family_scopes(&catalog, &args.filter);
     let stdout = std::io::stdout();
@@ -294,6 +323,7 @@ pub(crate) async fn evaluate_all_families() -> Result<(), Box<dyn Error>> {
             &family_id,
             evaluated_at_unix_ms,
             args.promote_ready,
+            &qualification_root,
         )
         .await;
         summary.record(&outcome);
@@ -306,21 +336,80 @@ pub(crate) async fn evaluate_all_families() -> Result<(), Box<dyn Error>> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use cerebro_organizational_store::ProjectionAuthority;
+
     use super::*;
 
-    #[test]
-    fn promotion_request_keeps_the_production_gate_strict() {
-        let request = promotion_request(
-            "tenant-a".to_owned(),
-            "box".to_owned(),
-            "users".to_owned(),
-            1,
-        )
-        .unwrap();
-        assert_eq!(request.tenant_id(), "tenant-a");
-        assert_eq!(request.source_id(), "box");
-        assert_eq!(request.family_id(), "users");
-        assert_eq!(request.projection_lag(), 0);
+    #[tokio::test]
+    #[ignore = "requires disposable PostgreSQL"]
+    async fn unverifiable_asana_receipts_cannot_select_rust_authority() {
+        let postgres_dsn = env::var("CEREBRO_TEST_POSTGRES_DSN").unwrap();
+        let authority = PostgresLedger::connect_tls(&postgres_dsn).await.unwrap();
+        authority.migrate().await.unwrap();
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+            .to_string();
+        let tenant_id = format!("platform-promotion-evidence-{suffix}");
+        let mut parity_digests = Vec::new();
+        for index in 1..=3 {
+            let receipt = cerebro_organizational_store::ParityReceipt::compare_scoped(
+                tenant_id.clone(),
+                "asana-runtime",
+                "asana",
+                "users",
+                format!("corpus-{suffix}-{index}"),
+                "sha256:equal",
+                "sha256:equal",
+                true,
+                index,
+            )
+            .unwrap();
+            parity_digests.push(receipt.receipt_digest().to_owned());
+            authority.record_parity(&receipt).await.unwrap();
+        }
+        let catalog = load_catalog().unwrap();
+        let mut qualification = cutover_evidence::authority_qualification_fixture(
+            &catalog,
+            "asana",
+            "users",
+            &format!("corpus-{suffix}-3"),
+        );
+        qualification.parity_receipt_digests = parity_digests;
+        let decision = authority
+            .evaluate_projection_authority(
+                &catalog,
+                &cerebro_organizational_store::ProjectionPromotionRequest::new(
+                    tenant_id.clone(),
+                    "asana",
+                    "users",
+                    cerebro_organizational_store::CutoverPolicy::new(3, 0).unwrap(),
+                    0,
+                    100,
+                    qualification,
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(!decision.is_allowed());
+        assert!(
+            decision
+                .reasons()
+                .iter()
+                .any(|reason| { reason == "product-read receipt verifier is unavailable" })
+        );
+        assert_eq!(
+            authority
+                .projection_authority(&tenant_id, "asana", "users")
+                .await
+                .unwrap()
+                .authority,
+            ProjectionAuthority::Legacy
+        );
     }
 
     #[test]

--- a/crates/cerebro-platform/src/cutover_evidence.rs
+++ b/crates/cerebro-platform/src/cutover_evidence.rs
@@ -1,0 +1,148 @@
+use std::{
+    error::Error,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use cerebro_source_catalog::AuthorityQualificationEvidence;
+
+use crate::required_env;
+
+pub(crate) fn load_single_authority_qualification()
+-> Result<AuthorityQualificationEvidence, Box<dyn Error>> {
+    let path = PathBuf::from(required_env("CEREBRO_AUTHORITY_EVIDENCE_PATH")?);
+    load_authority_qualification(&path)
+}
+
+pub(crate) fn authority_qualification_root() -> Result<PathBuf, Box<dyn Error>> {
+    Ok(PathBuf::from(required_env(
+        "CEREBRO_AUTHORITY_EVIDENCE_DIR",
+    )?))
+}
+
+pub(crate) fn load_family_authority_qualification(
+    root: &Path,
+    source_id: &str,
+    family_id: &str,
+) -> Result<AuthorityQualificationEvidence, Box<dyn Error>> {
+    load_authority_qualification(&root.join(source_id).join(format!("{family_id}.json")))
+}
+
+fn load_authority_qualification(
+    path: &Path,
+) -> Result<AuthorityQualificationEvidence, Box<dyn Error>> {
+    let bytes = fs::read(path).map_err(|error| {
+        format!(
+            "read authority evidence {}: {error}",
+            path.to_string_lossy()
+        )
+    })?;
+    decode_authority_qualification(&bytes).map_err(|error| {
+        format!(
+            "decode authority evidence {}: {error}",
+            path.to_string_lossy()
+        )
+        .into()
+    })
+}
+
+fn decode_authority_qualification(
+    bytes: &[u8],
+) -> Result<AuthorityQualificationEvidence, serde_json::Error> {
+    serde_json::from_slice(bytes)
+}
+
+#[cfg(test)]
+pub(crate) fn authority_qualification_fixture(
+    catalog: &cerebro_source_catalog::SourceCatalog,
+    source_id: &str,
+    family_id: &str,
+    corpus: &str,
+) -> AuthorityQualificationEvidence {
+    use cerebro_source_catalog::{
+        PagePublicationReceiptReference, PersistedReceiptReference,
+        SourceCollectionReceiptReference,
+    };
+    use cerebro_source_runtime_next::source_execution::{
+        SourceExecutionDispatcher, SourceExecutionSelectionRequestV1,
+    };
+
+    let plan_digest = catalog
+        .compiled_family_plan_digest(source_id, family_id)
+        .unwrap();
+    let runtime_plan_digest = SourceExecutionDispatcher
+        .compile_plan(&SourceExecutionSelectionRequestV1 {
+            source_id: source_id.to_owned(),
+            family_id: family_id.to_owned(),
+        })
+        .unwrap()
+        .plan_digest_sha256;
+    AuthorityQualificationEvidence {
+        plan_digest,
+        runtime_plan_digest,
+        fixture_corpus_revision: corpus.to_owned(),
+        supported_auth_modes: vec!["api_key".to_owned()],
+        supported_pagination_grammar: vec!["cursor".to_owned()],
+        supported_provider_errors: vec!["unauthorized".to_owned()],
+        egress_allowlist: vec!["https://provider.example.test".to_owned()],
+        response_limits: "body=1048576,decompression=4x".to_owned(),
+        credential_lease_mode: "one_operation".to_owned(),
+        projection_dependency: "rust_projection".to_owned(),
+        rollback_receipt: PersistedReceiptReference {
+            receipt_id: "rollback-test".to_owned(),
+            receipt_digest_sha256: "c".repeat(64),
+        },
+        parity_status: "passed".to_owned(),
+        canonical_digest_vectors: vec!["plan".to_owned()],
+        config_safety_proof: "receipt:config".to_owned(),
+        cursor_checkpoint_proof: "receipt:checkpoint".to_owned(),
+        fencing_recovery_proof: "receipt:fencing".to_owned(),
+        runtime_revision_sha256: "d".repeat(64),
+        worker_runtime_build_identity: "source-runtime-next:test".to_owned(),
+        promotion_receipt: PersistedReceiptReference {
+            receipt_id: "promotion-test".to_owned(),
+            receipt_digest_sha256: "e".repeat(64),
+        },
+        authenticated_collection_receipt: SourceCollectionReceiptReference {
+            source_runtime_id: format!("{source_id}-runtime"),
+            collection_id: corpus.to_owned(),
+            manifest_digest_sha256: "f".repeat(64),
+        },
+        append_projection_checkpoint_receipt: PagePublicationReceiptReference {
+            source_runtime_id: format!("{source_id}-runtime"),
+            logical_page_id: "page-test".to_owned(),
+            revision: 5,
+            snapshot_digest_sha256: "1".repeat(64),
+        },
+        lease_restart_receipt: PagePublicationReceiptReference {
+            source_runtime_id: format!("{source_id}-runtime"),
+            logical_page_id: "page-restart-test".to_owned(),
+            revision: 6,
+            snapshot_digest_sha256: "2".repeat(64),
+        },
+        product_read_receipt: PersistedReceiptReference {
+            receipt_id: "product-read-test".to_owned(),
+            receipt_digest_sha256: "3".repeat(64),
+        },
+        parity_receipt_digests: vec!["4".repeat(64), "5".repeat(64), "6".repeat(64)],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evidence_input_rejects_unknown_or_incomplete_json_shapes() {
+        assert!(decode_authority_qualification(br#"{"plan_digest":"abc"}"#).is_err());
+        let catalog = crate::load_catalog().unwrap();
+        let complete =
+            authority_qualification_fixture(&catalog, "asana", "users", "fixture-corpus:test");
+        let mut value = serde_json::to_value(complete).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("unexpected".to_owned(), true.into());
+        assert!(decode_authority_qualification(&serde_json::to_vec(&value).unwrap()).is_err());
+    }
+}

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -4,6 +4,7 @@ mod append_log_consumer;
 mod ask_queries;
 mod audit_events;
 mod cutover_command;
+mod cutover_evidence;
 mod graph_provenance;
 mod oidc;
 mod parity_command;
@@ -8235,107 +8236,6 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(wrong_tenant.status(), StatusCode::FORBIDDEN);
-    }
-
-    #[tokio::test]
-    #[ignore = "requires disposable PostgreSQL and Neo4j instances"]
-    async fn promoted_box_family_projects_only_through_rust() {
-        let postgres_dsn = env::var("CEREBRO_TEST_POSTGRES_DSN").unwrap();
-        let authority = PostgresLedger::connect_tls(&postgres_dsn).await.unwrap();
-        authority.migrate().await.unwrap();
-        let store_ledger = PostgresLedger::connect_tls(&postgres_dsn).await.unwrap();
-        store_ledger.migrate().await.unwrap();
-        let graph = Neo4jProjector::connect(
-            &env::var("CEREBRO_TEST_NEO4J_URI").unwrap(),
-            &env::var("CEREBRO_TEST_NEO4J_USERNAME").unwrap(),
-            &env::var("CEREBRO_TEST_NEO4J_PASSWORD").unwrap(),
-        )
-        .await
-        .unwrap();
-        graph.migrate().await.unwrap();
-        let suffix = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-            .to_string();
-        let tenant_id = format!("platform-cutover-{suffix}");
-        for index in 1..=3 {
-            authority
-                .record_parity(
-                    &cerebro_organizational_store::ParityReceipt::compare_scoped(
-                        tenant_id.clone(),
-                        "box-runtime",
-                        "box",
-                        "content_assets",
-                        format!("corpus-{suffix}-{index}"),
-                        "sha256:equal",
-                        "sha256:equal",
-                        true,
-                        index,
-                    )
-                    .unwrap(),
-                )
-                .await
-                .unwrap();
-        }
-        let catalog = load_catalog().unwrap();
-        authority
-            .evaluate_and_promote_projection_authority(
-                &catalog,
-                &cerebro_organizational_store::ProjectionPromotionRequest::new(
-                    tenant_id.clone(),
-                    "box",
-                    "content_assets",
-                    cerebro_organizational_store::CutoverPolicy::new(3, 0).unwrap(),
-                    0,
-                    100,
-                )
-                .unwrap(),
-            )
-            .await
-            .unwrap();
-        let runtime = Arc::new(ProjectionRuntime {
-            catalog,
-            authority,
-            store: Mutex::new(DurableGraphStore::new(store_ledger, graph.clone())),
-        });
-        let resource_urn = format!("urn:cerebro:{tenant_id}:runtime_file:asset-1");
-        let response = runtime
-            .project_committed_with_intent(
-                CommittedSourceEvent::from_input(
-                    cerebro_source_runtime_next::CommittedSourceInput {
-                        tenant_id: TenantId::parse(tenant_id.clone()).unwrap(),
-                        source_runtime_id: SourceRuntimeId::parse("box-runtime").unwrap(),
-                        observation_id: ObservationId::parse("event-1").unwrap(),
-                        source_id: "box".to_owned(),
-                        family_id: "content_assets".to_owned(),
-                        event_kind: "box.content_assets".to_owned(),
-                        schema_ref: "box/content_assets/v1".to_owned(),
-                        observed_at_unix_ms: 100,
-                        attributes: BTreeMap::from([
-                            ("resource_id".to_owned(), "asset-1".to_owned()),
-                            ("resource_name".to_owned(), "Architecture".to_owned()),
-                            ("resource_type".to_owned(), "file".to_owned()),
-                            ("resource_urn".to_owned(), resource_urn.clone()),
-                        ]),
-                        payload: serde_json::json!({
-                            "id": "asset-1",
-                            "name": "Architecture",
-                            "type": "file",
-                            "resource_urn": resource_urn.clone()
-                        }),
-                    },
-                )
-                .unwrap(),
-                false,
-            )
-            .await
-            .unwrap();
-        assert!(response.projected);
-        let tenant = TenantId::parse(tenant_id).unwrap();
-        let entity = graph.resolve(&tenant, &resource_urn).await.unwrap();
-        assert_eq!(entity.label, "Architecture");
-        assert_eq!(entity.properties.get("resource_urn"), Some(&resource_urn));
     }
 
     #[test]

--- a/crates/organizational-store/src/cutover.rs
+++ b/crates/organizational-store/src/cutover.rs
@@ -1,10 +1,15 @@
 use std::{collections::BTreeMap, error::Error, fmt};
 
-use cerebro_source_catalog::SourceCatalog;
-use serde::Serialize;
+use cerebro_source_catalog::{
+    AuthorityQualificationEvidence, SourceCatalog, authority_qualification_digest,
+};
 use sha2::{Digest, Sha256};
 
-use crate::{ParityReceipt, ParityStatus};
+use crate::{
+    ParityReceipt, ParityStatus,
+    promotion::{CutoverDecision, promotion_evidence_reasons},
+    promotion_evidence_store::{PromotionEvidenceVerification, VerifiedPromotionReceiptKind},
+};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CutoverPolicy {
@@ -24,121 +29,6 @@ impl CutoverPolicy {
             min_consecutive_matches,
             max_projection_lag,
         })
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ProjectionPromotionRequest {
-    tenant_id: String,
-    source_id: String,
-    family_id: String,
-    policy: CutoverPolicy,
-    projection_lag: u64,
-    promoted_at_unix_ms: i64,
-}
-
-impl ProjectionPromotionRequest {
-    pub fn new(
-        tenant_id: impl Into<String>,
-        source_id: impl Into<String>,
-        family_id: impl Into<String>,
-        policy: CutoverPolicy,
-        projection_lag: u64,
-        promoted_at_unix_ms: i64,
-    ) -> Result<Self, CutoverError> {
-        let tenant_id = checked_text(tenant_id.into(), "tenant_id")?;
-        let source_id = checked_text(source_id.into(), "source_id")?;
-        let family_id = checked_text(family_id.into(), "family_id")?;
-        if promoted_at_unix_ms <= 0 {
-            return Err(CutoverError::Invalid("promoted_at_unix_ms"));
-        }
-        Ok(Self {
-            tenant_id,
-            source_id,
-            family_id,
-            policy,
-            projection_lag,
-            promoted_at_unix_ms,
-        })
-    }
-
-    pub fn tenant_id(&self) -> &str {
-        &self.tenant_id
-    }
-
-    pub fn source_id(&self) -> &str {
-        &self.source_id
-    }
-
-    pub fn family_id(&self) -> &str {
-        &self.family_id
-    }
-
-    pub(crate) fn policy(&self) -> CutoverPolicy {
-        self.policy
-    }
-
-    pub fn projection_lag(&self) -> u64 {
-        self.projection_lag
-    }
-
-    pub(crate) fn promoted_at_unix_ms(&self) -> i64 {
-        self.promoted_at_unix_ms
-    }
-}
-
-fn checked_text(value: String, field: &'static str) -> Result<String, CutoverError> {
-    if value.is_empty() || value.trim() != value {
-        return Err(CutoverError::Invalid(field));
-    }
-    Ok(value)
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-pub struct CutoverDecision {
-    source_id: String,
-    family_id: String,
-    allowed: bool,
-    reasons: Vec<String>,
-    evidence_digest: String,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ProjectionAuthority {
-    Legacy,
-    Rust,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-pub struct ProjectionAuthorityRecord {
-    pub tenant_id: String,
-    pub source_id: String,
-    pub family_id: String,
-    pub authority: ProjectionAuthority,
-    pub evidence_digest: String,
-    pub promoted_at_unix_ms: Option<i64>,
-}
-
-impl CutoverDecision {
-    pub fn source_id(&self) -> &str {
-        &self.source_id
-    }
-
-    pub fn family_id(&self) -> &str {
-        &self.family_id
-    }
-
-    pub fn is_allowed(&self) -> bool {
-        self.allowed
-    }
-
-    pub fn reasons(&self) -> &[String] {
-        &self.reasons
-    }
-
-    pub fn evidence_digest(&self) -> &str {
-        &self.evidence_digest
     }
 }
 
@@ -165,31 +55,49 @@ impl fmt::Display for CutoverError {
 
 impl Error for CutoverError {}
 
-pub struct CutoverGate {
+pub(crate) struct CutoverGate {
     policy: CutoverPolicy,
 }
 
 impl CutoverGate {
-    pub fn new(policy: CutoverPolicy) -> Self {
+    pub(crate) fn new(policy: CutoverPolicy) -> Self {
         Self { policy }
     }
 
-    pub fn evaluate(
+    pub(crate) fn evaluate(
         &self,
         catalog: &SourceCatalog,
+        tenant_id: &str,
         source_id: &str,
         family_id: &str,
         receipts: &[ParityReceipt],
         projection_lag: u64,
+        qualification: &AuthorityQualificationEvidence,
+        verification: &PromotionEvidenceVerification,
     ) -> Result<CutoverDecision, CutoverError> {
         let source = catalog
             .get(source_id)
             .ok_or_else(|| CutoverError::UnknownSource(source_id.to_owned()))?;
-        let mut reasons = Vec::new();
+        let mut reasons = promotion_evidence_reasons(catalog, source_id, family_id, qualification)?;
+        reasons.extend(verification.reasons().iter().cloned());
+        reasons.extend(verified_scope_reasons(
+            tenant_id,
+            source_id,
+            family_id,
+            qualification,
+            verification,
+        ));
+        reasons.extend(verified_receipt_binding_reasons(
+            qualification,
+            verification,
+        ));
         let family = source
             .families()
             .iter()
             .find(|family| family.id() == family_id)
+            .ok_or_else(|| CutoverError::UnknownSource(format!("{source_id}/{family_id}")))?;
+        let catalog_plan_digest = catalog
+            .compiled_family_plan_digest(source_id, family_id)
             .ok_or_else(|| CutoverError::UnknownSource(format!("{source_id}/{family_id}")))?;
         if !family.is_projection_authoritative() {
             reasons.push("provider method and path proof is incomplete".to_owned());
@@ -203,11 +111,24 @@ impl CutoverGate {
                 self.policy.max_projection_lag
             ));
         }
-        let source_receipts: Vec<_> = receipts
+        if receipts.iter().any(|receipt| {
+            receipt.source_id() == source_id
+                && receipt.family_id() == family_id
+                && receipt.tenant_id() != tenant_id
+        }) {
+            reasons.push("parity receipt tenant does not match promotion request".to_owned());
+        }
+        let mut source_receipts: Vec<_> = receipts
             .iter()
+            .filter(|receipt| receipt.tenant_id() == tenant_id)
             .filter(|receipt| receipt.source_id() == source_id)
             .filter(|receipt| receipt.family_id() == family_id)
             .collect();
+        source_receipts.sort_by(|left, right| {
+            left.compared_at_unix_ms()
+                .cmp(&right.compared_at_unix_ms())
+                .then_with(|| left.receipt_digest().cmp(right.receipt_digest()))
+        });
         let consecutive = source_receipts
             .iter()
             .rev()
@@ -219,9 +140,20 @@ impl CutoverGate {
                 self.policy.min_consecutive_matches
             ));
         }
+        let qualifying_receipt_digests = source_receipts
+            .iter()
+            .rev()
+            .take(self.policy.min_consecutive_matches)
+            .rev()
+            .map(|receipt| receipt.receipt_digest().to_owned())
+            .collect::<Vec<_>>();
+        if qualification.parity_receipt_digests != qualifying_receipt_digests {
+            reasons
+                .push("persisted parity receipt sequence does not match qualification".to_owned());
+        }
         let mut latest_by_corpus = BTreeMap::new();
-        for receipt in source_receipts {
-            latest_by_corpus.insert(receipt.collection_id(), receipt);
+        for receipt in &source_receipts {
+            latest_by_corpus.insert(receipt.collection_id(), *receipt);
         }
         if latest_by_corpus
             .values()
@@ -235,22 +167,188 @@ impl CutoverGate {
         {
             reasons.push("a latest parity receipt exceeds the projection lag policy".to_owned());
         }
+        if source_receipts
+            .last()
+            .is_some_and(|receipt| receipt.collection_id() != qualification.fixture_corpus_revision)
+        {
+            reasons
+                .push("qualification fixture corpus is not the latest parity receipt".to_owned());
+        }
+        let qualification_digest = authority_qualification_digest(qualification);
+        let verification_digest = verification.digest();
         let evidence_digest = digest(
-            &receipts
+            &source_receipts
                 .iter()
-                .filter(|receipt| receipt.source_id() == source_id)
-                .filter(|receipt| receipt.family_id() == family_id)
-                .map(ParityReceipt::receipt_digest)
+                .map(|receipt| receipt.receipt_digest())
+                .chain([
+                    tenant_id,
+                    source_id,
+                    family_id,
+                    qualification_digest.as_str(),
+                    catalog_plan_digest.as_str(),
+                    qualification.runtime_plan_digest.as_str(),
+                    verification_digest.as_str(),
+                ])
                 .collect::<Vec<_>>(),
         );
+        reasons.sort();
+        reasons.dedup();
         Ok(CutoverDecision {
+            tenant_id: tenant_id.to_owned(),
             source_id: source_id.to_owned(),
             family_id: family_id.to_owned(),
             allowed: reasons.is_empty(),
             reasons,
             evidence_digest,
+            qualification: qualification.clone(),
+            verified_receipts: verification.receipts().to_vec(),
         })
     }
+}
+
+fn verified_scope_reasons(
+    tenant_id: &str,
+    source_id: &str,
+    family_id: &str,
+    qualification: &AuthorityQualificationEvidence,
+    verification: &PromotionEvidenceVerification,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    if verification.tenant_id() != tenant_id {
+        reasons.push("persisted verification tenant does not match promotion request".to_owned());
+    }
+    if verification.source_id() != source_id {
+        reasons.push("persisted verification source does not match promotion request".to_owned());
+    }
+    if verification.family_id() != family_id {
+        reasons.push("persisted verification family does not match promotion request".to_owned());
+    }
+    let collection_runtime = qualification
+        .authenticated_collection_receipt
+        .source_runtime_id
+        .as_str();
+    if qualification
+        .append_projection_checkpoint_receipt
+        .source_runtime_id
+        != collection_runtime
+        || qualification.lease_restart_receipt.source_runtime_id != collection_runtime
+    {
+        reasons.push("qualified receipt runtime identifiers do not match".to_owned());
+    }
+    if verification.source_runtime_id() != collection_runtime {
+        reasons.push("persisted verification runtime does not match qualification".to_owned());
+    }
+    if verification.runtime_revision_sha256() != qualification.runtime_revision_sha256 {
+        reasons.push(
+            "persisted verification runtime revision does not match qualification".to_owned(),
+        );
+    }
+    reasons
+}
+
+fn verified_receipt_binding_reasons(
+    qualification: &AuthorityQualificationEvidence,
+    verification: &PromotionEvidenceVerification,
+) -> Vec<String> {
+    let collection = &qualification.authenticated_collection_receipt;
+    let append = &qualification.append_projection_checkpoint_receipt;
+    let restart = &qualification.lease_restart_receipt;
+    let mut reasons = Vec::new();
+    for (kind, receipt_id, receipt_digest, label) in [
+        (
+            VerifiedPromotionReceiptKind::DurableCollection,
+            collection.collection_id.as_str(),
+            collection.manifest_digest_sha256.as_str(),
+            "durable collection",
+        ),
+        (
+            VerifiedPromotionReceiptKind::AuthenticatedCollection,
+            collection.collection_id.as_str(),
+            collection.manifest_digest_sha256.as_str(),
+            "authenticated collection",
+        ),
+        (
+            VerifiedPromotionReceiptKind::AppendProjectionCheckpoint,
+            append.logical_page_id.as_str(),
+            append.snapshot_digest_sha256.as_str(),
+            "append/projection/checkpoint",
+        ),
+        (
+            VerifiedPromotionReceiptKind::LeaseRestart,
+            restart.logical_page_id.as_str(),
+            restart.snapshot_digest_sha256.as_str(),
+            "lease/restart",
+        ),
+        (
+            VerifiedPromotionReceiptKind::RuntimeRevision,
+            qualification.runtime_revision_sha256.as_str(),
+            qualification.runtime_revision_sha256.as_str(),
+            "runtime revision",
+        ),
+        (
+            VerifiedPromotionReceiptKind::ProductRead,
+            qualification.product_read_receipt.receipt_id.as_str(),
+            qualification
+                .product_read_receipt
+                .receipt_digest_sha256
+                .as_str(),
+            "product-read",
+        ),
+        (
+            VerifiedPromotionReceiptKind::PromotionApproval,
+            qualification.promotion_receipt.receipt_id.as_str(),
+            qualification
+                .promotion_receipt
+                .receipt_digest_sha256
+                .as_str(),
+            "promotion approval",
+        ),
+        (
+            VerifiedPromotionReceiptKind::Recovery,
+            qualification.rollback_receipt.receipt_id.as_str(),
+            qualification
+                .rollback_receipt
+                .receipt_digest_sha256
+                .as_str(),
+            "recovery",
+        ),
+    ] {
+        let matching_kind = verification
+            .receipts()
+            .iter()
+            .filter(|receipt| receipt.kind() == kind)
+            .collect::<Vec<_>>();
+        if matching_kind.is_empty() {
+            reasons.push(format!("verified {label} proof is missing"));
+        } else if matching_kind.len() != 1
+            || matching_kind[0].receipt_id() != receipt_id
+            || matching_kind[0].receipt_digest() != receipt_digest
+        {
+            reasons.push(format!(
+                "verified {label} proof does not match qualification"
+            ));
+        }
+    }
+
+    let mut actual_parity = verification
+        .receipts()
+        .iter()
+        .filter(|receipt| receipt.kind() == VerifiedPromotionReceiptKind::Parity)
+        .map(|receipt| (receipt.receipt_id(), receipt.receipt_digest()))
+        .collect::<Vec<_>>();
+    actual_parity.sort_unstable();
+    let mut expected_parity = qualification
+        .parity_receipt_digests
+        .iter()
+        .map(|digest| (digest.as_str(), digest.as_str()))
+        .collect::<Vec<_>>();
+    expected_parity.sort_unstable();
+    if actual_parity.is_empty() {
+        reasons.push("verified parity proof is missing".to_owned());
+    } else if actual_parity != expected_parity {
+        reasons.push("verified parity proof does not match qualification".to_owned());
+    }
+    reasons
 }
 
 fn digest(parts: &[&str]) -> String {
@@ -269,230 +367,5 @@ fn digest(parts: &[&str]) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::SemanticSnapshot;
-    use std::path::{Path, PathBuf};
-
-    fn repository_root() -> PathBuf {
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../..")
-            .canonicalize()
-            .unwrap()
-    }
-
-    #[test]
-    fn cutover_requires_proof_three_matches_and_zero_lag() {
-        let root = repository_root();
-        let catalog = SourceCatalog::load(
-            root.join("internal/connectorcatalog/catalog"),
-            root.join("sources"),
-        )
-        .unwrap();
-        let receipts: Vec<_> = (1..=3)
-            .map(|index| {
-                ParityReceipt::compare(
-                    "box",
-                    "users",
-                    format!("corpus-{index}"),
-                    "sha256:same",
-                    "sha256:same",
-                    true,
-                    index,
-                )
-                .unwrap()
-            })
-            .collect();
-        let gate = CutoverGate::new(CutoverPolicy::new(3, 0).unwrap());
-        assert!(
-            gate.evaluate(&catalog, "box", "users", &receipts, 0)
-                .unwrap()
-                .is_allowed()
-        );
-        assert!(
-            !gate
-                .evaluate(&catalog, "box", "users", &receipts[..2], 0)
-                .unwrap()
-                .is_allowed()
-        );
-        assert!(
-            !gate
-                .evaluate(&catalog, "agiloft", "users", &receipts, 0)
-                .unwrap()
-                .is_allowed()
-        );
-    }
-
-    #[test]
-    fn promotion_request_and_decision_bind_the_exact_scope() {
-        let policy = CutoverPolicy::new(3, 2).unwrap();
-        let request =
-            ProjectionPromotionRequest::new("tenant-a", "box", "users", policy, 1, 100).unwrap();
-        assert_eq!(request.tenant_id(), "tenant-a");
-        assert_eq!(request.source_id(), "box");
-        assert_eq!(request.family_id(), "users");
-        assert_eq!(request.policy(), policy);
-        assert_eq!(request.projection_lag(), 1);
-        assert_eq!(request.promoted_at_unix_ms(), 100);
-
-        assert_eq!(CutoverPolicy::new(2, 0), Err(CutoverError::UnsafePolicy));
-        assert_eq!(
-            ProjectionPromotionRequest::new("", "box", "users", policy, 0, 1),
-            Err(CutoverError::Invalid("tenant_id"))
-        );
-        assert_eq!(
-            ProjectionPromotionRequest::new("tenant", " box", "users", policy, 0, 1),
-            Err(CutoverError::Invalid("source_id"))
-        );
-        assert_eq!(
-            ProjectionPromotionRequest::new("tenant", "box", "users", policy, 0, 0),
-            Err(CutoverError::Invalid("promoted_at_unix_ms"))
-        );
-        assert_eq!(
-            CutoverError::UnsafePolicy.to_string(),
-            "cutover requires at least three matching runs"
-        );
-        assert_eq!(
-            CutoverError::UnknownSource("missing".to_owned()).to_string(),
-            "source missing is not in the catalog"
-        );
-    }
-
-    #[test]
-    fn cutover_reports_each_failed_proof_instead_of_collapsing_them() {
-        let root = repository_root();
-        let catalog = SourceCatalog::load(
-            root.join("internal/connectorcatalog/catalog"),
-            root.join("sources"),
-        )
-        .unwrap();
-        let receipts = vec![
-            ParityReceipt::compare_scoped(
-                "tenant-a",
-                "box-prod",
-                "box",
-                "users",
-                "corpus-1",
-                "sha256:same",
-                "sha256:same",
-                true,
-                1,
-            )
-            .unwrap(),
-            ParityReceipt::compare_scoped(
-                "tenant-a",
-                "box-prod",
-                "box",
-                "users",
-                "corpus-2",
-                "sha256:left",
-                "sha256:right",
-                true,
-                2,
-            )
-            .unwrap(),
-            ParityReceipt::compare_scoped(
-                "tenant-a",
-                "box-prod",
-                "box",
-                "users",
-                "corpus-3",
-                "sha256:same",
-                "sha256:same",
-                false,
-                3,
-            )
-            .unwrap(),
-        ];
-        let gate = CutoverGate::new(CutoverPolicy::new(3, 0).unwrap());
-        let decision = gate
-            .evaluate(&catalog, "box", "users", &receipts, 4)
-            .unwrap();
-        assert_eq!(decision.source_id(), "box");
-        assert_eq!(decision.family_id(), "users");
-        assert!(!decision.is_allowed());
-        assert!(
-            decision
-                .reasons()
-                .iter()
-                .any(|reason| reason.contains("projection lag 4"))
-        );
-        assert!(
-            decision
-                .reasons()
-                .iter()
-                .any(|reason| reason.contains("consecutive parity matches"))
-        );
-        assert!(
-            decision
-                .reasons()
-                .iter()
-                .any(|reason| reason == "latest corpus comparison is not a match")
-        );
-        assert!(decision.evidence_digest().starts_with("sha256:"));
-
-        assert_eq!(
-            gate.evaluate(&catalog, "missing", "users", &receipts, 0),
-            Err(CutoverError::UnknownSource("missing".to_owned()))
-        );
-        assert_eq!(
-            gate.evaluate(&catalog, "box", "missing", &receipts, 0),
-            Err(CutoverError::UnknownSource("box/missing".to_owned()))
-        );
-    }
-
-    #[test]
-    fn receipt_lag_is_checked_independently_of_current_projection_lag() {
-        let root = repository_root();
-        let catalog = SourceCatalog::load(
-            root.join("internal/connectorcatalog/catalog"),
-            root.join("sources"),
-        )
-        .unwrap();
-        let base = ParityReceipt::compare(
-            "box",
-            "users",
-            "corpus-1",
-            "sha256:same",
-            "sha256:same",
-            true,
-            1,
-        )
-        .unwrap();
-        let legacy = SemanticSnapshot::from_facts(
-            "legacy-shadow",
-            "legacy-shadow",
-            "box",
-            "users",
-            "corpus-1",
-            "legacy-shadow",
-            "legacy",
-            true,
-            Vec::new(),
-        )
-        .unwrap();
-        let rust = SemanticSnapshot::from_facts(
-            "legacy-shadow",
-            "legacy-shadow",
-            "box",
-            "users",
-            "corpus-1",
-            "legacy-shadow",
-            "rust",
-            true,
-            Vec::new(),
-        )
-        .unwrap();
-        let lagged =
-            ParityReceipt::compare_snapshots(&legacy, &rust, 3, 2, BTreeMap::new()).unwrap();
-        let gate = CutoverGate::new(CutoverPolicy::new(3, 0).unwrap());
-        let decision = gate
-            .evaluate(&catalog, "box", "users", &[base.clone(), base, lagged], 0)
-            .unwrap();
-        assert!(!decision.is_allowed());
-        assert!(decision
-            .reasons()
-            .iter()
-            .any(|reason| reason == "a latest parity receipt exceeds the projection lag policy"));
-    }
-}
+#[path = "cutover_tests.rs"]
+mod tests;

--- a/crates/organizational-store/src/cutover_tests.rs
+++ b/crates/organizational-store/src/cutover_tests.rs
@@ -1,0 +1,505 @@
+use super::*;
+use crate::{
+    SemanticSnapshot,
+    promotion_evidence_store::test_support::{
+        complete_test_verification, empty_test_verification, mismatched_test_verification,
+    },
+};
+use cerebro_source_catalog::{
+    PagePublicationReceiptReference, PersistedReceiptReference, SourceCollectionReceiptReference,
+};
+use cerebro_source_runtime_next::source_execution::{
+    SourceExecutionDispatcher, SourceExecutionError, SourceExecutionSelectionRequestV1,
+};
+use std::path::{Path, PathBuf};
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .unwrap()
+}
+
+fn qualification(
+    catalog: &SourceCatalog,
+    source_id: &str,
+    family_id: &str,
+    corpus: &str,
+) -> AuthorityQualificationEvidence {
+    let plan_digest = catalog
+        .compiled_family_plan_digest(source_id, family_id)
+        .unwrap();
+    let selection = SourceExecutionSelectionRequestV1 {
+        source_id: source_id.to_owned(),
+        family_id: family_id.to_owned(),
+    };
+    let runtime_plan_digest = match SourceExecutionDispatcher.compile_plan(&selection) {
+        Ok(plan) => plan.plan_digest_sha256,
+        Err(SourceExecutionError::UnknownAdapter) => plan_digest.clone(),
+        Err(error) => panic!("compile runtime plan: {error}"),
+    };
+    AuthorityQualificationEvidence {
+        plan_digest,
+        runtime_plan_digest,
+        fixture_corpus_revision: corpus.to_owned(),
+        supported_auth_modes: vec!["api_key".to_owned()],
+        supported_pagination_grammar: vec!["cursor".to_owned()],
+        supported_provider_errors: vec!["unauthorized".to_owned()],
+        egress_allowlist: vec!["https://provider.example.test".to_owned()],
+        response_limits: "body=1048576,decompression=4x".to_owned(),
+        credential_lease_mode: "one_operation".to_owned(),
+        projection_dependency: "rust_projection".to_owned(),
+        rollback_receipt: PersistedReceiptReference {
+            receipt_id: "rollback-test".to_owned(),
+            receipt_digest_sha256: "c".repeat(64),
+        },
+        parity_status: "passed".to_owned(),
+        canonical_digest_vectors: vec!["plan".to_owned()],
+        config_safety_proof: "receipt:config".to_owned(),
+        cursor_checkpoint_proof: "receipt:checkpoint".to_owned(),
+        fencing_recovery_proof: "receipt:fencing".to_owned(),
+        runtime_revision_sha256: "d".repeat(64),
+        worker_runtime_build_identity: "source-runtime-next:test".to_owned(),
+        promotion_receipt: PersistedReceiptReference {
+            receipt_id: "promotion-test".to_owned(),
+            receipt_digest_sha256: "e".repeat(64),
+        },
+        authenticated_collection_receipt: SourceCollectionReceiptReference {
+            source_runtime_id: format!("{source_id}-runtime"),
+            collection_id: corpus.to_owned(),
+            manifest_digest_sha256: "f".repeat(64),
+        },
+        append_projection_checkpoint_receipt: PagePublicationReceiptReference {
+            source_runtime_id: format!("{source_id}-runtime"),
+            logical_page_id: "page-test".to_owned(),
+            revision: 5,
+            snapshot_digest_sha256: "1".repeat(64),
+        },
+        lease_restart_receipt: PagePublicationReceiptReference {
+            source_runtime_id: format!("{source_id}-runtime"),
+            logical_page_id: "page-restart-test".to_owned(),
+            revision: 6,
+            snapshot_digest_sha256: "2".repeat(64),
+        },
+        product_read_receipt: PersistedReceiptReference {
+            receipt_id: "product-read-test".to_owned(),
+            receipt_digest_sha256: "3".repeat(64),
+        },
+        parity_receipt_digests: vec!["4".repeat(64), "5".repeat(64), "6".repeat(64)],
+    }
+}
+
+fn asana_verification(
+    qualification: &AuthorityQualificationEvidence,
+) -> PromotionEvidenceVerification {
+    complete_test_verification("tenant-a", "asana", "users", qualification)
+}
+
+#[test]
+fn promotion_gate_requires_complete_proof_three_matches_and_zero_lag() {
+    let root = repository_root();
+    let catalog = SourceCatalog::load(
+        root.join("internal/connectorcatalog/catalog"),
+        root.join("sources"),
+    )
+    .unwrap();
+    let receipts: Vec<_> = (1..=3)
+        .map(|index| {
+            ParityReceipt::compare_scoped(
+                "tenant-a",
+                "asana-runtime",
+                "asana",
+                "users",
+                format!("corpus-{index}"),
+                "sha256:same",
+                "sha256:same",
+                true,
+                index,
+            )
+            .unwrap()
+        })
+        .collect();
+    let gate = CutoverGate::new(CutoverPolicy::new(3, 0).unwrap());
+    let mut qualification = qualification(&catalog, "asana", "users", "corpus-3");
+    qualification.parity_receipt_digests = receipts
+        .iter()
+        .map(|receipt| receipt.receipt_digest().to_owned())
+        .collect();
+    let empty_verification = gate
+        .evaluate(
+            &catalog,
+            "tenant-a",
+            "asana",
+            "users",
+            &receipts,
+            0,
+            &qualification,
+            &empty_test_verification("tenant-a", "asana", "users", &qualification),
+        )
+        .unwrap();
+    assert!(!empty_verification.is_allowed());
+    for reason in [
+        "verified durable collection proof is missing",
+        "verified authenticated collection proof is missing",
+        "verified append/projection/checkpoint proof is missing",
+        "verified lease/restart proof is missing",
+        "verified parity proof is missing",
+        "verified runtime revision proof is missing",
+        "verified product-read proof is missing",
+        "verified promotion approval proof is missing",
+        "verified recovery proof is missing",
+    ] {
+        assert!(
+            empty_verification
+                .reasons()
+                .iter()
+                .any(|actual| actual == reason),
+            "missing blocker: {reason}"
+        );
+    }
+    let mismatched_product_read = gate
+        .evaluate(
+            &catalog,
+            "tenant-a",
+            "asana",
+            "users",
+            &receipts,
+            0,
+            &qualification,
+            &mismatched_test_verification(
+                "tenant-a",
+                "asana",
+                "users",
+                &qualification,
+                VerifiedPromotionReceiptKind::ProductRead,
+            ),
+        )
+        .unwrap();
+    assert!(!mismatched_product_read.is_allowed());
+    assert!(
+        mismatched_product_read
+            .reasons()
+            .iter()
+            .any(|reason| { reason == "verified product-read proof does not match qualification" })
+    );
+    let tenant_a = gate
+        .evaluate(
+            &catalog,
+            "tenant-a",
+            "asana",
+            "users",
+            &receipts,
+            0,
+            &qualification,
+            &asana_verification(&qualification),
+        )
+        .unwrap();
+    assert!(tenant_a.is_allowed());
+    let tenant_b = gate
+        .evaluate(
+            &catalog,
+            "tenant-b",
+            "asana",
+            "users",
+            &receipts,
+            0,
+            &qualification,
+            &complete_test_verification("tenant-b", "asana", "users", &qualification),
+        )
+        .unwrap();
+    assert!(!tenant_b.is_allowed());
+    assert!(
+        tenant_b
+            .reasons()
+            .iter()
+            .any(|reason| { reason == "parity receipt tenant does not match promotion request" })
+    );
+    assert_ne!(tenant_a.evidence_digest(), tenant_b.evidence_digest());
+    let shuffled = vec![
+        receipts[2].clone(),
+        receipts[0].clone(),
+        receipts[1].clone(),
+    ];
+    let shuffled_decision = gate
+        .evaluate(
+            &catalog,
+            "tenant-a",
+            "asana",
+            "users",
+            &shuffled,
+            0,
+            &qualification,
+            &asana_verification(&qualification),
+        )
+        .unwrap();
+    assert!(
+        shuffled_decision.is_allowed(),
+        "receipt order must not change the latest qualifying parity sequence"
+    );
+    assert_eq!(
+        shuffled_decision.evidence_digest(),
+        tenant_a.evidence_digest()
+    );
+    assert!(
+        !gate
+            .evaluate(
+                &catalog,
+                "tenant-a",
+                "asana",
+                "users",
+                &receipts[..2],
+                0,
+                &qualification,
+                &asana_verification(&qualification),
+            )
+            .unwrap()
+            .is_allowed()
+    );
+    assert!(
+        !gate
+            .evaluate(
+                &catalog,
+                "tenant-a",
+                "agiloft",
+                "users",
+                &receipts,
+                0,
+                &qualification,
+                &asana_verification(&qualification),
+            )
+            .unwrap()
+            .is_allowed()
+    );
+}
+
+#[test]
+fn catalog_only_family_cannot_pass_without_a_closed_runtime_adapter() {
+    let root = repository_root();
+    let catalog = SourceCatalog::load(
+        root.join("internal/connectorcatalog/catalog"),
+        root.join("sources"),
+    )
+    .unwrap();
+    let receipts = (1..=3)
+        .map(|index| {
+            ParityReceipt::compare_scoped(
+                "tenant-a",
+                "box-runtime",
+                "box",
+                "content_assets",
+                format!("corpus-{index}"),
+                "sha256:same",
+                "sha256:same",
+                true,
+                index,
+            )
+            .unwrap()
+        })
+        .collect::<Vec<_>>();
+    let qualification = qualification(&catalog, "box", "content_assets", "corpus-3");
+    let decision = CutoverGate::new(CutoverPolicy::new(3, 0).unwrap())
+        .evaluate(
+            &catalog,
+            "tenant-a",
+            "box",
+            "content_assets",
+            &receipts,
+            0,
+            &qualification,
+            &complete_test_verification("tenant-a", "box", "content_assets", &qualification),
+        )
+        .unwrap();
+    assert!(!decision.is_allowed());
+    assert!(
+        decision
+            .reasons()
+            .iter()
+            .any(|reason| { reason == "closed Rust source-execution adapter is not registered" })
+    );
+}
+
+#[test]
+fn promotion_gate_reports_each_failed_proof_instead_of_collapsing_them() {
+    let root = repository_root();
+    let catalog = SourceCatalog::load(
+        root.join("internal/connectorcatalog/catalog"),
+        root.join("sources"),
+    )
+    .unwrap();
+    let receipts = vec![
+        ParityReceipt::compare_scoped(
+            "tenant-a",
+            "asana-prod",
+            "asana",
+            "users",
+            "corpus-1",
+            "sha256:same",
+            "sha256:same",
+            true,
+            1,
+        )
+        .unwrap(),
+        ParityReceipt::compare_scoped(
+            "tenant-a",
+            "asana-prod",
+            "asana",
+            "users",
+            "corpus-2",
+            "sha256:left",
+            "sha256:right",
+            true,
+            2,
+        )
+        .unwrap(),
+        ParityReceipt::compare_scoped(
+            "tenant-a",
+            "asana-prod",
+            "asana",
+            "users",
+            "corpus-3",
+            "sha256:same",
+            "sha256:same",
+            false,
+            3,
+        )
+        .unwrap(),
+    ];
+    let gate = CutoverGate::new(CutoverPolicy::new(3, 0).unwrap());
+    let qualification = qualification(&catalog, "asana", "users", "corpus-3");
+    let decision = gate
+        .evaluate(
+            &catalog,
+            "tenant-a",
+            "asana",
+            "users",
+            &receipts,
+            4,
+            &qualification,
+            &asana_verification(&qualification),
+        )
+        .unwrap();
+    assert_eq!(decision.tenant_id(), "tenant-a");
+    assert_eq!(decision.source_id(), "asana");
+    assert_eq!(decision.family_id(), "users");
+    assert!(!decision.is_allowed());
+    assert!(
+        decision
+            .reasons()
+            .iter()
+            .any(|reason| reason.contains("projection lag 4"))
+    );
+    assert!(
+        decision
+            .reasons()
+            .iter()
+            .any(|reason| reason.contains("consecutive parity matches"))
+    );
+    assert!(
+        decision
+            .reasons()
+            .iter()
+            .any(|reason| reason == "latest corpus comparison is not a match")
+    );
+    assert!(decision.evidence_digest().starts_with("sha256:"));
+    let decision_json = serde_json::to_value(&decision).unwrap();
+    assert_eq!(decision_json["tenant_id"], "tenant-a");
+    assert_eq!(
+        decision_json["qualification"]["product_read_receipt"]["receipt_id"],
+        "product-read-test"
+    );
+
+    assert_eq!(
+        gate.evaluate(
+            &catalog,
+            "tenant-a",
+            "missing",
+            "users",
+            &receipts,
+            0,
+            &qualification,
+            &asana_verification(&qualification),
+        ),
+        Err(CutoverError::UnknownSource("missing".to_owned()))
+    );
+    assert_eq!(
+        gate.evaluate(
+            &catalog,
+            "tenant-a",
+            "asana",
+            "missing",
+            &receipts,
+            0,
+            &qualification,
+            &asana_verification(&qualification),
+        ),
+        Err(CutoverError::UnknownSource("asana/missing".to_owned()))
+    );
+}
+
+#[test]
+fn receipt_lag_is_checked_independently_of_current_projection_lag() {
+    let root = repository_root();
+    let catalog = SourceCatalog::load(
+        root.join("internal/connectorcatalog/catalog"),
+        root.join("sources"),
+    )
+    .unwrap();
+    let base = ParityReceipt::compare_scoped(
+        "tenant-a",
+        "asana-runtime",
+        "asana",
+        "users",
+        "corpus-1",
+        "sha256:same",
+        "sha256:same",
+        true,
+        1,
+    )
+    .unwrap();
+    let legacy = SemanticSnapshot::from_facts(
+        "tenant-a",
+        "asana-runtime",
+        "asana",
+        "users",
+        "corpus-1",
+        "legacy-shadow",
+        "legacy",
+        true,
+        Vec::new(),
+    )
+    .unwrap();
+    let rust = SemanticSnapshot::from_facts(
+        "tenant-a",
+        "asana-runtime",
+        "asana",
+        "users",
+        "corpus-1",
+        "legacy-shadow",
+        "rust",
+        true,
+        Vec::new(),
+    )
+    .unwrap();
+    let lagged = ParityReceipt::compare_snapshots(&legacy, &rust, 3, 2, BTreeMap::new()).unwrap();
+    let gate = CutoverGate::new(CutoverPolicy::new(3, 0).unwrap());
+    let qualification = qualification(&catalog, "asana", "users", "corpus-1");
+    let decision = gate
+        .evaluate(
+            &catalog,
+            "tenant-a",
+            "asana",
+            "users",
+            &[base.clone(), base, lagged],
+            0,
+            &qualification,
+            &asana_verification(&qualification),
+        )
+        .unwrap();
+    assert!(!decision.is_allowed());
+    assert!(
+        decision
+            .reasons()
+            .iter()
+            .any(|reason| reason == "a latest parity receipt exceeds the projection lag policy")
+    );
+}

--- a/crates/organizational-store/src/lib.rs
+++ b/crates/organizational-store/src/lib.rs
@@ -30,11 +30,10 @@ mod neo4j;
 mod page_publication;
 mod parity;
 mod postgres;
+mod promotion;
+mod promotion_evidence_store;
 
-pub use cutover::{
-    CutoverDecision, CutoverGate, CutoverPolicy, ProjectionAuthority, ProjectionAuthorityRecord,
-    ProjectionPromotionRequest,
-};
+pub use cutover::CutoverPolicy;
 pub use neo4j::{
     CloudAttackPath, CloudAttackPathCounts, CloudAttackPathEdge, CloudAttackPathNode,
     CloudAttackPathOwnership, CloudAttackPathPage, ComplianceImpactDependency,
@@ -62,6 +61,10 @@ pub use postgres::{
     SourceRuntimeCollectionObservation, SourceRuntimeObservation, StoredAuditEvent,
     StoredAuditEventPage, StoredSourceRuntime,
 };
+pub use promotion::{
+    CutoverDecision, ProjectionAuthority, ProjectionAuthorityRecord, ProjectionPromotionRequest,
+};
+pub use promotion_evidence_store::{VerifiedPromotionReceipt, VerifiedPromotionReceiptKind};
 
 use std::{error::Error, fmt};
 

--- a/crates/organizational-store/src/postgres.rs
+++ b/crates/organizational-store/src/postgres.rs
@@ -2290,8 +2290,8 @@ LIMIT $3
         .await
     }
 
-    /// Evaluate the durable cutover evidence without changing projection
-    /// authority. Operators use this before the irreversible promotion step.
+    /// Evaluate tenant-scoped persisted promotion evidence without changing
+    /// projection authority. Missing receipt owners fail closed.
     pub async fn evaluate_projection_authority(
         &self,
         catalog: &SourceCatalog,
@@ -2304,13 +2304,17 @@ LIMIT $3
                 request.family_id(),
             )
             .await?;
+        let verification = self.verify_projection_promotion_evidence(request).await?;
         let decision = CutoverGate::new(request.policy())
             .evaluate(
                 catalog,
+                request.tenant_id(),
                 request.source_id(),
                 request.family_id(),
                 &receipts,
                 request.projection_lag(),
+                request.qualification(),
+                &verification,
             )
             .map_err(|error| StoreError::Conflict(error.to_string()))?;
         Ok(decision)
@@ -2322,6 +2326,11 @@ LIMIT $3
         decision: &CutoverDecision,
         promoted_at_unix_ms: i64,
     ) -> Result<ProjectionAuthorityRecord, StoreError> {
+        if decision.tenant_id() != tenant_id {
+            return Err(StoreError::Conflict(
+                "projection promotion tenant does not match decision evidence".to_owned(),
+            ));
+        }
         if !decision.is_allowed() {
             return Err(StoreError::Conflict(format!(
                 "projection cutover is blocked: {}",
@@ -3213,7 +3222,7 @@ fn audit_event_text_filter(clauses: &mut Vec<String>, values: &mut Vec<String>, 
     ));
 }
 
-async fn set_tenant(
+pub(crate) async fn set_tenant(
     transaction: &tokio_postgres::Transaction<'_>,
     tenant_id: &str,
 ) -> Result<(), tokio_postgres::Error> {

--- a/crates/organizational-store/src/promotion.rs
+++ b/crates/organizational-store/src/promotion.rs
@@ -1,0 +1,336 @@
+//! Promotion request validation, runtime-plan binding, and persisted decision types.
+
+use cerebro_source_catalog::{
+    AuthorityEvidenceError, AuthorityQualificationEvidence, SourceCatalog,
+    validate_authority_qualification_evidence,
+};
+use cerebro_source_runtime_next::source_execution::{
+    SourceExecutionDispatcher, SourceExecutionError, SourceExecutionSelectionRequestV1,
+};
+use serde::Serialize;
+
+use crate::{
+    cutover::{CutoverError, CutoverPolicy},
+    promotion_evidence_store::VerifiedPromotionReceipt,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectionPromotionRequest {
+    tenant_id: String,
+    source_id: String,
+    family_id: String,
+    policy: CutoverPolicy,
+    projection_lag: u64,
+    promoted_at_unix_ms: i64,
+    qualification: AuthorityQualificationEvidence,
+}
+
+impl ProjectionPromotionRequest {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        tenant_id: impl Into<String>,
+        source_id: impl Into<String>,
+        family_id: impl Into<String>,
+        policy: CutoverPolicy,
+        projection_lag: u64,
+        promoted_at_unix_ms: i64,
+        qualification: AuthorityQualificationEvidence,
+    ) -> Result<Self, CutoverError> {
+        let tenant_id = checked_text(tenant_id.into(), "tenant_id")?;
+        let source_id = checked_text(source_id.into(), "source_id")?;
+        let family_id = checked_text(family_id.into(), "family_id")?;
+        if promoted_at_unix_ms <= 0 {
+            return Err(CutoverError::Invalid("promoted_at_unix_ms"));
+        }
+        validate_qualification(&qualification)?;
+        Ok(Self {
+            tenant_id,
+            source_id,
+            family_id,
+            policy,
+            projection_lag,
+            promoted_at_unix_ms,
+            qualification,
+        })
+    }
+
+    pub fn tenant_id(&self) -> &str {
+        &self.tenant_id
+    }
+
+    pub fn source_id(&self) -> &str {
+        &self.source_id
+    }
+
+    pub fn family_id(&self) -> &str {
+        &self.family_id
+    }
+
+    pub(crate) fn policy(&self) -> CutoverPolicy {
+        self.policy
+    }
+
+    pub fn projection_lag(&self) -> u64 {
+        self.projection_lag
+    }
+
+    pub(crate) fn promoted_at_unix_ms(&self) -> i64 {
+        self.promoted_at_unix_ms
+    }
+
+    pub fn qualification(&self) -> &AuthorityQualificationEvidence {
+        &self.qualification
+    }
+}
+
+fn checked_text(value: String, field: &'static str) -> Result<String, CutoverError> {
+    if value.is_empty() || value.trim() != value {
+        return Err(CutoverError::Invalid(field));
+    }
+    Ok(value)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CutoverDecision {
+    pub(crate) tenant_id: String,
+    pub(crate) source_id: String,
+    pub(crate) family_id: String,
+    pub(crate) allowed: bool,
+    pub(crate) reasons: Vec<String>,
+    pub(crate) evidence_digest: String,
+    pub(crate) qualification: AuthorityQualificationEvidence,
+    pub(crate) verified_receipts: Vec<VerifiedPromotionReceipt>,
+}
+
+impl CutoverDecision {
+    pub fn tenant_id(&self) -> &str {
+        &self.tenant_id
+    }
+
+    pub fn source_id(&self) -> &str {
+        &self.source_id
+    }
+
+    pub fn family_id(&self) -> &str {
+        &self.family_id
+    }
+
+    pub fn is_allowed(&self) -> bool {
+        self.allowed
+    }
+
+    pub fn reasons(&self) -> &[String] {
+        &self.reasons
+    }
+
+    pub fn evidence_digest(&self) -> &str {
+        &self.evidence_digest
+    }
+
+    pub fn qualification(&self) -> &AuthorityQualificationEvidence {
+        &self.qualification
+    }
+
+    pub fn verified_receipts(&self) -> &[VerifiedPromotionReceipt] {
+        &self.verified_receipts
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectionAuthority {
+    Legacy,
+    Rust,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ProjectionAuthorityRecord {
+    pub tenant_id: String,
+    pub source_id: String,
+    pub family_id: String,
+    pub authority: ProjectionAuthority,
+    pub evidence_digest: String,
+    pub promoted_at_unix_ms: Option<i64>,
+}
+
+pub(crate) fn promotion_evidence_reasons(
+    catalog: &SourceCatalog,
+    source_id: &str,
+    family_id: &str,
+    qualification: &AuthorityQualificationEvidence,
+) -> Result<Vec<String>, CutoverError> {
+    validate_qualification(qualification)?;
+    let catalog_plan_digest = catalog
+        .compiled_family_plan_digest(source_id, family_id)
+        .ok_or_else(|| CutoverError::UnknownSource(format!("{source_id}/{family_id}")))?;
+    let mut reasons = Vec::new();
+    if qualification.plan_digest != catalog_plan_digest {
+        reasons.push("compiled catalog plan digest does not match qualification".to_owned());
+    }
+    let selection = SourceExecutionSelectionRequestV1 {
+        source_id: source_id.to_owned(),
+        family_id: family_id.to_owned(),
+    };
+    match SourceExecutionDispatcher.compile_plan(&selection) {
+        Ok(plan) if qualification.runtime_plan_digest != plan.plan_digest_sha256 => {
+            reasons.push("compiled runtime plan digest does not match qualification".to_owned());
+        }
+        Ok(_) => {}
+        Err(SourceExecutionError::UnknownAdapter) => {
+            reasons.push("closed Rust source-execution adapter is not registered".to_owned());
+        }
+        Err(error) => {
+            reasons.push(format!("closed Rust runtime plan failed: {}", error.code()));
+        }
+    }
+    Ok(reasons)
+}
+
+fn validate_qualification(
+    qualification: &AuthorityQualificationEvidence,
+) -> Result<(), CutoverError> {
+    validate_authority_qualification_evidence(qualification).map_err(|error| match error {
+        AuthorityEvidenceError::Invalid(field) => CutoverError::Invalid(field),
+        AuthorityEvidenceError::Immutable => CutoverError::Invalid("qualification_evidence"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::*;
+    use cerebro_source_catalog::{
+        PagePublicationReceiptReference, PersistedReceiptReference,
+        SourceCollectionReceiptReference,
+    };
+    use cerebro_source_runtime_next::source_execution::{
+        SourceExecutionDispatcher, SourceExecutionSelectionRequestV1,
+    };
+
+    fn repository_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()
+            .unwrap()
+    }
+
+    fn catalog() -> SourceCatalog {
+        let root = repository_root();
+        SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap()
+    }
+
+    fn qualification(catalog: &SourceCatalog) -> AuthorityQualificationEvidence {
+        let selection = SourceExecutionSelectionRequestV1 {
+            source_id: "asana".to_owned(),
+            family_id: "users".to_owned(),
+        };
+        AuthorityQualificationEvidence {
+            plan_digest: catalog
+                .compiled_family_plan_digest("asana", "users")
+                .unwrap(),
+            runtime_plan_digest: SourceExecutionDispatcher
+                .compile_plan(&selection)
+                .unwrap()
+                .plan_digest_sha256,
+            fixture_corpus_revision: "corpus-3".to_owned(),
+            supported_auth_modes: vec!["bearer".to_owned()],
+            supported_pagination_grammar: vec!["cursor".to_owned()],
+            supported_provider_errors: vec!["unauthorized".to_owned()],
+            egress_allowlist: vec!["https://app.asana.com".to_owned()],
+            response_limits: "body=1048576,decompression=4x".to_owned(),
+            credential_lease_mode: "one_operation".to_owned(),
+            projection_dependency: "rust_projection".to_owned(),
+            rollback_receipt: PersistedReceiptReference {
+                receipt_id: "rollback-test".to_owned(),
+                receipt_digest_sha256: "c".repeat(64),
+            },
+            parity_status: "passed".to_owned(),
+            canonical_digest_vectors: vec!["plan".to_owned()],
+            config_safety_proof: "receipt:config".to_owned(),
+            cursor_checkpoint_proof: "receipt:checkpoint".to_owned(),
+            fencing_recovery_proof: "receipt:fencing".to_owned(),
+            runtime_revision_sha256: "d".repeat(64),
+            worker_runtime_build_identity: "source-runtime-next:test".to_owned(),
+            promotion_receipt: PersistedReceiptReference {
+                receipt_id: "promotion-test".to_owned(),
+                receipt_digest_sha256: "e".repeat(64),
+            },
+            authenticated_collection_receipt: SourceCollectionReceiptReference {
+                source_runtime_id: "asana-runtime".to_owned(),
+                collection_id: "corpus-3".to_owned(),
+                manifest_digest_sha256: "f".repeat(64),
+            },
+            append_projection_checkpoint_receipt: PagePublicationReceiptReference {
+                source_runtime_id: "asana-runtime".to_owned(),
+                logical_page_id: "page-test".to_owned(),
+                revision: 5,
+                snapshot_digest_sha256: "1".repeat(64),
+            },
+            lease_restart_receipt: PagePublicationReceiptReference {
+                source_runtime_id: "asana-runtime".to_owned(),
+                logical_page_id: "page-restart-test".to_owned(),
+                revision: 6,
+                snapshot_digest_sha256: "2".repeat(64),
+            },
+            product_read_receipt: PersistedReceiptReference {
+                receipt_id: "product-read-test".to_owned(),
+                receipt_digest_sha256: "3".repeat(64),
+            },
+            parity_receipt_digests: vec!["4".repeat(64), "5".repeat(64), "6".repeat(64)],
+        }
+    }
+
+    #[test]
+    fn promotion_request_requires_complete_qualification_for_exact_scope() {
+        let catalog = catalog();
+        let request = ProjectionPromotionRequest::new(
+            "tenant-a",
+            "asana",
+            "users",
+            CutoverPolicy::new(3, 0).unwrap(),
+            0,
+            1,
+            qualification(&catalog),
+        )
+        .unwrap();
+        assert_eq!(request.tenant_id(), "tenant-a");
+        assert_eq!(request.source_id(), "asana");
+        assert_eq!(request.family_id(), "users");
+
+        let mut incomplete = qualification(&catalog);
+        incomplete.product_read_receipt.receipt_id.clear();
+        assert_eq!(
+            ProjectionPromotionRequest::new(
+                "tenant-a",
+                "asana",
+                "users",
+                CutoverPolicy::new(3, 0).unwrap(),
+                0,
+                1,
+                incomplete,
+            ),
+            Err(CutoverError::Invalid("product_read_receipt"))
+        );
+    }
+
+    #[test]
+    fn promotion_evidence_binds_catalog_and_runtime_plan_digests() {
+        let catalog = catalog();
+        let mut evidence = qualification(&catalog);
+        evidence.plan_digest = "a".repeat(64);
+        evidence.runtime_plan_digest = "b".repeat(64);
+        let reasons = promotion_evidence_reasons(&catalog, "asana", "users", &evidence).unwrap();
+        assert_eq!(
+            reasons,
+            vec![
+                "compiled catalog plan digest does not match qualification".to_owned(),
+                "compiled runtime plan digest does not match qualification".to_owned(),
+            ]
+        );
+    }
+}

--- a/crates/organizational-store/src/promotion_evidence_store.rs
+++ b/crates/organizational-store/src/promotion_evidence_store.rs
@@ -1,0 +1,423 @@
+//! Read-only verification of promotion evidence against durable PostgreSQL records.
+
+use std::collections::BTreeSet;
+
+use cerebro_source_catalog::PagePublicationReceiptReference;
+use cerebro_source_runtime_next::{PagePublication, PagePublicationState};
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::{PostgresLedger, ProjectionPromotionRequest, StoreError};
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VerifiedPromotionReceiptKind {
+    DurableCollection,
+    AuthenticatedCollection,
+    AppendProjectionCheckpoint,
+    LeaseRestart,
+    Parity,
+    RuntimeRevision,
+    ProductRead,
+    PromotionApproval,
+    Recovery,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct VerifiedPromotionReceipt {
+    kind: VerifiedPromotionReceiptKind,
+    receipt_id: String,
+    receipt_digest: String,
+}
+
+impl VerifiedPromotionReceipt {
+    fn new(
+        kind: VerifiedPromotionReceiptKind,
+        receipt_id: impl Into<String>,
+        receipt_digest: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            receipt_id: receipt_id.into(),
+            receipt_digest: receipt_digest.into(),
+        }
+    }
+
+    pub fn kind(&self) -> VerifiedPromotionReceiptKind {
+        self.kind
+    }
+
+    pub fn receipt_id(&self) -> &str {
+        &self.receipt_id
+    }
+
+    pub fn receipt_digest(&self) -> &str {
+        &self.receipt_digest
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct PromotionEvidenceVerification {
+    tenant_id: String,
+    source_id: String,
+    family_id: String,
+    source_runtime_id: String,
+    runtime_revision_sha256: String,
+    reasons: Vec<String>,
+    receipts: Vec<VerifiedPromotionReceipt>,
+}
+
+impl PromotionEvidenceVerification {
+    fn verified_by_store(
+        tenant_id: impl Into<String>,
+        source_id: impl Into<String>,
+        family_id: impl Into<String>,
+        source_runtime_id: impl Into<String>,
+        runtime_revision_sha256: impl Into<String>,
+        mut reasons: Vec<String>,
+        mut receipts: Vec<VerifiedPromotionReceipt>,
+    ) -> Self {
+        reasons.sort();
+        reasons.dedup();
+        receipts.sort_by(|left, right| {
+            left.kind
+                .cmp(&right.kind)
+                .then_with(|| left.receipt_id.cmp(&right.receipt_id))
+                .then_with(|| left.receipt_digest.cmp(&right.receipt_digest))
+        });
+        Self {
+            tenant_id: tenant_id.into(),
+            source_id: source_id.into(),
+            family_id: family_id.into(),
+            source_runtime_id: source_runtime_id.into(),
+            runtime_revision_sha256: runtime_revision_sha256.into(),
+            reasons,
+            receipts,
+        }
+    }
+
+    pub(crate) fn tenant_id(&self) -> &str {
+        &self.tenant_id
+    }
+
+    pub(crate) fn source_id(&self) -> &str {
+        &self.source_id
+    }
+
+    pub(crate) fn family_id(&self) -> &str {
+        &self.family_id
+    }
+
+    pub(crate) fn source_runtime_id(&self) -> &str {
+        &self.source_runtime_id
+    }
+
+    pub(crate) fn runtime_revision_sha256(&self) -> &str {
+        &self.runtime_revision_sha256
+    }
+
+    pub(crate) fn reasons(&self) -> &[String] {
+        &self.reasons
+    }
+
+    pub(crate) fn receipts(&self) -> &[VerifiedPromotionReceipt] {
+        &self.receipts
+    }
+
+    pub(crate) fn digest(&self) -> String {
+        let bytes = serde_json::to_vec(self).expect("promotion verification serializes");
+        let digest = Sha256::digest(bytes);
+        digest.iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+}
+
+impl PostgresLedger {
+    pub(crate) async fn verify_projection_promotion_evidence(
+        &self,
+        request: &ProjectionPromotionRequest,
+    ) -> Result<PromotionEvidenceVerification, StoreError> {
+        let qualification = request.qualification();
+        let mut reasons = unavailable_verifier_reasons();
+        let mut receipts = Vec::new();
+        let mut client = self.client.lock().await;
+        let transaction = client.transaction().await?;
+        super::postgres::set_tenant(&transaction, request.tenant_id()).await?;
+
+        let collection = &qualification.authenticated_collection_receipt;
+        let collection_row = transaction
+            .query_opt(
+                "SELECT source_runtime_id, source_id, status, pages_read, records_accepted, records_rejected, entities_projected, links_projected, manifest_digest, manifest_json FROM organizational_source_collection_receipts WHERE tenant_id = $1 AND collection_id = $2",
+                &[&request.tenant_id(), &collection.collection_id],
+            )
+            .await?;
+        match collection_row {
+            Some(row) => {
+                let source_runtime_id: String = row.get(0);
+                let source_id: String = row.get(1);
+                let status: String = row.get(2);
+                let pages_read: i64 = row.get(3);
+                let records_accepted: i64 = row.get(4);
+                let records_rejected: i64 = row.get(5);
+                let entities_projected: i64 = row.get(6);
+                let links_projected: i64 = row.get(7);
+                let manifest_digest: String = row.get(8);
+                let manifest: Value = row.get(9);
+                let observed_family = manifest
+                    .get("observed_family_ids")
+                    .and_then(Value::as_array)
+                    .is_some_and(|families| {
+                        families
+                            .iter()
+                            .any(|family| family.as_str() == Some(request.family_id()))
+                    });
+                if let Some(reason) = collection_block_reason(
+                    request.source_id(),
+                    collection,
+                    &source_runtime_id,
+                    &source_id,
+                    &status,
+                    pages_read,
+                    records_accepted,
+                    records_rejected,
+                    entities_projected,
+                    links_projected,
+                    &manifest_digest,
+                    observed_family,
+                ) {
+                    reasons.push(reason);
+                } else {
+                    receipts.push(VerifiedPromotionReceipt::new(
+                        VerifiedPromotionReceiptKind::DurableCollection,
+                        collection.collection_id.clone(),
+                        manifest_digest,
+                    ));
+                }
+            }
+            None => reasons.push("persisted collection receipt was not found".to_owned()),
+        }
+
+        verify_page_reference(
+            &transaction,
+            request,
+            &qualification.append_projection_checkpoint_receipt,
+            VerifiedPromotionReceiptKind::AppendProjectionCheckpoint,
+            "append_projection_checkpoint",
+            false,
+            &mut reasons,
+            &mut receipts,
+        )
+        .await?;
+        verify_page_reference(
+            &transaction,
+            request,
+            &qualification.lease_restart_receipt,
+            VerifiedPromotionReceiptKind::LeaseRestart,
+            "lease_restart",
+            true,
+            &mut reasons,
+            &mut receipts,
+        )
+        .await?;
+
+        let parity_rows = transaction
+            .query(
+                "SELECT receipt_digest FROM organizational_parity_receipts WHERE tenant_id = $1 AND source_id = $2 AND family_id = $3 AND receipt_digest = ANY($4::TEXT[])",
+                &[
+                    &request.tenant_id(),
+                    &request.source_id(),
+                    &request.family_id(),
+                    &qualification.parity_receipt_digests,
+                ],
+            )
+            .await?;
+        let found_parity = parity_rows
+            .into_iter()
+            .map(|row| row.get::<_, String>(0))
+            .collect::<BTreeSet<_>>();
+        let expected_parity = qualification
+            .parity_receipt_digests
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        if found_parity != expected_parity {
+            reasons
+                .push("persisted parity receipts do not match the qualified sequence".to_owned());
+        } else {
+            receipts.extend(found_parity.into_iter().map(|digest| {
+                VerifiedPromotionReceipt::new(
+                    VerifiedPromotionReceiptKind::Parity,
+                    digest.clone(),
+                    digest,
+                )
+            }));
+        }
+
+        transaction.commit().await?;
+        Ok(PromotionEvidenceVerification::verified_by_store(
+            request.tenant_id(),
+            request.source_id(),
+            request.family_id(),
+            &qualification
+                .authenticated_collection_receipt
+                .source_runtime_id,
+            &qualification.runtime_revision_sha256,
+            reasons,
+            receipts,
+        ))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn verify_page_reference(
+    transaction: &tokio_postgres::Transaction<'_>,
+    request: &ProjectionPromotionRequest,
+    reference: &PagePublicationReceiptReference,
+    kind: VerifiedPromotionReceiptKind,
+    kind_label: &str,
+    require_successor_generation: bool,
+    reasons: &mut Vec<String>,
+    receipts: &mut Vec<VerifiedPromotionReceipt>,
+) -> Result<(), StoreError> {
+    let row = transaction
+        .query_opt(
+            "SELECT source_runtime_id, source_id, family_id, state, revision, publication_json FROM source_runtime_page_publications WHERE tenant_id = $1 AND logical_page_id = $2",
+            &[&request.tenant_id(), &reference.logical_page_id],
+        )
+        .await?;
+    let Some(row) = row else {
+        reasons.push(format!(
+            "persisted {kind_label} page publication was not found"
+        ));
+        return Ok(());
+    };
+    let source_runtime_id: String = row.get(0);
+    let source_id: String = row.get(1);
+    let family_id: String = row.get(2);
+    let state: String = row.get(3);
+    let revision: i64 = row.get(4);
+    let snapshot: Value = row.get(5);
+    let snapshot_digest = json_digest(&snapshot);
+    let page = PagePublication::restore_snapshot(snapshot).map_err(|_| {
+        StoreError::Conflict(format!("stored {kind_label} page publication is invalid"))
+    })?;
+    let revision_matches = u64::try_from(revision).ok() == Some(reference.revision);
+    let claim_generation = page.publish_claim().map(|claim| claim.generation());
+    if let Some(reason) = page_block_reason(
+        request.source_id(),
+        request.family_id(),
+        reference,
+        &source_runtime_id,
+        &source_id,
+        &family_id,
+        &state,
+        page.state(),
+        revision_matches,
+        &snapshot_digest,
+        require_successor_generation,
+        claim_generation,
+    ) {
+        reasons.push(reason.replace("{kind}", kind_label));
+    } else {
+        receipts.push(VerifiedPromotionReceipt::new(
+            kind,
+            reference.logical_page_id.clone(),
+            snapshot_digest,
+        ));
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collection_block_reason(
+    request_source_id: &str,
+    reference: &cerebro_source_catalog::SourceCollectionReceiptReference,
+    stored_runtime_id: &str,
+    stored_source_id: &str,
+    status: &str,
+    pages_read: i64,
+    records_accepted: i64,
+    records_rejected: i64,
+    entities_projected: i64,
+    links_projected: i64,
+    stored_manifest_digest: &str,
+    observed_family: bool,
+) -> Option<String> {
+    if stored_runtime_id != reference.source_runtime_id {
+        Some("collection receipt runtime does not match qualification".to_owned())
+    } else if stored_source_id != request_source_id {
+        Some("collection receipt source does not match promotion request".to_owned())
+    } else if status != "complete" {
+        Some("collection receipt is not complete".to_owned())
+    } else if pages_read <= 0 || records_accepted <= 0 {
+        Some("collection receipt does not prove accepted provider records".to_owned())
+    } else if records_rejected != 0 {
+        Some("collection receipt contains rejected records".to_owned())
+    } else if entities_projected <= 0 && links_projected <= 0 {
+        Some("collection receipt does not prove a durable projection".to_owned())
+    } else if stored_manifest_digest != reference.manifest_digest_sha256 {
+        Some("collection manifest digest does not match qualification".to_owned())
+    } else if !observed_family {
+        Some("collection receipt does not include the promoted family".to_owned())
+    } else {
+        None
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn page_block_reason(
+    request_source_id: &str,
+    request_family_id: &str,
+    reference: &PagePublicationReceiptReference,
+    stored_runtime_id: &str,
+    stored_source_id: &str,
+    stored_family_id: &str,
+    stored_state: &str,
+    page_state: PagePublicationState,
+    revision_matches: bool,
+    snapshot_digest: &str,
+    require_successor_generation: bool,
+    claim_generation: Option<u64>,
+) -> Option<String> {
+    if stored_runtime_id != reference.source_runtime_id {
+        Some("{kind} page runtime does not match qualification".to_owned())
+    } else if stored_source_id != request_source_id || stored_family_id != request_family_id {
+        Some("{kind} page source family does not match promotion request".to_owned())
+    } else if stored_state != "committed" || page_state != PagePublicationState::Committed {
+        Some("{kind} page did not commit append projection and checkpoint".to_owned())
+    } else if !revision_matches {
+        Some("{kind} page revision is stale".to_owned())
+    } else if snapshot_digest != reference.snapshot_digest_sha256 {
+        Some("{kind} page snapshot digest does not match qualification".to_owned())
+    } else if require_successor_generation
+        && claim_generation.is_none_or(|generation| generation <= 1)
+    {
+        Some("lease/restart page does not prove a successor generation".to_owned())
+    } else {
+        None
+    }
+}
+
+fn json_digest(value: &Value) -> String {
+    let bytes = serde_json::to_vec(value).expect("JSON value serializes");
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn unavailable_verifier_reasons() -> Vec<String> {
+    vec![
+        "authenticated provider collection verifier is unavailable".to_owned(),
+        "runtime revision verifier is unavailable".to_owned(),
+        "product-read receipt verifier is unavailable".to_owned(),
+        "promotion approval receipt verifier is unavailable".to_owned(),
+        "rollback receipt verifier is unavailable".to_owned(),
+    ]
+}
+
+#[cfg(test)]
+#[path = "promotion_evidence_test_support.rs"]
+pub(crate) mod test_support;
+
+#[cfg(test)]
+#[path = "promotion_evidence_store_tests.rs"]
+mod tests;

--- a/crates/organizational-store/src/promotion_evidence_store_tests.rs
+++ b/crates/organizational-store/src/promotion_evidence_store_tests.rs
@@ -1,0 +1,163 @@
+use super::*;
+use cerebro_source_catalog::SourceCollectionReceiptReference;
+
+fn page_reference() -> PagePublicationReceiptReference {
+    PagePublicationReceiptReference {
+        source_runtime_id: "runtime-a".to_owned(),
+        logical_page_id: "page-a".to_owned(),
+        revision: 8,
+        snapshot_digest_sha256: "a".repeat(64),
+    }
+}
+
+#[test]
+fn persisted_page_verification_rejects_cross_family_stale_and_incomplete_states() {
+    let reference = page_reference();
+    assert_eq!(
+        page_block_reason(
+            "asana",
+            "users",
+            &reference,
+            "runtime-a",
+            "asana",
+            "projects",
+            "committed",
+            PagePublicationState::Committed,
+            true,
+            &"a".repeat(64),
+            false,
+            Some(2),
+        ),
+        Some("{kind} page source family does not match promotion request".to_owned())
+    );
+    assert_eq!(
+        page_block_reason(
+            "asana",
+            "users",
+            &reference,
+            "runtime-a",
+            "asana",
+            "users",
+            "committed",
+            PagePublicationState::Committed,
+            false,
+            &"a".repeat(64),
+            false,
+            Some(2),
+        ),
+        Some("{kind} page revision is stale".to_owned())
+    );
+    for (stored_state, page_state) in [
+        ("published", PagePublicationState::Published),
+        ("projected", PagePublicationState::Projected),
+        ("publishing", PagePublicationState::Publishing),
+    ] {
+        assert_eq!(
+            page_block_reason(
+                "asana",
+                "users",
+                &reference,
+                "runtime-a",
+                "asana",
+                "users",
+                stored_state,
+                page_state,
+                true,
+                &"a".repeat(64),
+                true,
+                Some(1),
+            ),
+            Some("{kind} page did not commit append projection and checkpoint".to_owned())
+        );
+    }
+}
+
+#[test]
+fn persisted_collection_verification_rejects_scope_digest_and_family_mismatches() {
+    let reference = SourceCollectionReceiptReference {
+        source_runtime_id: "runtime-a".to_owned(),
+        collection_id: "collection-a".to_owned(),
+        manifest_digest_sha256: "a".repeat(64),
+    };
+    assert_eq!(
+        collection_block_reason(
+            "asana",
+            &reference,
+            "runtime-b",
+            "asana",
+            "complete",
+            1,
+            1,
+            0,
+            1,
+            0,
+            &"a".repeat(64),
+            true,
+        ),
+        Some("collection receipt runtime does not match qualification".to_owned())
+    );
+    assert_eq!(
+        collection_block_reason(
+            "asana",
+            &reference,
+            "runtime-a",
+            "asana",
+            "complete",
+            1,
+            1,
+            0,
+            1,
+            0,
+            &"b".repeat(64),
+            true,
+        ),
+        Some("collection manifest digest does not match qualification".to_owned())
+    );
+    assert_eq!(
+        collection_block_reason(
+            "asana",
+            &reference,
+            "runtime-a",
+            "asana",
+            "complete",
+            1,
+            1,
+            0,
+            1,
+            0,
+            &"a".repeat(64),
+            false,
+        ),
+        Some("collection receipt does not include the promoted family".to_owned())
+    );
+}
+
+#[test]
+fn persisted_page_verification_requires_restart_successor_generation() {
+    let reference = page_reference();
+    assert_eq!(
+        page_block_reason(
+            "asana",
+            "users",
+            &reference,
+            "runtime-a",
+            "asana",
+            "users",
+            "committed",
+            PagePublicationState::Committed,
+            true,
+            &"a".repeat(64),
+            true,
+            Some(1),
+        ),
+        Some("lease/restart page does not prove a successor generation".to_owned())
+    );
+}
+
+#[test]
+fn unavailable_receipt_owners_block_product_read_and_approval() {
+    let reasons = unavailable_verifier_reasons();
+    assert!(reasons.contains(&"product-read receipt verifier is unavailable".to_owned()));
+    assert!(reasons.contains(&"promotion approval receipt verifier is unavailable".to_owned()));
+    assert!(reasons.contains(&"runtime revision verifier is unavailable".to_owned()));
+}

--- a/crates/organizational-store/src/promotion_evidence_test_support.rs
+++ b/crates/organizational-store/src/promotion_evidence_test_support.rs
@@ -1,0 +1,114 @@
+use super::*;
+use cerebro_source_catalog::AuthorityQualificationEvidence;
+
+pub(crate) fn complete_test_verification(
+    tenant_id: &str,
+    source_id: &str,
+    family_id: &str,
+    qualification: &AuthorityQualificationEvidence,
+) -> PromotionEvidenceVerification {
+    let collection = &qualification.authenticated_collection_receipt;
+    let append = &qualification.append_projection_checkpoint_receipt;
+    let restart = &qualification.lease_restart_receipt;
+    let mut receipts = vec![
+        VerifiedPromotionReceipt::new(
+            VerifiedPromotionReceiptKind::DurableCollection,
+            collection.collection_id.clone(),
+            collection.manifest_digest_sha256.clone(),
+        ),
+        VerifiedPromotionReceipt::new(
+            VerifiedPromotionReceiptKind::AuthenticatedCollection,
+            collection.collection_id.clone(),
+            collection.manifest_digest_sha256.clone(),
+        ),
+        VerifiedPromotionReceipt::new(
+            VerifiedPromotionReceiptKind::AppendProjectionCheckpoint,
+            append.logical_page_id.clone(),
+            append.snapshot_digest_sha256.clone(),
+        ),
+        VerifiedPromotionReceipt::new(
+            VerifiedPromotionReceiptKind::LeaseRestart,
+            restart.logical_page_id.clone(),
+            restart.snapshot_digest_sha256.clone(),
+        ),
+        VerifiedPromotionReceipt::new(
+            VerifiedPromotionReceiptKind::RuntimeRevision,
+            qualification.runtime_revision_sha256.clone(),
+            qualification.runtime_revision_sha256.clone(),
+        ),
+        VerifiedPromotionReceipt::new(
+            VerifiedPromotionReceiptKind::ProductRead,
+            qualification.product_read_receipt.receipt_id.clone(),
+            qualification
+                .product_read_receipt
+                .receipt_digest_sha256
+                .clone(),
+        ),
+        VerifiedPromotionReceipt::new(
+            VerifiedPromotionReceiptKind::PromotionApproval,
+            qualification.promotion_receipt.receipt_id.clone(),
+            qualification
+                .promotion_receipt
+                .receipt_digest_sha256
+                .clone(),
+        ),
+        VerifiedPromotionReceipt::new(
+            VerifiedPromotionReceiptKind::Recovery,
+            qualification.rollback_receipt.receipt_id.clone(),
+            qualification.rollback_receipt.receipt_digest_sha256.clone(),
+        ),
+    ];
+    receipts.extend(qualification.parity_receipt_digests.iter().map(|digest| {
+        VerifiedPromotionReceipt::new(
+            VerifiedPromotionReceiptKind::Parity,
+            digest.clone(),
+            digest.clone(),
+        )
+    }));
+    PromotionEvidenceVerification::verified_by_store(
+        tenant_id,
+        source_id,
+        family_id,
+        &collection.source_runtime_id,
+        &qualification.runtime_revision_sha256,
+        Vec::new(),
+        receipts,
+    )
+}
+
+pub(crate) fn empty_test_verification(
+    tenant_id: &str,
+    source_id: &str,
+    family_id: &str,
+    qualification: &AuthorityQualificationEvidence,
+) -> PromotionEvidenceVerification {
+    PromotionEvidenceVerification::verified_by_store(
+        tenant_id,
+        source_id,
+        family_id,
+        &qualification
+            .authenticated_collection_receipt
+            .source_runtime_id,
+        &qualification.runtime_revision_sha256,
+        Vec::new(),
+        Vec::new(),
+    )
+}
+
+pub(crate) fn mismatched_test_verification(
+    tenant_id: &str,
+    source_id: &str,
+    family_id: &str,
+    qualification: &AuthorityQualificationEvidence,
+    kind: VerifiedPromotionReceiptKind,
+) -> PromotionEvidenceVerification {
+    let mut verification =
+        complete_test_verification(tenant_id, source_id, family_id, qualification);
+    verification
+        .receipts
+        .iter_mut()
+        .find(|receipt| receipt.kind == kind)
+        .expect("complete test verification contains every receipt kind")
+        .receipt_digest = "0".repeat(64);
+    verification
+}

--- a/crates/organizational-store/tests/live_cutover.rs
+++ b/crates/organizational-store/tests/live_cutover.rs
@@ -8,12 +8,85 @@ use std::{
 use cerebro_organizational_store::{
     CutoverPolicy, ParityReceipt, PostgresLedger, ProjectionAuthority, ProjectionPromotionRequest,
 };
-use cerebro_source_catalog::SourceCatalog;
+use cerebro_source_catalog::{
+    AuthorityQualificationEvidence, PagePublicationReceiptReference, PersistedReceiptReference,
+    SourceCatalog, SourceCollectionReceiptReference,
+};
 use tokio_postgres::NoTls;
+
+fn qualification(
+    catalog: &SourceCatalog,
+    source_id: &str,
+    family_id: &str,
+    corpus: &str,
+) -> AuthorityQualificationEvidence {
+    let plan_digest = catalog
+        .compiled_family_plan_digest(source_id, family_id)
+        .unwrap();
+    let runtime_plan_digest =
+        cerebro_source_runtime_next::source_execution::SourceExecutionDispatcher
+            .compile_plan(
+                &cerebro_source_runtime_next::source_execution::SourceExecutionSelectionRequestV1 {
+                    source_id: source_id.to_owned(),
+                    family_id: family_id.to_owned(),
+                },
+            )
+            .unwrap()
+            .plan_digest_sha256;
+    AuthorityQualificationEvidence {
+        runtime_plan_digest,
+        plan_digest,
+        fixture_corpus_revision: corpus.to_owned(),
+        supported_auth_modes: vec!["api_key".to_owned()],
+        supported_pagination_grammar: vec!["cursor".to_owned()],
+        supported_provider_errors: vec!["unauthorized".to_owned()],
+        egress_allowlist: vec!["https://provider.example.test".to_owned()],
+        response_limits: "body=1048576,decompression=4x".to_owned(),
+        credential_lease_mode: "one_operation".to_owned(),
+        projection_dependency: "rust_projection".to_owned(),
+        rollback_receipt: PersistedReceiptReference {
+            receipt_id: "rollback-test".to_owned(),
+            receipt_digest_sha256: "c".repeat(64),
+        },
+        parity_status: "passed".to_owned(),
+        canonical_digest_vectors: vec!["plan".to_owned()],
+        config_safety_proof: "receipt:config".to_owned(),
+        cursor_checkpoint_proof: "receipt:checkpoint".to_owned(),
+        fencing_recovery_proof: "receipt:fencing".to_owned(),
+        runtime_revision_sha256: "d".repeat(64),
+        worker_runtime_build_identity: "source-runtime-next:test".to_owned(),
+        promotion_receipt: PersistedReceiptReference {
+            receipt_id: "promotion-test".to_owned(),
+            receipt_digest_sha256: "e".repeat(64),
+        },
+        authenticated_collection_receipt: SourceCollectionReceiptReference {
+            source_runtime_id: "asana-runtime".to_owned(),
+            collection_id: corpus.to_owned(),
+            manifest_digest_sha256: "f".repeat(64),
+        },
+        append_projection_checkpoint_receipt: PagePublicationReceiptReference {
+            source_runtime_id: "asana-runtime".to_owned(),
+            logical_page_id: "page-test".to_owned(),
+            revision: 5,
+            snapshot_digest_sha256: "1".repeat(64),
+        },
+        lease_restart_receipt: PagePublicationReceiptReference {
+            source_runtime_id: "asana-runtime".to_owned(),
+            logical_page_id: "page-restart-test".to_owned(),
+            revision: 6,
+            snapshot_digest_sha256: "2".repeat(64),
+        },
+        product_read_receipt: PersistedReceiptReference {
+            receipt_id: "product-read-test".to_owned(),
+            receipt_digest_sha256: "3".repeat(64),
+        },
+        parity_receipt_digests: vec!["4".repeat(64), "5".repeat(64), "6".repeat(64)],
+    }
+}
 
 #[tokio::test]
 #[ignore = "requires disposable PostgreSQL"]
-async fn persisted_cutover_requires_three_matching_receipts_and_is_irreversible()
+async fn persisted_promotion_rejects_fabricated_and_unverifiable_receipt_references()
 -> Result<(), Box<dyn Error>> {
     let postgres_dsn = env::var("CEREBRO_TEST_POSTGRES_DSN")?;
     let (client, connection) = tokio_postgres::connect(&postgres_dsn, NoTls).await?;
@@ -26,87 +99,101 @@ async fn persisted_cutover_requires_three_matching_receipts_and_is_irreversible(
         .duration_since(UNIX_EPOCH)?
         .as_nanos()
         .to_string();
-    let tenant_id = format!("cutover-{suffix}");
+    let tenant_id = format!("promotion-evidence-{suffix}");
+    let mut parity_digests = Vec::new();
     for index in 1..=3 {
-        ledger
-            .record_parity(&ParityReceipt::compare_scoped(
-                tenant_id.clone(),
-                "box-runtime",
-                "box",
-                "users",
-                format!("cutover-{suffix}-{index}"),
-                "sha256:equal",
-                "sha256:equal",
-                true,
-                index,
-            )?)
-            .await?;
+        let receipt = ParityReceipt::compare_scoped(
+            tenant_id.clone(),
+            "asana-runtime",
+            "asana",
+            "users",
+            format!("promotion-evidence-{suffix}-{index}"),
+            "sha256:equal",
+            "sha256:equal",
+            true,
+            index,
+        )?;
+        parity_digests.push(receipt.receipt_digest().to_owned());
+        ledger.record_parity(&receipt).await?;
     }
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
     let catalog = SourceCatalog::load(
         root.join("internal/connectorcatalog/catalog"),
         root.join("sources"),
     )?;
+    let mut evidence = qualification(
+        &catalog,
+        "asana",
+        "users",
+        &format!("promotion-evidence-{suffix}-3"),
+    );
+    evidence.parity_receipt_digests = parity_digests;
+    ledger
+        .record_source_collection(
+            &format!("other-tenant-{suffix}"),
+            &evidence.authenticated_collection_receipt.collection_id,
+            &evidence.authenticated_collection_receipt.source_runtime_id,
+            "asana",
+            1,
+            2,
+            "complete",
+            1,
+            1,
+            1,
+            0,
+            1,
+            0,
+            &evidence
+                .authenticated_collection_receipt
+                .manifest_digest_sha256,
+            &serde_json::json!({"observed_family_ids": ["users"]}),
+        )
+        .await?;
     let request = ProjectionPromotionRequest::new(
         tenant_id.clone(),
-        "box",
+        "asana",
         "users",
         CutoverPolicy::new(3, 0)?,
         0,
         100,
+        evidence,
     )?;
     let decision = ledger
         .evaluate_projection_authority(&catalog, &request)
         .await?;
-    assert!(decision.is_allowed());
+    assert!(!decision.is_allowed());
+    assert!(
+        decision
+            .reasons()
+            .iter()
+            .any(|reason| reason == "persisted collection receipt was not found")
+    );
+    assert!(
+        decision
+            .reasons()
+            .iter()
+            .any(|reason| reason == "product-read receipt verifier is unavailable")
+    );
     assert_eq!(
         ledger
-            .projection_authority(&tenant_id, "box", "users")
+            .projection_authority(&tenant_id, "asana", "users")
             .await?
             .authority,
         ProjectionAuthority::Legacy,
         "evaluation must not change authority"
     );
-    let authority = ledger
-        .evaluate_and_promote_projection_authority(&catalog, &request)
-        .await?;
-    assert_eq!(authority.authority, ProjectionAuthority::Rust);
-    assert_eq!(
-        ledger
-            .projection_authority(&tenant_id, "box", "users")
-            .await?
-            .authority,
-        ProjectionAuthority::Rust
-    );
-
-    ledger
-        .record_parity(&ParityReceipt::compare_scoped(
-            tenant_id.clone(),
-            "box-runtime",
-            "box",
-            "users",
-            format!("cutover-{suffix}-4"),
-            "sha256:equal",
-            "sha256:equal",
-            true,
-            4,
-        )?)
-        .await?;
     assert!(
         ledger
-            .evaluate_and_promote_projection_authority(
-                &catalog,
-                &ProjectionPromotionRequest::new(
-                    tenant_id.clone(),
-                    "box",
-                    "users",
-                    CutoverPolicy::new(3, 0)?,
-                    0,
-                    101,
-                )?,
-            )
+            .evaluate_and_promote_projection_authority(&catalog, &request)
             .await
             .is_err()
+    );
+    assert_eq!(
+        ledger
+            .projection_authority(&tenant_id, "asana", "users")
+            .await?
+            .authority,
+        ProjectionAuthority::Legacy
     );
     Ok(())
 }

--- a/crates/source-catalog/src/authority_evidence.rs
+++ b/crates/source-catalog/src/authority_evidence.rs
@@ -1,10 +1,16 @@
 use std::collections::BTreeSet;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use crate::{
+    AuthorityQualificationEvidence, PagePublicationReceiptReference, PersistedReceiptReference,
+    SourceCollectionReceiptReference, authority_qualification_digest,
+    validate_authority_qualification_evidence,
+};
+
 /// Source-family authority decision kinds recorded in the append-only evidence stream.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AuthorityDecisionKind {
     /// Promote one tenant/source/family to Rust authority.
@@ -18,7 +24,7 @@ pub enum AuthorityDecisionKind {
 }
 
 /// Immutable authority evidence for one tenant/source/family decision.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AuthorityEvidenceRecord {
     /// Tenant scope.
     pub tenant_id: String,
@@ -44,6 +50,11 @@ pub struct AuthorityEvidenceRecord {
     pub authenticated_receipt_id: String,
     /// Detached signature, when available.
     pub receipt_signature: String,
+    /// Prior decision in the exact tenant/source/family authority chain.
+    pub previous_decision_id: String,
+    /// Complete proof bundle for a promotion decision.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub qualification: Option<AuthorityQualificationEvidence>,
     /// Canonical record digest assigned at append time.
     pub record_digest_sha256: String,
 }
@@ -71,16 +82,58 @@ impl AuthorityEvidenceStream {
         mut record: AuthorityEvidenceRecord,
     ) -> Result<AuthorityEvidenceRecord, AuthorityEvidenceError> {
         validate_authority_evidence_record(&record)?;
+        self.validate_append_sequence(&record)?;
+        record.record_digest_sha256.clear();
+        record.record_digest_sha256 = digest_authority_evidence_record(&record);
+        self.insert_validated(record.clone())?;
+        Ok(record)
+    }
+
+    /// Hydrate one already-persisted record after verifying its digest and
+    /// monotonic family decision chain.
+    pub fn append_persisted(
+        &mut self,
+        record: AuthorityEvidenceRecord,
+    ) -> Result<(), AuthorityEvidenceError> {
+        validate_authority_evidence_record(&record)?;
+        if !is_sha256_hex(&record.record_digest_sha256)
+            || digest_authority_evidence_record(&record) != record.record_digest_sha256
+        {
+            return Err(AuthorityEvidenceError::Invalid("record_digest_sha256"));
+        }
+        self.validate_append_sequence(&record)?;
+        self.insert_validated(record)
+    }
+
+    fn insert_validated(
+        &mut self,
+        record: AuthorityEvidenceRecord,
+    ) -> Result<(), AuthorityEvidenceError> {
         if !self
             .decision_ids
             .insert(record.decision_id.trim().to_owned())
         {
             return Err(AuthorityEvidenceError::Immutable);
         }
-        record.record_digest_sha256.clear();
-        record.record_digest_sha256 = digest_authority_evidence_record(&record);
-        self.records.push(record.clone());
-        Ok(record)
+        self.records.push(record);
+        Ok(())
+    }
+
+    fn validate_append_sequence(
+        &self,
+        record: &AuthorityEvidenceRecord,
+    ) -> Result<(), AuthorityEvidenceError> {
+        let previous = self.latest(&record.tenant_id, &record.source_id, &record.family_id);
+        match previous {
+            Some(previous)
+                if record.authority_epoch == previous.authority_epoch + 1
+                    && record.previous_decision_id == previous.decision_id =>
+            {
+                Ok(())
+            }
+            None if record.previous_decision_id.trim().is_empty() => Ok(()),
+            _ => Err(AuthorityEvidenceError::Invalid("authority_sequence")),
+        }
     }
 
     /// Return ordered authority history for one tenant/source/family.
@@ -99,6 +152,20 @@ impl AuthorityEvidenceStream {
             })
             .cloned()
             .collect()
+    }
+
+    /// Return the latest verified record for one exact authority scope.
+    pub fn latest(
+        &self,
+        tenant_id: &str,
+        source_id: &str,
+        family_id: &str,
+    ) -> Option<&AuthorityEvidenceRecord> {
+        self.records.iter().rev().find(|record| {
+            record.tenant_id == tenant_id
+                && record.source_id == source_id
+                && record.family_id == family_id
+        })
     }
 
     /// Reject any post-append mutation to a stored record.
@@ -121,7 +188,8 @@ impl AuthorityEvidenceStream {
     }
 }
 
-/// Validate an authority evidence record before any authority decision can use it.
+/// Validate the shape and chain binding of an audit evidence record. This does
+/// not verify persisted receipts or authorize projection.
 pub fn validate_authority_evidence_record(
     record: &AuthorityEvidenceRecord,
 ) -> Result<(), AuthorityEvidenceError> {
@@ -134,7 +202,7 @@ pub fn validate_authority_evidence_record(
     {
         return Err(AuthorityEvidenceError::Invalid("required_identity"));
     }
-    if record.authority_epoch == 0 {
+    if record.authority_epoch == 0 || record.timestamp_unix_ms <= 0 {
         return Err(AuthorityEvidenceError::Invalid("authority_epoch"));
     }
     if !is_sha256_hex(&record.input_evidence_digest_sha256) {
@@ -142,17 +210,33 @@ pub fn validate_authority_evidence_record(
             "input_evidence_digest_sha256",
         ));
     }
-    if record.decision_kind == AuthorityDecisionKind::Promotion
-        && record.authenticated_receipt_id.trim().is_empty()
-        && !record.receipt_signature.trim().starts_with("sig:")
-    {
-        return Err(AuthorityEvidenceError::Invalid("promotion_receipt"));
+    if record.decision_kind == AuthorityDecisionKind::Promotion {
+        if record.authenticated_receipt_id.trim().is_empty() {
+            return Err(AuthorityEvidenceError::Invalid("promotion_receipt"));
+        }
+        let qualification = record
+            .qualification
+            .as_ref()
+            .ok_or(AuthorityEvidenceError::Invalid("qualification_evidence"))?;
+        validate_authority_qualification_evidence(qualification)?;
+        if authority_qualification_digest(qualification)
+            != record
+                .input_evidence_digest_sha256
+                .trim()
+                .to_ascii_lowercase()
+        {
+            return Err(AuthorityEvidenceError::Invalid(
+                "input_evidence_digest_sha256",
+            ));
+        }
     }
     Ok(())
 }
 
 fn digest_authority_evidence_record(record: &AuthorityEvidenceRecord) -> String {
-    let bytes = serde_json::to_vec(record).expect("authority evidence serializes");
+    let mut record = record.clone();
+    record.record_digest_sha256.clear();
+    let bytes = serde_json::to_vec(&record).expect("authority evidence serializes");
     let digest = Sha256::digest(bytes);
     digest.iter().map(|byte| format!("{byte:02x}")).collect()
 }
@@ -209,6 +293,15 @@ mod tests {
             Err(AuthorityEvidenceError::Immutable)
         );
 
+        let mut hydrated = AuthorityEvidenceStream::default();
+        hydrated.append_persisted(first.clone()).unwrap();
+        let mut tampered = second.clone();
+        tampered.reason_code = "tampered".to_owned();
+        assert_eq!(
+            hydrated.append_persisted(tampered),
+            Err(AuthorityEvidenceError::Invalid("record_digest_sha256"))
+        );
+
         let mut bad_digest =
             authority_record("decision-bad-digest", 4, AuthorityDecisionKind::Promotion);
         bad_digest.input_evidence_digest_sha256 = "not-a-sha".to_owned();
@@ -221,7 +314,7 @@ mod tests {
         let mut unsigned =
             authority_record("decision-unsigned", 5, AuthorityDecisionKind::Promotion);
         unsigned.authenticated_receipt_id.clear();
-        unsigned.receipt_signature.clear();
+        unsigned.receipt_signature = "sig:unverified-prefix".to_owned();
         assert_eq!(
             validate_authority_evidence_record(&unsigned),
             Err(AuthorityEvidenceError::Invalid("promotion_receipt"))
@@ -229,6 +322,13 @@ mod tests {
         let mut blocked = unsigned;
         blocked.decision_kind = AuthorityDecisionKind::ShadowOnlyBlocked;
         assert_eq!(validate_authority_evidence_record(&blocked), Ok(()));
+
+        let mut incomplete = qualification_evidence("a".repeat(64));
+        incomplete.product_read_receipt.receipt_id.clear();
+        assert_eq!(
+            validate_authority_qualification_evidence(&incomplete),
+            Err(AuthorityEvidenceError::Invalid("product_read_receipt"))
+        );
     }
 
     fn authority_record(
@@ -236,6 +336,11 @@ mod tests {
         authority_epoch: u64,
         decision_kind: AuthorityDecisionKind,
     ) -> AuthorityEvidenceRecord {
+        let qualification = (decision_kind == AuthorityDecisionKind::Promotion)
+            .then(|| qualification_evidence("a".repeat(64)));
+        let input_evidence_digest_sha256 = qualification
+            .as_ref()
+            .map_or_else(|| "a".repeat(64), authority_qualification_digest);
         AuthorityEvidenceRecord {
             tenant_id: "tenant-a".to_owned(),
             source_id: "custom_deposit".to_owned(),
@@ -243,13 +348,71 @@ mod tests {
             authority_epoch,
             decision_id: decision_id.to_owned(),
             decision_kind,
-            input_evidence_digest_sha256: "a".repeat(64),
+            input_evidence_digest_sha256,
             actor_id: "system:cutover".to_owned(),
             timestamp_unix_ms: 1_787_136_000_000,
             reason_code: "provider_proof_complete".to_owned(),
             authenticated_receipt_id: "receipt:promotion".to_owned(),
             receipt_signature: String::new(),
+            previous_decision_id: match authority_epoch {
+                1 => String::new(),
+                2 => "decision-promote".to_owned(),
+                _ => "decision-rollback".to_owned(),
+            },
+            qualification,
             record_digest_sha256: String::new(),
+        }
+    }
+
+    fn qualification_evidence(plan_digest: String) -> AuthorityQualificationEvidence {
+        AuthorityQualificationEvidence {
+            plan_digest,
+            runtime_plan_digest: "b".repeat(64),
+            fixture_corpus_revision: "fixture-corpus:v1".to_owned(),
+            supported_auth_modes: vec!["api_key".to_owned()],
+            supported_pagination_grammar: vec!["cursor".to_owned()],
+            supported_provider_errors: vec!["unauthorized".to_owned(), "rate_limited".to_owned()],
+            egress_allowlist: vec!["https://provider.example.test".to_owned()],
+            response_limits: "body=1048576,decompression=4x".to_owned(),
+            credential_lease_mode: "one_operation".to_owned(),
+            projection_dependency: "rust_projection".to_owned(),
+            rollback_receipt: PersistedReceiptReference {
+                receipt_id: "rollback-test".to_owned(),
+                receipt_digest_sha256: "c".repeat(64),
+            },
+            parity_status: "passed".to_owned(),
+            canonical_digest_vectors: vec!["plan".to_owned(), "result".to_owned()],
+            config_safety_proof: "receipt:config-safety".to_owned(),
+            cursor_checkpoint_proof: "receipt:cursor-checkpoint".to_owned(),
+            fencing_recovery_proof: "receipt:fencing-recovery".to_owned(),
+            runtime_revision_sha256: "d".repeat(64),
+            worker_runtime_build_identity: "source-runtime-next:test".to_owned(),
+            promotion_receipt: PersistedReceiptReference {
+                receipt_id: "promotion-test".to_owned(),
+                receipt_digest_sha256: "e".repeat(64),
+            },
+            authenticated_collection_receipt: SourceCollectionReceiptReference {
+                source_runtime_id: "runtime-test".to_owned(),
+                collection_id: "collection-test".to_owned(),
+                manifest_digest_sha256: "f".repeat(64),
+            },
+            append_projection_checkpoint_receipt: PagePublicationReceiptReference {
+                source_runtime_id: "runtime-test".to_owned(),
+                logical_page_id: "page-test".to_owned(),
+                revision: 5,
+                snapshot_digest_sha256: "1".repeat(64),
+            },
+            lease_restart_receipt: PagePublicationReceiptReference {
+                source_runtime_id: "runtime-test".to_owned(),
+                logical_page_id: "page-restart-test".to_owned(),
+                revision: 6,
+                snapshot_digest_sha256: "2".repeat(64),
+            },
+            product_read_receipt: PersistedReceiptReference {
+                receipt_id: "product-read-test".to_owned(),
+                receipt_digest_sha256: "3".repeat(64),
+            },
+            parity_receipt_digests: vec!["4".repeat(64), "5".repeat(64), "6".repeat(64)],
         }
     }
 }

--- a/crates/source-catalog/src/authority_qualification.rs
+++ b/crates/source-catalog/src/authority_qualification.rs
@@ -1,0 +1,378 @@
+//! Typed promotion references and shape validation before persisted verification.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::authority_evidence::AuthorityEvidenceError;
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PersistedReceiptReference {
+    pub receipt_id: String,
+    pub receipt_digest_sha256: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceCollectionReceiptReference {
+    pub source_runtime_id: String,
+    pub collection_id: String,
+    pub manifest_digest_sha256: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PagePublicationReceiptReference {
+    pub source_runtime_id: String,
+    pub logical_page_id: String,
+    pub revision: u64,
+    pub snapshot_digest_sha256: String,
+}
+
+/// Typed, non-secret references submitted for persisted promotion verification.
+/// Neither deserialization nor shape validation grants runtime authority.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthorityQualificationEvidence {
+    pub plan_digest: String,
+    pub runtime_plan_digest: String,
+    pub fixture_corpus_revision: String,
+    pub supported_auth_modes: Vec<String>,
+    pub supported_pagination_grammar: Vec<String>,
+    pub supported_provider_errors: Vec<String>,
+    pub egress_allowlist: Vec<String>,
+    pub response_limits: String,
+    pub credential_lease_mode: String,
+    pub projection_dependency: String,
+    pub rollback_receipt: PersistedReceiptReference,
+    pub parity_status: String,
+    pub canonical_digest_vectors: Vec<String>,
+    pub config_safety_proof: String,
+    pub cursor_checkpoint_proof: String,
+    pub fencing_recovery_proof: String,
+    pub runtime_revision_sha256: String,
+    pub worker_runtime_build_identity: String,
+    pub promotion_receipt: PersistedReceiptReference,
+    pub authenticated_collection_receipt: SourceCollectionReceiptReference,
+    pub append_projection_checkpoint_receipt: PagePublicationReceiptReference,
+    pub lease_restart_receipt: PagePublicationReceiptReference,
+    pub product_read_receipt: PersistedReceiptReference,
+    pub parity_receipt_digests: Vec<String>,
+}
+
+/// Validate the typed reference shape required before persisted verification.
+pub fn validate_authority_qualification_evidence(
+    evidence: &AuthorityQualificationEvidence,
+) -> Result<(), AuthorityEvidenceError> {
+    let missing = missing_authority_qualification_evidence(evidence);
+    if let Some(field) = missing.first() {
+        return Err(AuthorityEvidenceError::Invalid(field));
+    }
+    if !is_sha256_hex(&evidence.plan_digest) {
+        return Err(AuthorityEvidenceError::Invalid("compiled_plan_digest"));
+    }
+    if !is_sha256_hex(&evidence.runtime_plan_digest) {
+        return Err(AuthorityEvidenceError::Invalid("runtime_plan_digest"));
+    }
+    if !matches!(evidence.parity_status.trim(), "passed" | "matched") {
+        return Err(AuthorityEvidenceError::Invalid("fixture_parity_status"));
+    }
+    for (field, digest) in [
+        ("runtime_revision_sha256", &evidence.runtime_revision_sha256),
+        (
+            "collection_manifest_digest_sha256",
+            &evidence
+                .authenticated_collection_receipt
+                .manifest_digest_sha256,
+        ),
+        (
+            "page_publication_snapshot_digest_sha256",
+            &evidence
+                .append_projection_checkpoint_receipt
+                .snapshot_digest_sha256,
+        ),
+        (
+            "lease_restart_snapshot_digest_sha256",
+            &evidence.lease_restart_receipt.snapshot_digest_sha256,
+        ),
+        (
+            "product_read_receipt_digest_sha256",
+            &evidence.product_read_receipt.receipt_digest_sha256,
+        ),
+        (
+            "promotion_receipt_digest_sha256",
+            &evidence.promotion_receipt.receipt_digest_sha256,
+        ),
+        (
+            "rollback_receipt_digest_sha256",
+            &evidence.rollback_receipt.receipt_digest_sha256,
+        ),
+    ] {
+        if !is_sha256_hex(digest) {
+            return Err(AuthorityEvidenceError::Invalid(field));
+        }
+    }
+    if evidence
+        .parity_receipt_digests
+        .iter()
+        .any(|digest| !is_canonical_sha256(digest))
+    {
+        return Err(AuthorityEvidenceError::Invalid("parity_receipt_digests"));
+    }
+    Ok(())
+}
+
+/// Return stable field names for every absent authority reference.
+pub fn missing_authority_qualification_evidence(
+    evidence: &AuthorityQualificationEvidence,
+) -> Vec<&'static str> {
+    let mut missing = Vec::new();
+    if evidence.plan_digest.trim().is_empty() {
+        missing.push("compiled_plan_digest");
+    }
+    if evidence.runtime_plan_digest.trim().is_empty() {
+        missing.push("runtime_plan_digest");
+    }
+    if evidence.fixture_corpus_revision.trim().is_empty() {
+        missing.push("fixture_corpus_revision");
+    }
+    for (field, values) in [
+        ("supported_auth_modes", &evidence.supported_auth_modes),
+        (
+            "supported_pagination_grammar",
+            &evidence.supported_pagination_grammar,
+        ),
+        (
+            "supported_provider_error_modes",
+            &evidence.supported_provider_errors,
+        ),
+        ("egress_allowlist", &evidence.egress_allowlist),
+        (
+            "canonical_digest_vectors",
+            &evidence.canonical_digest_vectors,
+        ),
+    ] {
+        if values.iter().all(|value| value.trim().is_empty()) {
+            missing.push(field);
+        }
+    }
+    for (field, value) in [
+        ("response_decompression_limits", &evidence.response_limits),
+        ("credential_lease_mode", &evidence.credential_lease_mode),
+        ("projection_dependency", &evidence.projection_dependency),
+        ("fixture_parity_status", &evidence.parity_status),
+        (
+            "credential_config_safety_proof",
+            &evidence.config_safety_proof,
+        ),
+        (
+            "cursor_checkpoint_rollback_proof",
+            &evidence.cursor_checkpoint_proof,
+        ),
+        (
+            "operational_fencing_recovery_proof",
+            &evidence.fencing_recovery_proof,
+        ),
+        ("runtime_revision_sha256", &evidence.runtime_revision_sha256),
+        (
+            "worker_runtime_build_identity",
+            &evidence.worker_runtime_build_identity,
+        ),
+    ] {
+        if value.trim().is_empty() {
+            missing.push(field);
+        }
+    }
+    for (field, value) in [
+        (
+            "rollback_receipt_digest_sha256",
+            &evidence.rollback_receipt.receipt_digest_sha256,
+        ),
+        (
+            "promotion_receipt_digest_sha256",
+            &evidence.promotion_receipt.receipt_digest_sha256,
+        ),
+        (
+            "collection_manifest_digest_sha256",
+            &evidence
+                .authenticated_collection_receipt
+                .manifest_digest_sha256,
+        ),
+        (
+            "page_publication_snapshot_digest_sha256",
+            &evidence
+                .append_projection_checkpoint_receipt
+                .snapshot_digest_sha256,
+        ),
+        (
+            "lease_restart_snapshot_digest_sha256",
+            &evidence.lease_restart_receipt.snapshot_digest_sha256,
+        ),
+        (
+            "product_read_receipt_digest_sha256",
+            &evidence.product_read_receipt.receipt_digest_sha256,
+        ),
+    ] {
+        if value.trim().is_empty() {
+            missing.push(field);
+        }
+    }
+    for (field, value) in [
+        ("rollback_receipt", &evidence.rollback_receipt.receipt_id),
+        ("promotion_receipt", &evidence.promotion_receipt.receipt_id),
+        (
+            "authenticated_collection_receipt",
+            &evidence.authenticated_collection_receipt.collection_id,
+        ),
+        (
+            "authenticated_collection_runtime",
+            &evidence.authenticated_collection_receipt.source_runtime_id,
+        ),
+        (
+            "append_projection_checkpoint_receipt",
+            &evidence
+                .append_projection_checkpoint_receipt
+                .logical_page_id,
+        ),
+        (
+            "append_projection_checkpoint_runtime",
+            &evidence
+                .append_projection_checkpoint_receipt
+                .source_runtime_id,
+        ),
+        (
+            "lease_restart_receipt",
+            &evidence.lease_restart_receipt.logical_page_id,
+        ),
+        (
+            "lease_restart_runtime",
+            &evidence.lease_restart_receipt.source_runtime_id,
+        ),
+        (
+            "product_read_receipt",
+            &evidence.product_read_receipt.receipt_id,
+        ),
+    ] {
+        if value.trim().is_empty() {
+            missing.push(field);
+        }
+    }
+    if evidence.append_projection_checkpoint_receipt.revision == 0 {
+        missing.push("append_projection_checkpoint_revision");
+    }
+    if evidence.lease_restart_receipt.revision == 0 {
+        missing.push("lease_restart_revision");
+    }
+    if evidence.parity_receipt_digests.is_empty() {
+        missing.push("parity_receipt_digests");
+    }
+    missing.sort_unstable();
+    missing
+}
+
+/// Digest the canonical typed reference bundle bound by a decision.
+pub fn authority_qualification_digest(evidence: &AuthorityQualificationEvidence) -> String {
+    let bytes = serde_json::to_vec(evidence).expect("authority qualification serializes");
+    let digest = Sha256::digest(bytes);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn is_sha256_hex(value: &str) -> bool {
+    let value = value.trim();
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_canonical_sha256(value: &str) -> bool {
+    value
+        .trim()
+        .strip_prefix("sha256:")
+        .is_some_and(is_sha256_hex)
+        || is_sha256_hex(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn qualification_shape_validation_reports_all_missing_fields() {
+        let missing =
+            missing_authority_qualification_evidence(&AuthorityQualificationEvidence::default());
+
+        for field in [
+            "compiled_plan_digest",
+            "runtime_plan_digest",
+            "authenticated_collection_receipt",
+            "append_projection_checkpoint_receipt",
+            "lease_restart_receipt",
+            "product_read_receipt",
+            "promotion_receipt",
+            "rollback_receipt",
+            "runtime_revision_sha256",
+            "worker_runtime_build_identity",
+            "parity_receipt_digests",
+        ] {
+            assert!(missing.contains(&field), "missing {field}");
+        }
+        assert!(missing.len() > 10, "all missing fields must be retained");
+    }
+
+    #[test]
+    fn opaque_receipt_labels_are_not_accepted_as_digests() {
+        let mut evidence = AuthorityQualificationEvidence::default();
+        evidence.plan_digest = "a".repeat(64);
+        evidence.runtime_plan_digest = "b".repeat(64);
+        evidence.fixture_corpus_revision = "fixtures:v1".to_owned();
+        evidence.supported_auth_modes = vec!["api_key".to_owned()];
+        evidence.supported_pagination_grammar = vec!["cursor".to_owned()];
+        evidence.supported_provider_errors = vec!["rate_limited".to_owned()];
+        evidence.egress_allowlist = vec!["https://provider.example.test".to_owned()];
+        evidence.response_limits = "body=1048576".to_owned();
+        evidence.credential_lease_mode = "one_operation".to_owned();
+        evidence.projection_dependency = "rust_projection".to_owned();
+        evidence.parity_status = "passed".to_owned();
+        evidence.canonical_digest_vectors = vec!["vector".to_owned()];
+        evidence.config_safety_proof = "receipt:config".to_owned();
+        evidence.cursor_checkpoint_proof = "receipt:checkpoint".to_owned();
+        evidence.fencing_recovery_proof = "receipt:fencing".to_owned();
+        evidence.runtime_revision_sha256 = "c".repeat(64);
+        evidence.worker_runtime_build_identity = "source-runtime-next:test".to_owned();
+        evidence.rollback_receipt = PersistedReceiptReference {
+            receipt_id: "rollback".to_owned(),
+            receipt_digest_sha256: "sig:rollback".to_owned(),
+        };
+        evidence.promotion_receipt = PersistedReceiptReference {
+            receipt_id: "promotion".to_owned(),
+            receipt_digest_sha256: "d".repeat(64),
+        };
+        evidence.authenticated_collection_receipt = SourceCollectionReceiptReference {
+            source_runtime_id: "runtime".to_owned(),
+            collection_id: "collection".to_owned(),
+            manifest_digest_sha256: "e".repeat(64),
+        };
+        evidence.append_projection_checkpoint_receipt = PagePublicationReceiptReference {
+            source_runtime_id: "runtime".to_owned(),
+            logical_page_id: "page".to_owned(),
+            revision: 1,
+            snapshot_digest_sha256: "f".repeat(64),
+        };
+        evidence.lease_restart_receipt = PagePublicationReceiptReference {
+            source_runtime_id: "runtime".to_owned(),
+            logical_page_id: "restart".to_owned(),
+            revision: 2,
+            snapshot_digest_sha256: "1".repeat(64),
+        };
+        evidence.product_read_receipt = PersistedReceiptReference {
+            receipt_id: "product-read".to_owned(),
+            receipt_digest_sha256: "2".repeat(64),
+        };
+        evidence.parity_receipt_digests = vec!["3".repeat(64)];
+
+        assert_eq!(
+            validate_authority_qualification_evidence(&evidence),
+            Err(AuthorityEvidenceError::Invalid(
+                "rollback_receipt_digest_sha256"
+            ))
+        );
+    }
+}

--- a/crates/source-catalog/src/authority_readiness.rs
+++ b/crates/source-catalog/src/authority_readiness.rs
@@ -1,0 +1,283 @@
+//! Evidence-aware catalog readiness reporting and compiled plan-digest lookup.
+
+use super::{
+    AuthorityDecisionKind, AuthorityEvidenceStream, AuthorityReadinessFamilyReport,
+    AuthorityReadinessReport, CompiledFamily, SourceCatalog, family_plan_digest,
+};
+
+pub(super) fn compiled_family_plan_digest(
+    catalog: &SourceCatalog,
+    source_id: &str,
+    family_id: &str,
+) -> Option<String> {
+    let source = catalog.get(source_id.trim())?;
+    let family = source
+        .families()
+        .iter()
+        .find(|family| family.id() == family_id.trim())?;
+    Some(family_plan_digest(source, family))
+}
+
+pub(super) fn report_with_evidence(
+    catalog: &SourceCatalog,
+    tenant_id: &str,
+    evidence: &AuthorityEvidenceStream,
+) -> AuthorityReadinessReport {
+    let mut families = Vec::new();
+    let mut rust_authoritative_families = 0;
+    for source in catalog.sources() {
+        for family in source.families() {
+            let plan_digest = family_plan_digest(source, family);
+            let latest = (!tenant_id.trim().is_empty())
+                .then(|| evidence.latest(tenant_id, source.id(), family.id()))
+                .flatten();
+            let mut engine = "go_or_shadow_only".to_owned();
+            let mut authority_epoch = 0;
+            let mut proof_revision = "provider-proof:incomplete".to_owned();
+            let mut fixture_revision = String::new();
+            let mut parity_status = "missing".to_owned();
+            let mut rollback_status = "missing".to_owned();
+            let mut projection_status = if family.is_projection_authoritative() {
+                "go_projection_dependency".to_owned()
+            } else {
+                "missing".to_owned()
+            };
+            let mut promotion_decision_id = String::new();
+            let mut blocking_reasons = default_blocking_reasons(family);
+
+            if let Some(record) = latest {
+                authority_epoch = record.authority_epoch;
+                promotion_decision_id = record.decision_id.clone();
+                proof_revision = record.input_evidence_digest_sha256.clone();
+                match record.decision_kind {
+                    AuthorityDecisionKind::Promotion => {
+                        let qualification = record
+                            .qualification
+                            .as_ref()
+                            .expect("verified promotion carries qualification evidence");
+                        fixture_revision = qualification.fixture_corpus_revision.clone();
+                        parity_status = qualification.parity_status.clone();
+                        rollback_status = qualification.rollback_receipt.receipt_id.clone();
+                        projection_status = qualification.projection_dependency.clone();
+                        blocking_reasons.clear();
+                        if !family.is_authoritative() {
+                            blocking_reasons.push("compiled_collection_authority".to_owned());
+                        }
+                        if !family.is_projection_authoritative() {
+                            blocking_reasons.push("projection_intent_readiness".to_owned());
+                        }
+                        if qualification.plan_digest != plan_digest {
+                            blocking_reasons.push("compiled_plan_digest".to_owned());
+                        }
+                        blocking_reasons
+                            .push("projection_authority_ledger_verification".to_owned());
+                        if blocking_reasons.is_empty() {
+                            engine = "rust_authoritative".to_owned();
+                            rust_authoritative_families += 1;
+                        }
+                    }
+                    AuthorityDecisionKind::Rollback => {
+                        blocking_reasons = vec!["authority_decision_rollback".to_owned()];
+                    }
+                    AuthorityDecisionKind::ShadowOnlyBlocked => {
+                        blocking_reasons =
+                            vec!["authority_decision_shadow_only_blocked".to_owned()];
+                    }
+                    AuthorityDecisionKind::CapabilityChanged => {
+                        blocking_reasons = vec!["authority_decision_capability_changed".to_owned()];
+                    }
+                }
+            }
+            blocking_reasons.sort();
+            blocking_reasons.dedup();
+            families.push(AuthorityReadinessFamilyReport {
+                source_id: source.id().to_owned(),
+                family_id: family.id().to_owned(),
+                engine,
+                authority_epoch,
+                plan_digest,
+                proof_revision,
+                fixture_revision,
+                parity_status,
+                rollback_status,
+                projection_status,
+                promotion_decision_id,
+                blocking_reasons,
+            });
+        }
+    }
+    AuthorityReadinessReport {
+        total_families: families.len(),
+        rust_authoritative_families,
+        shadow_or_go_families: families.len() - rust_authoritative_families,
+        families,
+    }
+}
+
+fn default_blocking_reasons(family: &CompiledFamily) -> Vec<String> {
+    let mut blocking_reasons = vec![
+        "fixture_corpus_revision".to_owned(),
+        "supported_auth_modes".to_owned(),
+        "supported_pagination_grammar".to_owned(),
+        "supported_provider_error_modes".to_owned(),
+        "egress_allowlist".to_owned(),
+        "response_decompression_limits".to_owned(),
+        "credential_lease_mode".to_owned(),
+        "rollback_receipt".to_owned(),
+        "fixture_parity_status".to_owned(),
+        "canonical_digest_vectors".to_owned(),
+        "credential_config_safety_proof".to_owned(),
+        "cursor_checkpoint_rollback_proof".to_owned(),
+        "operational_fencing_recovery_proof".to_owned(),
+        "runtime_revision_sha256".to_owned(),
+        "worker_runtime_build_identity".to_owned(),
+        "promotion_receipt".to_owned(),
+        "authenticated_collection_receipt".to_owned(),
+        "append_projection_checkpoint_receipt".to_owned(),
+        "lease_restart_receipt".to_owned(),
+        "product_read_receipt".to_owned(),
+        "parity_receipt_digests".to_owned(),
+    ];
+    if !family.is_projection_authoritative() {
+        blocking_reasons.push("projection_intent_readiness".to_owned());
+    }
+    blocking_reasons.sort();
+    blocking_reasons
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use crate::{
+        AuthorityEvidenceRecord, AuthorityQualificationEvidence, PagePublicationReceiptReference,
+        PersistedReceiptReference, SourceCollectionReceiptReference,
+        authority_qualification_digest,
+    };
+
+    use super::*;
+
+    fn repository_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()
+            .unwrap()
+    }
+
+    #[test]
+    fn catalog_evidence_cannot_replace_persisted_projection_authority() {
+        let root = repository_root();
+        let catalog = SourceCatalog::load(
+            root.join("internal/connectorcatalog/catalog"),
+            root.join("sources"),
+        )
+        .unwrap();
+        let report = catalog.authority_readiness_report();
+        let (source, family) = catalog
+            .sources()
+            .find_map(|source| {
+                source
+                    .families()
+                    .iter()
+                    .find(|family| {
+                        family.is_authoritative() && family.is_projection_authoritative()
+                    })
+                    .map(|family| (source, family))
+            })
+            .expect("compile-qualified family");
+        let plan_digest = report
+            .families
+            .iter()
+            .find(|row| row.source_id == source.id() && row.family_id == family.id())
+            .expect("readiness row")
+            .plan_digest
+            .clone();
+        let qualification = complete_authority_qualification(plan_digest);
+        let mut stream = AuthorityEvidenceStream::default();
+        stream
+            .append(AuthorityEvidenceRecord {
+                tenant_id: "tenant-readiness".to_owned(),
+                source_id: source.id().to_owned(),
+                family_id: family.id().to_owned(),
+                authority_epoch: 1,
+                decision_id: "decision-promote-readiness".to_owned(),
+                decision_kind: AuthorityDecisionKind::Promotion,
+                input_evidence_digest_sha256: authority_qualification_digest(&qualification),
+                actor_id: "system:cutover".to_owned(),
+                timestamp_unix_ms: 1_787_136_000_000,
+                reason_code: "complete_runtime_evidence".to_owned(),
+                authenticated_receipt_id: "receipt:promotion".to_owned(),
+                receipt_signature: String::new(),
+                previous_decision_id: String::new(),
+                qualification: Some(qualification),
+                record_digest_sha256: String::new(),
+            })
+            .expect("verified promotion record");
+        let promoted =
+            catalog.authority_readiness_report_with_evidence("tenant-readiness", &stream);
+        assert_eq!(promoted.rust_authoritative_families, 0);
+        let promoted_family = promoted
+            .families
+            .iter()
+            .find(|row| row.source_id == source.id() && row.family_id == family.id())
+            .expect("promoted readiness row");
+        assert_eq!(promoted_family.engine, "go_or_shadow_only");
+        assert_eq!(promoted_family.authority_epoch, 1);
+        assert_eq!(
+            promoted_family.blocking_reasons,
+            vec!["projection_authority_ledger_verification"]
+        );
+    }
+
+    fn complete_authority_qualification(plan_digest: String) -> AuthorityQualificationEvidence {
+        AuthorityQualificationEvidence {
+            plan_digest,
+            runtime_plan_digest: "b".repeat(64),
+            fixture_corpus_revision: "fixture-corpus:v1".to_owned(),
+            supported_auth_modes: vec!["api_key".to_owned()],
+            supported_pagination_grammar: vec!["cursor".to_owned()],
+            supported_provider_errors: vec!["unauthorized".to_owned(), "rate_limited".to_owned()],
+            egress_allowlist: vec!["https://provider.example.test".to_owned()],
+            response_limits: "body=1048576,decompression=4x".to_owned(),
+            credential_lease_mode: "one_operation".to_owned(),
+            projection_dependency: "rust_projection".to_owned(),
+            rollback_receipt: PersistedReceiptReference {
+                receipt_id: "rollback-test".to_owned(),
+                receipt_digest_sha256: "c".repeat(64),
+            },
+            parity_status: "passed".to_owned(),
+            canonical_digest_vectors: vec!["plan".to_owned(), "result".to_owned()],
+            config_safety_proof: "receipt:config-safety".to_owned(),
+            cursor_checkpoint_proof: "receipt:cursor-checkpoint".to_owned(),
+            fencing_recovery_proof: "receipt:fencing-recovery".to_owned(),
+            runtime_revision_sha256: "d".repeat(64),
+            worker_runtime_build_identity: "source-runtime-next:test".to_owned(),
+            promotion_receipt: PersistedReceiptReference {
+                receipt_id: "promotion-test".to_owned(),
+                receipt_digest_sha256: "e".repeat(64),
+            },
+            authenticated_collection_receipt: SourceCollectionReceiptReference {
+                source_runtime_id: "runtime-test".to_owned(),
+                collection_id: "collection-test".to_owned(),
+                manifest_digest_sha256: "f".repeat(64),
+            },
+            append_projection_checkpoint_receipt: PagePublicationReceiptReference {
+                source_runtime_id: "runtime-test".to_owned(),
+                logical_page_id: "page-test".to_owned(),
+                revision: 5,
+                snapshot_digest_sha256: "1".repeat(64),
+            },
+            lease_restart_receipt: PagePublicationReceiptReference {
+                source_runtime_id: "runtime-test".to_owned(),
+                logical_page_id: "page-restart-test".to_owned(),
+                revision: 6,
+                snapshot_digest_sha256: "2".repeat(64),
+            },
+            product_read_receipt: PersistedReceiptReference {
+                receipt_id: "product-read-test".to_owned(),
+                receipt_digest_sha256: "3".repeat(64),
+            },
+            parity_receipt_digests: vec!["4".repeat(64), "5".repeat(64), "6".repeat(64)],
+        }
+    }
+}

--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -16,9 +16,16 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 mod authority_evidence;
+mod authority_qualification;
+mod authority_readiness;
 pub use authority_evidence::{
     AuthorityDecisionKind, AuthorityEvidenceError, AuthorityEvidenceRecord,
     AuthorityEvidenceStream, validate_authority_evidence_record,
+};
+pub use authority_qualification::{
+    AuthorityQualificationEvidence, PagePublicationReceiptReference, PersistedReceiptReference,
+    SourceCollectionReceiptReference, authority_qualification_digest,
+    missing_authority_qualification_evidence, validate_authority_qualification_evidence,
 };
 
 const MAX_PAGE_SIZE: usize = 1_000;
@@ -820,57 +827,22 @@ impl SourceCatalog {
     }
 
     pub fn authority_readiness_report(&self) -> AuthorityReadinessReport {
-        let mut families = Vec::new();
-        for source in self.sources() {
-            for family in source.families() {
-                let plan_digest = family_plan_digest(source, family);
-                let mut blocking_reasons = vec![
-                    "fixture_corpus_revision".to_owned(),
-                    "supported_auth_modes".to_owned(),
-                    "supported_pagination_grammar".to_owned(),
-                    "supported_provider_error_modes".to_owned(),
-                    "egress_allowlist".to_owned(),
-                    "response_decompression_limits".to_owned(),
-                    "credential_lease_mode".to_owned(),
-                    "rollback_receipt".to_owned(),
-                    "fixture_parity_status".to_owned(),
-                    "canonical_digest_vectors".to_owned(),
-                    "credential_config_safety_proof".to_owned(),
-                    "cursor_checkpoint_rollback_proof".to_owned(),
-                    "operational_fencing_recovery_proof".to_owned(),
-                    "worker_runtime_build_identity".to_owned(),
-                    "promotion_receipt".to_owned(),
-                ];
-                if !family.is_projection_authoritative() {
-                    blocking_reasons.push("projection_intent_readiness".to_owned());
-                }
-                blocking_reasons.sort();
-                families.push(AuthorityReadinessFamilyReport {
-                    source_id: source.id().to_owned(),
-                    family_id: family.id().to_owned(),
-                    engine: "go_or_shadow_only".to_owned(),
-                    authority_epoch: 0,
-                    plan_digest,
-                    proof_revision: "provider-proof:incomplete".to_owned(),
-                    fixture_revision: String::new(),
-                    parity_status: "missing".to_owned(),
-                    rollback_status: "missing".to_owned(),
-                    projection_status: if family.is_projection_authoritative() {
-                        "go_projection_dependency".to_owned()
-                    } else {
-                        "missing".to_owned()
-                    },
-                    promotion_decision_id: String::new(),
-                    blocking_reasons,
-                });
-            }
-        }
-        AuthorityReadinessReport {
-            total_families: families.len(),
-            rust_authoritative_families: 0,
-            shadow_or_go_families: families.len(),
-            families,
-        }
+        self.authority_readiness_report_with_evidence("", &AuthorityEvidenceStream::default())
+    }
+
+    /// Return the exact compiled catalog plan digest for one source family.
+    pub fn compiled_family_plan_digest(&self, source_id: &str, family_id: &str) -> Option<String> {
+        authority_readiness::compiled_family_plan_digest(self, source_id, family_id)
+    }
+
+    /// Render one tenant's audit evidence against the compiled catalog. This
+    /// report never substitutes for the persisted projection-authority ledger.
+    pub fn authority_readiness_report_with_evidence(
+        &self,
+        tenant_id: &str,
+        evidence: &AuthorityEvidenceStream,
+    ) -> AuthorityReadinessReport {
+        authority_readiness::report_with_evidence(self, tenant_id, evidence)
     }
 }
 

--- a/crates/source-runtime-next/src/protocol.rs
+++ b/crates/source-runtime-next/src/protocol.rs
@@ -4,6 +4,8 @@ use serde::Serialize;
 use serde_json::json;
 use sha2::{Digest, Sha256};
 
+pub use cerebro_source_catalog::AuthorityQualificationEvidence as AuthorityEvidence;
+
 const PROTOCOL_REVISION: u16 = 1;
 
 /// Versioned source-runtime operations that a worker may execute.
@@ -110,45 +112,6 @@ pub struct SourceRuntimeErrorShape {
     pub diagnostics: BTreeMap<String, String>,
 }
 
-/// Complete evidence required before source-family Rust authority promotion.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct AuthorityEvidence {
-    /// Compiled execution plan digest.
-    pub plan_digest: String,
-    /// Fixture corpus revision.
-    pub fixture_corpus_revision: String,
-    /// Supported auth modes.
-    pub supported_auth_modes: Vec<String>,
-    /// Supported pagination grammar entries.
-    pub supported_pagination_grammar: Vec<String>,
-    /// Supported provider error modes.
-    pub supported_provider_errors: Vec<String>,
-    /// Bounded provider egress allowlist.
-    pub egress_allowlist: Vec<String>,
-    /// Response and decompression limits proof.
-    pub response_limits: String,
-    /// Credential lease mode proof.
-    pub credential_lease_mode: String,
-    /// Projection readiness or explicit Go dependency.
-    pub projection_dependency: String,
-    /// Rollback receipt.
-    pub rollback_receipt: String,
-    /// Fixture parity status.
-    pub parity_status: String,
-    /// Canonical digest vector names.
-    pub canonical_digest_vectors: Vec<String>,
-    /// Credential/config safety proof.
-    pub config_safety_proof: String,
-    /// Cursor/checkpoint rollback proof.
-    pub cursor_checkpoint_proof: String,
-    /// Fencing/recovery proof.
-    pub fencing_recovery_proof: String,
-    /// Worker/runtime build identity.
-    pub worker_build_id: String,
-    /// Signed or authenticated promotion receipt.
-    pub promotion_receipt: String,
-}
-
 /// Protocol validation failures.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ProtocolError {
@@ -237,19 +200,39 @@ pub fn validate_envelope_json(value: &serde_json::Value) -> Result<(), ProtocolE
 
 /// Validate complete provider proof before authority promotion.
 pub fn validate_authority_evidence(evidence: &AuthorityEvidence) -> Result<(), ProtocolError> {
-    let missing = missing_authority_evidence(evidence);
+    let missing = cerebro_source_catalog::missing_authority_qualification_evidence(evidence);
     if !missing.is_empty() {
         return Err(ProtocolError::MissingAuthorityEvidence(missing));
     }
-    if !is_sha256_hex(&evidence.plan_digest) {
-        return Err(ProtocolError::InvalidAuthorityDigest(
-            "compiled_plan_digest",
-        ));
+    match cerebro_source_catalog::validate_authority_qualification_evidence(evidence) {
+        Ok(()) => Ok(()),
+        Err(cerebro_source_catalog::AuthorityEvidenceError::Invalid("compiled_plan_digest")) => {
+            Err(ProtocolError::InvalidAuthorityDigest(
+                "compiled_plan_digest",
+            ))
+        }
+        Err(cerebro_source_catalog::AuthorityEvidenceError::Invalid("runtime_plan_digest")) => {
+            Err(ProtocolError::InvalidAuthorityDigest("runtime_plan_digest"))
+        }
+        Err(cerebro_source_catalog::AuthorityEvidenceError::Invalid(
+            "promotion_receipt_digest_sha256",
+        )) => Err(ProtocolError::InvalidAuthorityDigest(
+            "promotion_receipt_digest_sha256",
+        )),
+        Err(cerebro_source_catalog::AuthorityEvidenceError::Invalid(field))
+            if field.ends_with("_sha256") || field == "parity_receipt_digests" =>
+        {
+            Err(ProtocolError::InvalidAuthorityDigest(field))
+        }
+        Err(cerebro_source_catalog::AuthorityEvidenceError::Invalid(field)) => {
+            Err(ProtocolError::MissingAuthorityEvidence(vec![field]))
+        }
+        Err(cerebro_source_catalog::AuthorityEvidenceError::Immutable) => {
+            Err(ProtocolError::MissingAuthorityEvidence(vec![
+                "authority_evidence_immutable",
+            ]))
+        }
     }
-    if !authenticated_promotion_receipt(&evidence.promotion_receipt) {
-        return Err(ProtocolError::UnauthenticatedPromotionReceipt);
-    }
-    Ok(())
 }
 
 /// Return canonical SHA-256 hex for a serializable JSON/protobuf-shaped value.
@@ -472,88 +455,6 @@ fn normalize_protocol_field_name(name: &str) -> String {
     normalized.trim_matches('_').to_owned()
 }
 
-fn missing_authority_evidence(evidence: &AuthorityEvidence) -> Vec<&'static str> {
-    let mut missing = Vec::new();
-    if evidence.plan_digest.trim().is_empty() {
-        missing.push("compiled_plan_digest");
-    }
-    if evidence.fixture_corpus_revision.trim().is_empty() {
-        missing.push("fixture_corpus_revision");
-    }
-    if evidence
-        .supported_auth_modes
-        .iter()
-        .all(|value| value.trim().is_empty())
-    {
-        missing.push("supported_auth_modes");
-    }
-    if evidence
-        .supported_pagination_grammar
-        .iter()
-        .all(|value| value.trim().is_empty())
-    {
-        missing.push("supported_pagination_grammar");
-    }
-    if evidence
-        .supported_provider_errors
-        .iter()
-        .all(|value| value.trim().is_empty())
-    {
-        missing.push("supported_provider_error_modes");
-    }
-    if evidence
-        .egress_allowlist
-        .iter()
-        .all(|value| value.trim().is_empty())
-    {
-        missing.push("egress_allowlist");
-    }
-    for (field, value) in [
-        ("response_decompression_limits", &evidence.response_limits),
-        ("credential_lease_mode", &evidence.credential_lease_mode),
-        ("projection_dependency", &evidence.projection_dependency),
-        ("rollback_receipt", &evidence.rollback_receipt),
-        ("fixture_parity_status", &evidence.parity_status),
-        (
-            "credential_config_safety_proof",
-            &evidence.config_safety_proof,
-        ),
-        (
-            "cursor_checkpoint_rollback_proof",
-            &evidence.cursor_checkpoint_proof,
-        ),
-        (
-            "operational_fencing_recovery_proof",
-            &evidence.fencing_recovery_proof,
-        ),
-        ("worker_runtime_build_identity", &evidence.worker_build_id),
-        ("promotion_receipt", &evidence.promotion_receipt),
-    ] {
-        if value.trim().is_empty() {
-            missing.push(field);
-        }
-    }
-    if evidence
-        .canonical_digest_vectors
-        .iter()
-        .all(|value| value.trim().is_empty())
-    {
-        missing.push("canonical_digest_vectors");
-    }
-    missing.sort_unstable();
-    missing
-}
-
-fn is_sha256_hex(value: &str) -> bool {
-    let value = value.trim();
-    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
-}
-
-fn authenticated_promotion_receipt(value: &str) -> bool {
-    let value = value.trim();
-    value.starts_with("sig:") || value.starts_with("auth:")
-}
-
 #[cfg(test)]
 pub(crate) fn fixture_envelope(operation: SourceRuntimeOperation) -> SourceRuntimeEnvelope {
     SourceRuntimeEnvelope {
@@ -609,6 +510,10 @@ fn fixture_envelope(operation: SourceRuntimeOperation) -> SourceRuntimeEnvelope 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cerebro_source_catalog::{
+        PagePublicationReceiptReference, PersistedReceiptReference,
+        SourceCollectionReceiptReference,
+    };
 
     #[test]
     fn source_runtime_protocol_contract_accepts_and_rejects_expected_shapes() {
@@ -771,8 +676,30 @@ mod tests {
 
     #[test]
     fn authority_readiness_requires_complete_evidence() {
+        let Err(ProtocolError::MissingAuthorityEvidence(all_missing)) =
+            validate_authority_evidence(&AuthorityEvidence::default())
+        else {
+            panic!("empty authority evidence did not report all missing fields")
+        };
+        for field in [
+            "compiled_plan_digest",
+            "runtime_plan_digest",
+            "authenticated_collection_receipt",
+            "append_projection_checkpoint_receipt",
+            "lease_restart_receipt",
+            "product_read_receipt",
+            "promotion_receipt",
+            "parity_receipt_digests",
+        ] {
+            assert!(
+                all_missing.contains(&field),
+                "missing field {field} was omitted"
+            );
+        }
+
         let complete = AuthorityEvidence {
             plan_digest: "a".repeat(64),
+            runtime_plan_digest: "b".repeat(64),
             fixture_corpus_revision: "fixture-corpus:v1".to_owned(),
             supported_auth_modes: vec!["api_key".to_owned()],
             supported_pagination_grammar: vec!["cursor".to_owned()],
@@ -781,7 +708,10 @@ mod tests {
             response_limits: "body=1048576,decompression=4x".to_owned(),
             credential_lease_mode: "one_operation".to_owned(),
             projection_dependency: "go_projection_dependency".to_owned(),
-            rollback_receipt: "rollback:test".to_owned(),
+            rollback_receipt: PersistedReceiptReference {
+                receipt_id: "rollback-test".to_owned(),
+                receipt_digest_sha256: "c".repeat(64),
+            },
             parity_status: "passed".to_owned(),
             canonical_digest_vectors: vec![
                 "plan".to_owned(),
@@ -791,13 +721,39 @@ mod tests {
             config_safety_proof: "config:redacted".to_owned(),
             cursor_checkpoint_proof: "cursor:go-compatible".to_owned(),
             fencing_recovery_proof: "fence:rejected-stale".to_owned(),
-            worker_build_id: "source-runtime-next:test".to_owned(),
-            promotion_receipt: "sig:promotion:test".to_owned(),
+            runtime_revision_sha256: "d".repeat(64),
+            worker_runtime_build_identity: "source-runtime-next:test".to_owned(),
+            promotion_receipt: PersistedReceiptReference {
+                receipt_id: "promotion-test".to_owned(),
+                receipt_digest_sha256: "e".repeat(64),
+            },
+            authenticated_collection_receipt: SourceCollectionReceiptReference {
+                source_runtime_id: "runtime-test".to_owned(),
+                collection_id: "collection-test".to_owned(),
+                manifest_digest_sha256: "f".repeat(64),
+            },
+            append_projection_checkpoint_receipt: PagePublicationReceiptReference {
+                source_runtime_id: "runtime-test".to_owned(),
+                logical_page_id: "page-test".to_owned(),
+                revision: 5,
+                snapshot_digest_sha256: "1".repeat(64),
+            },
+            lease_restart_receipt: PagePublicationReceiptReference {
+                source_runtime_id: "runtime-test".to_owned(),
+                logical_page_id: "page-restart-test".to_owned(),
+                revision: 6,
+                snapshot_digest_sha256: "2".repeat(64),
+            },
+            product_read_receipt: PersistedReceiptReference {
+                receipt_id: "product-read-test".to_owned(),
+                receipt_digest_sha256: "3".repeat(64),
+            },
+            parity_receipt_digests: vec!["4".repeat(64), "5".repeat(64), "6".repeat(64)],
         };
         validate_authority_evidence(&complete).unwrap();
 
         let mut incomplete = complete;
-        incomplete.rollback_receipt.clear();
+        incomplete.rollback_receipt.receipt_id.clear();
         incomplete.egress_allowlist.clear();
         let Err(ProtocolError::MissingAuthorityEvidence(missing)) =
             validate_authority_evidence(&incomplete)
@@ -809,9 +765,10 @@ mod tests {
     }
 
     #[test]
-    fn authority_evidence_rejects_malformed_digest_and_unsigned_promotion_receipt() {
+    fn authority_evidence_rejects_malformed_plan_and_receipt_digests() {
         let complete = AuthorityEvidence {
             plan_digest: "a".repeat(64),
+            runtime_plan_digest: "b".repeat(64),
             fixture_corpus_revision: "fixture-corpus:v1".to_owned(),
             supported_auth_modes: vec!["api_key".to_owned()],
             supported_pagination_grammar: vec!["cursor".to_owned()],
@@ -820,7 +777,10 @@ mod tests {
             response_limits: "body=1048576,decompression=4x".to_owned(),
             credential_lease_mode: "one_operation".to_owned(),
             projection_dependency: "go_projection_dependency".to_owned(),
-            rollback_receipt: "rollback:test".to_owned(),
+            rollback_receipt: PersistedReceiptReference {
+                receipt_id: "rollback-test".to_owned(),
+                receipt_digest_sha256: "c".repeat(64),
+            },
             parity_status: "passed".to_owned(),
             canonical_digest_vectors: vec![
                 "plan".to_owned(),
@@ -830,8 +790,34 @@ mod tests {
             config_safety_proof: "config:redacted".to_owned(),
             cursor_checkpoint_proof: "cursor:go-compatible".to_owned(),
             fencing_recovery_proof: "fence:rejected-stale".to_owned(),
-            worker_build_id: "source-runtime-next:test".to_owned(),
-            promotion_receipt: "sig:promotion:test".to_owned(),
+            runtime_revision_sha256: "d".repeat(64),
+            worker_runtime_build_identity: "source-runtime-next:test".to_owned(),
+            promotion_receipt: PersistedReceiptReference {
+                receipt_id: "promotion-test".to_owned(),
+                receipt_digest_sha256: "e".repeat(64),
+            },
+            authenticated_collection_receipt: SourceCollectionReceiptReference {
+                source_runtime_id: "runtime-test".to_owned(),
+                collection_id: "collection-test".to_owned(),
+                manifest_digest_sha256: "f".repeat(64),
+            },
+            append_projection_checkpoint_receipt: PagePublicationReceiptReference {
+                source_runtime_id: "runtime-test".to_owned(),
+                logical_page_id: "page-test".to_owned(),
+                revision: 5,
+                snapshot_digest_sha256: "1".repeat(64),
+            },
+            lease_restart_receipt: PagePublicationReceiptReference {
+                source_runtime_id: "runtime-test".to_owned(),
+                logical_page_id: "page-restart-test".to_owned(),
+                revision: 6,
+                snapshot_digest_sha256: "2".repeat(64),
+            },
+            product_read_receipt: PersistedReceiptReference {
+                receipt_id: "product-read-test".to_owned(),
+                receipt_digest_sha256: "3".repeat(64),
+            },
+            parity_receipt_digests: vec!["4".repeat(64), "5".repeat(64), "6".repeat(64)],
         };
         let mut bad_digest = complete.clone();
         bad_digest.plan_digest = "not-a-sha256".to_owned();
@@ -842,11 +828,20 @@ mod tests {
             ))
         );
 
+        let mut bad_runtime_digest = complete.clone();
+        bad_runtime_digest.runtime_plan_digest = "not-a-sha256".to_owned();
+        assert_eq!(
+            validate_authority_evidence(&bad_runtime_digest),
+            Err(ProtocolError::InvalidAuthorityDigest("runtime_plan_digest"))
+        );
+
         let mut unsigned = complete;
-        unsigned.promotion_receipt = "promotion:test".to_owned();
+        unsigned.promotion_receipt.receipt_digest_sha256 = "sig:promotion:test".to_owned();
         assert_eq!(
             validate_authority_evidence(&unsigned),
-            Err(ProtocolError::UnauthenticatedPromotionReceipt)
+            Err(ProtocolError::InvalidAuthorityDigest(
+                "promotion_receipt_digest_sha256"
+            ))
         );
     }
 


### PR DESCRIPTION
## Summary

- replace operator-shaped promotion inputs with typed, non-secret receipt references
- verify tenant-, source-, family-, runtime-, revision-, and digest-bound collection, page-publication, and parity records from PostgreSQL
- require the closed set of authenticated collection, durable append/projection/checkpoint, lease/restart, runtime revision, product read, approval, and recovery bindings before Rust projection authority can be selected
- keep catalog readiness fail-closed until the persisted projection-authority ledger is verified
- move cutover, evidence-loading, readiness, and focused tests into sibling Rust modules; the existing `main.rs`, catalog `lib.rs`, and cutover root shrink in this diff

## Current authority boundary

This change does not promote a source family. Authenticated provider collection, runtime-revision, product-read, approval, and recovery verifier owners remain explicitly unavailable, so every production promotion request remains blocked. It does not retire a Go writer, deploy a candidate, or establish provider or product-read evidence.

## Changed paths

Exactly 18 `.rs` paths. No manifests, lockfiles, fixtures, catalogs, docs, scripts, workflows, generated outputs, or other non-Rust artifacts change.

## Validation

- independent Luna/max source review found no remaining immediate source, module, or Clippy blocker after the worker-build identity and test-import fixes
- `cargo metadata --no-deps`: pass
- direct stable `rustfmt --edition 2024 --check` for all changed Rust paths: pass
- `git diff --check`: pass
- managed Cargo check, tests, and Clippy: not executed because DDESK is waiting for disk capacity; exact-head hosted checks are required before readiness
