### PR TITLE
refactor(sources): retire Meraki Go projection writer

### DIFF
--- a/internal/sourceprojection/meraki.go
+++ b/internal/sourceprojection/meraki.go
@@ -1,43 +1,26 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func merakiEventtypeProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "meraki"})
+var errMerakiRustProjectionRequired = errors.New("meraki projection requires Rust authority")
+
+func merakiEventtypeProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errMerakiRustProjectionRequired
 }
 
-func merakiOrganizationProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityGroupProjections(event, identityProjectionProfile{Provider: "meraki"})
+func merakiOrganizationProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errMerakiRustProjectionRequired
 }
 
-func merakiMerakiauthuserProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "meraki"})
+func merakiMerakiauthuserProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errMerakiRustProjectionRequired
 }
 
-func merakiAccesspolicyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return merakiGenericPolicyProjections(event)
-}
-
-func merakiGenericPolicyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	policyID := firstNonEmpty(attributes["policy_id"], event.GetId())
-	policyURN := projectionURN(tenantID, "policy", policyID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: policyURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "policy", Label: firstNonEmpty(attributes["policy_name"], policyID), Attributes: map[string]string{"policy_id": policyID, "policy_type": strings.TrimSpace(attributes["policy_type"]), "policy_status": strings.TrimSpace(attributes["policy_status"]), "policy_severity": strings.TrimSpace(attributes["policy_severity"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), policyURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func merakiAccesspolicyProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errMerakiRustProjectionRequired
 }

--- a/internal/sourceprojection/meraki_test.go
+++ b/internal/sourceprojection/meraki_test.go
@@ -1,54 +1,32 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestMerakiAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "meraki", Kind: "meraki.eventtype", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := merakiEventtypeProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
-	}
-}
-
-func TestMerakiIdentityGroupProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "meraki", Kind: "meraki.organization", Attributes: map[string]string{"group_id": "group-1", "group_email": "group@example.test", "group_name": "Group One"}}
-	entities, _, err := merakiOrganizationProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity group")
-	}
-}
-
-func TestMerakiIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "meraki", Kind: "meraki.merakiauthuser", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := merakiMerakiauthuserProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestMerakiPolicyProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "meraki", Kind: "meraki.accesspolicy", Attributes: map[string]string{"policy_id": "policy-1", "policy_name": "Require MFA", "policy_type": "access", "policy_status": "enabled", "evidence_id": "evidence-1"}}
-	entities, links, err := merakiAccesspolicyProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected policy")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
+func TestMerakiGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"meraki.accesspolicy",
+		"meraki.eventtype",
+		"meraki.merakiauthuser",
+		"meraki.organization",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "meraki",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errMerakiRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Retires the Go projection writer for the `meraki` provider in
`internal/sourceprojection`, following the standard fail-closed pattern
(deepseek #2658 and the 17 retirements since, most recently the shared-helper
variant used for Cloudflare #2747).

- All four `meraki.*` family projectors dispatched from
  `registry_builtins.go` — `meraki.accesspolicy`, `meraki.eventtype`,
  `meraki.merakiauthuser`, `meraki.organization` — now fail closed, returning
  `nil, nil, errMerakiRustProjectionRequired` instead of computing
  entities/links. Function names and signatures in `registry_builtins.go`
  are unchanged.
- `merakiEventtypeProjections`, `merakiOrganizationProjections`, and
  `merakiMerakiauthuserProjections` previously delegated to the
  multi-provider shared helpers `identityAuditProjections`,
  `identityGroupProjections`, and `identityUserProjections` respectively.
  Those shared helpers are untouched (still used by many other providers,
  e.g. torii, robin, fathom_video, tallyfy) — only the meraki-named dispatch
  wrappers themselves were rewritten to fail closed.
- `merakiAccesspolicyProjections` previously delegated to a meraki-only
  helper, `merakiGenericPolicyProjections`. That helper had no other callers
  in the package, so it is deleted along with the now-unused `strings`
  import.
- `meraki_test.go` is rewritten as a single table-driven test,
  `TestMerakiGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering
  all four `meraki.*` kinds via `ProjectEvent`, asserting `errors.Is` against
  the new sentinel and zero entities/links.

## Authority proof

The compiled Rust source catalog marks every `meraki` family
collection- and projection-authoritative (full-catalog census 2026-08-25/26)
— this was independently verified before this PR and is not re-derived here.
The Go static loader carries no fallback plan for `meraki`.

## Cross-package blast radius

`grep -rn "\"meraki\." --include='*.go' internal cmd | grep -v internal/sourceprojection`
returned no matches — no other package (test corpora, fixtures, findings
rules) projects `meraki.*` events through `ProjectEvent`, so no other file
needed adjustment. `internal/sourceregistry/standard_source_plan_index.txt`
still lists the `meraki` family plan (`accesspolicy,eventtype,
merakiauthuser,organization`); that index tracks which families a provider
supports at all, independent of Go/Rust projection status, and is unchanged
by this or prior retirements (deepseek/cloudflare entries remain listed
there too).

No oracle/parity/corpus tests in `internal/sourceprojection` referenced the
meraki functions, so no oracle-preservation was needed.

## Validation

Run from the worktree root:

```
gofmt -l internal/sourceprojection
go build ./internal/sourceprojection
go test ./internal/sourceprojection -count=1
go test ./internal/sourceregistry -count=1
go build ./...
```

All pass with no output / `ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
