### PR TITLE
feat(rust): serve the persisted identity directory from the Rust product surface

### DIFF
--- a/crates/cerebro-platform/src/identity_directory.rs
+++ b/crates/cerebro-platform/src/identity_directory.rs
@@ -1,0 +1,420 @@
+//! Native Rust parity for the Go identity-directory reads.
+//!
+//! Mirrors `internal/sourcehttp/identitydirectory` for the persisted half of
+//! the directory: the Go handler also merges identities derived from the Go
+//! auth configuration (API keys, API credentials, MCP OAuth clients and
+//! entitlements). That configuration lives with the Go trusted host until the
+//! auth pipeline moves to Rust, so these responses always report
+//! `meta.configured: 0` and serve the Postgres-persisted directory with the
+//! Go route's exact filter, ordering, and response contract.
+
+use serde::{Deserialize, Serialize};
+
+use cerebro_organizational_store::{
+    IdentityDirectoryQuery, StoredIdentityOrganization, StoredIdentityUser,
+};
+
+const DEFAULT_DIRECTORY_LIMIT: u32 = 100;
+const MAX_DIRECTORY_LIMIT: u32 = 500;
+const DEFAULT_DIRECTORY_SOURCE: &str = "identity_directory";
+
+/// Query parameters accepted by both directory list routes; `status` is only
+/// meaningful for the users route, matching the Go handlers.
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct IdentityDirectoryRequestParams {
+    pub tenant_id: Option<String>,
+    pub org_id: Option<String>,
+    pub provider: Option<String>,
+    pub source: Option<String>,
+    pub status: Option<String>,
+    pub q: Option<String>,
+    pub limit: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct OrganizationResponse {
+    pub org_id: String,
+    pub tenant_id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub slug: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub domain: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub provider: String,
+    pub source: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub external_id: String,
+    pub user_count: i32,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub last_synced_at: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub created_at: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct UserResponse {
+    pub user_id: String,
+    pub tenant_id: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub org_id: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub subject: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub email: String,
+    pub display_name: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub provider: String,
+    pub source: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub roles: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub groups: Vec<String>,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub last_seen_at: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub last_synced_at: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub created_at: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ListMeta {
+    pub limit: u32,
+    pub loaded: usize,
+    pub configured: usize,
+    pub persisted: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ListOrganizationsResponse {
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub tenant_id: String,
+    pub organizations: Vec<OrganizationResponse>,
+    pub meta: ListMeta,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ListUsersResponse {
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub tenant_id: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub org_id: String,
+    pub users: Vec<UserResponse>,
+    pub meta: ListMeta,
+}
+
+/// Mirrors the Go `directoryLimit` parse: unparseable or zero falls back to
+/// the default, larger values clamp to the maximum.
+pub(crate) fn directory_limit(raw: Option<&str>) -> u32 {
+    match raw.map(str::trim).unwrap_or_default().parse::<u32>() {
+        Ok(0) | Err(_) => DEFAULT_DIRECTORY_LIMIT,
+        Ok(parsed) if parsed > MAX_DIRECTORY_LIMIT => MAX_DIRECTORY_LIMIT,
+        Ok(parsed) => parsed,
+    }
+}
+
+/// Builds the store scope shared by both routes from the request parameters.
+pub(crate) fn store_query(
+    params: &IdentityDirectoryRequestParams,
+    tenant_id: &str,
+    include_status: bool,
+) -> IdentityDirectoryQuery {
+    let field = |value: &Option<String>| {
+        value
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or_default()
+            .to_owned()
+    };
+    IdentityDirectoryQuery {
+        tenant_id: tenant_id.trim().to_owned(),
+        org_id: field(&params.org_id),
+        user_id: String::new(),
+        provider: field(&params.provider),
+        source: field(&params.source),
+        status: if include_status {
+            field(&params.status)
+        } else {
+            String::new()
+        },
+        text: field(&params.q),
+        limit: directory_limit(params.limit.as_deref()),
+    }
+}
+
+/// Truncates a microsecond RFC 3339 UTC store timestamp to the Go route's
+/// second-precision display form; empty input stays empty.
+pub(crate) fn display_time(micro: &str) -> String {
+    if micro.len() >= 20 {
+        format!("{}Z", &micro[..19])
+    } else {
+        micro.to_owned()
+    }
+}
+
+fn first_non_empty(primary: &str, fallback: &str) -> String {
+    let primary = primary.trim();
+    if primary.is_empty() {
+        fallback.to_owned()
+    } else {
+        primary.to_owned()
+    }
+}
+
+/// Mirrors the Go `normalized` helper: trim, drop empties, dedupe in order.
+pub(crate) fn normalized(values: &[String]) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    values
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .filter(|value| seen.insert(value.to_owned()))
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Applies the Go merge ordering for organizations: name, then org id.
+pub(crate) fn sort_organizations(organizations: &mut [StoredIdentityOrganization]) {
+    organizations.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| left.org_id.cmp(&right.org_id))
+    });
+}
+
+/// Applies the Go merge ordering for users: most recently seen first (never
+/// seen last), then display name, then user id. Microsecond RFC 3339 UTC
+/// strings order the same way as the underlying instants.
+pub(crate) fn sort_users(users: &mut [StoredIdentityUser]) {
+    users.sort_by(|left, right| {
+        right
+            .last_seen_at
+            .cmp(&left.last_seen_at)
+            .then_with(|| left.display_name.cmp(&right.display_name))
+            .then_with(|| left.user_id.cmp(&right.user_id))
+    });
+}
+
+pub(crate) fn organizations_response(
+    tenant_id: &str,
+    limit: u32,
+    mut organizations: Vec<StoredIdentityOrganization>,
+) -> ListOrganizationsResponse {
+    sort_organizations(&mut organizations);
+    let persisted = organizations.len();
+    let organizations: Vec<OrganizationResponse> = organizations
+        .into_iter()
+        .map(|org| OrganizationResponse {
+            org_id: org.org_id.trim().to_owned(),
+            tenant_id: org.tenant_id.trim().to_owned(),
+            name: org.name.trim().to_owned(),
+            slug: org.slug.trim().to_owned(),
+            domain: org.domain.trim().to_owned(),
+            provider: org.provider.trim().to_owned(),
+            source: first_non_empty(&org.source, DEFAULT_DIRECTORY_SOURCE),
+            external_id: org.external_id.trim().to_owned(),
+            user_count: org.user_count,
+            last_synced_at: display_time(&org.last_synced_at),
+            created_at: display_time(&org.created_at),
+            updated_at: display_time(&org.updated_at),
+        })
+        .collect();
+    ListOrganizationsResponse {
+        tenant_id: tenant_id.trim().to_owned(),
+        meta: ListMeta {
+            limit,
+            loaded: organizations.len(),
+            configured: 0,
+            persisted,
+        },
+        organizations,
+    }
+}
+
+pub(crate) fn users_response(
+    tenant_id: &str,
+    org_id: &str,
+    limit: u32,
+    mut users: Vec<StoredIdentityUser>,
+) -> ListUsersResponse {
+    sort_users(&mut users);
+    let persisted = users.len();
+    let users: Vec<UserResponse> = users
+        .into_iter()
+        .map(|user| UserResponse {
+            user_id: user.user_id.trim().to_owned(),
+            tenant_id: user.tenant_id.trim().to_owned(),
+            org_id: user.org_id.trim().to_owned(),
+            subject: user.subject.trim().to_owned(),
+            email: user.email.trim().to_owned(),
+            display_name: user.display_name.trim().to_owned(),
+            status: first_non_empty(&user.status, "active"),
+            provider: user.provider.trim().to_owned(),
+            source: first_non_empty(&user.source, DEFAULT_DIRECTORY_SOURCE),
+            roles: normalized(&user.roles),
+            groups: normalized(&user.groups),
+            last_seen_at: display_time(&user.last_seen_at),
+            last_synced_at: display_time(&user.last_synced_at),
+            created_at: display_time(&user.created_at),
+            updated_at: display_time(&user.updated_at),
+        })
+        .collect();
+    ListUsersResponse {
+        tenant_id: tenant_id.trim().to_owned(),
+        org_id: org_id.trim().to_owned(),
+        meta: ListMeta {
+            limit,
+            loaded: users.len(),
+            configured: 0,
+            persisted,
+        },
+        users,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn org(name: &str, org_id: &str) -> StoredIdentityOrganization {
+        StoredIdentityOrganization {
+            tenant_id: "tenant-a".to_owned(),
+            org_id: org_id.to_owned(),
+            name: name.to_owned(),
+            source: String::new(),
+            user_count: 3,
+            created_at: "2026-08-01T00:00:00.000000Z".to_owned(),
+            updated_at: "2026-08-02T00:00:00.000000Z".to_owned(),
+            ..StoredIdentityOrganization::default()
+        }
+    }
+
+    fn user(display_name: &str, user_id: &str, last_seen_at: &str) -> StoredIdentityUser {
+        StoredIdentityUser {
+            tenant_id: "tenant-a".to_owned(),
+            user_id: user_id.to_owned(),
+            display_name: display_name.to_owned(),
+            status: "active".to_owned(),
+            last_seen_at: last_seen_at.to_owned(),
+            ..StoredIdentityUser::default()
+        }
+    }
+
+    #[test]
+    fn directory_limit_matches_go_bounds() {
+        assert_eq!(directory_limit(None), 100);
+        assert_eq!(directory_limit(Some("")), 100);
+        assert_eq!(directory_limit(Some("abc")), 100);
+        assert_eq!(directory_limit(Some("0")), 100);
+        assert_eq!(directory_limit(Some("-5")), 100);
+        assert_eq!(directory_limit(Some(" 42 ")), 42);
+        assert_eq!(directory_limit(Some("500")), 500);
+        assert_eq!(directory_limit(Some("501")), 500);
+    }
+
+    #[test]
+    fn store_query_trims_and_scopes_fields() {
+        let params = IdentityDirectoryRequestParams {
+            tenant_id: None,
+            org_id: Some(" org-1 ".to_owned()),
+            provider: Some("okta".to_owned()),
+            source: Some(" api_key ".to_owned()),
+            status: Some("inactive".to_owned()),
+            q: Some(" search ".to_owned()),
+            limit: Some("9".to_owned()),
+        };
+        let orgs = store_query(&params, "tenant-a", false);
+        assert_eq!(orgs.org_id, "org-1");
+        assert_eq!(orgs.text, "search");
+        assert_eq!(orgs.status, "");
+        assert_eq!(orgs.limit, 9);
+        let users = store_query(&params, "tenant-a", true);
+        assert_eq!(users.status, "inactive");
+    }
+
+    #[test]
+    fn display_time_truncates_microseconds_to_seconds() {
+        assert_eq!(
+            display_time("2026-08-26T12:34:56.123456Z"),
+            "2026-08-26T12:34:56Z"
+        );
+        assert_eq!(display_time(""), "");
+    }
+
+    #[test]
+    fn organizations_sort_by_name_then_id_and_default_source() {
+        let response = organizations_response(
+            "tenant-a",
+            100,
+            vec![org("Beta", "b"), org("Alpha", "z"), org("Alpha", "a")],
+        );
+        let ids: Vec<&str> = response
+            .organizations
+            .iter()
+            .map(|org| org.org_id.as_str())
+            .collect();
+        assert_eq!(ids, ["a", "z", "b"]);
+        assert!(
+            response
+                .organizations
+                .iter()
+                .all(|org| org.source == "identity_directory")
+        );
+        assert_eq!(response.meta.loaded, 3);
+        assert_eq!(response.meta.configured, 0);
+        assert_eq!(response.meta.persisted, 3);
+        assert_eq!(response.organizations[0].updated_at, "2026-08-02T00:00:00Z");
+    }
+
+    #[test]
+    fn users_sort_recently_seen_first_and_never_seen_last() {
+        let response = users_response(
+            "tenant-a",
+            "",
+            100,
+            vec![
+                user("Never Seen", "n", ""),
+                user("Older", "o", "2026-08-01T00:00:00.000000Z"),
+                user("Newer", "w", "2026-08-02T00:00:00.500000Z"),
+                user("Also Newer", "a", "2026-08-02T00:00:00.500000Z"),
+            ],
+        );
+        let ids: Vec<&str> = response
+            .users
+            .iter()
+            .map(|user| user.user_id.as_str())
+            .collect();
+        assert_eq!(ids, ["a", "w", "o", "n"]);
+        assert_eq!(response.users[0].last_seen_at, "2026-08-02T00:00:00Z");
+    }
+
+    #[test]
+    fn user_roles_and_groups_are_normalized() {
+        let mut record = user("User", "u", "");
+        record.roles = vec![" admin ".to_owned(), "".to_owned(), "admin".to_owned()];
+        record.groups = vec!["ops".to_owned(), "ops".to_owned()];
+        let response = users_response("tenant-a", "", 100, vec![record]);
+        assert_eq!(response.users[0].roles, ["admin"]);
+        assert_eq!(response.users[0].groups, ["ops"]);
+    }
+
+    #[test]
+    fn empty_lists_serialize_with_go_field_names() {
+        let payload =
+            serde_json::to_value(organizations_response("tenant-a", 100, Vec::new())).unwrap();
+        assert_eq!(payload["tenant_id"], "tenant-a");
+        assert!(payload["organizations"].as_array().unwrap().is_empty());
+        assert_eq!(payload["meta"]["limit"], 100);
+        assert_eq!(payload["meta"]["configured"], 0);
+        let users =
+            serde_json::to_value(users_response("tenant-a", "org-1", 5, Vec::new())).unwrap();
+        assert_eq!(users["org_id"], "org-1");
+        assert!(users["users"].as_array().unwrap().is_empty());
+    }
+}

--- a/crates/cerebro-platform/src/main.rs
+++ b/crates/cerebro-platform/src/main.rs
@@ -5,6 +5,7 @@ mod ask_queries;
 mod audit_events;
 mod cutover_command;
 mod graph_provenance;
+mod identity_directory;
 mod oidc;
 mod parity_command;
 mod ratelimit;
@@ -634,6 +635,8 @@ fn oidc_scope_for_route(method: &Method, path: &str) -> &'static str {
     match path {
         "/v1/me" => "identity:read",
         "/v1/audit-events" => "cerebro:read",
+        "/v1/identity/orgs" => "cerebro:read",
+        "/v1/identity/users" => "cerebro:read",
         "/v1/source-runtimes/health" | "/v1/source-runtimes/freshness" => "cerebro:read",
         _ if path.starts_with("/v1/source-runtimes/") && method == Method::PUT => "cerebro:write",
         _ if path.starts_with("/v1/source-runtimes/") && path.ends_with("/sync") => "cerebro:write",
@@ -692,6 +695,8 @@ fn bounded_operation(method: &Method, path: &str) -> &'static str {
         "/v1/action-reconciliation-runs" => "run_action_reconciliation",
         "/v1/sources/summary" => "source_summary",
         "/v1/audit-events" => "list_audit_events",
+        "/v1/identity/orgs" => "list_identity_orgs",
+        "/v1/identity/users" => "list_identity_users",
         "/platform/graph/neighborhood" => "neighborhood",
         "/v1/graph/search" => "search",
         "/v1/graph/expand" => "expand",
@@ -2355,6 +2360,8 @@ fn router_with_backend(
             get(list_source_runtime_invalid_events),
         )
         .route("/v1/audit-events", get(list_audit_events))
+        .route("/v1/identity/orgs", get(list_identity_organizations))
+        .route("/v1/identity/users", get(list_identity_users))
         .route(
             "/v1/projections/legacy-deltas",
             post(record_legacy_projection),
@@ -2924,6 +2931,86 @@ fn source_runtime_invalid_events_error(
             "Source-runtime invalid-event evidence is temporarily unavailable.",
         ),
     }
+}
+
+/// Serves the persisted identity organizations for the authenticated tenant.
+/// Auth-config-derived organizations remain on the Go route until the auth
+/// pipeline moves; `meta.configured` is always zero here.
+async fn list_identity_organizations(
+    State(state): State<AppState>,
+    Extension(authenticated): Extension<AuthenticatedTenant>,
+    Query(params): Query<identity_directory::IdentityDirectoryRequestParams>,
+) -> Result<Json<identity_directory::ListOrganizationsResponse>, (StatusCode, Json<ErrorResponse>)>
+{
+    let ledger = state.runtime_ledger.clone().ok_or_else(|| {
+        service_unavailable(
+            "identity_directory_unavailable",
+            "The Rust identity directory store is not configured.",
+        )
+    })?;
+    let tenant_id = match params
+        .tenant_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|requested| !requested.is_empty())
+    {
+        Some(requested) => authorized_tenant(&authenticated, requested.to_owned())?,
+        None => authenticated.0.clone(),
+    };
+    let query = identity_directory::store_query(&params, tenant_id.as_str(), false);
+    let organizations = ledger
+        .list_identity_organizations(&query)
+        .await
+        .map_err(|error| {
+            eprintln!("Rust identity organization read failed: {error}");
+            service_unavailable(
+                "identity_directory_unavailable",
+                "Identity organizations are temporarily unavailable.",
+            )
+        })?;
+    Ok(Json(identity_directory::organizations_response(
+        tenant_id.as_str(),
+        query.limit,
+        organizations,
+    )))
+}
+
+/// Serves the persisted identity users for the authenticated tenant; see
+/// [`list_identity_organizations`] for the configured-identity scope note.
+async fn list_identity_users(
+    State(state): State<AppState>,
+    Extension(authenticated): Extension<AuthenticatedTenant>,
+    Query(params): Query<identity_directory::IdentityDirectoryRequestParams>,
+) -> Result<Json<identity_directory::ListUsersResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let ledger = state.runtime_ledger.clone().ok_or_else(|| {
+        service_unavailable(
+            "identity_directory_unavailable",
+            "The Rust identity directory store is not configured.",
+        )
+    })?;
+    let tenant_id = match params
+        .tenant_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|requested| !requested.is_empty())
+    {
+        Some(requested) => authorized_tenant(&authenticated, requested.to_owned())?,
+        None => authenticated.0.clone(),
+    };
+    let query = identity_directory::store_query(&params, tenant_id.as_str(), true);
+    let users = ledger.list_identity_users(&query).await.map_err(|error| {
+        eprintln!("Rust identity user read failed: {error}");
+        service_unavailable(
+            "identity_directory_unavailable",
+            "Identity users are temporarily unavailable.",
+        )
+    })?;
+    Ok(Json(identity_directory::users_response(
+        tenant_id.as_str(),
+        query.org_id.as_str(),
+        query.limit,
+        users,
+    )))
 }
 
 /// Native REST parity route for `GET /platform/audit-events`: one bounded,

