### PR TITLE
refactor(sources): retire Botify Go projection writer

### DIFF
--- a/internal/sourceprojection/botify.go
+++ b/internal/sourceprojection/botify.go
@@ -1,76 +1,58 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func botifyFilterProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return botifyGenericAssetProjections(event)
+var errBotifyRustProjectionRequired = errors.New("botify projection requires Rust authority")
+
+func botifyFilterProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errBotifyRustProjectionRequired
 }
 
-func botifyExportProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return botifyGenericAssetProjections(event)
+func botifyExportProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errBotifyRustProjectionRequired
 }
 
-func botifyOutOfConfigProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return botifyGenericAssetProjections(event)
+func botifyOutOfConfigProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errBotifyRustProjectionRequired
 }
 
-func botifySitemapOnlyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return botifyGenericAssetProjections(event)
+func botifySitemapOnlyProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errBotifyRustProjectionRequired
 }
 
-func botifyReportProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return botifyGenericAssetProjections(event)
+func botifyReportProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errBotifyRustProjectionRequired
 }
 
-func botifyProjectProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return botifyGenericAssetProjections(event)
+func botifyProjectProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errBotifyRustProjectionRequired
 }
 
-func botifyAnalysesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return botifyGenericAssetProjections(event)
+func botifyAnalysesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errBotifyRustProjectionRequired
 }
 
-func botifyUrlProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return botifyGenericAssetProjections(event)
+func botifyUrlProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errBotifyRustProjectionRequired
 }
 
-func botifyOrphanUrlProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return botifyGenericAssetProjections(event)
+func botifyOrphanUrlProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errBotifyRustProjectionRequired
 }
 
-func botifyDatamodelProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return botifyGenericAssetProjections(event)
+func botifyDatamodelProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errBotifyRustProjectionRequired
 }
 
-func botifyDomainProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return botifyGenericAssetProjections(event)
+func botifyDomainProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errBotifyRustProjectionRequired
 }
 
-func botifyPercentileProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return botifyGenericAssetProjections(event)
-}
-
-func botifyGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func botifyPercentileProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errBotifyRustProjectionRequired
 }

--- a/internal/sourceprojection/botify_test.go
+++ b/internal/sourceprojection/botify_test.go
@@ -1,21 +1,40 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestBotifyAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "botify", Kind: "botify.filter", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := botifyFilterProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
+func TestBotifyGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"botify.analyses",
+		"botify.datamodel",
+		"botify.domain",
+		"botify.export",
+		"botify.filter",
+		"botify.orphan_url",
+		"botify.out_of_config",
+		"botify.percentile",
+		"botify.project",
+		"botify.report",
+		"botify.sitemap_only",
+		"botify.url",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "botify",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errBotifyRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Retires the Botify Go projection writer in `internal/sourceprojection/botify.go`, following the fail-closed pattern already applied to DeepSeek (#2658) and 17+ other providers.
- Every `botify.*` kind dispatched from `registry_builtins.go` (`botify.analyses`, `botify.datamodel`, `botify.domain`, `botify.export`, `botify.filter`, `botify.orphan_url`, `botify.out_of_config`, `botify.percentile`, `botify.project`, `botify.report`, `botify.sitemap_only`, `botify.url`) now returns `nil, nil, errBotifyRustProjectionRequired` instead of executing Go projection logic. Function names/signatures are unchanged (event param becomes `_`), so `registry_builtins.go` needed no edits.
- All 12 kinds dispatched to a single botify-only shared helper (`botifyGenericAssetProjections`); it was not shared with any other provider (verified with a package-wide grep), so it was deleted outright along with the now-unused `strings` import — no Cloudflare-style (#2747) wrapper/repoint was needed.
- Rewrote `botify_test.go` as `TestBotifyGoProjectionFailsClosedForRustAuthoritativeFamilies`, a table-driven test covering all 12 `botify.*` kinds via `ProjectEvent`, asserting `errors.Is` against the new sentinel error and zero entities/links.

## Authority proof
Compiled Rust catalog marks every botify family collection- and projection-authoritative (full-catalog census 2026-08-26); Go static loader: botify has none.

## Cross-package blast radius
`grep -rn "\"botify\." --include='*.go' internal cmd | grep -v internal/sourceprojection` found only `internal/connectorcatalog/catalog_test.go`, which exercises `BuiltinEntry("botify")` (connector catalog/auth metadata) — it does not call `ProjectEvent` or any botify projection function, so no change was needed there. No test corpora, fixtures, or other packages project `botify.*` events through `ProjectEvent`.

## Validation
Run from the worktree root:
- `gofmt -l internal/sourceprojection` (empty)
- `go build ./internal/sourceprojection`
- `go test ./internal/sourceprojection -count=1`
- `go test ./internal/sourceregistry -count=1`
- `go test ./internal/connectorcatalog -count=1` (cross-package botify reference, confirmed unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)