### PR TITLE
refactor(sources): retire Mailchimp Go projection writer

### DIFF
--- a/internal/sourceprojection/mailchimp.go
+++ b/internal/sourceprojection/mailchimp.go
@@ -1,18 +1,22 @@
 package sourceprojection
 
 import (
+	"errors"
+
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func mailchimpListsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityGroupProjections(event, identityProjectionProfile{Provider: "mailchimp"})
+var errMailchimpRustProjectionRequired = errors.New("mailchimp projection requires Rust authority")
+
+func mailchimpListsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errMailchimpRustProjectionRequired
 }
 
-func mailchimpMembersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "mailchimp"})
+func mailchimpMembersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errMailchimpRustProjectionRequired
 }
 
-func mailchimpAuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "mailchimp"})
+func mailchimpAuditEventsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errMailchimpRustProjectionRequired
 }

--- a/internal/sourceprojection/mailchimp_test.go
+++ b/internal/sourceprojection/mailchimp_test.go
@@ -1,40 +1,27 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestMailchimpIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "mailchimp", Kind: "mailchimp.members", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := mailchimpMembersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestMailchimpIdentityGroupProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "mailchimp", Kind: "mailchimp.lists", Attributes: map[string]string{"group_id": "group-1", "group_email": "group@example.test", "group_name": "Group One"}}
-	entities, _, err := mailchimpListsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity group")
-	}
-}
-
-func TestMailchimpAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "mailchimp", Kind: "mailchimp.audit_events", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := mailchimpAuditEventsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestMailchimpGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{"mailchimp.lists", "mailchimp.members", "mailchimp.audit_events"} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "mailchimp",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errMailchimpRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
Stacked on #2818 — this PR targets `claude/mailchimp-rust-authority` and will retarget to `main` automatically once that one merges.

## Summary
- All three Mailchimp families (`lists`, `members`, `audit_events`) are now Rust collection- and projection-authoritative (see #2818). The Go projection writer for `mailchimp` is dead code on the live path — any committed Mailchimp event is projected by the native Rust lane.
- `internal/sourceprojection/mailchimp.go`'s three wrapper functions (`mailchimpListsProjections`, `mailchimpMembersProjections`, `mailchimpAuditEventsProjections`) previously delegated to the shared `identityGroupProjections`/`identityUserProjections`/`identityAuditProjections` helpers. Those shared helpers are used by many other still-Go-authoritative providers and were left untouched — only Mailchimp's wrappers were changed. Each now returns a typed `errMailchimpRustProjectionRequired` sentinel error instead of running Go projection logic, so the writer fails closed rather than silently producing entities/links that Rust is now authoritative for. This follows the same pattern used for `deepseek` (#2658) and the other already-retired sources.
- `registry_builtins.go` is untouched: the `mailchimp.lists` / `mailchimp.members` / `mailchimp.audit_events` kind entries still route to these functions, which now simply refuse to run.
- Replaced `mailchimp_test.go`'s per-family happy-path tests with a single table-driven test asserting the Go writer fails closed (`errors.Is(err, errMailchimpRustProjectionRequired)`, zero entities/links) for all three kinds via `ProjectEvent`.

## Cross-package check
- `grep -rn "\"mailchimp\." --include='*.go' internal cmd` outside `internal/sourceprojection` returns no hits — no other package parses or asserts on `mailchimp.*` event kinds, so there is no test corpus to move to another provider.
- The few other Go files matching `mailchimp` (`internal/sourcefixture/sanitize.go`, `sanitize_test.go`, `internal/findings/policy_rule_catalog_github_gen.go`) are unrelated: they handle Mailchimp API-key secret-scanning fixture/URL sanitization, not event projection, and were not touched.

## Validation
- `gofmt -l internal/sourceprojection` — empty
- `go build ./internal/sourceprojection/...` — clean
- `go test ./internal/sourceprojection/... -count=1` — ok
- `go test ./internal/sourceregistry/... -count=1` — ok (no consumer packages reference Mailchimp projection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)