### PR TITLE
refactor(sources): retire GitGuardian Go projection writer

### DIFF
--- a/internal/sourceprojection/gitguardian.go
+++ b/internal/sourceprojection/gitguardian.go
@@ -1,42 +1,30 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func gitguardianIncidentsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return gitguardianGenericFindingProjections(event)
+var errGitguardianRustProjectionRequired = errors.New("gitguardian projection requires Rust authority")
+
+func gitguardianIncidentsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errGitguardianRustProjectionRequired
 }
 
-func gitguardianMembersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "gitguardian"})
+// gitguardianMembersProjections previously dispatched straight to the shared
+// identityUserProjections helper. It now fails closed on its own so that
+// shared helper (still used by other identity-user providers) is left
+// untouched.
+func gitguardianMembersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errGitguardianRustProjectionRequired
 }
 
-func gitguardianAuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "gitguardian"})
-}
-
-func gitguardianGenericFindingProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	findingID := firstNonEmpty(attributes["finding_id"], event.GetId())
-	findingURN := projectionURN(tenantID, "finding", findingID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: findingURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "finding", Label: firstNonEmpty(attributes["title"], findingID), Attributes: map[string]string{"finding_id": findingID, "severity": strings.TrimSpace(attributes["severity"]), "status": strings.TrimSpace(attributes["status"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if resourceURN := strings.TrimSpace(attributes["resource_urn"]); resourceURN != "" {
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), findingURN, resourceURN, relationAffects, map[string]string{"event_id": event.GetId()}))
-	}
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), evidenceURN, findingURN, relationSupports, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+// gitguardianAuditEventsProjections previously dispatched straight to the
+// shared identityAuditProjections helper. It now fails closed on its own so
+// that shared helper (still used by other identity-audit providers) is left
+// untouched.
+func gitguardianAuditEventsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errGitguardianRustProjectionRequired
 }

--- a/internal/sourceprojection/gitguardian_test.go
+++ b/internal/sourceprojection/gitguardian_test.go
@@ -1,46 +1,31 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestGitguardianFindingProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "gitguardian", Kind: "gitguardian.incidents", Attributes: map[string]string{"finding_id": "finding-1", "title": "Finding One", "severity": "high", "status": "open", "resource_urn": "urn:cerebro:tenant:runtime_asset:asset-1", "evidence_id": "evidence-1"}}
-	entities, links, err := gitguardianIncidentsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected finding")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected finding links")
-	}
-	if !hasProjectedEntityType(entities, "runtime_evidence") {
-		t.Fatal("expected projected runtime evidence entity")
-	}
-}
-
-func TestGitguardianIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "gitguardian", Kind: "gitguardian.members", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := gitguardianMembersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestGitguardianAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "gitguardian", Kind: "gitguardian.audit_events", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := gitguardianAuditEventsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestGitguardianGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"gitguardian.audit_events",
+		"gitguardian.incidents",
+		"gitguardian.members",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "gitguardian",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errGitguardianRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- `incidents`, `members`, and `audit_events` are now fully collection- and projection-authoritative in the Rust source catalog (#2817), so `internal/sourceprojection/gitguardian.go` is redundant.
- Every family projector now fails closed with `errGitguardianRustProjectionRequired` instead of computing entities/links, following the deepseek/cloudflare_zero_trust retirement pattern.
- `gitguardianMembersProjections` and `gitguardianAuditEventsProjections` previously delegated straight to the shared `identityUserProjections`/`identityAuditProjections` helpers in `identity.go` — those helpers are used by well over a hundred other still-live providers, so this PR leaves them untouched and only changes this file's own wrapper functions (the shared-helper wrapper rule from #2747).
- `gitguardianGenericFindingProjections` was private to this file (not referenced anywhere else in `internal/sourceprojection`), so it's deleted outright along with its only caller rather than wrapped.

**Stacking note:** this branches off `claude/gitguardian-rust-authority` (#2817) since it depends on that PR's authority proof. It will retarget to `main` automatically once #2817 merges.

## Cross-package check

```
grep -rn "\"gitguardian\." --include='*.go' internal cmd
```
outside `internal/sourceprojection` returned nothing — no test corpus in another package projects `gitguardian.*` events, so there was nothing to migrate to a still-live provider. (Note: `gitguardian_secrets` is a distinct source id/provider and is untouched by this PR.)

## Validation

- `gofmt -l internal/sourceprojection` — empty.
- `go build ./internal/sourceprojection` — clean.
- `go test ./internal/sourceprojection ./internal/sourceregistry -count=1` — both packages pass, including the new table-driven `TestGitguardianGoProjectionFailsClosedForRustAuthoritativeFamilies` over every `gitguardian.*` kind in `registry_builtins.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)