### PR TITLE
refactor(sources): retire Mastodon Go projection writer

### DIFF
--- a/internal/sourceprojection/mastodon.go
+++ b/internal/sourceprojection/mastodon.go
@@ -1,43 +1,26 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func mastodonAccountProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "mastodon"})
+var errMastodonRustProjectionRequired = errors.New("mastodon projection requires Rust authority")
+
+func mastodonAccountProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errMastodonRustProjectionRequired
 }
 
-func mastodonActivityProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "mastodon"})
+func mastodonActivityProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errMastodonRustProjectionRequired
 }
 
-func mastodonVerifyCredentialProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "mastodon"})
+func mastodonVerifyCredentialProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errMastodonRustProjectionRequired
 }
 
-func mastodonNotificationProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return mastodonGenericAlertProjections(event)
-}
-
-func mastodonGenericAlertProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	alertID := firstNonEmpty(attributes["alert_id"], event.GetId())
-	alertURN := projectionURN(tenantID, "alert", alertID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: alertURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "alert", Label: firstNonEmpty(attributes["alert_name"], alertID), Attributes: map[string]string{"alert_id": alertID, "alert_severity": strings.TrimSpace(attributes["alert_severity"]), "alert_status": strings.TrimSpace(attributes["alert_status"]), "alert_type": strings.TrimSpace(attributes["alert_type"]), "alert_source": strings.TrimSpace(attributes["alert_source"]), "alert_fired_at": strings.TrimSpace(attributes["alert_fired_at"]), "alert_resolved_at": strings.TrimSpace(attributes["alert_resolved_at"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), alertURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func mastodonNotificationProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errMastodonRustProjectionRequired
 }

--- a/internal/sourceprojection/mastodon_test.go
+++ b/internal/sourceprojection/mastodon_test.go
@@ -1,54 +1,27 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestMastodonIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "mastodon", Kind: "mastodon.account", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := mastodonAccountProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestMastodonAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "mastodon", Kind: "mastodon.activity", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := mastodonActivityProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
-	}
-}
-
-func TestMastodonVerifiedAccountProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "mastodon", Kind: "mastodon.verify_credential", Attributes: map[string]string{"user_id": "user-1", "login": "user", "display_name": "User One"}}
-	entities, _, err := mastodonVerifyCredentialProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestMastodonAlertProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "mastodon", Kind: "mastodon.notification", Attributes: map[string]string{"alert_id": "alert-1", "alert_name": "High Error Rate", "alert_severity": "critical", "alert_status": "open", "evidence_id": "evidence-1"}}
-	entities, links, err := mastodonNotificationProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected alert")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
+func TestMastodonGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{"mastodon.account", "mastodon.activity", "mastodon.notification", "mastodon.verify_credential"} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "mastodon",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errMastodonRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Retires the Mastodon Go projection writer. Every family projector in `internal/sourceprojection/mastodon.go` (`mastodon.account`, `mastodon.activity`, `mastodon.notification`, `mastodon.verify_credential`) now fails closed with `errMastodonRustProjectionRequired` instead of computing entities/links, following the deepseek.go pattern (#2658 and 17 more since).

`mastodonAccountProjections` and `mastodonVerifyCredentialProjections` previously delegated to the shared `identityUserProjections` helper, and `mastodonActivityProjections` to the shared `identityAuditProjections` helper — both used by ~500+ other provider call sites across the package. Neither shared helper was touched; only the mastodon-specific wrapper functions that `registry_builtins.go` dispatches to were changed, so no repointing of registry entries was needed (unlike the Cloudflare retirement, #2747, where a registry entry pointed straight at a shared helper). `mastodonNotificationProjections` delegated to a mastodon-only helper, `mastodonGenericAlertProjections`, which became unused once its caller failed closed and was deleted, along with the now-unused `strings` import.

## Authority proof

Compiled Rust catalog marks every mastodon family collection- and projection-authoritative (full-catalog census 2026-08-26). Go static loader: mastodon has none.

## Validation

```
gofmt -l internal/sourceprojection
go build ./internal/sourceprojection
go test ./internal/sourceprojection -count=1
go test ./internal/sourceregistry -count=1
```

Cross-package check: `grep -rn "\"mastodon\." --include='*.go' internal cmd | grep -v internal/sourceprojection` returned no matches outside `internal/connectorcatalog/catalog_test.go`, which asserts catalog config (`BuiltinEntry("mastodon")`, auth type, static projection fields) rather than routing events through `ProjectEvent` — not a projection consumer, so no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
