### PR TITLE
refactor(sources): retire Apollo Go projection writer

### DIFF
--- a/internal/sourceprojection/apollo.go
+++ b/internal/sourceprojection/apollo.go
@@ -1,46 +1,22 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func apolloUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "apollo"})
+var errApolloRustProjectionRequired = errors.New("apollo projection requires Rust authority")
+
+func apolloUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApolloRustProjectionRequired
 }
 
-func apolloContactsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "apollo"})
+func apolloContactsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApolloRustProjectionRequired
 }
 
-func apolloAccountsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["organization_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], "apollo_account")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{
-		URN:        resourceURN,
-		TenantID:   tenantID,
-		SourceID:   event.GetSourceId(),
-		EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."),
-		Label:      firstNonEmpty(attributes["resource_name"], attributes["domain"], resourceID),
-		Attributes: map[string]string{
-			"account_stage_id":  strings.TrimSpace(attributes["account_stage_id"]),
-			"domain":            strings.TrimSpace(attributes["domain"]),
-			"organization_id":   strings.TrimSpace(attributes["organization_id"]),
-			"owner_id":          strings.TrimSpace(attributes["owner_id"]),
-			"resource_id":       resourceID,
-			"resource_type":     resourceType,
-			"source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID]),
-		},
-	})
-	return identityProjectionResult(entities, links)
+func apolloAccountsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApolloRustProjectionRequired
 }

--- a/internal/sourceprojection/apollo_test.go
+++ b/internal/sourceprojection/apollo_test.go
@@ -1,40 +1,31 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestApolloAccountProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apollo", Kind: "apollo.accounts", Attributes: map[string]string{"resource_id": "account-1", "resource_type": "apollo_account", "resource_name": "Apollo Account", "domain": "example.test", "organization_id": "org-1"}}
-	entities, _, err := apolloAccountsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected account entity")
-	}
-}
-
-func TestApolloIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apollo", Kind: "apollo.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := apolloUsersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestApolloContactProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apollo", Kind: "apollo.contacts", Attributes: map[string]string{"user_id": "contact-1", "email": "contact@example.test", "display_name": "Contact One"}}
-	entities, _, err := apolloContactsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected contact identity")
+func TestApolloGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"apollo.accounts",
+		"apollo.contacts",
+		"apollo.users",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "apollo",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errApolloRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Retires the Apollo Go projection writer, following the pattern established by deepseek (#2658) and the 17 subsequent provider retirements (most recently cloudflare). All three `apollo.*` family projectors in `internal/sourceprojection/apollo.go` now fail closed with `errApolloRustProjectionRequired` instead of computing entities/links:

- `apolloUsersProjections` and `apolloContactsProjections` previously dispatched to the shared, multi-provider `identityUserProjections` helper (used by hundreds of other providers, e.g. `alation.go`, `hubspot.go`, `salesforce.go`). That shared helper is untouched — only the two apollo-only wrapper functions were gutted, since the registry already dispatched through per-provider wrapper names rather than the shared helper directly.
- `apolloAccountsProjections` computed its own account entity inline and is now a plain fail-closed stub.

`internal/sourceprojection/apollo_test.go` was rewritten as a single table-driven test, `TestApolloGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering all three `apollo.*` kinds dispatched in `registry_builtins.go` (`apollo.accounts`, `apollo.contacts`, `apollo.users`), calling `ProjectEvent` with a minimal `EventEnvelope` and asserting `errors.Is` against the new sentinel plus zero entities/links.

No changes were needed in `registry_builtins.go` — the three `apollo.*` dispatch entries already point at the apollo-only wrapper function names, which keep their exact signatures.

## Authority proof

Compiled Rust catalog marks every apollo family collection- and projection-authoritative (full-catalog census 2026-08-25). Go static loader: apollo has none.

## Cross-package blast radius

`grep -rn "\"apollo\." --include='*.go' internal cmd | grep -v internal/sourceprojection` returned no matches. Apollo has no references outside `internal/sourceprojection` — no test corpora, fixtures, or other packages route `apollo.*` events through `ProjectEvent`, so no cross-package changes (a la the box → dropbox_business.content_assets move in #2709) were required.

## Validation

Run from the worktree root:

```
gofmt -l internal/sourceprojection            # empty
go build ./internal/sourceprojection          # ok
go test ./internal/sourceprojection -count=1  # ok
go test ./internal/sourceregistry -count=1    # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