--- a/crates/organizational-store/src/lib.rs
+++ b/crates/organizational-store/src/lib.rs
@@ -57,10 +57,10 @@ pub use parity::{
 pub use postgres::{
     AskQueryRecord, AskQueryWrite, AuditEventPageQuery, ConsumerFamilyProgress,
     ConsumerMessageOutcome, ConsumerRunFence, ConsumerRunInspection, ConsumerRunProgress,
-    ConsumerRunReceiptState, ConsumerSkipCategory, LegacyProjectionReceipt, POSTGRES_SCHEMA,
-    PostgresLedger, SourceCollectionReceipt, SourceEventReceipt,
+    ConsumerRunReceiptState, ConsumerSkipCategory, IdentityDirectoryQuery, LegacyProjectionReceipt,
+    POSTGRES_SCHEMA, PostgresLedger, SourceCollectionReceipt, SourceEventReceipt,
     SourceRuntimeCollectionObservation, SourceRuntimeObservation, StoredAuditEvent,
-    StoredAuditEventPage, StoredSourceRuntime,
+    StoredAuditEventPage, StoredIdentityOrganization, StoredIdentityUser, StoredSourceRuntime,
 };
 
 use std::{error::Error, fmt};

--- a/crates/organizational-store/src/postgres.rs
+++ b/crates/organizational-store/src/postgres.rs
@@ -2147,6 +2147,159 @@ LIMIT $3
         })
     }
 
