### PR TITLE
refactor(sources): retire Anomalo Go projection writer

### DIFF
--- a/internal/sourceprojection/anomalo.go
+++ b/internal/sourceprojection/anomalo.go
@@ -1,67 +1,30 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func anomaloWarehousesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return anomaloGenericAssetProjections(event)
+var errAnomaloRustProjectionRequired = errors.New("anomalo projection requires Rust authority")
+
+func anomaloWarehousesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAnomaloRustProjectionRequired
 }
 
-func anomaloTablesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return anomaloGenericAssetProjections(event)
+func anomaloTablesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAnomaloRustProjectionRequired
 }
 
-func anomaloChecksProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return anomaloGenericPolicyProjections(event)
+func anomaloChecksProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAnomaloRustProjectionRequired
 }
 
-func anomaloNotificationChannelsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return anomaloGenericAssetProjections(event)
+func anomaloNotificationChannelsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAnomaloRustProjectionRequired
 }
 
-func anomaloOrganizationsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return anomaloGenericAssetProjections(event)
-}
-
-func anomaloGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func anomaloGenericPolicyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	policyID := firstNonEmpty(attributes["policy_id"], event.GetId())
-	policyURN := projectionURN(tenantID, "policy", policyID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: policyURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "policy", Label: firstNonEmpty(attributes["policy_name"], policyID), Attributes: map[string]string{"policy_id": policyID, "policy_type": strings.TrimSpace(attributes["policy_type"]), "policy_status": strings.TrimSpace(attributes["policy_status"]), "policy_severity": strings.TrimSpace(attributes["policy_severity"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), policyURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func anomaloOrganizationsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAnomaloRustProjectionRequired
 }

--- a/internal/sourceprojection/anomalo_test.go
+++ b/internal/sourceprojection/anomalo_test.go
@@ -1,71 +1,33 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestAnomaloAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "anomalo", Kind: "anomalo.warehouses", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "warehouse", "resource_name": "warehouse-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := anomaloWarehousesProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAnomaloPolicyProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "anomalo", Kind: "anomalo.checks", Attributes: map[string]string{"policy_id": "policy-1", "policy_name": "Row count check", "policy_type": "RowCount", "policy_status": "enabled", "evidence_id": "evidence-1"}}
-	entities, links, err := anomaloChecksProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected policy")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAnomaloTableProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "anomalo", Kind: "anomalo.tables", Attributes: map[string]string{"resource_id": "table-1", "resource_type": "table", "resource_name": "warehouse.schema.table"}}
-	entities, _, err := anomaloTablesProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected table")
-	}
-}
-
-func TestAnomaloNotificationChannelProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "anomalo", Kind: "anomalo.notification_channels", Attributes: map[string]string{"resource_id": "channel-1", "resource_type": "notification_channel", "resource_name": "Data alerts"}}
-	entities, _, err := anomaloNotificationChannelsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected notification channel")
-	}
-}
-
-func TestAnomaloOrganizationProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "anomalo", Kind: "anomalo.organizations", Attributes: map[string]string{"resource_id": "org-1", "resource_type": "organization", "resource_name": "Primary Organization"}}
-	entities, links, err := anomaloOrganizationsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatalf("entities = %d, want organization projection", len(entities))
-	}
-	if len(links) != 0 {
-		t.Fatalf("links = %d, want no evidence links", len(links))
+func TestAnomaloGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"anomalo.checks",
+		"anomalo.notification_channels",
+		"anomalo.organizations",
+		"anomalo.tables",
+		"anomalo.warehouses",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "anomalo",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAnomaloRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Retires the Anomalo Go projection writer, following the exact house pattern already applied across 18+ prior retirements (deepseek #2658, abnormal_security #2758, activtrak #2755, aha #2754, abuseipdb #2753, airbyte_cloud #2751, and others).
- All five `anomalo.*` kinds dispatched from `registry_builtins.go` (`anomalo.checks`, `anomalo.notification_channels`, `anomalo.organizations`, `anomalo.tables`, `anomalo.warehouses`) now return a single typed sentinel error, `errAnomaloRustProjectionRequired`, instead of computing entities/links in Go.
- Deleted the two now-unused anomalo-only helpers (`anomaloGenericAssetProjections`, `anomaloGenericPolicyProjections`) — grepped the whole `internal/sourceprojection` package first; these were anomalo-private (not shared with any other provider), so no Cloudflare-style (#2747) fail-closed wrapper was needed.
- Rewrote `anomalo_test.go` as one table-driven test, `TestAnomaloGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering every `anomalo.*` kind in `registry_builtins.go`, calling `ProjectEvent` with a minimal `EventEnvelope` and asserting `errors.Is` plus zero entities/links.
- No `registry_builtins.go` changes were needed — the dispatch table entries keep the same function names/signatures.

## Authority proof
Compiled Rust catalog marks every anomalo family collection- and projection-authoritative (full-catalog census 2026-08-26). Go static loader: anomalo has none.

## Cross-package blast radius
`grep -rn "\"anomalo\." --include='*.go' internal cmd | grep -v internal/sourceprojection` returned no matches — no other package (test corpora, fixtures, findings rules) projects `anomalo.*` events through `ProjectEvent`, so no cross-package usage needed to move to a still-live provider.

Also confirmed no oracle/parity/corpus test in `internal/sourceprojection` references any `anomalo*` function name.

## Validation
- `gofmt -l internal/sourceprojection` (empty)
- `go build ./internal/sourceprojection`
- `go test ./internal/sourceprojection -count=1`
- `go test ./internal/sourceregistry -count=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
