### PR TITLE
refactor(sources): retire Apache Go projection writer

### DIFF
--- a/internal/sourceprojection/apache.go
+++ b/internal/sourceprojection/apache.go
@@ -1,44 +1,26 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func apacheEventlogProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "apache"})
+var errApacheRustProjectionRequired = errors.New("apache projection requires Rust authority")
+
+func apacheEventlogProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApacheRustProjectionRequired
 }
 
-func apacheRoleProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityGroupProjections(event, identityProjectionProfile{Provider: "apache"})
+func apacheRoleProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApacheRustProjectionRequired
 }
 
-func apacheUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "apache"})
+func apacheUserProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApacheRustProjectionRequired
 }
 
-func apachePermissionProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return apacheGenericAssetProjections(event)
-}
-
-func apacheGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func apachePermissionProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApacheRustProjectionRequired
 }

--- a/internal/sourceprojection/apache_test.go
+++ b/internal/sourceprojection/apache_test.go
@@ -1,54 +1,27 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestApacheAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apache", Kind: "apache.permission", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := apachePermissionProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestApacheIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apache", Kind: "apache.user", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := apacheUserProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestApacheIdentityGroupProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apache", Kind: "apache.role", Attributes: map[string]string{"group_id": "group-1", "group_email": "group@example.test", "group_name": "Group One"}}
-	entities, _, err := apacheRoleProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity group")
-	}
-}
-
-func TestApacheAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apache", Kind: "apache.eventlog", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := apacheEventlogProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestApacheGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{"apache.eventlog", "apache.permission", "apache.role", "apache.user"} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "apache",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errApacheRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Retires the Apache Go projection writer in `internal/sourceprojection/apache.go`. All four `apache.*` family projectors (`apacheEventlogProjections`, `apacheRoleProjections`, `apacheUserProjections`, `apachePermissionProjections`) now fail closed with a single typed `errApacheRustProjectionRequired` error instead of computing entities/links, following the `deepseek.go` pattern.
- `apacheEventlogProjections`, `apacheRoleProjections`, and `apacheUserProjections` previously delegated to the shared multi-provider helpers `identityAuditProjections`, `identityGroupProjections`, and `identityUserProjections` respectively (still used by dozens of other providers — agiloft, airbase, alteryx, etc.); those shared helpers are untouched. Because `registry_builtins.go` already dispatched to apache-specific wrapper function names (not directly to the shared helpers), no new wrapper was needed — the existing apache-only functions were simply changed to fail closed in place.
- `apachePermissionProjections` previously delegated to `apacheGenericAssetProjections`, an apache-only helper (confirmed via grep across the package — not used by any other provider). That helper is now dead code and has been deleted along with its now-unused `strings` import.
- Rewrote `internal/sourceprojection/apache_test.go` as one table-driven test, `TestApacheGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering all four `apache.*` kinds registered in `registry_builtins.go` (`apache.eventlog`, `apache.permission`, `apache.role`, `apache.user`), calling `ProjectEvent` with a minimal `EventEnvelope` and asserting `errors.Is` against the typed error plus zero entities/links.
- No registry rewiring was needed: `registry_builtins.go`'s four `apache.*` entries already pointed at the apache-specific function names, which now fail closed directly.

## Authority proof

The compiled Rust catalog marks every apache family collection- and projection-authoritative (full-catalog census 2026-08-26). Go static loader: apache has none.

## Cross-package blast radius

`grep -rn "\"apache\." --include='*.go' internal cmd | grep -v internal/sourceprojection` and a package-wide `grep -rln "apache"` across `internal` and `cmd` found no other package projecting `apache.*` events through `ProjectEvent`, and no oracle/parity/corpus test referencing the apache projection functions. The lone unrelated hit was `sources/aws/source_test.go`, which contains `org.apache.hadoop.*` Java class-name strings in AWS Glue fixture data — coincidental substring match, not the apache provider, so no change was needed there.

## Validation

Run from the worktree root:

```
gofmt -l internal/sourceprojection            # empty
go build ./internal/sourceprojection          # ok
go test ./internal/sourceprojection -count=1  # ok
go test ./internal/sourceregistry -count=1    # ok
```

No cross-package consumers were touched (none found), so no additional package tests were required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
