### PR TITLE
refactor(sources): retire Gitlab Go projection writer

### DIFF
--- a/internal/sourceprojection/gitlab.go
+++ b/internal/sourceprojection/gitlab.go
@@ -1,40 +1,22 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func gitlabRepositoriesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return gitlabGenericAssetProjections(event)
+var errGitlabRustProjectionRequired = errors.New("gitlab projection requires Rust authority")
+
+func gitlabRepositoriesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errGitlabRustProjectionRequired
 }
 
-func gitlabUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "gitlab"})
+func gitlabUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errGitlabRustProjectionRequired
 }
 
-func gitlabAuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "gitlab"})
-}
-
-func gitlabGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func gitlabAuditEventsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errGitlabRustProjectionRequired
 }

--- a/internal/sourceprojection/gitlab_test.go
+++ b/internal/sourceprojection/gitlab_test.go
@@ -1,43 +1,27 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestGitlabAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "gitlab", Kind: "gitlab.repositories", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := gitlabRepositoriesProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestGitlabIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "gitlab", Kind: "gitlab.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := gitlabUsersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestGitlabAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "gitlab", Kind: "gitlab.audit_events", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := gitlabAuditEventsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestGitlabGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{"gitlab.audit_events", "gitlab.repositories", "gitlab.users"} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "gitlab",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errGitlabRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Retires the Go-side projection writer for `gitlab.*` events, following the standing house pattern for providers that the compiled Rust source catalog has taken over (deepseek #2658 and 17+ since, most recently the Cloudflare retirement #2747).

- `gitlabRepositoriesProjections`, `gitlabUsersProjections`, and `gitlabAuditEventsProjections` — the three functions `registry_builtins.go` dispatches every `gitlab.*` kind to — now fail closed, returning `nil, nil, errGitlabRustProjectionRequired` instead of projecting.
- Deleted `gitlabGenericAssetProjections`, the gitlab-only helper `gitlabRepositoriesProjections` used to call; it had no other callers.
- The shared multi-provider helpers `identityUserProjections` and `identityAuditProjections` (used by `gitlabUsersProjections`/`gitlabAuditEventsProjections` before this change, and by many other providers) are untouched — only the gitlab-named wrapper functions were repointed to fail closed, per the shared-helper precedent (Cloudflare retirement #2747).
- Rewrote `gitlab_test.go` as one table-driven test, `TestGitlabGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering all three `gitlab.*` kinds (`gitlab.audit_events`, `gitlab.repositories`, `gitlab.users`), calling `ProjectEvent` and asserting `errors.Is(err, errGitlabRustProjectionRequired)` plus zero entities/links.

## Authority proof

Compiled Rust catalog marks every gitlab family collection- and projection-authoritative (full-catalog census 2026-08-26). Go static loader: gitlab has none.

## Validation

Run from the worktree root:

```
gofmt -l internal/sourceprojection
go build ./internal/sourceprojection
go test ./internal/sourceprojection -count=1
go test ./internal/sourceregistry -count=1
```

All four pass.

### Cross-package blast radius

`grep -rn "\"gitlab\." --include='*.go' internal cmd | grep -v internal/sourceprojection` found one match outside the projection package: `internal/findings/policy_rule_catalog_cicd_gen.go`, which references `"gitlab"` only in a findings-rule tag/resource-type string (`gitlab::runner`), not a `ProjectEvent` call — it does not project events and needs no change. No other package (test corpora, fixtures) projects `gitlab.*` events through `ProjectEvent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
