### PR TITLE
catalog(gitguardian): close collection/projection authority gap (path-join mismatch)

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -3611,6 +3611,7 @@ mod tests {
             "duo",
             "elevenlabs",
             "fivetran",
+            "gitguardian",
             "gitlab",
             "google_vertex_ai",
             "increase",

--- a/sources/gitguardian/catalog.yaml
+++ b/sources/gitguardian/catalog.yaml
@@ -16,7 +16,7 @@ provider_api:
   transport: rest
   auth: api_key
   auth_mechanics: authorization_token_header
-  base_url: https://api.gitguardian.com/v1
+  base_url: https://api.gitguardian.com
   spec_url: https://docs.gitguardian.com/api-docs/api-reference
   spec_kind: openapi_embedded_html
   references:
@@ -31,13 +31,13 @@ provider_api:
   families:
     - id: audit_events
       method: GET
-      path: /audit_logs
+      path: /v1/audit_logs
     - id: incidents
       method: GET
-      path: /incidents/secrets
+      path: /v1/incidents/secrets
     - id: members
       method: GET
-      path: /members
+      path: /v1/members
 kind_lifecycle:
   - kind: gitguardian.incidents
     status: active


### PR DESCRIPTION
## Summary

- GitGuardian's three runtime families (`incidents`, `members`, `audit_events`) were compiling as `MissingProviderProof` / `IncompleteRuntimeFamilyProof` despite `sources/gitguardian/catalog.yaml` carrying a complete `provider_api` proof (status: verified, basis: declared, spec_url + references present).
- Root cause: `sources/gitguardian/catalog.yaml` declared `provider_api.base_url: https://api.gitguardian.com/v1` with relative family paths (`/audit_logs`, `/incidents/secrets`, `/members`), while the compiled definition (`internal/connectorcatalog/catalog/security-posture-vulnerability/gitguardian.yaml`) uses `base_url: https://api.gitguardian.com` with `/v1`-prefixed family paths. `ProviderApiWire` (the proof-manifest struct `verified_families()` deserializes from `catalog.yaml`) has no `base_url` field at all — it canonicalizes the raw `family.path` only. So the proof locators (`/audit_logs`, `/incidents/secrets`, `/members`) never joined onto `/v1` and could never match the compiled definition's locators (`/v1/audit_logs`, `/v1/incidents/secrets`, `/v1/members`). This is the same class of defect as #2716 (DigitalOcean), just with the version segment misplaced in the opposite direction.
- Fix: rewrote `sources/gitguardian/catalog.yaml`'s `provider_api.base_url` to `https://api.gitguardian.com` and its three family paths to `/v1/audit_logs`, `/v1/incidents/secrets`, `/v1/members` — matching the compiled definition's actual outbound request path exactly.
- Added `gitguardian` (alphabetical, between `fivetran` and `gitlab`) to `retired_static_loader_sources_are_fully_rust_authoritative` in `crates/source-catalog/src/lib.rs`, since all three families are now both collection- and projection-authoritative.
- No compiled-definition or fixture changes were needed or made; only `sources/gitguardian/catalog.yaml` and the one test-list line in `lib.rs` changed.

## Authority proof

- Verified the real endpoint shape against GitGuardian's documented API, not just the census hint:
  - `https://docs.gitguardian.com/api-docs/authentication` states the base URL is `https://api.gitguardian.com` and every endpoint carries a `/v1` prefix (documented example: `curl ... https://api.gitguardian.com/v1/health`).
  - Public documentation/blog references confirm the three concrete endpoints used here: `GET https://api.gitguardian.com/v1/incidents/secrets` (secret incidents, filterable by `status`/`date_before`/`date_after`/`severity`), `GET https://api.gitguardian.com/v1/members` (workspace members), and `GET https://api.gitguardian.com/v1/audit_logs` (workspace audit logs, gated by the `audit_logs:read` scope).
  - Direct unauthenticated fetches to `api.gitguardian.com/*` uniformly return `403` regardless of path validity (confirmed against a deliberately bogus path), so path existence could not be confirmed by live HTTP probing alone — the fix relies on the documented spec content above, cross-checked against the compiled definition's own path/base_url pairing, which already issues correct live requests today.
- All three families (`audit_events`, `incidents`, `members`) have fixture coverage under `sources/gitguardian/testdata` and remain in `runtime_families` unchanged.
- No compiled-definition families were added, removed, or altered — only the catalog.yaml proof's base_url/path factoring was corrected to match what the compiled definition already sends on the wire.

### Probe output (throwaway test, deleted before commit)

Before fix:
```
gitguardian authority: ShadowOnly
family=incidents authoritative=false projection_authoritative=false reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof] path=/v1/incidents/secrets base_url=None
family=members authoritative=false projection_authoritative=false reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof] path=/v1/members base_url=None
family=audit_events authoritative=false projection_authoritative=false reasons=[MissingProviderProof, IncompleteRuntimeFamilyProof] path=/v1/audit_logs base_url=None
```

After fix:
```
gitguardian authority: Authoritative
family=incidents authoritative=true projection_authoritative=true reasons=[] path=/v1/incidents/secrets base_url=None
family=members authoritative=true projection_authoritative=true reasons=[] path=/v1/members base_url=None
family=audit_events authoritative=true projection_authoritative=true reasons=[] path=/v1/audit_logs base_url=None
```

## Validation

- `cargo test -p cerebro-source-catalog --lib` — 27 passed, 0 failed (includes `retired_static_loader_sources_are_fully_rust_authoritative`, `standard_source_plan_index_matches_compiled_authoritative_plans`, `compiles_the_complete_checked_in_catalog`).
- Throwaway probe test (`crates/source-catalog/tests/wave5_probe_gitguardian.rs`) was deleted before committing; it is not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)