### PR TITLE
refactor(sources): retire Amplitude Go projection writer

### DIFF
--- a/internal/sourceprojection/amplitude.go
+++ b/internal/sourceprojection/amplitude.go
@@ -1,14 +1,18 @@
 package sourceprojection
 
 import (
+	"errors"
+
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func amplitudeUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "amplitude"})
+var errAmplitudeRustProjectionRequired = errors.New("amplitude projection requires Rust authority")
+
+func amplitudeUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAmplitudeRustProjectionRequired
 }
 
-func amplitudeGroupsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityGroupProjections(event, identityProjectionProfile{Provider: "amplitude"})
+func amplitudeGroupsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAmplitudeRustProjectionRequired
 }

--- a/internal/sourceprojection/amplitude_test.go
+++ b/internal/sourceprojection/amplitude_test.go
@@ -1,29 +1,27 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestAmplitudeIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "amplitude", Kind: "amplitude.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := amplitudeUsersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestAmplitudeIdentityGroupProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "amplitude", Kind: "amplitude.groups", Attributes: map[string]string{"group_id": "group-1", "group_name": "Amplitude Admins"}}
-	entities, _, err := amplitudeGroupsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity group")
+func TestAmplitudeGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{"amplitude.groups", "amplitude.users"} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "amplitude",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAmplitudeRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Amplitude's Go projection writer is retired: `amplitudeUsersProjections` and `amplitudeGroupsProjections` in `internal/sourceprojection/amplitude.go` now fail closed with a typed `errAmplitudeRustProjectionRequired` error instead of delegating to the shared `identityUserProjections` / `identityGroupProjections` helpers, following the deepseek.go canonical pattern (deepseek #2658 and 17 more since).
- Both `amplitude.*` kinds (`amplitude.users`, `amplitude.groups`) previously dispatched straight to the shared multi-provider identity helpers in `internal/sourceprojection/identity.go`, which remain in heavy use by many other providers (agiloft, airbase, alation, akeneo, alchemer, etc.). Per the Cloudflare retirement precedent (#2747), the shared helpers are left untouched; amplitude keeps its own two wrapper functions (unchanged names/signatures, event params now `_`) that now fail closed directly, so `registry_builtins.go` needed no changes — it already pointed at the amplitude-specific wrapper names.
- `internal/sourceprojection/amplitude_test.go` is rewritten as one table-driven test, `TestAmplitudeGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering every `amplitude.*` kind registered in `registry_builtins.go` (`amplitude.groups`, `amplitude.users`), calling `ProjectEvent` with a minimal `EventEnvelope` and asserting `errors.Is` plus zero entities/links.
- No amplitude-only helpers or imports became unused; no other functions to delete.

## Authority proof
Compiled Rust catalog marks every amplitude family collection- and projection-authoritative (full-catalog census 2026-08-26); Go static loader: amplitude has none.

## Cross-package blast radius
`grep -rn "\"amplitude\." --include='*.go' internal cmd | grep -v internal/sourceprojection` returned no matches — no other package (test corpora, fixtures, findings rules) references `amplitude.*` event kinds, so nothing else needed to move to a still-live provider or be adjusted.

## Validation
```
gofmt -l internal/sourceprojection            # empty
go build ./internal/sourceprojection           # ok
go test ./internal/sourceprojection -count=1   # ok
go test ./internal/sourceregistry -count=1     # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
