### PR TITLE
refactor(sources): retire Cloudflare Workers Ai Go projection writer

### DIFF
--- a/internal/sourceprojection/cloudflare_workers_ai.go
+++ b/internal/sourceprojection/cloudflare_workers_ai.go
@@ -1,108 +1,34 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func cloudflareWorkersAiModelCatalogProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return cloudflareWorkersAiGenericAssetProjections(event)
+var errCloudflareWorkersAiRustProjectionRequired = errors.New("cloudflare_workers_ai projection requires Rust authority")
+
+func cloudflareWorkersAiModelCatalogProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCloudflareWorkersAiRustProjectionRequired
 }
 
-func cloudflareWorkersAiAiGatewaysProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return cloudflareWorkersAiGenericDeploymentProjections(event)
+func cloudflareWorkersAiAiGatewaysProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCloudflareWorkersAiRustProjectionRequired
 }
 
-func cloudflareWorkersAiGatewayProviderConfigsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return cloudflareWorkersAiGenericSecretProjections(event)
+func cloudflareWorkersAiGatewayProviderConfigsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCloudflareWorkersAiRustProjectionRequired
 }
 
-func cloudflareWorkersAiGatewayEvaluationsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return cloudflareWorkersAiGenericPolicyProjections(event)
+func cloudflareWorkersAiGatewayEvaluationsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCloudflareWorkersAiRustProjectionRequired
 }
 
-func cloudflareWorkersAiGatewayLogsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "cloudflare_workers_ai"})
+func cloudflareWorkersAiGatewayLogsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCloudflareWorkersAiRustProjectionRequired
 }
 
-func cloudflareWorkersAiVectorizeIndexesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return cloudflareWorkersAiGenericAssetProjections(event)
-}
-
-func cloudflareWorkersAiGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func cloudflareWorkersAiGenericSecretProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	secretID := firstNonEmpty(attributes["secret_id"], event.GetId())
-	secretURN := projectionURN(tenantID, "secret", secretID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: secretURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "secret", Label: firstNonEmpty(attributes["secret_name"], secretID), Attributes: map[string]string{"secret_id": secretID, "secret_type": strings.TrimSpace(attributes["secret_type"]), "secret_status": strings.TrimSpace(attributes["secret_status"]), "secret_rotation_enabled": strings.TrimSpace(attributes["secret_rotation_enabled"]), "secret_last_rotated_at": strings.TrimSpace(attributes["secret_last_rotated_at"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), secretURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func cloudflareWorkersAiGenericPolicyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	policyID := firstNonEmpty(attributes["policy_id"], event.GetId())
-	policyURN := projectionURN(tenantID, "policy", policyID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: policyURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "policy", Label: firstNonEmpty(attributes["policy_name"], policyID), Attributes: map[string]string{"policy_id": policyID, "policy_type": strings.TrimSpace(attributes["policy_type"]), "policy_status": strings.TrimSpace(attributes["policy_status"]), "policy_severity": strings.TrimSpace(attributes["policy_severity"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), policyURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-func cloudflareWorkersAiGenericDeploymentProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	deploymentID := firstNonEmpty(attributes["deployment_id"], event.GetId())
-	deploymentURN := projectionURN(tenantID, "deployment", deploymentID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: deploymentURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "deployment", Label: firstNonEmpty(attributes["deployment_name"], deploymentID), Attributes: map[string]string{"deployment_id": deploymentID, "deployment_environment": strings.TrimSpace(attributes["deployment_environment"]), "deployment_status": strings.TrimSpace(attributes["deployment_status"]), "deployment_url": strings.TrimSpace(attributes["deployment_url"]), "deployment_commit_sha": strings.TrimSpace(attributes["deployment_commit_sha"]), "deployment_branch": strings.TrimSpace(attributes["deployment_branch"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), deploymentURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func cloudflareWorkersAiVectorizeIndexesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCloudflareWorkersAiRustProjectionRequired
 }

--- a/internal/sourceprojection/cloudflare_workers_ai_test.go
+++ b/internal/sourceprojection/cloudflare_workers_ai_test.go
@@ -1,88 +1,34 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestCloudflareWorkersAiAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "cloudflare_workers_ai", Kind: "cloudflare_workers_ai.model_catalog", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := cloudflareWorkersAiModelCatalogProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestCloudflareWorkersAiDeploymentProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "cloudflare_workers_ai", Kind: "cloudflare_workers_ai.ai_gateways", Attributes: map[string]string{"deployment_id": "dep-1", "deployment_name": "Production", "deployment_environment": "production", "deployment_status": "ready", "evidence_id": "evidence-1"}}
-	entities, links, err := cloudflareWorkersAiAiGatewaysProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected deployment")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestCloudflareWorkersAiSecretProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "cloudflare_workers_ai", Kind: "cloudflare_workers_ai.gateway_provider_configs", Attributes: map[string]string{"secret_id": "secret-1", "secret_name": "DB Password", "secret_type": "password", "secret_status": "active", "evidence_id": "evidence-1"}}
-	entities, links, err := cloudflareWorkersAiGatewayProviderConfigsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected secret")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestCloudflareWorkersAiPolicyProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "cloudflare_workers_ai", Kind: "cloudflare_workers_ai.gateway_evaluations", Attributes: map[string]string{"policy_id": "policy-1", "policy_name": "Require MFA", "policy_type": "access", "policy_status": "enabled", "evidence_id": "evidence-1"}}
-	entities, links, err := cloudflareWorkersAiGatewayEvaluationsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected policy")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestCloudflareWorkersAiAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "cloudflare_workers_ai", Kind: "cloudflare_workers_ai.gateway_logs", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := cloudflareWorkersAiGatewayLogsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
-	}
-}
-
-func TestCloudflareWorkersAiVectorizeIndexesProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "cloudflare_workers_ai", Kind: "cloudflare_workers_ai.vectorize_indexes", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := cloudflareWorkersAiVectorizeIndexesProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
+func TestCloudflareWorkersAiGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"cloudflare_workers_ai.ai_gateways",
+		"cloudflare_workers_ai.gateway_evaluations",
+		"cloudflare_workers_ai.gateway_logs",
+		"cloudflare_workers_ai.gateway_provider_configs",
+		"cloudflare_workers_ai.model_catalog",
+		"cloudflare_workers_ai.vectorize_indexes",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "cloudflare_workers_ai",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errCloudflareWorkersAiRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Retires the Go projection writer for `cloudflare_workers_ai`, following the same house pattern already applied to deepseek (#2658) and 17+ other providers since. All six `cloudflare_workers_ai.*` registry entries in `internal/sourceprojection/registry_builtins.go` now fail closed with a single typed error instead of writing entities/links from Go.

- `internal/sourceprojection/cloudflare_workers_ai.go`: replaced the six dispatched functions (`cloudflareWorkersAiModelCatalogProjections`, `cloudflareWorkersAiAiGatewaysProjections`, `cloudflareWorkersAiGatewayProviderConfigsProjections`, `cloudflareWorkersAiGatewayEvaluationsProjections`, `cloudflareWorkersAiGatewayLogsProjections`, `cloudflareWorkersAiVectorizeIndexesProjections`) with fail-closed stubs returning `nil, nil, errCloudflareWorkersAiRustProjectionRequired`, keeping exact names/signatures (event params become `_`).
- Deleted the four cloudflare_workers_ai-only helpers that became unused after the stub conversion (`cloudflareWorkersAiGenericAssetProjections`, `cloudflareWorkersAiGenericSecretProjections`, `cloudflareWorkersAiGenericPolicyProjections`, `cloudflareWorkersAiGenericDeploymentProjections`) and the now-unused `strings` import. Confirmed via package-wide grep that none of these four helpers were used outside `cloudflare_workers_ai.go`.
- `cloudflareWorkersAiGatewayLogsProjections` called the shared, multi-provider `identityAuditProjections` helper (used by 650+ other call sites across the package) — that shared helper was left untouched; only the cloudflare_workers_ai-only wrapper registered in `registry_builtins.go` was converted, consistent with the Cloudflare retirement precedent (#2747).
- `internal/sourceprojection/cloudflare_workers_ai_test.go` rewritten as one table-driven test, `TestCloudflareWorkersAiGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering all six `cloudflare_workers_ai.*` kinds dispatched in `registry_builtins.go`, asserting `errors.Is` against the typed error and zero entities/links via `ProjectEvent`.

No oracle/parity/corpus tests elsewhere in `internal/sourceprojection` reference any `cloudflareWorkersAi*` function names, so none needed adjustment.

## Authority proof

Compiled Rust catalog marks every `cloudflare_workers_ai` family collection- and projection-authoritative (full-catalog census 2026-08-26). Go static loader: `cloudflare_workers_ai` has none.

## Cross-package check

`grep -rn "\"cloudflare_workers_ai\." --include='*.go' internal cmd` (excluding `internal/sourceprojection`) surfaced no other package projecting `cloudflare_workers_ai.*` events through `ProjectEvent`. The matches found were all non-projection: `internal/sourceops/source_execution.go` and `source_execution_test.go` (source-execution default/dispatch routing by provider name), `internal/sourceruntime/sourceworker/pull.go` and `pull_test.go` (pull-path provider switch cases), and `internal/connectorcatalog/ai_governance_catalog_test.go` (catalog family/field definitions for the connector). None of these call `sourceprojection.ProjectEvent` or import `sourceprojection`, so none required changes; their test suites were still run as a precaution (all green).

## Validation

Run from the worktree root:

```
gofmt -l internal/sourceprojection
go build ./internal/sourceprojection
go test ./internal/sourceprojection -count=1
go test ./internal/sourceregistry -count=1
go test ./internal/sourceops/... ./internal/sourceruntime/... ./internal/connectorcatalog/... -count=1
```

All pass; `gofmt -l` produced no output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
