### PR TITLE
refactor(sources): retire Cohere Go projection writer

### DIFF
--- a/internal/sourceprojection/cohere.go
+++ b/internal/sourceprojection/cohere.go
@@ -1,63 +1,26 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func cohereModelCatalogProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return cohereGenericAssetProjections(event)
+var errCohereRustProjectionRequired = errors.New("cohere projection requires Rust authority")
+
+func cohereModelCatalogProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCohereRustProjectionRequired
 }
 
-func cohereConnectorsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return cohereGenericAssetProjections(event)
+func cohereConnectorsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCohereRustProjectionRequired
 }
 
-func cohereDatasetsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return cohereGenericAssetProjections(event)
+func cohereDatasetsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCohereRustProjectionRequired
 }
 
-func cohereFineTunedModelsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return cohereGenericDeploymentProjections(event)
-}
-
-func cohereGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func cohereGenericDeploymentProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	deploymentID := firstNonEmpty(attributes["deployment_id"], event.GetId())
-	deploymentURN := projectionURN(tenantID, "deployment", deploymentID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: deploymentURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "deployment", Label: firstNonEmpty(attributes["deployment_name"], deploymentID), Attributes: map[string]string{"deployment_id": deploymentID, "deployment_environment": strings.TrimSpace(attributes["deployment_environment"]), "deployment_status": strings.TrimSpace(attributes["deployment_status"]), "deployment_url": strings.TrimSpace(attributes["deployment_url"]), "deployment_commit_sha": strings.TrimSpace(attributes["deployment_commit_sha"]), "deployment_branch": strings.TrimSpace(attributes["deployment_branch"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), deploymentURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func cohereFineTunedModelsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errCohereRustProjectionRequired
 }

--- a/internal/sourceprojection/cohere_test.go
+++ b/internal/sourceprojection/cohere_test.go
@@ -1,63 +1,27 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestCohereAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "cohere", Kind: "cohere.model_catalog", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := cohereModelCatalogProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestCohereConnectorsProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "cohere", Kind: "cohere.connectors", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := cohereConnectorsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestCohereDatasetsProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "cohere", Kind: "cohere.datasets", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := cohereDatasetsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestCohereDeploymentProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "cohere", Kind: "cohere.fine_tuned_models", Attributes: map[string]string{"deployment_id": "dep-1", "deployment_name": "Production", "deployment_environment": "production", "deployment_status": "ready", "evidence_id": "evidence-1"}}
-	entities, links, err := cohereFineTunedModelsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected deployment")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
+func TestCohereGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{"cohere.connectors", "cohere.datasets", "cohere.fine_tuned_models", "cohere.model_catalog"} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "cohere",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errCohereRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Retires the Cohere Go projection writer, following the standing house pattern for provider retirements (deepseek #2658 and 17 more since, most recently the Cloudflare retirement #2747).
- All four `cohere.*` dispatch entries in `registry_builtins.go` (`cohere.connectors`, `cohere.datasets`, `cohere.fine_tuned_models`, `cohere.model_catalog`) now route to fail-closed stubs that return `nil, nil, errCohereRustProjectionRequired` instead of building entities/links in Go.
- Deleted the two cohere-only helpers (`cohereGenericAssetProjections`, `cohereGenericDeploymentProjections`) that became unused — grepped the whole `internal/sourceprojection` package first to confirm no other provider referenced them.
- Rewrote `cohere_test.go` as a single table-driven test, `TestCohereGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering all four `cohere.*` kinds via `ProjectEvent`, asserting `errors.Is(err, errCohereRustProjectionRequired)` and zero entities/links for each.
- No shared multi-provider helpers were involved (the two deleted helpers were cohere-only), so no Cloudflare-style repoint wrapper was needed.

## Authority proof
Compiled Rust catalog marks every cohere family collection- and projection-authoritative (full-catalog census 2026-08-26); Go static loader: cohere has none.

## Cross-package blast radius
- `grep -rn "\"cohere\." --include='*.go' internal cmd | grep -v internal/sourceprojection` returned no matches — no other package projects `cohere.*` events through `ProjectEvent`.
- A broader `grep -rli cohere` across the repo turned up `internal/sourceops/source_execution.go`, `internal/sourceruntime/sourceworker/pull.go` (and their tests), `internal/connectorcatalog/ai_governance_catalog_test.go`, and `tools/connectorcatalogfidelity/main_test.go`. All of these reference `cohere` only as a source-id string in pull-scheduling/catalog-fidelity config — none import `sourceprojection` or call `ProjectEvent`. No changes needed there.

## Validation
Run from the worktree root:
```
gofmt -l internal/sourceprojection      # empty
go build ./internal/sourceprojection    # ok
go test ./internal/sourceprojection -count=1   # ok
go test ./internal/sourceregistry -count=1     # ok
```
No cross-package consumers were found, so no additional package tests were required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
