### PR TITLE
refactor(sources): retire New Relic Go projection writer

### DIFF
--- a/internal/sourceprojection/new_relic.go
+++ b/internal/sourceprojection/new_relic.go
@@ -1,62 +1,22 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func newRelicAssetsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return newRelicGenericAssetProjections(event)
+var errNewRelicRustProjectionRequired = errors.New("new_relic projection requires Rust authority")
+
+func newRelicAssetsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errNewRelicRustProjectionRequired
 }
 
-func newRelicFindingsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return newRelicGenericFindingProjections(event)
+func newRelicFindingsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errNewRelicRustProjectionRequired
 }
 
-func newRelicAuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "new_relic"})
-}
-
-func newRelicGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func newRelicGenericFindingProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	findingID := firstNonEmpty(attributes["finding_id"], event.GetId())
-	findingURN := projectionURN(tenantID, "finding", findingID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: findingURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "finding", Label: firstNonEmpty(attributes["title"], findingID), Attributes: map[string]string{"finding_id": findingID, "severity": strings.TrimSpace(attributes["severity"]), "status": strings.TrimSpace(attributes["status"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if resourceURN := strings.TrimSpace(attributes["resource_urn"]); resourceURN != "" {
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), findingURN, resourceURN, relationAffects, map[string]string{"event_id": event.GetId()}))
-	}
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), evidenceURN, findingURN, relationSupports, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func newRelicAuditEventsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errNewRelicRustProjectionRequired
 }

--- a/internal/sourceprojection/new_relic_test.go
+++ b/internal/sourceprojection/new_relic_test.go
@@ -1,49 +1,27 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestNewRelicAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "new_relic", Kind: "new_relic.assets", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := newRelicAssetsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestNewRelicFindingProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "new_relic", Kind: "new_relic.findings", Attributes: map[string]string{"finding_id": "finding-1", "title": "Finding One", "severity": "high", "status": "open", "resource_urn": "urn:cerebro:tenant:runtime_asset:asset-1", "evidence_id": "evidence-1"}}
-	entities, links, err := newRelicFindingsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected finding")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected finding links")
-	}
-	if !hasProjectedEntityType(entities, "runtime_evidence") {
-		t.Fatal("expected projected runtime evidence entity")
-	}
-}
-
-func TestNewRelicAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "new_relic", Kind: "new_relic.audit_events", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := newRelicAuditEventsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestNewRelicGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{"new_relic.assets", "new_relic.audit_events", "new_relic.findings"} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "new_relic",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errNewRelicRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- New Relic is fully Rust-authoritative for collection and projection across all families. Every family projector in `internal/sourceprojection/new_relic.go` (`new_relic.assets`, `new_relic.audit_events`, `new_relic.findings`) now fails closed with `errNewRelicRustProjectionRequired` instead of computing entities/links, following the `deepseek.go` pattern established in #2658 (and 17 subsequent retirements).
- `newRelicAuditEventsProjections` previously dispatched straight to the shared `identityAuditProjections` helper (also used by postmark, appgate, vidyard, elmah, cloudbees_ci, honeycomb, opsgenie, red_canary, torii, and others); it now fails closed directly, leaving the shared helper untouched (same precedent as the Cloudflare retirement, #2747, for `cloudflareAuditLogProjections`).
- Deleted `newRelicGenericAssetProjections` and `newRelicGenericFindingProjections`, the two new_relic-only helpers that became unused once their callers (`newRelicAssetsProjections`, `newRelicFindingsProjections`) stopped computing projections. Confirmed via package-wide grep that neither helper was referenced anywhere else.
- Rewrote `internal/sourceprojection/new_relic_test.go` as a single table-driven test, `TestNewRelicGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering all three `new_relic.*` kinds registered in `registry_builtins.go`, asserting `errors.Is` against the sentinel error and zero entities/links via `ProjectEvent`.
- No `registry_builtins.go` changes were needed: all three dispatch entries (`new_relic.assets`, `new_relic.audit_events`, `new_relic.findings`) already pointed at new_relic-only wrapper functions, so only their bodies changed.

## Authority proof

Compiled Rust catalog marks every new_relic family collection- and projection-authoritative (full-catalog census 2026-08-26); Go static loader: new_relic has none.

## Cross-package check

`grep -rn "\"new_relic\." --include='*.go' internal cmd | grep -v internal/sourceprojection` found no projection consumers outside `internal/sourceprojection`. The one incidental match, `internal/connectorcatalog/catalog_test.go:1166` (`{"new_relic", "findings"}`), only asserts `BuiltinEntry` catalog status metadata — it does not call `ProjectEvent` or otherwise exercise projection, so it needed no change and was left as-is. No oracle/parity/corpus tests elsewhere in `internal/sourceprojection` reference new_relic-specific function names.

## Validation

Run from the worktree root:

```
gofmt -l internal/sourceprojection
go build ./internal/sourceprojection
go test ./internal/sourceprojection -count=1
go test ./internal/sourceregistry -count=1
```

All four passed (`gofmt` produced no output; both test packages reported `ok`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
