### PR TITLE
refactor(sources): retire Appwrite Go projection writer

### DIFF
--- a/internal/sourceprojection/appwrite.go
+++ b/internal/sourceprojection/appwrite.go
@@ -1,44 +1,26 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func appwriteTeamProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityGroupProjections(event, identityProjectionProfile{Provider: "appwrite"})
+var errAppwriteRustProjectionRequired = errors.New("appwrite projection requires Rust authority")
+
+func appwriteTeamProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAppwriteRustProjectionRequired
 }
 
-func appwriteLogProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "appwrite"})
+func appwriteLogProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAppwriteRustProjectionRequired
 }
 
-func appwriteMembershipProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityGroupMembershipProjections(event, identityProjectionProfile{Provider: "appwrite"})
+func appwriteMembershipProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAppwriteRustProjectionRequired
 }
 
-func appwriteContinentProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return appwriteGenericAssetProjections(event)
-}
-
-func appwriteGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func appwriteContinentProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAppwriteRustProjectionRequired
 }

--- a/internal/sourceprojection/appwrite_test.go
+++ b/internal/sourceprojection/appwrite_test.go
@@ -1,54 +1,32 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestAppwriteAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "appwrite", Kind: "appwrite.continent", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := appwriteContinentProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAppwriteIdentityGroupProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "appwrite", Kind: "appwrite.team", Attributes: map[string]string{"group_id": "group-1", "group_email": "group@example.test", "group_name": "Group One"}}
-	entities, _, err := appwriteTeamProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity group")
-	}
-}
-
-func TestAppwriteGroupMembershipProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "appwrite", Kind: "appwrite.membership", Attributes: map[string]string{"group_id": "group-1", "group_email": "group@example.test", "member_id": "user-1", "member_email": "user@example.test"}}
-	entities, links, err := appwriteMembershipProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want membership projection", len(entities), len(links))
-	}
-}
-
-func TestAppwriteAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "appwrite", Kind: "appwrite.log", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := appwriteLogProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestAppwriteGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"appwrite.continent",
+		"appwrite.log",
+		"appwrite.membership",
+		"appwrite.team",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "appwrite",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAppwriteRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Retires the now-redundant Go projection writer at
`internal/sourceprojection/appwrite.go`, following the merged pattern in
`deepseek.go`/`deepseek_test.go` (and the 17+ retirements since, including
the Cloudflare precedent in #2747 for the shared-helper wrapper case):

- Added one typed error: `errAppwriteRustProjectionRequired`.
- All 4 event kinds Appwrite dispatches through
  `internal/sourceprojection/registry_builtins.go`
  (`appwrite.continent`, `appwrite.log`, `appwrite.membership`,
  `appwrite.team`) keep their exact function names and signatures
  (`appwriteContinentProjections`, `appwriteLogProjections`,
  `appwriteMembershipProjections`, `appwriteTeamProjections`) but now
  return `nil, nil, errAppwriteRustProjectionRequired` instead of computing
  entities/links. `registry_builtins.go` needed no changes — the dispatch
  table already points at these same function names.
- `appwrite.team`, `appwrite.log`, and `appwrite.membership` previously
  dispatched straight to shared multi-provider helpers
  (`identityGroupProjections`, `identityAuditProjections`,
  `identityGroupMembershipProjections` respectively — grepped and confirmed
  still used by many other providers, e.g. akeneo, alation, alteryx,
  amplitude, apache, appveyor, appgate, and more). Those shared helpers were
  left untouched; only the appwrite-specific wrapper functions were changed
  to fail closed.
- `appwrite.continent` dispatched to `appwriteGenericAssetProjections`, an
  appwrite-only helper (grepped the whole package and repo — it had no
  other callers). It is now deleted as dead code along with its now-unused
  `strings` import; `appwriteContinentProjections` fails closed directly.
- Rewrote `appwrite_test.go` as one table-driven test
  `TestAppwriteGoProjectionFailsClosedForRustAuthoritativeFamilies`
  covering all 4 `appwrite.*` kinds via `ProjectEvent`, asserting
  `errors.Is` against the new typed error and zero entities/links,
  mirroring `deepseek_test.go`/`cloudflare_test.go`.
- No appwrite-only unconditional hooks (e.g. a retractions hook like
  Cloudflare's DNS-record case) exist for this provider, so no no-op hook
  was needed.

## Cross-package blast radius

`grep -rn "\"appwrite\." --include='*.go' internal cmd | grep -v
internal/sourceprojection` returned no matches — no other package (test
corpora, fixtures, oracle/parity tests) projects `appwrite.*` events or
references any `appwrite*Projections` function name. This is a
self-contained change to `internal/sourceprojection`.

## Authority proof — compiled Rust catalog marks every appwrite family
collection- and projection-authoritative (full-catalog census
2026-08-26). `crates/source-catalog/src/lib.rs`'s
`verified_source_is_authoritative_but_unproven_source_is_not` test already
lists `appwrite` among the fully Rust-authoritative sources on `main`, and
this branch is built directly on current `main` so that assertion is
already in effect here too (no further Rust changes needed in this PR).
Go static loader: appwrite has none — it was never in
`builtinSourceLoaders` (`internal/sourceregistry`), so no changes were
needed there either.

## Validation

- `gofmt -l internal/sourceprojection` — empty
- `go build ./internal/sourceprojection` — clean
- `go test ./internal/sourceprojection -count=1` — all tests pass,
  including the new
  `TestAppwriteGoProjectionFailsClosedForRustAuthoritativeFamilies` (all 4
  kinds)
- `go test ./internal/sourceregistry -count=1` — passes (appwrite has no
  static loader entry to update)
- No cross-package consumers were found (see blast-radius grep above), so
  no additional package tests required changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
