### PR TITLE
refactor(sources): retire Authentik Cloud Go projection writer

### DIFF
--- a/internal/sourceprojection/authentik_cloud.go
+++ b/internal/sourceprojection/authentik_cloud.go
@@ -1,67 +1,30 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func authentikCloudUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "authentik_cloud"})
+var errAuthentikCloudRustProjectionRequired = errors.New("authentik_cloud projection requires Rust authority")
+
+func authentikCloudUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAuthentikCloudRustProjectionRequired
 }
 
-func authentikCloudGroupsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityGroupProjections(event, identityProjectionProfile{Provider: "authentik_cloud"})
+func authentikCloudGroupsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAuthentikCloudRustProjectionRequired
 }
 
-func authentikCloudRolesProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return authentikCloudGenericPolicyProjections(event)
+func authentikCloudRolesProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAuthentikCloudRustProjectionRequired
 }
 
-func authentikCloudApplicationsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return authentikCloudGenericAssetProjections(event)
+func authentikCloudApplicationsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAuthentikCloudRustProjectionRequired
 }
 
-func authentikCloudAuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "authentik_cloud"})
-}
-
-func authentikCloudGenericAssetProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	resourceID := firstNonEmpty(attributes["resource_id"], attributes["external_id"], event.GetId())
-	resourceType := firstNonEmpty(attributes["resource_type"], attributes["schema"], "asset")
-	resourceURN := firstNonEmpty(attributes["resource_urn"], projectionURN(tenantID, "runtime_"+normalizeCloudType(resourceType), resourceID))
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: resourceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime." + strings.ReplaceAll(normalizeCloudType(resourceType), "_", "."), Label: firstNonEmpty(attributes["resource_name"], resourceID), Attributes: map[string]string{"resource_id": resourceID, "resource_type": resourceType, "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime.evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), resourceURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
-}
-
-func authentikCloudGenericPolicyProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	policyID := firstNonEmpty(attributes["policy_id"], event.GetId())
-	policyURN := projectionURN(tenantID, "policy", policyID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: policyURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "policy", Label: firstNonEmpty(attributes["policy_name"], policyID), Attributes: map[string]string{"policy_id": policyID, "policy_type": strings.TrimSpace(attributes["policy_type"]), "policy_status": strings.TrimSpace(attributes["policy_status"]), "policy_severity": strings.TrimSpace(attributes["policy_severity"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), policyURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func authentikCloudAuditEventsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errAuthentikCloudRustProjectionRequired
 }

--- a/internal/sourceprojection/authentik_cloud_test.go
+++ b/internal/sourceprojection/authentik_cloud_test.go
@@ -1,68 +1,33 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestAuthentikCloudAssetProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "authentik_cloud", Kind: "authentik_cloud.applications", Attributes: map[string]string{"resource_id": "asset-1", "resource_type": "host", "resource_name": "host-1", "evidence_id": "evidence-1", "evidence_cas_uri": "cas://cases/evidence-1", "evidence_cas_digest": "sha256:test"}}
-	entities, links, err := authentikCloudApplicationsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected entities")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAuthentikCloudPolicyProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "authentik_cloud", Kind: "authentik_cloud.roles", Attributes: map[string]string{"policy_id": "policy-1", "policy_name": "Require MFA", "policy_type": "access", "policy_status": "enabled", "evidence_id": "evidence-1"}}
-	entities, links, err := authentikCloudRolesProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected policy")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestAuthentikCloudIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "authentik_cloud", Kind: "authentik_cloud.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := authentikCloudUsersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestAuthentikCloudIdentityGroupProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "authentik_cloud", Kind: "authentik_cloud.groups", Attributes: map[string]string{"group_id": "group-1", "group_email": "group@example.test", "group_name": "Group One"}}
-	entities, _, err := authentikCloudGroupsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity group")
-	}
-}
-
-func TestAuthentikCloudAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "authentik_cloud", Kind: "authentik_cloud.audit_events", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := authentikCloudAuditEventsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestAuthentikCloudGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"authentik_cloud.applications",
+		"authentik_cloud.audit_events",
+		"authentik_cloud.groups",
+		"authentik_cloud.roles",
+		"authentik_cloud.users",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "authentik_cloud",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errAuthentikCloudRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
Stacked on #2807 (`catalog(authentik_cloud): fix provider contract path mismatch for full Rust authority`) — this PR's base will retarget to `main` automatically once that one merges.

## Summary

- `users`, `groups`, `roles`, `applications`, and `audit_events` are now fully collection- and projection-authoritative in the Rust source catalog (#2807), so the Go projection writer in `internal/sourceprojection/authentik_cloud.go` is redundant.
- Every family projector keeps its exported name and signature but now fails closed with `errAuthentikCloudRustProjectionRequired`, matching the deepseek/digitalocean/cloudflare retirement pattern.
- `authentikCloudUsersProjections`, `authentikCloudGroupsProjections`, and `authentikCloudAuditEventsProjections` previously dispatched straight into the shared `identityUserProjections` / `identityGroupProjections` / `identityAuditProjections` helpers, which are still used by `appgate`, `torii`, `vidyard`, `rivery`, `tallyfy`, `postmark`, `thoropass`, `burp_suite_enterprise`, and others. Per the shared-helper wrapper rule (cloudflare #2747), those shared helpers are untouched — only authentik_cloud's own wrapper functions now fail closed.
- The two authentik_cloud-only generic helpers (`authentikCloudGenericAssetProjections`, `authentikCloudGenericPolicyProjections`) had no other callers anywhere in the repo and are deleted outright.
- `authentik_cloud_test.go` is rewritten as a table-driven test over every `authentik_cloud.*` kind registered in `registry_builtins.go`, routed through `ProjectEvent`, asserting the Go path never produces entities or links and always returns the sentinel error.

## Cross-package check

`grep -rn "\"authentik_cloud\." --include='*.go' internal cmd` outside `internal/sourceprojection` returned no hits — no other Go package references these event kinds, and no test corpus needed to move to a still-live provider.

## Validation

- `gofmt -l internal/sourceprojection` — empty
- `go build ./internal/sourceprojection` — clean
- `go vet ./internal/sourceprojection ./internal/sourceregistry` — clean
- `go test ./internal/sourceprojection ./internal/sourceregistry -count=1` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)