### PR TITLE
refactor(sources): retire Hashicorp Vault Go projection writer

### DIFF
--- a/internal/graphrebuild/relationship_graph_test.go
+++ b/internal/graphrebuild/relationship_graph_test.go
@@ -61,21 +61,26 @@ func TestRebuildDryRunMergesDopplerSecretProjectWithoutFragmentation(t *testing.
 	}
 }
 
-// TestRebuildDryRunLinksHashicorpVaultSecretToMount pins the relationship
-// Vault can prove from /sys/mounts: a secret engine belongs to its mounted
-// Vault engine, with no identity fragmentation.
-func TestRebuildDryRunLinksHashicorpVaultSecretToMount(t *testing.T) {
+// TestRebuildDryRunSynthesizesDopplerProjectFromSecretRelationship pins the
+// single-event relationship-synthesis case previously covered by HashiCorp
+// Vault's secret-belongs-to-mount edge (retired along with its Go projection
+// writer once the family became fully Rust-authoritative, see
+// writer/cerebro#2822): a lone doppler.secrets event carries only project_id,
+// with no separate project event, and the catalog-declared secret_project
+// relationship must still synthesize the doppler.project entity and link to
+// it, with no identity fragmentation.
+func TestRebuildDryRunSynthesizesDopplerProjectFromSecretRelationship(t *testing.T) {
 	events := []*cerebrov1.EventEnvelope{
-		testRuntimeEvent("vault-secret-1", "hashicorp_vault.secrets", "writer-vault", map[string]string{
-			"secret_id":   "vsecret-1",
-			"secret_name": "kv/",
-			"vault_id":    "kv",
+		testRuntimeEvent("doppler-secret-1", "doppler.secrets", "writer-doppler", map[string]string{
+			"secret_id":   "secret-1",
+			"secret_name": "DATABASE_URL",
+			"project_id":  "proj-1",
 		}),
 	}
-	result := replayDryRun(t, "writer-vault", "hashicorp_vault", events)
+	result := replayDryRun(t, "writer-doppler", "doppler", events)
 
-	vaultURN := "urn:cerebro:writer:hashicorp_vault_vault:kv"
-	if !containsLink(result.PreviewLinks, "urn:cerebro:writer:secret:vsecret-1", "belongs_to", vaultURN) {
+	projectURN := "urn:cerebro:writer:doppler_project:proj-1"
+	if !containsLink(result.PreviewLinks, "urn:cerebro:writer:secret:secret-1", "belongs_to", projectURN) {
 		t.Fatalf("missing belongs_to edge: %#v", result.PreviewLinks)
 	}
 	if !containsAssertion(result.GraphAssertions, "cross_kind_identity_fragmentation", 0, 0, true) {

--- a/internal/sourceprojection/catalogruntime_test.go
+++ b/internal/sourceprojection/catalogruntime_test.go
@@ -1004,26 +1004,34 @@ func TestBuiltinRegistryAppliesDeclaredCatalogRelationships(t *testing.T) {
 		}
 	})
 
-	t.Run("hashicorp_vault secrets belongs_to vault", func(t *testing.T) {
-		projector := registry.projectors["hashicorp_vault.secrets"]
+	// hashicorp_vault secrets belongs_to vault was covered here before
+	// hashicorp_vault.secrets became fully Rust-authoritative and its Go
+	// projection writer was retired (writer/cerebro#2822), at which point
+	// the registered projector always fails closed and can no longer reach
+	// this relationship-augmentation layer. pagerduty.integration is a
+	// still-live provider exercising the identical single-event,
+	// relationship-synthesizes-the-target-entity semantics.
+	t.Run("pagerduty integration belongs_to service", func(t *testing.T) {
+		projector := registry.projectors["pagerduty.integration"]
 		if projector == nil {
-			t.Fatal("missing registered projector for hashicorp_vault.secrets")
+			t.Fatal("missing registered projector for pagerduty.integration")
 		}
 		_, links, err := projector(&cerebrov1.EventEnvelope{
 			Id:       "event-1",
 			TenantId: "tenant",
-			SourceId: "hashicorp_vault",
-			Kind:     "hashicorp_vault.secrets",
+			SourceId: "pagerduty",
+			Kind:     "pagerduty.integration",
 			Attributes: map[string]string{
-				"secret_id":   "secret-1",
-				"secret_name": "kv/db",
-				"vault_id":    "kv",
+				"integration_id": "integration-1",
+				"name":           "Datadog",
+				"service_id":     "service-1",
+				"service_name":   "API",
 			},
 		})
 		if err != nil {
-			t.Fatalf("hashicorp_vault.secrets projector error = %v", err)
+			t.Fatalf("pagerduty.integration projector error = %v", err)
 		}
-		if !projectedLinksContain(links, "urn:cerebro:tenant:secret:secret-1", relationBelongsTo, "urn:cerebro:tenant:hashicorp_vault_vault:kv") {
+		if !projectedLinksContain(links, "urn:cerebro:tenant:pagerduty_integration:integration-1", relationBelongsTo, "urn:cerebro:tenant:pagerduty_service:service-1") {
 			t.Fatalf("declared belongs_to edge not emitted by registered projector: %#v", links)
 		}
 	})

--- a/internal/sourceprojection/hashicorp_vault.go
+++ b/internal/sourceprojection/hashicorp_vault.go
@@ -1,39 +1,22 @@
 package sourceprojection
 
 import (
-	"strings"
+	"errors"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 	"github.com/writer/cerebro/internal/ports"
 )
 
-func hashicorpVaultUsersProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityUserProjections(event, identityProjectionProfile{Provider: "hashicorp_vault"})
+var errHashicorpVaultRustProjectionRequired = errors.New("hashicorp_vault projection requires Rust authority")
+
+func hashicorpVaultUsersProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errHashicorpVaultRustProjectionRequired
 }
 
-func hashicorpVaultSecretsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return hashicorpVaultSecretProjections(event)
+func hashicorpVaultSecretsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errHashicorpVaultRustProjectionRequired
 }
 
-func hashicorpVaultAuditEventsProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	return identityAuditProjections(event, identityProjectionProfile{Provider: "hashicorp_vault"})
-}
-
-func hashicorpVaultSecretProjections(event *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
-	tenantID, err := tenantID(event)
-	if err != nil {
-		return nil, nil, err
-	}
-	attributes := event.GetAttributes()
-	secretID := firstNonEmpty(attributes["secret_id"], event.GetId())
-	secretURN := projectionURN(tenantID, "secret", secretID)
-	entities := map[string]*ports.ProjectedEntity{}
-	links := map[string]*ports.ProjectedLink{}
-	addEntity(entities, &ports.ProjectedEntity{URN: secretURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "secret", Label: firstNonEmpty(attributes["secret_name"], secretID), Attributes: map[string]string{"secret_id": secretID, "secret_type": strings.TrimSpace(attributes["secret_type"]), "secret_status": strings.TrimSpace(attributes["secret_status"]), "secret_rotation_enabled": strings.TrimSpace(attributes["secret_rotation_enabled"]), "secret_last_rotated_at": strings.TrimSpace(attributes["secret_last_rotated_at"]), "source_runtime_id": strings.TrimSpace(attributes[ports.EventAttributeSourceRuntimeID])}})
-	if evidenceID := strings.TrimSpace(attributes["evidence_id"]); evidenceID != "" {
-		evidenceURN := projectionURN(tenantID, "runtime_evidence", evidenceID)
-		addEntity(entities, &ports.ProjectedEntity{URN: evidenceURN, TenantID: tenantID, SourceID: event.GetSourceId(), EntityType: "runtime_evidence", Label: evidenceID, Attributes: map[string]string{"evidence_id": evidenceID, "evidence_cas_uri": strings.TrimSpace(attributes["evidence_cas_uri"]), "evidence_cas_digest": strings.TrimSpace(attributes["evidence_cas_digest"])}})
-		addLink(links, projectedLink(tenantID, event.GetSourceId(), secretURN, evidenceURN, relationHasEvidence, map[string]string{"event_id": event.GetId()}))
-	}
-	return identityProjectionResult(entities, links)
+func hashicorpVaultAuditEventsProjections(_ *cerebrov1.EventEnvelope) ([]*ports.ProjectedEntity, []*ports.ProjectedLink, error) {
+	return nil, nil, errHashicorpVaultRustProjectionRequired
 }

--- a/internal/sourceprojection/hashicorp_vault_test.go
+++ b/internal/sourceprojection/hashicorp_vault_test.go
@@ -1,43 +1,31 @@
 package sourceprojection
 
 import (
+	"errors"
 	"testing"
 
 	cerebrov1 "github.com/writer/cerebro/gen/cerebro/v1"
 )
 
-func TestHashicorpVaultSecretProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "hashicorp_vault", Kind: "hashicorp_vault.secrets", Attributes: map[string]string{"secret_id": "secret-1", "secret_name": "DB Password", "secret_type": "password", "secret_status": "active", "evidence_id": "evidence-1"}}
-	entities, links, err := hashicorpVaultSecretsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected secret")
-	}
-	if len(links) == 0 {
-		t.Fatal("expected projected evidence links")
-	}
-}
-
-func TestHashicorpVaultIdentityUserProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "hashicorp_vault", Kind: "hashicorp_vault.users", Attributes: map[string]string{"user_id": "user-1", "email": "user@example.test", "display_name": "User One"}}
-	entities, _, err := hashicorpVaultUsersProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 {
-		t.Fatal("expected projected identity user")
-	}
-}
-
-func TestHashicorpVaultAuditProjection(t *testing.T) {
-	event := &cerebrov1.EventEnvelope{Id: "event-1", TenantId: "tenant", SourceId: "hashicorp_vault", Kind: "hashicorp_vault.audit_events", Attributes: map[string]string{"event_type": "user.login", "actor_id": "user-1", "actor_email": "user@example.test", "resource_id": "app-1", "resource_type": "application"}}
-	entities, links, err := hashicorpVaultAuditEventsProjections(event)
-	if err != nil {
-		t.Fatalf("projection error = %v", err)
-	}
-	if len(entities) == 0 || len(links) == 0 {
-		t.Fatalf("entities/links = %d/%d, want audit projection", len(entities), len(links))
+func TestHashicorpVaultGoProjectionFailsClosedForRustAuthoritativeFamilies(t *testing.T) {
+	for _, kind := range []string{
+		"hashicorp_vault.audit_events",
+		"hashicorp_vault.secrets",
+		"hashicorp_vault.users",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			entities, links, err := ProjectEvent(&cerebrov1.EventEnvelope{
+				Id:       "event-1",
+				TenantId: "tenant",
+				SourceId: "hashicorp_vault",
+				Kind:     kind,
+			})
+			if !errors.Is(err, errHashicorpVaultRustProjectionRequired) {
+				t.Fatalf("ProjectEvent() error = %v", err)
+			}
+			if len(entities) != 0 || len(links) != 0 {
+				t.Fatalf("Go projection produced entities=%d links=%d", len(entities), len(links))
+			}
+		})
 	}
 }


