### PR TITLE
catalog(mailchimp): close Rust collection/projection authority gap

### DIFF
--- a/crates/source-catalog/src/lib.rs
+++ b/crates/source-catalog/src/lib.rs
@@ -3617,6 +3617,7 @@ mod tests {
             "jira",
             "jumpcloud",
             "langchain",
+            "mailchimp",
             "mastodon",
             "meraki",
             "microsoft_entra_id",

--- a/crates/source-catalog/tests/mailchimp_contract.rs
+++ b/crates/source-catalog/tests/mailchimp_contract.rs
@@ -2,11 +2,10 @@ use std::path::PathBuf;
 
 use cerebro_source_catalog::{
     AuthModel, CollectionAuthority, HttpMethod, Pagination, PathParameterBinding, SourceCatalog,
-    UnsupportedReasonCode,
 };
 
 #[test]
-fn mailchimp_compiles_the_provider_shapes_but_stays_unpromoted() {
+fn mailchimp_compiles_the_provider_shapes_and_is_fully_rust_authoritative() {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let catalog = SourceCatalog::load(
         root.join("internal/connectorcatalog/catalog"),
@@ -15,7 +14,7 @@ fn mailchimp_compiles_the_provider_shapes_but_stays_unpromoted() {
     .expect("load source catalog");
     let source = catalog.get("mailchimp").expect("Mailchimp source");
 
-    assert_eq!(source.authority(), CollectionAuthority::ShadowOnly);
+    assert_eq!(source.authority(), CollectionAuthority::Authoritative);
     assert_eq!(source.auth(), &AuthModel::Basic);
     assert_eq!(source.token_header(), "Authorization");
     assert_eq!(source.token_scheme(), "Basic");
@@ -49,10 +48,17 @@ fn mailchimp_compiles_the_provider_shapes_but_stays_unpromoted() {
             }
         );
         assert!(
-            family
-                .unsupported_reasons()
-                .contains(&UnsupportedReasonCode::UnboundConfigAttribute),
-            "Mailchimp {family_id} must stay shadow-only until authenticated tenant binding is compiled"
+            family.unsupported_reasons().is_empty(),
+            "Mailchimp {family_id} should have no outstanding unsupported reasons, found {:?}",
+            family.unsupported_reasons()
+        );
+        assert!(
+            family.is_authoritative(),
+            "Mailchimp {family_id} must be collection-authoritative"
+        );
+        assert!(
+            family.is_projection_authoritative(),
+            "Mailchimp {family_id} must be projection-authoritative"
         );
     }
 

--- a/internal/connectorcatalog/catalog/observability-soar-threat-intel/mailchimp.yaml
+++ b/internal/connectorcatalog/catalog/observability-soar-threat-intel/mailchimp.yaml
@@ -62,9 +62,6 @@ entries:
             page_size: 100
             type: offset
           path: /lists
-          config:
-            config_attributes:
-              tenant_id: tenant_id
           projection:
             fields:
               description: permission_reminder
@@ -104,9 +101,6 @@ entries:
             page_size: 100
             type: offset
           path: /lists/${config.list_id}/members
-          config:
-            config_attributes:
-              tenant_id: tenant_id
           projection:
             fields:
               display_name: full_name|email_address
@@ -147,8 +141,6 @@ entries:
             type: offset
           path: /activity-feed/chimp-chatter
           config:
-            config_attributes:
-              tenant_id: tenant_id
             encode_urn_id: true
             identity_keys: [campaign_id, list_id, url, message]
           projection:


### PR DESCRIPTION
## Summary
- Mailchimp's compiled definition (`internal/connectorcatalog/catalog/observability-soar-threat-intel/mailchimp.yaml`) declared `config: { config_attributes: { tenant_id: tenant_id } }` on all three families (`lists`, `members`, `audit_events`). `tenant_id` is not declared in the source's `config_fields` (only `dc` and `list_id` are) and is not a path parameter, so `config_binding("tenant_id", …)` could never resolve it — `config_attributes_configured` was always `false`, which forced `UnboundConfigAttribute` on every family and pinned collection authority at `ShadowOnly` even though `provider_api` was already `verified` for all three families.
- `tenant_id` is populated automatically from the execution context by the generic runtime (see e.g. `crates/source-runtime-next/src/discord/source_execution.rs:186`, `crates/source-runtime-next/src/cerebro_source.rs`), not from provider config — no other authoritative source in the catalog uses `config_attributes` to source `tenant_id` (e.g. `digitalocean.yaml` doesn't declare it at all; `slack.yaml`'s `config_attributes` bind real declared config fields like `channel_id`/`usergroup_id`, not `tenant_id`). The stanza was dead/vestigial wiring, not a real requirement, so it was removed from all three families in the compiled definition. `sources/mailchimp/catalog.yaml` needed no changes — its `provider_api` families/paths were already correct.
- Updated `crates/source-catalog/tests/mailchimp_contract.rs`, which previously asserted Mailchimp stayed `ShadowOnly` with `UnboundConfigAttribute` on every family — it now asserts `Authoritative`/no unsupported reasons/`is_authoritative()`/`is_projection_authoritative()` for `lists`, `members`, and `audit_events`.
- Added `"mailchimp"` (alphabetical) to `retired_static_loader_sources_are_fully_rust_authoritative` in `crates/source-catalog/src/lib.rs`.

## Authority proof
- Families: `lists`, `members`, `audit_events` — all three now both collection- and projection-authoritative, and all three have real fixture coverage under `sources/mailchimp/testdata/` (`read_lists.json`, `read_members.json`, `read_audit_events.json`, plus `testdata/api/{lists,members,audit_events}/...`) so all stay in `runtime_families`.
- Verified against the pinned provider spec named in `sources/mailchimp/catalog.yaml`'s `provider_api.spec_url` / `certification.evidence` (`https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/74feb256f8ba8bb9d5a322de83c92b42306831fd/spec/marketing.json`, an OpenAPI document): downloaded the spec at that exact commit digest and confirmed `GET /lists`, `GET /lists/{list_id}/members`, and `GET /activity-feed/chimp-chatter` are all real, documented operations in it (no path/method changes were made — this only confirms the pre-existing paths in both `catalog.yaml` and the compiled definition are genuine).
- Probe output (throwaway `crates/source-catalog/tests/wave5_probe_mailchimp.rs`, deleted before commit) before the fix:
  ```
  mailchimp authority = ShadowOnly
  family=lists authoritative=false projection_authoritative=true reasons=[UnboundConfigAttribute]
  family=members authoritative=false projection_authoritative=true reasons=[UnboundConfigAttribute]
  family=audit_events authoritative=false projection_authoritative=true reasons=[UnboundConfigAttribute]
  ```
  After the fix:
  ```
  mailchimp authority = Authoritative
  family=lists authoritative=true projection_authoritative=true reasons=[]
  family=members authoritative=true projection_authoritative=true reasons=[]
  family=audit_events authoritative=true projection_authoritative=true reasons=[]
  ```

## Validation
- `cargo test -p cerebro-source-catalog --lib` — 27 passed
- `cargo test -p cerebro-source-catalog` (lib + `mailchimp_contract.rs` + `okta_contract.rs` + doctests) — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)