### PR TITLE
refactor(sources): retire Alteryx Go projection writer

### DIFF
--- a/internal/sourceprojection/alteryx.go
+++ b/internal/sourceprojection/alteryx.go
@@ -1,51 +1,30 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func alteryxUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "alteryx"})
+var errAlteryxRustProjectionRequired = errors.New("alteryx projection requires Rust authority")
+
+func alteryxUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAlteryxRustProjectionRequired
 }
 
-func alteryxUserGroupsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityGroupProjections(event, identityProjectionProfile{Provider: "alteryx"})
+func alteryxUserGroupsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAlteryxRustProjectionRequired
 }
 
-func alteryxWorkflowsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return alteryxGenericAssetProjections(event)
+func alteryxWorkflowsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAlteryxRustProjectionRequired
 }
 
-func alteryxCollectionsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return alteryxGenericAssetProjections(event)
+func alteryxCollectionsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAlteryxRustProjectionRequired
 }
 
-func alteryxAuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "alteryx"})
-}
-
-func alteryxGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attrs := event.GetAttributes()
-	resourceID := firstNonEmpty(attrs["resource_id"], attrs["id"])
-	resourceType := firstNonEmpty(attrs["resource_type"], "asset")
-	resourceName := firstNonEmpty(attrs["resource_name"], attrs["name"], resourceID)
-	resourceURN := firstNonEmpty(attrs["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	if resourceURN != "" {
-		addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: resourceName, Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "resource_name": resourceName, "owner_id": attrs["owner_id"]}})
-		if evidenceID := strings.TrimSpace(attrs["evidence_id"]); evidenceID != "" {
-			evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-			addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attrs["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attrs["evidence_cas_digest"])}})
-			addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-		}
-	}
-	return identityProjectionResult(entities, links)
+func alteryxAuditEventsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAlteryxRustProjectionRequired
 }

--- a/internal/sourceprojection/alteryx_test.go
+++ b/internal/sourceprojection/alteryx_test.go
@@ -1,65 +1,33 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestAlteryxWorkflowProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "alteryx", Kind: "alteryx.workflows", Attributes: map[string]string{"resource_id": "workflow-1", "resource_type": "workflow", "resource_name": "Workflow One", "owner_id": "user-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := alteryxWorkflowsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAlteryxCollectionProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "alteryx", Kind: "alteryx.collections", Attributes: map[string]string{"resource_id": "collection-1", "resource_type": "collection", "resource_name": "Security", "evidence_id": "evidence-1"}}
-	entities, _, err := alteryxCollectionsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected collection")
-	}
-}
-
-func TestAlteryxUserGroupProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "alteryx", Kind: "alteryx.usergroups", Attributes: map[string]string{"group_id": "group-1", "group_name": "Curators"}}
-	entities, _, err := alteryxUserGroupsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity group")
-	}
-}
-
-func TestAlteryxIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "alteryx", Kind: "alteryx.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := alteryxUsersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestAlteryxAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "alteryx", Kind: "alteryx.audit_events", Attributes: map[string]string{"event_type": "Update", "actor_id": "user-1", "resource_id": "app-1", "resource_type": "User"}}
-	entities, links, err := alteryxAuditEventsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestAlteryxGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"alteryx.audit_events",
+		"alteryx.collections",
+		"alteryx.usergroups",
+		"alteryx.users",
+		"alteryx.workflows",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "alteryx",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAlteryxRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Retires the Alteryx Go projection writer in `internal/sourceprojection/alteryx.go`, following the deepseek.go fail-closed pattern used across the many prior provider retirements (deepseek #2658 and 17 more since, most recently the Cloudflare retirement #2747).
- Every `alteryx.*` kind dispatched from `registry_builtins.go` (`alteryx.audit_events`, `alteryx.collections`, `alteryx.usergroups`, `alteryx.users`, `alteryx.workflows`) now routes through its existing per-provider wrapper function, which returns `nil, nil, errAlteryxRustProjectionRequired` instead of computing entities/links.
- Two of those wrappers (`alteryxUsersProjections`, `alteryxUserGroupsProjections`, `alteryxAuditEventsProjections`) previously delegated to the shared multi-provider `identityUserProjections` / `identityGroupProjections` / `identityAuditProjections` helpers (508 / 184 / 658 callers across the package respectively) — those shared helpers are untouched; only the alteryx-only wrapper bodies changed.
- Deleted `alteryxGenericAssetProjections`, the alteryx-only helper backing `alteryxWorkflowsProjections`/`alteryxCollectionsProjections`, since it becomes unused (confirmed via package-wide grep — no other provider referenced it) and the now-unused `strings` import.
- Rewrote `internal/sourceprojection/alteryx_test.go` as one table-driven test, `TestAlteryxGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering all five `alteryx.*` kinds dispatched in `registry_builtins.go`, asserting `errors.Is(err, errAlteryxRustProjectionRequired)` and zero entities/links via `ProjectEvent`.
- No changes to `registry_builtins.go` — every `alteryx.*` entry already dispatched to a per-provider wrapper (not directly to a shared helper), unlike the Cloudflare `audit_log` case, so no entry needed repointing.

## Authority proof

Compiled Rust catalog marks every alteryx family collection- and projection-authoritative (full-catalog census 2026-08-26). Go static loader: alteryx has none.

## Validation

Run from the worktree root:

```
gofmt -l internal/sourceprojection            # empty output
go build ./internal/sourceprojection          # passes
go test ./internal/sourceprojection -count=1  # ok
go test ./internal/sourceregistry -count=1    # ok
```

Cross-package blast radius: `grep -rn "\"alteryx\." --include='*.go' internal cmd | grep -v internal/sourceprojection` returns no matches — no other package (test corpora, fixtures) projects `alteryx.*` events through `ProjectEvent`, so no cross-package consumer needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
