### PR TITLE
refactor(sources): retire Azure Openai Go projection writer

### DIFF
--- a/internal/sourceprojection/azure_openai.go
+++ b/internal/sourceprojection/azure_openai.go
@@ -1,85 +1,30 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func azureOpenaiDeploymentsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return azureOpenaiGenericDeploymentProjections(event)
+var errAzureOpenaiRustProjectionRequired = errors.New("azure_openai projection requires Rust authority")
+
+func azureOpenaiDeploymentsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAzureOpenaiRustProjectionRequired
 }
 
-func azureOpenaiModelCatalogProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return azureOpenaiGenericAssetProjections(event)
+func azureOpenaiModelCatalogProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAzureOpenaiRustProjectionRequired
 }
 
-func azureOpenaiRaiPoliciesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return azureOpenaiGenericPolicyProjections(event)
+func azureOpenaiRaiPoliciesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAzureOpenaiRustProjectionRequired
 }
 
-func azureOpenaiRaiBlocklistsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return azureOpenaiGenericPolicyProjections(event)
+func azureOpenaiRaiBlocklistsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAzureOpenaiRustProjectionRequired
 }
 
-func azureOpenaiPrivateEndpointConnectionsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return azureOpenaiGenericAssetProjections(event)
-}
-
-func azureOpenaiGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func azureOpenaiGenericPolicyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	policyID := firstNonEmpty(attributes["policy_id"], event.GetId())
-	policyURN := projectionURN(tenantID, "policy", policyID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: policyURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "policy", Label: firstNonEmpty(attributes["policy_name"], policyID), Attributes: map[string]string{"policy_id": policyID, "policy_type": strings.TrimSpace(attributes["policy_type"]), "policy_status": strings.TrimSpace(attributes["policy_status"]), "policy_severity": strings.TrimSpace(attributes["policy_severity"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), policyURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-func azureOpenaiGenericDeploymentProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	deploymentID := firstNonEmpty(attributes["deployment_id"], event.GetId())
-	deploymentURN := projectionURN(tenantID, "deployment", deploymentID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: deploymentURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "deployment", Label: firstNonEmpty(attributes["deployment_name"], deploymentID), Attributes: map[string]string{"deployment_id": deploymentID, "deployment_environment": strings.TrimSpace(attributes["deployment_environment"]), "deployment_status": strings.TrimSpace(attributes["deployment_status"]), "deployment_url": strings.TrimSpace(attributes["deployment_url"]), "deployment_commit_sha": strings.TrimSpace(attributes["deployment_commit_sha"]), "deployment_branch": strings.TrimSpace(attributes["deployment_branch"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), deploymentURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func azureOpenaiPrivateEndpointConnectionsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAzureOpenaiRustProjectionRequired
 }

--- a/internal/sourceprojection/azure_openai_test.go
+++ b/internal/sourceprojection/azure_openai_test.go
@@ -1,77 +1,33 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestAzureOpenaiDeploymentProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "azure_openai", Kind: "azure_openai.deployments", Attributes: map[string]string{"deployment_id": "dep-1", "deployment_name": "Production", "deployment_environment": "production", "deployment_status": "ready", "evidence_id": "evidence-1"}}
-	entities, links, err := azureOpenaiDeploymentsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected deployment")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAzureOpenaiAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "azure_openai", Kind: "azure_openai.model_catalog", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := azureOpenaiModelCatalogProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAzureOpenaiPolicyProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "azure_openai", Kind: "azure_openai.rai_policies", Attributes: map[string]string{"policy_id": "policy-1", "policy_name": "Require MFA", "policy_type": "access", "policy_status": "enabled", "evidence_id": "evidence-1"}}
-	entities, links, err := azureOpenaiRaiPoliciesProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected policy")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAzureOpenaiRaiBlocklistsProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "azure_openai", Kind: "azure_openai.rai_blocklists", Attributes: map[string]string{"policy_id": "policy-1", "policy_name": "Require MFA", "policy_type": "access", "policy_status": "enabled", "evidence_id": "evidence-1"}}
-	entities, links, err := azureOpenaiRaiBlocklistsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected policy")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAzureOpenaiPrivateEndpointConnectionsProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "azure_openai", Kind: "azure_openai.private_endpoint_connections", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := azureOpenaiPrivateEndpointConnectionsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
+func TestAzureOpenaiGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"azure_openai.deployments",
+		"azure_openai.model_catalog",
+		"azure_openai.private_endpoint_connections",
+		"azure_openai.rai_blocklists",
+		"azure_openai.rai_policies",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "azure_openai",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAzureOpenaiRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Retires the `azure_openai` Go projection writer in `internal/sourceprojection`, following the standard fail-closed pattern already applied to deepseek (#2658) and 17+ other providers. All five `azure_openai.*` registry entries — `deployments`, `model_catalog`, `private_endpoint_connections`, `rai_blocklists`, `rai_policies` — now return a single typed error (`errAzureOpenaiRustProjectionRequired`) instead of building entities/links in Go. The three `azureOpenaiGeneric*` helper functions those five entries used (`azureOpenaiGenericAssetProjections`, `azureOpenaiGenericPolicyProjections`, `azureOpenaiGenericDeploymentProjections`) were `azure_openai`-only — not shared with any other provider — so they were deleted outright along with the now-unused `strings` import, rather than wrapped.

## Authority proof

Compiled Rust catalog marks every `azure_openai` family collection- and projection-authoritative (full-catalog census 2026-08-26). Go static loader: azure_openai has none.

## Cross-package blast radius

- `grep -rn "\"azure_openai\." --include='*.go' internal cmd | grep -v internal/sourceprojection` — no hits. No other package projects `azure_openai.*` events through `ProjectEvent` (checked `internal/graphrebuild`, `internal/sourceruntime` benchmark/parity tests, `internal/findings`, `cmd/projection-parity-adapter` — none reference `azure_openai`).
- Broader `grep -rl "azure_openai" internal cmd` (Go + YAML) turned up matches only in the collection/execution layer, not projection: `internal/sourceops/source_execution.go`, `internal/sourceruntime/sourceworker/pull.go` (+ their tests), `internal/connectorcatalog/ai_governance_catalog_test.go`, and the catalog config `internal/connectorcatalog/catalog/ai-governance/azure_openai.yaml`. These are source-ID lists, credential-field requirements, and collection family/pagination config — none call into `sourceprojection` — so no changes were needed there.
- No oracle/parity/corpus test in `internal/sourceprojection` (`openai_oracle_test.go`, `kubernetes_rust_parity_test.go`, `oracle_hcm*.go`) references any `azureOpenai*` function or the `azure_openai` source ID.

## Validation

Run from the worktree root:

```
gofmt -l internal/sourceprojection
go build ./internal/sourceprojection
go test ./internal/sourceprojection -count=1
go test ./internal/sourceregistry -count=1
```

All pass. No other package required test runs since none consume `azure_openai.*` projections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
