### PR TITLE
catalog(apigee): fix provider contract path mismatch for full Rust authority

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -3589,6 +3589,7 @@ mod tests {
             "apacta",
             "api2cart",
             "apideck",
+            "apigee",
             "apollo",
             "appwrite",
             "aws_bedrock",

--- a/sources/apigee/catalog.yaml
+++ b/sources/apigee/catalog.yaml
@@ -48,19 +48,19 @@ provider_api:
       operation: apigee.organizations.list
     - id: api_proxies
       method: GET
-      path: /v1/{parent=organizations/*}/apis
+      path: /v1/organizations/{organization}/apis
       operation: apigee.organizations.apis.list
     - id: deployments
       method: GET
-      path: /v1/{parent=organizations/*}/deployments
+      path: /v1/organizations/{organization}/deployments
       operation: apigee.organizations.deployments.list
     - id: developers
       method: GET
-      path: /v1/{parent=organizations/*}/developers
+      path: /v1/organizations/{organization}/developers
       operation: apigee.organizations.developers.list
     - id: apps
       method: GET
-      path: /v1/{parent=organizations/*}/apps
+      path: /v1/organizations/{organization}/apps
       operation: apigee.organizations.apps.list
 coverage_contract:
   owner_domain: source_runtime


### PR DESCRIPTION
## Summary

- Closes the Rust source-catalog collection/projection authority gap for the Apigee provider by fixing a path-canonicalization mismatch between `sources/apigee/catalog.yaml`'s `provider_api.families` and the compiled definition (`internal/connectorcatalog/catalog/devops-ci-cd/apigee.yaml`).
- All five Apigee families (`organizations`, `api_proxies`, `deployments`, `developers`, `apps`) are now both collection-authoritative and projection-authoritative.
- `apigee` is added to `retired_static_loader_sources_are_fully_rust_authoritative` in `crates/source-catalog/src/lib.rs`.

## Authority proof

**Probe (Step 1), before the fix** — throwaway test loading `SourceCatalog::load` and printing each family's authority/reasons:

```
family=organizations authoritative=true  projection_authoritative=true  reasons=[]
family=api_proxies    authoritative=false projection_authoritative=false reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]
family=deployments    authoritative=false projection_authoritative=false reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]
family=developers     authoritative=false projection_authoritative=false reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]
family=apps           authoritative=false projection_authoritative=false reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]
```

**Root cause** — `canonical_path_template()` (`crates/source-catalog/src/lib.rs`) only recognizes a path parameter segment written as `${config.x}` or `{x}` (alphanumeric/`_`/`-` only). `provider_api.families` declared the Google Discovery-style templated path `/v1/{parent=organizations/*}/apis` (and the `deployments`/`developers`/`apps` siblings) — the segment `{parent=organizations/*}` contains `=` and `/`, so it fails the path-parameter check, the whole path fails to canonicalize, and `verified_families()` silently drops the family. The compiled definition's relative path `/v1/organizations/${config.organization}/apis` therefore never found a match in the verified set, even though `organizations` (whose provider_api path `/v1/organizations` has no template segment) was already proven. This is the same shape of bug as the DigitalOcean fix in #2716, per the census hint.

**Fix** — rewrote the four templated `provider_api.families` paths to the relative form `/v1/organizations/{organization}/<family>`, matching the compiled definition's `${config.organization}` parameter.

**Verified against the provider's real documented API** — fetched the catalog's own declared `spec_url` (`https://apigee.googleapis.com/$discovery/rest?version=v1`, the live Google API Discovery document) directly and extracted the method definitions:

```
apigee.organizations.list             GET  flatPath=v1/organizations
apigee.organizations.apis.list        GET  flatPath=v1/organizations/{organizationsId}/apis
apigee.organizations.deployments.list GET  flatPath=v1/organizations/{organizationsId}/deployments
apigee.organizations.developers.list  GET  flatPath=v1/organizations/{organizationsId}/developers
apigee.organizations.apps.list        GET  flatPath=v1/organizations/{organizationsId}/apps
```

Each `flatPath` genuinely exists in the provider's discovery document and matches (modulo the path-parameter name, which doesn't affect canonicalization) the corrected `provider_api.families` paths and the compiled definition's paths. All five families have fixture coverage under `sources/apigee/testdata/` (`discover_*`/`read_*` for every family), so all five stay in `runtime_families`.

**Probe, after the fix:**

```
family=organizations authoritative=true projection_authoritative=true reasons=[]
family=api_proxies   authoritative=true projection_authoritative=true reasons=[]
family=deployments   authoritative=true projection_authoritative=true reasons=[]
family=developers    authoritative=true projection_authoritative=true reasons=[]
family=apps          authoritative=true projection_authoritative=true reasons=[]
```

The probe test (`crates/source-catalog/tests/wave5_probe_apigee.rs`) was throwaway and has been deleted before this commit.

## Validation

- `cargo test -p cerebro-source-catalog --lib` — 27/27 passed, including the updated `retired_static_loader_sources_are_fully_rust_authoritative`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)