### PR TITLE
refactor(sources): retire Apigee Go projection writer

### DIFF
--- a/internal/sourceprojection/apigee.go
+++ b/internal/sourceprojection/apigee.go
@@ -1,67 +1,30 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func apigeeOrganizationsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return apigeeGenericAssetProjections(event)
+var errApigeeRustProjectionRequired = errors.New("apigee projection requires Rust authority")
+
+func apigeeOrganizationsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApigeeRustProjectionRequired
 }
 
-func apigeeAPIProxiesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return apigeeGenericAssetProjections(event)
+func apigeeAPIProxiesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApigeeRustProjectionRequired
 }
 
-func apigeeDeploymentsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return apigeeGenericDeploymentProjections(event)
+func apigeeDeploymentsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApigeeRustProjectionRequired
 }
 
-func apigeeDevelopersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "apigee"})
+func apigeeDevelopersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApigeeRustProjectionRequired
 }
 
-func apigeeAppsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return apigeeGenericAssetProjections(event)
-}
-
-func apigeeGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func apigeeGenericDeploymentProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	deploymentID := firstNonEmpty(attributes["deployment_id"], event.GetId())
-	deploymentURN := projectionURN(tenantID, "deployment", deploymentID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: deploymentURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "deployment", Label: firstNonEmpty(attributes["deployment_name"], deploymentID), Attributes: map[string]string{"deployment_id": deploymentID, "deployment_environment": strings.TrimSpace(attributes["deployment_environment"]), "deployment_status": strings.TrimSpace(attributes["deployment_status"]), "deployment_url": strings.TrimSpace(attributes["deployment_url"]), "deployment_commit_sha": strings.TrimSpace(attributes["deployment_commit_sha"]), "deployment_branch": strings.TrimSpace(attributes["deployment_branch"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), deploymentURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func apigeeAppsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errApigeeRustProjectionRequired
 }

--- a/internal/sourceprojection/apigee_test.go
+++ b/internal/sourceprojection/apigee_test.go
@@ -1,74 +1,33 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestApigeeDeveloperProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apigee", Kind: "apigee.developers", Attributes: map[string]string{"user_id": "dev-1", "email": "dev@fixture.invalid", "display_name": "Developer One"}}
-	entities, _, err := apigeeDevelopersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected developer identity")
-	}
-}
-
-func TestApigeeOrganizationProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apigee", Kind: "apigee.organizations", Attributes: map[string]string{"resource_id": "org-1", "resource_type": "apigee_organization", "resource_name": "org-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := apigeeOrganizationsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected organization entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestApigeeAPIProxiesProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apigee", Kind: "apigee.api_proxies", Attributes: map[string]string{"resource_id": "proxy-1", "resource_type": "apigee_api_proxy", "resource_name": "proxy-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := apigeeAPIProxiesProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected API proxy entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestApigeeDeploymentProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apigee", Kind: "apigee.deployments", Attributes: map[string]string{"deployment_id": "dep-1", "deployment_name": "Production", "deployment_environment": "production", "deployment_status": "ready", "evidence_id": "evidence-1"}}
-	entities, links, err := apigeeDeploymentsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected deployment")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestApigeeAppsProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "apigee", Kind: "apigee.apps", Attributes: map[string]string{"resource_id": "app-1", "resource_type": "apigee_app", "resource_name": "orders-app", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := apigeeAppsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected app entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
+func TestApigeeGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"apigee.api_proxies",
+		"apigee.apps",
+		"apigee.deployments",
+		"apigee.developers",
+		"apigee.organizations",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "apigee",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errApigeeRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Retires the Go projection writer for the `apigee` provider following the standard fail-closed pattern (deepseek #2658, and many more since, most recently the Cohere retirement #2803).
- All five `apigee.*` family projectors in `internal/sourceprojection/apigee.go` (`apigee.organizations`, `apigee.api_proxies`, `apigee.deployments`, `apigee.developers`, `apigee.apps`) now return `nil, nil, errApigeeRustProjectionRequired` instead of computing entities/links. Function names and signatures in `registry_builtins.go`'s dispatch table are unchanged.
- `apigeeOrganizationsProjections` / `apigeeAPIProxiesProjections` / `apigeeAppsProjections` previously delegated to an apigee-only helper, `apigeeGenericAssetProjections`, and `apigeeDeploymentsProjections` delegated to `apigeeGenericDeploymentProjections` — both had no callers anywhere else in the package, so both are deleted along with the now-unused `strings` import.
- `apigeeDevelopersProjections` previously delegated to the shared `identityUserProjections` helper (still used by hundreds of other providers — rivery, torii, appgate, robin, tallyfy, matillion, and more), so it keeps its own apigee-only fail-closed wrapper rather than touching that shared helper — same precedent as the Cloudflare retirement (#2747).
- `apigee_test.go` is rewritten as one table-driven test, `TestApigeeGoProjectionFailsClosedForRustAuthoritativeFamilies`, covering all five `apigee.*` kinds via `ProjectEvent`, asserting `errors.Is` against the typed error and zero entities/links.

## Authority proof
This PR stacks on #2806, which makes every apigee family collection- and projection-authoritative in the compiled Rust catalog (probe output and provider-spec verification are in that PR's description). Go static loader: apigee has none. This retirement PR is safe to merge only after #2806 lands on `main` (it will then retarget automatically).

## Cross-package blast radius
`grep -rn "\"apigee\." --include='*.go' internal cmd | grep -v internal/sourceprojection` returned no matches — no other package (test corpora, fixtures, findings rules, action constants, `internal/sourceregistry`) projects or otherwise references `apigee.*` event kinds. `runtime_depth_promoted_sources_test.go` (the same-package oracle test some prior retirements had to trim) has no `apigee` references either. No cross-package changes were needed.

## Validation
Run from the worktree root:
```
gofmt -l internal/sourceprojection            # empty
go build ./internal/sourceprojection          # ok
go test ./internal/sourceprojection -count=1  # ok
go test ./internal/sourceregistry -count=1    # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)