### PR TITLE
refactor(sources): retire Elevenlabs Go projection writer

### DIFF
--- a/internal/sourceprojection/elevenlabs.go
+++ b/internal/sourceprojection/elevenlabs.go
@@ -1,108 +1,34 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func elevenlabsModelCatalogProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return elevenlabsGenericAssetProjections(event)
+var errElevenlabsRustProjectionRequired = errors.New("elevenlabs projection requires Rust authority")
+
+func elevenlabsModelCatalogProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errElevenlabsRustProjectionRequired
 }
 
-func elevenlabsVoicesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return elevenlabsGenericAssetProjections(event)
+func elevenlabsVoicesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errElevenlabsRustProjectionRequired
 }
 
-func elevenlabsServiceAccountsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "elevenlabs"})
+func elevenlabsServiceAccountsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errElevenlabsRustProjectionRequired
 }
 
-func elevenlabsServiceAccountApiKeysProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return elevenlabsGenericSecretProjections(event)
+func elevenlabsServiceAccountApiKeysProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errElevenlabsRustProjectionRequired
 }
 
-func elevenlabsWebhooksProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return elevenlabsGenericDeploymentProjections(event)
+func elevenlabsWebhooksProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errElevenlabsRustProjectionRequired
 }
 
-func elevenlabsAuthConnectionsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return elevenlabsGenericSecretProjections(event)
-}
-
-func elevenlabsGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func elevenlabsGenericSecretProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	secretID := firstNonEmpty(attributes["secret_id"], event.GetId())
-	secretURN := projectionURN(tenantID, "secret", secretID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: secretURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "secret", Label: firstNonEmpty(attributes["secret_name"], secretID), Attributes: map[string]string{"secret_id": secretID, "secret_type": strings.TrimSpace(attributes["secret_type"]), "secret_status": elevenlabsSecretStatus(attributes), "secret_rotation_enabled": strings.TrimSpace(attributes["secret_rotation_enabled"]), "secret_last_rotated_at": strings.TrimSpace(attributes["secret_last_rotated_at"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), secretURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func elevenlabsSecretStatus(attributes map[string]string) string {
-	if status := strings.TrimSpace(attributes["secret_status"]); status != "" {
-		return status
-	}
-	return normalizeElevenLabsDisabledStatus(attributes["service_account_key_disabled"])
-}
-
-func normalizeElevenLabsDisabledStatus(raw string) string {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "true":
-		return "disabled"
-	case "false":
-		return "active"
-	default:
-		return ""
-	}
-}
-
-func elevenlabsGenericDeploymentProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	deploymentID := firstNonEmpty(attributes["deployment_id"], event.GetId())
-	deploymentURN := projectionURN(tenantID, "deployment", deploymentID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: deploymentURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "deployment", Label: firstNonEmpty(attributes["deployment_name"], deploymentID), Attributes: map[string]string{"deployment_id": deploymentID, "deployment_environment": strings.TrimSpace(attributes["deployment_environment"]), "deployment_status": strings.TrimSpace(attributes["deployment_status"]), "deployment_url": strings.TrimSpace(attributes["deployment_url"]), "deployment_commit_sha": strings.TrimSpace(attributes["deployment_commit_sha"]), "deployment_branch": strings.TrimSpace(attributes["deployment_branch"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), deploymentURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func elevenlabsAuthConnectionsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errElevenlabsRustProjectionRequired
 }

--- a/internal/sourceprojection/elevenlabs_test.go
+++ b/internal/sourceprojection/elevenlabs_test.go
@@ -1,106 +1,34 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestElevenlabsAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "elevenlabs", Kind: "elevenlabs.model_catalog", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := elevenlabsModelCatalogProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestElevenlabsVoicesProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "elevenlabs", Kind: "elevenlabs.voices", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := elevenlabsVoicesProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestElevenlabsIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "elevenlabs", Kind: "elevenlabs.service_accounts", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := elevenlabsServiceAccountsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestElevenlabsSecretProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "elevenlabs", Kind: "elevenlabs.service_account_api_keys", Attributes: map[string]string{"secret_id": "secret-1", "secret_name": "DB Password", "secret_type": "password", "secret_status": "active", "evidence_id": "evidence-1"}}
-	entities, links, err := elevenlabsServiceAccountApiKeysProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected secret")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestElevenlabsSecretProjectionNormalizesDisabledFlag(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "elevenlabs", Kind: "elevenlabs.service_account_api_keys", Attributes: map[string]string{"secret_id": "secret-1", "secret_name": "DB Password", "secret_type": "api_key", "service_account_key_disabled": "false"}}
-	entities, _, err := elevenlabsServiceAccountApiKeysProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	for _, entity := range entities {
-		if entity.EntityType != "secret" {
-			continue
-		}
-		if got := entity.Attributes["secret_status"]; got != "active" {
-			t.Fatalf("secret_status = %q, want active", got)
-		}
-		return
-	}
-	t.Fatal("expected projected secret")
-}
-
-func TestElevenlabsDeploymentProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "elevenlabs", Kind: "elevenlabs.webhooks", Attributes: map[string]string{"deployment_id": "dep-1", "deployment_name": "Production", "deployment_environment": "production", "deployment_status": "ready", "evidence_id": "evidence-1"}}
-	entities, links, err := elevenlabsWebhooksProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected deployment")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestElevenlabsAuthConnectionsProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "elevenlabs", Kind: "elevenlabs.auth_connections", Attributes: map[string]string{"secret_id": "secret-1", "secret_name": "DB Password", "secret_type": "password", "secret_status": "active", "evidence_id": "evidence-1"}}
-	entities, links, err := elevenlabsAuthConnectionsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected secret")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
+func TestElevenlabsGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"elevenlabs.auth_connections",
+		"elevenlabs.model_catalog",
+		"elevenlabs.service_account_api_keys",
+		"elevenlabs.service_accounts",
+		"elevenlabs.voices",
+		"elevenlabs.webhooks",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "elevenlabs",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errElevenlabsRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
Retires the Go projection writer for the `elevenlabs` provider, following the standard fail-closed pattern established by the DeepSeek retirement (#2658) and 17+ subsequent providers. All six `elevenlabs.*` registry entries (`auth_connections`, `model_catalog`, `service_account_api_keys`, `service_accounts`, `voices`, `webhooks`) now return a single typed error, `errElevenlabsRustProjectionRequired`, instead of writing projections in Go.

- `elevenlabsServiceAccountsProjections` previously delegated to the shared multi-provider `identityUserProjections` helper; that helper is untouched (still used by 100+ other providers) — only the elevenlabs call site was repointed to fail closed.
- `elevenlabsModelCatalogProjections` and `elevenlabsVoicesProjections` previously delegated to `elevenlabsGenericAssetProjections`; `elevenlabsServiceAccountApiKeysProjections` and `elevenlabsAuthConnectionsProjections` to `elevenlabsGenericSecretProjections`; `elevenlabsWebhooksProjections` to `elevenlabsGenericDeploymentProjections`. All three were elevenlabs-only helpers (plus `elevenlabsSecretStatus` / `normalizeElevenLabsDisabledStatus`) and are deleted along with the now-unused `strings` import.
- `internal/sourceprojection/elevenlabs_test.go` is rewritten as one table-driven test, `TestElevenlabsGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering all six `elevenlabs.*` kinds dispatched in `registry_builtins.go`, asserting `errors.Is` against the typed error and zero entities/links.

## Authority proof
The compiled Rust source catalog marks every elevenlabs family collection- and projection-authoritative (full-catalog census 2026-08-26). The Go static loader has no elevenlabs entries. This is not re-derived here; it is the precondition for retiring the Go writer, per the same authority proof used in the DeepSeek and Cloudflare Workers AI retirements.

## Cross-package check
`grep -rn "\"elevenlabs\." --include='*.go' internal cmd | grep -v internal/sourceprojection` found no other package projecting `elevenlabs.*` events through `ProjectEvent`. The remaining matches are unrelated to Go projection and required no change:
- `internal/sourceruntime/sourceworker/host.go` / `host_test.go`: `elevenlabs.xi_api_key` is a credential/auth-header dispatch key, not an event kind.
- `internal/sourceops/source_execution.go`, `internal/sourceruntime/sourceworker/pull.go` / `pull_test.go`: source-ID membership lists / pull-worker dispatch for fetching from the ElevenLabs API — unrelated to Go projection.
- `internal/connectorcatalog/ai_governance_catalog_test.go`: connector catalog definitions (auth, pagination, selectors) for the source connector, not projection.
- `internal/findings/coverage_control_domain_refs_test.go`: a findings rule referencing `elevenlabs` as a `SourceID`, not a projection call.
- `internal/sourcegen/generator_test.go`: fixture-payload generation for the source connector, unrelated to `ProjectEvent`.

No elevenlabs-only helpers remain referenced anywhere in the module; `go build` confirms nothing is left dangling.

## Validation
Run from the worktree root:
```
gofmt -l internal/sourceprojection                                  # empty
go build ./internal/sourceprojection                                # ok
go test ./internal/sourceprojection -count=1                        # ok
go test ./internal/sourceregistry -count=1                          # ok
go test ./internal/sourceops/... ./internal/sourceruntime/sourceworker/... \
  ./internal/connectorcatalog/... ./internal/findings/... ./internal/sourcegen/... -count=1   # ok (cross-package consumers identified above)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
