### PR TITLE
refactor(sources): retire Apacta Go projection writer

### DIFF
--- a/internal/sourceprojection/apacta.go
+++ b/internal/sourceprojection/apacta.go
@@ -1,48 +1,30 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func apactaActivityProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return apactaGenericAssetProjections(event)
+var errApactaRustProjectionRequired = errors.New("apacta projection requires Rust authority")
+
+func apactaActivityProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApactaRustProjectionRequired
 }
 
-func apactaCityProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return apactaGenericAssetProjections(event)
+func apactaCityProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApactaRustProjectionRequired
 }
 
-func apactaUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "apacta"})
+func apactaUserProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApactaRustProjectionRequired
 }
 
-func apactaContactPersonProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "apacta"})
+func apactaContactPersonProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApactaRustProjectionRequired
 }
 
-func apactaProjectsUserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "apacta"})
-}
-
-func apactaGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func apactaProjectsUserProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApactaRustProjectionRequired
 }

--- a/internal/sourceprojection/apacta_test.go
+++ b/internal/sourceprojection/apacta_test.go
@@ -1,68 +1,33 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestApactaAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apacta", Kind: "apacta.city", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := apactaCityProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestApactaIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apacta", Kind: "apacta.user", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := apactaUserProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestApactaContactPersonProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apacta", Kind: "apacta.contact_person", Attributes: map[string]string{"user_id": "contact-person-1", "email": "contact@example.test", "display_name": "Contact Person"}}
-	entities, _, err := apactaContactPersonProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected contact person identity")
-	}
-}
-
-func TestApactaProjectsUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apacta", Kind: "apacta.projects_user", Attributes: map[string]string{"user_id": "project-user-1", "email": "project.user@example.test", "display_name": "Project User"}}
-	entities, _, err := apactaProjectsUserProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected project user identity")
-	}
-}
-
-func TestApactaActivityProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apacta", Kind: "apacta.activity", Attributes: map[string]string{"resource_id": "activity-1", "resource_type": "activity", "resource_name": "Installation"}}
-	entities, links, err := apactaActivityProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected activity asset")
-	}
-	if len(links) != 0 {
-		t.Fatalf("links = %d, want none without evidence", len(links))
+func TestApactaGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"apacta.activity",
+		"apacta.city",
+		"apacta.contact_person",
+		"apacta.projects_user",
+		"apacta.user",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "apacta",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errApactaRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Retires the Go projection writer for the `apacta` provider, following the house pattern established by the DeepSeek retirement (#2658) and applied ~17 times since.
- All five `apacta.*` registry entries (`apacta.activity`, `apacta.city`, `apacta.contact_person`, `apacta.projects_user`, `apacta.user`) now fail closed with a single typed error, `errApactaRustProjectionRequired`, instead of computing entities/links in Go.
- `apactaUserProjections`, `apactaContactPersonProjections`, and `apactaProjectsUserProjections` previously delegated to the shared, multi-provider `identityUserProjections` helper (used by dozens of other still-live providers). Per the Cloudflare precedent (#2747), that shared helper is untouched — each apacta wrapper simply keeps its exact name/signature and now returns the fail-closed error directly instead of calling into it.
- `apactaActivityProjections` and `apactaCityProjections` previously delegated to `apactaGenericAssetProjections`, an apacta-only helper (not used by any other provider). That helper, and its unused `strings` import, were deleted along with the rest of the old apacta.go body.
- `internal/sourceprojection/apacta_test.go` was rewritten as one table-driven test, `TestApactaGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering every `apacta.*` kind registered in `registry_builtins.go`, calling `ProjectEvent` with a minimal `EventEnvelope` and asserting `errors.Is` plus zero entities/links.

## Authority proof
Compiled Rust catalog marks every apacta family collection- and projection-authoritative (full-catalog census 2026-08-26); Go static loader: apacta has none.

## Cross-package check
`grep -rn "\"apacta\." --include='*.go' internal cmd | grep -v internal/sourceprojection` returned no matches — no other package (test corpora, fixtures, findings rules) references any `apacta.*` event kind, so there was no blast radius outside `internal/sourceprojection` to migrate.

## Validation
```
gofmt -l internal/sourceprojection            # empty
go build ./internal/sourceprojection          # ok
go test ./internal/sourceprojection -count=1  # ok
go test ./internal/sourceregistry -count=1    # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
