### PR TITLE
catalog(authentik_cloud): fix provider contract path mismatch for full Rust authority

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -3591,6 +3591,7 @@ mod tests {
             "apideck",
             "apollo",
             "appwrite",
+            "authentik_cloud",
             "aws_bedrock",
             "azure_openai",
             "backstage",

--- a/sources/authentik_cloud/catalog.yaml
+++ b/sources/authentik_cloud/catalog.yaml
@@ -20,7 +20,7 @@ provider_api:
   transport: rest
   auth: bearer_token
   auth_mechanics: authorization_bearer_api_token_or_oauth_access_token
-  base_url: ${config.base_url}/api/v3
+  base_url: ${config.base_url}
   spec_url: https://raw.githubusercontent.com/goauthentik/authentik/main/schema.yml
   spec_kind: openapi
   references:
@@ -43,23 +43,23 @@ provider_api:
   families:
     - id: applications
       method: GET
-      path: /core/applications/
+      path: /api/v3/core/applications/
       operation: core_applications_list
     - id: audit_events
       method: GET
-      path: /events/events/
+      path: /api/v3/events/events/
       operation: events_events_list
     - id: groups
       method: GET
-      path: /core/groups/
+      path: /api/v3/core/groups/
       operation: core_groups_list
     - id: roles
       method: GET
-      path: /rbac/roles/
+      path: /api/v3/rbac/roles/
       operation: rbac_roles_list
     - id: users
       method: GET
-      path: /core/users/
+      path: /api/v3/core/users/
       operation: core_users_list
 kind_lifecycle:
   - kind: authentik_cloud.users


### PR DESCRIPTION
## Summary

- Fixed a path-join mismatch in `sources/authentik_cloud/catalog.yaml` that was blocking Rust collection/projection authority for all five `authentik_cloud` families (users, groups, roles, applications, audit_events).
- `provider_api.families[].path` was written relative to the documented `base_url` (`${config.base_url}/api/v3`), e.g. `/core/users/`, but the compiled connector definition (`internal/connectorcatalog/catalog/identity-access-secrets/authentik_cloud.yaml`) has no per-family `config.base_url` override, so `canonical_family_locator()` compares the family's bare `path` field with no base_url joined in at all. The compiled definition's path is the full instance-relative path including the `/api/v3` prefix (e.g. `/api/v3/core/users/`), so the un-prefixed proof paths never matched.
- Prefixed all five `provider_api.families[].path` entries with `/api/v3` to match the compiled definition's literal paths, and corrected the documented `provider_api.base_url` from `${config.base_url}/api/v3` to `${config.base_url}` so the base_url + path documentation stays internally consistent (no more double `/api/v3`).
- Added `authentik_cloud` (alphabetical, between `appwrite` and `aws_bedrock`) to `retired_static_loader_sources_are_fully_rust_authoritative` in `crates/source-catalog/src/lib.rs`.

## Authority proof

Ran the probe (`SourceCatalog::load` over `internal/connectorcatalog/catalog` + `sources`, printing `is_authoritative()` / `is_projection_authoritative()` / `unsupported_reasons()` for every `authentik_cloud` family) before and after the fix.

**Before:**
```
family=users authoritative=false projection_authoritative=false path=/api/v3/core/users/ base_url=None reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]
family=groups authoritative=false projection_authoritative=false path=/api/v3/core/groups/ base_url=None reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]
family=roles authoritative=false projection_authoritative=false path=/api/v3/rbac/roles/ base_url=None reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]
family=applications authoritative=false projection_authoritative=false path=/api/v3/core/applications/ base_url=None reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]
family=audit_events authoritative=false projection_authoritative=false path=/api/v3/events/events/ base_url=None reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]
```

**After:**
```
family=users authoritative=true projection_authoritative=true path=/api/v3/core/users/ base_url=None reasons=[]
family=groups authoritative=true projection_authoritative=true path=/api/v3/core/groups/ base_url=None reasons=[]
family=roles authoritative=true projection_authoritative=true path=/api/v3/rbac/roles/ base_url=None reasons=[]
family=applications authoritative=true projection_authoritative=true path=/api/v3/core/applications/ base_url=None reasons=[]
family=audit_events authoritative=true projection_authoritative=true path=/api/v3/events/events/ base_url=None reasons=[]
```

Each corrected path was verified against the live authentik API reference documentation (not just the catalog's own claims):

- `GET /core/users/` — https://api.goauthentik.io/reference/core-users-list/
- `GET /core/groups/` — https://api.goauthentik.io/reference/core-groups-list/
- `GET /rbac/roles/` — https://api.goauthentik.io/reference/rbac-roles-list/
- `GET /core/applications/` — https://api.goauthentik.io/reference/core-applications-list/
- `GET /events/events/` — https://api.goauthentik.io/reference/events-events-list/
- Base path — https://api.goauthentik.io/ confirms every authentik instance exposes its API browser/schema at the fixed `/api/v3/` prefix (`https://<authentik.company>/api/v3/`), and the reference-page paths above are relative to that prefix. So the full canonical request path for each family is `/api/v3/<reference-page-path>`, which is exactly what the compiled Go definition already used and what this PR now writes into `provider_api.families[].path`.

All five families already have fixture coverage under `sources/authentik_cloud/testdata/` (`discover_*.json` and `read_*.json` for each), so no family needed to be dropped from `runtime_families`.

## Validation

- `cargo test -p cerebro-source-catalog --lib` — 27 passed, including `retired_static_loader_sources_are_fully_rust_authoritative`.
- `cargo test -p cerebro-source-catalog` (lib + integration tests) — all green.
- Probe test file (`crates/source-catalog/tests/wave5_probe_authentik_cloud.rs`) was throwaway and deleted before this commit — not part of the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)