### PR TITLE
refactor(sources): retire Microsoft Entra Id Go projection writer

### DIFF
--- a/internal/sourceprojection/microsoft_entra_id.go
+++ b/internal/sourceprojection/microsoft_entra_id.go
@@ -1,18 +1,22 @@
 package sourceprojection
 
 import (
+	"errors"
+
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func microsoftEntraIdUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "microsoft_entra_id"})
+var errMicrosoftEntraIdRustProjectionRequired = errors.New("microsoft_entra_id projection requires Rust authority")
+
+func microsoftEntraIdUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errMicrosoftEntraIdRustProjectionRequired
 }
 
-func microsoftEntraIdGroupsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityGroupProjections(event, identityProjectionProfile{Provider: "microsoft_entra_id"})
+func microsoftEntraIdGroupsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errMicrosoftEntraIdRustProjectionRequired
 }
 
-func microsoftEntraIdAuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "microsoft_entra_id"})
+func microsoftEntraIdAuditEventsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errMicrosoftEntraIdRustProjectionRequired
 }

--- a/internal/sourceprojection/microsoft_entra_id_test.go
+++ b/internal/sourceprojection/microsoft_entra_id_test.go
@@ -1,40 +1,27 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestMicrosoftEntraIdIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "microsoft_entra_id", Kind: "microsoft_entra_id.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := microsoftEntraIdUsersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestMicrosoftEntraIdIdentityGroupProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "microsoft_entra_id", Kind: "microsoft_entra_id.groups", Attributes: map[string]string{"group_id": "group-1", "group_email": "group@example.test", "group_name": "Group One"}}
-	entities, _, err := microsoftEntraIdGroupsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity group")
-	}
-}
-
-func TestMicrosoftEntraIdAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "microsoft_entra_id", Kind: "microsoft_entra_id.audit_events", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := microsoftEntraIdAuditEventsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestMicrosoftEntraIdGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{"microsoft_entra_id.audit_events", "microsoft_entra_id.groups", "microsoft_entra_id.users"} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "microsoft_entra_id",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errMicrosoftEntraIdRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
Retires the Go source-projection writer for `microsoft_entra_id`. All three registry-dispatched projection functions (`microsoftEntraIdUsersProjections`, `microsoftEntraIdGroupsProjections`, `microsoftEntraIdAuditEventsProjections`) now fail closed with a single typed error, `errMicrosoftEntraIdRustProjectionRequired`, instead of delegating to the shared `identityUserProjections` / `identityGroupProjections` / `identityAuditProjections` helpers. Those shared helpers are untouched (grepped: still used by many other providers, e.g. `agiloft`, `airbase`). No microsoft_entra_id-only helpers or imports were left unused. This follows the exact house pattern from `deepseek` (#2658) and the 17 retirements since.

## Authority proof
Compiled Rust catalog marks every microsoft_entra_id family collection- and projection-authoritative (full-catalog census 2026-08-25). Go static loader: microsoft_entra_id has none.

## Validation
```
gofmt -l internal/sourceprojection
go build ./internal/sourceprojection
go test ./internal/sourceprojection -count=1
go test ./internal/sourceregistry -count=1
```
All pass. Cross-package blast radius check (`grep -rn "\"microsoft_entra_id\." --include='*.go' internal cmd | grep -v internal/sourceprojection`) found no other package projecting `microsoft_entra_id.*` events through `ProjectEvent`; the remaining matches (`internal/bootstrap/connectors_test.go` catalog-status assertions, `internal/findings/source_coverage_refs.go` alias tables, `internal/findings/coverage_control_domain_refs_test.go` finding-rule tests) are non-projection consumers and needed no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)