### PR TITLE
test(connectorcatalog): align vault mirror test with tenant_id binding removal

### DIFF
--- a/internal/connectorcatalog/catalog_test.go
+++ b/internal/connectorcatalog/catalog_test.go
@@ -650,8 +650,8 @@ func TestBuiltinCatalogHashicorpVaultFamiliesMirrorRuntimeConfig(t *testing.T) {
 
 	for _, familyID := range []string{"users", "secrets", "audit_events"} {
 		family := catalogFamily(t, entry.Definition.ResourceFamilies, familyID)
-		if family.Config == nil || family.Config.ConfigAttributes["tenant_id"] != "tenant_id" {
-			t.Fatalf("%s config = %#v, want tenant_id config attribute", familyID, family.Config)
+		if family.Config != nil && family.Config.ConfigAttributes["tenant_id"] != "" {
+			t.Fatalf("%s config = %#v, want no tenant_id config attribute (tenant scoping lives on the envelope)", familyID, family.Config)
 		}
 		if family.Projection == nil {
 			t.Fatalf("%s projection = nil, want static fields", familyID)


### PR DESCRIPTION
## Summary

- #2822 dropped hashicorp_vault's unbindable `tenant_id` config attribute; `TestBuiltinCatalogHashicorpVaultFamiliesMirrorRuntimeConfig` still asserted it, failing on main
- inverted the assertion so a reintroduction of the binding now fails instead

Also noting for the record: the `codegen` job's current failure on main is buf.build BSR rate limiting (`resource_exhausted: too many requests` on proto checks) — transient infra from today's CI volume, not a code defect; it passes on retry.

## Validation

- go test ./internal/connectorcatalog -count=1 — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)