+    /// Lists persisted identity organizations for one tenant, mirroring the Go
+    /// state store: exact `org_id`, case-insensitive `provider`/`source`
+    /// (source defaulting to `identity_directory`), an unescaped lowercase
+    /// substring search, and top-N selection by recency. Timestamps are
+    /// returned as microsecond RFC 3339 UTC text so callers can order on full
+    /// precision before truncating for display. A missing table yields the Go
+    /// steady-state empty result.
+    pub async fn list_identity_organizations(
+        &self,
+        query: &IdentityDirectoryQuery,
+    ) -> Result<Vec<StoredIdentityOrganization>, StoreError> {
+        if query.tenant_id.trim().is_empty() || query.limit == 0 || query.limit > 500 {
+            return Err(StoreError::Conflict(
+                "identity directory query scope is invalid".to_owned(),
+            ));
+        }
+        let mut clauses = vec!["tenant_id = $1".to_owned()];
+        let mut values = vec![query.tenant_id.trim().to_owned()];
+        identity_exact_filter(&mut clauses, &mut values, "org_id", &query.org_id);
+        identity_normalized_filter(&mut clauses, &mut values, "provider", &query.provider);
+        identity_source_filter(&mut clauses, &mut values, &query.source);
+        if !query.text.trim().is_empty() {
+            values.push(format!("%{}%", query.text.trim().to_lowercase()));
+            let index = values.len();
+            clauses.push(format!(
+                "(LOWER(org_id) LIKE ${index} OR LOWER(name) LIKE ${index} OR LOWER(domain) LIKE ${index} \
+                 OR LOWER(provider) LIKE ${index} OR LOWER({IDENTITY_SOURCE_SQL}) LIKE ${index} \
+                 OR LOWER(external_id) LIKE ${index})"
+            ));
+        }
+        let limit = i64::from(query.limit);
+        let mut params: Vec<&(dyn ToSql + Sync)> = values
+            .iter()
+            .map(|value| value as &(dyn ToSql + Sync))
+            .collect();
+        params.push(&limit);
+        let statement = format!(
+            "SELECT tenant_id, org_id, name, slug, domain, provider, {IDENTITY_SOURCE_SQL}, external_id, \
+             GREATEST(user_count, (SELECT COUNT(*)::INTEGER FROM identity_users \
+             WHERE identity_users.tenant_id = identity_organizations.tenant_id \
+             AND identity_users.org_id = identity_organizations.org_id)), \
+             COALESCE(to_char(last_synced_at AT TIME ZONE 'UTC', '{IDENTITY_TS_FORMAT}'), ''), \
+             to_char(created_at AT TIME ZONE 'UTC', '{IDENTITY_TS_FORMAT}'), \
+             to_char(updated_at AT TIME ZONE 'UTC', '{IDENTITY_TS_FORMAT}') \
+             FROM identity_organizations WHERE {} \
+             ORDER BY updated_at DESC, name ASC, org_id ASC LIMIT ${}",
+            clauses.join(" AND "),
+            params.len()
+        );
+        let rows = match self.client.lock().await.query(&statement, &params).await {
+            Ok(rows) => rows,
+            Err(error) if error.code() == Some(&SqlState::UNDEFINED_TABLE) => {
+                return Ok(Vec::new());
+            }
+            Err(error) => return Err(StoreError::Postgres(error)),
+        };
+        Ok(rows
+            .iter()
+            .map(|row| StoredIdentityOrganization {
+                tenant_id: row.get(0),
+                org_id: row.get(1),
+                name: row.get(2),
+                slug: row.get(3),
+                domain: row.get(4),
+                provider: row.get(5),
+                source: row.get(6),
+                external_id: row.get(7),
+                user_count: row.get(8),
+                last_synced_at: row.get(9),
+                created_at: row.get(10),
+                updated_at: row.get(11),
+            })
+            .collect())
+    }
+
+    /// Lists persisted identity users for one tenant with the Go state
+    /// store's exact filter and selection semantics; see
+    /// [`Self::list_identity_organizations`].
+    pub async fn list_identity_users(
+        &self,
+        query: &IdentityDirectoryQuery,
+    ) -> Result<Vec<StoredIdentityUser>, StoreError> {
+        if query.tenant_id.trim().is_empty() || query.limit == 0 || query.limit > 500 {
+            return Err(StoreError::Conflict(
+                "identity directory query scope is invalid".to_owned(),
+            ));
+        }
+        let mut clauses = vec!["tenant_id = $1".to_owned()];
+        let mut values = vec![query.tenant_id.trim().to_owned()];
+        identity_exact_filter(&mut clauses, &mut values, "org_id", &query.org_id);
+        identity_exact_filter(&mut clauses, &mut values, "user_id", &query.user_id);
+        identity_normalized_filter(&mut clauses, &mut values, "provider", &query.provider);
+        identity_source_filter(&mut clauses, &mut values, &query.source);
+        identity_normalized_filter(&mut clauses, &mut values, "status", &query.status);
+        if !query.text.trim().is_empty() {
+            values.push(format!("%{}%", query.text.trim().to_lowercase()));
+            let index = values.len();
+            clauses.push(format!(
+                "(LOWER(user_id) LIKE ${index} OR LOWER(email) LIKE ${index} OR LOWER(display_name) LIKE ${index} \
+                 OR LOWER(subject) LIKE ${index} OR LOWER(provider) LIKE ${index} \
+                 OR LOWER({IDENTITY_SOURCE_SQL}) LIKE ${index})"
+            ));
+        }
+        let limit = i64::from(query.limit);
+        let mut params: Vec<&(dyn ToSql + Sync)> = values
+            .iter()
+            .map(|value| value as &(dyn ToSql + Sync))
+            .collect();
+        params.push(&limit);
+        let statement = format!(
+            "SELECT tenant_id, user_id, org_id, subject, email, display_name, status, provider, \
+             {IDENTITY_SOURCE_SQL}, roles_json::text, groups_json::text, \
+             COALESCE(to_char(last_seen_at AT TIME ZONE 'UTC', '{IDENTITY_TS_FORMAT}'), ''), \
+             COALESCE(to_char(last_synced_at AT TIME ZONE 'UTC', '{IDENTITY_TS_FORMAT}'), ''), \
+             to_char(created_at AT TIME ZONE 'UTC', '{IDENTITY_TS_FORMAT}'), \
+             to_char(updated_at AT TIME ZONE 'UTC', '{IDENTITY_TS_FORMAT}') \
+             FROM identity_users WHERE {} \
+             ORDER BY updated_at DESC, display_name ASC, user_id ASC LIMIT ${}",
+            clauses.join(" AND "),
+            params.len()
+        );
+        let rows = match self.client.lock().await.query(&statement, &params).await {
+            Ok(rows) => rows,
+            Err(error) if error.code() == Some(&SqlState::UNDEFINED_TABLE) => {
+                return Ok(Vec::new());
+            }
+            Err(error) => return Err(StoreError::Postgres(error)),
+        };
+        let mut users = Vec::with_capacity(rows.len());
+        for row in &rows {
+            let roles_json: String = row.get(9);
+            let groups_json: String = row.get(10);
+            users.push(StoredIdentityUser {
+                tenant_id: row.get(0),
+                user_id: row.get(1),
+                org_id: row.get(2),
+                subject: row.get(3),
+                email: row.get(4),
+                display_name: row.get(5),
+                status: row.get(6),
+                provider: row.get(7),
+                source: row.get(8),
+                roles: serde_json::from_str(&roles_json)?,
+                groups: serde_json::from_str(&groups_json)?,
+                last_seen_at: row.get(11),
+                last_synced_at: row.get(12),
+                created_at: row.get(13),
+                updated_at: row.get(14),
+            });
+        }
+        Ok(users)
+    }
+
     pub async fn record_parity(&self, receipt: &ParityReceipt) -> Result<(), StoreError> {
         let mismatch_count = i64::try_from(receipt.mismatch_count())
             .map_err(|_| StoreError::Conflict("parity mismatch count overflow".to_owned()))?;
@@ -3168,6 +3321,99 @@ pub struct StoredAuditEventPage {
     pub events: Vec<StoredAuditEvent>,
     pub has_more: bool,
     pub partial: bool,
+}
+
+/// The identity-directory read scope: one tenant plus the Go handler's
+/// optional exact and substring filters.
+#[derive(Clone, Debug, Default)]
+pub struct IdentityDirectoryQuery {
+    pub tenant_id: String,
+    pub org_id: String,
+    pub user_id: String,
+    pub provider: String,
+    pub source: String,
+    pub status: String,
+    pub text: String,
+    pub limit: u32,
+}
+
+/// One persisted identity organization row; timestamps are microsecond
+/// RFC 3339 UTC text (empty when NULL).
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct StoredIdentityOrganization {
+    pub tenant_id: String,
+    pub org_id: String,
+    pub name: String,
+    pub slug: String,
+    pub domain: String,
+    pub provider: String,
+    pub source: String,
+    pub external_id: String,
+    pub user_count: i32,
+    pub last_synced_at: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// One persisted identity user row; timestamps are microsecond RFC 3339 UTC
+/// text (empty when NULL).
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct StoredIdentityUser {
+    pub tenant_id: String,
+    pub user_id: String,
+    pub org_id: String,
+    pub subject: String,
+    pub email: String,
+    pub display_name: String,
+    pub status: String,
+    pub provider: String,
+    pub source: String,
+    pub roles: Vec<String>,
+    pub groups: Vec<String>,
+    pub last_seen_at: String,
+    pub last_synced_at: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+const IDENTITY_SOURCE_SQL: &str = "COALESCE(NULLIF(source, ''), 'identity_directory')";
+const IDENTITY_TS_FORMAT: &str = "YYYY-MM-DD\"T\"HH24:MI:SS.US\"Z\"";
+
+fn identity_exact_filter(
+    clauses: &mut Vec<String>,
+    values: &mut Vec<String>,
+    column: &str,
+    value: &str,
+) {
+    let value = value.trim();
+    if value.is_empty() {
+        return;
+    }
+    values.push(value.to_owned());
+    clauses.push(format!("{column} = ${}", values.len()));
+}
+
+fn identity_normalized_filter(
+    clauses: &mut Vec<String>,
+    values: &mut Vec<String>,
+    column: &str,
+    value: &str,
+) {
+    let value = value.trim().to_lowercase();
+    if value.is_empty() {
+        return;
+    }
+    values.push(value);
+    clauses.push(format!("LOWER({column}) = ${}", values.len()));
+}
+
+fn identity_source_filter(clauses: &mut Vec<String>, values: &mut Vec<String>, value: &str) {
+    let value = value.trim().to_lowercase();
+    if value.is_empty() {
+        return;
+    }
+    values.push(value);
+    clauses.push(format!("LOWER({IDENTITY_SOURCE_SQL}) = ${}", values.len()));
 }
 
 fn audit_event_exact_filter(


### PR DESCRIPTION
## Summary

- add `GET /v1/identity/orgs` and `GET /v1/identity/users` as native Rust parity routes for the persisted half of the Go identity directory
- `PostgresLedger` reads mirror the Go state store exactly: exact `org_id`, case-insensitive `provider`/`source` (with the `identity_directory` default), unescaped lowercase substring search, the GREATEST user-count subquery, and top-N selection by recency; no DDL — a missing table yields the Go steady-state empty result
- the module re-applies the Go merge ordering (orgs by name then id; users by most-recently-seen with never-seen last) and renders the field-for-field response contract including `meta` counts
- registered in router / `oidc_scope_for_route` (`cerebro:read`) / `bounded_operation`; `tenant_id` param must match the authenticated tenant

## Scope (deliberate, documented in code)

- the Go handler also merges identities derived from the Go **auth config** (API keys, API credentials, MCP OAuth clients/entitlements) — that moves with the Wave-7 auth pipeline, so these responses always report `meta.configured: 0`
- the user-preferences routes are deferred to the same wave: they need the authenticated *user* identity that only the OIDC surface carries

## Validation

- cargo fmt --all -- --check; cargo clippy -p cerebro-platform -p cerebro-organizational-store --all-targets --locked -- -D warnings
- cargo test -p cerebro-platform -p cerebro-organizational-store --locked (399 + 44 pass; 7 new identity tests)
- diff touches only Rust files

🤖 Generated with [Claude Code](https://claude.com/claude-code)