### PR TITLE
refactor(sources): retire Api2cart Go projection writer

### DIFF
--- a/internal/sourceprojection/api2cart.go
+++ b/internal/sourceprojection/api2cart.go
@@ -1,36 +1,18 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func api2cartAttributeGroupListJsonProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityGroupProjections(event, identityProjectionProfile{Provider: "api2cart"})
+var errApi2cartRustProjectionRequired = errors.New("api2cart projection requires Rust authority")
+
+func api2cartAttributeGroupListJsonProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApi2cartRustProjectionRequired
 }
 
-func api2cartAttributeAttributesetListJsonProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return api2cartGenericAssetProjections(event)
-}
-
-func api2cartGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func api2cartAttributeAttributesetListJsonProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApi2cartRustProjectionRequired
 }

--- a/internal/sourceprojection/api2cart_test.go
+++ b/internal/sourceprojection/api2cart_test.go
@@ -1,32 +1,27 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestApi2cartAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "api2cart", Kind: "api2cart.attribute_attributeset_list_json", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := api2cartAttributeAttributesetListJsonProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestApi2cartIdentityGroupProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "api2cart", Kind: "api2cart.attribute_group_list_json", Attributes: map[string]string{"group_id": "group-1", "group_email": "group@example.test", "group_name": "Group One"}}
-	entities, _, err := api2cartAttributeGroupListJsonProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity group")
+func TestApi2cartGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{"api2cart.attribute_group_list_json", "api2cart.attribute_attributeset_list_json"} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "api2cart",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errApi2cartRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Retires the Go projection writer for the `api2cart` source, following the deepseek (#2658) / cloudflare (#2747) / airtable (#2756) house pattern for sources verified Rust-authoritative.
- Both dispatched kinds — `api2cart.attribute_group_list_json` and `api2cart.attribute_attributeset_list_json` — now fail closed with `errApi2cartRustProjectionRequired` instead of computing entities/links. `api2cartAttributeGroupListJsonProjections` previously delegated to the shared `identityGroupProjections` helper (still used by dozens of other providers, untouched) and `api2cartAttributeAttributesetListJsonProjections` delegated to an api2cart-only helper `api2cartGenericAssetProjections`, which is now dead code and removed along with its now-unused `strings` import.
- `internal/sourceprojection/api2cart_test.go` is rewritten as one table-driven test, `TestApi2cartGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering every `api2cart.*` kind registered in `registry_builtins.go` and asserting `errors.Is` plus zero projected entities/links.
- Cross-package sweep (`grep -rn "\"api2cart\." --include='*.go' internal cmd`, excluding `internal/sourceprojection`) found zero hits — no other package projects `api2cart.*` events through `ProjectEvent`, so no test corpora or fixtures needed migrating to another provider.

## Authority proof
Compiled Rust catalog marks every api2cart family collection- and projection-authoritative (full-catalog census 2026-08-26). Go static loader: api2cart has none.

## Validation
```
gofmt -l internal/sourceprojection
go build ./internal/sourceprojection
go test ./internal/sourceprojection -count=1
go test ./internal/sourceregistry -count=1
```
All four passed. No cross-package consumers were found, so no additional package tests were required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
