### PR TITLE
test(sources): refresh mailchimp generated fixtures after definition change

### DIFF
--- a/sources/mailchimp/catalog.yaml
+++ b/sources/mailchimp/catalog.yaml
@@ -92,7 +92,6 @@ event_contracts:
   - kind: mailchimp.lists
     schema_ref: mailchimp/lists/v1
     required_attributes:
-      - tenant_id
       - source_event_id
       - group_id
     required_payload_fields:
@@ -100,7 +99,6 @@ event_contracts:
   - kind: mailchimp.members
     schema_ref: mailchimp/members/v1
     required_attributes:
-      - tenant_id
       - source_event_id
       - user_id
     required_payload_fields:
@@ -108,7 +106,6 @@ event_contracts:
   - kind: mailchimp.audit_events
     schema_ref: mailchimp/audit_events/v1
     required_attributes:
-      - tenant_id
       - source_event_id
       - event_type
       - actor_id

--- a/sources/mailchimp/testdata/read_audit_events.json
+++ b/sources/mailchimp/testdata/read_audit_events.json
@@ -27,7 +27,6 @@
       "source_event_id": "2017-08-04T11%3A09%3A01+00%3A00/lists%3Anew-subscriber/1%20new%20subscriber/https%3A%2F%2Fexample.test%2Freports%2Fsummary%3Fid=1/A%20subscriber%20joined%20an%20audience./fixture-campaign/fixture-list",
       "source_provider": "mailchimp",
       "source_system": "mailchimp",
-      "tenant_id": "tenant",
       "title": "1 new subscriber"
     }
   }

--- a/sources/mailchimp/testdata/read_lists.json
+++ b/sources/mailchimp/testdata/read_lists.json
@@ -182,8 +182,7 @@
       "resource_name": "example-57a6d1b3",
       "source_event_id": "example-2e767a40",
       "source_provider": "mailchimp",
-      "source_system": "mailchimp",
-      "tenant_id": "tenant"
+      "source_system": "mailchimp"
     }
   }
 ]

--- a/sources/mailchimp/testdata/read_members.json
+++ b/sources/mailchimp/testdata/read_members.json
@@ -20,7 +20,6 @@
       "source_event_id": "user-f660ab91@example.test",
       "source_provider": "mailchimp",
       "source_system": "mailchimp",
-      "tenant_id": "tenant",
       "user_id": "user-f660ab91@example.test"
     }
   }


### PR DESCRIPTION
## Summary

- #2818's mailchimp compiled-definition fix (dropping unbindable `tenant_id` config_attributes) staled the generated replay fixtures, failing `TestMailchimpCatalogRuntimeReplays*` and therefore `sourcegen-test` / `codegen` in CI
- regenerated the three fixtures via the test suite's own `CEREBRO_UPDATE_SOURCE_FIXTURES=1` path

## Validation

- go test ./internal/catalogruntime -count=1 (sources module) — green
- make codegen-check — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)