### PR TITLE
catalog(cloudflare_zero_trust): fix compiled definition path mismatch for full Rust authority

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -3600,6 +3600,7 @@ mod tests {
             "box",
             "cloudflare",
             "cloudflare_workers_ai",
+            "cloudflare_zero_trust",
             "cohere",
             "conjur",
             "datadog",

--- a/internal/connectorcatalog/catalog/identity-access-secrets/cloudflare_zero_trust.yaml
+++ b/internal/connectorcatalog/catalog/identity-access-secrets/cloudflare_zero_trust.yaml
@@ -14,9 +14,9 @@ entries:
         - saas
         - identity_access_secrets
       config_fields:
-        - help: Tenant or regional API base URL.
-          key: base_url
-          label: API base URL
+        - help: Cloudflare account ID that owns the Zero Trust Access users, groups, policies, applications, and audit logs.
+          key: account_id
+          label: Account ID
           required: true
       description: Collects users, groups, roles, applications, and audit events from Cloudflare Zero Trust and projects them into the Cerebro graph as users, groups, policies, assets, and audit events for identity, access, device, and secret context.
       display_name: Cloudflare Zero Trust
@@ -49,12 +49,13 @@ entries:
           method: GET
           name_field: name
           pagination:
-            cursor_json_path: $.next_cursor
-            cursor_param: cursor
+            inject_first_page: true
+            page_param: page
             page_size: 100
-            page_size_param: limit
-            type: cursor
-          path: /v1/users
+            page_size_param: per_page
+            start_page: 1
+            type: page
+          path: /accounts/{account_id}/access/users
           projection:
             fields:
               display_name: name
@@ -62,7 +63,7 @@ entries:
               status: status
               user_id: id
             template: identity_user
-          record_selector: $.data[*]
+          record_selector: $.result[*]
         - coverage:
             - control_domains:
                 - asset_inventory
@@ -88,18 +89,19 @@ entries:
           method: GET
           name_field: name
           pagination:
-            cursor_json_path: $.next_cursor
-            cursor_param: cursor
+            inject_first_page: true
+            page_param: page
             page_size: 100
-            page_size_param: limit
-            type: cursor
-          path: /v1/groups
+            page_size_param: per_page
+            start_page: 1
+            type: page
+          path: /accounts/{account_id}/access/groups
           projection:
             fields:
               group_id: id
               group_name: name
             template: identity_group
-          record_selector: $.data[*]
+          record_selector: $.result[*]
         - coverage:
             - control_domains:
                 - access_review
@@ -125,12 +127,13 @@ entries:
           method: GET
           name_field: name
           pagination:
-            cursor_json_path: $.next_cursor
-            cursor_param: cursor
+            inject_first_page: true
+            page_param: page
             page_size: 100
-            page_size_param: limit
-            type: cursor
-          path: /v1/roles
+            page_size_param: per_page
+            start_page: 1
+            type: page
+          path: /accounts/{account_id}/access/policies
           projection:
             fields:
               policy_id: id
@@ -138,7 +141,7 @@ entries:
               policy_status: status
               policy_type: role
             template: policy
-          record_selector: $.data[*]
+          record_selector: $.result[*]
         - coverage:
             - control_domains:
                 - asset_inventory
@@ -164,12 +167,13 @@ entries:
           method: GET
           name_field: name
           pagination:
-            cursor_json_path: $.next_cursor
-            cursor_param: cursor
+            inject_first_page: true
+            page_param: page
             page_size: 100
-            page_size_param: limit
-            type: cursor
-          path: /v1/applications
+            page_size_param: per_page
+            start_page: 1
+            type: page
+          path: /accounts/{account_id}/access/apps
           projection:
             fields:
               id: id
@@ -178,7 +182,7 @@ entries:
               resource_name: name
               resource_type: application
             template: asset
-          record_selector: $.data[*]
+          record_selector: $.result[*]
         - coverage:
             - control_domains:
                 - logging_monitoring
@@ -199,34 +203,35 @@ entries:
             schema_ref: cloudflare_zero_trust/audit_events/v1
             urn_kind: cloudflare_zero_trust_audit_events
           id: audit_events
-          id_field: id
+          id_field: ray_id
           label: Audit events
           method: GET
-          name_field: name
+          name_field: app_domain
           pagination:
-            cursor_json_path: $.next_cursor
-            cursor_param: cursor
+            inject_first_page: true
+            page_param: page
             page_size: 100
-            page_size_param: limit
-            type: cursor
-          path: /v1/audit_events
+            page_size_param: per_page
+            start_page: 1
+            type: page
+          path: /accounts/{account_id}/access/logs/access_requests
           projection:
             fields:
-              actor_email: actor_email
-              actor_id: actor_id
-              event_type: event_type
-              id: id
-              resource_id: resource_id
-              resource_type: resource_type
+              actor_email: user_email
+              actor_id: user_email
+              event_type: action
+              id: ray_id
+              resource_id: app_uid
+              resource_type: application
             template: audit_event
-          record_selector: $.data[*]
+          record_selector: $.result[*]
       schema_version: cerebro.integration/v1
       source_id: cloudflare_zero_trust
       tenant_id: builtin_catalog
       transport:
-        base_url: ${config.base_url}
+        base_url: https://api.cloudflare.com/client/v4
         verification:
           expect_status:
             - 200
           method: GET
-          path: /v1/me
+          path: /accounts


### PR DESCRIPTION
## Summary

- `sources/cloudflare_zero_trust/catalog.yaml`'s `provider_api` block already declared the correct, spec-verified endpoints (`GET /accounts/{account_id}/access/{users,groups,policies,apps}` and `GET /accounts/{account_id}/access/logs/access_requests` against `https://api.cloudflare.com/client/v4`) — no change needed there.
- The compiled definition (`internal/connectorcatalog/catalog/identity-access-secrets/cloudflare_zero_trust.yaml`) called fictional endpoints instead: `GET {config.base_url}/v1/users`, `/v1/groups`, `/v1/roles`, `/v1/applications`, `/v1/audit_events`, none of which exist in Cloudflare's API. `verified_families()`/`canonical_family_locator()` could never match these against the genuine `provider_api` paths, so every family failed with `MissingProviderProof`/`IncompleteRuntimeFamilyProof` despite the source having a fully verified provider contract.
- Fixed the compiled definition to call the real, documented endpoints, and corrected the pagination/record-selector/id-field details that the fictional paths had also gotten wrong (see Authority proof).
- Added `cloudflare_zero_trust` (alphabetical) to `retired_static_loader_sources_are_fully_rust_authoritative`.

## Authority proof

Probe output before the fix (`crates/source-catalog/tests/wave5_probe_cloudflare_zero_trust.rs`, deleted before commit):

```
source authority: ShadowOnly
family=users authoritative=false projection_authoritative=false reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]
family=groups authoritative=false projection_authoritative=false reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]
family=roles authoritative=false projection_authoritative=false reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]
family=applications authoritative=false projection_authoritative=false reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]
family=audit_events authoritative=false projection_authoritative=false reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof]
```

No `UnboundConfigAttribute` reason appeared for any family, so — unlike the sibling `cloudflare` fix (#2715) — there was no dangling `tenant_id` config-attribute binding to unwind here; this is a pure path-mismatch defect, confirmed by the probe rather than assumed from the census hint.

I fetched `sources/cloudflare_zero_trust/catalog.yaml`'s `provider_api.spec_url` (`https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json`, the full Cloudflare OpenAPI spec, ~24MB) and confirmed every affected method+path genuinely exists:

- `GET /accounts/{account_id}/access/users` — present, response `$ref: access_response_collection-24` → `result: array of access_users-2` (has `id`, `name`, `email`, ... — matches original `id_field`/`name_field`).
- `GET /accounts/{account_id}/access/groups` — present, `result: array of access_groups-2` (has `id`, `name`).
- `GET /accounts/{account_id}/access/policies` — present (the `roles` family maps to Access Policies, matching the existing `policy` projection template and `sources/cloudflare_zero_trust/catalog.yaml`'s own family layout), `result: array of access_reusable_policy_resp` → `access_base_policy_resp` (has `id`, `name`).
- `GET /accounts/{account_id}/access/apps` — present, `result: array of access_app_response` (anyOf app-type variants, all sharing `access_basic_app_response_props`: `id`, and `name` via `access_self_hosted_props`/`access_saas_props`).
- `GET /accounts/{account_id}/access/logs/access_requests` — present, `result: array of access_access-requests`, whose properties are `action, allowed, app_domain, app_uid, connection, created_at, ip_address, ray_id, user_email` — **no `id`, `actor_id`, `resource_type`, or `event_type` field** (unlike the other four families, whose original `id`/`name` field names already happened to match the real schema).
- All five operations accept `access_page`/`access_per_page` query parameters (page-based pagination), not the cursor grammar the compiled definition had.
- `GET /accounts` (used for `transport.verification`, replacing the fictional `GET /v1/me`) is already proven real — it's the verification endpoint the already-authoritative sibling `cloudflare` source uses in this same catalog file.

Given that, the fix:
- `transport.base_url` → literal `https://api.cloudflare.com/client/v4` (matches `provider_api.base_url` and the sibling `cloudflare` source's convention; this API has no real per-tenant base URL, so the old user-supplied `base_url` config field was itself part of the defect).
- `config_fields` → `account_id` (required) instead of the unused `base_url` field; each family path gains `{account_id}`, which `config_binding()` resolves against it with no extra `config_attributes` wiring needed (path parameters bind automatically from `{...}` path segments — confirmed via `crates/source-catalog/src/lib.rs` around the `path_parameters`/`config_binding` logic).
- Each family `path` → the real endpoint listed above.
- `pagination` → `type: page, page_param: page, page_size_param: per_page, page_size: 100, start_page: 1, inject_first_page: true` (matches the spec and the sibling `cloudflare` source).
- `record_selector` → `$.result[*]` (was `$.data[*]`, which would return zero records against the real envelope).
- `audit_events` only: `id_field: ray_id` (was `id`), `name_field: app_domain` (was `name`), and `projection.fields` remapped to the real response fields (`actor_email`/`actor_id: user_email`, `event_type: action`, `id: ray_id`, `resource_id: app_uid`, `resource_type: application` as a literal since the endpoint has no resource-type field, matching the same literal-value convention the `applications` family already used for its own `resource_type`).

Probe output after the fix:

```
source authority: Authoritative
family=users authoritative=true projection_authoritative=true reasons=[]
family=groups authoritative=true projection_authoritative=true reasons=[]
family=roles authoritative=true projection_authoritative=true reasons=[]
family=applications authoritative=true projection_authoritative=true reasons=[]
family=audit_events authoritative=true projection_authoritative=true reasons=[]
```

All 5 families — `users`, `groups`, `roles`, `applications`, `audit_events` — are now both collection- and projection-authoritative, with genuine fixture coverage already present under `sources/cloudflare_zero_trust/testdata` for all 5.

**Reviewer note:** `sources/cloudflare_zero_trust/deploy.yaml` (a separate deployment scaffold, unrelated to `internal/connectorcatalog/catalog` compilation) already referenced `config.account_id` and a `/accounts/${config.account_id}/access/users`-shaped `health_path`, independently corroborating that account-scoped Access paths were always the intended API surface here, not the `/v1/...` placeholders the compiled definition had. `deploy.yaml` was left untouched — it isn't consumed by the Rust authority path and its `base_url` env var reference is self-consistent (declared in its own `secretKeys`), so nothing there needed to change for this PR.

## Validation

- `cargo test -p cerebro-source-catalog --lib` — 27/27 passed, including `compiles_the_complete_checked_in_catalog`, `standard_source_plan_index_matches_compiled_authoritative_plans`, and the updated `retired_static_loader_sources_are_fully_rust_authoritative`.
- Probe test (`wave5_probe_cloudflare_zero_trust.rs`) confirmed authority before/after as shown above, then deleted before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)