### PR DESCRIPTION
Stacked on #2822 (`claude/hashicorp_vault-rust-authority`) -- base is set to that branch so review only shows this PR's own diff; it will retarget to `main` automatically once #2822 merges.

## Summary
- `users`, `secrets`, and `audit_events` are now fully collection- and projection-authoritative in the Rust source catalog (#2822), so the Go projection writer in `internal/sourceprojection/hashicorp_vault.go` is redundant.
- Every family projector now fails closed with `errHashicorpVaultRustProjectionRequired` instead of computing entities/links, following the deepseek / cloudflare_zero_trust retirement pattern.
  - `hashicorpVaultUsersProjections` and `hashicorpVaultAuditEventsProjections` previously delegated straight to the shared `identityUserProjections` / `identityAuditProjections` helpers (used by hundreds of other providers) -- those shared helpers are untouched, only this file's wrappers change.
  - `hashicorpVaultSecretProjections` was private to this file (not referenced anywhere else in `internal/sourceprojection`) and is deleted outright along with its caller.
- `hashicorp_vault_test.go` is rewritten as a table-driven test over every `hashicorp_vault.*` kind registered in `registry_builtins.go`, routed through `ProjectEvent`, asserting the Go path never produces entities or links.

## Cross-package check (the box lesson, #2709)
`grep -rn "\"hashicorp_vault\." --include='*.go' internal cmd` outside `internal/sourceprojection` turned up two fixtures that exercised the Go writer indirectly, both migrated to still-live providers with identical semantics:

1. **`internal/graphrebuild/relationship_graph_test.go`** -- `TestRebuildDryRunLinksHashicorpVaultSecretToMount` asserted, via a full `RebuildDryRun` replay, that a lone `hashicorp_vault.secrets` event (only `vault_id`, no separate vault event) gets a synthesized `hashicorp_vault.vault` entity and a `belongs_to` edge purely from the catalog's declared `relationships:` block (`augmentCatalogRuntimeProjector` in `catalogrelationships.go`). That layer only runs when the base Go projector succeeds, so it silently stopped being exercised the moment `hashicorp_vault`'s writer started failing closed. Replaced with `TestRebuildDryRunSynthesizesDopplerProjectFromSecretRelationship`, using `doppler.secrets` -- a still-live provider whose catalog declares the structurally identical `secret_project` relationship (single event, target entity synthesized purely from the relationship's `to:` spec, no separate project event).
2. **`internal/sourceprojection/catalogruntime_test.go`** -- `TestBuiltinRegistryAppliesDeclaredCatalogRelationships` had a `hashicorp_vault secrets belongs_to vault` subtest calling the registered `hashicorp_vault.secrets` projector directly to assert the same relationship-augmentation layer. Replaced with a `pagerduty integration belongs_to service` subtest (also still-live, same single-event synthesized-target-entity shape via `pagerduty.integration` -> `pagerduty.service`).

Only `doppler` and `pagerduty` (besides the now-retired `hashicorp_vault`) declare a `relationships:` block anywhere in `internal/connectorcatalog/catalog/**`, so both were available as live migration targets and both are now exercised.

## Validation
- `gofmt -l internal/sourceprojection` -- empty.
- `go build ./internal/sourceprojection/...` -- clean.
- `go test ./internal/sourceprojection/... ./internal/sourceregistry/... ./internal/graphrebuild/... -count=1` -- all green, including both migrated relationship tests and the new fail-closed table test.
- `go build ./...` -- clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)