### PR TITLE
refactor(sources): retire Alchemer Go projection writer

### DIFF
--- a/internal/sourceprojection/alchemer.go
+++ b/internal/sourceprojection/alchemer.go
@@ -1,71 +1,34 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func alchemerAccountProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return alchemerGenericAssetProjections(event)
+var errAlchemerRustProjectionRequired = errors.New("alchemer projection requires Rust authority")
+
+func alchemerAccountProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAlchemerRustProjectionRequired
 }
 
-func alchemerAccountUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "alchemer"})
+func alchemerAccountUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAlchemerRustProjectionRequired
 }
 
-func alchemerAccountTeamsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return alchemerGenericAssetProjections(event)
+func alchemerAccountTeamsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAlchemerRustProjectionRequired
 }
 
-func alchemerSurveysProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return alchemerGenericAssetProjections(event)
+func alchemerSurveysProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAlchemerRustProjectionRequired
 }
 
-func alchemerContactListsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return alchemerGenericAssetProjections(event)
+func alchemerContactListsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAlchemerRustProjectionRequired
 }
 
-func alchemerSSOIntegrationsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return alchemerGenericPolicyProjections(event)
-}
-
-func alchemerGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func alchemerGenericPolicyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	policyID := firstNonEmpty(attributes["policy_id"], event.GetId())
-	policyURN := projectionURN(tenantID, "policy", policyID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: policyURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "policy", Label: firstNonEmpty(attributes["policy_name"], policyID), Attributes: map[string]string{"policy_id": policyID, "policy_type": strings.TrimSpace(attributes["policy_type"]), "policy_status": strings.TrimSpace(attributes["policy_status"]), "policy_severity": strings.TrimSpace(attributes["policy_severity"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), policyURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func alchemerSSOIntegrationsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAlchemerRustProjectionRequired
 }

--- a/internal/sourceprojection/alchemer_test.go
+++ b/internal/sourceprojection/alchemer_test.go
@@ -1,73 +1,34 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestAlchemerAccountProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "alchemer", Kind: "alchemer.account", Attributes: map[string]string{"resource_id": "acct-1", "resource_type": "account", "resource_name": "Writer Account", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := alchemerAccountProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want projected account with evidence", len(entities), len(links))
-	}
-}
-
-func TestAlchemerAccountTeamProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "alchemer", Kind: "alchemer.account_teams", Attributes: map[string]string{"resource_id": "team-1", "resource_type": "account_team", "resource_name": "Security Team", "evidence_id": "evidence-1"}}
-	entities, links, err := alchemerAccountTeamsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want projected team with evidence", len(entities), len(links))
-	}
-}
-
-func TestAlchemerIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "alchemer", Kind: "alchemer.account_users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := alchemerAccountUsersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestAlchemerContactListProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "alchemer", Kind: "alchemer.contact_lists", Attributes: map[string]string{"resource_id": "list-1", "resource_type": "contact_list", "resource_name": "Customers", "evidence_id": "evidence-1"}}
-	entities, links, err := alchemerContactListsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want projected contact list with evidence", len(entities), len(links))
-	}
-}
-
-func TestAlchemerPolicyProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "alchemer", Kind: "alchemer.sso_integrations", Attributes: map[string]string{"policy_id": "sso-1", "policy_name": "Corporate SSO", "policy_type": "sso_integration", "policy_status": "Active", "evidence_id": "evidence-1"}}
-	entities, links, err := alchemerSSOIntegrationsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want projected SSO policy with evidence", len(entities), len(links))
-	}
-}
-
-func TestAlchemerSurveyProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "alchemer", Kind: "alchemer.surveys", Attributes: map[string]string{"resource_id": "survey-1", "resource_type": "survey", "resource_name": "Security Survey", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := alchemerSurveysProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want projected survey with evidence", len(entities), len(links))
+func TestAlchemerGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"alchemer.account",
+		"alchemer.account_teams",
+		"alchemer.account_users",
+		"alchemer.contact_lists",
+		"alchemer.sso_integrations",
+		"alchemer.surveys",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "alchemer",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAlchemerRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Retires the Alchemer Go projection writer in `internal/sourceprojection/alchemer.go`, following the deepseek.go house pattern (already applied 18+ times, e.g. deepseek #2658, Cloudflare #2747).
- All six `alchemer.*` kinds dispatched from `registry_builtins.go` (`alchemer.account`, `alchemer.account_teams`, `alchemer.account_users`, `alchemer.contact_lists`, `alchemer.sso_integrations`, `alchemer.surveys`) now fail closed with a single typed error, `errAlchemerRustProjectionRequired`, instead of computing entities/links.
- The two alchemer-only helpers (`alchemerGenericAssetProjections`, `alchemerGenericPolicyProjections`) are deleted since they become dead code and were not used by any other provider. `alchemer.account_users` called the shared `identityUserProjections` helper indirectly through its own `alchemerAccountUsersProjections` wrapper (not a direct registry dispatch to the shared helper), so no Cloudflare-style (#2747) rewiring was needed — `identityUserProjections` itself is untouched and still serves appgate, torii, tallyfy, and 20+ other providers.
- `internal/sourceprojection/alchemer_test.go` is rewritten as a single table-driven test, `TestAlchemerGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering every `alchemer.*` kind in `registry_builtins.go` via `ProjectEvent`, asserting `errors.Is` against the typed error and zero entities/links.

## Authority proof
Compiled Rust catalog marks every alchemer family collection- and projection-authoritative (full-catalog census 2026-08-26). Go static loader: alchemer has none.

## Validation
Run from the worktree root:
```
gofmt -l internal/sourceprojection        # empty
go build ./internal/sourceprojection      # ok
go test ./internal/sourceprojection -count=1   # ok
go test ./internal/sourceregistry -count=1     # ok
```
Cross-package blast radius check: `grep -rn '"alchemer\.' --include='*.go' internal cmd | grep -v internal/sourceprojection` returned no matches — no other package (test corpora, fixtures, findings rules) references `alchemer.*` event kinds, so no additional package needed changes or test runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
